### PR TITLE
ci: restrict provider deployments to main

### DIFF
--- a/.agents/skills/publishing-plan-progress/SKILL.md
+++ b/.agents/skills/publishing-plan-progress/SKILL.md
@@ -119,6 +119,18 @@ An instruction not to commit or push postpones publication; it does not waive
 any completion gate. Continue safe uncommitted work and report the plan as
 incomplete until the publication and remote gates are permitted and successful.
 
+## Feature-Branch Check Scope
+
+Cloudflare Workers, Cloudflare Pages, and Deno Deploy production or preview
+contexts are default-branch deployment concerns. They must run only for `main`;
+they are not additional feature-branch release gates. If one appears on a
+feature branch, report provider branch-control configuration drift and use
+`docs/production-deployment.md` for remediation. Do not reinterpret a provider
+preview failure as an application failure required by **Branch Release Gate**.
+
+On `main`, provider deployment failures remain real release evidence and must
+be investigated when those deployments are enabled.
+
 ## Publication Failure
 
 If the environment cannot create or push the branch, preserve the work and

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skip_release_gate:
-        description: "Skip release gate validation for this manual deploy"
+        description: 'Skip release gate validation for this manual deploy'
         required: false
         default: false
         type: boolean
@@ -16,19 +16,48 @@ permissions:
   contents: read
   deployments: write
 
+concurrency:
+  group: production-deploy-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   release-gate:
     name: Release Gate
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_release_gate != true }}
     uses: ./.github/workflows/release-gate.yml
 
+  deno-deploy-preflight:
+    name: Verify Deno Deploy access
+    needs: release-gate
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    runs-on: ubuntu-latest
+    env:
+      DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+
+    steps:
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Verify token and application access
+        run: |
+          if [ -z "$DENO_DEPLOY_TOKEN" ]; then
+            echo "::error::DENO_DEPLOY_TOKEN is not configured"
+            exit 1
+          fi
+          deno deploy whoami --json --non-interactive
+          deno deploy apps get --org intact-software-systems --app rallar-server --json --non-interactive
+          deno deploy apps get --org intact-software-systems --app rallar-bb-server --json --non-interactive
+          deno deploy apps get --org intact-software-systems --app relic-hunters --json --non-interactive
+
   # ----------------------------
-  # Web SPA → Cloudflare Pages
+  # Web SPA build for Cloudflare Pages
   # ----------------------------
   deploy-eye-hunter:
-    name: Deploy Eye Hunter Web (Cloudflare Pages)
+    name: Build Eye Hunter Web for Cloudflare Pages
     needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -46,19 +75,19 @@ jobs:
           API_BASE_URL: https://api.rallar.intactss.com
           VITE_RALLAR_AUTH_STORAGE: session
           VITE_RALLAR_BROWSER_AI: webllm
-          VITE_RALLAR_BROWSER_AI_ENABLED: "true"
+          VITE_RALLAR_BROWSER_AI_ENABLED: 'true'
           VITE_RALLAR_WEBLLM_MODEL: Llama-3.2-1B-Instruct-q4f16_1-MLC
         run: |
           npm install
           npm run build
 
   # ----------------------------
-  # Web SPA → Cloudflare Pages
+  # Web SPA build for Cloudflare Workers
   # ----------------------------
   deploy-relic-web:
-    name: Deploy Relic Hunter Web (Cloudflare Pages)
+    name: Build Relic Hunter Web for Cloudflare Workers
     needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -77,12 +106,12 @@ jobs:
           npm run build
 
   # ----------------------------
-  # Web SPA → Cloudflare Pages
+  # Web SPA build for Cloudflare Workers
   # ----------------------------
   deploy-rallar-kit:
-    name: Deploy Rallar Kit black-box Web (Cloudflare Pages)
+    name: Build Rallar Kit black-box Web for Cloudflare Workers
     needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -105,8 +134,10 @@ jobs:
   # ----------------------------
   deploy-api:
     name: Deploy API (Deno Deploy)
