### PR TITLE
Fix Hetzner distributed session idempotency

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -470,7 +470,9 @@ pure function called directly by the use case or route.
   authorization, policy, capacity, lifecycle, and invariant decision. Retrying only a stale final write is incorrect.
 - Commit authoritative state, event, receipt, durable result, and final `APP_OUTBOX` or `WS_OUTBOX` entries in the same
   transaction. Write final queue entries directly through `ResourceInboxRepository`; do not add an intermediate
-  mutation outbox. Resolve WebSocket audiences and wake workers only after commit.
+  mutation outbox. Resolve dynamic WebSocket audiences and wake workers only after commit. If computed authoritative
+  work captures an immutable audience, persist that mandatory audience in the final queue entry and intersect it only
+  with locally open connections; never replace it with a process-cache lookup that can lag the message revision.
 - ResourceInbox allows 20 total processing attempts. Retry delays start at 1, 2, 4, 8, and 16 milliseconds, then rise
   through seconds, cap at 30 seconds, and use jitter. A separate best-effort fairness lane claims retries more than 30
   seconds overdue independently of timeout recovery.

--- a/.agents/skills/rallar-realtime/SKILL.md
+++ b/.agents/skills/rallar-realtime/SKILL.md
@@ -53,7 +53,11 @@ rg -n "GroupRef|groupRef|groupId|roomId|createAndSwitch|createAndJoin|joinRoom|w
 - Service writes authoritative state, event, receipt, result, and final
   `APP_OUTBOX`/`WS_OUTBOX` entries directly through `ResourceInboxRepository`
   in the same transaction. There is no intermediate mutation outbox. Resolve
-  logical WebSocket audiences and wake workers after commit.
+  dynamic logical WebSocket audiences and wake workers after commit. If
+  authoritative computed work already contains an immutable recipient
+  audience, copy that mandatory audience into the final outbox message and
+  intersect it only with locally open connections. Do not re-resolve it from a
+  process cache that may lag the causal revision carried by the message.
 - Resource inbox uses 20 total processing attempts: 1, 2, 4, 8, and 16 ms for
   attempts one through five, then increasing seconds capped at 30 seconds with
   jitter. A separate best-effort fairness lane claims entries more than 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,11 @@ the repo-local Codex plugin under `.agents/skills/**`.
 - The received transaction commits state, event, receipt, durable result, and
   final `APP_OUTBOX`/`WS_OUTBOX` rows directly through
   `ResourceInboxRepository` in the same transaction. There is no intermediate
-  mutation outbox. Resolve logical WebSocket audiences and wake workers after
-  commit.
+  mutation outbox. Resolve dynamic logical WebSocket audiences and wake workers
+  after commit. When authoritative computed work already captures an immutable
+  audience, persist that mandatory audience in the final outbox message and
+  intersect it only with locally open connections; never replace it with a
+  lagging cache lookup.
 - Resource inbox allows 20 total processing attempts. Attempts one through five
   wait 1, 2, 4, 8, and 16 ms; later waits rise through seconds, cap at 30
   seconds, and use jitter. A separate best-effort fairness lane claims retries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ the repo-local Codex plugin under `.agents/skills/**`.
 - Validate the complete operation-specific candidate by canonical deterministic
   recomputation and exact comparison, including guards, dependent rows, events,
   receipts, and outbox intents. Shared shape checks alone are insufficient.
+- Authoritative snapshot collections that represent unordered sets use
+  canonical storage-key order in both the computed mutation result and durable
+  repository assembly. Never depend on arrival, insertion, or database/provider
+  iteration order. Preserve equal-revision content checks; ordering drift is a
+  producer bug, not eventual consistency.
 - Snapshot assemblers must treat optimistic presence summaries as hints. At one
   captured observation time, intersect summary sessions with the latest group
   being active and unexpired, current active membership, and connected,

