### PR TITLE
ci: scope branch release gate triggers

### DIFF
--- a/.agents/skills/publishing-plan-progress/SKILL.md
+++ b/.agents/skills/publishing-plan-progress/SKILL.md
@@ -117,8 +117,15 @@ removal condition.
 
 ## Plan Completion Gate
 
-Do not approve, report, or mark a written implementation plan complete until
-the final uncommitted working tree passes all three commands:
+Plan-only branches do not wait for local or Branch Release Gate builds. This
+exception applies only when every changed path is an implementation-plan or
+agent-guidance path excluded by `.github/workflows/branch-release-gate.yml`.
+Branch Release Gate remains required for branches that change code, workflows,
+scripts, tests, or plugin metadata.
+
+For build-affecting written implementation plans, do not approve, report, or
+mark the plan complete until the final uncommitted working tree passes all three
+commands:
 
 ```bash
 npm run test:unit
@@ -129,17 +136,18 @@ npm run build
 Focused checks are earlier feedback and never replace these final commands. Any
 change after a successful gate invalidates that gate and requires a fresh run.
 
-Completion also requires a current draft pull request and successful published
-gates. **Branch Release Gate** must be green for the final feature-branch
-commit. **Run Hetzner Supported Distributed Manifests** must be green for the
-resulting default-branch commit. Record the exact commit SHA for each workflow;
-do not infer success from a run on different code. Do not approve completion:
-the plan is not complete while any required command or workflow is pending,
-skipped, failed, or attached to an older commit.
+For build-affecting implementation plans, completion also requires a current
+draft pull request and successful published gates. **Branch Release Gate** must
+be green for the final feature-branch commit. **Run Hetzner Supported Distributed
+Manifests** must be green for the resulting default-branch commit. Record the
+exact commit SHA for each workflow; do not infer success from a run on different
+code. Do not approve completion: the plan is not complete while any required
+command or workflow is pending, skipped, failed, or attached to an older commit.
 
-An instruction not to commit or push postpones publication; it does not waive
-any completion gate. Continue safe uncommitted work and report the plan as
-incomplete until the publication and remote gates are permitted and successful.
+For build-affecting implementation plans, an instruction not to commit or push
+postpones publication; it does not waive any completion gate. Continue safe
+uncommitted work and report the plan as incomplete until the publication and
+remote gates are permitted and successful.
 
 ## Feature-Branch Check Scope
 

--- a/.agents/skills/rallar-testing/SKILL.md
+++ b/.agents/skills/rallar-testing/SKILL.md
@@ -74,10 +74,16 @@ When UI behavior changes, acceptance requires a Playwright test that operates vi
 
 ## Plan Completion Gate
 
+Plan-only branches do not wait for local or Branch Release Gate builds. This
+exception applies only when every changed path is an implementation-plan or
+agent-guidance path excluded by `.github/workflows/branch-release-gate.yml`.
+Branch Release Gate remains required for branches that change code, workflows,
+scripts, tests, or plugin metadata.
+
 Focused tests are feedback, not a substitute for completion gates. Before a
-written implementation plan can be approved or marked complete, apply this
-rule: Run the commands from the final uncommitted working tree before
-publication:
+build-affecting written implementation plan can be approved or marked
+complete, apply this rule: Run the commands from the final uncommitted working
+tree before publication:
 
 ```bash
 npm run test:unit