-    needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    needs:
+      - release-gate
+      - deno-deploy-preflight
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && needs.deno-deploy-preflight.result == 'success' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -127,6 +158,15 @@ jobs:
           key: ${{ runner.os }}-deno-${{ hashFiles('apps/api-v1/deno.lock') }}
           restore-keys: |
             ${{ runner.os }}-deno-
+
+      - name: Verify checked out commit is current main
+        run: |
+          git fetch --no-tags origin main
+          remote_main_sha="$(git rev-parse origin/main)"
+          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
+            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+            exit 1
+          fi
 
       - name: Prisma validate
         working-directory: apps/api-v1
@@ -146,14 +186,17 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: deno task prisma migrate deploy
 
-      - name: Trigger Deno Deploy
-        run: |
-          echo "Deno Deploy auto-deploys from GitHub main branch"
+      - name: Deploy rallar-server to Deno Deploy
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+        run: deno deploy . --config apps/api-v1/deno.json --org intact-software-systems --app rallar-server --prod --json --non-interactive
 
-  deploy-in-memory-api:
-    name: Deploy In-Memory API (Deno Deploy)
-    needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+  deploy-control-server:
+    name: Deploy Black Box Control Server (Deno Deploy)
+    needs:
+      - release-gate
+      - deno-deploy-preflight
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && needs.deno-deploy-preflight.result == 'success' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -171,18 +214,30 @@ jobs:
           path: |
             ~/.cache/deno
             ~/.npm
-          key: ${{ runner.os }}-deno-${{ hashFiles('apps/api-v1/deno.lock') }}
+          key: ${{ runner.os }}-deno-${{ hashFiles('apps/rallar-black-box-control-server/deno.lock') }}
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      - name: Trigger Deno Deploy
+      - name: Verify checked out commit is current main
         run: |
-          echo "Deno Deploy auto-deploys from GitHub main branch"
+          git fetch --no-tags origin main
+          remote_main_sha="$(git rev-parse origin/main)"
+          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
+            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+            exit 1
+          fi
+
+      - name: Deploy rallar-bb-server to Deno Deploy
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+        run: deno deploy . --config apps/rallar-black-box-control-server/deno.json --org intact-software-systems --app rallar-bb-server --prod --json --non-interactive
 
   deploy-relic-api:
     name: Deploy Relic API (Deno Deploy)
-    needs: release-gate
-    if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
+    needs:
+      - release-gate
+      - deno-deploy-preflight
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && needs.deno-deploy-preflight.result == 'success' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -203,6 +258,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
+      - name: Verify checked out commit is current main
+        run: |
+          git fetch --no-tags origin main
+          remote_main_sha="$(git rev-parse origin/main)"
+          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
+            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+            exit 1
+          fi
+
       - name: Prisma validate
         working-directory: apps/api-v1
         env:
@@ -221,6 +285,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL_RELIC }}
         run: deno task prisma migrate deploy
 
-      - name: Trigger Deno Deploy
-        run: |
-          echo "Deno Deploy auto-deploys from GitHub main branch"
+      - name: Deploy relic-hunters to Deno Deploy
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+        run: deno deploy . --config apps/relic-hunter-server-v1/deno.json --org intact-software-systems --app relic-hunters --prod --json --non-interactive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,17 @@ the repo-local Codex plugin under `.agents/skills/**`.
   - Any follow-up needed.
 - Keep the handoff structured, not just an action list. If tradeoffs were made,
   call them out explicitly.
+- Every final handoff ends with a collapsed `<details>` block using exactly
+  `<summary>Commands executed and what they taught us</summary>`. If no
+  commands or tool actions ran, say so inside the collapsed block.
+- Group repeated or equivalent commands. For each command or consequential
+  tool action, explain why the command or action was chosen, the important
+  result or exit status, what its result means, and one useful lesson or
+  reusable troubleshooting insight. Keep routine output summarized instead of
+  pasting raw logs.
+- Never expose secrets, tokens, credentials, authorization headers,
+  environment-file contents, or other sensitive values in the learning
+  summary. Describe only the safe shape and outcome of sensitive operations.
 
 ## Performance analysis repo guidance
 

