### PR TITLE
Enforce main-only provider branch controls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  cloudflare-branch-controls:
+    name: Enforce Cloudflare main-only branch controls
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Disable feature-branch Workers and Pages builds
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: node scripts/deploy/configure-cloudflare-main-only.mjs --apply
+
   release-gate:
     name: Release Gate
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_release_gate != true }}

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -31,18 +31,35 @@ Deno job refuses to proceed when its checked-out commit is no longer the remote
 
 ## Cloudflare branch controls
 
-Apply these settings to the `rallar-kit` and `relic-hunters-v1` Workers
-projects:
+The main-only `cloudflare-branch-controls` job applies and verifies these
+settings on every **Deploy Web + API** workflow run. It uses the repository's
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` secrets without printing
+their values. The token must be user-scoped and have **Workers Builds
+Configuration: Edit**, **Workers Scripts: Read**, and the Pages project edit
+permission.
+
+The job reads every expected project before its first mutation. It then removes
+the non-production trigger from the `rallar-kit` and `relic-hunters-v1`
+Workers, preserves one production trigger restricted to `main`, and configures
+the `ar-eye-hunter` Pages project with preview deployments disabled. A missing,
+renamed, ambiguous, or unverifiable project fails the job instead of partially
+applying a guessed configuration.
+
+The resulting settings for both Workers projects are:
 
 - Production branch: `main`
 - Builds for non-production branches: disabled
 
-For the `ar-eye-hunter` Pages project, keep `main` as the production branch and
-set Preview branch to `None` when all Cloudflare checks must be main-only.
+For the `ar-eye-hunter` Pages project, the production branch is `main` and the
+Preview branch setting is `None`.
 
 Verify the next feature-branch push has no `Workers Builds:*` or `Cloudflare
 Pages` check. Do not use commit-message skip directives as a permanent branch
 policy.
+
+If the enforcement job reports an authorization failure, replace
+`CLOUDFLARE_API_TOKEN` with a user-scoped token carrying the permissions above;
+do not broaden the workflow or expose the token in diagnostic output.
 
 ## Deno Deploy cutover
 

--- a/packages/tests/hetzner/cloudflare-main-only-branch-controls.test.ts
+++ b/packages/tests/hetzner/cloudflare-main-only-branch-controls.test.ts
@@ -1,0 +1,183 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const scriptUrl = pathToFileURL(
+  path.join(repoRoot, 'scripts/deploy/configure-cloudflare-main-only.mjs'),
+).href;
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+};
+
+type FakeCloudflareState = {
+  includeAllWorkers: boolean;
+  pagesPreviewSetting: 'all' | 'none';
+  previewTriggerIds: Set<string>;
+  requests: RecordedRequest[];
+};
+
+function cloudflareResponse(status: number, result: unknown): Response {
+  return new Response(JSON.stringify({ success: status < 400, result, errors: [] }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function createFakeFetch(state: FakeCloudflareState): typeof fetch {
+  return async (input, init) => {
+    const url = new URL(typeof input === 'string' ? input : input.url);
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    state.requests.push({ method, path: url.pathname, body });
+
+    if (method === 'GET' && url.pathname === '/accounts/account/workers/scripts') {
+      return cloudflareResponse(200, [
+        { id: 'rallar-kit', tag: 'tag-rallar' },
+        ...(state.includeAllWorkers ? [{ id: 'relic-hunters-v1', tag: 'tag-relic' }] : []),
+      ]);
+    }
+
+    const triggerMatch = url.pathname.match(
+      /^\/accounts\/account\/builds\/workers\/(tag-rallar|tag-relic)\/triggers$/,
+    );
+    if (method === 'GET' && triggerMatch) {
+      const suffix = triggerMatch[1] === 'tag-rallar' ? 'rallar' : 'relic';
+      return cloudflareResponse(200, [
+        {
+          trigger_uuid: `production-${suffix}`,
+          trigger_name: 'Deploy production',
+          branch_includes: ['main'],
+          branch_excludes: [],
+        },
+        ...(state.previewTriggerIds.has(`preview-${suffix}`)
+          ? [
+              {
+                trigger_uuid: `preview-${suffix}`,
+                trigger_name: 'Deploy non-production branches',
+                branch_includes: ['*'],
+                branch_excludes: ['main'],
+              },
+            ]
+          : []),
+      ]);
+    }
+
+    const deleteMatch = url.pathname.match(
+      /^\/accounts\/account\/builds\/triggers\/(preview-(?:rallar|relic))$/,
+    );
+    if (method === 'DELETE' && deleteMatch) {
+      state.previewTriggerIds.delete(deleteMatch[1]);
+      return cloudflareResponse(200, { trigger_uuid: deleteMatch[1] });
+    }
+
+    if (url.pathname === '/accounts/account/pages/projects/ar-eye-hunter') {
+      if (method === 'GET') {
+        return cloudflareResponse(200, {
+          name: 'ar-eye-hunter',
+          production_branch: 'main',
+          source: {
+            type: 'github',
+            config: {
+              production_branch: 'main',
+              production_deployments_enabled: true,
+              preview_deployment_setting: state.pagesPreviewSetting,
+            },
+          },
+        });
+      }
+
+      if (method === 'PATCH') {
+        const payload = body as {
+          source?: { config?: { preview_deployment_setting?: 'all' | 'none' } };
+        };
+        state.pagesPreviewSetting = payload.source?.config?.preview_deployment_setting ?? 'all';
+        return cloudflareResponse(200, payload);
+      }
+    }
+
+    return cloudflareResponse(404, null);
+  };
+}
+
+async function loadCommand(): Promise<{
+  configureCloudflareMainOnly: (input: {
+    accountId: string;
+    apiBaseUrl: string;
+    fetchImpl: typeof fetch;
+    output: (message: string) => void;
+    token: string;
+  }) => Promise<void>;
+}> {
+  return await import(scriptUrl);
+}
+
+describe('Cloudflare main-only branch controls command', () => {
+  it('removes preview Worker triggers and disables Pages preview deployments', async () => {
+    const state: FakeCloudflareState = {
+      includeAllWorkers: true,
+      pagesPreviewSetting: 'all',
+      previewTriggerIds: new Set(['preview-rallar', 'preview-relic']),
+      requests: [],
+    };
+    const output: string[] = [];
+    const { configureCloudflareMainOnly } = await loadCommand();
+
+    await configureCloudflareMainOnly({
+      accountId: 'account',
+      apiBaseUrl: 'https://cloudflare.test',
+      fetchImpl: createFakeFetch(state),
+      output: (message) => output.push(message),
+      token: 'test-token',
+    });
+
+    expect(state.previewTriggerIds).toEqual(new Set());
+    expect(state.pagesPreviewSetting).toBe('none');
+    expect(
+      state.requests
+        .filter((request) => request.method === 'DELETE')
+        .map((request) => request.path),
+    ).toEqual([
+      '/accounts/account/builds/triggers/preview-rallar',
+      '/accounts/account/builds/triggers/preview-relic',
+    ]);
+    expect(state.requests.find((request) => request.method === 'PATCH')?.body).toEqual({
+      production_branch: 'main',
+      source: {
+        config: {
+          production_branch: 'main',
+          production_deployments_enabled: true,
+          preview_deployment_setting: 'none',
+        },
+      },
+    });
+    expect(output).toEqual(['Cloudflare branch controls verified: main only']);
+  });
+
+  it('does not mutate any provider setting when preflight cannot find every expected Worker', async () => {
+    const state: FakeCloudflareState = {
+      includeAllWorkers: false,
+      pagesPreviewSetting: 'all',
+      previewTriggerIds: new Set(['preview-rallar', 'preview-relic']),
+      requests: [],
+    };
+    const { configureCloudflareMainOnly } = await loadCommand();
+
+    await expect(
+      configureCloudflareMainOnly({
+        accountId: 'account',
+        apiBaseUrl: 'https://cloudflare.test',
+        fetchImpl: createFakeFetch(state),
+        output: () => undefined,
+        token: 'test-token',
+      }),
+    ).rejects.toThrow('Missing expected Cloudflare Worker: relic-hunters-v1');
+
+    expect(state.requests.every((request) => request.method === 'GET')).toBe(true);
+    expect(state.previewTriggerIds).toEqual(new Set(['preview-rallar', 'preview-relic']));
+    expect(state.pagesPreviewSetting).toBe('all');
+  });
+});

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -194,6 +194,16 @@ describe('Deploy workflow release gate', () => {
     }
   });
 
+  it('enforces Cloudflare branch controls only from main with repository-held credentials', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+    const job = getJobBlock(workflow, 'cloudflare-branch-controls');
+
+    expect(job).toContain("if: ${{ github.ref == 'refs/heads/main' }}");
+    expect(job).toContain('CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}');
+    expect(job).toContain('CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}');
+    expect(job).toContain('node scripts/deploy/configure-cloudflare-main-only.mjs --apply');
+  });
+
   it('keeps the Postgres presence expiry test from rewriting node_modules', async () => {
     const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
       scripts: Record<string, string>;

--- a/scripts/deploy/configure-cloudflare-main-only.mjs
+++ b/scripts/deploy/configure-cloudflare-main-only.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const expectedWorkers = ['rallar-kit', 'relic-hunters-v1'];
+const pagesProject = 'ar-eye-hunter';
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function isMainOnlyTrigger(trigger) {
+  return (
+    Array.isArray(trigger.branch_includes) &&
+    trigger.branch_includes.length === 1 &&
+    trigger.branch_includes[0] === 'main' &&
+    Array.isArray(trigger.branch_excludes) &&
+    trigger.branch_excludes.length === 0
+  );
+}
+
+function findProductionTrigger(workerName, triggers) {
+  const mainOnlyCandidates = triggers.filter(isMainOnlyTrigger);
+  const candidates =
+    mainOnlyCandidates.length > 0
+      ? mainOnlyCandidates
+      : triggers.filter(
+          (trigger) =>
+            typeof trigger.trigger_name === 'string' &&
+            /(^|\s)production(\s|$)/i.test(trigger.trigger_name) &&
+            !/non-production/i.test(trigger.trigger_name),
+        );
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Expected one production trigger for ${workerName}, found ${candidates.length}; no changes applied`,
+    );
+  }
+  return candidates[0];
+}
+
+function assertTriggerIdentity(workerName, trigger) {
+  if (!trigger || typeof trigger.trigger_uuid !== 'string' || trigger.trigger_uuid.length === 0) {
+    throw new Error(`Cloudflare returned an invalid trigger for ${workerName}; no changes applied`);
+  }
+}
+
+export async function configureCloudflareMainOnly({
+  accountId,
+  apiBaseUrl,
+  fetchImpl,
+  output,
+  token,
+}) {
+  const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
+  async function request(method, resourcePath, body) {
+    const response = await fetchImpl(`${normalizedApiBaseUrl}${resourcePath}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok || payload?.success !== true) {
+      const providerErrors = Array.isArray(payload?.errors)
+        ? payload.errors
+            .map((error) => error?.message)
+            .filter(Boolean)
+            .join('; ')
+        : '';
+      throw new Error(
+        `Cloudflare ${method} ${resourcePath} failed with HTTP ${response.status}${
+          providerErrors ? `: ${providerErrors}` : ''
+        }`,
+      );
+    }
+    return payload.result;
+  }
+
+  const accountPath = `/accounts/${encodeURIComponent(accountId)}`;
+
+  // Complete every discovery read before the first mutation. A renamed or
+  // missing project must fail closed instead of partially changing production.
+  const scripts = await request('GET', `${accountPath}/workers/scripts`);
+  if (!Array.isArray(scripts)) throw new Error('Cloudflare returned an invalid Workers list');
+
+  const workers = [];
+  for (const workerName of expectedWorkers) {
+    const worker = scripts.find((candidate) => candidate?.id === workerName);
+    if (!worker || typeof worker.tag !== 'string' || worker.tag.length === 0) {
+      throw new Error(`Missing expected Cloudflare Worker: ${workerName}; no changes applied`);
+    }
+    workers.push({ name: workerName, tag: worker.tag });
+  }
+
+  const discoveredWorkers = [];
+  for (const worker of workers) {
+    const triggerPath = `${accountPath}/builds/workers/${encodeURIComponent(worker.tag)}/triggers`;
+    const triggers = await request('GET', triggerPath);
+    if (!Array.isArray(triggers)) {
+      throw new Error(
+        `Cloudflare returned an invalid trigger list for ${worker.name}; no changes applied`,
+      );
+    }
+    const productionTrigger = findProductionTrigger(worker.name, triggers);
+    assertTriggerIdentity(worker.name, productionTrigger);
+    const previewTriggers = triggers.filter((trigger) => trigger !== productionTrigger);
+    for (const trigger of previewTriggers) assertTriggerIdentity(worker.name, trigger);
+    discoveredWorkers.push({ ...worker, productionTrigger, previewTriggers });
+  }
+
+  const pagesPath = `${accountPath}/pages/projects/${encodeURIComponent(pagesProject)}`;
+  const pages = await request('GET', pagesPath);
+  if (pages?.name !== pagesProject || pages?.source?.type !== 'github') {
+    throw new Error(
+      `Expected GitHub-backed Cloudflare Pages project ${pagesProject}; no changes applied`,
+    );
+  }
+
+  for (const worker of discoveredWorkers) {
+    if (!isMainOnlyTrigger(worker.productionTrigger)) {
+      await request(
+        'PATCH',
+        `${accountPath}/builds/triggers/${encodeURIComponent(worker.productionTrigger.trigger_uuid)}`,
+        { branch_includes: ['main'], branch_excludes: [] },
+      );
+    }
+    for (const previewTrigger of worker.previewTriggers) {
+      await request(
+        'DELETE',
+        `${accountPath}/builds/triggers/${encodeURIComponent(previewTrigger.trigger_uuid)}`,
+      );
+    }
+  }
+
+  const desiredPagesConfiguration = {
+    production_branch: 'main',
+    source: {
+      config: {
+        production_branch: 'main',
+        production_deployments_enabled: true,
+        preview_deployment_setting: 'none',
+      },
+    },
+  };
+  const pagesConfig = pages.source.config;
+  if (
+    pages.production_branch !== 'main' ||
+    pagesConfig?.production_branch !== 'main' ||
+    pagesConfig?.production_deployments_enabled !== true ||
+    pagesConfig?.preview_deployment_setting !== 'none'
+  ) {
+    await request('PATCH', pagesPath, desiredPagesConfiguration);
+  }
+
+  for (const worker of workers) {
+    const verifiedTriggers = await request(
+      'GET',
+      `${accountPath}/builds/workers/${encodeURIComponent(worker.tag)}/triggers`,
+    );
+    if (
+      !Array.isArray(verifiedTriggers) ||
+      verifiedTriggers.length !== 1 ||
+      !isMainOnlyTrigger(verifiedTriggers[0])
+    ) {
+      throw new Error(`Cloudflare Worker ${worker.name} did not verify as main-only`);
+    }
+  }
+
+  const verifiedPages = await request('GET', pagesPath);
+  if (
+    verifiedPages?.production_branch !== 'main' ||
+    verifiedPages?.source?.config?.production_branch !== 'main' ||
+    verifiedPages?.source?.config?.production_deployments_enabled !== true ||
+    verifiedPages?.source?.config?.preview_deployment_setting !== 'none'
+  ) {
+    throw new Error(`Cloudflare Pages project ${pagesProject} did not verify as main-only`);
+  }
+
+  output('Cloudflare branch controls verified: main only');
+}
+
+async function main() {
+  if (process.argv.slice(2).join(' ') !== '--apply') {
+    throw new Error('Refusing to change Cloudflare without the exact --apply argument');
+  }
+
+  await configureCloudflareMainOnly({
+    accountId: requiredEnvironment('CLOUDFLARE_ACCOUNT_ID'),
+    apiBaseUrl: process.env.CLOUDFLARE_API_BASE_URL ?? 'https://api.cloudflare.com/client/v4',
+    fetchImpl: fetch,
+    output: (message) => console.log(message),
+    token: requiredEnvironment('CLOUDFLARE_API_TOKEN'),
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- continuously enforce main-only Cloudflare Workers build triggers and disable Cloudflare Pages previews from the main-only deployment workflow
- fail closed after complete provider discovery and verify the resulting configuration
- document required token permissions and add deterministic provider-boundary tests

## Validation
- `npx vitest run packages/tests/hetzner/cloudflare-main-only-branch-controls.test.ts packages/tests/hetzner/deploy-release-gate.test.ts` — passed (9 tests)
- `npm run check:repo-style` — passed with existing warning-only findings
- `npm run test:unit` — passed (553 files, 5,537 tests; 4 files/18 tests skipped)
- `npm run test:ci` — passed outside socket sandboxing, matching CI permissions
- `npm run build` — passed with existing large-chunk warnings

## Remaining external cutover
- Cloudflare settings will be applied automatically by the first main `Deploy Web + API` run after merge.
- Deno remains fail-safe: the repository has no `DENO_DEPLOY_TOKEN` or `DENO_DEPLOY_ACTIONS_ENABLED` variable, so its Git integration must not be disconnected until an organization token is stored and the replacement deployment preflight passes.
- After both provider cutovers, push a fresh feature commit and verify no Cloudflare or Deno contexts are created.