### PR TITLE
Isolate Hetzner recipes by run group

### DIFF
--- a/.agents/skills/rallar-hetzner-ops/SKILL.md
+++ b/.agents/skills/rallar-hetzner-ops/SKILL.md
@@ -31,6 +31,14 @@ start, stop, install, or restart headless agents for that flow.
   shared control server/control run.
 - Use checked-in distributed manifest JSON files. Do not paste secrets or admin
   tokens into prompts, manifests, workflow inputs, or URLs.
+- Do not reset the database to isolate recipes. Spawned Hetzner runs with a
+  blank `room_id` must materialize a deterministic group unique to the workflow
+  run attempt and use it consistently for workers and every manifest command.
+  Leave completed groups to normal lifecycle expiry.
+- Treat a non-empty `room_id` as an explicit stable-group request. For external,
+  mixed, or no-spawn agents, a blank override preserves the checked-in manifest
+  `GroupRef`, including its application and workspace; workflow defaults must
+  not rewrite that preserved scope.
 - Treat `scripts/hetzner/controller/*.sh` as the source of truth for VM service
   management.
 - Read the GitHub **Hetzner operation diagnostics** summary and uploaded
@@ -38,6 +46,9 @@ start, stop, install, or restart headless agents for that flow.
   false, treat its stage, component, sanitized evidence, and next action as the
   authoritative pre-recipe diagnosis; absent distributed artifacts are
   expected.
+- Compare `sourceGroupRef`, `effectiveGroupRef`, isolation mode, and both
+  manifest hashes in schema-v2 operation diagnostics before investigating a
+  manifest-scope or cross-run contamination concern.
 - If `recipeStarted` is true, inspect uploaded distributed artifacts before
   proposing fixes and cite the failure evidence file, command id, affected
   agents, and minimal fix area.

--- a/.agents/skills/rallar-hetzner-ops/references/failure-triage.md
+++ b/.agents/skills/rallar-hetzner-ops/references/failure-triage.md
@@ -8,9 +8,13 @@ Use this order:
 3. If `recipeStarted` is false, use its `stage`, `failureCategory`, `component`,
    `evidenceExcerpt`, and `nextAction`. Do not request distributed analysis;
    no recipe artifact should exist.
-4. If `recipeStarted` is true, read `analysis/analysis.json`, then
+4. For `manifest-scope`, compare `sourceGroupRef`, `effectiveGroupRef`,
+   `groupIsolationMode`, both manifest hashes, and
+   `materialized-manifest.json`. A mismatch is a preparation failure; do not
+   reset the database or retry the recipe in the source group.
+5. If `recipeStarted` is true, read `analysis/analysis.json`, then
    `analysis/fix-proposal.md`, then the cited evidence file.
-5. Map the minimal fix area:
+6. Map the minimal fix area:
    - `dependency-repository`, `browser-dependencies`, `browser-installation`,
      `browser-verification`: controller preparation before any recipe.
    - `deployment-readiness`, `service-health`, `ssh`: deployment or controller
@@ -22,7 +26,7 @@ Use this order:
    - `API/CORS/auth`: login, API config, WebSocket ticketing, allowed origins.
    - `recipe assertion`: expected vs observed payload or wait/assert command.
    - `control-server/runtime`: orchestration or artifact export behavior.
-6. Propose one minimal fix and one focused verification command.
+7. Propose one minimal fix and one focused verification command.
 
 Do not propose broad refactors from one run. If the operation report itself is
 missing, use the named failing GitHub step and request a same-ref rerun. Do not

--- a/.agents/skills/rallar-hetzner-ops/references/github-action-workflow.md
+++ b/.agents/skills/rallar-hetzner-ops/references/github-action-workflow.md
@@ -70,8 +70,10 @@ active installer process is running and the lock is older than
 `RALLAR_PLAYWRIGHT_LOCK_STALE_SECONDS` seconds, default `600`. After the repair
 succeeds, return to `--fast`.
 
-The helper derives `agent_count`, `room_id`, `application_id`, and
-`workspace_id` from the manifest. It checks the required repository or
+The helper derives `agent_count`, `application_id`, and `workspace_id` from the
+manifest. By default it leaves `room_id` blank so spawned Hetzner agents use a
+deterministic group unique to the workflow run attempt. Pass `--room-id` only
+when intentionally reusing a stable group. It checks the required repository or
 `production` environment secret names before dispatch and refuses diagnostic
 manifests unless `--allow-diagnostic` is supplied. `--fast` sets
 `rollout_before_run=false`, `install_playwright=false`, `npm_ci=false`,
@@ -90,8 +92,10 @@ TLS requirement.
 
 - `agent_count`: number of headless browser agents.
 - `run_id`: optional control run id. Leave blank for `gh-<run>-<attempt>`.
-- `room_id`, `agent_prefix`, `application_id`, `workspace_id`: headless agent
-  scope.
+- `room_id`: optional explicit stable group. Blank isolates spawned Hetzner
+  recipes per workflow run attempt and preserves the manifest group for
+  external, mixed, and no-spawn agents.
+- `agent_prefix`, `application_id`, `workspace_id`: headless agent scope.
 - `rollout_before_run`: roll out the selected ref before the run.
 - `install_playwright`: install/update Chromium and Linux dependencies before
   starting browsers.
@@ -112,7 +116,6 @@ gh workflow run hetzner-distributed-recipe.yml \
   --ref main \
   -f manifest_path=apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json \
   -f agent_count=2 \
-  -f room_id=hetzner-headless-room \
   -f application_id=rallar-server \
   -f workspace_id=default \
   -f register_before_login=true \
@@ -132,6 +135,25 @@ hash, Playwright version, browser engine/path, Ubuntu version, and service
 health, then runs each supported manifest with rollout and installation
 disabled. Run-only Hetzner and mixed-agent phases reject a missing or stale
 stamp before starting workers.
+
+## Run Group Isolation
+
+The workflow never resets the database between recipes. Before copying a
+manifest to the controller, it writes an immutable materialized copy and a
+materialization record. For a spawned Hetzner run with blank `room_id`, the
+effective group id is derived from the repository, workflow run id and attempt,
+control run id, source manifest hash, and source `GroupRef`. Workers and all
+executable group, room, path, and request identities use that one effective
+scope.
+
+The same derivation inputs reproduce the same group, while a new workflow
+attempt produces a new group. Explicit room overrides remain stable. External,
+mixed, and no-spawn runs preserve the complete checked-in manifest `GroupRef`
+when the override is blank; workflow application/workspace defaults do not
+rewrite it. A split topology prepare/run pair fences preparation with the
+stable source-manifest hash, because materialized manifests contain distinct
+run identifiers. Completed groups are retained and follow ordinary server
+expiry; recipe cleanup must never delete or reset unrelated data.
 
 ## Required Secrets
 
@@ -156,7 +178,10 @@ the GitHub step summary, uploads artifacts, and fails only after evidence is
 uploaded when the distributed run did not pass. Independently of recipe
 artifacts, it always publishes a **Hetzner operation diagnostics** summary and
 an artifact containing `operation-report.json`, `summary.md`, and sanitized
-`evidence.log`.
+`evidence.log`. Schema-v2 diagnostics also include
+`manifest-materialization.json` and, when available,
+`materialized-manifest.json`. The report records the source and effective
+`GroupRef`, isolation mode, and SHA-256 hashes for both manifests.
 
 For every run, start with `operation-report.json`. If `recipeStarted` is false,
 stop there and follow `nextAction`. If it is true, use

--- a/.github/workflows/hetzner-distributed-recipe-runner.yml
+++ b/.github/workflows/hetzner-distributed-recipe-runner.yml
@@ -33,7 +33,7 @@ on:
         type: string
         default: ''
       room_id:
-        description: Rallar room id for headless agents; blank derives from manifest group.groupId
+        description: Optional stable room id; blank isolates spawned Hetzner agents per run
         required: false
         type: string
         default: ''
@@ -253,7 +253,7 @@ jobs:
           esac
 
           resolve_value agent_count "${INPUT_AGENT_COUNT}" "${manifest_agent_count}"
-          resolve_value room_id "${INPUT_ROOM_ID}" "${manifest_room_id}"
+          printf 'source_room_id=%s\n' "${manifest_room_id}" >> "${GITHUB_OUTPUT}"
           resolve_value application_id "${INPUT_APPLICATION_ID}" "${manifest_application_id}"
           resolve_value workspace_id "${INPUT_WORKSPACE_ID}" "${manifest_workspace_id}"
           resolve_optional_value terminal_timeout_seconds "${INPUT_TERMINAL_TIMEOUT_SECONDS}" "${manifest_terminal_timeout_seconds}" "300"
@@ -278,6 +278,53 @@ jobs:
             echo "::error::Manifest ${MANIFEST_PATH} requires rollout_before_run=true unless operator_phase=run validates a prepare marker." >&2
             exit 1
           fi
+
+      - name: Materialize run manifest
+        id: manifest_materialization
+        shell: bash
+        env:
+          SOURCE_MANIFEST_PATH: ${{ inputs.manifest_path }}
+          INPUT_AGENT_SOURCE: ${{ inputs.agent_source }}
+          INPUT_OPERATOR_PHASE: ${{ inputs.operator_phase }}
+          INPUT_ROOM_ID: ${{ inputs.room_id }}
+          EFFECTIVE_APPLICATION_ID: ${{ steps.manifest_defaults.outputs.application_id }}
+          EFFECTIVE_WORKSPACE_ID: ${{ steps.manifest_defaults.outputs.workspace_id }}
+          CONTROL_RUN_ID: ${{ steps.ids.outputs.run_id }}
+          DISTRIBUTED_RUN_ID: ${{ steps.ids.outputs.distributed_run_id }}
+        run: |
+          set -euo pipefail
+          operation_log="${RUNNER_TEMP}/hetzner-operation.log"
+          manifest_path="${RUNNER_TEMP}/rallar-distributed-manifest.json"
+          record_path="${RUNNER_TEMP}/rallar-manifest-materialization.json"
+          echo "RALLAR_OPERATION_STAGE=manifest-materialization" | tee "${operation_log}"
+          node scripts/github-actions/materialize-hetzner-run-manifest.mjs \
+            --source "${SOURCE_MANIFEST_PATH}" \
+            --output "${manifest_path}" \
+            --record-output "${record_path}" \
+            --agent-source "${INPUT_AGENT_SOURCE}" \
+            --operator-phase "${INPUT_OPERATOR_PHASE}" \
+            --control-run-id "${CONTROL_RUN_ID}" \
+            --distributed-run-id "${DISTRIBUTED_RUN_ID}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --workflow-run-id "${GITHUB_RUN_ID}" \
+            --workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --application-id "${EFFECTIVE_APPLICATION_ID}" \
+            --workspace-id "${EFFECTIVE_WORKSPACE_ID}" \
+            --room-id "${INPUT_ROOM_ID}" 2>&1 | tee -a "${operation_log}"
+          printf 'manifest_path=%s\n' "${manifest_path}" >> "${GITHUB_OUTPUT}"
+          printf 'record_path=%s\n' "${record_path}" >> "${GITHUB_OUTPUT}"
+          printf 'application_id=%s\n' \
+            "$(jq -r '.effectiveGroupRef.applicationId' "${record_path}")" >> "${GITHUB_OUTPUT}"
+          printf 'workspace_id=%s\n' \
+            "$(jq -r '.effectiveGroupRef.workspaceId' "${record_path}")" >> "${GITHUB_OUTPUT}"
+          printf 'group_id=%s\n' \
+            "$(jq -r '.effectiveGroupRef.groupId' "${record_path}")" >> "${GITHUB_OUTPUT}"
+          printf 'isolation_mode=%s\n' \
+            "$(jq -r '.isolationMode' "${record_path}")" >> "${GITHUB_OUTPUT}"
+          printf 'source_manifest_sha256=%s\n' \
+            "$(jq -r '.sourceManifestSha256' "${record_path}")" >> "${GITHUB_OUTPUT}"
+          printf 'materialized_manifest_sha256=%s\n' \
+            "$(jq -r '.materializedManifestSha256' "${record_path}")" >> "${GITHUB_OUTPUT}"
 
       - name: Resolve headless credentials
         shell: bash