--- a/apps/api-v1/deno.json
+++ b/apps/api-v1/deno.json
@@ -35,6 +35,13 @@
     "db:status": "deno task prisma migrate status",
     "rtc:migrate-persisted-state": "deno run --allow-env --allow-net --allow-read --allow-write scripts/migrate-rtc-persisted-state.ts"
   },
+  "deploy": {
+    "runtime": {
+      "type": "dynamic",
+      "entrypoint": "./src/main.ts",
+      "cwd": "."
+    }
+  },
   "compilerOptions": {
     "strict": true,
     "lib": [

--- a/apps/rallar-black-box-control-server/deno.json
+++ b/apps/rallar-black-box-control-server/deno.json
@@ -14,6 +14,13 @@
     "check": "deno check src/main.ts test/control-service.test.ts test/control-retention.test.ts test/retention-cleanup.test.ts test/retention-main-wiring.test.ts test/retention-plan-token.test.ts test/retention-query.test.ts test/swagger-routes.test.ts test/control-artifacts.test.ts test/cors.test.ts test/api-black-box.test.ts",
     "test": "deno test --allow-run --allow-net --allow-env --allow-read --allow-write"
   },
+  "deploy": {
+    "runtime": {
+      "type": "dynamic",
+      "entrypoint": "./src/main.ts",
+      "cwd": "."
+    }
+  },
   "compilerOptions": {
     "strict": true,
     "lib": [

--- a/apps/relic-hunter-server-v1/deno.json
+++ b/apps/relic-hunter-server-v1/deno.json
@@ -23,6 +23,13 @@
     "lint": "deno lint",
     "test": "deno test --allow-env --allow-read"
   },
+  "deploy": {
+    "runtime": {
+      "type": "dynamic",
+      "entrypoint": "./src/main.ts",
+      "cwd": "."
+    }
+  },
   "compilerOptions": {
     "strict": true,
     "lib": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ and authoritative persisted/shared contracts use mandatory fields by default.
 
 ## Documents
 
+- [Production Deployment And Branch Controls](./production-deployment.md)
+  Main-only Cloudflare and Deno deployment policy, staged Deno Actions cutover,
+  and human verification steps for provider configuration drift.
 - [Repo Human Style Review Guide](./repo-human-style-guide.md) Human review
   sequence and warning-only checker usage for the authoritative repo TypeScript
   standard in

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,104 @@
+# Production Deployment and Branch Controls
+
+Production deployments run from `main`. Feature branches use **Branch Release
+Gate** for repository validation and must not create Cloudflare or Deno Deploy
+contexts. A provider deployment context on a feature branch is configuration
+drift, not an additional application release gate.
+
+## Repository workflow
+
+`.github/workflows/deploy.yml` accepts pushes to `main` and explicit manual
+dispatches. It never listens to `pull_request` or non-main push events. Every
+deployment job also checks that its ref is `refs/heads/main`, so dispatching the
+workflow from another ref cannot publish. Deno deployments and the repository's
+Cloudflare build checks wait for the shared release gate unless an operator
+explicitly uses the manual `skip_release_gate` break-glass input from `main`.
+
+The three Cloudflare-named jobs in this workflow are repository build checks;
+they do not publish to Cloudflare. Until a separate authenticated Actions
+cutover is implemented, Cloudflare's Git integration publishes `main`
+independently and therefore does not wait for this workflow's release gate.
+The provider branch controls below enforce branch scope, not release-gate
+ordering.
+
+Deno deployment through GitHub Actions is staged behind the repository variable
+`DENO_DEPLOY_ACTIONS_ENABLED=true`. Leaving the variable unset or false keeps
+the three Deno jobs disabled while the provider Git integration remains in
+control. This prevents an incomplete credential migration from breaking a
+normal main-branch workflow. Production workflow runs are serialized, and each
+Deno job refuses to proceed when its checked-out commit is no longer the remote
+`main` tip.
+
+## Cloudflare branch controls
+
+Apply these settings to the `rallar-kit` and `relic-hunters-v1` Workers
+projects:
+
+- Production branch: `main`
+- Builds for non-production branches: disabled
+
+For the `ar-eye-hunter` Pages project, keep `main` as the production branch and
+set Preview branch to `None` when all Cloudflare checks must be main-only.
+
+Verify the next feature-branch push has no `Workers Builds:*` or `Cloudflare
+Pages` check. Do not use commit-message skip directives as a permanent branch
+policy.
+
+## Deno Deploy cutover
+
+The Deno GitHub integration creates branch timelines and corresponding GitHub
+status contexts. The repository-controlled workflow avoids that behavior by
+deploying only from the main-only GitHub Actions workflow.
+
+Before any database migration, the workflow verifies the token and access to
+all three applications. Each deployment uploads the repository root so
+monorepo imports under `packages/**` are present, then selects the app-specific
+`deno.json`. The checked-in `deploy.runtime` configuration fixes the entrypoint
+and working directory for each service.
+
+Complete the cutover in this order:
+
+1. Create a least-privilege Deno organization token allowed to deploy the three
+   existing applications.
+2. Store it as the repository Actions secret `DENO_DEPLOY_TOKEN`. Never put the
+   value in a command argument, workflow file, issue, pull request, or log.
+3. Disconnect the Deno GitHub integration for:
+   - `rallar-server`, sourced from `apps/api-v1`;
+   - `rallar-bb-server`, sourced from
+     `apps/rallar-black-box-control-server`;
+   - `relic-hunters`, sourced from `apps/relic-hunter-server-v1`.
+4. Set the repository Actions variable `DENO_DEPLOY_ACTIONS_ENABLED=true`.
+5. Manually run **Deploy Web + API** with release-gate skipping disabled.
+6. Confirm the preflight recognizes all three applications before any migration
+   begins.
+7. Verify all three Deno jobs deploy the exact default-branch commit and the
+   production health endpoints remain healthy.
+
+If the token is not ready, do not disconnect the integration and do not enable
+the variable. If the cutover fails, set `DENO_DEPLOY_ACTIONS_ENABLED=false`
+before deciding whether to reconnect the provider integration.
+
+The GitHub-side commands are intentionally interactive for the secret value:
+
+```sh
+gh secret set DENO_DEPLOY_TOKEN
+gh variable set DENO_DEPLOY_ACTIONS_ENABLED --body true
+gh workflow run deploy.yml --ref main -f skip_release_gate=false
+```
+
+For rollback, keep the token but disable execution with
+`gh variable set DENO_DEPLOY_ACTIONS_ENABLED --body false`.
+
+## Human verification
+
+After changing provider settings:
+
+1. Push a feature-branch commit and inspect its pull request checks. It should
+   have **Branch Release Gate** but no Cloudflare Worker, Cloudflare Pages, or
+   `deploy/intact-software-systems/*` context.
+2. Merge only after Branch Release Gate passes.
+3. Confirm the resulting `main` commit runs **Deploy Web + API** and that all
+   enabled production deployments refer to that exact commit SHA.
+
+Absent provider contexts on a feature branch are expected. Provider contexts
+on a feature branch mean the branch controls have regressed.

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -4,109 +4,206 @@ import { describe, expect, it } from 'vitest';
 
 const repoRoot = path.resolve(__dirname, '../../..');
 const deployAfterReleaseGateCondition =
-    "if: ${{ always() && !cancelled() && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}";
+  "if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}";
+const denoPreflightCondition =
+  "if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}";
+const deployDenoAfterPreflightCondition =
+  "if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && vars.DENO_DEPLOY_ACTIONS_ENABLED == 'true' && needs.deno-deploy-preflight.result == 'success' && (needs.release-gate.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_release_gate == true)) }}";
 const releaseGateEnabledCondition =
-    "if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_release_gate != true }}";
+  "if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_release_gate != true }}";
 
 function getJobBlock(workflow: string, jobName: string): string {
-    const jobStart = workflow.indexOf(`  ${jobName}:\n`);
-    expect(jobStart).toBeGreaterThanOrEqual(0);
+  const jobStart = workflow.indexOf(`  ${jobName}:\n`);
+  expect(jobStart).toBeGreaterThanOrEqual(0);
 
-    const rest = workflow.slice(jobStart);
-    const nextJob = rest.slice(`  ${jobName}:\n`.length).match(/\n  [a-z0-9-]+:\n/);
-    return nextJob
-        ? rest.slice(0, `  ${jobName}:\n`.length + nextJob.index)
-        : rest;
+  const rest = workflow.slice(jobStart);
+  const nextJob = rest.slice(`  ${jobName}:\n`.length).match(/\n  [a-z0-9-]+:\n/);
+  return nextJob ? rest.slice(0, `  ${jobName}:\n`.length + nextJob.index) : rest;
 }
 
 describe('Deploy workflow release gate', () => {
-    it('runs validation before every main deploy job publishes', async () => {
-        const workflow = await readFile(
-            path.join(repoRoot, '.github/workflows/deploy.yml'),
-            'utf8',
-        );
-        const releaseGateWorkflow = await readFile(
-            path.join(repoRoot, '.github/workflows/release-gate.yml'),
-            'utf8',
-        );
+  it('runs validation before every main deployment job proceeds', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+    const releaseGateWorkflow = await readFile(
+      path.join(repoRoot, '.github/workflows/release-gate.yml'),
+      'utf8',
+    );
 
-        expect(workflow).toContain('release-gate:');
-        expect(workflow).toContain('name: Release Gate');
-        expect(getJobBlock(workflow, 'release-gate')).toContain(
-            'uses: ./.github/workflows/release-gate.yml',
-        );
-        expect(getJobBlock(workflow, 'release-gate')).toContain(
-            releaseGateEnabledCondition,
-        );
-        expect(releaseGateWorkflow).toContain('postgres:');
-        expect(releaseGateWorkflow).toContain('npm ci');
-        expect(releaseGateWorkflow).toContain('npx playwright install --with-deps chromium');
-        expect(releaseGateWorkflow).toMatch(
-            /RALLAR_AUTH_CREDENTIAL_SECRET:\s*["']?[^\n"']{32,}["']?/,
-        );
-        expect(releaseGateWorkflow).toContain('npm run test:ci');
-        expect(releaseGateWorkflow).toContain('npm run build:ar-eye-hunter-v1');
-        expect(releaseGateWorkflow).toContain('npm run build:relic-hunters-v1');
-        expect(releaseGateWorkflow).toContain('npm run build:rallar');
-        expect(releaseGateWorkflow).toContain('cd apps/api-v1 && deno task check');
-        expect(releaseGateWorkflow).toContain('cd apps/relic-hunter-server-v1 && deno task check');
-        expect(releaseGateWorkflow).toContain('cd apps/rallar-black-box-control-server && deno task check');
-        expect(releaseGateWorkflow).toContain('npm run db:migrate');
-        expect(releaseGateWorkflow).toContain('npm run test:postgres:presence-expiry');
-        expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:rest');
-        expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:control');
+    expect(workflow).toContain('release-gate:');
+    expect(workflow).toContain('name: Release Gate');
+    expect(getJobBlock(workflow, 'release-gate')).toContain(
+      'uses: ./.github/workflows/release-gate.yml',
+    );
+    expect(getJobBlock(workflow, 'release-gate')).toContain(releaseGateEnabledCondition);
+    expect(releaseGateWorkflow).toContain('postgres:');
+    expect(releaseGateWorkflow).toContain('npm ci');
+    expect(releaseGateWorkflow).toContain('npx playwright install --with-deps chromium');
+    expect(releaseGateWorkflow).toMatch(/RALLAR_AUTH_CREDENTIAL_SECRET:\s*["']?[^\n"']{32,}["']?/);
+    expect(releaseGateWorkflow).toContain('npm run test:ci');
+    expect(releaseGateWorkflow).toContain('npm run build:ar-eye-hunter-v1');
+    expect(releaseGateWorkflow).toContain('npm run build:relic-hunters-v1');
+    expect(releaseGateWorkflow).toContain('npm run build:rallar');
+    expect(releaseGateWorkflow).toContain('cd apps/api-v1 && deno task check');
+    expect(releaseGateWorkflow).toContain('cd apps/relic-hunter-server-v1 && deno task check');
+    expect(releaseGateWorkflow).toContain(
+      'cd apps/rallar-black-box-control-server && deno task check',
+    );
+    expect(releaseGateWorkflow).toContain('npm run db:migrate');
+    expect(releaseGateWorkflow).toContain('npm run test:postgres:presence-expiry');
+    expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:rest');
+    expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:control');
 
-        const deployJobs = [
-            'deploy-eye-hunter',
-            'deploy-relic-web',
-            'deploy-rallar-kit',
-            'deploy-api',
-            'deploy-in-memory-api',
-            'deploy-relic-api',
-        ];
+    const deployJobs = ['deploy-eye-hunter', 'deploy-relic-web', 'deploy-rallar-kit'];
 
-        for (const jobName of deployJobs) {
-            const jobBlock = getJobBlock(workflow, jobName);
+    for (const jobName of deployJobs) {
+      const jobBlock = getJobBlock(workflow, jobName);
 
-            expect(jobBlock).toContain('needs: release-gate');
-            expect(jobBlock).toContain(deployAfterReleaseGateCondition);
-            expect(workflow.indexOf('  release-gate:\n')).toBeLessThan(
-                workflow.indexOf(`  ${jobName}:\n`),
-            );
-        }
-    });
+      expect(jobBlock).toContain('needs: release-gate');
+      expect(jobBlock).toContain(deployAfterReleaseGateCondition);
+      expect(workflow.indexOf('  release-gate:\n')).toBeLessThan(
+        workflow.indexOf(`  ${jobName}:\n`),
+      );
+    }
 
-    it('defaults manual release-gate skipping off while keeping push-to-main deploys gated', async () => {
-        const workflow = await readFile(
-            path.join(repoRoot, '.github/workflows/deploy.yml'),
-            'utf8',
-        );
+    const denoDeployJobs = ['deploy-api', 'deploy-control-server', 'deploy-relic-api'];
 
-        expect(workflow).toContain('push:\n    branches:\n      - main');
-        expect(workflow).toContain('workflow_dispatch:\n    inputs:');
-        expect(workflow).toContain('skip_release_gate:');
-        expect(workflow).toContain('description: "Skip release gate validation for this manual deploy"');
-        expect(workflow).toContain('default: false');
-        expect(workflow).toContain('type: boolean');
-        expect(getJobBlock(workflow, 'release-gate')).toContain(
-            releaseGateEnabledCondition,
-        );
-    });
+    for (const jobName of denoDeployJobs) {
+      const jobBlock = getJobBlock(workflow, jobName);
 
-    it('keeps the Postgres presence expiry test from rewriting node_modules', async () => {
-        const packageJson = JSON.parse(
-            await readFile(path.join(repoRoot, 'package.json'), 'utf8'),
-        ) as {
-            scripts: Record<string, string>;
-            devDependencies: Record<string, string>;
+      expect(jobBlock).toContain('- release-gate');
+      expect(jobBlock).toContain('- deno-deploy-preflight');
+      expect(jobBlock).toContain(deployDenoAfterPreflightCondition);
+      expect(workflow.indexOf('  release-gate:\n')).toBeLessThan(
+        workflow.indexOf(`  ${jobName}:\n`),
+      );
+    }
+  });
+
+  it('defaults manual release-gate skipping off while keeping push-to-main deploys gated', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+    expect(workflow).toContain('push:\n    branches:\n      - main');
+    expect(workflow).toContain('workflow_dispatch:\n    inputs:');
+    expect(workflow).toContain('skip_release_gate:');
+    expect(workflow).toContain('Skip release gate validation for this manual deploy');
+    expect(workflow).toContain('default: false');
+    expect(workflow).toContain('type: boolean');
+    expect(getJobBlock(workflow, 'release-gate')).toContain(releaseGateEnabledCondition);
+    expect(workflow).not.toContain('pull_request:');
+  });
+
+  it('stages three explicit main-only Deno Deploy applications without placeholder jobs', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+    const expectedDeployments = [
+      {
+        jobName: 'deploy-api',
+        configPath: 'apps/api-v1/deno.json',
+        appName: 'rallar-server',
+      },
+      {
+        jobName: 'deploy-control-server',
+        configPath: 'apps/rallar-black-box-control-server/deno.json',
+        appName: 'rallar-bb-server',
+      },
+      {
+        jobName: 'deploy-relic-api',
+        configPath: 'apps/relic-hunter-server-v1/deno.json',
+        appName: 'relic-hunters',
+      },
+    ];
+
+    for (const deployment of expectedDeployments) {
+      const jobBlock = getJobBlock(workflow, deployment.jobName);
+
+      expect(jobBlock).toContain(deployDenoAfterPreflightCondition);
+      expect(jobBlock).toContain('DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}');
+      expect(jobBlock).toContain(
+        `deno deploy . --config ${deployment.configPath} --org intact-software-systems --app ${deployment.appName} --prod --json --non-interactive`,
+      );
+
+      const config = JSON.parse(
+        await readFile(path.join(repoRoot, deployment.configPath), 'utf8'),
+      ) as {
+        deploy?: {
+          runtime?: {
+            type?: string;
+            entrypoint?: string;
+            cwd?: string;
+          };
         };
-        const script = packageJson.scripts['test:postgres:presence-expiry'];
+      };
 
-        expect(script).toContain('--node-modules-dir=none');
-        expect(script).toContain(
-            '--config packages/tests/shared-server/vitest.deno.config.mjs',
-        );
-        expect(script).not.toContain('--node-modules-dir=auto');
-        expect(packageJson.devDependencies.postgres).toBe('^3.4.9');
-    });
+      expect(config.deploy?.runtime).toEqual({
+        type: 'dynamic',
+        entrypoint: './src/main.ts',
+        cwd: '.',
+      });
+    }
+
+    expect(workflow).not.toContain('deploy-in-memory-api:');
+    expect(workflow).not.toContain('Deno Deploy auto-deploys from GitHub main branch');
+  });
+
+  it('serializes deployment and authenticates every Deno application before mutation', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+    const preflight = getJobBlock(workflow, 'deno-deploy-preflight');
+
+    expect(workflow).toContain('concurrency:\n  group: production-deploy-${{ github.repository }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(preflight).toContain('needs: release-gate');
+    expect(preflight).toContain(denoPreflightCondition);
+    expect(preflight).toContain('DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}');
+    expect(preflight).toContain('deno deploy whoami --json --non-interactive');
+
+    for (const appName of ['rallar-server', 'rallar-bb-server', 'relic-hunters']) {
+      expect(preflight).toContain(
+        `deno deploy apps get --org intact-software-systems --app ${appName} --json --non-interactive`,
+      );
+    }
+
+    for (const jobName of ['deploy-api', 'deploy-control-server', 'deploy-relic-api']) {
+      const jobBlock = getJobBlock(workflow, jobName);
+      const staleGuardIndex = jobBlock.indexOf('Verify checked out commit is current main');
+      const firstMutationIndex = Math.min(
+        ...['Prisma migrate deploy', 'run: deno deploy .']
+          .map((marker) => jobBlock.indexOf(marker))
+          .filter((index) => index >= 0),
+      );
+
+      expect(staleGuardIndex).toBeGreaterThanOrEqual(0);
+      expect(jobBlock).toContain('git fetch --no-tags origin main');
+      expect(jobBlock).toContain('Refusing stale production deploy');
+      expect(staleGuardIndex).toBeLessThan(firstMutationIndex);
+    }
+  });
+
+  it('documents provider settings that prevent feature-branch deployment contexts', async () => {
+    const runbook = await readFile(path.join(repoRoot, 'docs/production-deployment.md'), 'utf8');
+
+    for (const requirement of [
+      'Production branch: `main`',
+      'Builds for non-production branches: disabled',
+      'Disconnect the Deno GitHub integration',
+      '`DENO_DEPLOY_TOKEN`',
+      '`DENO_DEPLOY_ACTIONS_ENABLED=true`',
+      'Branch Release Gate',
+      'configuration drift',
+    ]) {
+      expect(runbook.replace(/\s+/g, ' ')).toContain(requirement);
+    }
+  });
+
+  it('keeps the Postgres presence expiry test from rewriting node_modules', async () => {
+    const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    const script = packageJson.scripts['test:postgres:presence-expiry'];
+
+    expect(script).toContain('--node-modules-dir=none');
+    expect(script).toContain('--config packages/tests/shared-server/vitest.deno.config.mjs');
+    expect(script).not.toContain('--node-modules-dir=auto');
+    expect(packageJson.devDependencies.postgres).toBe('^3.4.9');
+  });
 });

--- a/packages/tests/repo/rallar-skill-integrity.test.ts
+++ b/packages/tests/repo/rallar-skill-integrity.test.ts
@@ -256,6 +256,21 @@ describe('Rallar repo skill and documentation integrity', () => {
     ]);
   });
 