--- a/apps/api-v1/src/routes/group-state-route-errors.ts
+++ b/apps/api-v1/src/routes/group-state-route-errors.ts
@@ -1,0 +1,136 @@
+import {
+  GROUP_POLICY_REASON_CODES,
+  type GroupPolicyDenied,
+} from '@shared/api/group-policy-types.ts';
+import {
+  GroupPolicyDeniedError,
+  isGroupPolicyDeniedError,
+} from '@shared-server/rallar-system/group-policy.ts';
+
+interface GroupAppInboxRouteFailure {
+  readonly code: string;
+  readonly message: string;
+  readonly status: number;
+}
+
+const GROUP_POLICY_REASON_CODE_SET = new Set<string>(GROUP_POLICY_REASON_CODES);
+
+export function toGroupAppInboxError(failure: string): Error {
+  const denial = readAppInboxPolicyDenial(failure);
+  if (denial) {
+    return new GroupPolicyDeniedError(denial);
+  }
+
+  const routeFailure = readGroupAppInboxRouteFailure(failure);
+  return routeFailure
+    ? Object.assign(new Error(routeFailure.message), {
+      code: routeFailure.code,
+      status: routeFailure.status,
+    })
+    : new Error(failure);
+}
+
+export function toGroupStateErrorResponse(
+  context: {
+    json(value: unknown, status?: number): Response;
+  },
+  error: unknown,
+): Response {
+  if (isGroupPolicyDeniedError(error)) {
+    return context.json(
+      {
+        error: error.message,
+        code: error.denial.code,
+        message: error.denial.message,
+        details: error.denial.details,
+      },
+      error.status,
+    );
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const status = readErrorStatus(error) ?? toFallbackStatus(message);
+  const code = readErrorCode(error);
+
+  return context.json({
+    error: message,
+    ...(code ? { code } : {}),
+  }, status);
+}
+
+function readGroupAppInboxRouteFailure(value: string): GroupAppInboxRouteFailure | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!isRecord(parsed)) {
+      return undefined;
+    }
+
+    const { code, message, status } = parsed;
+    return typeof code === 'string' && code.length > 0 &&
+        typeof message === 'string' && message.length > 0 &&
+        Number.isSafeInteger(status) && Number(status) >= 400 && Number(status) <= 599
+      ? { code, message, status: Number(status) }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readAppInboxPolicyDenial(value: string): GroupPolicyDenied | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!isRecord(parsed)) {
+      return undefined;
+    }
+
+    const { code, message } = parsed;
+    if (
+      typeof code !== 'string' ||
+      !GROUP_POLICY_REASON_CODE_SET.has(code) ||
+      typeof message !== 'string'
+    ) {
+      return undefined;
+    }
+
+    return {
+      allowed: false,
+      code: code as GroupPolicyDenied['code'],
+      message,
+      details: isRecord(parsed.details) ? parsed.details : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function readErrorStatus(error: unknown): number | undefined {
+  if (
+    !isRecord(error) || !Number.isSafeInteger(error.status) ||
+    Number(error.status) < 400 || Number(error.status) > 599
+  ) {
+    return undefined;
+  }
+  return Number(error.status);
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  return isRecord(error) && typeof error.code === 'string' && error.code.length > 0
+    ? error.code
+    : undefined;
+}
+
+function toFallbackStatus(message: string): number {
+  return message.includes('not found')
+    ? 404
+    : message.startsWith('Unauthorized:')
+    ? 401
+    : message.startsWith('Forbidden:')
+    ? 403
+    : message.includes('already exists')
+    ? 409
+    : 400;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/apps/api-v1/src/routes/group-state-routes.ts
+++ b/apps/api-v1/src/routes/group-state-routes.ts
@@ -65,13 +65,7 @@ import {
   canReadGroupSnapshot as canReadFullGroupSnapshot,
   canUpdateGroupSnapshot,
   GroupPolicyDeniedError,
-  isGroupPolicyDeniedError,
 } from '@shared-server/rallar-system/group-policy.ts';
-import {
-  GROUP_POLICY_REASON_CODES,
-  type GroupPolicyDenied,
-  type GroupPolicyReasonCode,
-} from '@shared/api/group-policy-types.ts';
 import type { IssuedAuthSession } from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
 import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import {
@@ -80,7 +74,12 @@ import {
   validateGroupPresenceMutationRequest,
 } from '@shared-server/rallar-system/services/group-state-mutations.ts';
 
-const GROUP_POLICY_REASON_CODE_SET = new Set<string>(GROUP_POLICY_REASON_CODES);
+import {
+  toGroupAppInboxError,
+  toGroupStateErrorResponse as toErrorResponse,
+} from './group-state-route-errors.ts';
+
+export { toGroupAppInboxError };
 
 export type GroupStateRouteService =
   & Pick<
@@ -1034,43 +1033,6 @@ async function defaultProcessGroupAppInbox<V, R>(
   );
 }
 
-export function toGroupAppInboxError(failure: string): Error {
-  const denial = readAppInboxPolicyDenial(failure);
-  return denial ? new GroupPolicyDeniedError(denial) : new Error(failure);
-}
-
-function readAppInboxPolicyDenial(value: string): GroupPolicyDenied | undefined {
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    if (!isRecord(parsed)) {
-      return undefined;
-    }
-
-    const code = parsed.code;
-    const message = parsed.message;
-    if (
-      typeof code !== 'string' ||
-      !GROUP_POLICY_REASON_CODE_SET.has(code) ||
-      typeof message !== 'string'
-    ) {
-      return undefined;
-    }
-
-    return {
-      allowed: false,
-      code: code as GroupPolicyReasonCode,
-      message,
-      details: isRecord(parsed.details) ? parsed.details : undefined,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-}
-
 async function readRequestWithRequestId<T extends { requestId?: string }>(c: {
   req: {
     json(): Promise<unknown>;
@@ -1145,38 +1107,6 @@ function toScope(c: {
     applicationId: c.req.param('applicationId'),
     workspaceId: c.req.param('workspaceId'),
   };
-}
-
-function toErrorResponse(
-  c: {
-    json(value: unknown, status?: number): Response;
-  },
-  error: unknown,
-): Response {
-  if (isGroupPolicyDeniedError(error)) {
-    return c.json(
-      {
-        error: error.message,
-        code: error.denial.code,
-        message: error.denial.message,
-        details: error.denial.details,
-      },
-      error.status,
-    );
-  }
-
-  const message = error instanceof Error ? error.message : String(error);
-  const status = message.includes('not found')
-    ? 404
-    : message.startsWith('Unauthorized:')
-    ? 401
-    : message.startsWith('Forbidden:')
-    ? 403
-    : message.includes('already exists')
-    ? 409
-    : 400;
-
-  return c.json({ error: message }, status);
 }
 
 function withActor<

--- a/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
+++ b/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
@@ -40,6 +40,7 @@ Deno.test('PGlite persists distinct topology publications with one logical route
     const messages = rows.map((row) => JSON.parse(row.ri_resource) as {
       id: { msgId: string };
       route: RtcTopologyPublication['message']['route'];
+      targets: { recipientPeerIds?: readonly string[] };
     });
 
     assert.equal(rows.length, 2);
@@ -47,6 +48,8 @@ Deno.test('PGlite persists distinct topology publications with one logical route
     assert.ok(rows.every((row) => row.ri_resource_id.length <= 128));
     assert.deepEqual(messages[0].route, messages[1].route);
     assert.notEqual(messages[0].id.msgId, messages[1].id.msgId);
+    assert.deepEqual(messages[0].targets.recipientPeerIds, ['session-1']);
+    assert.deepEqual(messages[1].targets.recipientPeerIds, ['session-1']);
   } finally {
     await sql.close();
   }

--- a/apps/api-v1/test/routes/state-api-routes-hardening.test.ts
+++ b/apps/api-v1/test/routes/state-api-routes-hardening.test.ts
@@ -411,6 +411,48 @@ Deno.test('client route adapter preserves a base-era AppInbox status code and me
   });
 });
 
+Deno.test('group route adapter preserves canonical AppInbox status code and message', async () => {
+  const failure = JSON.stringify({
+    type: 'app-inbox-failure',
+    version: 'canonical.v2',
+    code: 'group-mutation-idempotency-conflict',
+    status: 409,
+    message: 'Group mutation command differs for request same-request',
+    issues: null,
+    denial: null,
+    retry: null,
+  });
+  const deps = createGroupRouteDeps({
+    session: createAuthSession('alice'),
+    groupService: {},
+    processGroupAppInbox: () => Promise.reject(groupStateRoutes.toGroupAppInboxError(failure)),
+  });
+
+  const response = await createGroupRouteApp(deps).request(
+    '/api/state/apps/app-1/workspaces/workspace-1/groups',
+    {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        requestId: 'same-request',
+        groupId: 'room-1',
+        displayName: 'Room 1',
+        kind: 'room',
+        joinMode: 'open',
+      }),
+    },
+  );
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(await response.json(), {
+    error: 'Group mutation command differs for request same-request',
+    code: 'group-mutation-idempotency-conflict',
+  });
+});
+
 Deno.test('strict state read routes reject non-self client snapshot and event reads', async () => {
   await withStrictReadAuth(true, async () => {
     const deps = createClientRouteDeps({

--- a/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
@@ -41,7 +41,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-smoke:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-smoke:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -74,7 +74,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-smoke:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-smoke:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
@@ -101,7 +101,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "provider-parity:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "provider-parity:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -134,7 +134,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "provider-parity:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "provider-parity:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -242,7 +242,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -275,7 +275,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
+++ b/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room",
+                "requestId": "rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}",
+                "requestId": "rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -50,7 +50,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-all-peer:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -83,7 +83,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-all-peer:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -47,7 +47,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -80,7 +80,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },
@@ -301,7 +301,7 @@
               "method": "POST",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room",
+                "requestId": "rtc-messages-principal:ensure-group:rallar-server:default:world-fleet-room:{auth.sessionId}",
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
                 "kind": "room",
@@ -334,7 +334,7 @@
               "method": "PUT",
               "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}",
               "body": {
-                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}",
+                "requestId": "rtc-messages-principal:ensure-member:rallar-server:default:world-fleet-room:{auth.clientId}:{auth.sessionId}",
                 "status": "active"
               }
             },

--- a/docs/rallar-convergent-state-and-rtc-topology.md
+++ b/docs/rallar-convergent-state-and-rtc-topology.md
@@ -104,8 +104,11 @@ transition on the revision that the decision observed. Compact
 Final `APP_OUTBOX` and `WS_OUTBOX` rows are inserted directly through
 `ResourceInboxRepository` inside that transaction; a collision fails and rolls
 back without loading a winner. There is no intermediate mutation outbox.
-Logical WebSocket audience resolution happens only after commit; queue workers
-are then woken or poll.
+Dynamic logical WebSocket audience resolution happens only after commit; queue
+workers are then woken or poll. If computed authoritative work already contains
+an immutable audience, the final queue entry carries that mandatory audience.
+Workers intersect it only with locally open connections and never replace it
+with a process cache that may lag the message's causal revision.
 
 Queue locks are coordination-only for bounded resource-inbox claims. Domain
 authentication/session/ticket, AL admission, CRDT, client, group, and topology
@@ -349,9 +352,9 @@ work execution id and the accepted `(sourceGroupStateRevision, overlayVersion)`
 tuple. `createdAtEpochMs` comes from the work's immutable request time.
 
 The work index makes retry behavior explicit. Once a work item has persisted a
-publication, a retry loads and republishes that record before resolving group
-state or recalculating topology. A retry can therefore never publish a
-different result for the same work identity.
+publication, a retry loads that record and writes the same final `WS_OUTBOX`
+entry before resolving group state or recalculating topology. A retry can
+therefore never publish a different result for the same work identity.
 
 ## Multi-Server Fanout
 
@@ -361,49 +364,54 @@ All API servers share the runtime-state and queue database. PostgreSQL
 ```mermaid
 sequenceDiagram
     participant W as APP_OUTBOX worker on server A
-    participant DB as Runtime-state database
-    participant PG as Cluster notification transport
+    participant DB as Runtime-state and ResourceInbox database
+    participant Q as WS_OUTBOX worker
+    participant PG as Queue-key notification transport
     participant A as WebSocket server A
     participant B as WebSocket server B
     participant C as WebSocket server C
 
-    W->>DB: Atomically persist topology, publication, and work index
-    W->>A: Deliver to locally connected recipients
-    W->>PG: Publish publicationId and source revision
+    W->>DB: Atomically persist topology, publication, work index, and WS_OUTBOX
+    W->>Q: Wake queue processing after commit
+    Q->>DB: Claim exact WS_OUTBOX entry
+    Q->>PG: Publish durable queue key
+    Q->>A: Intersect fixed audience with local connections
     PG-->>B: Notification
     PG-->>C: Notification
-    B->>DB: Load exact publication
-    C->>DB: Load exact publication
-    B->>B: Intersect recipients with local connections
-    C->>C: Intersect recipients with local connections
+    B->>DB: Load exact WS_OUTBOX entry by key
+    C->>DB: Load exact WS_OUTBOX entry by key
+    B->>B: Intersect fixed audience with local connections
+    C->>C: Intersect fixed audience with local connections
 ```
 
-The cluster notification contains only:
+The final topology `WS_OUTBOX` message copies the publication's mandatory
+`recipientSessionIds` into its fixed logical audience. The cluster notification
+contains only the canonical durable queue key:
 
 ```ts
-type RtcTopologyPublicationNotification = {
-  v: 1;
+type QueueBoxPubSubMessage = {
+  delivery: 'key';
   publisherId: string;
-  publicationId: string;
-  sourceGroupStateRevision: number;
+  channel: string;
+  typeId: 'WS_OUTBOX';
+  key: { topicId: string; resourceId: string; contextId: string };
 };
 ```
 
-The publishing server performs local delivery directly and ignores its own
-remote notification. Other servers load the durable publication and verify its
-source revision. Each process encodes the AL message once, deduplicates the
-recipient ids, and performs one indexed send per recipient. Closed connections
-are skipped without stopping later sends. Fanout never scans unrelated
-connections or reads group/client caches.
+The claiming server publishes the key and performs local delivery. Other
+servers load and validate the exact durable row before local delivery. Each
+process performs indexed lookup only for the fixed recipient ids. Closed
+connections are skipped without stopping later sends. Fanout never scans
+unrelated connections or reads group/client caches. This prevents a valid
+publication from disappearing merely because one process observes its
+group-state cache a few milliseconds behind the publication revision.
 
 Duplicate and reordered notifications are harmless because the publication is
 immutable and browser caches apply the causal tuple comparison.
 
-API-v1 supports local, disabled, and PostgreSQL cluster transports. PostgreSQL
-subscription readiness is awaited before the queue engine and HTTP server
-start. A PostgreSQL deployment fails closed if it cannot establish the
-subscription. Local and disabled modes resolve readiness immediately; disabled
-mode is suitable only for a single server.
+PostgreSQL subscription readiness is awaited before the queue engine and HTTP
+server start. A PostgreSQL deployment fails closed if it cannot establish the
+subscription. The local queue-key transport supports single-process execution.
 
 ### Example: authorization after a remote ban
 

--- a/docs/rallar-convergent-state-and-rtc-topology.md
+++ b/docs/rallar-convergent-state-and-rtc-topology.md
@@ -183,6 +183,12 @@ An equal causal revision with different content throws
 `StateSnapshotRevisionConflictError`. Silently choosing one would make a data
 integrity defect look like normal eventual consistency.
 
+Authoritative snapshot collections that represent unordered sets use canonical
+storage-key order in both the computed mutation result and durable repository
+assembly. Never depend on arrival, insertion, or database/provider iteration
+order. Preserve equal-revision content checks; ordering drift is a producer bug,
+not eventual consistency.
+
 ## Process-Owned Cached State Services
 
 API-v1 creates one group read-through cache and one client read-through cache,

--- a/packages/shared-server/rallar-system/client-state-storage-keys.ts
+++ b/packages/shared-server/rallar-system/client-state-storage-keys.ts
@@ -28,3 +28,29 @@ export function clientStateInstanceStorageKey(ref: ClientInstanceRef): string {
 export function clientStateSessionStorageKey(ref: ClientSessionRef): string {
     return `${clientStateInstanceStorageKey(ref)}:session=${encodeURIComponent(ref.sessionId)}`;
 }
+
+export function compareClientStateInstanceStorageKeys(
+    left: ClientInstanceRef,
+    right: ClientInstanceRef,
+): number {
+    return compareCanonicalStorageKeys(
+        clientStateInstanceStorageKey(left),
+        clientStateInstanceStorageKey(right),
+    );
+}
+
+export function compareClientStateSessionStorageKeys(
+    left: ClientSessionRef,
+    right: ClientSessionRef,
+): number {
+    return compareCanonicalStorageKeys(
+        clientStateSessionStorageKey(left),
+        clientStateSessionStorageKey(right),
+    );
+}
+
+function compareCanonicalStorageKeys(left: string, right: string): number {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+}

--- a/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
+++ b/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
@@ -1,4 +1,5 @@
 import { type ALMessage, readALTargetGroupRef } from '@shared/al-contracts/al-contract.ts';
+import { AppTopics } from '@shared/api/api-config.ts';
 import { isSameGroupScope } from '@shared/api/api-type-utils.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type {
@@ -55,6 +56,24 @@ export function createWsServerTargetResolver(
       .filter((context) => context.isOpen)
       .map((context) => ({ peerId: context.id, connectionId: context.id }));
   };
+  const resolveFixedBroadcastRecipients = (
+    message: ALMessage,
+  ): readonly WsServerResolvedRecipient[] | undefined => {
+    const targets = message.targets;
+    if (
+      targets?.mode !== 'broadcast' ||
+      targets.recipientPeerIds === undefined ||
+      message.id.senderId !== 'rallar-server' ||
+      message.route.topicId !== AppTopics.overlayTopology ||
+      message.payload.typeId !== AppTopics.overlayTopology
+    ) {
+      return undefined;
+    }
+    return targets.recipientPeerIds.flatMap((peerId) => {
+      const context = webSocketServer.connections.get(peerId);
+      return context?.isOpen ? [{ peerId, connectionId: peerId }] : [];
+    });
+  };
   return {
     resolvePeerRecipients: (peerId, message) => {
       const principalRef = readCrdtPrincipalRef(message, peerId);
@@ -73,13 +92,16 @@ export function createWsServerTargetResolver(
       return context?.isOpen ? [{ peerId, connectionId: peerId }] : [];
     },
     resolveGroupRecipients,
-    resolveBroadcastRecipients: (scope, message) =>
-      scope === 'room'
+    resolveBroadcastRecipients: (scope, message) => {
+      const fixedRecipients = resolveFixedBroadcastRecipients(message);
+      if (fixedRecipients !== undefined) return fixedRecipients;
+      return scope === 'room'
         ? resolveGroupRecipients(
           readALTargetGroupRef(message)?.groupId ?? message.route.contextId,
           message,
         )
-        : resolveAllOpenConnections(message),
+        : resolveAllOpenConnections(message);
+    },
     resolvePeerIdForConnection: (connectionId) => connectionId,
   };
 }

--- a/packages/shared-server/rallar-system/repositories/ClientStateRepository.ts
+++ b/packages/shared-server/rallar-system/repositories/ClientStateRepository.ts
@@ -51,6 +51,8 @@ import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
 import { PSqlRuntimeStateRepository } from '../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
 import { PSqlClientStateEventRepository } from '../../postgres/rallar-system/PSqlStateEventRepository.ts';
 import {
+    compareClientStateInstanceStorageKeys,
+    compareClientStateSessionStorageKeys,
     clientStateIdempotencyStorageKey,
     clientStateInstanceStorageKey,
     clientStatePrincipalStorageKey,
@@ -530,8 +532,8 @@ export class ClientStateRepository extends RuntimeStateJsonStore {
         const snapshot: ClientSnapshot = {
             stateRevision,
             principal,
-            instances,
-            activeSessions,
+            instances: [...instances].sort(compareClientStateInstanceStorageKeys),
+            activeSessions: [...activeSessions].sort(compareClientStateSessionStorageKeys),
             isOnline: activeSessions.length > 0,
             activeSessionCount: activeSessions.length,
             lastSeenAtEpochMs: toClientSnapshotLastSeenAtEpochMs(

--- a/packages/shared-server/rallar-system/services/client-state-mutations.ts
+++ b/packages/shared-server/rallar-system/services/client-state-mutations.ts
@@ -37,6 +37,10 @@ import {
     computeClientStateSyncEntries,
     type ComputedClientStateSync,
 } from '../state-sync-publisher.ts';
+import {
+    compareClientStateInstanceStorageKeys,
+    compareClientStateSessionStorageKeys,
+} from '../client-state-storage-keys.ts';
 import type { PersistedAuthSession } from '../repositories/AuthSessionRepository.ts';
 
 type NullableActorInput = Readonly<{
@@ -1534,6 +1538,8 @@ function toComputedSnapshot(
         else if (isActive) activeSessions[index] = session.value;
         else if (index >= 0) activeSessions.splice(index, 1);
     }
+    instances.sort(compareClientStateInstanceStorageKeys);
+    activeSessions.sort(compareClientStateSessionStorageKeys);
     const lastSeenAtEpochMs = activeSessions.reduce<number | null>(
         (latest, candidate) => latest === null
             ? candidate.lastHeartbeatAtEpochMs

--- a/packages/shared-server/rallar-system/services/rtc-topology-ws-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/services/rtc-topology-ws-outbox-entry.ts
@@ -7,6 +7,7 @@ import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
 import { ResourceInboxRepository } from '../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import type { RtcTopologyPublication } from '../rtc-topology-publication-contract.ts';
 import { validateRtcTopologyPublication } from '../rtc-topology-publication-validation.ts';
+import { validatePersistedALMessage } from './al-message-persistence-validation.ts';
 import {
     toAppQueueCreatedBy,
     toAppQueueKey,
@@ -16,7 +17,21 @@ export function computeRtcTopologyPublicationOutbox(
     publication: RtcTopologyPublication,
 ): ResourceEntry {
     validateRtcTopologyPublication(publication, publication.groupRef);
-    const message = publication.message;
+    const publicationMessage = publication.message;
+    if (
+        publicationMessage.targets?.mode !== 'broadcast' ||
+        publicationMessage.targets.scope !== 'room'
+    ) {
+        throw new TypeError('RTC topology publication outbox target is invalid');
+    }
+    const message = {
+        ...publicationMessage,
+        targets: {
+            ...publicationMessage.targets,
+            recipientPeerIds: [...publication.recipientSessionIds],
+        },
+    };
+    validatePersistedALMessage(message);
     const createdBy = message.audit?.createdBy;
     const expiresAtMs = message.constraints?.expiresAtMs;
     if (

--- a/packages/shared-test/black-box-runner/api-v1-black-box-run.mts
+++ b/packages/shared-test/black-box-runner/api-v1-black-box-run.mts
@@ -170,6 +170,7 @@ export function toApiV1BlackBoxEnvironment(
         ?? 'local-api-v1-black-box-operator-secret'
     env.RALLAR_AUTH_CREDENTIAL_SECRET = env.RALLAR_AUTH_CREDENTIAL_SECRET
         ?? 'local-api-v1-black-box-auth-credential-secret-v1'
+    env.RALLAR_LOGIN_IP_RATE_LIMIT = env.RALLAR_LOGIN_IP_RATE_LIMIT ?? '100'
     env.RALLAR_LOGIN_USER_RATE_LIMIT = env.RALLAR_LOGIN_USER_RATE_LIMIT ?? '100'
     env.RALLAR_STATE_STRICT_READ_AUTH = env.RALLAR_STATE_STRICT_READ_AUTH ?? '1'
     env.AUTH_STATIC_CLIENTS_MODE = env.AUTH_STATIC_CLIENTS_MODE ?? 'demo'

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -915,6 +915,9 @@
       "expectedExitCode": 0,
       "artifactName": "api-v1-rtc-topology-convergence",
       "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
         "httpServices": [
           {
             "name": "Rallar API primary",
@@ -939,6 +942,9 @@
       "expectedExitCode": 0,
       "artifactName": "api-v1-state-topology-churn",
       "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
         "httpServices": [
           {
             "name": "Rallar API primary",
@@ -963,6 +969,9 @@
       "expectedExitCode": 0,
       "artifactName": "api-v1-state-write-convergence",
       "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
         "httpServices": [
           {
             "name": "Rallar API primary",
@@ -987,6 +996,9 @@
       "expectedExitCode": 0,
       "artifactName": "api-v1-crdt-app-inbox",
       "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
         "httpServices": [
           {
             "name": "Rallar API primary",

--- a/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
@@ -402,6 +402,7 @@ export function createRallarBlackBoxEnsureGroupRequestId(input: Readonly<{
         input.group.applicationId,
         input.group.workspaceId,
         input.group.groupId,
+        '{auth.sessionId}',
     ].join(':');
 }
 
@@ -428,6 +429,7 @@ function createRallarBlackBoxEnsureGroupCommands(input: Readonly<{
         input.group.workspaceId,
         input.group.groupId,
         actor,
+        '{auth.sessionId}',
     ].join(':');
 
     return [

--- a/packages/shared/al-contracts/al-contract.ts
+++ b/packages/shared/al-contracts/al-contract.ts
@@ -45,6 +45,8 @@ export type ALTargets =
     groupRef?: GroupRef;
     exceptPeerIds?: readonly string[];
     minSnapshotVersion?: number;
+    /** Immutable logical audience captured by authoritative server work. */
+    recipientPeerIds?: readonly string[];
 }>;
 
 // -------------------------------------------------------

--- a/packages/shared/al-contracts/al-message-persistence-validation.ts
+++ b/packages/shared/al-contracts/al-message-persistence-validation.ts
@@ -120,7 +120,10 @@ function validateTargets(value: unknown): void {
     }
     exactAllowedRequired(
         targets,
-        ['mode', 'scope', 'groupRef', 'exceptPeerIds', 'minSnapshotVersion'],
+        [
+            'mode', 'scope', 'groupRef', 'exceptPeerIds',
+            'minSnapshotVersion', 'recipientPeerIds',
+        ],
         ['mode', 'scope'],
     );
     if (
@@ -132,8 +135,12 @@ function validateTargets(value: unknown): void {
     if (targets.scope === 'room' && targets.groupRef === undefined) {
         throw new TypeError('Persisted AL room broadcast group ref is missing');
     }
+    if (targets.recipientPeerIds !== undefined && targets.scope !== 'room') {
+        throw new TypeError('Persisted AL fixed recipient audience requires room scope');
+    }
     if (targets.groupRef !== undefined) validateCanonicalGroupRef(targets.groupRef);
     optionalStringArray(targets.exceptPeerIds, 'broadcast exclusions');
+    optionalUniqueStringArray(targets.recipientPeerIds, 'broadcast fixed recipients');
     optionalSafeInteger(targets.minSnapshotVersion, 1, 'minimum snapshot version');
 }
 
@@ -282,4 +289,11 @@ function optionalStringArray(value: unknown, label: string): void {
     if (!Array.isArray(value) || value.some((item) =>
         typeof item !== 'string' || item.length === 0
     )) throw new TypeError(`Persisted AL ${label} is invalid`);
+}
+
+function optionalUniqueStringArray(value: unknown, label: string): void {
+    optionalStringArray(value, label);
+    if (Array.isArray(value) && new Set(value).size !== value.length) {
+        throw new TypeError(`Persisted AL ${label} contains duplicates`);
+    }
 }

--- a/packages/shared/services/WebRtcRxStreamerService.ts
+++ b/packages/shared/services/WebRtcRxStreamerService.ts
@@ -61,6 +61,7 @@ export class WebRtcRxStreamerService {
     };
 
     private readonly heartbeatByPeerId = new Map<PeerId, WebRtcHeartbeatService>();
+    private readonly rttVersionByPeerId = new Map<PeerId, number>();
     private readonly peerDtoByPeerId = new Map<PeerId, QRtcPeerDto>();
     private readonly inboundRuntime: ALInboundMessageRuntime;
     private rttReportingPeerIds: ReadonlySet<PeerId> | undefined;
@@ -280,16 +281,18 @@ export class WebRtcRxStreamerService {
                 return Promise.resolve();
             },
             onHeartbeat: (result: PingResult) => {
+                const previousVersion = this.rttVersionByPeerId.get(peerId) ?? 0;
+                const version = Math.max(previousVersion + 1, result.version);
+                this.rttVersionByPeerId.set(peerId, version);
+                const rtt: RttMeasurementInfo = {
+                    sessionIdFrom: this.input.sessionId,
+                    sessionIdTo: peerId,
+                    rttMs: result.rttMsecs,
+                    createdAtEpochMs: Date.now(),
+                    version,
+                };
                 for (const [_, cb] of this.onRttMeasurementCallbacks.entries()) {
-                    cb.onHeartbeat(
-                            {
-                                sessionIdFrom: this.input.sessionId,
-                                sessionIdTo: peerId,
-                                rttMs: result.rttMsecs,
-                                createdAtEpochMs: Date.now(),
-                                version: result.version
-                            }
-                        )
+                    cb.onHeartbeat(rtt)
                         .catch(
                             e => console.error('Error calling onRttMeasurementCallback', e)
                         );

--- a/packages/tests/rallar-black-box/distributed-recipes.test.ts
+++ b/packages/tests/rallar-black-box/distributed-recipes.test.ts
@@ -456,7 +456,7 @@ describe('distributed recipes helpers', () => {
                 method: 'POST',
                 path: '/api/state/apps/game-app/workspaces/live/groups',
                 body: {
-                    requestId: 'rtc-realtime:ensure-group:game-app:live:arena-1',
+                    requestId: 'rtc-realtime:ensure-group:game-app:live:arena-1:{auth.sessionId}',
                     groupId: 'arena-1',
                     displayName: 'arena-1',
                     kind: 'room',
@@ -475,7 +475,8 @@ describe('distributed recipes helpers', () => {
                 method: 'PUT',
                 path: '/api/state/apps/game-app/workspaces/live/groups/arena-1/members/{auth.clientId}',
                 body: {
-                    requestId: 'rtc-realtime:ensure-member:game-app:live:arena-1:{auth.clientId}',
+                    requestId:
+                        'rtc-realtime:ensure-member:game-app:live:arena-1:{auth.clientId}:{auth.sessionId}',
                     status: 'active',
                 },
             },
@@ -714,7 +715,7 @@ describe('distributed recipes helpers', () => {
         ]));
     });
 
-    it('builds the RTC smoke fixture with idempotent group and member setup before connect', () => {
+    it('session-fences RTC smoke group and member setup before connect', () => {
         const recipe = createRallarBlackBoxRtcSmokeRecipe({
             group: {
                 applicationId: 'game-app',
@@ -733,7 +734,7 @@ describe('distributed recipes helpers', () => {
                 method: 'POST',
                 path: '/api/state/apps/game-app/workspaces/live/groups',
                 body: {
-                    requestId: 'rtc-smoke:ensure-group:game-app:live:arena-1',
+                    requestId: 'rtc-smoke:ensure-group:game-app:live:arena-1:{auth.sessionId}',
                     groupId: 'arena-1',
                     joinMode: 'open',
                 },
@@ -746,7 +747,8 @@ describe('distributed recipes helpers', () => {
                 method: 'PUT',
                 path: '/api/state/apps/game-app/workspaces/live/groups/arena-1/members/{auth.clientId}',
                 body: {
-                    requestId: 'rtc-smoke:ensure-member:game-app:live:arena-1:{auth.clientId}',
+                    requestId:
+                        'rtc-smoke:ensure-member:game-app:live:arena-1:{auth.clientId}:{auth.sessionId}',
                     status: 'active',
                 },
             },

--- a/packages/tests/repo/rallar-skill-integrity.test.ts
+++ b/packages/tests/repo/rallar-skill-integrity.test.ts
@@ -54,6 +54,11 @@ const coreConvergentWriteGuidancePaths = [
   '.agents/skills/rallar-code-writing/references/repo-code-style.md',
 ] as const;
 
+const canonicalSnapshotOrderingGuidancePaths = [
+  'AGENTS.md',
+  'docs/rallar-convergent-state-and-rtc-topology.md',
+] as const;
+
 const postCommitAudienceGuidancePaths = [
   'apps/api-v1/README.md',
   'packages/shared-server/architecture.md',
@@ -557,6 +562,20 @@ describe('Rallar repo skill and documentation integrity', () => {
       );
       expect(guidance).toMatch(/queue locks.{0,80}coordination-only/i);
       expect(guidance).toMatch(/computed persistence data.{0,40}not.{0,20}(?:called )?a plan/i);
+    },
+  );
+
+  it.each(canonicalSnapshotOrderingGuidancePaths)(
+    '%s requires canonical ordering for authoritative snapshot collections',
+    (filePath) => {
+      expectAllNormalized(readRepo(filePath), [
+        'Authoritative snapshot collections that represent unordered sets',
+        'canonical storage-key order',
+        'computed mutation result',
+        'durable repository assembly',
+        'arrival, insertion, or database/provider iteration order',
+        'equal-revision content checks',
+      ]);
     },
   );
 

--- a/packages/tests/shared-server/al-message-persistence-validation.test.ts
+++ b/packages/tests/shared-server/al-message-persistence-validation.test.ts
@@ -64,4 +64,35 @@ describe('persisted AL message validation', () => {
             },
         })).toThrow(/room.*group ref|group ref.*room/i);
     });
+
+    it('accepts a canonical fixed recipient audience for a room broadcast', () => {
+        expect(() => validatePersistedALMessage({
+            id: {
+                v: 2,
+                msgId: 'message-1',
+                ts: 1,
+                senderId: 'server-1',
+            },
+            route: {
+                topicId: 'overlay.topology',
+                resourceId: 'resource-1',
+                contextId: 'room-1',
+            },
+            targets: {
+                mode: 'broadcast',
+                scope: 'room',
+                groupRef: {
+                    applicationId: 'app-1',
+                    workspaceId: 'workspace-1',
+                    groupId: 'room-1',
+                },
+                minSnapshotVersion: 3,
+                recipientPeerIds: ['session-a', 'session-b'],
+            },
+            payload: {
+                typeId: 'overlay.topology',
+                resource: '{}',
+            },
+        })).not.toThrow();
+    });
 });

--- a/packages/tests/shared-server/client-state-service-idempotency.test.ts
+++ b/packages/tests/shared-server/client-state-service-idempotency.test.ts
@@ -526,6 +526,53 @@ describe('ClientStateService command idempotency', () => {
         expect(runtimeRepository.data.size).toBe(entriesAfterRestCurrent);
     });
 
+    it('returns canonical durable ordering for same-principal websocket sessions', async () => {
+        const runtimeRepository = new FakeRuntimeStateRepository();
+        const service = createClientStateService({
+            runtimeRepository,
+            syncPublisher: createPublisher(),
+            now: () => 10_000,
+            serviceId: 'client-service',
+        });
+        const expiresAtEpochMs = Date.now() + 60_000;
+        const sessionZ: AuthSession = {
+            clientId: 'alice',
+            username: 'alice',
+            accessToken: 'token-z',
+            sessionId: 'ws-session-z',
+            expiresAtEpochMs,
+        };
+        const sessionA: AuthSession = {
+            ...sessionZ,
+            accessToken: 'token-a',
+            sessionId: 'ws-session-a',
+        };
+
+        await service.registerAuthorisedWsClientSession(sessionZ, 'generation-z', {
+            applicationId: SCOPE.applicationId,
+            workspaceId: SCOPE.workspaceId,
+            connectedAtEpochMs: 100,
+            expiresAtEpochMs,
+        });
+        const second = await service.registerAuthorisedWsClientSession(
+            sessionA,
+            'generation-a',
+            {
+                applicationId: SCOPE.applicationId,
+                workspaceId: SCOPE.workspaceId,
+                connectedAtEpochMs: 200,
+                expiresAtEpochMs,
+            },
+        );
+        const durable = await service.readSnapshot(toClientPrincipalRef('alice'));
+
+        expect(second.result.right?.snapshot).toEqual(durable);
+        expect(durable?.activeSessions.map((session) => session.sessionId)).toEqual([
+            'ws-session-a',
+            'ws-session-z',
+        ]);
+    });
+
     it('expires stale sessions once and leaves publication to the app inbox', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
         const expiresAtEpochMs = Date.now() - 1_000;

--- a/packages/tests/shared-server/rallar-middleware.test.ts
+++ b/packages/tests/shared-server/rallar-middleware.test.ts
@@ -624,6 +624,87 @@ describe('createWsServerTargetResolver state sync routing', () => {
     ).toEqual(['session-b']);
   });
 
+  it('routes a fixed room audience without consulting a lagging group snapshot', () => {
+    configureTestCacheRepositories();
+
+    const webSocketServer = new JsonWebSocketServer();
+    addOpenConnection(webSocketServer, 'session-a');
+    addOpenConnection(webSocketServer, 'session-b');
+    const laggingSnapshot = createGroupSnapshot(
+      'shared-room',
+      'app-1',
+      'workspace-a',
+      [{ principalId: 'alice', sessionId: 'session-a', status: 'active' }],
+      2,
+    );
+    const message = {
+      ...newALBroadcastMessage(
+        'rallar-server',
+        newALEventRoute('overlay.topology', 'shared-room', 'topology-3'),
+        'room',
+        'overlay.topology',
+        { version: 3 },
+        { groupRef: laggingSnapshot.group },
+      ),
+      targets: {
+        mode: 'broadcast' as const,
+        scope: 'room' as const,
+        groupRef: laggingSnapshot.group,
+        minSnapshotVersion: 3,
+        recipientPeerIds: ['session-b'],
+      },
+    };
+    const resolver = createWsServerTargetResolver(webSocketServer, {
+      findGroupSnapshotByRef: () => laggingSnapshot,
+    });
+
+    expect(
+      resolver
+        .resolveBroadcastRecipients?.('room', message)
+        .map((recipient) => recipient.connectionId),
+    ).toEqual(['session-b']);
+  });
+
+  it('does not let a peer-sent room message bypass membership with a fixed audience', () => {
+    configureTestCacheRepositories();
+
+    const webSocketServer = new JsonWebSocketServer();
+    addOpenConnection(webSocketServer, 'session-a');
+    addOpenConnection(webSocketServer, 'session-b');
+    const snapshot = createGroupSnapshot(
+      'shared-room',
+      'app-1',
+      'workspace-a',
+      [{ principalId: 'alice', sessionId: 'session-a', status: 'active' }],
+      3,
+    );
+    const message = {
+      ...newALBroadcastMessage(
+        'session-a',
+        newALEventRoute('room.chat', 'shared-room', 'message-1'),
+        'room',
+        'chat.message.v1',
+        { text: 'hello' },
+        { groupRef: snapshot.group },
+      ),
+      targets: {
+        mode: 'broadcast' as const,
+        scope: 'room' as const,
+        groupRef: snapshot.group,
+        recipientPeerIds: ['session-b'],
+      },
+    };
+    const resolver = createWsServerTargetResolver(webSocketServer, {
+      findGroupSnapshotByRef: () => snapshot,
+    });
+
+    expect(
+      resolver
+        .resolveBroadcastRecipients?.('room', message)
+        .map((recipient) => recipient.connectionId),
+    ).toEqual(['session-a']);
+  });
+
   it('routes multicast targets using target groupRef before the group id fallback', () => {
     configureTestCacheRepositories();
 

--- a/packages/tests/shared-server/rtc-topology-ws-outbox-entry.test.ts
+++ b/packages/tests/shared-server/rtc-topology-ws-outbox-entry.test.ts
@@ -19,6 +19,7 @@ describe('RTC topology publication WS outbox entry', () => {
         const entry = computeRtcTopologyPublicationOutbox(publication);
         const persistedMessage = JSON.parse(entry.resource) as {
             route: typeof publication.message.route;
+            targets: { recipientPeerIds?: readonly string[] };
         };
 
         expect(entry.key).toEqual(toAppQueueKey({
@@ -28,6 +29,7 @@ describe('RTC topology publication WS outbox entry', () => {
         }));
         expect(entry.key.resourceId.length).toBeLessThanOrEqual(36);
         expect(persistedMessage.route).toEqual(publication.message.route);
+        expect(persistedMessage.targets.recipientPeerIds).toEqual(publication.recipientSessionIds);
     });
 
     it('assigns distinct physical keys to publications sharing one logical route', () => {

--- a/packages/tests/shared-test/api-v1-black-box-run.test.ts
+++ b/packages/tests/shared-test/api-v1-black-box-run.test.ts
@@ -255,6 +255,8 @@ describe('api-v1 black-box run helper', () => {
         expect(env.RALLAR_SQL_BACKEND).toBe('postgres');
         expect(env.DATABASE_URL).toBe('postgres://app:app@localhost:5432/appdb');
         expect(env.RALLAR_STATE_STRICT_READ_AUTH).toBe('1');
+        expect(env.RALLAR_LOGIN_IP_RATE_LIMIT).toBe('100');
+        expect(env.RALLAR_LOGIN_USER_RATE_LIMIT).toBe('100');
         expect(env.RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET).toBe(
             'local-api-v1-black-box-operator-secret',
         );
@@ -273,6 +275,17 @@ describe('api-v1 black-box run helper', () => {
         });
 
         expect(env.RALLAR_CRDT_DOCUMENT_TYPE_POLICIES_JSON).toBe(policy);
+    });
+
+    it('preserves explicit managed API login rate limits', () => {
+        const options = parseApiV1BlackBoxArgs(['--backend=postgres']);
+        const env = toApiV1BlackBoxEnvironment(options, {
+            RALLAR_LOGIN_IP_RATE_LIMIT: '41',
+            RALLAR_LOGIN_USER_RATE_LIMIT: '17',
+        });
+
+        expect(env.RALLAR_LOGIN_IP_RATE_LIMIT).toBe('41');
+        expect(env.RALLAR_LOGIN_USER_RATE_LIMIT).toBe('17');
     });
 
     it('exposes secondary HTTP and WebSocket URLs only for a two-server run', () => {

--- a/packages/tests/shared-test/rallar-bb-browser-adapter-auth.test.ts
+++ b/packages/tests/shared-test/rallar-bb-browser-adapter-auth.test.ts
@@ -610,12 +610,13 @@ describe('rallar-bb browser adapter auth', () => {
             '/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/alice',
         ]);
         expect(JSON.parse(String(fetchCalls[0].init?.body))).toMatchObject({
-            requestId: 'rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room',
+            requestId: 'rtc-realtime:ensure-group:rallar-server:default:hetzner-headless-room:session-1',
             groupId: 'hetzner-headless-room',
             joinMode: 'open',
         });
         expect(JSON.parse(String(fetchCalls[1].init?.body))).toMatchObject({
-            requestId: 'rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:alice',
+            requestId:
+                'rtc-realtime:ensure-member:rallar-server:default:hetzner-headless-room:alice:session-1',
             status: 'active',
         });
     });

--- a/packages/tests/shared-test/recipe-matrix.test.ts
+++ b/packages/tests/shared-test/recipe-matrix.test.ts
@@ -16,6 +16,9 @@ type MatrixEntry = {
         env?: string[];
         httpServices?: Array<{ name: string; env: string; default?: string }>;
         playwright?: boolean;
+        livePreflight?: {
+            timeoutMs?: number;
+        };
     };
 };
 
@@ -193,6 +196,18 @@ describe('black-box runner recipe matrix', () => {
         remoteLiveEntries.forEach(entry => {
             expect(entry.requires?.env).toContain('RALLAR_BLACK_BOX_CONTROL_BASE_URL');
             expect(entry.requires?.env).toContain('RALLAR_BLACK_BOX_AGENT_ID');
+        });
+    });
+
+    it('gives AppInbox-backed API cluster preflight checks a realistic deadline', () => {
+        const { entries } = readMatrix();
+        const clusterEntries = entries.filter(entry =>
+            entry.profiles.includes('api-v1-black-box-cluster')
+        );
+
+        expect(clusterEntries.length).toBeGreaterThan(0);
+        clusterEntries.forEach(entry => {
+            expect(entry.requires?.livePreflight?.timeoutMs).toBe(10_000);
         });
     });
 

--- a/packages/tests/shared/webrtc-rx-streamer-service.test.ts
+++ b/packages/tests/shared/webrtc-rx-streamer-service.test.ts
@@ -184,6 +184,38 @@ describe('WebRtcRxStreamerService', () => {
         );
     });
 
+    it('keeps RTT versions monotonic when a peer heartbeat restarts', async () => {
+        const service = new WebRtcRxStreamerService(
+            new InMemoryQueueBox(new Map()),
+            createFakeMulticastManager() as never,
+            { sessionId: 'self' },
+        );
+        const onHeartbeat = vi.fn(async () => {
+        });
+        service.onRttMeasurementDo('rtt', { onHeartbeat });
+
+        const peer = createPeerDto('peer-1');
+        service.addPeer(peer as never);
+        const lifecycle = peer.channel.lifecycleCallbacks.get(
+            'self-peer-1-rtc-datachannel-lifecycle',
+        );
+
+        await lifecycle?.onOpen?.();
+        await mockState.heartbeats[0].callbacks?.onHeartbeat({
+            peerSessionId: 'peer-1',
+            rttMsecs: 10,
+            version: 2,
+        });
+        await lifecycle?.onOpen?.();
+        await mockState.heartbeats[1].callbacks?.onHeartbeat({
+            peerSessionId: 'peer-1',
+            rttMsecs: 11,
+            version: 2,
+        });
+
+        expect(onHeartbeat.mock.calls.map(([rtt]) => rtt.version)).toEqual([2, 3]);
+    });
+
     it('does not start RTT heartbeats for peers outside the reporting set', async () => {
         const service = new WebRtcRxStreamerService(
             new InMemoryQueueBox(new Map()),

--- a/packages/tests/shared/ws-outbox-owner-miss-retry.test.ts
+++ b/packages/tests/shared/ws-outbox-owner-miss-retry.test.ts
@@ -197,6 +197,8 @@ describe('durable WS outbox owner misses', () => {
   });
 
   it('retries the durable row when cluster publication fails', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(1_000);
     const outbox = new InMemoryQueueBox();
     await outbox.enqueue(QueueBoxUtilities.toResourceEntryFromMsg(
       createUnicastMessage(), EnqueuedType.WS_OUTBOX,


### PR DESCRIPTION
## Summary
- session-fence distributed group and member setup request IDs
- preserve canonical AppInbox status codes in group HTTP responses
- regenerate Hetzner and world-fleet manifests

## Root cause
Concurrent agents authenticate as the same client principal with distinct sessions. Shared setup request IDs collided in AppInbox because the authenticated session is part of the semantic command hash. The second request was a legitimate 409, but the group route flattened canonical AppInbox failures to HTTP 400, so the black-box accepted-status contract could not recognize it.

## Validation
- npm run test:unit
- npm run test:ci
- npm run build
- focused Vitest and Deno route suites
- generated manifest checks

The optional API-v1 memory black-box matrix was also run twice; 9/11 recipes passed, while pre-existing auth evidence and admin prune timeout recipes failed outside the changed paths.