@@ -329,7 +376,7 @@ jobs:
         env:
           HETZNER_HOST: ${{ secrets.HETZNER_HOST }}
           HETZNER_USER: ${{ secrets.HETZNER_USER }}
-          MANIFEST_PATH: ${{ inputs.manifest_path }}
+          MANIFEST_PATH: ${{ steps.manifest_materialization.outputs.manifest_path }}
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/hetzner "${HETZNER_USER}@${HETZNER_HOST}" \
@@ -359,12 +406,12 @@ jobs:
           RALLAR_BLACK_BOX_AGENT_SOURCE: ${{ inputs.agent_source }}
           RALLAR_HETZNER_OPERATOR_PHASE: ${{ inputs.operator_phase }}
           RALLAR_BLACK_BOX_RUN_ID: ${{ steps.ids.outputs.run_id }}
-          RALLAR_BLACK_BOX_ROOM_ID: ${{ steps.manifest_defaults.outputs.room_id }}
+          RALLAR_BLACK_BOX_ROOM_ID: ${{ steps.manifest_materialization.outputs.group_id }}
           RALLAR_BLACK_BOX_AGENT_PREFIX: ${{ inputs.agent_prefix }}
           RALLAR_BLACK_BOX_AGENT_COUNT: ${{ steps.manifest_defaults.outputs.agent_count }}
           RALLAR_BLACK_BOX_AGENT_START_INDEX: '1'
-          RALLAR_BLACK_BOX_APPLICATION_ID: ${{ steps.manifest_defaults.outputs.application_id }}
-          RALLAR_BLACK_BOX_WORKSPACE_ID: ${{ steps.manifest_defaults.outputs.workspace_id }}
+          RALLAR_BLACK_BOX_APPLICATION_ID: ${{ steps.manifest_materialization.outputs.application_id }}
+          RALLAR_BLACK_BOX_WORKSPACE_ID: ${{ steps.manifest_materialization.outputs.workspace_id }}
           RALLAR_BLACK_BOX_REGISTER: ${{ inputs.register_before_login }}
           RALLAR_BLACK_BOX_BROWSER_LOG_LEVEL: ${{ inputs.browser_log_level }}
           RALLAR_BLACK_BOX_HEADLESS_ENTRY: ${{ inputs.headless_entry }}
@@ -381,6 +428,7 @@ jobs:
           RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS: ${{ steps.manifest_defaults.outputs.terminal_timeout_seconds }}
           RALLAR_DISTRIBUTED_RUN_ID: ${{ steps.ids.outputs.distributed_run_id }}
           RALLAR_DISTRIBUTED_CONTROL_RUN_ID: ${{ steps.ids.outputs.run_id }}
+          RALLAR_SOURCE_MANIFEST_SHA256: ${{ steps.manifest_materialization.outputs.source_manifest_sha256 }}
           RALLAR_DISTRIBUTED_MANIFEST_PATH: /tmp/rallar-distributed-manifest.json
           RALLAR_DISTRIBUTED_ARTIFACT_DIR: /tmp/rallar-distributed-runs
           RALLAR_DISTRIBUTED_PREPARE_MARKER: /tmp/rallar-distributed-prepare-${{ steps.ids.outputs.distributed_run_id }}.json
@@ -430,6 +478,7 @@ jobs:
             printf 'RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS=%s\n' "$(quote "${RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS}")"
             printf 'RALLAR_DISTRIBUTED_RUN_ID=%s\n' "$(quote "${RALLAR_DISTRIBUTED_RUN_ID}")"
             printf 'RALLAR_DISTRIBUTED_CONTROL_RUN_ID=%s\n' "$(quote "${RALLAR_DISTRIBUTED_CONTROL_RUN_ID}")"
+            printf 'RALLAR_SOURCE_MANIFEST_SHA256=%s\n' "$(quote "${RALLAR_SOURCE_MANIFEST_SHA256}")"
             printf 'RALLAR_DISTRIBUTED_MANIFEST_PATH=%s\n' "$(quote "${RALLAR_DISTRIBUTED_MANIFEST_PATH}")"
             printf 'RALLAR_DISTRIBUTED_ARTIFACT_DIR=%s\n' "$(quote "${RALLAR_DISTRIBUTED_ARTIFACT_DIR}")"
             printf 'RALLAR_DISTRIBUTED_PREPARE_MARKER=%s\n' "$(quote "${RALLAR_DISTRIBUTED_PREPARE_MARKER}")"
@@ -463,7 +512,7 @@ jobs:
           operation_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           set +e
           ssh -i ~/.ssh/hetzner "${HETZNER_USER}@${HETZNER_HOST}" \
-            bash -s 2>&1 <<'REMOTE' | tee "${operation_log}"
+            bash -s 2>&1 <<'REMOTE' | tee -a "${operation_log}"
           set -euo pipefail
           cd "${HOME}/rallar-controller"
           chmod +x *.sh
@@ -498,12 +547,12 @@ jobs:
           }
 
           write_prepare_marker() {
-            local manifest_sha
-            manifest_sha="$(sha256sum "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" | awk '{print $1}')"
+            local manifestSha
+            manifestSha="${RALLAR_SOURCE_MANIFEST_SHA256}"
             jq -n \
               --arg runId "${RALLAR_DISTRIBUTED_RUN_ID}" \
               --arg ref "${RALLAR_REPO_REF}" \
-              --arg manifestSha "${manifest_sha}" \
+              --arg manifestSha "${manifestSha}" \
               --arg degreeLimit "${RALLAR_RTC_TOPOLOGY_DEGREE_LIMIT:-}" \
               --arg treeMinSize "${RALLAR_RTC_TOPOLOGY_TREE_MIN_SIZE:-}" \
               --arg meshMinSize "${RALLAR_RTC_TOPOLOGY_MESH_MIN_SIZE:-}" \
@@ -529,7 +578,7 @@ jobs:
               exit 1
             fi
             local expected_manifest_sha
-            expected_manifest_sha="$(sha256sum "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" | awk '{print $1}')"
+            expected_manifest_sha="${RALLAR_SOURCE_MANIFEST_SHA256}"
             jq -e \
               --arg ref "${RALLAR_REPO_REF}" \
               --arg manifestSha "${expected_manifest_sha}" \
@@ -602,7 +651,6 @@ jobs:
               wait_for_external_agents_if_requested
               ;;
           esac
-          echo "RALLAR_OPERATION_STAGE=recipe-execution"
           ./14-run-distributed-recipe.sh
           REMOTE
           operation_exit_code="${PIPESTATUS[0]}"
@@ -613,7 +661,7 @@ jobs:
           printf 'finished_at=%s\n' "${operation_finished_at}" >> "${GITHUB_OUTPUT}"
 
       - name: Copy distributed artifacts
-        if: always() && inputs.operator_phase != 'prepare'
+        if: always() && inputs.operator_phase != 'prepare' && steps.manifest_materialization.outcome == 'success'
         shell: bash
         env:
           HETZNER_HOST: ${{ secrets.HETZNER_HOST }}
@@ -638,7 +686,7 @@ jobs:
           fi
 
       - name: Upload distributed artifacts
-        if: always() && inputs.operator_phase != 'prepare'
+        if: always() && inputs.operator_phase != 'prepare' && steps.manifest_materialization.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: hetzner-distributed-${{ steps.ids.outputs.distributed_run_id }}
@@ -647,7 +695,7 @@ jobs:
 
       - name: Check distributed artifact availability
         id: artifact_status
-        if: always() && inputs.operator_phase != 'prepare'
+        if: always() && inputs.operator_phase != 'prepare' && steps.manifest_materialization.outcome == 'success'
         shell: bash
         env:
           DISTRIBUTED_RUN_ID: ${{ steps.ids.outputs.distributed_run_id }}
@@ -760,7 +808,9 @@ jobs:
             --distributed-run-id "${DISTRIBUTED_RUN_ID}" \
             --artifact-available "${ARTIFACT_AVAILABLE}" \
             --started-at "${operation_started_at}" \
-            --finished-at "${operation_finished_at}"
+            --finished-at "${operation_finished_at}" \
+            --materialization-record "${RUNNER_TEMP}/rallar-manifest-materialization.json" \
+            --materialized-manifest "${RUNNER_TEMP}/rallar-distributed-manifest.json"
           cat "${diagnostics_dir}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
           report_path="${diagnostics_dir}/operation-report.json"
           printf 'failure_category=%s\n' "$(jq -r '.failureCategory' "${report_path}")" >> "${GITHUB_OUTPUT}"
@@ -778,7 +828,7 @@ jobs:
           if-no-files-found: error
 
       - name: Stop headless browsers
-        if: always() && inputs.stop_after_run && inputs.agent_source != 'external'
+        if: always() && inputs.stop_after_run && inputs.agent_source != 'external' && steps.manifest_materialization.outcome == 'success'
         shell: bash
         env:
           HETZNER_HOST: ${{ secrets.HETZNER_HOST }}

--- a/.github/workflows/hetzner-distributed-recipe.yml
+++ b/.github/workflows/hetzner-distributed-recipe.yml
@@ -28,9 +28,9 @@ on:
         required: false
         default: ''
       room_id:
-        description: Rallar room id for headless agents
-        required: true
-        default: hetzner-headless-room
+        description: Optional stable room id; blank isolates spawned Hetzner agents per run
+        required: false
+        default: ''
       agent_prefix:
         description: Agent id prefix for headless agents
         required: true

--- a/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
@@ -100,7 +100,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 5000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
@@ -154,7 +154,7 @@
             "actor": "{auth.clientId}",
             "roomId": "hetzner-headless-room",
             "transport": "realtime",
-            "timeoutMs": 5000,
+            "timeoutMs": 15000,
             "rallar": {
               "sessionId": "alice-session",
               "apiBaseUrl": "https://api.rallar.intactss.com",

--- a/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,
@@ -301,7 +301,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
+++ b/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 2,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
@@ -106,7 +106,7 @@
               "groupId": "hetzner-headless-room"
             },
             "transport": "realtime",
-            "timeoutMs": 10000,
+            "timeoutMs": 15000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 10000,

--- a/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -113,7 +113,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -110,7 +110,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,
@@ -364,7 +364,7 @@
               "typeId": "black-box.group.multicast.position",
               "topicId": "black-box.group.multicast.position"
             },