+  it('requires a collapsed learning-oriented command summary in every final handoff', () => {
+    const agents = readRepo('AGENTS.md');
+
+    expectAllNormalized(agents, [
+      'Every final handoff ends with a collapsed `<details>` block',
+      '<summary>Commands executed and what they taught us</summary>',
+      'If no commands or tool actions ran, say so inside the collapsed block',
+      'Group repeated or equivalent commands',
+      'why the command or action was chosen',
+      'what its result means',
+      'useful lesson or reusable troubleshooting insight',
+      'Never expose secrets, tokens, credentials, authorization headers',
+    ]);
+  });
+
   it('provides the greenfield app workflow and audited evidence map', () => {
     const skill = readRepo('.agents/skills/building-rallar-apps/SKILL.md');
     const scaffolding = readRepo(


### PR DESCRIPTION
## Summary

- guard every repository deployment job to `refs/heads/main`, including manual dispatch
- stage authenticated, serialized Deno Deploy jobs behind `DENO_DEPLOY_ACTIONS_ENABLED`
- upload the monorepo root with per-app runtime config so shared packages are included
- add pre-migration token/app-access checks and stale-main refusal
- document the remaining Cloudflare and Deno dashboard cutover
- require learning-oriented collapsed command/tool summaries in future AI handoffs

## Validation

- `npx vitest run packages/tests/hetzner/deploy-release-gate.test.ts packages/tests/repo/rallar-skill-integrity.test.ts packages/tests/repo/repo-code-style-integrity.test.ts packages/tests/repo/repo-style-check.test.ts` — 87 passed
- `npm run check:repo-style` — exit 0; existing warning-only findings
- `npm run test:unit` — 5,534 passed, 18 skipped
- `npm run test:ci` — passed
- `npm run build` — passed
- Prettier, YAML parse, Deno checks, and `git diff --check` — passed

## Deliberately pending

Cloudflare branch controls and the Deno dashboard/GitHub-integration cutover require provider login. Deno Actions remain disabled until `DENO_DEPLOY_TOKEN` is configured, the Git integrations are disconnected, and `DENO_DEPLOY_ACTIONS_ENABLED=true` is set. This PR should remain draft until those operator steps can be coordinated.