### PR TITLE
docs: revise distributed group RTC activation design after review

### DIFF
--- a/plans/rallar-distributed-group-rtc-activation-design.md
+++ b/plans/rallar-distributed-group-rtc-activation-design.md
@@ -1,6 +1,15 @@
 # Distributed Group RTC Activation Design
 
-Status: approved design direction; implementation not started.
+Status: approved design direction; implementation not started. Revised
+2026-08-07 after a full design review (activation-flow correctness,
+distributed-systems behavior, scalability at hundreds of sessions, security,
+and operational complexity). All review decisions are folded into this
+document.
+
+Governance note: before implementation starts, this design must be reconciled
+with `plans/rallar-architecture-quality-and-rtc-program-roadmap.md`, which
+holds RTC Phase 1 reservations approved-inactive and requires an explicit
+gate before Phase 1 implementation. This document is design authority only.
 
 ## Executive Summary
 
@@ -10,31 +19,41 @@ server sharing the PostgreSQL database may later claim and process each piece
 of activation work.
 
 The existing `resource_inbox` table remains the physical work table. It hosts
-the logical `APP_INBOX`, `APP_OUTBOX`, and `WS_OUTBOX` queues and will also host
-remote browser work awaiting confirmation through a new logical
+the logical `APP_INBOX`, `APP_OUTBOX`, and `WS_OUTBOX` queues and will also
+host remote browser work awaiting confirmation through a new logical
 `ASYNC_REMOTE_QUEUE` lane. Edge chunks remain `APP_INBOX` rows. Remote work
 adds one queue status, `AWAITING_REMOTE`, but otherwise reuses the existing
 payload, attempts, expiry, reservation, retry scheduling, and terminal-state
 machinery.
 
 One new `group_batch` row coordinates each activation attempt. It records the
-original activation input, the planned topology, the source group revision, a
-deterministic topology-input fingerprint, the expected edge-chunk count,
-capacity already allocated to remote work, the aggregate outcome, and an
-optimistic version. There is one batch row per activation attempt, not one row
-per edge or chunk.
+original activation input, the planned topology, the source causal group
+revision (as a tuple), a deterministic topology-input fingerprint, expected
+and terminal work counters, capacity allocated to in-flight remote work, the
+aggregate outcome, and an optimistic version. There is one batch row per
+activation attempt, not one row per edge or chunk.
 
-All domain services follow the same cycle:
+Server-directed activation coexists with the existing browser-owned overlay
+reconciliation: activation drives commanded edge establishment and
+confirmation; browser reconciliation continues to own healing, drift repair,
+and steady-state connection lifecycle. The coexistence contract in this
+document (commanded-edge retention and command-origin validation) is a
+mandatory part of the design, not an optimization.
+
+All domain services follow the repository's convergent service doctrine
+unchanged:
 
 ```text
-read -> compute -> validate -> write
+read -> compute -> validate -> write(transaction, computed)
 ```
 
 Computation is side-effect-free and happens outside a database transaction.
-The write phase uses a short transaction with expected-state or
-expected-version conditions. A conflict rolls back the entire write and
-restarts the whole cycle from a fresh read, including authorization, policy,
-capacity, lifecycle, and invariant validation.
+AppInbox owns the transaction and the retry boundary. The write phase
+receives the transaction and uses expected-state or expected-version
+conditions; it never opens, commits, replaces, or retries a transaction. A
+conflict rolls back the entire write and restarts the whole cycle from a
+fresh read, including authorization, policy, capacity, lifecycle, and
+invariant validation.
 
 ## Goals
 
@@ -46,12 +65,16 @@ capacity, lifecycle, and invariant validation.
 - Reuse `resource_inbox` for all durable work, including work performed by a
   browser and awaiting confirmation.
 - Keep one durable coordination row per group activation attempt.
-- Bound RTC connection concurrency per group without relying on a racy
-  pre-dequeue count.
+- Bound RTC connection-establishment concurrency per batch without relying on
+  a racy pre-dequeue count.
 - Make duplicate commands, queue delivery, WebSocket delivery, browser
   acknowledgements, timeouts, and server restarts safe.
 - Preserve the existing full `GroupRef` scope and causal group revisions.
 - Keep group business lifecycle separate from RTC activation lifecycle.
+- Keep commanded edges alive against the browser overlay reconciler until
+  the batch promotes or aborts.
+- Bound replan churn so activation converges under realistic membership
+  change rates.
 
 ## Non-Goals
 
@@ -60,13 +83,20 @@ capacity, lifecycle, and invariant validation.
   A director may be an authorized activation requester, but it owns no server
   work.
 - Do not replace PostgreSQL with a separate broker in the first iteration.
-- Do not create a dedicated table for edge chunks or remote work.
+- Do not create a dedicated table for edge chunks or remote work in the first
+  iteration. A partitioning or dedicated-table follow-up is a committed,
+  scheduled successor, not an open-ended possibility; see Scale Posture.
 - Do not treat Rallar Data, CRDT state, browser memory, or PostgreSQL
   notifications as authoritative activation state.
 - Do not require synchronous HTTP requests to wait for RTC establishment.
-- Do not overwrite the last accepted active topology with an unconfirmed plan.
+- Do not overwrite the last accepted active topology with an unconfirmed
+  plan.
 - Do not add or remove edges from a running batch when membership changes;
-  supersede and replan instead.
+  supersede and replan instead. Incremental per-delta batches are deferred
+  behind a measured trigger (see Scale Posture).
+- Do not plan across a browser's other groups. The browser-local peer
+  connection cap is a documented v1 limitation; a cap-blocked result is a
+  definitive terminal rejection.
 
 ## Existing Repository Fit
 
@@ -75,52 +105,104 @@ The current repository already provides most of the required primitives:
 - `resource_inbox` stores a typed JSON resource, logical queue type, status,
   attempts, creation and processing timestamps, next-attempt timestamp, and
   expiry timestamp.
-- `APP_INBOX`, `APP_OUTBOX`, and `WS_OUTBOX` are existing `EnqueuedType`
-  values.
+- `APP_INBOX`, `APP_OUTBOX`, `WS_OUTBOX`, `WS_INBOX`, `RTC_INBOX`, and
+  `RTC_OUTBOX` are the existing `EnqueuedType` values; the RTC pair is
+  browser-side only. This design adds `ASYNC_REMOTE_QUEUE` as a seventh lane.
 - `ResourceInboxRepository` and `PSqlQueueBox` provide durable insert,
-  reservation, retry, timeout, and expiry behavior.
+  reservation (`SELECT ... FOR UPDATE SKIP LOCKED`), retry, reserved-timeout
+  recovery, and expiry behavior. `FAILED` rows are terminal for ordinary
+  queue machinery; no failed-entry retry loop exists.
+- The shared PostgreSQL unit of work already exists:
+  `AppInboxTransactionWriter` opens one transaction and passes one
+  `PSqlTransactionSql` to transaction-bound repositories
+  (`app-inbox-transaction-writer.ts`, `run-in-transaction.ts`,
+  `createTransactionBoundGroupStateRepository`). The activation write
+  boundary reuses it; `group_batch` and the topology-plan reads/writes get
+  transaction-bound constructors in the same pattern.
 - `resource_inbox_results` provides durable results for current synchronous
-  app-inbox operations. Activation polling should instead read the activation
-  command and `group_batch`, because RTC completion is intentionally
-  asynchronous and longer-lived.
-- Current group snapshots carry a full `GroupRef` and `stateRevision`.
+  app-inbox operations. Activation ticket polling instead reads the
+  activation command and `group_batch`, because RTC completion is
+  intentionally asynchronous and longer-lived.
+- The authoritative group revision is the causal tuple
+  `GroupStateCausalRevision { groupRevision, presenceRevision }` with a
+  partial order (`compareGroupCausalRevision`: equal, dominates, dominated,
+  incomparable). `GroupSnapshot.stateRevision` is a lossy compatibility sum
+  and must not be used for activation decisions.
+- The accepted RTC topology already has a durable owner:
+  `RtcTopologySnapshotRepository` stores one `RallarOverlayTopologySnapshot`
+  per `GroupRef` with monotonic compare-and-set ordering on
+  `(sourceGroupStateCausalRevision, version)`
+  (`compareOverlayTopologyCausalTuple`). Promotion in this design writes
+  through that repository and its ordering; it does not add a second
+  accepted-topology store.
 - Current topology work uses immutable group-revision inputs, deterministic
   work identities, durable publications, and multi-server WebSocket fanout.
-- Current queue claiming uses a short `SELECT ... FOR UPDATE SKIP LOCKED`
-  reservation transaction. The new design does not introduce long-running
-  locks around computation or remote work.
 
-The current generic repository has a 50-row limit on some list methods and no
-batch-specific aggregate query. Batch finalization must therefore add focused,
-indexed aggregate queries; it must not use `findByTypeId()` or parse every JSON
-payload in the queue.
+Two identifier constraints bind harder than the column widths:
+
+- Every queue write routes through `toAppQueueKey` (`AppQueueIdentity.ts`),
+  which clamps `topicId` and `resourceId` to 36 characters, `contextId` to
+  35 characters, and `createdBy` to 16 characters, silently rewriting longer
+  values to a `prefix-fnv1a64` hash. Identifiers that must be queryable by
+  equality (for example `contextId = batchId`) must fit their budget by
+  construction; relying on the silent rewrite is forbidden.
+- The queue uniqueness constraint is `(contextId, resourceId, topicId)` and
+  does not include `ri_type_id`. Queue keys must be lane-qualified or
+  otherwise distinct across lanes.
+
+The current generic repository has a 50-row limit on `findByTopicId` and
+`findByTypeId` and no batch-specific aggregate query. Batch finalization must
+therefore add focused, indexed aggregate queries; it must not use
+`findByTypeId()` or parse every JSON payload in the queue.
 
 ## Core Decisions
 
 ### No server owns a group
 
 The database owns durable coordination. A server is only the temporary worker
-that successfully claims a queue row or wins an optimistic write. It may crash
-after any commit without transferring an in-memory lease or group-director
-role to another server.
+that successfully claims a queue row or wins an optimistic write. It may
+crash after any commit without transferring an in-memory lease or
+group-director role to another server.
 
 PostgreSQL notifications may wake workers, but notifications are not work or
 state. A missed notification is recovered by polling durable rows.
 
-### One physical work table, four logical lanes
+### Coexistence with browser-owned reconciliation
+
+Browsers keep owning steady-state connection lifecycle: the server broadcasts
+the accepted overlay snapshot and `WebRtcGroupManager` reconciles toward it,
+including disconnecting peers that are not in the desired set. Because this
+design deliberately keeps the planned topology out of the accepted store
+until promotion, commanded edges are not yet part of any browser's desired
+set. Two browser-side rules are therefore mandatory:
+
+- **Commanded-edge retention.** From acceptance of an edge command until the
+  browser observes promotion, abort, or a bounded retention deadline, both
+  the initiator and the responder register the commanded peer connection as
+  retained so the overlay reconciler does not tear it down. The existing
+  retained-peer exclusion in `WebRtcGroupManager` is the extension point.
+- **Command-origin validation.** A browser accepts activation edge commands
+  only from the authenticated server origin (the `rallar-server` sender
+  identity), never from peers. See Authorization And Trust.
+
+Without these rules the reconciler closes commanded connections on the next
+presence-triggered reconcile and activation cannot complete.
+
+### One physical work table, five logical lanes
 
 `resource_inbox.ri_type_id` identifies the lane:
 
-| Logical lane | Purpose |
-| --- | --- |
-| `APP_INBOX` | Incoming commands and internal edge-chunk work |
-| `APP_OUTBOX` | Outbound application work, including existing topology/publication work where applicable |
-| `WS_OUTBOX` | Durable messages to WebSocket-connected browser sessions |
-| `ASYNC_REMOTE_QUEUE` | Work assigned to a remote browser and awaiting a correlated result |
+| Logical lane         | Purpose                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `APP_INBOX`          | Incoming commands and internal edge-chunk work                 |
+| `APP_OUTBOX`         | Outbound application work, including existing topology work    |
+| `WS_OUTBOX`          | Durable messages to WebSocket-connected browser sessions       |
+| `WS_INBOX`           | Existing inbound WS lane (unchanged)                           |
+| `ASYNC_REMOTE_QUEUE` | Work assigned to a remote browser awaiting a correlated result |
 
 The lane is not the operation. The AL message type or resource payload kind
-distinguishes `ACTIVATE_GROUP`, `ACTIVATE_EDGE_CHUNK`, and
-`ESTABLISH_RTC_EDGE`.
+distinguishes `ACTIVATE_GROUP`, `ACTIVATE_EDGE_CHUNK`, `ESTABLISH_RTC_EDGE`,
+`RTC_EDGE_RESULT`, `GROUP_BATCH_ABORT_SWEEP`, and `GROUP_BATCH_FINALIZE`.
 
 ### One batch row per activation attempt
 
@@ -131,7 +213,51 @@ child batch rows.
 Repeated activation attempts create new batch rows. Reusing one permanent row
 per group would break old tickets, erase audit history, and make late browser
 acknowledgements ambiguous. A group may have many historical batches but at