@@ -85,14 +91,15 @@ npm run test:ci
 npm run build
 ```
 
-Any change after a successful gate invalidates that gate. Keep the draft pull
-request current, then require **Branch Release Gate** to pass for the final
-feature-branch commit and **Run Hetzner Supported Distributed Manifests** to
-pass for the resulting default-branch commit. Record the exact commit SHA for
-each result. Do not approve completion: the plan is not complete while any
-required command or workflow is pending, skipped, failed, or attached to an
-older commit. An instruction not to commit or push postpones publication but
-does not waive these completion gates.
+Any change after a successful gate invalidates that gate. For build-affecting
+implementation plans, keep the draft pull request current, then require
+**Branch Release Gate** to pass for the final feature-branch commit and **Run
+Hetzner Supported Distributed Manifests** to pass for the resulting
+default-branch commit. Record the exact commit SHA for each result. Do not
+approve completion: the plan is not complete while any required command or
+workflow is pending, skipped, failed, or attached to an older commit. An
+instruction not to commit or push postpones publication but does not waive
+these completion gates.
 
 ## Reporting
 

--- a/.agents/skills/rallar-testing/references/test-commands.md
+++ b/.agents/skills/rallar-testing/references/test-commands.md
@@ -140,8 +140,15 @@ as the governed candidate.
 
 ## Plan Completion Gate
 
+Plan-only branches do not wait for local or Branch Release Gate builds. This
+exception applies only when every changed path is an implementation-plan or
+agent-guidance path excluded by `.github/workflows/branch-release-gate.yml`.
+Branch Release Gate remains required for branches that change code, workflows,
+scripts, tests, or plugin metadata.
+
 Focused checks and surface-specific suites are feedback; they never substitute
-for the plan completion gate. From the final uncommitted working tree, run:
+for the plan completion gate for build-affecting implementation plans. From the
+final uncommitted working tree, run:
 
 ```bash
 npm run test:unit
