### PR TITLE
Fix messages.rtc selectors in distributed recipes

### DIFF
--- a/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -96,6 +96,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -99,6 +99,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -96,6 +96,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,
@@ -336,6 +340,10 @@
               "groupId": "world-fleet-room"
             },
             "transport": "messages.rtc",
+            "rallar": {
+              "typeId": "black-box.group.multicast.position",
+              "topicId": "black-box.group.multicast.position"
+            },
             "timeoutMs": 45000,
             "readiness": {
               "minReadyPeers": 1,

--- a/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
@@ -229,6 +229,11 @@ function multicastDeliveryPlan(options: Readonly<{
     };
 }
 
+const RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR = {
+    typeId: 'black-box.group.multicast.position',
+    topicId: 'black-box.group.multicast.position',
+} as const;
+
 function messagesRtcConnectCommand(options: Readonly<{
     commandId: string;
     connection: string;
@@ -248,6 +253,7 @@ function messagesRtcConnectCommand(options: Readonly<{
         workspaceId: options.group.workspaceId,
         roomRef,
         transport: 'messages.rtc',
+        rallar: { ...RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR },
         timeoutMs: options.readyTimeoutMs ?? 45_000,
         readiness: {
             minReadyPeers: options.minReadyPeers,
@@ -322,11 +328,10 @@ function messagesRtcStreamCommand(options: Readonly<{
             roomId: options.group.groupId,
             roomRef,
             deliveryMode: 'multicast',
-            typeId: 'black-box.group.multicast.position',
-            topicId: 'black-box.group.multicast.position',
+            ...RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR,
             payload: {
-                topic: 'black-box.group.multicast.position',
-                typeId: 'black-box.group.multicast.position',
+                topic: RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR.topicId,
+                typeId: RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR.typeId,
                 actor: '{auth.clientId}',
                 seq: '{stream.index}',
                 rateHz: options.plan.rateHz,

--- a/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
+++ b/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
@@ -60,6 +60,8 @@ function allValues(value: unknown): readonly string[] {
 type ManifestCommand = Readonly<{
     kind?: string;
     commandId?: string;
+    transport?: string;
+    rallar?: Readonly<Record<string, unknown>>;
     commands?: readonly ManifestCommand[];
     groups?: readonly Readonly<{
         commands?: readonly ManifestCommand[];
@@ -232,6 +234,21 @@ describe('Hetzner distributed manifest catalog', () => {
             const match = entry.filePath.match(/-(\d+)-agent/);
             expect(match?.[1], entry.filePath).toBe(String(entry.agentCount));
             expect(entry.manifest.targetPolicy.expectedParticipantCount).toBe(entry.agentCount);
+        }
+    });
+
+    it('configures matching selectors for every messages.rtc connection', () => {
+        for (const entry of buildHetznerDistributedManifestCatalog()) {
+            for (const command of manifestCommands(entry.manifest)) {
+                if (command.kind !== 'rtc.connect' || command.transport !== 'messages.rtc') {
+                    continue;
+                }
+
+                expect(command.rallar, entry.filePath).toEqual({
+                    typeId: 'black-box.group.multicast.position',
+                    topicId: 'black-box.group.multicast.position',
+                });
+            }
         }
     });
 

--- a/packages/tests/rallar-black-box/world-fleet-distributed-manifests.test.ts
+++ b/packages/tests/rallar-black-box/world-fleet-distributed-manifests.test.ts
@@ -12,7 +12,29 @@ import {
 } from '../../../packages/shared-test/rallar-bb-test/schema.ts';
 import {
     validateDistributedRunManifestContract,
+    type RallarBlackBoxDistributedRunManifest,
 } from '../../../packages/shared-test/rallar-bb-test/distributed-run.ts';
+
+type ManifestCommand = Readonly<{
+    kind?: string;
+    transport?: string;
+    rallar?: Readonly<Record<string, unknown>>;
+    commands?: readonly ManifestCommand[];
+    groups?: readonly Readonly<{
+        commands?: readonly ManifestCommand[];
+    }>[];
+}>;
+
+function manifestCommands(manifest: RallarBlackBoxDistributedRunManifest): readonly ManifestCommand[] {
+    const walk = (commands: readonly ManifestCommand[]): readonly ManifestCommand[] =>
+        commands.flatMap(command => [
+            command,
+            ...walk(command.commands ?? []),
+            ...(command.groups ?? []).flatMap(group => walk(group.commands ?? [])),
+        ]);
+
+    return manifest.recipes.flatMap(selection => walk((selection.recipe?.commands ?? []) as readonly ManifestCommand[]));
+}
 
 describe('world fleet distributed manifest catalog', () => {
     it('writes checked-in JSON that matches the generated catalog exactly', async () => {
@@ -71,6 +93,21 @@ describe('world fleet distributed manifest catalog', () => {
             expectedInboundMessages: 600,
             minReceiveRatio: 0.95,
         });
+    });
+
+    it('configures matching selectors for every messages.rtc connection', () => {
+        for (const entry of buildWorldFleetDistributedManifestCatalog()) {
+            for (const command of manifestCommands(entry.manifest)) {
+                if (command.kind !== 'rtc.connect' || command.transport !== 'messages.rtc') {
+                    continue;
+                }
+
+                expect(command.rallar, entry.filePath).toEqual({
+                    typeId: 'black-box.group.multicast.position',
+                    topicId: 'black-box.group.multicast.position',
+                });
+            }
+        }
     });
 
     it('keeps 20 Hz all-peer and 60m world-fleet runs diagnostic', () => {

--- a/packages/tests/shared-test/rallar-bb-test-recipe-fixtures.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-recipe-fixtures.test.ts
@@ -16,6 +16,11 @@ import {
     validateJsonSchema,
 } from '../../../packages/shared-test/rallar-bb-test/schema.ts';
 
+const EXPECTED_MESSAGES_RTC_MULTICAST_SELECTOR = {
+    typeId: 'black-box.group.multicast.position',
+    topicId: 'black-box.group.multicast.position',
+} as const;
+
 describe('rallar-bb-test recipe fixtures', () => {
     it('builds principal messages.rtc multicast sender and receiver recipes for 50-agent runs', () => {
         const [sender, receiver] = createRallarBlackBoxRtcMessagesPrincipalMulticastRecipes({
@@ -65,6 +70,7 @@ describe('rallar-bb-test recipe fixtures', () => {
         expect(senderConnect).toMatchObject({
             kind: 'rtc.connect',
             transport: 'messages.rtc',
+            rallar: EXPECTED_MESSAGES_RTC_MULTICAST_SELECTOR,
             readiness: {
                 minReadyPeers: 1,
                 timeoutMs: 45_000,
@@ -110,6 +116,7 @@ describe('rallar-bb-test recipe fixtures', () => {
         expect(receiverConnect).toMatchObject({
             kind: 'rtc.connect',
             transport: 'messages.rtc',
+            rallar: EXPECTED_MESSAGES_RTC_MULTICAST_SELECTOR,
             readiness: {
                 minReadyPeers: 1,
                 timeoutMs: 45_000,
@@ -189,6 +196,7 @@ describe('rallar-bb-test recipe fixtures', () => {
         expect(connect).toMatchObject({
             kind: 'rtc.connect',
             transport: 'messages.rtc',
+            rallar: EXPECTED_MESSAGES_RTC_MULTICAST_SELECTOR,
             readiness: {
                 minReadyPeers: 1,
                 timeoutMs: 45_000,


### PR DESCRIPTION
## Summary

- configure every generated `messages.rtc` connect command with the multicast position type/topic selector used by its stream
- keep the selector canonical in the recipe fixture so connect, send, and payload construction cannot drift
- add fixture and catalog-wide regression coverage, then regenerate the 46 affected Hetzner and 8 world-fleet manifests

## Root cause

The failed distributed run reached `rtc-messages-all-peer-connect`, but the generated `rtc.connect` command did not declare the type/topic selector used by the subsequent multicast stream. The browser runtime therefore initialized the `messages.rtc` connection with its default selector instead of `black-box.group.multicast.position`.

This fixes the recipe source rather than adding a runtime fallback or changing timeouts.

## Validation

- `npx vitest run packages/tests/shared-test/rallar-bb-test-recipe-fixtures.test.ts packages/tests/shared-test/rallar-bb-test-distributed-run.test.ts packages/tests/shared-test/rallar-bb-test-schema.test.ts packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts packages/tests/rallar-black-box/world-fleet-distributed-manifests.test.ts`
- `npm --workspace @ar-eye-hunter/shared-test run check:ts`
- `npm --workspace rallar-black-box run build`
- both distributed manifest writers in `--check` mode
- `npm run test:rallar:full-stack:memory:live-rtc-3`

The historical distributed workflow was not rerun from this unmerged branch.
