### PR TITLE
docs: define TypeScript size and cohesion guidance

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -120,21 +120,68 @@ public. Do not create a type-only file for a single private shape when colocatin
 
 ## File size and complexity
 
-- 400 physical lines is the TypeScript-file review threshold, including blank lines and comments. A new TypeScript file
-  should stay at or below it.
-- An existing TypeScript file above 400 lines must not grow without explicit human approval. When a change materially
-  touches more than one responsibility, split it along those responsibilities as part of the change.
-- Split route modules by business action, normally `*-read.ts`, `*-write.ts`, and
-  `*-admin.ts`. Shared HTTP error translation may use `*-errors.ts`.
-- A route handler should normally stay at or below 30 physical lines.
-- A route handler should normally have estimated cyclomatic complexity at or below 8.
+A file owns one coherent responsibility that a developer can summarize in one
+sentence. Count all physical lines, including blank lines and comments, when
+applying these tiers:
+
+- `<=400` physical lines: normal target;
+- `401-500` physical lines: cohesion warning;
+- `501-800` physical lines: required separation review;
+- `>800` physical lines: refactor or record an approved persistent exception in
+  [the repo code-style exception registry](../../../../docs/repo-code-style-exceptions.md).
+
+An existing TypeScript file above 400 lines must not grow without explicit human
+approval. When a change materially touches more than one responsibility, split
+it along those responsibilities as part of the change.
+
+For a general function, count from its declaration through its closing brace,
+including blank lines and comments:
+
+- `<=40` physical lines: normal target;
+- `41-49` physical lines: warning;
+- `50-60` physical lines: required separation review;
+- `>60` physical lines: refactor or record an approved symbol-level exception in
+  [the repo code-style exception registry](../../../../docs/repo-code-style-exceptions.md).
+
+Route handlers retain the stricter `<=30`-line target. Split route modules by
+business action, normally `*-read.ts`, `*-write.ts`, and `*-admin.ts`. Shared
+HTTP error translation may use `*-errors.ts`. A route handler should normally
+have estimated cyclomatic complexity at or below 8.
 
 Cyclomatic complexity starts at 1 and adds one for each decision path: `if`
 (including each `else if` once), non-default `case`, loop, and `catch`. `else`
 alone does not add a path. The checker is a warning heuristic, not a substitute for reading the control flow.
 
-File length is a signal, not a reason to create pass-through modules. A split is successful only when each resulting
-module owns a coherent responsibility.
+Treat a file or function as too large when one or more of these qualitative
+signals apply, even when it remains below a numeric threshold:
+
+1. A developer cannot summarize its responsibility in one sentence.
+2. It has several independent reasons to change.
+3. Its imports naturally form unrelated groups.
+4. A reader must jump repeatedly between distant sections.
+5. Private helpers fall into distinct conceptual clusters.
+6. Its tests require several unrelated setup modes.
+7. It owns multiple lifecycles or state machines.
+8. Changes commonly produce merge conflicts in unrelated areas.
+
+Accepted exception categories are declarative schemas or protocol definitions,
+static lookup data, carefully structured test scenarios, parser or
+state-transition tables, approved export-only package barrels, and cohesive
+algorithms whose steps are easier to follow together. Generated code remains
+outside human-authored size enforcement.
+
+Materially touched means behavior, contracts, control flow, state, lifecycle,
+structure, or responsibility changed. Import-only, formatting-only, typo, and
+path-only changes do not trigger exception registration. When a materially
+touched `>800`-line file or `>60`-line function remains above its threshold,
+record the approved exception in
+[the registry](../../../../docs/repo-code-style-exceptions.md). Do not put size
+justifications in source comments.
+
+Size is a review signal, never an instruction to create pass-through files or
+helper chains. A split is successful only when each resulting module or function
+owns a coherent responsibility and makes the public API, state, dataflow, and
+change ownership easier to locate.
 
 ## Canonical function vocabulary
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ and authoritative persisted/shared contracts use mandatory fields by default.
   sequence and warning-only checker usage for the authoritative repo TypeScript
   standard in
   [repo-code-style.md](../.agents/skills/rallar-code-writing/references/repo-code-style.md).