-most one `STARTED` batch.
+most one `STARTED` batch, enforced by a partial unique index.
+
+### Supersession is planner-atomic
+
+Only the planner of a replacement batch supersedes a running batch. In one
+transaction the replacement planner compare-and-sets the old batch
+`STARTED -> SUPERSEDED`, inserts the new `STARTED` batch, and enqueues the
+durable abort-sweep command for the old batch's outstanding chunk and remote
+rows. Membership and presence mutations never touch `group_batch`; they only
+enqueue a deterministic activation command for the newer causal input.
+
+The finalizer also emits `SUPERSEDED` in exactly one case: the batch is still
+the current generation, all of its work is terminal, and the current durable
+topology input no longer matches the batch fingerprint (drift detected with
+no replacement request). In that case the finalizer both records
+`SUPERSEDED` and enqueues a deterministic activation command for the current
+input, so a client-requested activation always converges on a batch for the
+current state or a typed failure.
+
+### Same-fingerprint requests attach
+
+Activation requests are idempotent at two levels. The same scoped
+`activationRequestId` returns the same ticket and batch. A different
+`activationRequestId` whose canonical topology input produces the same
+`topologyInputHash` as the current `STARTED` batch attaches to that batch:
+no new batch is created, and the request's ticket resolves to the existing
+batch. Supersession requires a changed fingerprint. This prevents concurrent
+activation requests from superseding each other's identical work.
+
+### Replan churn is bounded
+
+Whole-topology replanning per membership change is the v1 policy, so churn
+must be coalesced:
+
+- Activation commands triggered by group changes are debounced per group
+  (`activationDebounceMs`, default 2000 ms) using pending-command
+  replacement, so a burst of joins and leaves collapses into one successor
+  command carrying the newest causal input.
+- A `STARTED` batch younger than `minimumBatchAgeMs` (default 5000 ms) is not
+  superseded; the successor command defers until the age threshold passes and
+  then replans from the then-current input.
+
+Both constants are policy configuration with server-clamped bounds. This is
+also the primary defense against forced-replan abuse; see Authorization And
+Trust.
 
 ### The planned topology is not yet active topology
 
@@ -142,41 +268,81 @@ edge plan from being advertised as active.
 
 After finalization:
 
-- `COMPLETED` promotes the planned topology as active.
+- `COMPLETED` promotes the planned topology as accepted.
 - `PARTIAL` promotes it only if topology validation proves that the confirmed
   edges still satisfy the configured minimum connectivity and degree
   invariants.
 - `FAILED` does not replace a previously accepted topology.
+
+Promotion writes through `RtcTopologySnapshotRepository` using the batch's
+source causal revision tuple and the repository's monotonic ordering; see
+Flow 7 for the stale-promotion outcome.
+
+### Capacity is a predicate-bounded counter, not a version race
+
+`group_batch.in_flight_remote_count` bounds concurrent in-flight remote
+confirmation units per batch. Increments and decrements are commutative
+conditional updates whose predicate carries the bound and the batch status:
+
+```sql
+UPDATE group_batch
+SET in_flight_remote_count = in_flight_remote_count + :k,
+    updated_ts = now()
+WHERE batch_id = :batch_id
+  AND status = 'STARTED'
+  AND in_flight_remote_count + :k <= :capacity_ceiling
+RETURNING in_flight_remote_count;
+```
+
+Counter updates do not check or bump the optimistic `version`; the `version`
+compare-and-set is reserved for batch status transitions. This keeps chunk
+expansion and remote terminal transitions from conflicting with each other on
+the hot batch row while preserving the capacity bound.
+
+The capacity ceiling is the configured maximum number of concurrently
+outstanding remote confirmation units for one batch. It is a policy value
+with a server default and clamp; it is distinct from the structural
+`degreeLimit` (edges per session) and from the browser-local peer-connection
+cap.
+
+The bound is per batch. During supersession, stragglers of the old batch may
+briefly overlap the new batch's work; the overlap is bounded by abort-sweep
+latency and is accepted.
 
 ## Architecture
 
 ```mermaid
 flowchart TD
     C[Authorized client] -->|ACTIVATE via HTTP or WS| S[Any API server]
-    S -->|insert| AI[(resource_inbox: APP_INBOX command)]
+    S -->|insert| AI[(resource_inbox: APP_INBOX ACTIVATE_GROUP)]
     S -->|202 + activation ticket| C
 
     AI --> P[Any activation planner]
-    P -->|read group| G[(Durable group state)]
-    P -->|one transaction| B[(group_batch STARTED)]
-    P -->|one transaction| EC[(resource_inbox: APP_INBOX edge chunks)]
-    P -->|one transaction| WP[(resource_inbox: WS_OUTBOX progress)]
+    P -->|read group + config| G[(Durable group state)]
+    P -->|one transaction| B[(group_batch STARTED
+      + supersede predecessor
+      + abort-sweep command)]
+    P -->|same transaction| EC[(resource_inbox: APP_INBOX edge chunks)]
+    P -->|same transaction| WP[(resource_inbox: WS_OUTBOX progress)]
 
     EC --> E[Any edge-chunk worker]
-    E -->|capacity CAS| B
+    E -->|capacity predicate| B
     E -->|one transaction| RW[(resource_inbox: ASYNC_REMOTE_QUEUE)]
-    E -->|one transaction| WO[(resource_inbox: WS_OUTBOX edge commands)]
+    E -->|same transaction| WO[(resource_inbox: WS_OUTBOX edge commands)]
     WO --> BR[Target browsers]
 
-    BR -->|correlated ACK over HTTP or WS| A[Any API server]
-    A -->|conditional terminal transition| RW
-    RW --> T[Any timeout/retry worker]
-    T -->|retry WS work or terminal failure| WO
+    BR -->|correlated result over HTTP or WS| A[Any API server]
+    A -->|202| BR
+    A -->|insert| AK[(resource_inbox: APP_INBOX RTC_EDGE_RESULT)]
+    AK --> W[Any ack worker]
+    W -->|conditional terminal transition + decrement| RW
+    RW --> T[Any remote timeout worker]
+    T -->|retry WS dispatch or terminal failure| WO
 
-    RW --> F[Any batch finalizer]
-    EC --> F
-    F -->|optimistic terminal transition| B
-    F -->|promote accepted topology| AT[(Accepted topology)]
+    W -->|eligibility observed: enqueue| FZ[(resource_inbox: APP_INBOX GROUP_BATCH_FINALIZE)]
+    FZ --> F[Any batch finalizer]
+    F -->|version CAS terminal transition| B
+    F -->|promote via snapshot CAS| AT[(Accepted topology)]
     F -->|final progress| WP
 ```
 
@@ -187,62 +353,82 @@ Every authoritative contract carries the complete group scope:
 ```ts
 type GroupRef = Readonly<{
   applicationId: string;
-  workspaceId?: string;
+  workspaceId: string;
   groupId: string;
 }>;
 ```
 
-The following identities are stable:
+`workspaceId` is required, matching the repository's `GroupRef`. The domain
+canonical for an unscoped workspace is the `'default'` sentinel
+(`DEFAULT_STATE_WORKSPACE_ID`); `group_batch.workspace_id` stores that
+canonical and never `NULL` or the empty string.
+
+The following identities are stable, with explicit queue-key budgets
+(`resourceId` <= 36 characters, `contextId` <= 35 characters):
 
 - `activationRequestId`: idempotency identity of the client request and the
-  ticket returned by the API.
-- `batchId`: deterministic from the activation request identity, or a UUID
-  claimed by a first-writer-wins insert.
-- `batchGeneration`: monotonically increasing within a `GroupRef`.
+  ticket returned by the API. Client-supplied or derived; validated to at
+  most 36 characters.
+- `batchId`: a ULID (26 characters, lexicographically sortable, unique).
+  A ULID fits the 35-character `contextId` budget, so batch-scoped queue rows
+  are queryable by `contextId = batchId` without hash rewriting.
+- `batchGeneration`: assigned by a global PostgreSQL `bigint` sequence
+  (`DEFAULT nextval(...)`). It is monotonically increasing within every
+  `GroupRef` (with gaps, which are acceptable); no read-max-plus-one
+  assignment exists.
 - `topologyInputHash`: deterministic digest of topology-relevant membership,
   active-session identities, effective topology configuration, and capacity
   policy. It excludes unrelated metadata and heartbeat timestamps.
-- `chunkId`: deterministic from `batchId` and chunk ordinal.
-- `remoteWorkId`: deterministic from `batchId`, `chunkId`, edge identity, and
-  confirmation role.
-- `dispatchId`: deterministic from `remoteWorkId` and attempt number.
+- `chunkId`: deterministic from `batchId` and chunk ordinal
+  (`ck-<ordinal>`).
+- `remoteWorkId`: deterministic namespaced hash (<= 32 characters) of
+  `(batchId, chunkId, edgeId, confirmationRole)`. The composite natural key
+  exceeds the column budget, so the hash form is the identity; the full
+  components remain inside the payload.
+- `dispatchId`: `remoteWorkId` plus `:a<attempt>`; fits the 36-character
+  budget.
+- Ack command identity: deterministic from `remoteWorkId`, dispatch attempt,
+  and normalized outcome kind, so a late success after an earlier failure
+  report is a distinct durable command rather than a key collision.
 
-Identifiers stored in `resource_inbox` must fit the current column lengths.
-When a composite natural key would exceed the limit, use a stable namespaced
-hash or UUID rather than truncating it.
+Deterministic identities are not capabilities. Any holder of a ticket can
+derive every `remoteWorkId` in a batch; authorization comes exclusively from
+the authenticated sender binding described in Authorization And Trust.
 
-The current queue uniqueness constraint does not include `ri_type_id`; it is
-`(contextId, resourceId, topicId)`. Queue keys must therefore be lane-qualified
-or otherwise distinct. A remote tracking row and its WS dispatch must never
-reuse the same three-part key merely because their `ri_type_id` differs.
+Because the queue uniqueness constraint ignores `ri_type_id`, a remote
+tracking row and its WS dispatch never share the same
+`(contextId, resourceId, topicId)` triple: topics are lane-qualified
+operation topics, and `resourceId` differs (`remoteWorkId` versus
+`dispatchId`).
 
 For batch-scoped `APP_INBOX` edge chunks and `ASYNC_REMOTE_QUEUE` rows,
-`fk_ext_bank_id`/`contextId` should contain `batchId`. This makes the batch
-queryable without parsing `ri_resource`. The full `GroupRef` remains mandatory
-inside the authoritative payload and is validated against the batch row.
+`fk_ext_bank_id`/`contextId` contains `batchId`. This makes the batch
+queryable without parsing `ri_resource`. The full `GroupRef` remains
+mandatory inside the authoritative payload and is validated against the batch
+row.
 
 ## Data Model
 
 ### `resource_inbox`
 
-No second remote-work table is added. Existing columns keep their current
-meaning, with these activation-specific conventions:
+No second remote-work table is added in v1. Existing columns keep their
+current meaning, with these activation-specific conventions:
 
-| Column | Activation use |
-| --- | --- |
-| `ri_resource_id` | Stable activation, chunk, remote-work, or dispatch identity |
-| `ri_topic_id` | Operation topic such as group activation, edge chunk, or RTC edge |
-| `ri_resource` | Versioned authoritative JSON/AL message |
-| `ri_type_id` | Logical lane: `APP_INBOX`, `APP_OUTBOX`, `WS_OUTBOX`, or `ASYNC_REMOTE_QUEUE` |
-| `ri_status` | Queue/remote lifecycle status |
-| `fk_ext_bank_id` | Existing context; `batchId` for batch-scoped chunk and remote rows |
-| `start_ts` | Time the current server processing attempt was reserved |
-| `end_ts` | Terminal processing time when applicable |
-| `next_ts` | Retry eligibility or remote-response deadline |
-| `ri_attempts` | Server processing or remote dispatch attempt number |
-| `expire_ts` | Retention deadline; never earlier than the batch result and ticket retention window |
+| Column           | Activation use                                                             |
+| ---------------- | -------------------------------------------------------------------------- |
+| `ri_resource_id` | Stable activation, chunk, remote-work, dispatch, ack, or finalize identity |
+| `ri_topic_id`    | Operation topic such as group activation, edge chunk, or RTC edge          |
+| `ri_resource`    | Versioned authoritative JSON/AL message                                    |
+| `ri_type_id`     | Logical lane, including the new `ASYNC_REMOTE_QUEUE`                       |
+| `ri_status`      | Queue/remote lifecycle status                                              |
+| `fk_ext_bank_id` | Existing context; `batchId` (ULID) for batch-scoped chunk and remote rows  |
+| `start_ts`       | Time the current server processing attempt was reserved                    |
+| `end_ts`         | Terminal processing time when applicable                                   |
+| `next_ts`        | Retry eligibility or remote-response deadline                              |
+| `ri_attempts`    | Server processing or remote dispatch attempt number                        |
+| `expire_ts`      | Retention deadline; never earlier than the batch result and ticket window  |
 
-Add a focused batch index if query plans show that the existing unique index is
+Add a focused batch index if query plans show that the existing indexes are
 not sufficient:
 
 ```sql
@@ -251,13 +437,18 @@ ON resource_inbox
   (fk_ext_bank_id, ri_type_id, ri_status, next_ts, ri_row_id);
 ```
 
