### PR TITLE
Make human understanding the primary code goal

### DIFF
--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -7,6 +7,16 @@ description: Use when writing, generating, refactoring, or reviewing TypeScript 
 
 ## Start Here
 
+Code is written first for human developers. Correctness, safety, security,
+compatibility, and required performance remain mandatory; within those
+constraints, choose the shape a human can locate, trace, understand, and
+modify most directly.
+
+A mechanically compliant change is not acceptable when it adds indirection,
+hides a decision, fragments one dataflow, weakens names, or makes ownership
+less obvious. When a detailed rule conflicts with human understandability,
+stop and explain the conflict instead of satisfying the rule mechanically.
+
 Always read `references/repo-code-style.md` completely before writing,
 refactoring, generating, or reviewing TypeScript. It is the authoritative
 repo-wide coding standard; local guidance may tighten it but may not relax it.

--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -6,6 +6,7 @@ version of these rules.
 
 ## Contents
 
+- [First principle: code is for human developers](#first-principle-code-is-for-human-developers)
 - [Scope and adoption](#scope-and-adoption)
 - [Formatting and spacing](#formatting-and-spacing)
 - [Predictable file layout](#predictable-file-layout)
@@ -27,6 +28,24 @@ version of these rules.
 - [Comments and self-explanatory code](#comments-and-self-explanatory-code)
 - [Review and automation](#review-and-automation)
 
+## First principle: code is for human developers
+
+Code is written first for human developers. Correctness, safety, security,
+compatibility, and required performance are non-negotiable constraints.
+Within those constraints, human understandability is the governing design criterion
+for this standard.
+
+Prefer code whose owner, inputs, defaults, decisions, side effects, failures,
+and result can be located and followed directly from descriptive filenames,
+symbols, and call paths. Do not apply a rule mechanically when doing so adds
+pass-through abstractions, hides a decision, fragments one coherent dataflow,
+or otherwise makes the code harder to review, debug, or change.
+
+The rules below are defaults derived from this principle together with the
+repository's correctness and operational requirements. When two rules pull in
+different directions, state the concrete tradeoff and ask the human rather than
+inventing another abstraction.
+
 ## Scope and adoption
 
 - The standard applies to TypeScript under `apps/**`, `packages/**`, `scripts/**`, examples, tests, and support tooling.
@@ -40,8 +59,9 @@ version of these rules.
 - A deliberate exception requires explicit human approval and a short rationale in the task handoff. Existing violations
   are not precedent.
 
-The goal is human traceability: a reader should be able to follow inputs, decisions, side effects, and failures without
-repeatedly jumping through generic helpers or reconstructing partially optional types.
+Apply the first principle by keeping inputs, decisions, side effects, and
+failures traceable without repeated jumps through generic helpers or
+reconstruction of partially optional types.
 
 ## Formatting and spacing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,19 @@
 Use this file as the lightweight repo orientation. Detailed workflows live in
 the repo-local Codex plugin under `.agents/skills/**`.
 
+## Primary Code Goal
+
+Code is written first for human developers. Correctness, safety, security,
+compatibility, and required performance are non-negotiable. Within those
+constraints, human understandability is the governing design criterion:
+prefer the design whose ownership, dataflow, decisions, side effects,
+failures, and call paths a human can locate and follow most directly.
+
+Every coding and architecture rule is interpreted through this principle. A
+mechanically compliant change is not successful when it makes the code harder
+for a human to understand, review, debug, or modify. For TypeScript, use the
+`rallar-code-writing` skill and its authoritative repo standard.
+
 ## Start Here
 
 - Inspect the existing code and relevant `examples/**` before editing; Rallar

--- a/docs/repo-human-style-guide.md
+++ b/docs/repo-human-style-guide.md
@@ -8,6 +8,15 @@ The authoritative coding standard is
 reviewing a change. This guide supplies the review sequence and checker usage; it
 does not define a second version of the rules.
 
+Code is written first for human developers. Correctness, safety, security,
+compatibility, and required performance remain mandatory; within those
+constraints, human understandability is the governing review criterion.
+
+The first review question is whether a human can locate the owner and follow
+the dataflow, decisions, side effects, failures, and result without unnecessary
+jumps. Mechanical compliance does not compensate for code that became harder
+to understand.
+
 ## Human review sequence
 
 ### 1. Read the change as dataflow

--- a/packages/tests/repo/repo-code-style-integrity.test.ts
+++ b/packages/tests/repo/repo-code-style-integrity.test.ts
@@ -11,9 +11,11 @@ describe('repo code style authority integrity', () => {
     const codeWriting = readRepo('.agents/skills/rallar-code-writing/SKILL.md');
     const humanGuide = readRepo('docs/repo-human-style-guide.md');
     const docsIndex = readRepo('docs/README.md');
+    const canonicalStyle = readRepo(canonicalStylePath);
     const packageJson = readJson('package.json') as {
       scripts?: Readonly<Record<string, string>>;
     };
+    const primaryCodeGoal = 'Code is written first for human developers.';
 
     expect(existsSync(path.join(repoRoot, canonicalStylePath))).toBe(true);
     expect(
@@ -22,12 +24,31 @@ describe('repo code style authority integrity', () => {
       ),
     ).toBe(false);
     expect(codeWriting).toContain('Always read `references/repo-code-style.md`');
-    expectAll(agents, ['any TypeScript change', canonicalStylePath]);
-    expectAll(humanGuide, [canonicalStylePath, 'authoritative coding standard']);
+    expectAll(agents, [
+      primaryCodeGoal,
+      'human understandability is the governing design criterion',
+      'any TypeScript change',
+      canonicalStylePath,
+    ]);
+    expectAll(codeWriting, [
+      primaryCodeGoal,
+      'A mechanically compliant change is not acceptable',
+      'references/repo-code-style.md',
+    ]);
+    expectAll(humanGuide, [
+      primaryCodeGoal,
+      'Mechanical compliance does not compensate',
+      canonicalStylePath,
+      'authoritative coding standard',
+    ]);
     expect(docsIndex).toContain('./repo-human-style-guide.md');
     expect(packageJson.scripts).not.toHaveProperty('check:repo-style:strict');
     expect(packageJson.scripts).toHaveProperty('check:repo-style:object-interfaces');
-    expectAll(readRepo(canonicalStylePath), [
+    expectAll(canonicalStyle, [
+      primaryCodeGoal,
+      '## First principle: code is for human developers',
+      'human understandability is the governing design criterion',
+      'The rules below are defaults derived from this principle',
       '`validateXxx` always returns all issues and never throws',
       'The caller or a central\n`classifyRuntimeFailure` policy decides the disposition',
       'Do not put a guessed\n`retryable` boolean on a low-level exception',


### PR DESCRIPTION
## What changed

- states the primary code goal in `AGENTS.md`
- turns the principle into required behavior in `rallar-code-writing`
- adds the authoritative interpretation to the repo code standard
- makes it the first human review criterion
- adds integrity assertions so the principle and routing cannot silently disappear

## Why

Code should be optimized for human understanding after non-negotiable
correctness, safety, security, compatibility, and required performance
constraints. Mechanical compliance is not success when it makes ownership or
dataflow harder to follow.

## Validation

- `npx vitest run packages/tests/repo/rallar-skill-integrity.test.ts packages/tests/repo/repo-code-style-integrity.test.ts packages/tests/repo/repo-style-check.test.ts` — 80 tests passed
- `npm run check:repo-style -- --root .agents/skills/rallar-code-writing` — passed
- Prettier check — passed
- forward pressure-scenario check — passed
- standalone `quick_validate.py` — unavailable because PyYAML is not installed in the active Python