@@ -149,15 +156,16 @@ npm run test:ci
 npm run build
 ```
 
-Any change after a successful command invalidates its result. Before completion,
-the draft pull request must be current, **Branch Release Gate** must pass for
-the final feature-branch commit, and **Run Hetzner Supported Distributed
-Manifests** must pass for the resulting default-branch commit. Verify and record
-the exact commit SHA; a Release Gate run on different code is not evidence for
-the current plan. Do not approve completion: the plan is not complete while any
-required command or workflow is pending, skipped, failed, or attached to an
-older commit. An instruction not to commit or push postpones publication but
-does not waive any completion gate.
+Any change after a successful command invalidates its result. Before completion
+of a build-affecting implementation plan, the draft pull request must be
+current, **Branch Release Gate** must pass for the final feature-branch commit,
+and **Run Hetzner Supported Distributed Manifests** must pass for the resulting
+default-branch commit. Verify and record the exact commit SHA; a Release Gate
+run on different code is not evidence for the current plan. Do not approve
+completion: the plan is not complete while any required command or workflow is
+pending, skipped, failed, or attached to an older commit. An instruction not to
+commit or push postpones publication but does not waive any completion gate for
+build-affecting implementation plans.
 
 `npm run test:ci` includes the repository Deno, E2E, and in-memory full-stack
 suites after unit tests. Run `npm run test:unit` separately as required so its

--- a/.github/workflows/branch-release-gate.yml
+++ b/.github/workflows/branch-release-gate.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches-ignore:
       - main
+    paths-ignore:
+      - 'docs/superpowers/plans/**'
+      - 'plans/**'
+      - '.agents/**'
+      - 'AGENTS.md'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,22 +106,28 @@ standard.
   bundle-boundary checks when exports or entry points change.
 - For game/realtime changes, include the relevant app tests/builds and shared
   package tests.
-- A written implementation plan may be approved or marked complete only after
-  the final uncommitted working tree passes `npm run test:unit`,
+- For build-affecting written implementation plans, the plan may be approved or
+  marked complete only after the final uncommitted working tree passes
+  `npm run test:unit`,
   `npm run test:ci`, and `npm run build`. Focused tests are feedback, not a
   substitute for these completion gates. Any change after a successful gate
   invalidates that gate and requires it to run again.
-- Publication is also part of completion: keep the draft pull request current,
-  require **Branch Release Gate** to pass for the final feature-branch commit,
-  and require **Run Hetzner Supported Distributed Manifests** to pass for the
-  resulting default-branch commit. Record the exact commit SHA validated by
-  each workflow. Do not approve completion: the plan is not complete while any
-  required command or workflow is pending, skipped, failed, or attached to an
-  older commit.
-- An explicit instruction not to commit or push postpones publication; it does
-  not waive any completion gate. Continue safe uncommitted work and report the
-  plan as incomplete until publication and remote gates are permitted and
-  successful.
+- Plan-only branches do not wait for local or Branch Release Gate builds. This
+  exception applies only when every changed path is an implementation-plan or
+  agent-guidance path excluded by `.github/workflows/branch-release-gate.yml`.
+  Branch Release Gate remains required for branches that change code, workflows,
+  scripts, tests, or plugin metadata.
+- For build-affecting implementation plans, publication is also part of
+  completion: keep the draft pull request current, require **Branch Release
+  Gate** to pass for the final feature-branch commit, and require **Run Hetzner
+  Supported Distributed Manifests** to pass for the resulting default-branch
+  commit. Record the exact commit SHA validated by each workflow. Do not
+  approve completion: the plan is not complete while any required command or
+  workflow is pending, skipped, failed, or attached to an older commit.
+- For build-affecting implementation plans, an explicit instruction not to
+  commit or push postpones publication; it does not waive any completion gate.
+  Continue safe uncommitted work and report the plan as incomplete until
+  publication and remote gates are permitted and successful.
 - Report commands that passed, failed, or were skipped.
 
 ## AI Handoff Contract (applies to all agents)

--- a/packages/tests/repo/rallar-skill-plugin-publication-integrity.test.ts
+++ b/packages/tests/repo/rallar-skill-plugin-publication-integrity.test.ts
@@ -151,7 +151,7 @@ describe('Rallar skill plugin and publication integrity', () => {
     }
 
     expectAllNormalized(progressSkill, [
-      'An instruction not to commit or push postpones publication',
+      'For build-affecting implementation plans, an instruction not to commit or push postpones publication',
       'does not waive any completion gate',
       'Any change after a successful gate invalidates that gate',
     ]);
@@ -165,6 +165,35 @@ describe('Rallar skill plugin and publication integrity', () => {
       'plan-completion gate',
       'Focused checks never substitute for that final gate',
     ]);
+  });
+
+  it('limits feature-branch release gates to changes that can affect builds', () => {
+    const branchWorkflow = readRepo('.github/workflows/branch-release-gate.yml');
+    const reusableWorkflow = readRepo('.github/workflows/release-gate.yml');
+    const agents = readRepo('AGENTS.md');
+    const progressSkill = readRepo('.agents/skills/publishing-plan-progress/SKILL.md');
+    const testingSkill = readRepo('.agents/skills/rallar-testing/SKILL.md');
+    const testCommands = readRepo('.agents/skills/rallar-testing/references/test-commands.md');
+
+    expectAllNormalized(branchWorkflow, [
+      'branches-ignore:',
+      '- main',
+      'paths-ignore:',
+      "- 'docs/superpowers/plans/**'",
+      "- 'plans/**'",
+      "- '.agents/**'",
+      "- 'AGENTS.md'",
+    ]);
+    expect(branchWorkflow).not.toContain('docs/superpowers/specs/**');
+    expect(branchWorkflow).not.toContain('.codex-plugin/**');
+    expect(reusableWorkflow).not.toContain('paths-ignore:');
+
+    for (const source of [agents, progressSkill, testingSkill, testCommands]) {
+      expectAllNormalized(source, [
+        'Plan-only branches do not wait for local or Branch Release Gate builds',
+        'Branch Release Gate remains required for branches that change code, workflows, scripts, tests, or plugin metadata',
+      ]);
+    }
   });
 
   it('requires a Markdown learning-oriented command summary in every final handoff', () => {


### PR DESCRIPTION
## Summary

- Skip Branch Release Gate for pushes that only change plan documents or agent guidance.
- Keep full release-gate behavior for build-affecting changes and mixed pushes.
- Update active repository guidance and governance coverage.

## Scope

Excluded paths: `docs/superpowers/plans/**`, `plans/**`, `.agents/**`, and `AGENTS.md`. Code, workflows, scripts, tests, plugin metadata, and mixed changes still run the gate.

## Validation

- `npm run test:repo-governance` — passed: 27 files, 292 tests.
- `npm run test:ci` — passed: unit, Deno, Playwright, and memory full-stack stages.
- `npm run build` — passed with existing large-chunk warnings.
- `npm run check:repo-style` — exited 0 with existing warning-only findings.