-This is an additive index, not a redesign of the resource table.
+This is an additive index, not a redesign of the resource table. Every schema
+change in this design lands in both the Prisma migration and
+`apps/api-v1/src/db/in-memory-schema.sql`; parity between the two is a
+review-blocking requirement because the in-memory schema backs the fast test
+path.
 
 ### Remote work payload
 
-Each `ASYNC_REMOTE_QUEUE` row is one confirmation unit. If both endpoints must
-confirm an edge, create two remote rows. Do not store an array whose members
-have independent completion states inside one row.
+Each `ASYNC_REMOTE_QUEUE` row is one confirmation unit. Both endpoints of an
+edge confirm it: the initiator and the responder each get one remote row. Do
+not store an array whose members have independent completion states inside
+one row.
 
 ```ts
 type AsyncRemoteRtcEdgeWorkV1 = Readonly<{
@@ -267,14 +458,17 @@ type AsyncRemoteRtcEdgeWorkV1 = Readonly<{
   batchId: string;
   chunkId: string;
   groupRef: GroupRef;
-  sourceGroupStateRevision: number;
+  sourceGroupStateCausalRevision: Readonly<{
+    groupRevision: number;
+    presenceRevision: number;
+  }>;
   topologyInputHash: string;
   edgeId: string;
   confirmationRole: 'initiator' | 'responder';
   targetPrincipalId: string;
   targetSessionId: string;
   peerSessionId: string;
-  topologyGeneration: number;
+  batchGeneration: number;
   maximumAttempts: number;
   responseTimeoutMs: number;
   createdAtEpochMs: number;
@@ -282,58 +476,94 @@ type AsyncRemoteRtcEdgeWorkV1 = Readonly<{
 ```
 
 All fields are mandatory because the row is persisted authoritative work. A
-sparse HTTP request uses a separate input type.
+sparse HTTP request uses a separate input type. `maximumAttempts` and
+`responseTimeoutMs` are server policy values clamped at the boundary; they
+are never accepted verbatim from client input.
+
+Role semantics:
+
+- The **initiator** opens the RTC connection to `peerSessionId` and reports
+  success when the data channel is open.
+- The **responder** passively awaits the inbound connection from
+  `peerSessionId`, bounded by the same `responseTimeoutMs`, and reports
+  success when the data channel is open. A responder that observes nothing by
+  the deadline simply lets the server-side timeout path fire; it may also
+  report a definitive rejection early.
+
+An edge is confirmed only when both roles' confirmation units succeed.
 
 ### New remote status
 
 Add `AWAITING_REMOTE` to `EntityStatus`.
 
 `AWAITING_REMOTE` means the durable browser command has been enqueued to
-`WS_OUTBOX`, and the server is waiting for a correlated response. The response
-deadline is `next_ts`.
+`WS_OUTBOX`, and the server is waiting for a correlated response. The
+response deadline is `next_ts`.
 
-The status must be added deliberately to status sets:
+The status must be added deliberately to status handling:
 
 - include it in nonterminal status reporting;
 - do not include it in ordinary `NEW`/`RETRY` app queue reservation;
 - include it only in the remote timeout scanner when `next_ts <= now()`;
 - treat `COMPLETED`, `FAILED`, and `ABORTED` as terminal remote outcomes.
 
-Existing generic helpers do not give every status the same meaning in every
-lane; for example, ordinary queue machinery may reconsider `FAILED` work.
-Introduce lane-aware helpers such as `isAsyncRemoteTerminalStatus()` and do
-not register `ASYNC_REMOTE_QUEUE` with the ordinary failed-entry retry loop.
+Statuses do not carry the same meaning in every lane. Introduce lane-aware
+predicates such as `isAsyncRemoteTerminalStatus()` beside the activation
+owner rather than widening the shared generic status sets. The blast radius
+of the new status spans the exported status sets in `ResourceEntry.ts`, the
+row-lifecycle invariant switch in `ResourceInboxRepository`, the lane-aware
+release logic in `QueueBoxTypes.ts`, and the in-memory queue mirror; the
+validation strategy therefore requires invariance tests proving that every
+existing lane's selector behavior is unchanged by the addition.
 
 Remote work transitions are:
 
 ```text
-                 browser acknowledgement
-AWAITING_REMOTE ----------------------------> COMPLETED
+                 browser result (success, or transient
+                 failure with no attempts remaining)
+AWAITING_REMOTE ----------------------------> COMPLETED | FAILED
        |
-       | deadline reached and conditionally claimed
+       | deadline reached, or transient failure reported,
+       | and conditionally claimed
        v
    RESERVED ---- attempts remain ----> AWAITING_REMOTE
-       |                                  + WS_OUTBOX retry
+       |                                  + WS_OUTBOX retry dispatch
        |
        +---- attempts exhausted --------> FAILED
 
-AWAITING_REMOTE or RESERVED -- obsolete plan --> ABORTED
+AWAITING_REMOTE or RESERVED -- batch superseded --> ABORTED
+RESERVED (worker crash) -- reserved-timeout recovery --> re-evaluated
 ```
 
-`AWAITING_REMOTE` begins when the remote row and its first `WS_OUTBOX` row are
-committed, not when the socket physically sends. This keeps the first version
-simple and durable. A delayed WebSocket delivery may therefore cause a harmless
-duplicate dispatch. Browsers must deduplicate by `remoteWorkId`, and the timeout
-must include a reasonable queue-delivery allowance. If measurement later shows
-false timeouts, add a delivery acknowledgement phase instead of guessing now.
+Failure taxonomy: a **transient** browser failure report (connection attempt
+failed, ICE failure, peer temporarily unreachable) follows the retry path
+while attempts remain, exactly like a timeout. Only **definitive** rejections
+are immediately terminal: wrong target session, unauthorized, browser
+capacity cap blocked, malformed command. This keeps a promptly-reporting
+browser from being punished relative to a silent one.
+
+`ASYNC_REMOTE_QUEUE` rows in `RESERVED` are registered with the existing
+reserved-timeout recovery scan. A recovered row is re-evaluated against the
+current batch: retried if the batch is `STARTED` and attempts remain, aborted
+if the batch is no longer current, failed if attempts are exhausted.
+
+`AWAITING_REMOTE` begins when the remote row and its first `WS_OUTBOX` row
+are committed, not when the socket physically sends. In cluster mode a
+dispatch with no locally connected recipient completes without delivery on
+the assumption another server delivers; when no server holds the socket, the
+remote deadline is the recovery net. This is safe under at-least-once
+semantics but means each missed dispatch costs up to one `responseTimeoutMs`
+before redispatch; the timeout must include a realistic delivery allowance.
+Browsers must deduplicate by `remoteWorkId`. If measurement later shows false
+timeouts, add a delivery acknowledgement phase instead of guessing now.
 
 ### Conditional remote transitions
 
 A new status alone does not make remote work safe. A browser acknowledgement
 can race a timeout worker.
 
-Acknowledgement uses an expected-state transition and never rewrites a
-terminal row:
+Acknowledgement processing uses an expected-state transition and never
+rewrites a terminal row:
 
 ```sql
 UPDATE resource_inbox
@@ -349,8 +579,8 @@ RETURNING *;
 
 A timeout retry conditions on the status and observed attempt number. Its
 transaction updates the remote row and inserts the attempt-specific
-`WS_OUTBOX` dispatch. If the conditional update affects no row, the transaction
-must not commit another dispatch.
+`WS_OUTBOX` dispatch. If the conditional update affects no row, the
+transaction must not commit another dispatch.
 
 No `ri_revision` column is required for the first iteration because
 `(expected status, expected attempts)` is the remote row's fencing condition.
@@ -362,20 +592,27 @@ attempts, add an explicit revision rather than weakening the condition.
 The conceptual schema is:
 
 ```sql