-            "timeoutMs": 45000,
+            "timeoutMs": 50000,
             "readiness": {
               "minReadyPeers": 1,
               "timeoutMs": 45000,

--- a/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
@@ -28,6 +28,7 @@ const RALLAR_BLACK_BOX_RTC_MESSAGES_PRINCIPAL_SENDER_WARMUP_INTERVAL_MS = 1_000;
 const RALLAR_BLACK_BOX_RTC_MESSAGES_ALL_PEER_SETTLE_DURATION_MS = 5_000;
 const RALLAR_BLACK_BOX_RTC_MESSAGES_ALL_PEER_SETTLE_INTERVAL_MS = 1_000;
 const RALLAR_BLACK_BOX_LIVE_API_BASE_URL = 'https://api.rallar.intactss.com';
+const RALLAR_BLACK_BOX_RTC_CONNECT_COMPLETION_MARGIN_MS = 5_000;
 
 export type RallarBlackBoxRtcRealtimeRecipeOptions = Readonly<{
     durationSeconds?: number;
@@ -179,6 +180,19 @@ function rtcConnectReadiness(
     };
 }
 
+function computeRtcConnectCommandTimeoutMs(
+    options: Readonly<{
+        readyPeerCount?: number;
+        readyTimeoutMs?: number;
+    }>,
+    fallbackTimeoutMs: number,
+): number {
+    const readiness = rtcConnectReadiness(options);
+    return readiness === undefined
+        ? fallbackTimeoutMs
+        : readiness.timeoutMs + RALLAR_BLACK_BOX_RTC_CONNECT_COMPLETION_MARGIN_MS;
+}
+
 function multicastDeliveryPlan(options: Readonly<{
     participantCount?: number;
     senderCount: number;
@@ -243,6 +257,7 @@ function messagesRtcConnectCommand(options: Readonly<{
     metadata: Readonly<Record<string, unknown>>;
 }>): RallarBlackBoxTestCommand {
     const roomRef = groupRoomRef(options.group);
+    const readinessTimeoutMs = options.readyTimeoutMs ?? 45_000;
     return {
         kind: 'rtc.connect',
         commandId: options.commandId,
@@ -254,10 +269,10 @@ function messagesRtcConnectCommand(options: Readonly<{
         roomRef,
         transport: 'messages.rtc',
         rallar: { ...RALLAR_BLACK_BOX_GROUP_MULTICAST_POSITION_SELECTOR },
-        timeoutMs: options.readyTimeoutMs ?? 45_000,
+        timeoutMs: readinessTimeoutMs + RALLAR_BLACK_BOX_RTC_CONNECT_COMPLETION_MARGIN_MS,
         readiness: {
             minReadyPeers: options.minReadyPeers,
-            timeoutMs: options.readyTimeoutMs ?? 45_000,
+            timeoutMs: readinessTimeoutMs,
             intervalMs: 100,
         },
         metadata: options.metadata,
@@ -516,7 +531,7 @@ export function createRallarBlackBoxRtcSmokeRecipe(
                 workspaceId: group.workspaceId,
                 roomRef,
                 transport: 'realtime',
-                timeoutMs: 5_000,
+                timeoutMs: computeRtcConnectCommandTimeoutMs(options, 5_000),
                 readiness: rtcConnectReadiness(options),
             },
             {
@@ -588,6 +603,7 @@ export function createRallarBlackBoxProviderParityLiveRecipe(
                 applicationId: group.applicationId,
                 workspaceId: group.workspaceId,
                 roomRef,
+                timeoutMs: computeRtcConnectCommandTimeoutMs(options, command.timeoutMs ?? 5_000),
                 rallar: {
                     ...command.rallar,
                     apiBaseUrl,
@@ -1071,7 +1087,7 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
                 workspaceId: group.workspaceId,
                 roomRef,
                 transport: 'realtime',
-                timeoutMs: 10_000,
+                timeoutMs: computeRtcConnectCommandTimeoutMs(options, 10_000),
                 readiness: rtcConnectReadiness(options),
                 metadata: {
                     realtime: {

--- a/packages/tests/hetzner/distributed-recipe-workflow.test.ts
+++ b/packages/tests/hetzner/distributed-recipe-workflow.test.ts
@@ -40,8 +40,20 @@ const supportedMainlineManifestPaths = [
   'apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json',
   'apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json',
 ];
+const operationSourceGroupRef = {
+  applicationId: 'rallar-server',
+  workspaceId: 'default',
+  groupId: 'hetzner-headless-room',
+};
+const operationEffectiveGroupRef = {
+  applicationId: 'rallar-server',
+  workspaceId: 'default',
+  groupId: `hetzner-run-${'a'.repeat(64)}`,
+};
 
 interface WorkflowStep {
+  readonly env?: Readonly<Record<string, string>>;
+  readonly id?: string;
   readonly name?: string;
   readonly if?: string;
   readonly run?: string;
@@ -62,6 +74,35 @@ interface WorkflowDocument {
 
 const readWorkflow = async (workflowPath: string): Promise<WorkflowDocument> =>
   loadYaml(await readFile(path.join(repoRoot, workflowPath), 'utf8')) as WorkflowDocument;
+
+const writeOperationMaterializationFixture = async (
+  directory: string,
+): Promise<readonly string[]> => {
+  const sourcePath = path.join(repoRoot, supportedMainlineManifestPaths[0]);
+  const sourceText = await readFile(sourcePath, 'utf8');
+  const materializedManifest = JSON.parse(sourceText);
+  materializedManifest.group = operationEffectiveGroupRef;
+  const materializedText = `${JSON.stringify(materializedManifest, null, 2)}\n`;
+  const materializedPath = path.join(directory, 'materialized-manifest.json');
+  const recordPath = path.join(directory, 'manifest-materialization.json');
+  await writeFile(materializedPath, materializedText);
+  await writeFile(
+    recordPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        isolationMode: 'isolated',
+        sourceGroupRef: operationSourceGroupRef,
+        effectiveGroupRef: operationEffectiveGroupRef,
+        sourceManifestSha256: createHash('sha256').update(sourceText).digest('hex'),
+        materializedManifestSha256: createHash('sha256').update(materializedText).digest('hex'),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return ['--materialization-record', recordPath, '--materialized-manifest', materializedPath];
+};
 
 const parseMajorMinorPatch = (version: string): [number, number, number] => {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
@@ -111,6 +152,289 @@ const workflowDispatchInputNames = (workflow: string): string[] => {
 };
 
 describe('Hetzner distributed recipe workflow', () => {
+  it('materializes a deterministic isolated group throughout executable manifest data', async () => {
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'rallar-manifest-isolation-'));
+    const sourcePath = path.join(
+      repoRoot,
+      'apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json',
+    );
+    const outputPath = path.join(temporaryDirectory, 'manifest.json');
+    const recordPath = path.join(temporaryDirectory, 'materialization.json');
+    const sourceBefore = await readFile(sourcePath, 'utf8');
+    const scriptPath = path.join(
+      repoRoot,
+      'scripts/github-actions/materialize-hetzner-run-manifest.mjs',
+    );
+
+    await execFileAsync('node', [
+      scriptPath,
+      '--source',
+      sourcePath,
+      '--output',
+      outputPath,
+      '--record-output',
+      recordPath,
+      '--agent-source',
+      'hetzner',
+      '--operator-phase',
+      'run',
+      '--control-run-id',
+      'main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s',
+      '--distributed-run-id',
+      'dist-main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s',
+      '--repository',
+      'intact-software-systems/ar-eye-hunter',
+      '--workflow-run-id',
+      '30327139535',
+      '--workflow-run-attempt',
+      '2',
+      '--application-id',
+      '',
+      '--workspace-id',
+      '',
+      '--room-id',
+      '',
+    ]);
+
+    const manifest = JSON.parse(await readFile(outputPath, 'utf8'));
+    const record = JSON.parse(await readFile(recordPath, 'utf8'));
+    const effectiveGroupId = manifest.group.groupId as string;
+    const repeatedOutputPath = path.join(temporaryDirectory, 'repeated-manifest.json');
+    const repeatedRecordPath = path.join(temporaryDirectory, 'repeated-materialization.json');
+    await execFileAsync('node', [
+      scriptPath,
+      '--source',
+      sourcePath,
+      '--output',
+      repeatedOutputPath,
+      '--record-output',
+      repeatedRecordPath,
+      '--agent-source',
+      'hetzner',
+      '--operator-phase',
+      'run',
+      '--control-run-id',
+      'main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s',
+      '--distributed-run-id',
+      'dist-main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s',
+      '--repository',
+      'intact-software-systems/ar-eye-hunter',
+      '--workflow-run-id',
+      '30327139535',
+      '--workflow-run-attempt',
+      '2',
+      '--application-id',
+      '',
+      '--workspace-id',
+      '',
+      '--room-id',
+      '',
+    ]);
+
+    expect(effectiveGroupId).toMatch(/^hetzner-run-[a-f0-9]{64}$/);
+    expect(record).toMatchObject({
+      schemaVersion: 1,
+      isolationMode: 'isolated',
+      sourceGroupRef: {
+        applicationId: 'rallar-server',
+        workspaceId: 'default',
+        groupId: 'hetzner-headless-room',
+      },
+      effectiveGroupRef: {
+        applicationId: 'rallar-server',
+        workspaceId: 'default',
+        groupId: effectiveGroupId,
+      },
+      sourceManifestSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      materializedManifestSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(manifest.distributedRunId).toBe(
+      'dist-main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s',
+    );
+    expect(manifest.controlRunId).toBe('main-30327139535-2-05a-rtc-realtime-stability-2-agent-5s');
+    expect(JSON.stringify(manifest)).not.toContain('hetzner-headless-room');
+    expect(JSON.stringify(manifest)).toContain(`/groups/${effectiveGroupId}/members/`);
+    expect(await readFile(repeatedOutputPath, 'utf8')).toBe(await readFile(outputPath, 'utf8'));
+    expect(await readFile(repeatedRecordPath, 'utf8')).toBe(await readFile(recordPath, 'utf8'));
+    expect(await readFile(sourcePath, 'utf8')).toBe(sourceBefore);
+  });
+
+  it('changes isolated groups across attempts and preserves explicit or external groups', async () => {
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'rallar-manifest-modes-'));
+    const sourcePath = path.join(
+      repoRoot,
+      'apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json',
+    );
+    const scriptPath = path.join(
+      repoRoot,
+      'scripts/github-actions/materialize-hetzner-run-manifest.mjs',
+    );
+
+    const materialize = async (
+      label: string,
+      agentSource: string,
+      runAttempt: string,
+      roomId: string,
+      applicationId = '',
+      workspaceId = '',
+    ): Promise<Record<string, any>> => {
+      const outputPath = path.join(temporaryDirectory, `${label}.json`);
+      const recordPath = path.join(temporaryDirectory, `${label}-record.json`);
+      await execFileAsync('node', [
+        scriptPath,
+        '--source',
+        sourcePath,
+        '--output',
+        outputPath,
+        '--record-output',
+        recordPath,
+        '--agent-source',
+        agentSource,
+        '--operator-phase',
+        'run',
+        '--control-run-id',
+        `control-${label}`,
+        '--distributed-run-id',
+        `dist-${label}`,
+        '--repository',
+        'intact-software-systems/ar-eye-hunter',
+        '--workflow-run-id',
+        '30327139535',
+        '--workflow-run-attempt',
+        runAttempt,
+        '--application-id',
+        applicationId,
+        '--workspace-id',
+        workspaceId,
+        '--room-id',
+        roomId,
+      ]);
+      return JSON.parse(await readFile(recordPath, 'utf8'));
+    };
+
+    const first = await materialize('first', 'hetzner', '1', '');
+    const second = await materialize('second', 'hetzner', '2', '');
+    const explicit = await materialize('explicit', 'hetzner', '2', 'operator-room');
+    const external = await materialize(
+      'external',
+      'external',
+      '2',
+      '',
+      'workflow-default-application',
+      'workflow-default-workspace',
+    );
+
+    expect(first.effectiveGroupRef.groupId).not.toBe(second.effectiveGroupRef.groupId);
+    expect(explicit).toMatchObject({
+      isolationMode: 'explicit',
+      effectiveGroupRef: { groupId: 'operator-room' },
+    });
+    expect(external).toMatchObject({
+      isolationMode: 'preserved',
+      effectiveGroupRef: {
+        applicationId: 'rallar-server',
+        workspaceId: 'default',
+        groupId: 'hetzner-headless-room',
+      },
+    });
+  });
+
+  it('rejects an executable command scoped outside the source manifest group', async () => {
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'rallar-manifest-mismatch-'));
+    const sourcePath = path.join(temporaryDirectory, 'source.json');
+    const outputPath = path.join(temporaryDirectory, 'manifest.json');
+    const recordPath = path.join(temporaryDirectory, 'materialization.json');
+    const source = JSON.parse(
+      await readFile(
+        path.join(repoRoot, 'apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json'),
+        'utf8',
+      ),
+    );
+    const connect = source.recipes[0].recipe.commands.find(
+      (command: { kind: string }) => command.kind === 'rtc.connect',
+    );
+    connect.roomId = 'wrong-room';
+    source.recipes[0].recipe.commands[0].request.body.requestId =
+      'rtc-smoke:ensure-group:rallar-server:default:wrong-request-room:{auth.sessionId}';
+    source.recipes[0].recipe.commands[1].request.path =
+      '/api/state/apps/rallar-server/workspaces/default/groups/wrong-path-room/members/{auth.clientId}';
+    await writeFile(sourcePath, `${JSON.stringify(source, null, 2)}\n`);
+
+    await expect(
+      execFileAsync('node', [
+        path.join(repoRoot, 'scripts/github-actions/materialize-hetzner-run-manifest.mjs'),
+        '--source',
+        sourcePath,
+        '--output',
+        outputPath,
+        '--record-output',
+        recordPath,
+        '--agent-source',
+        'hetzner',
+        '--operator-phase',
+        'run',
+        '--control-run-id',
+        'control-mismatch',
+        '--distributed-run-id',
+        'dist-mismatch',
+        '--repository',
+        'intact-software-systems/ar-eye-hunter',
+        '--workflow-run-id',
+        '30327139535',
+        '--workflow-run-attempt',
+        '1',
+        '--application-id',
+        '',
+        '--workspace-id',
+        '',
+        '--room-id',
+        '',
+      ]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining('wrong-room'),
+    });
+    await expect(
+      execFileAsync('node', [
+        path.join(repoRoot, 'scripts/github-actions/materialize-hetzner-run-manifest.mjs'),
+        '--source', sourcePath,
+        '--output', outputPath,
+        '--record-output', recordPath,
+        '--agent-source', 'hetzner',
+        '--operator-phase', 'run',
+        '--control-run-id', 'control-mismatch',
+        '--distributed-run-id', 'dist-mismatch',
+        '--repository', 'intact-software-systems/ar-eye-hunter',
+        '--workflow-run-id', '30327139535',
+        '--workflow-run-attempt', '1',
+        '--application-id', '',
+        '--workspace-id', '',
+        '--room-id', '',
+      ]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining('wrong-request-room'),
+    });
+    await expect(
+      execFileAsync('node', [
+        path.join(repoRoot, 'scripts/github-actions/materialize-hetzner-run-manifest.mjs'),
+        '--source', sourcePath,
+        '--output', outputPath,
+        '--record-output', recordPath,
+        '--agent-source', 'hetzner',
+        '--operator-phase', 'run',
+        '--control-run-id', 'control-mismatch',
+        '--distributed-run-id', 'dist-mismatch',
+        '--repository', 'intact-software-systems/ar-eye-hunter',
+        '--workflow-run-id', '30327139535',
+        '--workflow-run-attempt', '1',
+        '--application-id', '',
+        '--workspace-id', '',
+        '--room-id', '',
+      ]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining('wrong-path-room'),
+    });
+  });
+
   it('keeps workflow_dispatch inputs within the GitHub Actions limit', async () => {
     const workflowPaths = [
       distributedWorkflowPath,
@@ -137,6 +461,28 @@ describe('Hetzner distributed recipe workflow', () => {
     expect(workflow).toContain('manifest_path: ${{ inputs.manifest_path }}');
     expect(workflow).toContain('ref: ${{ inputs.ref }}');
     expect(workflow).toContain('run_id: ${{ inputs.run_id }}');
+    expect(workflow).toMatch(/room_id:[\s\S]*?required: false[\s\S]*?default: ''/);
+  });
+
+  it('uses one materialized manifest as the worker and distributed-run scope authority', async () => {
+    const workflow = await readWorkflow(distributedRunnerWorkflowPath);
+    const steps = workflow.jobs?.run?.steps ?? [];
+    const materialization = steps.find((step) => step.name === 'Materialize run manifest');
+    const copy = steps.find((step) => step.name === 'Copy controller scripts and manifest');
+    const render = steps.find((step) => step.name === 'Render remote run env');
+
+    expect(materialization).toMatchObject({
+      id: 'manifest_materialization',
+      name: 'Materialize run manifest',
+    });
+    expect(materialization?.run).toContain('materialize-hetzner-run-manifest.mjs');
+    expect(materialization?.run).toContain('RALLAR_OPERATION_STAGE=manifest-materialization');
+    expect(copy?.env?.MANIFEST_PATH).toBe(
+      '${{ steps.manifest_materialization.outputs.manifest_path }}',
+    );
+    expect(render?.env?.RALLAR_BLACK_BOX_ROOM_ID).toBe(
+      '${{ steps.manifest_materialization.outputs.group_id }}',
+    );
   });
 
   it('locks complete Hetzner production runs in their callers', async () => {
@@ -310,6 +656,19 @@ describe('Hetzner distributed recipe workflow', () => {
     expect(runnerWorkflow).toContain('RALLAR_WRITE_HEADLESS_ENV=1 ./09-start-headless-workers.sh');
   });
 
+  it('fences topology preparation with the stable source manifest hash', async () => {
+    const workflow = await readFile(path.join(repoRoot, distributedRunnerWorkflowPath), 'utf8');
+
+    expect(workflow).toContain(
+      'RALLAR_SOURCE_MANIFEST_SHA256: ${{ steps.manifest_materialization.outputs.source_manifest_sha256 }}',
+    );
+    expect(workflow).toContain('manifestSha="${RALLAR_SOURCE_MANIFEST_SHA256}"');
+    expect(workflow).toContain('expected_manifest_sha="${RALLAR_SOURCE_MANIFEST_SHA256}"');
+    expect(workflow).not.toContain(
+      'sha256sum "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" | awk',
+    );
+  });
+
   it('rejects topology-specific manifests in the reusable workflow when rollout is disabled', async () => {
     const runnerWorkflow = await readFile(
       path.join(repoRoot, distributedRunnerWorkflowPath),
@@ -447,6 +806,7 @@ describe('Hetzner distributed recipe workflow', () => {
       repoRoot,
       'scripts/github-actions/write-hetzner-operation-report.mjs',
     );
+    const materializationArguments = await writeOperationMaterializationFixture(tmp);
     await execFileAsync('node', [
       scriptPath,
       '--log',
@@ -463,6 +823,7 @@ describe('Hetzner distributed recipe workflow', () => {
       'f6224149a7f613555f935c12efcdcdd0f1a67e53',
       '--manifest',
       supportedMainlineManifestPaths[0],
+      ...materializationArguments,
       '--control-run-id',
       'main-30314398600-1-prepare',
       '--distributed-run-id',
@@ -479,7 +840,7 @@ describe('Hetzner distributed recipe workflow', () => {
       await readFile(path.join(outputDir, 'operation-report.json'), 'utf8'),
     );
     expect(report).toEqual({
-      schemaVersion: 1,
+      schemaVersion: 2,
       status: 'failed',
       phase: 'prepare',
       stage: 'playwright-system-dependencies',
@@ -488,6 +849,13 @@ describe('Hetzner distributed recipe workflow', () => {
       exitCode: 100,
       commitSha: 'f6224149a7f613555f935c12efcdcdd0f1a67e53',
       manifestPath: supportedMainlineManifestPaths[0],
+      materializationStatus: 'succeeded',
+      groupIsolationMode: 'isolated',
+      sourceGroupRef: operationSourceGroupRef,
+      effectiveGroupRef: operationEffectiveGroupRef,
+      sourceManifestSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      materializedManifestSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      materializedManifestAvailable: true,
       controlRunId: 'main-30314398600-1-prepare',
       distributedRunId: 'dist-main-30314398600-1-prepare',
       distributedArtifactAvailable: false,
@@ -502,6 +870,13 @@ describe('Hetzner distributed recipe workflow', () => {
     const evidence = await readFile(path.join(outputDir, 'evidence.log'), 'utf8');
     expect(summary).toContain('The distributed recipe did not start.');
     expect(summary).toContain('NodeSource apt repository');
+    expect(summary).toContain(operationEffectiveGroupRef.groupId);
+    await expect(
+      readFile(path.join(outputDir, 'materialized-manifest.json'), 'utf8'),
+    ).resolves.toContain(operationEffectiveGroupRef.groupId);
+    await expect(
+      readFile(path.join(outputDir, 'manifest-materialization.json'), 'utf8'),
+    ).resolves.toContain('materializedManifestSha256');
     expect(evidence).toContain('403  Forbidden');
     expect(evidence).not.toContain('secret-token');
     expect(evidence).not.toContain('secret-password');
@@ -510,6 +885,8 @@ describe('Hetzner distributed recipe workflow', () => {
 
   it('classifies browser, deployment, service, agent, and recipe operation stages', async () => {
     const cases = [
+      ['manifest-materialization', 'manifest-scope', false],
+      ['manifest-scope-validation', 'manifest-scope', false],
       ['playwright-system-dependencies', 'browser-dependencies', false],
       ['playwright-browser-install', 'browser-installation', false],
       ['playwright-browser-smoke', 'browser-verification', false],
@@ -533,6 +910,7 @@ describe('Hetzner distributed recipe workflow', () => {
           '\n',
         ),
       );
+      const materializationArguments = await writeOperationMaterializationFixture(tmp);
 
       await execFileAsync('node', [
         scriptPath,
@@ -550,6 +928,7 @@ describe('Hetzner distributed recipe workflow', () => {
         'f6224149a7f613555f935c12efcdcdd0f1a67e53',
         '--manifest',
         supportedMainlineManifestPaths[0],
+        ...materializationArguments,
         '--control-run-id',
         'controlled-run',
         '--distributed-run-id',
@@ -570,6 +949,75 @@ describe('Hetzner distributed recipe workflow', () => {
     }
   });
 
+  it('keeps diagnostics complete when manifest materialization fails before output exists', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'rallar-operation-materialization-failure-'));
+    const logPath = path.join(tmp, 'operation.log');
+    const outputDir = path.join(tmp, 'diagnostics');
+    await writeFile(
+      logPath,
+      'RALLAR_OPERATION_STAGE=manifest-materialization\nManifest scope is inconsistent.\n',
+    );
+
+    await execFileAsync('node', [
+      path.join(repoRoot, 'scripts/github-actions/write-hetzner-operation-report.mjs'),
+      '--log',
+      logPath,
+      '--output-dir',
+      outputDir,
+      '--status',
+      'failed',
+      '--phase',
+      'run',
+      '--exit-code',
+      '1',
+      '--commit',
+      'f6224149a7f613555f935c12efcdcdd0f1a67e53',
+      '--manifest',
+      supportedMainlineManifestPaths[0],
+      '--materialization-record',
+      path.join(tmp, 'missing-record.json'),
+      '--materialized-manifest',
+      path.join(tmp, 'missing-manifest.json'),
+      '--control-run-id',
+      'controlled-run',
+      '--distributed-run-id',
+      'dist-controlled-run',
+      '--artifact-available',
+      'false',
+      '--started-at',
+      '2026-07-28T00:00:00.000Z',
+      '--finished-at',
+      '2026-07-28T00:01:00.000Z',
+    ]);
+
+    const report = JSON.parse(
+      await readFile(path.join(outputDir, 'operation-report.json'), 'utf8'),
+    );
+    expect(report).toMatchObject({
+      schemaVersion: 2,
+      failureCategory: 'manifest-scope',
+      materializationStatus: 'failed',
+      groupIsolationMode: 'unresolved',
+      sourceGroupRef: {
+        applicationId: 'unavailable',
+        workspaceId: 'unavailable',
+        groupId: 'unavailable',
+      },
+      effectiveGroupRef: {
+        applicationId: 'unavailable',
+        workspaceId: 'unavailable',
+        groupId: 'unavailable',
+      },
+      sourceManifestSha256: 'unavailable',
+      materializedManifestSha256: 'unavailable',
+      materializedManifestAvailable: false,
+      recipeStarted: false,
+    });
+    await expect(
+      readFile(path.join(outputDir, 'manifest-materialization.json'), 'utf8'),
+    ).resolves.toContain('"status": "failed"');
+  });
+
   it('classifies absent run artifacts without replacing the successful remote exit code', async () => {
     const tmp = await mkdtemp(path.join(tmpdir(), 'rallar-operation-missing-artifacts-'));
     const logPath = path.join(tmp, 'operation.log');
@@ -588,6 +1036,7 @@ describe('Hetzner distributed recipe workflow', () => {
       repoRoot,
       'scripts/github-actions/write-hetzner-operation-report.mjs',
     );
+    const materializationArguments = await writeOperationMaterializationFixture(tmp);
 
     await execFileAsync('node', [
       scriptPath,
@@ -605,6 +1054,7 @@ describe('Hetzner distributed recipe workflow', () => {
       'f6224149a7f613555f935c12efcdcdd0f1a67e53',
       '--manifest',
       supportedMainlineManifestPaths[0],
+      ...materializationArguments,
       '--control-run-id',
       'controlled-run',
       '--distributed-run-id',
@@ -2005,6 +2455,38 @@ describe('Hetzner distributed recipe workflow', () => {
     expect(body.manifest.recipes[0].recipe.commands).toHaveLength(2);
   });
 
+  it('validates the remote manifest against the worker and run environment', async () => {
+    const scriptPath = path.join(
+      repoRoot,
+      'scripts/hetzner/controller/14-run-distributed-recipe.sh',
+    );
+    const manifestPath = path.join(
+      repoRoot,
+      'apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json',
+    );
+    const environment = {
+      ...process.env,
+      RALLAR_DISTRIBUTED_SCRIPT_SELF_TEST: 'validate-manifest-scope',
+      RALLAR_DISTRIBUTED_MANIFEST_PATH: manifestPath,
+      RALLAR_DISTRIBUTED_RUN_ID: 'hetzner-rtc-smoke-2-agent',
+      RALLAR_DISTRIBUTED_CONTROL_RUN_ID: 'hetzner-manifest-template-control-run',
+      RALLAR_BLACK_BOX_APPLICATION_ID: 'rallar-server',
+      RALLAR_BLACK_BOX_WORKSPACE_ID: 'default',
+      RALLAR_BLACK_BOX_ROOM_ID: 'hetzner-headless-room',
+    };
+
+    await expect(execFileAsync('bash', [scriptPath], { env: environment })).resolves.toMatchObject({
+      stdout: expect.stringContaining('manifestScope=valid'),
+    });
+    await expect(
+      execFileAsync('bash', [scriptPath], {
+        env: { ...environment, RALLAR_BLACK_BOX_ROOM_ID: 'wrong-room' },
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining('Manifest group does not match worker scope'),
+    });
+  });
+
   it('preserves failed control POST response bodies for artifact evidence', async () => {
     const tmp = await mkdtemp(path.join(tmpdir(), 'rallar-control-post-failure-'));
     const fakeCurl = path.join(tmp, 'curl');
@@ -2230,8 +2712,6 @@ describe('Hetzner distributed recipe workflow', () => {
       '-f',
       'agent_count=2',
       '-f',
-      'room_id=hetzner-headless-room',
-      '-f',
       'application_id=rallar-server',
       '-f',
       'workspace_id=default',
@@ -2263,6 +2743,7 @@ describe('Hetzner distributed recipe workflow', () => {
     expect(stdout).toContain('Dispatched hetzner-distributed-recipe.yml');
     expect(stdout).toContain('03-rtc-smoke-2-agent.json');
     expect(stdout).toContain('Mode     : rollout');
+    expect(stdout).toContain('Room     : isolated per run');
     expect(stdout).toContain('Entry    : headless');
     expect(stdout).toContain('Browser  : chromium');
     expect(stdout).toContain('Register : true');
@@ -2357,6 +2838,8 @@ describe('Hetzner distributed recipe workflow', () => {
         '0',
         '--register-before-login',
         'false',
+        '--room-id',
+        'operator-room',
         '--ready-timeout-seconds',
         '45',
         '--terminal-timeout-seconds',
@@ -2382,11 +2865,13 @@ describe('Hetzner distributed recipe workflow', () => {
     expect(args).toContain('npm_ci=true');
     expect(args).toContain('wait_for_agents=false');
     expect(args).toContain('register_before_login=false');
+    expect(args).toContain('room_id=operator-room');
     expect(args).toContain('ready_timeout_seconds=45');
     expect(args).toContain('terminal_timeout_seconds=90');
     expect(args).toContain('stop_after_run=false');
     expect(stdout).toContain('Mode     : custom');
     expect(stdout).toContain('Register : false');
+    expect(stdout).toContain('Room     : operator-room (explicit)');
     expect(stdout).toContain('Stop headless: false');
   });
 

--- a/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
+++ b/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
@@ -506,6 +506,12 @@ describe('Hetzner distributed manifest catalog', () => {
         expect(JSON.stringify(parity?.manifest)).toContain('{rtc.readyPeerIds}');
         expect(JSON.stringify(parity?.manifest)).not.toContain('bob-session');
         expect(JSON.stringify(parity?.manifest)).not.toContain('charlie-session');
+        expect(parity?.manifest.recipes[0]?.recipe.commands.find(command =>
+            command.kind === 'rtc.connect'
+        )).toMatchObject({
+            timeoutMs: 15_000,
+            readiness: { timeoutMs: 10_000 },
+        });
     });
 
     it('feeds Hetzner CI artifacts into SPA monitor and RTC performance views', () => {

--- a/packages/tests/shared-test/rallar-bb-test-recipe-fixtures.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-recipe-fixtures.test.ts
@@ -75,6 +75,10 @@ describe('rallar-bb-test recipe fixtures', () => {
             durationSeconds: 30,
             frameCount: 600,
         });
+        expect(senderConnect).toMatchObject({
+            timeoutMs: 50_000,
+            readiness: { timeoutMs: 45_000 },
+        });
         expect((sender.metadata as Record<string, unknown>).expectedInboundMessages).toBeUndefined();
         expect((sender.metadata as Record<string, unknown>).minExpectedInboundMessages).toBeUndefined();
         expect(receiver.metadata).toMatchObject({
@@ -285,6 +289,7 @@ describe('rallar-bb-test recipe fixtures', () => {
 
         expect(connect).toMatchObject({
             kind: 'rtc.connect',
+            timeoutMs: 15_000,
             readiness: {
                 minReadyPeers: 1,
                 timeoutMs: 10_000,
@@ -340,6 +345,7 @@ describe('rallar-bb-test recipe fixtures', () => {
         });
         expect(connect).toMatchObject({
             kind: 'rtc.connect',
+            timeoutMs: 15_000,
             readiness: {
                 minReadyPeers: 1,
                 timeoutMs: 10_000,

--- a/plans/hetzner-per-run-group-isolation-plan.md
+++ b/plans/hetzner-per-run-group-isolation-plan.md
@@ -1,0 +1,79 @@
+# Hetzner Per-Run Group Isolation
+
+Status: Implementation and review findings addressed on
+`codex/hetzner-per-run-group-isolation`. Final repository and publication
+gates remain required for the exact feature commit.
+
+## Goal
+
+Make every spawned Hetzner recipe independent from database state left by
+earlier runs without resetting the database. Materialize one deterministic,
+unique group scope per workflow run attempt, bind workers and every executable
+manifest reference to that scope, retain completed groups for normal expiry,
+and expose the source and effective scopes in human-readable diagnostics.
+
+## Implementation
+
+- [x] Materialize a run-specific manifest without modifying the checked-in
+      source manifest.
+- [x] Isolate blank-room Hetzner runs; preserve explicit room overrides and
+      preserve manifest groups for external-agent runs.
+- [x] Validate every executable manifest identity before worker startup and
+      reject a mismatch rather than partially rewriting it remotely.
+- [x] Use the same materialized manifest as the worker and distributed-run
+      scope authority.
+- [x] Nest RTC command completion timeouts five seconds outside their readiness
+      timeout and regenerate checked-in manifests.
+- [x] Extend operation diagnostics to schema v2 with source/effective groups,
+      isolation mode, both manifest hashes, the materialized manifest, and a
+      distinct manifest-scope failure category.
+- [x] Update operator guidance and controller documentation.
+- [ ] Pass focused tests and `npm run check:repo-style` on the final tree.
+- [ ] Pass `npm run test:unit`, `npm run test:ci`, and `npm run build` on the
+      unchanged final tree. Earlier passes predate the final review fixes and
+      are intentionally not accepted as final evidence.
+- [ ] Publish a draft pull request and pass Branch Release Gate on the exact
+      feature commit.
+- [ ] After review and integration, pass Run Hetzner Supported Distributed
+      Manifests on the exact default-branch commit.
+
+## Design Decisions
+
+- Do not reset the database between recipes. Isolation comes from a fresh group
+  identity, so recipes remain valid against persistent or in-memory storage and
+  cannot erase unrelated state.
+- Derive the isolated group from repository, workflow run id and attempt,
+  control run id, source manifest hash, and source `GroupRef`. The same inputs
+  reproduce the same group; a rerun attempt receives a different group.
+- An explicit `room_id` is an operator request for a stable shared group and is
+  therefore never replaced. External and mixed no-spawn use preserves the
+  complete checked-in `GroupRef` when no override is supplied; workflow
+  application/workspace defaults cannot rewrite it.
+- Fence split topology preparation with the source-manifest hash. The
+  materialized hash intentionally changes with run/control identifiers and is
+  therefore diagnostic evidence, not a prepare/run compatibility key.
+- Do not delete completed run groups. Existing lifecycle and expiry behavior is
+  authoritative; retained scope and hashes improve post-run investigation.
+
+## Verification Evidence
+
+- Baseline focused suite: 4 files and 107 tests passed.
+- TDD red runs proved the materializer, timeout nesting, workflow integration,
+  and diagnostics-v2 contract were absent.
+- Pre-review focused implementation, fixture, Hetzner/world-fleet
+  generated-manifest, provider-parity, and skill-integrity suite: 6 files and
+  173 tests passed.
+- Pre-review `npm run check:repo-style` passed with the repository's existing
+  warning-only findings.
+- Pre-review `npm run test:unit` passed: 552 files passed, 4 skipped; 5,540 tests passed,
+  18 skipped.
+- Pre-review `npm run test:ci` passed after an outside-sandbox rerun allowed its required
+  local IPC sockets and loopback listeners. The first complete attempt exposed
+  a missing lockfile-declared peer package in the worktree install; reinstalling
+  workspace dependencies from the unchanged lockfile corrected the environment.
+- Pre-review `npm run build` passed for every workspace. Existing bundle-size notices were
+  warning-only.
+- Final review found three important scope/fencing gaps. Regression tests now
+  cover embedded executable paths/request identities, stable source-hash
+  topology fencing, and full-`GroupRef` preservation; the focused workflow
+  suite passes 85 tests after the fixes.

--- a/scripts/github-actions/hetzner-operation-report.schema.json
+++ b/scripts/github-actions/hetzner-operation-report.schema.json
@@ -16,6 +16,13 @@
     "controlRunId",
     "distributedRunId",
     "distributedArtifactAvailable",
+    "materializationStatus",
+    "groupIsolationMode",
+    "sourceGroupRef",
+    "effectiveGroupRef",
+    "sourceManifestSha256",
+    "materializedManifestSha256",
+    "materializedManifestAvailable",
     "recipeStarted",
     "startedAt",
     "finishedAt",
@@ -23,7 +30,7 @@
     "nextAction"
   ],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "status": { "enum": ["succeeded", "failed"] },
     "phase": { "enum": ["full", "prepare", "run"] },
     "stage": { "type": "string", "minLength": 1 },
@@ -35,10 +42,29 @@
     "controlRunId": { "type": "string", "minLength": 1 },
     "distributedRunId": { "type": "string", "minLength": 1 },
     "distributedArtifactAvailable": { "type": "boolean" },
+    "materializationStatus": { "enum": ["succeeded", "failed"] },
+    "groupIsolationMode": { "enum": ["isolated", "explicit", "preserved", "unresolved"] },
+    "sourceGroupRef": { "$ref": "#/$defs/groupRef" },
+    "effectiveGroupRef": { "$ref": "#/$defs/groupRef" },
+    "sourceManifestSha256": { "type": "string", "minLength": 1 },
+    "materializedManifestSha256": { "type": "string", "minLength": 1 },
+    "materializedManifestAvailable": { "type": "boolean" },
     "recipeStarted": { "type": "boolean" },
     "startedAt": { "type": "string", "format": "date-time" },
     "finishedAt": { "type": "string", "format": "date-time" },
     "evidenceExcerpt": { "type": "string" },
     "nextAction": { "type": "string", "minLength": 1 }
+  },
+  "$defs": {
+    "groupRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["applicationId", "workspaceId", "groupId"],
+      "properties": {
+        "applicationId": { "type": "string", "minLength": 1 },
+        "workspaceId": { "type": "string", "minLength": 1 },
+        "groupId": { "type": "string", "minLength": 1 }
+      }
+    }
   }
 }

--- a/scripts/github-actions/materialize-hetzner-run-manifest.mjs
+++ b/scripts/github-actions/materialize-hetzner-run-manifest.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const argumentNames = [
+  'source',
+  'output',
+  'record-output',
+  'agent-source',
+  'operator-phase',
+  'control-run-id',
+  'distributed-run-id',
+  'repository',
+  'workflow-run-id',
+  'workflow-run-attempt',
+  'application-id',
+  'workspace-id',
+  'room-id',
+];
+
+const identityFieldNames = new Set(['applicationId', 'workspaceId', 'groupId', 'roomId']);
+
+function readArguments(values) {
+  const argumentsByName = new Map();
+
+  for (let index = 0; index < values.length; index += 2) {
+    const name = values[index]?.replace(/^--/, '');
+    const value = values[index + 1];
+    if (!name || value === undefined) {
+      throw new Error(`Expected --name value arguments; received ${values.join(' ')}`);
+    }
+    argumentsByName.set(name, value);
+  }
+
+  for (const name of argumentNames) {
+    if (!argumentsByName.has(name)) {
+      throw new Error(`Missing required argument --${name}`);
+    }
+  }
+
+  return argumentsByName;
+}
+
+function readRequiredString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function readGroupRef(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+
+  return {
+    applicationId: readRequiredString(value.applicationId, `${label}.applicationId`),
+    workspaceId: readRequiredString(value.workspaceId, `${label}.workspaceId`),
+    groupId: readRequiredString(value.groupId, `${label}.groupId`),
+  };
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function computeIsolatedGroupId(input) {
+  const canonicalIdentity = JSON.stringify({
+    namespace: 'rallar-hetzner-run-group-v1',
+    repository: input.repository,
+    workflowRunId: input.workflowRunId,
+    workflowRunAttempt: input.workflowRunAttempt,
+    controlRunId: input.controlRunId,
+    sourceManifestSha256: input.sourceManifestSha256,
+    sourceGroupRef: input.sourceGroupRef,
+  });
+
+  return `hetzner-run-${sha256(canonicalIdentity)}`;
+}
+
+function validateAgentSource(value) {
+  if (!['hetzner', 'external', 'mixed'].includes(value)) {
+    throw new Error(`agent-source must be hetzner, external, or mixed; received ${value}`);
+  }
+}
+
+function validateOperatorPhase(value) {
+  if (!['full', 'prepare', 'run'].includes(value)) {
+    throw new Error(`operator-phase must be full, prepare, or run; received ${value}`);
+  }
+}
+
+function resolveEffectiveGroup(input) {
+  if (input.roomId.length > 0) {
+    return {
+      isolationMode: 'explicit',
+      effectiveGroupRef: {
+        applicationId: input.applicationId || input.sourceGroupRef.applicationId,
+        workspaceId: input.workspaceId || input.sourceGroupRef.workspaceId,
+        groupId: input.roomId,
+      },
+    };
+  }
+
+  if (input.agentSource === 'hetzner' && input.operatorPhase !== 'prepare') {
+    return {
+      isolationMode: 'isolated',
+      effectiveGroupRef: {
+        applicationId: input.applicationId || input.sourceGroupRef.applicationId,
+        workspaceId: input.workspaceId || input.sourceGroupRef.workspaceId,
+        groupId: computeIsolatedGroupId(input),
+      },
+    };
+  }
+
+  return {
+    isolationMode: 'preserved',
+    effectiveGroupRef: input.sourceGroupRef,
+  };
+}
+
+function decodePathSegment(value, location, issues) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    issues.push(`${location} contains an invalid URI-encoded identity segment ${JSON.stringify(value)}`);
+    return value;
+  }
+}
+
+function validateEmbeddedPathScope(value, expectedGroupRef, location) {
+  if (!value.startsWith('/api/state/apps/')) {
+    return [];
+  }
+
+  const issues = [];
+  const match = value.match(
+    /^\/api\/state\/apps\/([^/]+)\/workspaces\/([^/]+)\/groups(?:\/([^/]+))?(?:\/|$)/,
+  );
+  if (!match) {
+    return [`${location} has an unrecognized state group path ${JSON.stringify(value)}`];
+  }
+
+  const applicationId = decodePathSegment(match[1], location, issues);
+  const workspaceId = decodePathSegment(match[2], location, issues);
+  const groupId = match[3] === undefined ? undefined : decodePathSegment(match[3], location, issues);
+  if (applicationId !== expectedGroupRef.applicationId) {
+    issues.push(
+      `${location} contains application ${JSON.stringify(applicationId)}; expected ${JSON.stringify(expectedGroupRef.applicationId)}`,
+    );
+  }
+  if (workspaceId !== expectedGroupRef.workspaceId) {
+    issues.push(
+      `${location} contains workspace ${JSON.stringify(workspaceId)}; expected ${JSON.stringify(expectedGroupRef.workspaceId)}`,
+    );
+  }
+  if (groupId !== undefined && groupId !== expectedGroupRef.groupId) {
+    issues.push(
+      `${location} contains group ${JSON.stringify(groupId)}; expected ${JSON.stringify(expectedGroupRef.groupId)}`,
+    );
+  }
+  return issues;
+}
+
+function validateEmbeddedRequestScope(value, expectedGroupRef, location) {
+  const marker = value.includes(':ensure-group:')
+    ? ':ensure-group:'
+    : value.includes(':ensure-member:')
+      ? ':ensure-member:'
+      : undefined;
+  if (!marker) {
+    return [];
+  }
+
+  const scope = value.slice(value.indexOf(marker) + marker.length).split(':');
+  const expectedScope = [
+    expectedGroupRef.applicationId,
+    expectedGroupRef.workspaceId,
+    expectedGroupRef.groupId,
+  ];
+  if (scope.length < expectedScope.length) {
+    return [`${location} has an incomplete scoped request identity ${JSON.stringify(value)}`];
+  }
+
+  return expectedScope.flatMap((expected, index) =>
+    scope[index] === expected
+      ? []
+      : [
+          `${location} contains scoped request identity ${JSON.stringify(value)}; expected ${JSON.stringify(expectedGroupRef)}`,
+        ],
+  );
+}
+
+function validateEmbeddedScope(value, key, expectedGroupRef, location) {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  if (key === 'path') {
+    return validateEmbeddedPathScope(value, expectedGroupRef, location);
+  }
+  if (key === 'requestId' || key.toLowerCase() === 'idempotency-key') {
+    return validateEmbeddedRequestScope(value, expectedGroupRef, location);
+  }
+  return [];
+}
+
+function validateManifestScope(value, expectedGroupRef, location = '$') {
+  const issues = [];
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      issues.push(...validateManifestScope(entry, expectedGroupRef, `${location}[${index}]`));
+    });
+    return issues;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return issues;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    const entryLocation = `${location}.${key}`;
+    issues.push(...validateEmbeddedScope(entry, key, expectedGroupRef, entryLocation));
+    if (identityFieldNames.has(key) && typeof entry === 'string') {
+      const expected =
+        key === 'applicationId'
+          ? expectedGroupRef.applicationId
+          : key === 'workspaceId'
+            ? expectedGroupRef.workspaceId
+            : expectedGroupRef.groupId;
+      if (entry !== expected) {
+        issues.push(
+          `${entryLocation} is ${JSON.stringify(entry)}; expected ${JSON.stringify(expected)}`,
+        );
+      }
+    }
+    issues.push(...validateManifestScope(entry, expectedGroupRef, entryLocation));
+  }
+
+  return issues;
+}
+
+function toEmbeddedScope(value, sourceGroupRef, effectiveGroupRef, key) {
+  if (key === 'path') {
+    const sourcePrefix =
+      `/apps/${encodeURIComponent(sourceGroupRef.applicationId)}` +
+      `/workspaces/${encodeURIComponent(sourceGroupRef.workspaceId)}/groups`;
+    const effectivePrefix =
+      `/apps/${encodeURIComponent(effectiveGroupRef.applicationId)}` +
+      `/workspaces/${encodeURIComponent(effectiveGroupRef.workspaceId)}/groups`;
+    return value
+      .replaceAll(sourcePrefix, effectivePrefix)
+      .replaceAll(
+        `/${encodeURIComponent(sourceGroupRef.groupId)}`,
+        `/${encodeURIComponent(effectiveGroupRef.groupId)}`,
+      );
+  }
+
+  const sourceRequestScope =
+    `:${sourceGroupRef.applicationId}:` +
+    `${sourceGroupRef.workspaceId}:${sourceGroupRef.groupId}:`;
+  const effectiveRequestScope =
+    `:${effectiveGroupRef.applicationId}:` +
+    `${effectiveGroupRef.workspaceId}:${effectiveGroupRef.groupId}:`;
+  return value
+    .replaceAll(sourceRequestScope, effectiveRequestScope)
+    .replaceAll(sourceGroupRef.groupId, effectiveGroupRef.groupId);
+}
+
+function toEffectiveScope(value, sourceGroupRef, effectiveGroupRef, key = '') {
+  if (Array.isArray(value)) {
+    return value.map((entry) => toEffectiveScope(entry, sourceGroupRef, effectiveGroupRef));
+  }
+
+  if (!value || typeof value !== 'object') {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    return toEmbeddedScope(value, sourceGroupRef, effectiveGroupRef, key);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([entryKey, entry]) => {
+      if (entryKey === 'applicationId' && entry === sourceGroupRef.applicationId) {
+        return [entryKey, effectiveGroupRef.applicationId];
+      }
+      if (entryKey === 'workspaceId' && entry === sourceGroupRef.workspaceId) {
+        return [entryKey, effectiveGroupRef.workspaceId];
+      }
+      if ((entryKey === 'groupId' || entryKey === 'roomId') && entry === sourceGroupRef.groupId) {
+        return [entryKey, effectiveGroupRef.groupId];
+      }
+      return [entryKey, toEffectiveScope(entry, sourceGroupRef, effectiveGroupRef, entryKey)];
+    }),
+  );
+}
+
+async function writeAtomic(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, value);
+  await rename(temporaryPath, filePath);
+}
+
+export async function materializeHetznerRunManifest(input) {
+  const sourceText = await readFile(input.sourcePath, 'utf8');
+  const sourceManifest = JSON.parse(sourceText);
+  const sourceGroupRef = readGroupRef(sourceManifest.group, 'manifest.group');
+  const sourceIssues = validateManifestScope(sourceManifest, sourceGroupRef);
+  if (sourceIssues.length > 0) {
+    throw new Error(`Source manifest scope is inconsistent:\n- ${sourceIssues.join('\n- ')}`);
+  }
+
+  const sourceManifestSha256 = sha256(sourceText);
+  const effective = resolveEffectiveGroup({
+    ...input,
+    sourceGroupRef,
+    sourceManifestSha256,
+  });
+  const scopedManifest = toEffectiveScope(
+    sourceManifest,
+    sourceGroupRef,
+    effective.effectiveGroupRef,
+  );
+  const manifest = {
+    ...scopedManifest,
+    distributedRunId: input.distributedRunId,
+    controlRunId: input.controlRunId,
+    metadata: {
+      ...(scopedManifest.metadata ?? {}),
+      runIsolation: {
+        schemaVersion: 1,
+        isolationMode: effective.isolationMode,
+        effectiveGroupRef: effective.effectiveGroupRef,
+        workflowRunId: input.workflowRunId,
+        workflowRunAttempt: input.workflowRunAttempt,
+      },
+    },
+  };
+  const effectiveIssues = validateManifestScope(manifest, effective.effectiveGroupRef);
+  if (effectiveIssues.length > 0) {
+    throw new Error(
+      `Materialized manifest scope is inconsistent:\n- ${effectiveIssues.join('\n- ')}`,
+    );
+  }
+
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const record = {
+    schemaVersion: 1,
+    isolationMode: effective.isolationMode,
+    sourceGroupRef,
+    effectiveGroupRef: effective.effectiveGroupRef,
+    sourceManifestSha256,
+    materializedManifestSha256: sha256(manifestText),
+  };
+
+  await writeAtomic(input.outputPath, manifestText);
+  await writeAtomic(input.recordOutputPath, `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
+
+async function main() {
+  const argumentsByName = readArguments(process.argv.slice(2));
+  const agentSource = argumentsByName.get('agent-source');
+  const operatorPhase = argumentsByName.get('operator-phase');
+  validateAgentSource(agentSource);
+  validateOperatorPhase(operatorPhase);
+
+  const record = await materializeHetznerRunManifest({
+    sourcePath: argumentsByName.get('source'),
+    outputPath: argumentsByName.get('output'),
+    recordOutputPath: argumentsByName.get('record-output'),
+    agentSource,
+    operatorPhase,
+    controlRunId: readRequiredString(argumentsByName.get('control-run-id'), 'control-run-id'),
+    distributedRunId: readRequiredString(
+      argumentsByName.get('distributed-run-id'),
+      'distributed-run-id',
+    ),
+    repository: readRequiredString(argumentsByName.get('repository'), 'repository'),
+    workflowRunId: readRequiredString(argumentsByName.get('workflow-run-id'), 'workflow-run-id'),
+    workflowRunAttempt: readRequiredString(
+      argumentsByName.get('workflow-run-attempt'),
+      'workflow-run-attempt',
+    ),
+    applicationId: argumentsByName.get('application-id'),
+    workspaceId: argumentsByName.get('workspace-id'),
+    roomId: argumentsByName.get('room-id'),
+  });
+
+  process.stdout.write(`${JSON.stringify(record)}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/github-actions/write-hetzner-operation-report.mjs
+++ b/scripts/github-actions/write-hetzner-operation-report.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const argumentNames = [
@@ -16,7 +17,15 @@ const argumentNames = [
   'artifact-available',
   'started-at',
   'finished-at',
+  'materialization-record',
+  'materialized-manifest',
 ];
+
+const unavailableGroupRef = Object.freeze({
+  applicationId: 'unavailable',
+  workspaceId: 'unavailable',
+  groupId: 'unavailable',
+});
 
 function readArguments(values) {
   const argumentsByName = new Map();
@@ -61,6 +70,74 @@ function readOperationStage(log) {
   return stages.at(-1)?.[1] ?? 'unknown';
 }
 
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function readGroupRef(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const result = {
+    applicationId: value.applicationId,
+    workspaceId: value.workspaceId,
+    groupId: value.groupId,
+  };
+  return Object.values(result).every((entry) => typeof entry === 'string' && entry.length > 0)
+    ? result
+    : null;
+}
+
+async function readMaterialization(recordPath, manifestPath) {
+  const recordText = await readFile(recordPath, 'utf8').catch(() => null);
+  const manifestText = await readFile(manifestPath, 'utf8').catch(() => null);
+  const unavailable = {
+    materializationStatus: 'failed',
+    groupIsolationMode: 'unresolved',
+    sourceGroupRef: unavailableGroupRef,
+    effectiveGroupRef: unavailableGroupRef,
+    sourceManifestSha256: 'unavailable',
+    materializedManifestSha256: 'unavailable',
+    materializedManifestAvailable: manifestText !== null,
+    record: null,
+  };
+  if (recordText === null || manifestText === null) {
+    return unavailable;
+  }
+
+  try {
+    const record = JSON.parse(recordText);
+    const manifest = JSON.parse(manifestText);
+    const sourceGroupRef = readGroupRef(record.sourceGroupRef);
+    const effectiveGroupRef = readGroupRef(record.effectiveGroupRef);
+    const manifestGroupRef = readGroupRef(manifest.group);
+    const validMode = ['isolated', 'explicit', 'preserved'].includes(record.isolationMode);
+    const validHashes =
+      /^[a-f0-9]{64}$/.test(record.sourceManifestSha256) &&
+      /^[a-f0-9]{64}$/.test(record.materializedManifestSha256);
+    const manifestMatches =
+      manifestGroupRef !== null &&
+      effectiveGroupRef !== null &&
+      JSON.stringify(manifestGroupRef) === JSON.stringify(effectiveGroupRef) &&
+      sha256(manifestText) === record.materializedManifestSha256;
+    if (!sourceGroupRef || !effectiveGroupRef || !validMode || !validHashes || !manifestMatches) {
+      return unavailable;
+    }
+    return {
+      materializationStatus: 'succeeded',
+      groupIsolationMode: record.isolationMode,
+      sourceGroupRef,
+      effectiveGroupRef,
+      sourceManifestSha256: record.sourceManifestSha256,
+      materializedManifestSha256: record.materializedManifestSha256,
+      materializedManifestAvailable: true,
+      record,
+    };
+  } catch {
+    return unavailable;
+  }
+}
+
 function classifyFailure({ status, stage, log, missingArtifacts }) {
   if (missingArtifacts) {
     return {
@@ -89,6 +166,17 @@ function classifyFailure({ status, stage, log, missingArtifacts }) {
   }
 
   const classifications = {
+    'manifest-materialization': {
+      failureCategory: 'manifest-scope',
+      component: 'Hetzner run manifest materialization',
+      nextAction: 'Inspect the source and effective group scope in the operation artifacts.',
+    },
+    'manifest-scope-validation': {
+      failureCategory: 'manifest-scope',
+      component: 'Hetzner run manifest scope',
+      nextAction:
+        'Compare the materialized manifest group with the worker scope and run identifiers.',
+    },
     'playwright-system-dependencies': {
       failureCategory: 'browser-dependencies',
       component: 'Playwright system dependencies',
@@ -166,6 +254,11 @@ function toSummary(report) {
     `| Commit | \`${report.commitSha}\` |`,
     `| Control run | \`${report.controlRunId}\` |`,
     `| Distributed run | \`${report.distributedRunId}\` |`,
+    `| Manifest materialization | ${report.materializationStatus} (${report.groupIsolationMode}) |`,
+    `| Source group | \`${report.sourceGroupRef.applicationId}/${report.sourceGroupRef.workspaceId}/${report.sourceGroupRef.groupId}\` |`,
+    `| Effective group | \`${report.effectiveGroupRef.applicationId}/${report.effectiveGroupRef.workspaceId}/${report.effectiveGroupRef.groupId}\` |`,
+    `| Source manifest SHA-256 | \`${report.sourceManifestSha256}\` |`,
+    `| Materialized manifest SHA-256 | \`${report.materializedManifestSha256}\` |`,
     '',
     `${recipeSentence} ${artifactSentence}`,
     '',
@@ -199,6 +292,10 @@ const distributedArtifactAvailable = readBoolean(
 const missingArtifacts =
   requestedStatus === 'succeeded' && phase !== 'prepare' && !distributedArtifactAvailable;
 const status = missingArtifacts ? 'failed' : requestedStatus;
+const materialization = await readMaterialization(
+  argumentsByName.get('materialization-record'),
+  argumentsByName.get('materialized-manifest'),
+);
 const classification = classifyFailure({
   status,
   stage,
@@ -206,7 +303,7 @@ const classification = classifyFailure({
   missingArtifacts,
 });
 const report = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   status,
   phase,
   stage,
@@ -218,6 +315,13 @@ const report = {
   controlRunId: argumentsByName.get('control-run-id'),
   distributedRunId: argumentsByName.get('distributed-run-id'),
   distributedArtifactAvailable,
+  materializationStatus: materialization.materializationStatus,
+  groupIsolationMode: materialization.groupIsolationMode,
+  sourceGroupRef: materialization.sourceGroupRef,
+  effectiveGroupRef: materialization.effectiveGroupRef,
+  sourceManifestSha256: materialization.sourceManifestSha256,
+  materializedManifestSha256: materialization.materializedManifestSha256,
+  materializedManifestAvailable: materialization.materializedManifestAvailable,
   recipeStarted: /^RALLAR_OPERATION_STAGE=recipe-execution$/m.test(sanitizedLog),
   startedAt: argumentsByName.get('started-at'),
   finishedAt: argumentsByName.get('finished-at'),
@@ -237,3 +341,25 @@ await writeFile(
 );
 await writeFile(path.join(outputDirectory, 'summary.md'), toSummary(report));
 await writeFile(path.join(outputDirectory, 'evidence.log'), `${report.evidenceExcerpt}\n`);
+if (materialization.materializedManifestAvailable) {
+  await copyFile(
+    argumentsByName.get('materialized-manifest'),
+    path.join(outputDirectory, 'materialized-manifest.json'),
+  );
+}
+await writeFile(
+  path.join(outputDirectory, 'manifest-materialization.json'),
+  `${JSON.stringify(
+    materialization.record ?? {
+      schemaVersion: 1,
+      status: 'failed',
+      isolationMode: 'unresolved',
+      sourceGroupRef: unavailableGroupRef,
+      effectiveGroupRef: unavailableGroupRef,
+      sourceManifestSha256: 'unavailable',
+      materializedManifestSha256: 'unavailable',
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/scripts/hetzner/controller/14-run-distributed-recipe.sh
+++ b/scripts/hetzner/controller/14-run-distributed-recipe.sh
@@ -8,6 +8,9 @@ RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS="${RALLAR_DISTRIBUTED_TERMINAL_TIMEO
 RALLAR_DISTRIBUTED_READY_TIMEOUT_SECONDS="${RALLAR_DISTRIBUTED_READY_TIMEOUT_SECONDS:-120}"
 RALLAR_DISTRIBUTED_RUN_ID="${RALLAR_DISTRIBUTED_RUN_ID:-}"
 RALLAR_DISTRIBUTED_CONTROL_RUN_ID="${RALLAR_DISTRIBUTED_CONTROL_RUN_ID:-}"
+RALLAR_BLACK_BOX_APPLICATION_ID="${RALLAR_BLACK_BOX_APPLICATION_ID:-}"
+RALLAR_BLACK_BOX_WORKSPACE_ID="${RALLAR_BLACK_BOX_WORKSPACE_ID:-}"
+RALLAR_BLACK_BOX_ROOM_ID="${RALLAR_BLACK_BOX_ROOM_ID:-}"
 RALLAR_CONTROL_ENV_FILE="${RALLAR_CONTROL_ENV_FILE:-/etc/rallar/control-server.env}"
 
 require_command() {
@@ -418,10 +421,44 @@ build_create_body() {
   jq -n -c --slurpfile manifest "${source_manifest_file}" '{manifest: $manifest[0]}'
 }
 
+validate_manifest_scope() {
+  local manifest_path="$1"
+  local actual_scope
+  actual_scope="$(jq -c '{
+    distributedRunId,
+    controlRunId,
+    applicationId: .group.applicationId,
+    workspaceId: .group.workspaceId,
+    groupId: .group.groupId
+  }' "${manifest_path}")"
+
+  if ! jq -e \
+    --arg distributedRunId "${RALLAR_DISTRIBUTED_RUN_ID}" \
+    --arg controlRunId "${RALLAR_DISTRIBUTED_CONTROL_RUN_ID}" \
+    --arg applicationId "${RALLAR_BLACK_BOX_APPLICATION_ID}" \
+    --arg workspaceId "${RALLAR_BLACK_BOX_WORKSPACE_ID}" \
+    --arg groupId "${RALLAR_BLACK_BOX_ROOM_ID}" \
+    '.distributedRunId == $distributedRunId and
+      .controlRunId == $controlRunId and
+      .group.applicationId == $applicationId and
+      .group.workspaceId == $workspaceId and
+      .group.groupId == $groupId' \
+    "${manifest_path}" >/dev/null; then
+    echo "Manifest group does not match worker scope or run identity. Actual: ${actual_scope}" >&2
+    echo "Expected run=${RALLAR_DISTRIBUTED_RUN_ID}, control=${RALLAR_DISTRIBUTED_CONTROL_RUN_ID}, application=${RALLAR_BLACK_BOX_APPLICATION_ID}, workspace=${RALLAR_BLACK_BOX_WORKSPACE_ID}, group=${RALLAR_BLACK_BOX_ROOM_ID}." >&2
+    return 1
+  fi
+}
+
 run_self_test() {
   require_command jq
 
   case "${RALLAR_DISTRIBUTED_SCRIPT_SELF_TEST}" in
+    validate-manifest-scope)
+      validate_manifest_scope "${RALLAR_DISTRIBUTED_MANIFEST_PATH}"
+      printf 'manifestScope=valid\n'
+      return 0
+      ;;
     create-body)
       if [[ -z "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" ]]; then
         echo "Missing RALLAR_DISTRIBUTED_MANIFEST_PATH for create-body self-test." >&2
@@ -514,20 +551,10 @@ fi
 validate_positive_integer RALLAR_DISTRIBUTED_READY_TIMEOUT_SECONDS "${RALLAR_DISTRIBUTED_READY_TIMEOUT_SECONDS}"
 validate_positive_integer RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS "${RALLAR_DISTRIBUTED_TERMINAL_TIMEOUT_SECONDS}"
 
-manifest_file="$(mktemp /tmp/rallar-distributed-manifest.XXXXXX.json)"
-trap 'rm -f "${manifest_file}"' EXIT
-if [[ -n "${RALLAR_DISTRIBUTED_RUN_ID}" ]]; then
-  jq \
-    --arg runId "${RALLAR_DISTRIBUTED_RUN_ID}" \
-    --arg controlRunId "${RALLAR_DISTRIBUTED_CONTROL_RUN_ID}" \
-    '.distributedRunId = $runId | .controlRunId = (if $controlRunId == "" then (.controlRunId // $runId) else $controlRunId end)' \
-    "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" >"${manifest_file}"
-else
-  jq \
-    --arg controlRunId "${RALLAR_DISTRIBUTED_CONTROL_RUN_ID}" \
-    '.controlRunId = (if $controlRunId == "" then (.controlRunId // .distributedRunId) else $controlRunId end)' \
-    "${RALLAR_DISTRIBUTED_MANIFEST_PATH}" >"${manifest_file}"
-fi
+manifest_file="${RALLAR_DISTRIBUTED_MANIFEST_PATH}"
+echo "RALLAR_OPERATION_STAGE=manifest-scope-validation"
+validate_manifest_scope "${manifest_file}"
+echo "RALLAR_OPERATION_STAGE=recipe-execution"
 
 distributed_run_id="$(jq -r '.distributedRunId // empty' "${manifest_file}")"
 control_run_id="$(jq -r '.controlRunId // .distributedRunId // empty' "${manifest_file}")"

--- a/scripts/hetzner/controller/README.md
+++ b/scripts/hetzner/controller/README.md
@@ -65,6 +65,21 @@ RALLAR_DISTRIBUTED_CONTROL_RUN_ID="${RALLAR_BLACK_BOX_RUN_ID}" \
 ./14-run-distributed-recipe.sh
 ```
 
+The manifest supplied to `14-run-distributed-recipe.sh` must already be the
+workflow's materialized run manifest. Its distributed/control run identifiers
+and top-level group must exactly match the worker environment. The runner
+rejects a mismatch before creating a distributed run.
+
+The supported workflow does not reset the database between recipes. Spawned
+Hetzner runs with no explicit `room_id` receive a deterministic group unique to
+the GitHub workflow run attempt; all worker and executable manifest identities
+are rebound to it before upload. An explicit room remains stable, while
+external, mixed, and no-spawn runs preserve the checked-in manifest group.
+Completed groups are retained for normal server expiry and diagnostics.
+Preservation includes the application and workspace. Split topology
+prepare/run operations compare the stable source-manifest hash rather than the
+run-specific materialized-manifest hash.
+
 Stop the Rallar API/control services:
 
 ```sh

--- a/scripts/hetzner/dispatch-distributed-recipe.sh
+++ b/scripts/hetzner/dispatch-distributed-recipe.sh
@@ -17,6 +17,7 @@ BROWSER_ENGINE="chromium"
 FAST_MODE="0"
 ALLOW_DIAGNOSTIC="0"
 RUN_ID=""
+ROOM_ID=""
 MANIFEST_INPUT=""
 SECRET_ENVIRONMENT="production"
 REQUIRED_GITHUB_SECRETS=(
@@ -42,6 +43,7 @@ Usage: scripts/hetzner/dispatch-distributed-recipe.sh <manifest.json> [options]
 Options:
   --ref <ref>                    Git ref to dispatch. Default: main.
   --run-id <id>                  Control run id. Default: manifest slug + UTC timestamp.
+  --room-id <id>                 Explicit stable room id. Default: isolate each spawned Hetzner run.
   --workflow <name>              Workflow file name. Default: hetzner-distributed-recipe.yml.
   --rollout-before-run <bool>    Pass rollout_before_run. Default: true.
   --install-playwright <bool>    Pass install_playwright. Default: true.
@@ -183,6 +185,11 @@ while [[ $# -gt 0 ]]; do
       RUN_ID="$2"
       shift 2
       ;;
+    --room-id)
+      [[ $# -ge 2 ]] || fail "--room-id requires a value."
+      ROOM_ID="$2"
+      shift 2
+      ;;
     --workflow)
       [[ $# -ge 2 ]] || fail "--workflow requires a value."
       WORKFLOW_NAME="$2"
@@ -314,10 +321,10 @@ if ! [[ "${agent_count}" =~ ^[1-9][0-9]*$ ]]; then
   fail "Manifest targetPolicy.expectedParticipantCount must be a positive integer: ${manifest_path}"
 fi
 
-room_id="$(jq -r '.group.groupId // empty' "${manifest_absolute}")"
+source_room_id="$(jq -r '.group.groupId // empty' "${manifest_absolute}")"
 application_id="$(jq -r '.group.applicationId // empty' "${manifest_absolute}")"
 workspace_id="$(jq -r '.group.workspaceId // empty' "${manifest_absolute}")"
-[[ -n "${room_id}" ]] || fail "Manifest group.groupId is required: ${manifest_path}"
+[[ -n "${source_room_id}" ]] || fail "Manifest group.groupId is required: ${manifest_path}"
 [[ -n "${application_id}" ]] || fail "Manifest group.applicationId is required: ${manifest_path}"
 [[ -n "${workspace_id}" ]] || fail "Manifest group.workspaceId is required: ${manifest_path}"
 
@@ -387,7 +394,11 @@ echo "Ref      : ${REF}"
 echo "Mode     : ${mode}"
 echo "Run ID   : ${safe_run_id}"
 echo "Agents   : ${agent_count}"
-echo "Room     : ${room_id}"
+if [[ -n "${ROOM_ID}" ]]; then
+  echo "Room     : ${ROOM_ID} (explicit)"
+else
+  echo "Room     : isolated per run"
+fi
 echo "Entry    : ${HEADLESS_ENTRY}"
 echo "Browser  : ${BROWSER_ENGINE}"
 echo "Register : ${REGISTER_BEFORE_LOGIN}"
@@ -400,11 +411,16 @@ if [[ "${#rtc_topology_env_lines[@]}" -gt 0 ]]; then
   echo "Topology : ${rtc_topology_env_lines[*]}"
 fi
 
-gh workflow run "${WORKFLOW_NAME}" \
-  --ref "${REF}" \
-  -f "manifest_path=${manifest_path}" \
-  -f "agent_count=${agent_count}" \
-  -f "room_id=${room_id}" \
+workflow_args=(
+  workflow run "${WORKFLOW_NAME}"
+  --ref "${REF}"
+  -f "manifest_path=${manifest_path}"
+  -f "agent_count=${agent_count}"
+)
+if [[ -n "${ROOM_ID}" ]]; then
+  workflow_args+=(-f "room_id=${ROOM_ID}")
+fi
+workflow_args+=(
   -f "application_id=${application_id}" \
   -f "workspace_id=${workspace_id}" \
   -f "register_before_login=${REGISTER_BEFORE_LOGIN}" \
@@ -419,5 +435,8 @@ gh workflow run "${WORKFLOW_NAME}" \
   -f "stop_after_run=${STOP_AFTER_RUN}" \
   -f "ref=${REF}" \
   -f "run_id=${safe_run_id}"
+)
+
+gh "${workflow_args[@]}"
 
 echo "Dispatched ${WORKFLOW_NAME}"


### PR DESCRIPTION
## Summary
- materialize a deterministic, run-attempt-specific GroupRef for spawned Hetzner recipes without resetting the database
- bind workers and executable manifest identities to the materialized scope and publish schema-v2 human diagnostics
- preserve explicit/external scopes, fence split preparation with the source hash, and give RTC readiness a five-second completion margin

## Validation
- npx vitest run focused touched-area tests: 110 passed
- npx vitest run packages/tests/repo/rallar-skill-integrity.test.ts: 55 passed
- npm run check:repo-style: passed with warning-only existing findings
- npm run test:unit: 552 files passed, 4 skipped; 5,541 tests passed, 18 skipped
- npm run test:ci: passed, including Deno, browser, Recipe Console, and memory full-stack suites
- npm run build: passed for all workspaces

## Remaining release gates
- Branch Release Gate must pass for this exact commit
- after integration, Run Hetzner Supported Distributed Manifests must pass on the exact default-branch commit