+- [Repo Code-Style Exception Registry](./repo-code-style-exceptions.md)
+  Human-approved persistent exceptions for materially touched files and
+  functions that remain above the hard size tiers.
 - [Rallar API Reference](./rallar-api-reference.md) Complete public API
   description for `rallar.ts`, `rallar-data.ts`, and `RallarMiddleware.ts`, with
   usage examples.

--- a/docs/repo-code-style-exceptions.md
+++ b/docs/repo-code-style-exceptions.md
@@ -1,0 +1,38 @@
+# Repo Code-Style Exception Registry
+
+This registry records approved persistent exceptions to the authoritative
+[repo TypeScript coding standard](../.agents/skills/rallar-code-writing/references/repo-code-style.md).
+It starts empty. Do not register all existing legacy files above the size
+thresholds retroactively.
+
+Add an entry only when a TypeScript file above 800 physical lines or a function
+above 60 physical lines is materially touched and remains above its threshold.
+Materially touched means behavior, contracts, control flow, state, lifecycle,
+structure, or responsibility changed. Import-only, formatting-only, typo, and
+path-only changes do not trigger registration.
+
+An exception records a deliberate human decision that keeping cohesive code
+together is easier to understand than the available separation. It does not
+suppress checker warnings, waive future review, or justify pass-through files
+and helper chains. Keep size justifications here rather than in source comments.
+
+## Required entry fields
+
+Each entry records:
+
+- Repository-relative path;
+- Symbol, when the exception applies to a function, method, constructor,
+  accessor, or callback;
+- Exception category;
+- Why cohesion is clearer than the available separation;
+- Approval date and reviewer;
+- Review or removal condition.
+
+Use one of the accepted categories from the canonical standard: declarative
+schema or protocol definition, static lookup data, structured test scenario,
+parser or state-transition table, approved export-only package barrel, or
+cohesive algorithm.
+
+## Approved exceptions
+
+No approved exceptions are recorded.

--- a/docs/repo-human-style-guide.md
+++ b/docs/repo-human-style-guide.md
@@ -104,6 +104,28 @@ Apply the formatting, spacing, file-order, file-size, handler-size, and
 complexity sections of the standard. Blank lines should expose phases in long
 factories and composition roots.
 
+Use this size and cohesion review sequence:
+
+1. Summarize the file responsibility in one sentence.
+2. Apply the numeric tier from the authoritative standard.
+3. Inspect the eight qualitative cohesion signals.
+4. Identify real responsibility boundaries before proposing extraction.
+5. Check whether an exception applies and is approved.
+6. Prefer the organization that makes the public API, state, dataflow, and
+   change ownership fastest to locate.
+
+The eight signals are an unclear one-sentence responsibility, independent
+reasons to change, unrelated import groups, repeated jumps between distant
+sections, distinct private-helper clusters, unrelated test setup modes,
+multiple lifecycles or state machines, and merge-conflict hotspots in unrelated
+areas. These signals can justify review below a numeric threshold; line count
+alone never justifies a pass-through split.
+
+When a materially touched file or function remains above the hard tier, verify
+that the human-approved rationale is recorded in the
+[repo code-style exception registry](./repo-code-style-exceptions.md). Do not
+register untouched legacy debt or place the justification in a source comment.
+
 Prefer self-explanatory names and structure. Ask for a comment only when it
 records a non-obvious invariant, external constraint, safety reason, or tradeoff.
 
@@ -113,7 +135,8 @@ records a non-obvious invariant, external constraint, safety reason, or tradeoff
 - Unrelated legacy code is not reformatted or refactored without authorization.
 - An existing over-threshold file does not grow silently.
 - Any deliberate exception has explicit human approval and appears in the