+CREATE SEQUENCE group_batch_generation_seq;
+
 CREATE TABLE group_batch (
-  batch_id                    varchar(128) PRIMARY KEY,
-  activation_request_id       varchar(128) NOT NULL,
+  batch_id                    varchar(32) PRIMARY KEY,
+  activation_request_id       varchar(36) NOT NULL,
   application_id              varchar(128) NOT NULL,
   workspace_id                varchar(128) NOT NULL,
   group_id                    varchar(128) NOT NULL,
-  batch_generation            bigint NOT NULL,
-  source_group_state_revision bigint NOT NULL,
+  batch_generation            bigint NOT NULL
+                                DEFAULT nextval('group_batch_generation_seq'),
+  source_group_revision       bigint NOT NULL,
+  source_presence_revision    bigint NOT NULL,
   topology_input_hash         varchar(128) NOT NULL,
   status                      varchar(36) NOT NULL,
   input_json                  jsonb NOT NULL,
   planned_topology_json       jsonb NOT NULL,
   expected_chunk_count        integer NOT NULL,
   planned_edge_count          integer NOT NULL,
+  terminal_chunk_count        integer NOT NULL DEFAULT 0,
+  terminal_remote_count       integer NOT NULL DEFAULT 0,
+  failed_remote_count         integer NOT NULL DEFAULT 0,
   in_flight_remote_count      integer NOT NULL DEFAULT 0,
   version                     bigint NOT NULL DEFAULT 1,
   created_ts                  timestamptz NOT NULL,
@@ -388,6 +625,9 @@ CREATE TABLE group_batch (
   UNIQUE (application_id, workspace_id, group_id, activation_request_id),
   CHECK (expected_chunk_count >= 0),
   CHECK (planned_edge_count >= 0),
+  CHECK (terminal_chunk_count >= 0),
+  CHECK (terminal_remote_count >= 0),
+  CHECK (failed_remote_count >= 0),
   CHECK (in_flight_remote_count >= 0)
 );
 
@@ -396,34 +636,53 @@ ON group_batch (application_id, workspace_id, group_id)
 WHERE status = 'STARTED';
 ```
 
-Use the repository's canonical representation for absent `workspaceId`; do
-not alternate between `NULL` and an empty string for the same scope.
+`batch_id` is a ULID. `workspace_id` stores the `'default'` canonical when
+the scope has no explicit workspace; `NULL` and the empty string are
+forbidden. The partial unique index has no precedent in the current schema
+and requires a raw SQL migration plus the in-memory schema mirror.
+
+The source revision is the causal tuple, stored as its two components. The
+scalar `stateRevision` sum is not stored: it cannot express the partial
+order, and promotion must construct the accepted snapshot from the tuple.
+
+The terminal counters are maintained by the same transactions that already
+touch the batch row (chunk expansion, remote terminal transitions, abort
+sweep) as commutative increments. They exist so finalization eligibility is
+an O(1) read of the batch row rather than a per-wake aggregate scan; the
+full aggregate query remains the final verification before a terminal
+transition. Counters and the large JSON columns are deliberately not
+indexed so counter updates stay HOT-updatable and the TOASTed plan JSON is
+not rewritten.
 
 The authoritative batch statuses are:
 
-| Status | Meaning |
-| --- | --- |
-| `STARTED` | Plan and edge chunks are sealed; work is incomplete |
-| `COMPLETED` | Every required remote confirmation succeeded and the topology was promoted |
-| `PARTIAL` | Work is terminal and some edges failed, but the confirmed topology still passes minimum invariants |
-| `FAILED` | Retry budget or validation failed and no acceptable new topology can be promoted |
-| `SUPERSEDED` | A newer causal group input replaced this batch before completion |
+| Status       | Meaning                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `STARTED`    | Plan and edge chunks are sealed; work is incomplete                          |
+| `COMPLETED`  | Every required remote confirmation succeeded                                 |
+| `PARTIAL`    | Work is terminal and some edges failed, but the confirmed topology validates |
+| `FAILED`     | Retry budget or validation failed; no acceptable new topology promoted       |
+| `SUPERSEDED` | A newer causal group input replaced this batch before completion             |
 
-`SUPERSEDED` is necessary for joins, leaves, and other topology-relevant group
-changes during activation. Reporting such a batch as a generic failure would
-mislead callers and operators.
+`SUPERSEDED` is necessary for joins, leaves, and other topology-relevant
+group changes during activation. Reporting such a batch as a generic failure
+would mislead callers and operators. A batch superseded by a replacement
+planner is terminal at supersession time; its `outcome_json` records
+best-effort counts (its remote rows may still be draining through the abort
+sweep).
 
-`source_group_state_revision` remains mandatory causal evidence and an
-expected-read check, but a greater revision alone does not supersede a batch.
-For example, a heartbeat may advance durable group state without changing the
-planned peers. Supersession requires a changed `topology_input_hash` or a
+`(source_group_revision, source_presence_revision)` remains mandatory causal
+evidence, but revision movement alone does not supersede a batch: the causal
+order is partial, and a heartbeat may advance durable state without changing
+the planned peers. Supersession requires a changed `topology_input_hash` or a
 business lifecycle transition that makes activation invalid.
 
-The `version` is the compare-and-set token. Every update uses:
+The `version` is the compare-and-set token for status transitions:
 
 ```sql
 UPDATE group_batch
-SET ...,
+SET status = :next_status,
+    ...,
     version = version + 1,
     updated_ts = now()
 WHERE batch_id = :batch_id
@@ -431,8 +690,10 @@ WHERE batch_id = :batch_id
 RETURNING *;
 ```
 
-A zero-row result is a conflict, not success. The caller rolls back and repeats
-the complete service cycle from a fresh read.
+A zero-row result is a conflict, not success. The caller's cycle restarts
+from a fresh read under AppInbox retry ownership. Counter updates use the
+capacity/status predicate form and do not touch `version` (see Core
+Decisions).
 
 ## Group RTC Activation Status
 
@@ -452,51 +713,65 @@ INACTIVE | INITIALISING | ACTIVE | RECONFIGURING | DEGRADED | FAILED
 accepted topology while a newer batch runs. Calling that group `INITIALISING`
 would incorrectly imply that it has no usable RTC topology.
 
-The projection is derived from the current batch plus the last accepted
-topology:
+The projection is derived from the current batch plus the accepted topology
+snapshot:
 
-| Current condition | RTC activation status |
-| --- | --- |
-| No accepted topology and no current batch | `INACTIVE` |
-| `STARTED` batch and no accepted topology | `INITIALISING` |
-| `STARTED` batch with an accepted predecessor | `RECONFIGURING` |
-| Current batch `COMPLETED` and promoted | `ACTIVE` |
-| Current batch `PARTIAL`, or reconfiguration failed while an older topology remains usable | `DEGRADED` |
-| Current batch `FAILED` and there is no usable topology | `FAILED` |
+| Current condition                                                             | RTC activation status |
+| ----------------------------------------------------------------------------- | --------------------- |
+| No accepted topology and no current batch                                     | `INACTIVE`            |
+| `STARTED` batch and no accepted topology                                      | `INITIALISING`        |
+| `STARTED` batch with an accepted predecessor                                  | `RECONFIGURING`       |
+| Current batch `COMPLETED` and promoted                                        | `ACTIVE`              |
+| Current batch `PARTIAL`, or reconfiguration failed with older usable topology | `DEGRADED`            |
+| Current batch `FAILED` and there is no usable topology                        | `FAILED`              |
 
-This projection should be returned by group/topology read APIs but should not
-replace `Group.status` or cause ordinary business-lifecycle mutations.
+The projection is served by group/topology read APIs and the activation
+ticket endpoint. All activation read surfaces require group read
+authorization unconditionally; they are not gated on the legacy
+`RALLAR_STATE_STRICT_READ_AUTH` flag, because batch state and the planned
+topology expose the group's session graph.
 
 ## Service Contract
 
 Transport adapters convert HTTP, WebSocket, or database queue inputs into the
-same typed domain input. Domain services expose the four phases; a small
-application runner invokes them and owns bounded optimistic retries.
+same typed domain input. Domain services follow the convergent service
+doctrine exactly as written in
+`.agents/skills/rallar-code-writing/references/convergent-service-writing.md`;
+this section repeats only the binding consequences:
 
-```ts
-interface ReadComputeValidateWriteService<I, R, P, O> {
-  read(input: I): Promise<R>;
-  compute(input: I, read: R): P;
-  validate(input: I, read: R, plan: P): void;
-  write(input: I, read: R, plan: P): Promise<O>;
-}
-```
-
-Rules for every service:
-
-- `read` obtains all state required for authorization, policy, capacity,
-  lifecycle, and invariant decisions.
-- `compute` is deterministic and side-effect-free for the same input and read
-  model.
-- `validate` checks both read data and the computed plan. It performs no
-  writes.
-- `write` opens the shortest practical transaction and uses expected versions
-  or expected row states.
-- An optimistic conflict restarts at `read`; it never retries only a stale
-  final write.
+- Services expose direct, named `read`, `compute`, `validate`, and
+  `write(transaction, computed)` members, in the same shape as
+  `GroupStateMutationService`. Computed persistence data is called
+  `computed`, never `plan` (the domain artifact `planned_topology_json`
+  keeps its name because it is a topology proposal, not the service's
+  computed persistence value).
+- AppInbox owns the transaction and the retry boundary. There is no
+  activation-specific in-process retry runner: a conflict is a classified
+  retryable error, the queue row releases to `RETRY` under the standard
+  20-attempt jittered schedule, and the next dequeue reruns the whole cycle
+  from `read`, including authorization, policy, capacity, lifecycle, and
+  invariant validation.
+- `write` receives the transaction from `AppInboxTransactionWriter` and never
+  opens, commits, replaces, or retries one. Its operation-specific
+  conditional guard is the first write.
+- Transaction, retry, lifecycle, and after-commit dependencies use named
+  ports declared beside the canonical owner. No generic
+  `ReadComputeValidateWriteService<I, R, P, O>` abstraction is introduced.
+- `read` obtains all state required for decisions from repositories, not
+  process caches. The cached group-state read-through paths are for serving
+  reads; activation decisions read authoritative state.
 - Malformed scope, authorization denial, invariant violation, resource-cap
-  violation, and exhausted retry budgets are typed terminal outcomes.
-- Retry budgets are bounded and observable.
+  violation, and exhausted retry budgets are typed terminal outcomes, not
+  exceptions.
+
+Placement: the canonical implementation lives in a new owned feature
+directory, `packages/shared-server/rallar-system/group-activation/**`, with a
+durable repository navigation README (the module count and control-flow
+family count exceed the thresholds in the realtime skill). Nothing new is
+added under `rallar-system/services/**`, which is compatibility-only for
+these capabilities. Shared contracts live with the existing API contracts in
+`packages/shared`; both runtimes (Node workspaces and Deno apps) consume them
+through the existing aliases.
 
 Network calls and RTC work never occur inside a database transaction.
 
@@ -508,20 +783,34 @@ An authorized group director or any other client allowed by group policy may
 request activation through HTTP or WebSocket.
 
 1. Authenticate the caller and normalize the complete `GroupRef`.
-2. Derive or accept an idempotency key as `activationRequestId`.
-3. Insert one `APP_INBOX` `ACTIVATE_GROUP` row with a deterministic key.
-4. Return HTTP `202 Accepted` or the WebSocket equivalent with the activation
-   ticket.
-5. Wake queue readers as an optimization.
+2. Derive or accept an idempotency key as `activationRequestId` (<= 36
+   characters, validated).
+3. Clamp all requested topology options to server policy.
+4. Insert one `APP_INBOX` `ACTIVATE_GROUP` row with a deterministic key.
+5. Return HTTP `202 Accepted` (or the WebSocket equivalent) with the
+   activation ticket.
+6. Wake queue readers as an optimization.
 
 The durable payload includes the actor, requested group scope, requested
-topology options, idempotency identity, and causal request metadata. The worker
-reruns authorization from durable current state; acceptance by the transport
-does not authorize a later stale decision.
+topology options, idempotency identity, and causal request metadata. The
+worker reruns authorization from durable current state; acceptance by the
+transport does not authorize a later stale decision.
 
-Before a `group_batch` row exists, ticket polling reports `QUEUED` from the
-activation command row. Once a batch exists, polling reports the batch and its
-derived RTC activation status.
+**Ticket read surface.** A new read endpoint resolves a ticket by scoped
+`activationRequestId`, under mandatory group read authorization:
+
+- If no batch references the request yet, the endpoint reads the activation
+  command row and reports `QUEUED`; if the command has terminally failed
+  before ever creating a batch (retry exhaustion, typed rejection), it
+  reports `QUEUED_FAILED` with the typed reason.
+- Once a batch exists (created by or attached to this request), the endpoint
+  reports the batch status, the derived RTC activation status, and the
+  outcome summary when terminal.
+
+The ticket state machine is
+`QUEUED -> (QUEUED_FAILED | STARTED -> COMPLETED | PARTIAL | FAILED | SUPERSEDED)`.
+Because the command's completion and the batch insert commit in the same
+AppInbox transaction, polling never observes a gap between them.
 
 ### 2. Plan group activation
 
@@ -529,10 +818,13 @@ Any server may claim the single activation command.
 
 Read:
 
-- Read the complete scoped group snapshot and causal revision.
-- Read the effective topology configuration and relevant RTT/capacity inputs.
+- Read the complete scoped group snapshot and causal revision tuple from
+  authoritative repositories.
+- Read the effective topology configuration and relevant RTT/capacity
+  inputs.
 - Read an existing batch for the same activation request.
-- Read any current `STARTED` batch and last accepted topology.
+- Read any current `STARTED` batch, its fingerprint and age, and the accepted
+  topology snapshot.
 - Rerun authorization and group lifecycle policy.
 
 Compute:
@@ -540,35 +832,43 @@ Compute:
 - Compute the topology in memory with the existing graph/topology packages.
 - Compute `topologyInputHash` from the canonical topology-relevant input.
 - Validate and deterministically order edges.
-- Divide edges into fixed-size chunks.
-- Assign deterministic batch, chunk, and edge identities.
-- Create the immutable batch plan and queue envelopes in memory.
+- Divide edges into fixed-size chunks sized within the capacity ceiling.
+- Assign the ULID `batchId` and deterministic chunk and edge identities.
+- Create the immutable batch content and queue envelopes in memory.
 
 Validate:
 
 - The group remains eligible for RTC activation.
-- The source revision is still the one used by the plan.
-- The canonical topology input still produces the planned
-  `topologyInputHash`; a revision-only change with the same fingerprint can be
-  rebased without discarding the plan after authorization is rerun.
+- The source causal revision tuple is still current for the computed input; a
+  revision-only change with an identical fingerprint is rebased after
+  authorization is rerun.
+- Idempotency: a batch for this `activationRequestId` already exists ->
+  return it. The current `STARTED` batch has the same fingerprint -> attach
+  (no new batch). The current `STARTED` batch is younger than
+  `minimumBatchAgeMs` -> defer this command.
 - Topology connectivity, degree, self-edge, duplicate-edge, and scope
   invariants hold.
-- Every chunk fits the configured group connection-capacity budget. A chunk
-  larger than the whole budget would otherwise block forever.
+- Every chunk's confirmation-unit count fits the capacity ceiling. A chunk
+  larger than the whole ceiling would otherwise block forever.
 - The batch and payload sizes stay within configured limits.
 
-Write in one transaction:
+Write in one transaction (received from AppInbox):
 
-- Conditionally insert the one `group_batch` row as `STARTED`.
+- If a different-fingerprint `STARTED` predecessor exists and is old enough,
+  compare-and-set it `STARTED -> SUPERSEDED` on its expected version and
+  enqueue the deterministic `GROUP_BATCH_ABORT_SWEEP` command for it.
+- Conditionally insert the one `group_batch` row as `STARTED` (unique
+  constraints and the partial index are the guards).
 - Persist the planned topology in `planned_topology_json`.
 - Insert exactly `expected_chunk_count` deterministic `APP_INBOX`
   `ACTIVATE_EDGE_CHUNK` rows.
-- Insert `WS_OUTBOX` activation-progress messages for connected group clients.
-- Record the accepted source revision and generation.
-- Record the accepted topology-input fingerprint.
+- Insert the coalesced `WS_OUTBOX` activation-progress message for connected
+  group clients.
+- Record the accepted source revision tuple, generation, and fingerprint.
 
 If any insert or expected-state condition fails, the transaction commits
-nothing. A duplicate activation request loads and returns the existing batch.
+nothing and the cycle restarts from `read`. A duplicate activation request
+loads and returns the existing batch.
 
 The batch is sealed by the atomic write of its expected count and all chunk
 rows. There is no end-of-batch sentinel.
@@ -578,11 +878,15 @@ rows. There is no end-of-batch sentinel.
 A simple query of outstanding remote rows before dequeue is not a concurrency
 control. Two servers can both observe spare capacity and oversubscribe it.
 
-Eligible processing therefore uses a purpose-specific optimistic
-claim-and-expand write. The edge chunks remain ordinary `resource_inbox`
-`APP_INBOX` rows, but the worker does not use a generic claim followed by an
-independent capacity update. Splitting those writes could leak capacity if the
-worker crashed between them.
+Chunks are ordinary `APP_INBOX` rows and use the standard reservation
+machinery: a worker claims the chunk with the existing
+`SELECT ... FOR UPDATE SKIP LOCKED` dequeue (row becomes `RESERVED`, attempts
+increment), computes outside any transaction, and then commits one atomic
+finish transaction conditioned on `(RESERVED, expected attempts)`. A worker
+crash before the finish commit leaves a `RESERVED` row for the existing
+reserved-timeout recovery; a crash after commit leaves the complete
+expansion. Capacity is written only in the finish transaction, so no crash
+point leaks capacity.
 
 Read:
 
@@ -591,91 +895,116 @@ Read:
 
 Compute:
 
-- Create one remote confirmation work item for each required browser result.
+- Create one remote confirmation work item per required browser result (two
+  per edge: initiator and responder).
 - Create the corresponding first-attempt `WS_OUTBOX` dispatch messages.
 
 Validate:
 
-- The batch is still `STARTED` and has the expected version/generation.
-- The group scope and topology-input fingerprint still match; newer causal
-  state with the same fingerprint is reauthorized and may continue.
+- The batch is still `STARTED` with the expected generation and fingerprint;
+  newer causal state with the same fingerprint is reauthorized and may
+  continue.
 - Each target session is still authorized and active enough to receive work.
 - Every remote identity belongs to exactly one planned edge and confirmation
   role.
 
 Write in one transaction:
 
-- Conditionally advance the chunk from `NEW` or `RETRY` to `COMPLETED`, using
-  its expected status and attempt number.
+- Conditionally advance the chunk from `RESERVED` to `COMPLETED`, using its
+  expected status and attempt number.
 - Conditionally increment `group_batch.in_flight_remote_count` by the number
-  of new remote confirmation units, using the expected batch version and the
-  configured capacity ceiling in the update predicate.
+  of new remote confirmation units and `terminal_chunk_count` by one, using
+  the capacity-predicate counter update (batch `STARTED`, ceiling in the
+  predicate; no version check).
 - Insert each deterministic `ASYNC_REMOTE_QUEUE` row as `AWAITING_REMOTE`.
 - Set each remote deadline in `next_ts` and initial attempts consistently.
 - Insert each deterministic first-attempt `WS_OUTBOX` row.
 - Record the chunk expansion outcome in its durable result payload.
 
-If capacity is unavailable, a conditional defer changes only the chunk to
-`RETRY` with a future `next_ts`; it does not reserve capacity or create child
-work. The chunk is never held as `RESERVED` while waiting for remote capacity.
-If the expansion worker crashes before commit, none of the chunk, capacity,
-remote, or WebSocket changes exist. If it crashes after commit, all of them
-exist and the chunk is already terminal.
-
-This purpose-specific write still reuses the existing physical table and
-queue contracts. It adds contention to the single batch row, but it provides a
-correct bound without a new capacity-token table. Chunk size and retry jitter
-limit the hot row in the first iteration.
+If capacity is unavailable, the worker releases the chunk to a short
+fixed-delay defer that does not consume the failure budget: the release rolls
+the reservation attempt back (or schedules through a defer-specific path)
+with a small constant `next_ts` delay, because waiting for capacity is not a
+failure and must not exhaust the 20-attempt budget on large batches. The
+chunk is never held `RESERVED` while waiting for capacity. Remote terminal
+transitions wake the queue engine so freed capacity is discovered promptly
+rather than at the next poll.
 
 ### 4. Perform RTC work in the browser
 
 The target browser receives a versioned edge command containing
-`remoteWorkId`, batch and topology generation, group scope, peer session, role,
-and deadline.
+`remoteWorkId`, batch and generation, group scope, peer session, role, and
+deadline.
 
 The browser:
 
+- validates that the message originates from the authenticated server sender
+  (`rallar-server`); commands from peers are rejected and counted;
 - validates that the message targets its current session and exact
   `GroupRef`;
 - deduplicates by `remoteWorkId`;
+- registers the commanded peer connection as retained so the overlay
+  reconciler does not tear it down before promotion, abort, or the retention
+  deadline (both roles);
 - performs assigned RTC connections in parallel within the server-provided
-  batch and browser-local safety limit;
-- reports a correlated success or failure through HTTP or WebSocket; and
-- treats repeat dispatch of the same `remoteWorkId` as a request to return the
-  same known result or continue the same idempotent operation.
+  batch and the browser-local safety limit (initiator connects; responder
+  awaits, bounded by the same deadline);
+- reports a correlated success, transient failure, or definitive rejection
+  through HTTP or WebSocket; and
+- treats repeat dispatch of the same `remoteWorkId` as a request to return
+  the same known result or continue the same idempotent operation.
 
-Browser output is proposal data. The server validates target identity, batch,
-edge, role, topology generation, and result shape before accepting it.
+Browser output is proposal data. The server validates the authenticated
+sender, target identity, batch, edge, role, generation, and result shape
+before accepting it.
 
 ### 5. Accept a remote result
 
-Any server may receive the browser response.
+Any server may receive the browser response. Result ingestion follows the
+mutation doctrine: the transport adapter authenticates, normalizes, clamps
+the payload size, and enqueues one deterministic `APP_INBOX`
+`RTC_EDGE_RESULT` command (identity from `remoteWorkId`, dispatch attempt,
+and outcome kind), then returns `202` without waiting for a durable result
+row. Duplicate submissions deduplicate at enqueue.
+
+The ack worker then runs the doctrinal cycle:
 
 Read:
 
-- Read the remote row, its batch, current group/session identity, and terminal
-  state.
+- Read the remote row, its batch, current group/session identity, and the
+  authenticated sender facts captured at the boundary.
 
 Compute:
 
 - Normalize the reported result.
-- Determine the legal remote transition and the corresponding decrement of
-  batch capacity.
-- Determine progress/finalization work to enqueue.
+- Determine the legal remote transition (terminal success, terminal
+  definitive failure, or transient-failure retry) and the corresponding
+  counter updates.
+- Determine coalesced progress and possible finalization eligibility.
 
 Validate:
 
-- The authenticated sender matches the expected principal and session.
-- The full group scope, batch, edge, confirmation role, and topology
-  generation match.
+- The authenticated sender session equals the row's `targetSessionId`, and
+  that session's principal equals `targetPrincipalId`.
+- The full group scope, batch, edge, confirmation role, and generation
+  match.
 - The result is valid for the current row state.
 - A stale or superseded result cannot reactivate an obsolete batch.
 
 Write in one transaction:
 
-- Conditionally transition the remote row to `COMPLETED` or terminal `FAILED`.
-- Optimistically decrement `group_batch.in_flight_remote_count` exactly once.
-- Insert any deterministic `WS_OUTBOX` progress message.
+- For terminal outcomes: conditionally transition the remote row to
+  `COMPLETED` or `FAILED`, decrement `in_flight_remote_count` and increment
+  `terminal_remote_count` (and `failed_remote_count` on failure) exactly
+  once via the counter predicate.
+- For transient failures with attempts remaining: conditionally transition
+  the row back through the retry path (equivalent to a deadline expiry) with
+  the attempt-specific next `WS_OUTBOX` dispatch.
+- Insert the coalesced `WS_OUTBOX` progress message when a progress
+  threshold is crossed.
+- When this write observes potential finalization eligibility (for example
+  the decrement that reaches zero in-flight with all chunks terminal),
+  enqueue the deterministic `GROUP_BATCH_FINALIZE` command.
 
 A duplicate acknowledgement observes the terminal row and succeeds as a
 no-op. A late successful result from an earlier dispatch attempt may complete
@@ -692,61 +1021,100 @@ status = AWAITING_REMOTE and next_ts <= now()
 
 For each due row:
 
-1. Conditionally reserve it using existing queue reservation behavior.
+1. Conditionally reserve it using the queue reservation behavior extended to
+   the remote lane.
 2. Reread the remote row, batch, group/session state, and attempt policy.
-3. Recompute and revalidate whether retry is still legal.
+3. Recompute and revalidate whether retry is still legal (batch still
+   `STARTED`, target session still live).
 4. If attempts remain, transactionally transition it back to
-   `AWAITING_REMOTE`, advance `next_ts`, increment/fence the attempt, and insert
-   the deterministic attempt-specific `WS_OUTBOX` row.
-5. If attempts are exhausted, transactionally mark it `FAILED`, decrement
-   batch in-flight capacity exactly once, and enqueue finalization/progress
-   work.
+   `AWAITING_REMOTE`, advance `next_ts`, increment/fence the attempt, and
+   insert the deterministic attempt-specific `WS_OUTBOX` row.
+5. If attempts are exhausted, transactionally mark it `FAILED`, update the
+   batch counters exactly once, and enqueue finalization eligibility work as
+   in Flow 5.
 
 If an acknowledgement wins while the timeout worker computes, the timeout
 worker's conditional write fails and its transaction emits no new dispatch.
+A timeout worker that crashes while holding `RESERVED` is recovered by the
+reserved-timeout scan and re-evaluated against the current batch status.
+
+Session death is handled proactively rather than deadline-paced: the
+presence-expiry and session-cleanup paths enqueue abort work for remote rows
+targeting the dead session, so a departed browser does not force every one of
+its confirmation units to wait out `responseTimeoutMs`.
 
 ### 7. Finalize a batch
 
-Finalization may be triggered after chunk completion, remote terminal
-transition, timeout exhaustion, or periodic reconciliation. Triggers are only
-wakeups; the database decides readiness.
+Finalization is a doctrinal `APP_INBOX` command. Any transaction that
+observes potential eligibility (Flows 5 and 6) enqueues
+`GROUP_BATCH_FINALIZE` with the deterministic identity
+`finalize:<batchId>:v<observed batch version>`; the version suffix makes
+re-triggering after a no-op run a distinct durable command instead of a key
+collision with the previous terminal row. A periodic reconciliation scanner
+enqueues the same command for any `STARTED` batch whose counters look
+eligible or whose age exceeds a policy bound, so a lost wake never strands a
+batch. Triggers remain wakeups; the database decides readiness.
 
-Read batch-scoped aggregates using `contextId = batchId`:
+Eligibility precheck is O(1) on the batch row:
 
-- number of expected edge chunks present;
-- edge chunks by status;
-- remote rows by terminal/success/failure status;
-- `group_batch` version and source group revision;
-- current group and accepted topology state.
+1. The batch is `STARTED`.
+2. `terminal_chunk_count = expected_chunk_count`.
+3. `in_flight_remote_count = 0`.
 
-The batch is eligible for finalization only when:
+Only when the precheck passes does the finalizer run the batch-scoped
+aggregate verification using `contextId = batchId`:
 
-1. Exactly `expected_chunk_count` edge chunks exist.
-2. Every edge chunk is terminal.
-3. No remote row is `AWAITING_REMOTE`, `RESERVED`, `NEW`, or `RETRY`.
-4. `in_flight_remote_count` is zero.
-5. The batch is still the current activation generation.
+- exactly `expected_chunk_count` edge chunks exist and every one is
+  terminal;
+- no remote row is `AWAITING_REMOTE` or `RESERVED`;
+- per-edge confirmation results for the confirmed-edge graph.
 
-Compute and validate the confirmed-edge graph:
+Compute and validate the confirmed-edge graph (an edge counts as confirmed
+only when both of its confirmation units succeeded):
 
 - `COMPLETED` when every required confirmation succeeded.
-- `PARTIAL` when failures exist but the confirmed graph remains an acceptable
-  connected topology under the configured policy.
+- `PARTIAL` when failures exist but the confirmed graph remains an
+  acceptable connected topology under the configured policy.
 - `FAILED` when no acceptable topology can be promoted.
-- `SUPERSEDED` when current durable state has a different topology-input
-  fingerprint or an incompatible business lifecycle.
+- `SUPERSEDED` when the batch is still the current generation but durable
+  state now has a different topology-input fingerprint or an incompatible
+  business lifecycle; in this case also enqueue the deterministic activation
+  command for the current input so replanning has an owner.
 
 Write in one transaction:
 
 - Conditionally update the batch from `STARTED` using its expected version.
-- Promote the accepted topology only for `COMPLETED` or validated `PARTIAL`.
-- Persist a mandatory outcome summary with total, completed, failed, and
+- For `COMPLETED` or validated `PARTIAL`, promote the confirmed topology
+  through `RtcTopologySnapshotRepository`: construct the snapshot from the
+  batch's source causal revision tuple and the next overlay version, and
+  commit through the repository's monotonic compare-and-set guard.
+- Record the promotion outcome inside `outcome_json` as
+  `promoted | stale | not-attempted`. A `stale` promotion (a newer accepted
+  snapshot already dominates) is not an error: the batch result stands, the
+  newer topology won, and the projection derives from the actual accepted
+  store.
+- Persist the mandatory outcome summary with total, completed, failed, and
   aborted confirmation counts.
 - Insert the deterministic final `WS_OUTBOX` notification.
 
-`GROUP_BATCH` is the completion barrier. A fake end-of-batch remote item is
+`group_batch` is the completion barrier. A fake end-of-batch remote item is
 unnecessary and would be vulnerable to arriving before slow chunk workers had
 created all their rows.
+
+### Abort sweep
+
+`GROUP_BATCH_ABORT_SWEEP`, enqueued by the superseding planner's transaction,
+is a doctrinal command that conditionally and idempotently:
+
+- transitions the superseded batch's `AWAITING_REMOTE` and recoverable
+  `RESERVED` remote rows to `ABORTED`, updating the old batch's counters;
+- transitions its unexpanded `NEW`/`RETRY` edge chunks to `ABORTED` so no
+  worker expands a dead batch;
+- leaves terminal rows untouched.
+
+The sweep is resumable after any crash because every transition is
+conditional. Late acknowledgements for aborted work observe the terminal row
+and are recorded as stale no-ops; they cannot promote the old topology.
 
 ## Join, Leave, And Disconnect Behavior
 
@@ -757,12 +1125,13 @@ An authorized client may request activation afterward.
 
 ### Join while `INITIALISING` or `RECONFIGURING`
 
-The membership/presence mutation may complete immediately, but it changes the
-topology input. The current batch becomes `SUPERSEDED`, and a deterministic
-activation command for the newer causal revision is enqueued.
+The membership/presence mutation completes immediately and enqueues the
+deterministic, debounced activation command for the newer causal revision. It
+never touches `group_batch`. The replacement planner supersedes the running
+batch atomically once the debounce and minimum-batch-age policies allow.
 
-The first implementation should replan the whole topology. Appending edges to
-an already sealed batch complicates expected counts, capacity, authorization,
+The first implementation replans the whole topology. Appending edges to an
+already sealed batch complicates expected counts, capacity, authorization,
 and optimal placement and makes completion ambiguous.
 
 ### Join while `ACTIVE`
@@ -770,23 +1139,22 @@ and optimal placement and makes completion ambiguous.
 Two policies are possible:
 
 - Recommended initial policy: retain the accepted topology temporarily, use
-  WS fallback where required, and enqueue a new reconfiguration batch.
+  WS fallback where required, and enqueue a debounced reconfiguration batch.
 - Later optimization: attach the new session as a leaf to an endpoint with
   spare capacity, then schedule a background topology optimization.
 
 The leaf optimization reduces join latency but risks poor RTT placement and a
-long-lived suboptimal topology. It should follow measurement, not be the first
-correctness path.
+long-lived suboptimal topology. It should follow measurement, not be the
+first correctness path.
 
 ### Leave or disconnect
 
-Existing presence expiry and RTC fault-tolerance mechanisms continue to remove
-or heal live connections. Topology-relevant departure supersedes a running
-batch and enqueues a new causal activation/reconfiguration command.
-
-Remote rows for a superseded batch become `ABORTED` through conditional,
-idempotent transitions. Late acknowledgements are recorded as stale no-ops and
-cannot promote the old topology.
+Existing presence expiry and RTC fault-tolerance mechanisms continue to
+remove or heal live connections. Topology-relevant departure enqueues the
+debounced activation command; a browser reconnect mints a new session
+identity and is a topology-relevant change like any other. The
+presence-cleanup path additionally enqueues proactive abort work for remote
+rows targeting the departed session (Flow 6).
 
 ## Transactions And Optimistic Concurrency
 
@@ -798,115 +1166,196 @@ required:
 - The transaction prevents a winning multi-row decision from being only
   partially persisted.
 
-The activation write boundary needs a shared PostgreSQL unit of work capable
-of passing one transaction-scoped repository to `group_batch`, runtime/group
-state, topology-plan, and resource-inbox operations. Calling several
-repositories that each open their own transaction does not satisfy the atomic
-write requirement.
+The activation write boundary reuses the existing shared unit of work:
+`AppInboxTransactionWriter` opens one transaction and passes the same
+`PSqlTransactionSql` to the transaction-bound `group_batch` repository, the
+group/runtime state repositories, the topology snapshot repository, and
+`ResourceInboxRepository`, exactly as existing group-state writes already do.
+Calling several repositories that each open their own transaction does not
+satisfy the atomic write requirement.
 
-No transaction includes topology computation, network I/O, WebSocket sending,
-browser waiting, retry sleeping, or unbounded row scans.
+AppInbox owns retries. There is no in-process optimistic retry loop; a
+conflict is a classified retryable error, the row releases to `RETRY`, and
+every subsequent attempt reruns authorization and policy from current state
+under the standard 20-attempt jittered schedule.
 
-The bounded retry loop is conceptually:
-
-```ts
-for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
-  const read = await service.read(input);
-  const plan = service.compute(input, read);
-  service.validate(input, read, plan);
-  const result = await service.write(input, read, plan);
-
-  if (result.kind !== 'conflict') return result;
-}
-
-return { kind: 'retry-exhausted' };
-```
-
-Every retry reruns authorization and policy from current state.
+No transaction includes topology computation, network I/O, WebSocket
+sending, browser waiting, retry sleeping, or unbounded row scans.
 
 ## Idempotency And Delivery Semantics
 
-- Activation request: first-writer-wins by scoped `activationRequestId`.
-- Batch creation: one row per request and one `STARTED` batch per group.
+- Activation request: first-writer-wins by scoped `activationRequestId`;
+  same-fingerprint requests attach to the current `STARTED` batch.
+- Batch creation: one row per request and one `STARTED` batch per group
+  (partial unique index); supersession is planner-atomic.
 - Edge chunks: deterministic by `(batchId, chunkOrdinal)`.
-- Remote work: deterministic by `(batchId, chunkId, edgeId,
-  confirmationRole)`.
+- Remote work: deterministic hash identity of
+  `(batchId, chunkId, edgeId, confirmationRole)`.
 - WebSocket dispatch: deterministic by `(remoteWorkId, attempt)`.
-- Browser acknowledgement: terminal conditional transition; duplicates are
-  no-ops.
-- Finalization: conditional transition from batch `STARTED` and deterministic
-  final publication identity.
+- Browser result command: deterministic by
+  `(remoteWorkId, attempt, outcome kind)`; duplicates dedupe at enqueue; the
+  row transition itself is a terminal conditional no-op on replay.
+- Abort sweep: deterministic per superseded `batchId`; every transition
+  conditional and idempotent.
+- Finalization: deterministic per `(batchId, observed batch version)`;
+  terminal transition conditional from `STARTED`; deterministic final
+  publication identity.
 
-Queue and WebSocket delivery are at least once. Exactly-once effects come from
-idempotent identities and conditional durable state transitions, not from an
-exactly-once transport claim.
+Queue and WebSocket delivery are at least once. Exactly-once effects come
+from idempotent identities and conditional durable state transitions, not
+from an exactly-once transport claim.
 
 ## Failure Handling
 
-| Failure | Recovery |
-| --- | --- |
-| Server crashes before a write | No durable effect; another worker retries |
-| Server crashes after enqueue commit | Durable queue row remains; any server can process it |
-| Server crashes during chunk expansion | Atomic chunk/capacity/remote/WS transaction leaves either no effect or the complete expansion |
-| Duplicate activation | Existing activation command/batch is returned |
-| Duplicate edge chunk delivery | Deterministic remote and WS identities prevent duplicate domain work |
-| Duplicate WebSocket delivery | Browser deduplicates by `remoteWorkId` |
-| Browser response races timeout | Conditional row transition selects the winner; losing transaction emits no new state-dependent work |
-| Browser never responds | Bounded retries, then terminal `FAILED` |
-| Group changes during activation | Old batch becomes `SUPERSEDED`; newer causal batch replans |
-| Worker repeatedly loses optimistic writes | Bounded retry-exhausted outcome; work remains retryable with backoff |
-| PostgreSQL notification is missed | Periodic durable queue scan finds the work |
-| Partial edge failure | Promote only if the confirmed topology still satisfies minimum invariants |
+| Failure                                   | Recovery                                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------------------- |
+| Server crashes before a write             | No durable effect; another worker retries                                       |
+| Server crashes after enqueue commit       | Durable queue row remains; any server can process it                            |
+| Server crashes holding a `RESERVED` chunk | Reserved-timeout recovery releases it; expansion is atomic so no capacity leaks |
+| Server crashes during chunk expansion     | The finish transaction leaves either no effect or the complete expansion        |
+| Duplicate activation                      | Existing command/batch returned; same fingerprint attaches                      |
+| Duplicate edge chunk delivery             | Deterministic remote and WS identities prevent duplicate domain work            |
+| Duplicate WebSocket delivery              | Browser deduplicates by `remoteWorkId`                                          |
+| Browser response races timeout            | Conditional row transition selects the winner; loser emits nothing              |
+| Browser reports transient failure         | Retry path while attempts remain; definitive rejects are terminal               |
+| Browser never responds                    | Bounded retries, then terminal `FAILED`                                         |
+| Target session dies mid-batch             | Presence cleanup proactively aborts its remote rows                             |
+| Group changes during activation           | Debounced command; replacement planner supersedes atomically; sweep aborts      |
+| Fingerprint drift with no new request     | Finalizer records `SUPERSEDED` and enqueues the replacement command             |
+| Promotion loses to a newer snapshot       | Outcome records `stale`; the newer accepted topology stands                     |
+| Worker repeatedly loses optimistic writes | Standard queue retry schedule; typed retry-exhausted outcome                    |
+| PostgreSQL notification is missed         | Periodic durable queue scan and finalization reconciler find the work           |
+| Partial edge failure                      | Promote only if the confirmed topology still satisfies minimum invariants       |
 
 ## Authorization And Trust
 
-- The activation request requires group policy authorization.
-- The worker reruns authorization when it processes the durable request.
+- The activation request requires group policy authorization, and the worker
+  reruns authorization when it processes the durable request and on every
+  retry.
 - Full `GroupRef` equality is mandatory at every queue, batch, WebSocket, and
   acknowledgement boundary.
-- Browser results are untrusted proposal data until the server validates the
-  authenticated principal/session, assigned role, edge, batch, and topology
-  generation.
-- A client cannot acknowledge work assigned to another session.
+- **Result authorization chain.** Deterministic work identities are not
+  capabilities. A result is accepted only when the transport-authenticated
+  session (WS: the envelope sender bound to the authenticated connection;
+  HTTP: the bearer session) equals the remote row's `targetSessionId`, and
+  that session's principal, resolved server-side, equals
+  `targetPrincipalId`. Payload-claimed identities are cross-checked against
+  the authenticated facts and never trusted. A client cannot acknowledge
+  work assigned to another session.
+- Unauthorized, stale, and mismatched results are typed rejections with
+  counters, never silent drops; the observability section's stale and
+  unauthorized acknowledgement metrics depend on this.
+- **Command origin.** Browsers accept `ESTABLISH_RTC_EDGE` only from the
+  authenticated server sender identity, in addition to target-session and
+  `GroupRef` validation. Without the origin check, a group peer could
+  command a victim browser to initiate RTC toward an attacker, exposing
+  addresses through ICE.
+- Browser results are untrusted proposal data until validated; result
+  payloads are size-capped at the boundary before enqueue.
+- `responseTimeoutMs`, `maximumAttempts`, capacity ceilings, debounce and
+  batch-age policies, and topology options are server policy values, clamped
+  at every boundary; client input never sets them directly.
 - A stale batch cannot publish or promote topology after a newer generation
-  wins.
-- Resource caps are checked on every optimistic retry.
+  wins; promotion goes through the monotonic snapshot compare-and-set.
+- Resource caps are checked on every retry attempt.
+- Abuse economics: fingerprint-attach makes identical-input request spam
+  free; debounce and minimum batch age bound forced-replan loops from
+  join/leave toggling; ordinary per-principal transport rate limits apply to
+  the activation endpoints.
+- The existing `TOPOLOGY_RECONFIGURE` path remains a second writer of the
+  accepted topology in v1. Both writers commit through the same monotonic
+  snapshot compare-and-set, so they cannot corrupt each other; operators
+  should prefer activation for RTC bring-up, and unifying reconfigure onto
+  activation batches is a scheduled follow-up decision.
+- The pre-existing RTC signaling relay gap (the inner `fromId` is not
+  asserted against the authenticated envelope sender) is tracked as a
+  separate hardening task outside this design; commanded edges raise its
+  priority because spoofed signaling can fail targeted edges.
 
 ## Retention And Cleanup
 
-- Activation commands, batch rows, edge chunks, remote work, durable results,
-  and final publications must share an explicit ticket-retention policy.
-- `expire_ts` must not remove a remote row before its response/retry window or
-  remove a completed row before duplicate acknowledgements are expected to
-  stop.
-- `group_batch.expire_ts` must outlive all child queue rows and the public
+- Activation commands, batch rows, edge chunks, remote work, result
+  commands, and final publications share an explicit ticket-retention
+  policy.
+- `expire_ts` must not remove a remote row before its response/retry window
+  or remove a completed row before duplicate acknowledgements are expected
+  to stop.
+- `group_batch.expire_ts` outlives all child queue rows and the public
   polling window.
 - Cleanup is conditional on expiry and terminal state. A `STARTED` batch is
-  reconciled or failed; it is not silently deleted.
-- Expiry of authoritative state uses expected-state or expected-version
-  conditions so cleanup cannot delete a refreshed replacement.
+  reconciled or failed; it is not silently deleted. This conditional
+  expected-state cleanup is new machinery: the existing unconditional
+  `deleteExpired` sweep is not sufficient for authoritative activation
+  state.
+- Cross-row retention ordering (batch outlives children) is a service-level
+  invariant validated in tests; JSON payloads provide no foreign keys.
 
 ## Observability And Operations
 
 Record at least:
 
-- activation commands queued, deduplicated, started, completed, partial,
-  failed, superseded, and retry-exhausted;
+- activation commands queued, deduplicated, attached, started, completed,
+  partial, failed, superseded, deferred by batch age, and retry-exhausted;
 - queue age by logical lane and operation;
-- batch duration and time spent waiting for capacity;
-- edge chunks runnable, reserved, completed, retried, and failed;
-- remote work awaiting, completed, failed, aborted, timed out, and retried;
+- batch duration, time waiting for capacity, and debounce coalescing counts;
+- edge chunks runnable, reserved, completed, deferred for capacity, retried,
+  aborted, and failed;
+- remote work awaiting, completed, failed, aborted, timed out, retried, and
+  proactively aborted on session death;
 - remote acknowledgement latency by attempt and browser/session class;
 - WebSocket dispatch retry count and no-local-recipient count;
-- optimistic conflicts by service and table;
-- batch capacity conflicts and `in_flight_remote_count`;
-- topology planned edges versus confirmed edges;
-- stale and unauthorized acknowledgement counts;
+- optimistic conflicts by service and table, and capacity-predicate
+  rejections;
+- topology planned edges versus confirmed edges; promotion outcomes
+  (promoted, stale, not-attempted);
+- stale, unauthorized, and origin-rejected command/acknowledgement counts;
 - ticket polling age and terminal result retention.
 
-Structured logs should always include `activationRequestId`, `batchId`, full
+Cardinality policy: per-batch rollups are the default granularity;
+per-remote-unit structured logs are sampled, not universal, because a single
+large batch emits thousands of units. Progress `WS_OUTBOX` messages are
+coalesced to a bounded count per batch (chunk completions and percentage
+thresholds, on the order of twenty messages), never per acknowledgement.
+Cluster wake notifications are coalesced per lane rather than emitted per
+row; the polling floor remains the correctness backstop.
+
+Structured logs always include `activationRequestId`, `batchId`, full
 `GroupRef`, chunk or remote work identity, attempt, server/service id, and
-causal group revision.
+the causal revision tuple.
+
+## Scale Posture
+
+The review's working model for a large group (mesh, degree limit 5):
+`E ≈ 2.5 × N` edges and `R = 2E` confirmation units. At `N = 400`: roughly
+1,000 edges, 2,000 remote rows, 40 chunks, and at least 2,000 dispatches;
+with result commands, a full generation writes on the order of 7,000-11,000
+`resource_inbox` rows, each transitioning status two to three times.
+
+Consequences this design accepts and plans for:
+
+- **Committed storage follow-up.** Activation traffic shares
+  `resource_inbox` with all product traffic. At hundreds of sessions the
+  original "reconsider a dedicated table upon measurement" triggers are met
+  immediately, so the follow-up is committed now: partition `resource_inbox`
+  by `ri_type_id` or move the remote/dispatch lanes to a dedicated table in
+  a scheduled successor change. The v1 schema, identities, and indexes are
+  designed to make that migration mechanical (lane-qualified keys,
+  batch-scoped context ids, additive index).
+- **Topology compute ceiling.** Planning cost grows quadratically in memory
+  and up to cubically in selection work (per the repository's RTC
+  performance baseline). Compute runs outside transactions, is debounced,
+  and is memoized by `topologyInputHash` across retries of the same input.
+  Groups beyond roughly 400 sessions are unvalidated until measured; do not
+  promise them.
+- **Counter-based finalization.** Eligibility prechecks are O(1) batch-row
+  reads; the full aggregate runs once per terminal decision.
+- **Capacity pacing.** Deferred chunks use short fixed delays and are woken
+  by remote terminal transitions, so drain speed tracks real capacity, not
+  the retry backoff curve.
+- **Browser cap.** Per-group planning does not see a browser's other
+  groups; the browser-local peer-connection cap can force cap-blocked
+  definitive rejections for multi-group browsers. This is a documented v1
+  limitation; a cross-group session budget is a possible successor.
 
 ## Critical Assessment
 
@@ -914,57 +1363,54 @@ causal group revision.
 
 - No designated server, leader election, or group ownership lease is needed.
 - Existing queue reservation, retry, expiry, and operational knowledge are
-  reused.
+  reused, including dashboards and operator intuition.
 - Edge chunks and remote results share one idempotent work model.
-- Cross-lane writes can use one PostgreSQL transaction because the rows share
-  the same database.
+- Cross-lane writes use the existing single-transaction unit of work.
 - `group_batch` provides one understandable completion barrier and public
-  ticket target.
-- Optimistic retries support multi-server progress without holding a lock
-  during topology calculation or browser work.
+  ticket target, with O(1) eligibility via counters.
+- Doctrinal AppInbox ownership means one retry model, one transaction owner,
+  and one verification style across every activation flow.
 - Deterministic identities make crash recovery and at-least-once delivery
   practical.
 - Separating business and RTC activation status avoids corrupting group
   lifecycle semantics.
+- The coexistence contract keeps browser-owned healing while adding
+  server-confirmed establishment.
 
 ### Costs And Risks
 
 - `resource_inbox` becomes heterogeneous. Every generic status switch,
   statistic, cleanup path, and dequeue selector must understand that
-  `AWAITING_REMOTE` is nonterminal but not ordinary runnable work.
-- The single `group_batch` row is a contention point for capacity allocation
-  and remote terminal decrements. This is acceptable for a bounded first
-  version but must be measured.
-- Batch-scoped aggregate queries need an indexed context convention and new
+  `AWAITING_REMOTE` is nonterminal but not ordinary runnable work; the
+  invariance tests in the validation strategy are the guard.
+- The browser-side retention and origin rules are mandatory coupled changes
+  in `shared-web`/shared services; server work alone cannot ship safely.
+- The single `group_batch` row remains a write hot spot, mitigated by
+  commutative counters; it must be measured under the target scale.
+- Batch-scoped aggregate queries need the indexed context convention and new
   repository methods; generic 50-row list methods are insufficient.
-- Starting the remote deadline when WS work is committed can cause duplicate
-  dispatch under a slow WS queue. This is safe but may be noisy.
-- One physical table mixes short-lived dispatch work with longer-lived remote
-  confirmations, increasing table and index churn.
-- JSON payloads do not provide relational foreign keys to batch rows. Scope and
-  batch identity must be validated in repository/service code.
-- Optimistic retry loops can amplify load under extreme contention. They need
-  bounded attempts, jitter, and conflict metrics.
+- Starting the remote deadline at commit can cause duplicate dispatch under
+  a slow WS queue; browsers deduplicate, and false-timeout measurement may
+  later justify a delivery acknowledgement phase.
+- One physical table mixes short-lived dispatch work with longer-lived
+  remote confirmations until the committed partition/table follow-up lands.
+- JSON payloads provide no relational foreign keys; scope and batch identity
+  are validated in repository/service code and tests.
 - A `PARTIAL` outcome is domain-sensitive. It must be decided by graph
   invariants, not merely by counting at least one successful edge.
+- Whole-topology replan per change is a small/medium-group policy. Debounce
+  bounds churn, but convergence at hundreds of sessions under heavy
+  membership change ultimately needs incremental or leaf-attach batches.
 
 ### Why not a separate `async_remote_work` table now?
 
 A separate table would give clearer constraints, status types, foreign keys,
 and retention indexes. It would also duplicate reservation, timeout, attempt,
-expiry, and idempotency machinery that `resource_inbox` already has. The
-current design defers that duplication until measurement proves the shared
-table is a bottleneck or correctness burden.
-
-Reconsider a dedicated table when one or more of these conditions are observed:
-
-- remote rows dominate `resource_inbox` size or vacuum/index cost;
-- remote retention differs materially from every other queue lane;
-- batch-scoped queries remain slow with the focused index;
-- shared status handling causes recurring defects;
-- remote work needs relational child results, quorum acknowledgements, or
-  payload updates that require an independent revision model;
-- operational ownership or access control differs from ordinary queue work.
+expiry, and idempotency machinery that `resource_inbox` already has. V1
+therefore reuses the shared table — but the successor is committed, not
+hypothetical (see Scale Posture), because at the target scale remote and
+dispatch rows dominate table churn immediately. The v1 design keeps the
+migration mechanical.
 
 ### Why not an end-of-batch work item?
 
@@ -977,103 +1423,164 @@ the marker race.
 ### Why not query outstanding work before dequeue?
 
 The query is a useful observation but not a reservation. Concurrent servers
-can read the same available capacity and all proceed. The optimistic
+can read the same available capacity and all proceed. The predicate-bounded
 `group_batch.in_flight_remote_count` update turns capacity into an atomic,
-bounded claim.
+bounded claim without serializing unrelated batch writes through one version
+counter.
 
 ## Validation Strategy
 
 ### Focused unit tests
 
-- Deterministic activation, batch, chunk, remote, and dispatch identities.
+- Deterministic activation, batch, chunk, remote, dispatch, ack, and
+  finalize identities, each within its queue-key budget (no silent hash
+  rewriting).
 - Topology chunking is deterministic and respects capacity-sized chunks.
 - `AWAITING_REMOTE` is nonterminal and excluded from ordinary runnable
-  selectors.
+  selectors; lane-aware predicates behave per lane.
+- **Existing-lane invariance:** adding the status changes no selector,
+  release, statistic, or cleanup behavior for `APP_INBOX`, `APP_OUTBOX`,
+  `WS_INBOX`, or `WS_OUTBOX` rows.
 - Due remote rows are selected only after `next_ts`.
 - Browser acknowledgement and timeout races have one monotonic terminal
-  outcome.
-- Duplicate acknowledgements are no-ops.
-- Late success from a prior dispatch attempt completes current work safely.
-- Batch status and RTC activation status projection for every state.
+  outcome; transient-failure reports retry, definitive rejects terminate.
+- Duplicate acknowledgements are no-ops; late success from a prior dispatch
+  attempt completes current work safely.
+- Fingerprint-attach, debounce, and minimum-batch-age decisions.
+- Batch status and RTC activation status projection for every state,
+  including `QUEUED_FAILED` tickets and stale promotions.
 - Partial topology passes only when connectivity and degree policy remain
-  valid.
+  valid, computed from both-role edge confirmation.
 
 ### PostgreSQL repository tests
 
 - Two servers race to insert the same activation and converge on one ticket.
-- Two servers race to create a batch and only one `STARTED` row wins.
-- Concurrent chunk claims cannot exceed group remote capacity.
-- Batch compare-and-set conflicts return a conflict without partial writes.
-- Remote acknowledgement versus timeout retry never regresses a terminal row.
-- A losing timeout transaction inserts no `WS_OUTBOX` dispatch.
-- Remote terminal transition decrements batch capacity exactly once.
+- Two servers race to create a batch and only one `STARTED` row wins; the
+  superseding planner's transaction atomically supersedes, inserts, and
+  enqueues the abort sweep.
+- Concurrent chunk expansions cannot exceed the capacity ceiling; counter
+  updates from expansions and decrements do not conflict with each other.
+- Batch status compare-and-set conflicts return a conflict without partial
+  writes.
+- Remote acknowledgement versus timeout retry never regresses a terminal
+  row; a losing timeout transaction inserts no `WS_OUTBOX` dispatch.
+- Remote terminal transition updates batch counters exactly once, including
+  the abort path.
+- Capacity deferral does not consume the chunk failure budget.
+- Finalize command identity re-arms across batch versions; the periodic
+  reconciler enqueues for eligible or over-age batches.
+- Promotion commits through the snapshot repository's monotonic guard;
+  stale promotion records the outcome without failing the batch.
 - Batch aggregate queries handle more than 50 chunks/remote rows.
-- Expiry cannot delete refreshed or nonterminal work.
+- Expiry cannot delete refreshed or nonterminal work; conditional cleanup
+  respects expected state.
+- Equal-tuple-different-content snapshot collisions surface as invariant
+  corruption; conflicting idempotency-key reuse is a typed rejection.
 
 ### Service tests
 
-- HTTP and WebSocket activation inputs produce the same normalized service
-  plan.
-- Every optimistic retry reruns authorization, capacity, lifecycle, and
-  topology validation.
-- Planner transaction writes batch, all chunks, and progress outbox atomically.
-- Edge expansion writes the chunk terminal state, capacity allocation, remote
-  rows, and WS rows atomically across simulated pre-commit and post-commit
-  crashes.
-- Finalization waits for the expected chunk count and all remote terminal
-  states.
-- Group join/leave supersedes stale activation and cannot promote its topology.
+- HTTP and WebSocket activation inputs produce the same normalized command.
+- Every retry reruns authorization, capacity, lifecycle, and topology
+  validation.
+- Planner transaction writes supersession, batch, all chunks, abort-sweep
+  command, and progress outbox atomically.
+- Edge expansion writes the chunk terminal state, capacity, remote rows, and
+  WS rows atomically across simulated pre-commit and post-commit crashes.
+- Result ingestion enforces the full authorization chain (session binding,
+  principal binding, scope, role, generation) with typed, counted
+  rejections.
+- Finalization waits for the counter precheck and aggregate verification.
+- Group join/leave supersedes stale activation and cannot promote its
+  topology; drift-detected supersession enqueues the replacement command.
 - Existing active topology survives a failed reconfiguration.
+- Per the convergent-service doctrine, every new AppInbox family
+  (activation, chunk, result, abort sweep, finalize) documents its
+  construction-and-registration timeline and runtime invocation timeline.
+
+### Browser tests
+
+- Command origin, target-session, and `GroupRef` validation, including
+  rejection counters.
+- Commanded-edge retention against reconciler teardown until promotion,
+  abort, or retention deadline, for both roles.
+- Dedup by `remoteWorkId` including repeat dispatch returning the same known
+  result.
+- Signaling readiness distinguished from data-channel readiness; at least
+  one reconnect scenario.
 
 ### Multi-server black-box tests
 
 - Client requests activation through server A; server B creates the batch;
-  servers C and A process chunks; browser acknowledgements arrive through a
-  different server; all converge on one batch outcome.
-- Kill a worker immediately before and after the atomic chunk-expansion commit;
-  another server observes either runnable work or the complete terminal
-  expansion, never a capacity leak or partial child set.
-- Drop queue wake notifications and prove periodic polling still completes.
+  servers C and A process chunks; browser results arrive through a different
+  server; all converge on one batch outcome.
+- Kill a worker immediately before and after the atomic chunk-expansion
+  commit; another server observes either runnable work or the complete
+  terminal expansion, never a capacity leak or partial child set.
+- Drop queue wake notifications and prove periodic polling and the
+  finalization reconciler still complete.
 - Delay and duplicate WebSocket commands and browser acknowledgements.
 - Run overlapping activation and membership-change traffic and prove stale
-  topology is never promoted.
-- Exhaust a browser retry budget and verify `PARTIAL` versus `FAILED` using the
-  topology invariants.
+  topology is never promoted and debounce bounds batch generations.
+- Exhaust a browser retry budget and verify `PARTIAL` versus `FAILED` using
+  the topology invariants.
 
 For REST behavior, add or update Rallar black-box recipes in
-`packages/shared-test/black-box-runner` as part of implementation.
+`packages/shared-test/black-box-runner` as part of implementation. API-v1
+mutation-path changes run the medium-scale convergence gate
+(`test:api-v1:black-box:postgres:medium-scale`) unweakened.
 
 ## Recommended Implementation Sequence
 
-1. Add shared activation, batch, remote-work, ticket, and status contracts.
-2. Add the `group_batch` migration, repository, optimistic transitions, and
-   batch-scoped resource-inbox aggregate queries/index.
-3. Add `ASYNC_REMOTE_QUEUE` and `AWAITING_REMOTE` semantics to queue contracts
-   and selectors.
-4. Add the common read/compute/validate/write optimistic runner.
-5. Add activation acceptance and batch planning with atomic chunk/progress
-   writes.
-6. Add capacity-aware edge-chunk claiming and deterministic remote/WS child
-   writes.
-7. Add browser command handling and HTTP/WS acknowledgement ingestion.
-8. Add timeout, retry, batch finalization, and topology promotion.
-9. Add join/leave supersession and reconfiguration behavior.
-10. Add focused, PostgreSQL, and multi-server black-box validation plus
-    operational metrics.
+1. Add shared activation, batch, remote-work, ticket, and status contracts in
+   `packages/shared`, consumable from both runtimes.
+2. Add the `group_batch` migration (sequence, partial unique index via raw
+   SQL) with the in-memory schema mirror, the transaction-bound repository,
+   status transitions, counter updates, and batch-scoped resource-inbox
+   aggregate queries/index.
+3. Add `ASYNC_REMOTE_QUEUE` and `AWAITING_REMOTE` with lane-aware predicates
+   and the existing-lane invariance tests.
+4. Add activation acceptance (202 + ticket), the ticket read endpoint with
+   mandatory group-read authorization, and batch planning with atomic
+   supersession/chunk/progress writes under `rallar-system/group-activation/**`.
+5. Add capacity-aware edge-chunk claiming (SKIP LOCKED plus atomic finish,
+   non-budget-consuming defer) and deterministic remote/WS child writes.
+6. Add browser command handling: origin validation, commanded-edge
+   retention, role semantics, dedup, and result reporting.
+7. Add result ingestion as doctrinal `APP_INBOX` commands with the full
+   authorization chain and failure taxonomy.
+8. Add remote timeout scanning, reserved-recovery registration, proactive
+   session-death aborts, the abort sweep, finalization with counter
+   prechecks, and promotion through the snapshot repository.
+9. Add join/leave supersession, debounce and minimum-batch-age policies, and
+   reconfiguration behavior.
+10. Add focused, PostgreSQL, browser, and multi-server black-box validation
+    plus operational metrics with the cardinality policy.
 
-This sequence is architectural guidance, not yet a file-by-file implementation
-plan.
+Follow-ups tracked outside this sequence: the committed
+partition/dedicated-table successor (Scale Posture), unifying
+`TOPOLOGY_RECONFIGURE` onto activation batches, the signaling-relay
+hardening task, incremental/leaf-attach batches behind a measured trigger,
+and a cross-group browser session budget.
+
+This sequence is architectural guidance, not yet a file-by-file
+implementation plan.
 
 ## Final Recommendation
 
-Proceed with `resource_inbox` as the one physical work table, including
-`ASYNC_REMOTE_QUEUE`, and add only `group_batch` as a new coordination table.
-Add `AWAITING_REMOTE`, batch-scoped indexed queries, conditional remote
-transitions, and one optimistic batch version. Keep the batch as the producer
-seal and capacity coordinator, and keep planned topology separate from the
-last accepted active topology until confirmations reach a validated terminal
-outcome.
+Proceed with `resource_inbox` as the one physical work table for v1,
+including `ASYNC_REMOTE_QUEUE`, and add only `group_batch` as a new
+coordination table — with the partition/dedicated-table successor committed
+for the target scale. Add `AWAITING_REMOTE` with lane-aware predicates,
+batch-scoped indexed queries, conditional remote transitions, commutative
+capacity counters, and one optimistic batch version for status transitions.
+Keep the batch as the producer seal and completion barrier, keep supersession
+planner-atomic and debounced, keep the planned topology separate from the
+accepted topology until confirmations reach a validated terminal outcome,
+and treat the browser coexistence contract (retention plus origin
+validation) and the result authorization chain as mandatory parts of the
+design.
 
 This is the smallest design that preserves multi-server safety, durable
-polling, bounded group concurrency, and correct completion without appointing
-a server to own the group.
+polling, bounded establishment concurrency, correct completion, and safe
+coexistence with browser-owned reconciliation, without appointing a server to
+own the group.

--- a/plans/rallar-distributed-group-rtc-activation-design.md
+++ b/plans/rallar-distributed-group-rtc-activation-design.md
@@ -1430,6 +1430,35 @@ counter.
 
 ## Validation Strategy
 
+### Black-box size tiers
+
+Batch behavior is validated end to end at three canonical group sizes,
+chosen against the topology-kind boundaries (star 1-4, tree 5-15, mesh
+16+):
+
+| Tier   | Sessions | Topology kind | Approximate work (degree limit 5)   |
+| ------ | -------- | ------------- | ----------------------------------- |
+| Small  | 6        | tree          | ~5 edges, ~10 confirmation units    |
+| Medium | 20       | mesh          | ~50 edges, ~100 confirmation units  |
+| Large  | 50       | mesh          | ~125 edges, ~250 confirmation units |
+
+Every tier asserts the full batch lifecycle: activation request and `202`
+ticket, ticket polling from `QUEUED` to terminal, planning and sealing,
+chunk expansion under the capacity ceiling, both-role confirmations,
+counter consistency (`terminal_chunk_count`, `terminal_remote_count`, and
+`in_flight_remote_count` returning to zero), finalization, promotion, and
+the RTC activation status projection.
+
+Two tier-specific additions: the small recipe starts the group at three
+sessions and joins up to six, so the star-to-tree boundary is crossed and a
+topology-kind transition is replanned at least once (no tier runs a
+star-only activation; star coverage comes from this crossing). The medium
+recipe runs a join mid-batch to assert debounced supersession and replan.
+
+The large tier doubles as the measurement rig for the Scale Posture
+observations: batch-row counter throughput, `resource_inbox` churn, and the
+partition/dedicated-table follow-up triggers.
+
 ### Focused unit tests
 
 - Deterministic activation, batch, chunk, remote, dispatch, ack, and
@@ -1524,10 +1553,30 @@ counter.
 - Exhaust a browser retry budget and verify `PARTIAL` versus `FAILED` using
   the topology invariants.
 
+### Hetzner distributed recipes
+
+The same three size tiers exist as distributed black-box recipes executed on
+the Hetzner fleet through the supported distributed-manifest machinery
+(`rallar-hetzner-ops`): real multi-server API processes over shared
+PostgreSQL, real `LISTEN/NOTIFY`, and headless browser agents performing the
+commanded RTC work.
+
+- **Small (6)** joins the supported distributed manifests that run on
+  regular `main` builds (the Run Hetzner Supported Distributed Manifests
+  workflow).
+- **Medium (20)** and **Large (50)** exist as manifests but run on demand or
+  on a schedule, not on every `main` build.
+
+Promoting medium or large into the regular `main` gate is a deliberate
+follow-up decision after measuring fleet cost and duration.
+
 For REST behavior, add or update Rallar black-box recipes in
-`packages/shared-test/black-box-runner` as part of implementation. API-v1
-mutation-path changes run the medium-scale convergence gate
-(`test:api-v1:black-box:postgres:medium-scale`) unweakened.
+`packages/shared-test/black-box-runner` as part of implementation. The
+api-v1 batch recipes exist at all three size tiers: small and medium join
+the standard recipe matrix (and therefore branch CI); large runs behind a
+focused Postgres command beside the existing medium-scale convergence gate
+(`test:api-v1:black-box:postgres:medium-scale`), which activation
+mutation-path changes continue to run unweakened.
 
 ## Recommended Implementation Sequence
 
@@ -1554,7 +1603,10 @@ mutation-path changes run the medium-scale convergence gate
 9. Add join/leave supersession, debounce and minimum-batch-age policies, and
    reconfiguration behavior.
 10. Add focused, PostgreSQL, browser, and multi-server black-box validation
-    plus operational metrics with the cardinality policy.
+    plus operational metrics with the cardinality policy, including the
+    api-v1 batch recipes at the small (6), medium (20), and large (50) size
+    tiers and the Hetzner distributed-manifest tiers (small on regular
+    `main` builds; medium and large on demand).
 
 Follow-ups tracked outside this sequence: the committed
 partition/dedicated-table successor (Scale Posture), unifying


### PR DESCRIPTION
## Summary

Full revision of `plans/rallar-distributed-group-rtc-activation-design.md`, folding in the 2026-08-07 interactive design review (five passes: activation-flow correctness, distributed-systems behavior, scalability at hundreds of sessions, security, operational complexity). The durable-coordination core is unchanged in direction; the revision fixes correctness gaps at the design's edges and locks in the mechanisms agreed during review.

## Key decisions folded in

**Correctness**
- Browser coexistence contract is now mandatory: commanded-edge retention (both roles) against `WebRtcGroupManager` reconciler teardown until promotion/abort, plus server-origin validation of edge commands. Without these the reconciler closes commanded edges mid-batch.
- Supersession is planner-atomic: the replacement planner CASes the old batch `STARTED -> SUPERSEDED`, inserts the new batch, and enqueues a durable abort sweep (remote rows and unexpanded chunks) in one transaction. The finalizer's self-contradicting eligibility rules are fixed; drift-detected supersession now enqueues its replacement command.
- Source revision stored as the causal tuple (`groupRevision`, `presenceRevision`) instead of the lossy scalar sum; promotion specified through the existing `RtcTopologySnapshotRepository` monotonic CAS with a recorded `promoted | stale | not-attempted` outcome.
- Doctrinal conformance with `convergent-service-writing.md`: `write(transaction, computed)`, AppInbox owns transactions and retries (generic runner and in-process retry loop removed), result ingestion as `APP_INBOX` commands, named ports, placement under `rallar-system/group-activation/**`.
- Identities fit real queue-key budgets: ULID `batchId` (26 chars vs the 35-char `contextId` clamp that silently FNV-hashes longer values), sequence-assigned `batchGeneration`, hashed `remoteWorkId`. Corrected repository facts (existing unit of work, six queue lanes, no FAILED retry loop, required `workspaceId`).

**Distributed systems / liveness**
- Fingerprint-attach for same-input concurrent requests; debounce + minimum batch age bound replan churn (also the forced-replan abuse control).
- Transient browser failure reports retry like timeouts; only definitive rejects are terminal.
- Proactive abort of remote rows on session death; reserved-timeout recovery registered for the remote lane.

**Scale (hundreds+ sessions)**
- Predicate-bounded commutative capacity counter (version CAS reserved for status transitions); SKIP LOCKED chunk claim with atomic finish; capacity defers no longer consume the 20-attempt failure budget; O(1) finalization eligibility via batch counters; version-suffixed finalize command identity with a periodic reconciler backstop.
- Committed (not open-ended) partition/dedicated-table follow-up for the remote/dispatch lanes; topology-compute ceiling stated with fingerprint memoization; progress/wake coalescing and telemetry cardinality policy; fire-and-forget ack ingestion (202, no result rows).

**Security**
- Full result authorization chain specified (deterministic ids are not capabilities; transport-authenticated session -> `targetSessionId`; resolved principal -> `targetPrincipalId`); typed, counted rejections instead of silent drops; mandatory group-read auth on all activation reads (not gated on the legacy strict-read-auth flag); server-clamped policy knobs and ack payload size caps.
- Pre-existing signaling-relay `fromId` gap spun off as a separate hardening task.

## Notes for reviewers

- Doc-only change; no code. Prettier-formatted.
- Governance: the doc now explicitly notes it must be reconciled with `plans/rallar-architecture-quality-and-rtc-program-roadmap.md` (RTC Phase 1 reservations approved-inactive) before implementation starts.
- The push warning about a merge commit (`f44da163`) refers to pre-existing `main` history carried by the branch, not this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)