-  completion handoff.
+  completion handoff and, when required by the hard size tier, the
+  [repo code-style exception registry](./repo-code-style-exceptions.md).
 
 ## Warning-only checker
 

--- a/packages/tests/repo/repo-code-style-integrity.test.ts
+++ b/packages/tests/repo/repo-code-style-integrity.test.ts
@@ -70,8 +70,90 @@ describe('repo code style authority integrity', () => {
   it('applies the human file-size threshold to every TypeScript surface', () => {
     const canonicalStyle = readRepo(canonicalStylePath);
 
-    expect(canonicalStyle).toContain('400 physical lines is the TypeScript-file review threshold');
+    expectAll(canonicalStyle, [
+      'A file owns one coherent responsibility',
+      '`<=400` physical lines: normal target',
+      '`401-500` physical lines: cohesion warning',
+      '`501-800` physical lines: required separation review',
+      '`>800` physical lines: refactor or record an approved persistent exception',
+      '`<=40` physical lines: normal target',
+      '`41-49` physical lines: warning',
+      '`50-60` physical lines: required separation review',
+      '`>60` physical lines: refactor or record an approved symbol-level exception',
+      'Route handlers retain the stricter `<=30`-line target',
+    ]);
     expect(canonicalStyle).not.toContain('production-file review threshold');
+  });
+
+  it('defines qualitative cohesion review before any size-driven extraction', () => {
+    const canonicalStyle = readRepo(canonicalStylePath).replace(/\s+/g, ' ');
+    const humanGuide = readRepo('docs/repo-human-style-guide.md').replace(/\s+/g, ' ');
+
+    expectAll(canonicalStyle, [
+      'summarize its responsibility in one sentence',
+      'independent reasons to change',
+      'imports naturally form unrelated groups',
+      'jump repeatedly between distant sections',
+      'Private helpers fall into distinct conceptual clusters',
+      'several unrelated setup modes',
+      'multiple lifecycles or state machines',
+      'merge conflicts in unrelated areas',
+      'Size is a review signal',
+      'pass-through files or helper chains',
+    ]);
+    expectAll(humanGuide, [
+      'Summarize the file responsibility in one sentence',
+      'Apply the numeric tier',
+      'Inspect the eight qualitative cohesion signals',
+      'Identify real responsibility boundaries before proposing extraction',
+      'Check whether an exception applies and is approved',
+      'public API, state, dataflow, and change ownership',
+    ]);
+  });
+
+  it('routes persistent size exceptions without duplicating thresholds in AGENTS.md', () => {
+    const agents = readRepo('AGENTS.md');
+    const codeWriting = readRepo('.agents/skills/rallar-code-writing/SKILL.md');
+    const canonicalStyle = readRepo(canonicalStylePath);
+    const humanGuide = readRepo('docs/repo-human-style-guide.md');
+    const docsIndex = readRepo('docs/README.md');
+    const exceptionPath = 'docs/repo-code-style-exceptions.md';
+
+    expect(existsSync(path.join(repoRoot, exceptionPath))).toBe(true);
+    const exceptionRegistry = readRepo(exceptionPath);
+
+    expectAll(canonicalStyle, [exceptionPath, 'Materially touched']);
+    expect(humanGuide).toContain('./repo-code-style-exceptions.md');
+    expect(docsIndex).toContain('./repo-code-style-exceptions.md');
+    expectAll(exceptionRegistry, [
+      'Repository-relative path',
+      'Symbol',
+      'Exception category',
+      'Why cohesion is clearer',
+      'Approval date and reviewer',
+      'Review or removal condition',
+    ]);
+    expect(codeWriting).toContain('Always read `references/repo-code-style.md`');
+    expect(agents).not.toContain('`501-800`');
+    expect(agents).not.toContain('`>800`');
+    expect(agents).not.toContain('`50-60`');
+    expect(agents).not.toContain('`>60`');
+  });
+
+  it('requires size-tier review at child-plan entry and exit', () => {
+    const refactoringPlan = readRepo('plans/repo-human-traceability-refactoring-program-plan.md');
+    const entryContract =
+      refactoringPlan.match(
+        /Every feature child plan begins with:([\s\S]*?)Every child plan ends with:/u,
+      )?.[1] ?? '';
+    const exitContract =
+      refactoringPlan.match(
+        /Every child plan ends with:([\s\S]*?)Feature status values are:/u,
+      )?.[1] ?? '';
+
+    expect(entryContract).toContain('file-size tier and 40/50/60 function review');
+    expect(exitContract).toContain('final file-size tier and 40/50/60 function review');
+    expect(exitContract).toContain('over-800-line file and over-60-line function');
   });
 
   it('connects runtime failures to the established Either flow', () => {

--- a/plans/repo-human-traceability-governance-and-checker-plan.md
+++ b/plans/repo-human-traceability-governance-and-checker-plan.md
@@ -102,6 +102,8 @@ threshold and not evidence that each warning requires a change.
 | Production TypeScript files                                  |                     1,372 | Files eligible for layout analysis.                                                          |
 | Existing default style findings                              |                     4,462 | Current file-level checker findings; output is capped at 200.                                |
 | Files over 400 physical lines                                |                       215 | Existing checker debt.                                                                       |
+| Files over 500 physical lines                                |                       162 | Required separation-review inventory.                                                        |
+| Files over 800 physical lines                                |                        97 | Hard-tier legacy debt; not a retroactive exception-registration campaign.                    |
 | Directories with more than 20 direct TypeScript files        |                        16 | Ownership review prompts.                                                                    |
 | Candidate feature-prefix clusters in those dense directories |   22 across 8 directories | Initial conservative prefix heuristic.                                                       |
 | Non-kebab TypeScript filenames                               | 422 across 90 directories | Excludes exact tool-discovered config names.                                                 |
@@ -113,6 +115,8 @@ threshold and not evidence that each warning requires a change.
 The initial implementation must regenerate these measures. If the production
 tree changed after this draft, record both the new count and the reason for the
 difference; do not alter a checker threshold merely to reproduce this table.
+Regenerate the 400-, 500-, and 800-line counts immediately before committing a
+change that records them when the production tree has changed.
 
 The two optional checks do not yet have authoritative baseline counts:
 
@@ -121,6 +125,32 @@ The two optional checks do not yet have authoritative baseline counts:
 
 Task 5 records those counts after the parser-backed rules exist. Their first
 inventory remains opt-in regardless of count.
+
+### 2.1 Size-guidance pressure baseline
+
+On 2026-07-28, five fresh-context agent samples reviewed each of three pressure
+scenarios using the pre-change `rallar-code-writing` skill and canonical
+standard:
+
+| Scenario                                           | Choices | Baseline rationale                                                                                                                |
+| -------------------------------------------------- | ------: | --------------------------------------------------------------------------------------------------------------------------------- |
+| 850-line mixed service under deadline pressure     |   5 x C | All rejected generic helper or pass-through extraction and required coherent responsibility boundaries or human approval.         |
+| 64-line orchestration mixing validation and writes |   5 x C | All favored real phase boundaries, but correctly found no general-function threshold or persistent symbol-level exception record. |
+| 1,200-line cohesive static transition table        |   5 x C | All preserved cohesion with human approval, but found no named declarative-data category or persistent exception record.          |
+
+The baseline already protected against mechanical extraction, so the skill does
+not need another size-specific instruction. The canonical standard and human
+guide must supply the missing numeric tiers, accepted categories, and stable
+exception registry. Post-change samples must preserve the same coherent choices
+while also identifying the hard-tier registration requirement.
+
+The post-change run repeated all 15 fresh-context samples. Every sample again
+chose C. The 850-line service samples identified the over-800 file tier and
+persistent registry; the 64-line orchestration samples identified the over-60
+symbol tier and persistent registry; and the 1,200-line table samples preserved
+the accepted state-transition-table exception while requiring human approval
+and registration. No sample proposed a mechanical split, ignored a hard tier,
+or split cohesive declarative data.
 
 ## 3. Locked Checker Semantics
 
@@ -242,6 +272,50 @@ repository must have no unexplained warning growth across three completed
 feature migrations. The human then decides whether that one rule should block;
 semantic ownership and traceability judgments remain manual.
 
+### 3.6 Future size-warning contract
+
+This subsection is a decision-complete contract for later checker work. It is
+not implemented by the documentation-only size-guidance change.
+
+The existing default file-length rule remains enabled, scans only the existing
+filtered production source set, and eventually reports exactly one
+highest-applicable-tier message per file:
+
+- 401-500 physical lines: cohesion warning;
+- 501-800 physical lines: required separation review;
+- over 800 physical lines: refactor or review the approved persistent
+  exception.
+
+Messages do not accumulate as a file crosses tiers. An exception-registry entry
+does not suppress a warning; it gives the human a stable rationale to review.
+Every finding remains a warning and every non-strict size scan exits with status
+`0`.
+
+General-function size scanning is opt-in through:
+
+```bash
+npm run check:repo-style:function-size
+```
+
+which expands to:
+
+```json
+{
+  "check:repo-style:function-size": "node scripts/repo-style-check.mjs --function-size"
+}
+```
+
+The future scanner uses the TypeScript compiler API for function declarations,
+methods, constructors, accessors, and callbacks. It applies the canonical
+40/50/60 tiers, groups findings by file, identifies the largest function, and
+prints at most five samples. It scans only the same filtered production source
+set used by the default checker. `--function-size` remains warning-only, exits
+with status `0`, and does not add strict mode or a CI gate.
+
+Do not record a general-function baseline from the current partial extractor.
+Record baseline counts only after the complete compiler-backed scanner exists
+and covers every declaration form listed above.
+
 ## 4. File Responsibility Map
 
 | File                                                               | Change                  | Single responsibility                                                                        |
@@ -250,6 +324,7 @@ semantic ownership and traceability judgments remain manual.
 | `.agents/skills/rallar-code-writing/SKILL.md`                      | Modify                  | Translate the primary code goal into required agent behavior for TypeScript work.            |
 | `.agents/skills/rallar-code-writing/references/repo-code-style.md` | Modify                  | Authoritative feature ownership, co-location, filename, symbol, and domain vocabulary rules. |
 | `docs/repo-human-style-guide.md`                                   | Modify                  | Human navigation review sequence and checker commands.                                       |
+| `docs/repo-code-style-exceptions.md`                               | Create                  | Stable human-approved rationale for hard-tier file and function exceptions.                  |
 | `scripts/repo-style-check/layout-rules.mjs`                        | Create                  | Pure repository-layout aggregation and TypeScript syntax heuristics over supplied sources.   |
 | `scripts/repo-style-check.mjs`                                     | Modify                  | CLI flags, shared source loading, rule orchestration, and output summaries.                  |
 | `package.json`                                                     | Modify                  | Warning-only layout scripts.                                                                 |

--- a/plans/repo-human-traceability-refactoring-program-plan.md
+++ b/plans/repo-human-traceability-refactoring-program-plan.md
@@ -123,6 +123,11 @@ The planning audit found these high-signal examples:
 | `packages/tests/shared-server`                      | 196 direct TypeScript files | Production features and their tests do not have matching navigable paths.                                |
 | `packages/shared-test/rallar-bb-test`               |  67 direct TypeScript files | Distributed run, fleet, artifact, browser, and control concerns are mixed.                               |
 
+Using the warning checker's filtered production source set, 215 TypeScript files
+are over 400 physical lines, 162 are over 500, and 97 are over 800 in the
+2026-07-28 planning baseline. These counts are review inventories, not commands
+to split files mechanically or to register every legacy hard-tier file.
+
 Important current hotspots include:
 
 - `packages/shared-server/rallar-system/services/group-state-mutations.ts` at
@@ -507,7 +512,10 @@ one feature branch and pull request:
    - replace expected exceptions with `Either` or validation issues;
    - normalize runtime exceptions at side-effect boundaries;
    - remove pass-through helpers and wrapper-only modules;
-   - reduce files and handlers over their review thresholds;
+   - apply the canonical 40/50/60 general-function review and the file-size
+     tiers before extracting code;
+   - reduce files, functions, and handlers over their review thresholds only at
+     coherent responsibility boundaries;
    - rerun behavior, contract, and integration tests.
 
 Do not hide semantic rewrites inside a rename-only change. Do not postpone all
@@ -520,6 +528,8 @@ While legacy migration proceeds:
 
 - all new files follow the target feature tree and naming rules;
 - a touched over-400-line file may not grow without explicit human approval;
+- a materially touched over-800-line file or over-60-line function is refactored
+  at a coherent boundary or recorded in the repo code-style exception registry;
 - a change that materially touches two responsibilities splits them;
 - new public optional fields require documented domain absence;
 - new production defaults are placed in OpenAPI or typed application
@@ -697,6 +707,8 @@ Every feature child plan begins with:
 - one representative top-to-bottom call trace;
 - existing behavior and characterization tests;
 - exact current-to-target file map;
+- file-size tier and 40/50/60 function review for the touched surface, including
+  any existing hard-tier exceptions that the change must remove or renew;
 - classification of mechanical, structural, semantic, contractual, and
   operational changes;
 - explicit compatibility decisions and retirement conditions;
@@ -709,6 +721,10 @@ Every child plan ends with:
 - matching primary symbols and filenames;
 - tests mirrored to the feature path;
 - no unexplained new checker warnings;
+- final file-size tier and 40/50/60 function review for the touched surface;
+- every materially touched over-800-line file and over-60-line function either
+  refactored at a coherent boundary or recorded with human approval in the repo
+  code-style exception registry;
 - documented remaining debt for the feature;
 - exact passed, failed, unavailable, and skipped validation results;
 - updated program progress in this plan or its approved successor ledger.
@@ -735,6 +751,8 @@ volume:
 - number of feature folders with an obvious entry file;
 - maximum direct TypeScript files in active production folders;
 - count of production files over 400 lines;
+- count of production files over 500 lines;
+- count of production files over 800 lines;
 - count of generic production filenames;
 - count of mixed-case filename violations;
 - count of wrapper-only call-stack hops found and removed through manual review;


### PR DESCRIPTION
## Summary\n\n- define canonical TypeScript file and function size tiers as cohesion review signals\n- add a human review sequence and an initially empty persistent exception registry\n- document future warning-only checker behavior and ratcheting in the traceability plans\n- add integrity assertions for policy authority and child-plan entry/exit review\n\n## Scope\n\nDocumentation and repository integrity tests only. No production code, checker implementation, package scripts, AGENTS.md, or program execution plan changed. SKILL.md remains unchanged because all 15 baseline pressure samples already rejected mechanical extraction; the missing details belong in the canonical standard.\n\n## Validation\n\n- npx vitest run packages/tests/repo/repo-code-style-integrity.test.ts\n- npx vitest run packages/tests/repo/rallar-skill-integrity.test.ts\n- npx vitest run packages/tests/repo/repo-style-check.test.ts\n- npx prettier --check on all touched files\n- npm run check:repo-style\n- npm run test:unit\n- npm run test:ci\n- npm run build\n- git diff --check\n\nAll commands passed on commit 5e5063631fd3744e7ef7c50d9da57eeb31e00e39.