### PR TITLE
REST snapshot convergence: foundations

### DIFF
--- a/packages/shared-server/mod.ts
+++ b/packages/shared-server/mod.ts
@@ -66,6 +66,8 @@ export type {
 } from './rallar-system/client-state/client-state-service-contracts.ts';
 export * from './rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts';
 export * from './rallar-system/client-state/snapshot/cached-client-state-service.ts';
+export * from './rallar-system/client-state/snapshot/client-rest-snapshot-read-selector.ts';
+export * from './rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts';
 export * from './rallar-system/services/cached-group-state-service.ts';
 export {
   createAuthMutationService,

--- a/packages/shared-server/rallar-system/client-state/snapshot/cached-client-state-service.ts
+++ b/packages/shared-server/rallar-system/client-state/snapshot/cached-client-state-service.ts
@@ -10,6 +10,7 @@ export type CachedClientStateServiceCache = Readonly<{
 export type CachedClientStateService = ClientStateService &
   Readonly<{
     observeSnapshot(snapshot: ClientSnapshot): Promise<ClientSnapshot>;
+    readCurrentSnapshot(ref: ClientPrincipalRef): Promise<ClientSnapshot | undefined>;
   }>;
 
 export function createCachedClientStateService(
@@ -25,6 +26,7 @@ export function createCachedClientStateService(
   const service: CachedClientStateService = {
     ...options.durable,
     observeSnapshot,
+    readCurrentSnapshot: async (ref) => await options.durable.readSnapshot(ref),
     listSnapshots: async (scope) => {
       const snapshots = await options.durable.listSnapshots(scope);
       return await Promise.all(snapshots.map(observeSnapshot));

--- a/packages/shared-server/rallar-system/client-state/snapshot/client-rest-snapshot-read-selector.ts
+++ b/packages/shared-server/rallar-system/client-state/snapshot/client-rest-snapshot-read-selector.ts
@@ -1,0 +1,214 @@
+import type {
+  ClientStateSnapshotReadOptions,
+  StateSnapshotReadCleanupOutcome,
+  StateSnapshotReadDiagnosticEvent,
+  StateSnapshotReadDiagnosticsSink,
+  StateSnapshotReadResult,
+  StateSnapshotReadSource,
+} from '@shared/api/state-snapshot-read.ts';
+import type {
+  ClientPrincipalRef,
+  ClientSnapshot,
+} from '@shared/api/client-types.ts';
+import { readClientStateRevision } from '@shared/api/group-client-views.ts';
+import type { StateSnapshotObservation } from '@shared/repository/state-snapshot-revision.ts';
+
+export interface ClientRestSnapshotReadRequest
+  extends ClientStateSnapshotReadOptions {
+  readonly strictMode?: boolean;
+}
+
+export interface ClientRestSnapshotReadSelector {
+  read(
+    ref: ClientPrincipalRef,
+    request?: ClientRestSnapshotReadRequest,
+  ): Promise<StateSnapshotReadResult<ClientSnapshot>>;
+}
+
+export type ClientRestSnapshotReadSelectorDependencies = Readonly<{
+  durable: Readonly<{
+    readSnapshot(ref: ClientPrincipalRef): Promise<ClientSnapshot | undefined>;
+  }>;
+  cache: Readonly<{
+    peek(ref: ClientPrincipalRef): ClientSnapshot | undefined;
+    observe(snapshot: ClientSnapshot): StateSnapshotObservation;
+    evictIfUnchanged(
+      ref: ClientPrincipalRef,
+      expected: ClientSnapshot,
+    ): boolean;
+  }>;
+  diagnostics?: StateSnapshotReadDiagnosticsSink;
+  now?: () => number;
+}>;
+
+interface ClientRestSnapshotReadContext {
+  readonly ref: ClientPrincipalRef;
+  readonly requestedFloor?: number;
+  readonly strictMode: boolean;
+  readonly startedAt: number;
+  source: StateSnapshotReadSource;
+}
+
+class ClientRestSnapshotReadSelectorOwner
+  implements ClientRestSnapshotReadSelector {
+  public constructor(
+    private readonly dependencies: ClientRestSnapshotReadSelectorDependencies,
+  ) {}
+
+  public async read(
+    ref: ClientPrincipalRef,
+    request: ClientRestSnapshotReadRequest = {},
+  ): Promise<StateSnapshotReadResult<ClientSnapshot>> {
+    const context = this.toContext(ref, request);
+    try {
+      return await this.select(context);
+    } catch (error) {
+      this.emit(context, {
+        source: context.source,
+        result: 'error',
+        floorOutcome: 'not-evaluated',
+        cleanupOutcome: 'not-attempted',
+        strictMode: context.strictMode,
+      });
+      throw error;
+    }
+  }
+
+  private toContext(
+    ref: ClientPrincipalRef,
+    request: ClientRestSnapshotReadRequest,
+  ): ClientRestSnapshotReadContext {
+    return {
+      ref,
+      requestedFloor: request.minStateRevision,
+      strictMode: request.strictMode ?? false,
+      startedAt: this.dependencies.now?.() ?? Date.now(),
+      source: 'cache',
+    };
+  }
+
+  private async select(
+    context: ClientRestSnapshotReadContext,
+  ): Promise<StateSnapshotReadResult<ClientSnapshot>> {
+    const observed = this.dependencies.cache.peek(context.ref);
+    const cached = this.selectCache(context, observed);
+    if (cached) return cached;
+    return await this.readDurable(context, observed);
+  }
+
+  private selectCache(
+    context: ClientRestSnapshotReadContext,
+    observed: ClientSnapshot | undefined,
+  ): StateSnapshotReadResult<ClientSnapshot> | undefined {
+    if (
+      context.requestedFloor === undefined ||
+      context.strictMode ||
+      observed === undefined ||
+      readClientStateRevision(observed) < context.requestedFloor
+    ) {
+      return undefined;
+    }
+
+    this.emitFound(context, 'cache', 'satisfied');
+    return { status: 'found', source: 'cache', snapshot: observed };
+  }
+
+  private async readDurable(
+    context: ClientRestSnapshotReadContext,
+    observed: ClientSnapshot | undefined,
+  ): Promise<StateSnapshotReadResult<ClientSnapshot>> {
+    context.source = 'durable';
+    const snapshot = await this.dependencies.durable.readSnapshot(context.ref);
+    if (!snapshot) return this.toNotFound(context, observed);
+
+    this.dependencies.cache.observe(snapshot);
+    if (
+      context.requestedFloor !== undefined &&
+      readClientStateRevision(snapshot) < context.requestedFloor
+    ) {
+      this.emit(context, {
+        source: 'durable',
+        result: 'floor-not-satisfied',
+        floorOutcome: 'not-satisfied',
+        cleanupOutcome: 'not-attempted',
+        strictMode: context.strictMode,
+      });
+      return {
+        status: 'floor-not-satisfied',
+        source: 'durable',
+        snapshot,
+      };
+    }
+
+    this.emitFound(
+      context,
+      'durable',
+      context.requestedFloor === undefined ? 'not-requested' : 'satisfied',
+    );
+    return { status: 'found', source: 'durable', snapshot };
+  }
+
+  private toNotFound(
+    context: ClientRestSnapshotReadContext,
+    observed: ClientSnapshot | undefined,
+  ): StateSnapshotReadResult<ClientSnapshot> {
+    const cleanupOutcome = this.cleanup(context.ref, observed);
+    this.emit(context, {
+      source: 'durable',
+      result: 'not-found',
+      floorOutcome: context.requestedFloor === undefined
+        ? 'not-requested'
+        : 'not-satisfied',
+      cleanupOutcome,
+      strictMode: context.strictMode,
+    });
+    return { status: 'not-found', source: 'durable' };
+  }
+
+  private cleanup(
+    ref: ClientPrincipalRef,
+    observed: ClientSnapshot | undefined,
+  ): StateSnapshotReadCleanupOutcome {
+    if (!observed) return 'not-attempted';
+    return this.dependencies.cache.evictIfUnchanged(ref, observed)
+      ? 'evicted'
+      : 'changed-or-absent';
+  }
+
+  private emitFound(
+    context: ClientRestSnapshotReadContext,
+    source: StateSnapshotReadSource,
+    floorOutcome: 'not-requested' | 'satisfied',
+  ): void {
+    this.emit(context, {
+      source,
+      result: 'found',
+      floorOutcome,
+      cleanupOutcome: 'not-attempted',
+      strictMode: context.strictMode,
+    });
+  }
+
+  private emit(
+    context: ClientRestSnapshotReadContext,
+    event: Omit<StateSnapshotReadDiagnosticEvent, 'name' | 'durationMs'>,
+  ): void {
+    if (!this.dependencies.diagnostics) return;
+    const finishedAt = this.dependencies.now?.() ?? Date.now();
+    try {
+      this.dependencies.diagnostics({
+        name: 'rallar.rest.client-state-snapshot-read',
+        ...event,
+        durationMs: Math.max(0, finishedAt - context.startedAt),
+      });
+    } catch {
+      // Diagnostics must not change read behavior.
+    }
+  }
+}
+
+export function createClientRestSnapshotReadSelector(
+  dependencies: ClientRestSnapshotReadSelectorDependencies,
+): ClientRestSnapshotReadSelector {
+  return new ClientRestSnapshotReadSelectorOwner(dependencies);
+}

--- a/packages/shared-server/rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts
+++ b/packages/shared-server/rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts
@@ -3,7 +3,9 @@ import { DEFAULT_STATE_WORKSPACE_ID } from '@shared/api/state-types.ts';
 import { readClientStateRevision, readClientVersion } from '@shared/api/group-client-views.ts';
 import {
   findClientStateSnapshotByRef,
+  fromClientStateSnapshotRepositoryKey,
   observeClientStateSnapshot,
+  removeClientStateSnapshotIfUnchanged,
   toClientStateSnapshotRepositoryKey as toSharedClientStateSnapshotRepositoryKey,
 } from '@shared/repository/client-state-snapshots-repository.ts';
 import type { StateSnapshotObservation } from '@shared/repository/state-snapshot-revision.ts';
@@ -43,7 +45,7 @@ export class ClientStateSnapshotReadThroughCache {
   constructor(private readonly options: ClientStateSnapshotReadThroughCacheOptions) {
     this.snapshots = new ObservableLoanedRepository<string, ClientSnapshot>(
       async (key) => {
-        const ref = fromClientStateSnapshotRepositoryKey(key);
+        const ref = toClientPrincipalRef(key);
         const snapshot = await options.clientsRepository.readSnapshot(ref);
         if (!snapshot) {
           throw new ClientStateSnapshotNotFoundError(ref);
@@ -110,6 +112,22 @@ export class ClientStateSnapshotReadThroughCache {
     await this.snapshots.whenIdle();
   }
 
+  public evictIfUnchanged(
+    ref: ClientPrincipalRef,
+    expected: ClientSnapshot,
+  ): boolean {
+    const latestRemoved = removeClientStateSnapshotIfUnchanged(
+      ref,
+      expected,
+      this.options.manager,
+    );
+    const loanedRemoved = this.snapshots.compareAndDelete(
+      toClientStateSnapshotRepositoryKey(ref),
+      expected,
+    );
+    return latestRemoved || loanedRemoved;
+  }
+
   public observe(snapshot: ClientSnapshot): StateSnapshotObservation {
     return observeClientStateSnapshot(snapshot, this.options.manager);
   }
@@ -167,12 +185,13 @@ export function toClientStateSnapshotRepositoryKey(ref: ClientPrincipalRef): str
   return toSharedClientStateSnapshotRepositoryKey(ref);
 }
 
-function fromClientStateSnapshotRepositoryKey(key: string): ClientPrincipalRef {
-  const [applicationId, workspaceId, principalId] = JSON.parse(key) as [string, string, string];
+function toClientPrincipalRef(key: string): ClientPrincipalRef {
+  const { applicationId, workspaceId, principalId } =
+    fromClientStateSnapshotRepositoryKey(key);
 
   return {
     applicationId,
-    workspaceId: workspaceId === '' ? DEFAULT_STATE_WORKSPACE_ID : workspaceId,
+    workspaceId: workspaceId ?? DEFAULT_STATE_WORKSPACE_ID,
     principalId,
   };
 }

--- a/packages/shared-server/rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts
+++ b/packages/shared-server/rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts
@@ -1,0 +1,229 @@
+import type {
+  GroupStateSnapshotReadOptions,
+  StateSnapshotReadCleanupOutcome,
+  StateSnapshotReadDiagnosticEvent,
+  StateSnapshotReadDiagnosticsSink,
+  StateSnapshotReadResult,
+  StateSnapshotReadSource,
+} from '@shared/api/state-snapshot-read.ts';
+import type {
+  GroupRef,
+  GroupSnapshot,
+  GroupStateCausalRevision,
+} from '@shared/api/group-types.ts';
+import {
+  compareGroupCausalRevision,
+  readGroupCausalRevision,
+} from '@shared/api/group-client-views.ts';
+import type { StateSnapshotObservation } from '@shared/repository/state-snapshot-revision.ts';
+
+export interface GroupRestSnapshotReadRequest
+  extends GroupStateSnapshotReadOptions {
+  readonly strictMode?: boolean;
+}
+
+export interface GroupRestSnapshotReadSelector {
+  read(
+    ref: GroupRef,
+    request?: GroupRestSnapshotReadRequest,
+  ): Promise<StateSnapshotReadResult<GroupSnapshot>>;
+}
+
+export type GroupRestSnapshotReadSelectorDependencies = Readonly<{
+  durable: Readonly<{
+    readSnapshot(ref: GroupRef): Promise<GroupSnapshot | undefined>;
+  }>;
+  cache: Readonly<{
+    peek(ref: GroupRef): GroupSnapshot | undefined;
+    observe(snapshot: GroupSnapshot): StateSnapshotObservation;
+    evictIfUnchanged(ref: GroupRef, expected: GroupSnapshot): boolean;
+  }>;
+  diagnostics?: StateSnapshotReadDiagnosticsSink;
+  now?: () => number;
+}>;
+
+interface GroupRestSnapshotReadContext {
+  readonly ref: GroupRef;
+  readonly requestedFloor?: GroupStateCausalRevision;
+  readonly strictMode: boolean;
+  readonly startedAt: number;
+  source: StateSnapshotReadSource;
+}
+
+class GroupRestSnapshotReadSelectorOwner
+  implements GroupRestSnapshotReadSelector {
+  public constructor(
+    private readonly dependencies: GroupRestSnapshotReadSelectorDependencies,
+  ) {}
+
+  public async read(
+    ref: GroupRef,
+    request: GroupRestSnapshotReadRequest = {},
+  ): Promise<StateSnapshotReadResult<GroupSnapshot>> {
+    const context = this.toContext(ref, request);
+    try {
+      return await this.select(context);
+    } catch (error) {
+      this.emit(context, {
+        source: context.source,
+        result: 'error',
+        floorOutcome: 'not-evaluated',
+        cleanupOutcome: 'not-attempted',
+        strictMode: context.strictMode,
+      });
+      throw error;
+    }
+  }
+
+  private toContext(
+    ref: GroupRef,
+    request: GroupRestSnapshotReadRequest,
+  ): GroupRestSnapshotReadContext {
+    return {
+      ref,
+      requestedFloor: request.minCausalRevision,
+      strictMode: request.strictMode ?? false,
+      startedAt: this.dependencies.now?.() ?? Date.now(),
+      source: 'cache',
+    };
+  }
+
+  private async select(
+    context: GroupRestSnapshotReadContext,
+  ): Promise<StateSnapshotReadResult<GroupSnapshot>> {
+    const observed = this.dependencies.cache.peek(context.ref);
+    const cached = this.selectCache(context, observed);
+    if (cached) return cached;
+    return await this.readDurable(context, observed);
+  }
+
+  private selectCache(
+    context: GroupRestSnapshotReadContext,
+    observed: GroupSnapshot | undefined,
+  ): StateSnapshotReadResult<GroupSnapshot> | undefined {
+    if (
+      context.requestedFloor === undefined ||
+      context.strictMode ||
+      observed === undefined ||
+      !satisfiesGroupFloor(
+        readGroupCausalRevision(observed),
+        context.requestedFloor,
+      )
+    ) {
+      return undefined;
+    }
+
+    this.emitFound(context, 'cache', 'satisfied');
+    return { status: 'found', source: 'cache', snapshot: observed };
+  }
+
+  private async readDurable(
+    context: GroupRestSnapshotReadContext,
+    observed: GroupSnapshot | undefined,
+  ): Promise<StateSnapshotReadResult<GroupSnapshot>> {
+    context.source = 'durable';
+    const snapshot = await this.dependencies.durable.readSnapshot(context.ref);
+    if (!snapshot) return this.toNotFound(context, observed);
+
+    this.dependencies.cache.observe(snapshot);
+    if (
+      context.requestedFloor !== undefined &&
+      !satisfiesGroupFloor(
+        readGroupCausalRevision(snapshot),
+        context.requestedFloor,
+      )
+    ) {
+      this.emit(context, {
+        source: 'durable',
+        result: 'floor-not-satisfied',
+        floorOutcome: 'not-satisfied',
+        cleanupOutcome: 'not-attempted',
+        strictMode: context.strictMode,
+      });
+      return {
+        status: 'floor-not-satisfied',
+        source: 'durable',
+        snapshot,
+      };
+    }
+
+    this.emitFound(
+      context,
+      'durable',
+      context.requestedFloor === undefined ? 'not-requested' : 'satisfied',
+    );
+    return { status: 'found', source: 'durable', snapshot };
+  }
+
+  private toNotFound(
+    context: GroupRestSnapshotReadContext,
+    observed: GroupSnapshot | undefined,
+  ): StateSnapshotReadResult<GroupSnapshot> {
+    const cleanupOutcome = this.cleanup(context.ref, observed);
+    this.emit(context, {
+      source: 'durable',
+      result: 'not-found',
+      floorOutcome: context.requestedFloor === undefined
+        ? 'not-requested'
+        : 'not-satisfied',
+      cleanupOutcome,
+      strictMode: context.strictMode,
+    });
+    return { status: 'not-found', source: 'durable' };
+  }
+
+  private cleanup(
+    ref: GroupRef,
+    observed: GroupSnapshot | undefined,
+  ): StateSnapshotReadCleanupOutcome {
+    if (!observed) return 'not-attempted';
+    return this.dependencies.cache.evictIfUnchanged(ref, observed)
+      ? 'evicted'
+      : 'changed-or-absent';
+  }
+
+  private emitFound(
+    context: GroupRestSnapshotReadContext,
+    source: StateSnapshotReadSource,
+    floorOutcome: 'not-requested' | 'satisfied',
+  ): void {
+    this.emit(context, {
+      source,
+      result: 'found',
+      floorOutcome,
+      cleanupOutcome: 'not-attempted',
+      strictMode: context.strictMode,
+    });
+  }
+
+  private emit(
+    context: GroupRestSnapshotReadContext,
+    event: Omit<StateSnapshotReadDiagnosticEvent, 'name' | 'durationMs'>,
+  ): void {
+    if (!this.dependencies.diagnostics) return;
+    const finishedAt = this.dependencies.now?.() ?? Date.now();
+    try {
+      this.dependencies.diagnostics({
+        name: 'rallar.rest.group-state-snapshot-read',
+        ...event,
+        durationMs: Math.max(0, finishedAt - context.startedAt),
+      });
+    } catch {
+      // Diagnostics must not change read behavior.
+    }
+  }
+}
+
+export function createGroupRestSnapshotReadSelector(
+  dependencies: GroupRestSnapshotReadSelectorDependencies,
+): GroupRestSnapshotReadSelector {
+  return new GroupRestSnapshotReadSelectorOwner(dependencies);
+}
+
+function satisfiesGroupFloor(
+  observed: GroupStateCausalRevision,
+  requested: GroupStateCausalRevision,
+): boolean {
+  const order = compareGroupCausalRevision(observed, requested);
+  return order === 'equal' || order === 'dominates';
+}

--- a/packages/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.ts
+++ b/packages/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.ts
@@ -8,7 +8,9 @@ import {
 } from '@shared/api/group-client-views.ts';
 import {
   findGroupStateSnapshotByRef,
+  fromGroupStateSnapshotRepositoryKey,
   observeGroupStateSnapshot,
+  removeGroupStateSnapshotIfUnchanged,
   toGroupStateSnapshotRepositoryKey,
 } from '@shared/repository/group-state-snapshots-repository.ts';
 import type { StateSnapshotObservation } from '@shared/repository/state-snapshot-revision.ts';
@@ -51,7 +53,7 @@ export class GroupStateSnapshotReadThroughCache {
   constructor(private readonly options: GroupStateSnapshotReadThroughCacheOptions) {
     this.snapshots = new ObservableLoanedRepository<string, GroupSnapshot>(
       async (key) => {
-        const ref = fromGroupStateSnapshotRepositoryKey(key);
+        const ref = toGroupRef(key);
         const snapshot = await options.groupsRepository.readSnapshot(ref);
         if (!snapshot) {
           throw new GroupStateSnapshotNotFoundError(ref);
@@ -114,6 +116,22 @@ export class GroupStateSnapshotReadThroughCache {
     await this.snapshots.whenIdle();
   }
 
+  public evictIfUnchanged(
+    ref: GroupRef,
+    expected: GroupSnapshot,
+  ): boolean {
+    const latestRemoved = removeGroupStateSnapshotIfUnchanged(
+      ref,
+      expected,
+      this.options.manager,
+    );
+    const loanedRemoved = this.snapshots.compareAndDelete(
+      toGroupStateSnapshotRepositoryKey(ref),
+      expected,
+    );
+    return latestRemoved || loanedRemoved;
+  }
+
   public observe(snapshot: GroupSnapshot): StateSnapshotObservation {
     return observeGroupStateSnapshot(snapshot, this.options.manager);
   }
@@ -168,12 +186,13 @@ export function createGroupStateSnapshotReadThroughCache(
   return new GroupStateSnapshotReadThroughCache(options);
 }
 
-function fromGroupStateSnapshotRepositoryKey(key: string): GroupRef {
-  const [applicationId, workspaceId, groupId] = JSON.parse(key) as [string, string, string];
+function toGroupRef(key: string): GroupRef {
+  const { applicationId, workspaceId, groupId } =
+    fromGroupStateSnapshotRepositoryKey(key);
 
   return {
     applicationId,
-    workspaceId: workspaceId === '' ? DEFAULT_STATE_WORKSPACE_ID : workspaceId,
+    workspaceId: workspaceId ?? DEFAULT_STATE_WORKSPACE_ID,
     groupId,
   };
 }

--- a/packages/shared/api/state-snapshot-read.ts
+++ b/packages/shared/api/state-snapshot-read.ts
@@ -1,0 +1,68 @@
+import type { GroupStateCausalRevision } from './group-types.ts';
+
+export interface ClientStateSnapshotReadOptions {
+    readonly minStateRevision?: number;
+}
+
+export interface GroupStateSnapshotReadOptions {
+    readonly minCausalRevision?: GroupStateCausalRevision;
+}
+
+export type StateSnapshotReadSource = 'cache' | 'durable';
+
+export interface StateSnapshotReadFound<T> {
+    readonly status: 'found';
+    readonly source: StateSnapshotReadSource;
+    readonly snapshot: T;
+}
+
+export interface StateSnapshotReadNotFound {
+    readonly status: 'not-found';
+    readonly source: 'durable';
+}
+
+export interface StateSnapshotReadFloorNotSatisfied<T> {
+    readonly status: 'floor-not-satisfied';
+    readonly source: 'durable';
+    readonly snapshot: T;
+}
+
+export type StateSnapshotReadResult<T> =
+    | StateSnapshotReadFound<T>
+    | StateSnapshotReadNotFound
+    | StateSnapshotReadFloorNotSatisfied<T>;
+
+export type StateSnapshotReadDiagnosticName =
+    | 'rallar.rest.client-state-snapshot-read'
+    | 'rallar.rest.group-state-snapshot-read';
+
+export type StateSnapshotReadDiagnosticResult =
+    | 'found'
+    | 'not-found'
+    | 'floor-not-satisfied'
+    | 'error';
+
+export type StateSnapshotReadFloorOutcome =
+    | 'not-requested'
+    | 'satisfied'
+    | 'not-satisfied'
+    | 'not-evaluated';
+
+export type StateSnapshotReadCleanupOutcome =
+    | 'not-attempted'
+    | 'evicted'
+    | 'changed-or-absent';
+
+export interface StateSnapshotReadDiagnosticEvent {
+    readonly name: StateSnapshotReadDiagnosticName;
+    readonly source: StateSnapshotReadSource;
+    readonly result: StateSnapshotReadDiagnosticResult;
+    readonly floorOutcome: StateSnapshotReadFloorOutcome;
+    readonly cleanupOutcome: StateSnapshotReadCleanupOutcome;
+    readonly strictMode: boolean;
+    readonly durationMs: number;
+}
+
+export type StateSnapshotReadDiagnosticsSink = (
+    event: StateSnapshotReadDiagnosticEvent,
+) => void;

--- a/packages/shared/cache/ObservableLatestRepository.ts
+++ b/packages/shared/cache/ObservableLatestRepository.ts
@@ -238,6 +238,11 @@ export class ObservableLatestRepository<K, V>
         return true;
     }
 
+    public compareAndDelete(key: K, expected: V): boolean {
+        const entry = this.entries.get(key);
+        return entry !== undefined && entry.peek() === expected && this.delete(key);
+    }
+
     public clear(key: K): void {
         const entry = this.entries.get(key);
         if (!entry) {
@@ -440,14 +445,9 @@ export class ObservableLatestRepository<K, V>
 
 function toUnsubscribe(unsubscribe: () => void): Unsubscribe {
     let active = true;
-    return {
-        unsubscribe: () => {
-            if (!active) {
-                return;
-            }
-
-            active = false;
-            unsubscribe();
-        },
-    };
+    return { unsubscribe: () => {
+        if (!active) return;
+        active = false;
+        unsubscribe();
+    } };
 }

--- a/packages/shared/cache/ObservableLoanedRepository.ts
+++ b/packages/shared/cache/ObservableLoanedRepository.ts
@@ -147,6 +147,11 @@ export class ObservableLoanedRepository<K, V>
         return true;
     }
 
+    public compareAndDelete(key: K, expected: V): boolean {
+        const entry = this.entries.get(key);
+        return entry !== undefined && entry.peek() === expected && this.delete(key);
+    }
+
     public clear(key: K): void {
         const entry = this.entries.get(key);
         if (!entry) {
@@ -378,14 +383,9 @@ export class ObservableLoanedRepository<K, V>
 
 function toUnsubscribe(unsubscribe: () => void): Unsubscribe {
     let active = true;
-    return {
-        unsubscribe: () => {
-            if (!active) {
-                return;
-            }
-
-            active = false;
-            unsubscribe();
-        },
-    };
+    return { unsubscribe: () => {
+        if (!active) return;
+        active = false;
+        unsubscribe();
+    } };
 }

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -17,6 +17,7 @@ export * from './api/group-policy-types.ts';
 export * from './api/overlay-topology.ts';
 export * from './api/rallar-validation.ts';
 export * from './api/spa-statistics-types.ts';
+export * from './api/state-snapshot-read.ts';
 
 export * from './crdt/mod.ts';
 

--- a/packages/shared/repository/client-state-snapshot-repository-key.ts
+++ b/packages/shared/repository/client-state-snapshot-repository-key.ts
@@ -1,0 +1,67 @@
+export type ClientStateSnapshotRepositoryRef = Readonly<{
+  applicationId: string;
+  workspaceId?: string;
+  principalId: string;
+}>;
+
+type ClientStateSnapshotRepositoryKey = readonly [
+  kind: 'client-state-snapshot',
+  applicationId: string,
+  workspaceId: readonly [kind: 'absent'] | readonly [kind: 'present', value: string],
+  principalId: string,
+];
+
+type ClientStateSnapshotRepositoryJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly ClientStateSnapshotRepositoryJsonValue[]
+  | { readonly [key: string]: ClientStateSnapshotRepositoryJsonValue };
+
+export function toClientStateSnapshotRepositoryKey(ref: ClientStateSnapshotRepositoryRef): string {
+  const key: ClientStateSnapshotRepositoryKey = [
+    'client-state-snapshot',
+    ref.applicationId,
+    ref.workspaceId === undefined ? ['absent'] : ['present', ref.workspaceId],
+    ref.principalId,
+  ];
+  return JSON.stringify(key);
+}
+
+export function fromClientStateSnapshotRepositoryKey(
+  key: string,
+): ClientStateSnapshotRepositoryRef {
+  const parsed = JSON.parse(key) as ClientStateSnapshotRepositoryJsonValue;
+  if (!isClientStateSnapshotRepositoryKey(parsed)) {
+    throw new Error('Invalid client state snapshot repository key');
+  }
+
+  const [, applicationId, workspaceId, principalId] = parsed;
+  return workspaceId[0] === 'present'
+    ? { applicationId, workspaceId: workspaceId[1], principalId }
+    : { applicationId, principalId };
+}
+
+function isClientStateSnapshotRepositoryKey(
+  value: ClientStateSnapshotRepositoryJsonValue,
+): value is ClientStateSnapshotRepositoryKey {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 4 ||
+    value[0] !== 'client-state-snapshot' ||
+    typeof value[1] !== 'string' ||
+    typeof value[3] !== 'string'
+  ) {
+    return false;
+  }
+
+  const workspaceId = value[2];
+  return (
+    Array.isArray(workspaceId) &&
+    ((workspaceId.length === 1 && workspaceId[0] === 'absent') ||
+      (workspaceId.length === 2 &&
+        workspaceId[0] === 'present' &&
+        typeof workspaceId[1] === 'string'))
+  );
+}

--- a/packages/shared/repository/client-state-snapshots-repository.ts
+++ b/packages/shared/repository/client-state-snapshots-repository.ts
@@ -24,6 +24,13 @@ import {
     type StateSnapshotRevisionDecision,
     toStateSnapshotObservation,
 } from './state-snapshot-revision.ts';
+import { toClientStateSnapshotRepositoryKey } from './client-state-snapshot-repository-key.ts';
+
+export {
+    fromClientStateSnapshotRepositoryKey,
+    toClientStateSnapshotRepositoryKey,
+    type ClientStateSnapshotRepositoryRef,
+} from './client-state-snapshot-repository-key.ts';
 
 export type ClientStateSnapshotRepositoryOptions =
     & Omit<
@@ -153,6 +160,17 @@ export function setClientStateSnapshotByPrincipalId(
     return decision === 'inserted' || decision === 'advanced';
 }
 
+export function removeClientStateSnapshotIfUnchanged(
+    ref: ClientPrincipalRef,
+    expected: ClientSnapshot,
+    manager?: RepositoryManager,
+): boolean {
+    return requireClientStateSnapshotRepository(manager).compareAndDelete(
+        toClientStateSnapshotRepositoryKey(ref),
+        expected,
+    );
+}
+
 export function observeClientStateSnapshot(
     snapshot: ClientSnapshot,
     manager?: RepositoryManager,
@@ -198,16 +216,6 @@ export function getAllClientStateSnapshots(
 
 function toClientSnapshotVersion(snapshot: ClientSnapshot): number {
     return readClientVersion(snapshot);
-}
-
-export function toClientStateSnapshotRepositoryKey(
-    ref: ClientPrincipalRef,
-): string {
-    return JSON.stringify([
-        ref.applicationId,
-        ref.workspaceId ?? '',
-        ref.principalId,
-    ]);
 }
 
 function toClientStateSnapshotChange(

--- a/packages/shared/repository/group-state-snapshot-repository-key.ts
+++ b/packages/shared/repository/group-state-snapshot-repository-key.ts
@@ -1,0 +1,65 @@
+export type GroupStateSnapshotRepositoryRef = Readonly<{
+  applicationId: string;
+  workspaceId?: string;
+  groupId: string;
+}>;
+
+type GroupStateSnapshotRepositoryKey = readonly [
+  kind: 'group-state-snapshot',
+  applicationId: string,
+  workspaceId: readonly [kind: 'absent'] | readonly [kind: 'present', value: string],
+  groupId: string,
+];
+
+type GroupStateSnapshotRepositoryJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly GroupStateSnapshotRepositoryJsonValue[]
+  | { readonly [key: string]: GroupStateSnapshotRepositoryJsonValue };
+
+export function toGroupStateSnapshotRepositoryKey(ref: GroupStateSnapshotRepositoryRef): string {
+  const key: GroupStateSnapshotRepositoryKey = [
+    'group-state-snapshot',
+    ref.applicationId,
+    ref.workspaceId === undefined ? ['absent'] : ['present', ref.workspaceId],
+    ref.groupId,
+  ];
+  return JSON.stringify(key);
+}
+
+export function fromGroupStateSnapshotRepositoryKey(key: string): GroupStateSnapshotRepositoryRef {
+  const parsed = JSON.parse(key) as GroupStateSnapshotRepositoryJsonValue;
+  if (!isGroupStateSnapshotRepositoryKey(parsed)) {
+    throw new Error('Invalid group state snapshot repository key');
+  }
+
+  const [, applicationId, workspaceId, groupId] = parsed;
+  return workspaceId[0] === 'present'
+    ? { applicationId, workspaceId: workspaceId[1], groupId }
+    : { applicationId, groupId };
+}
+
+function isGroupStateSnapshotRepositoryKey(
+  value: GroupStateSnapshotRepositoryJsonValue,
+): value is GroupStateSnapshotRepositoryKey {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 4 ||
+    value[0] !== 'group-state-snapshot' ||
+    typeof value[1] !== 'string' ||
+    typeof value[3] !== 'string'
+  ) {
+    return false;
+  }
+
+  const workspaceId = value[2];
+  return (
+    Array.isArray(workspaceId) &&
+    ((workspaceId.length === 1 && workspaceId[0] === 'absent') ||
+      (workspaceId.length === 2 &&
+        workspaceId[0] === 'present' &&
+        typeof workspaceId[1] === 'string'))
+  );
+}

--- a/packages/shared/repository/group-state-snapshot-revision.ts
+++ b/packages/shared/repository/group-state-snapshot-revision.ts
@@ -1,0 +1,38 @@
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import {
+    compareGroupCausalRevision,
+    readGroupCausalRevision,
+} from '@shared/api/group-client-views.ts';
+import { jsonEquals } from './state-utils.ts';
+import {
+    type StateSnapshotRevisionDecision,
+    StateSnapshotRevisionConflictError,
+} from './state-snapshot-revision.ts';
+
+export class GroupStateSnapshotIncomparableError extends Error {
+    constructor(readonly groupRef: GroupRef) {
+        super('Group snapshot causal tuple is incomparable');
+        this.name = 'GroupStateSnapshotIncomparableError';
+    }
+}
+
+export function decideGroupSnapshotCausalRevision(
+    current: GroupSnapshot | undefined,
+    incoming: GroupSnapshot,
+): StateSnapshotRevisionDecision {
+    if (!current) return 'inserted';
+
+    const order = compareGroupCausalRevision(
+        readGroupCausalRevision(incoming),
+        readGroupCausalRevision(current),
+    );
+    if (order === 'dominates') return 'advanced';
+    if (order === 'dominated') return 'stale';
+    if (order === 'incomparable') return 'incomparable';
+    if (jsonEquals(current, incoming)) return 'duplicate';
+
+    throw new StateSnapshotRevisionConflictError(
+        'Group',
+        incoming.stateRevision,
+    );
+}

--- a/packages/shared/repository/group-state-snapshots-repository.ts
+++ b/packages/shared/repository/group-state-snapshots-repository.ts
@@ -1,9 +1,5 @@
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
-import {
-    compareGroupCausalRevision,
-    readGroupCausalRevision,
-    readGroupVersion,
-} from '@shared/api/group-client-views.ts';
+import { readGroupVersion } from '@shared/api/group-client-views.ts';
 import {
     configureObservableLatestRepository,
     newObservableLatestRepositoryToken,
@@ -25,9 +21,20 @@ import { jsonEquals } from '@shared/repository/state-utils.ts';
 import {
     type StateSnapshotObservation,
     type StateSnapshotRevisionDecision,
-    StateSnapshotRevisionConflictError,
     toStateSnapshotObservation,
 } from './state-snapshot-revision.ts';
+import { toGroupStateSnapshotRepositoryKey } from './group-state-snapshot-repository-key.ts';
+import {
+    decideGroupSnapshotCausalRevision,
+    GroupStateSnapshotIncomparableError,
+} from './group-state-snapshot-revision.ts';
+
+export {
+    fromGroupStateSnapshotRepositoryKey,
+    toGroupStateSnapshotRepositoryKey,
+    type GroupStateSnapshotRepositoryRef,
+} from './group-state-snapshot-repository-key.ts';
+export { GroupStateSnapshotIncomparableError } from './group-state-snapshot-revision.ts';
 
 export type GroupStateSnapshotRepositoryOptions =
     & Omit<
@@ -51,13 +58,6 @@ export type GroupStateSnapshotChange = Readonly<{
 export type GroupStateSnapshotChangeListener = (
     change: GroupStateSnapshotChange,
 ) => void | Promise<void>;
-
-export class GroupStateSnapshotIncomparableError extends Error {
-    constructor(readonly groupRef: GroupRef) {
-        super('Group snapshot causal tuple is incomparable');
-        this.name = 'GroupStateSnapshotIncomparableError';
-    }
-}
 
 export const groupStateSnapshotRepositoryToken = newObservableLatestRepositoryToken<
     string,
@@ -248,27 +248,6 @@ function writeGroupStateSnapshot(
     return decision;
 }
 
-function decideGroupSnapshotCausalRevision(
-    current: GroupSnapshot | undefined,
-    incoming: GroupSnapshot,
-): StateSnapshotRevisionDecision {
-    if (!current) return 'inserted';
-
-    const order = compareGroupCausalRevision(
-        readGroupCausalRevision(incoming),
-        readGroupCausalRevision(current),
-    );
-    if (order === 'dominates') return 'advanced';
-    if (order === 'dominated') return 'stale';
-    if (order === 'incomparable') return 'incomparable';
-    if (jsonEquals(current, incoming)) return 'duplicate';
-
-    throw new StateSnapshotRevisionConflictError(
-        'Group',
-        incoming.stateRevision,
-    );
-}
-
 export function removeGroupStateSnapshotByRef(
     ref: GroupRef,
     manager?: RepositoryManager,
@@ -282,6 +261,24 @@ export function removeGroupStateSnapshotByRef(
             groupSessionIndexForRepository(repository),
             repositoryKey,
             previous,
+        );
+    }
+    return removed;
+}
+
+export function removeGroupStateSnapshotIfUnchanged(
+    ref: GroupRef,
+    expected: GroupSnapshot,
+    manager?: RepositoryManager,
+): boolean {
+    const repository = requireGroupStateSnapshotRepository(manager);
+    const repositoryKey = toGroupStateSnapshotRepositoryKey(ref);
+    const removed = repository.compareAndDelete(repositoryKey, expected);
+    if (removed) {
+        removeGroupSnapshotFromSessionIndex(
+            groupSessionIndexForRepository(repository),
+            repositoryKey,
+            expected,
         );
     }
     return removed;
@@ -397,14 +394,6 @@ function groupSnapshotHasSessionIds(
         snapshot.activeSessions.map((session) => session.sessionId),
     );
     return sessionIds.every((sessionId) => activeSessionIds.has(sessionId));
-}
-
-export function toGroupStateSnapshotRepositoryKey(ref: GroupRef): string {
-    return JSON.stringify([
-        ref.applicationId,
-        ref.workspaceId ?? '',
-        ref.groupId,
-    ]);
 }
 
 function toGroupStateSnapshotChange(

--- a/packages/tests/repo/group-state-server-source-ratchet.test.ts
+++ b/packages/tests/repo/group-state-server-source-ratchet.test.ts
@@ -94,6 +94,7 @@ const expectedGroupStateProductionTree = [
   'presence/reconcile-expired-group-presence.ts',
   'presence/validate-group-presence-summary-read-collections.ts',
   'snapshot/cached-group-state-service.ts',
+  'snapshot/group-rest-snapshot-read-selector.ts',
   'snapshot/group-state-snapshot-read-through-cache.ts',
   'snapshot/validate-persisted-group-snapshot.ts',
 ] as const;

--- a/packages/tests/shared-server/cached-state-services.test.ts
+++ b/packages/tests/shared-server/cached-state-services.test.ts
@@ -129,6 +129,30 @@ describe('cached state services', () => {
         expect(findOrLoadByRef).toHaveBeenCalledWith(snapshot.principal);
         expect(observe).toHaveBeenCalledWith(snapshot);
     });
+
+    it('reads current client authority durably without touching the cache', async () => {
+        type DurableCurrentClientReader = Readonly<{
+            readCurrentSnapshot?: ClientStateService['readSnapshot'];
+        }>;
+        const snapshot = createClientSnapshot(3);
+        const findOrLoadByRef = vi.fn();
+        const observe = vi.fn();
+        const durable = {
+            readSnapshot: vi.fn().mockResolvedValue(snapshot),
+        } as unknown as ClientStateService;
+        const service = createCachedClientStateService({
+            durable,
+            cache: { findOrLoadByRef, observe },
+        }) as DurableCurrentClientReader;
+
+        await expect(
+            service.readCurrentSnapshot?.(snapshot.principal),
+        ).resolves.toBe(snapshot);
+        expect(durable.readSnapshot).toHaveBeenCalledOnce();
+        expect(durable.readSnapshot).toHaveBeenCalledWith(snapshot.principal);
+        expect(findOrLoadByRef).not.toHaveBeenCalled();
+        expect(observe).not.toHaveBeenCalled();
+    });
 });
 
 function createGroupPhaseService(): GroupStateService {

--- a/packages/tests/shared-server/client-state/client-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/client-state/client-state-snapshot-read-through-cache.test.ts
@@ -54,8 +54,10 @@ describe('ClientStateSnapshotReadThroughCache', () => {
     expect(toPackageClientStateSnapshotRepositoryKey).toBe(toClientStateSnapshotRepositoryKey);
     expect(toLegacyClientStateSnapshotRepositoryKey).toBe(toClientStateSnapshotRepositoryKey);
     expect(toClientStateSnapshotRepositoryKey).not.toBe(toSharedClientStateSnapshotRepositoryKey);
-    expect(toClientStateSnapshotRepositoryKey(ref)).toBe('["app-1","workspace-a","alice"]');
-    expect(toSharedClientStateSnapshotRepositoryKey(ref)).toBe('["app-1","workspace-a","alice"]');
+    const expectedKey =
+      '["client-state-snapshot","app-1",["present","workspace-a"],"alice"]';
+    expect(toClientStateSnapshotRepositoryKey(ref)).toBe(expectedKey);
+    expect(toSharedClientStateSnapshotRepositoryKey(ref)).toBe(expectedKey);
   });
 
   it('hydrates a cold client snapshot cache from durable state', async () => {
@@ -243,6 +245,7 @@ describe('ClientStateSnapshotReadThroughCache', () => {
     ).toThrow('Client snapshot revision conflict');
     expect(readThroughCache.peek(base.principal)).toEqual(revisionTwo);
   });
+
 });
 
 async function putClientSnapshot(

--- a/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
@@ -172,6 +172,38 @@ describe('GroupStateSnapshotReadThroughCache', () => {
     );
     expect(cache.peek(ref)).toEqual(converged);
   });
+
+  it('evicts only identities that have not advanced in either cache layer', async () => {
+    type ConditionallyEvictable = Readonly<{
+      evictIfUnchanged?: (
+        ref: GroupRef,
+        expected: GroupSnapshot,
+      ) => boolean;
+    }>;
+    configureTestCacheRepositories();
+    const repository = new GroupStateRepository(new FakeRuntimeStateRepository());
+    const cache = createGroupStateSnapshotReadThroughCache({
+      groupsRepository: repository,
+    });
+    const first = createGroupSnapshot(1, ['session-a']);
+    const newer = createGroupSnapshot(2, ['session-a', 'session-b']);
+    await putGroupSnapshot(repository, first);
+    const loaded = await cache.findOrLoadByRef(first.group);
+    if (!loaded) throw new Error('Expected loaded group snapshot');
+
+    expect(cache.observe(newer)).toBe('advanced');
+    const conditionallyEvictable = cache as ConditionallyEvictable;
+
+    expect(
+      conditionallyEvictable.evictIfUnchanged?.(loaded.group, loaded) ?? false,
+    ).toBe(true);
+    expect(cache.peek(newer.group)).toBe(newer);
+
+    expect(
+      conditionallyEvictable.evictIfUnchanged?.(newer.group, newer) ?? false,
+    ).toBe(true);
+    expect(cache.peek(newer.group)).toBeUndefined();
+  });
 });
 
 async function convergePresenceSummaryForCacheTest(

--- a/packages/tests/shared-server/rest-state-snapshot-read-selectors.test.ts
+++ b/packages/tests/shared-server/rest-state-snapshot-read-selectors.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createClientRestSnapshotReadSelector,
+} from '@shared-server/rallar-system/client-state/snapshot/client-rest-snapshot-read-selector.ts';
+import {
+  createClientStateSnapshotReadThroughCache,
+} from '@shared-server/rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts';
+import {
+  createGroupRestSnapshotReadSelector,
+} from '@shared-server/rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts';
+import { configureTestCacheRepositories } from '../cache-repository-config.ts';
+import {
+  createClientCache,
+  createClientSnapshot,
+  createGroupCache,
+  createGroupSnapshot,
+} from './rest-state-snapshot-read-test-fixtures.ts';
+
+describe('client REST snapshot read selector', () => {
+  it('uses one durable read for tokenless and strict reads even with eligible cache state', async () => {
+    const cached = createClientSnapshot(5);
+    const durableSnapshot = createClientSnapshot(6);
+    const durable = { readSnapshot: vi.fn().mockResolvedValue(durableSnapshot) };
+    const cache = createClientCache(cached);
+    const selector = createClientRestSnapshotReadSelector({ durable, cache });
+
+    await expect(selector.read(cached.principal)).resolves.toEqual({
+      status: 'found',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+    await expect(
+      selector.read(cached.principal, {
+        minStateRevision: 5,
+        strictMode: true,
+      }),
+    ).resolves.toEqual({
+      status: 'found',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+
+    expect(durable.readSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses eligible scalar cache state without durable I/O', async () => {
+    const cached = createClientSnapshot(5);
+    const durable = { readSnapshot: vi.fn() };
+    const selector = createClientRestSnapshotReadSelector({
+      durable,
+      cache: createClientCache(cached),
+    });
+
+    await expect(
+      selector.read(cached.principal, { minStateRevision: 5 }),
+    ).resolves.toEqual({
+      status: 'found',
+      source: 'cache',
+      snapshot: cached,
+    });
+    expect(durable.readSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('falls back once and returns a typed durable scalar shortfall', async () => {
+    const cached = createClientSnapshot(2);
+    const durableSnapshot = createClientSnapshot(3);
+    const durable = { readSnapshot: vi.fn().mockResolvedValue(durableSnapshot) };
+    const selector = createClientRestSnapshotReadSelector({
+      durable,
+      cache: createClientCache(cached),
+    });
+
+    await expect(
+      selector.read(cached.principal, { minStateRevision: 4 }),
+    ).resolves.toEqual({
+      status: 'floor-not-satisfied',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+    expect(durable.readSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a newer observation when an older durable absence finishes', async () => {
+    const observed = createClientSnapshot(1);
+    const newer = createClientSnapshot(2);
+    const cache = createClientCache(observed);
+    const durable = {
+      readSnapshot: vi.fn(async () => {
+        cache.publish(newer);
+        return undefined;
+      }),
+    };
+    const diagnostics = vi.fn();
+    const now = vi.fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(17);
+    const selector = createClientRestSnapshotReadSelector({
+      durable,
+      cache,
+      diagnostics,
+      now,
+    });
+
+    await expect(selector.read(observed.principal)).resolves.toEqual({
+      status: 'not-found',
+      source: 'durable',
+    });
+    expect(cache.current()).toBe(newer);
+    expect(diagnostics).toHaveBeenCalledWith({
+      name: 'rallar.rest.client-state-snapshot-read',
+      source: 'durable',
+      result: 'not-found',
+      floorOutcome: 'not-requested',
+      cleanupOutcome: 'changed-or-absent',
+      strictMode: false,
+      durationMs: 7,
+    });
+    expect(Object.keys(diagnostics.mock.calls[0]?.[0] ?? {})).not.toContain(
+      'principalId',
+    );
+  });
+
+  it('evicts matching loaned state without deleting a newer latest snapshot', async () => {
+    configureTestCacheRepositories();
+    const first = createClientSnapshot(1);
+    const newer = createClientSnapshot(2);
+    const cache = createClientStateSnapshotReadThroughCache({
+      clientsRepository: {
+        readSnapshot: vi.fn().mockResolvedValue(first),
+      },
+    });
+    const loaded = await cache.findOrLoadByRef(first.principal);
+    if (!loaded) throw new Error('Expected loaded client snapshot');
+
+    expect(cache.observe(newer)).toBe('advanced');
+    expect(cache.evictIfUnchanged(loaded.principal, loaded)).toBe(true);
+    expect(cache.peek(newer.principal)).toBe(newer);
+
+    expect(cache.evictIfUnchanged(newer.principal, newer)).toBe(true);
+    expect(cache.peek(newer.principal)).toBeUndefined();
+  });
+});
+
+describe('group REST snapshot read selector', () => {
+  it.each([
+    ['equal', { groupRevision: 2, presenceRevision: 3 }],
+    ['dominates', { groupRevision: 4, presenceRevision: 5 }],
+  ] as const)('uses a cache tuple that %s the requested floor', async (_name, revision) => {
+    const cached = createGroupSnapshot(revision.groupRevision, revision.presenceRevision);
+    const durable = { readSnapshot: vi.fn() };
+    const selector = createGroupRestSnapshotReadSelector({
+      durable,
+      cache: createGroupCache(cached),
+    });
+
+    await expect(
+      selector.read(cached.group, {
+        minCausalRevision: { groupRevision: 2, presenceRevision: 3 },
+      }),
+    ).resolves.toEqual({
+      status: 'found',
+      source: 'cache',
+      snapshot: cached,
+    });
+    expect(durable.readSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['dominated', { groupRevision: 1, presenceRevision: 2 }],
+    ['incomparable', { groupRevision: 4, presenceRevision: 2 }],
+  ] as const)('falls back once when the cache tuple is %s', async (_name, revision) => {
+    const cached = createGroupSnapshot(revision.groupRevision, revision.presenceRevision);
+    const durableSnapshot = createGroupSnapshot(3, 3);
+    const durable = { readSnapshot: vi.fn().mockResolvedValue(durableSnapshot) };
+    const selector = createGroupRestSnapshotReadSelector({
+      durable,
+      cache: createGroupCache(cached),
+    });
+
+    await expect(
+      selector.read(cached.group, {
+        minCausalRevision: { groupRevision: 3, presenceRevision: 3 },
+      }),
+    ).resolves.toEqual({
+      status: 'found',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+    expect(durable.readSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['dominated', { groupRevision: 1, presenceRevision: 1 }],
+    ['incomparable', { groupRevision: 4, presenceRevision: 1 }],
+  ] as const)('returns a typed durable shortfall for a %s tuple', async (_name, revision) => {
+    const durableSnapshot = createGroupSnapshot(
+      revision.groupRevision,
+      revision.presenceRevision,
+    );
+    const durable = { readSnapshot: vi.fn().mockResolvedValue(durableSnapshot) };
+    const selector = createGroupRestSnapshotReadSelector({
+      durable,
+      cache: createGroupCache(),
+    });
+
+    await expect(
+      selector.read(durableSnapshot.group, {
+        minCausalRevision: { groupRevision: 3, presenceRevision: 3 },
+      }),
+    ).resolves.toEqual({
+      status: 'floor-not-satisfied',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+    expect(durable.readSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('forces a strict tokened read through one durable snapshot', async () => {
+    const cached = createGroupSnapshot(5, 5);
+    const durableSnapshot = createGroupSnapshot(6, 6);
+    const durable = { readSnapshot: vi.fn().mockResolvedValue(durableSnapshot) };
+    const selector = createGroupRestSnapshotReadSelector({
+      durable,
+      cache: createGroupCache(cached),
+    });
+
+    await expect(
+      selector.read(cached.group, {
+        minCausalRevision: { groupRevision: 5, presenceRevision: 5 },
+        strictMode: true,
+      }),
+    ).resolves.toMatchObject({
+      status: 'found',
+      source: 'durable',
+      snapshot: durableSnapshot,
+    });
+    expect(durable.readSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a newer group observation when durable absence loses the race', async () => {
+    const observed = createGroupSnapshot(1, 1);
+    const newer = createGroupSnapshot(2, 2);
+    const cache = createGroupCache(observed);
+    const durable = {
+      readSnapshot: vi.fn(async () => {
+        cache.publish(newer);
+        return undefined;
+      }),
+    };
+    const diagnostics = vi.fn();
+    const selector = createGroupRestSnapshotReadSelector({
+      durable,
+      cache,
+      diagnostics,
+      now: vi.fn().mockReturnValueOnce(4).mockReturnValueOnce(9),
+    });
+
+    await expect(selector.read(observed.group)).resolves.toEqual({
+      status: 'not-found',
+      source: 'durable',
+    });
+    expect(cache.current()).toBe(newer);
+    expect(diagnostics).toHaveBeenCalledWith({
+      name: 'rallar.rest.group-state-snapshot-read',
+      source: 'durable',
+      result: 'not-found',
+      floorOutcome: 'not-requested',
+      cleanupOutcome: 'changed-or-absent',
+      strictMode: false,
+      durationMs: 5,
+    });
+  });
+});
+
+describe('logical cache convergence', () => {
+  it('makes an isolated third client and group cache fall back to one durable source', async () => {
+    let durableClient = createClientSnapshot(1);
+    let durableGroup = createGroupSnapshot(1, 1);
+    const clientRead = vi.fn(async () => durableClient);
+    const groupRead = vi.fn(async () => durableGroup);
+    const clientCaches = [createClientCache(), createClientCache(), createClientCache()];
+    const groupCaches = [createGroupCache(), createGroupCache(), createGroupCache()];
+    const clientSelectors = clientCaches.map((cache) =>
+      createClientRestSnapshotReadSelector({
+        durable: { readSnapshot: clientRead },
+        cache,
+      })
+    );
+    const groupSelectors = groupCaches.map((cache) =>
+      createGroupRestSnapshotReadSelector({
+        durable: { readSnapshot: groupRead },
+        cache,
+      })
+    );
+
+    await Promise.all(clientSelectors.map((selector) =>
+      selector.read(durableClient.principal)
+    ));
+    await Promise.all(groupSelectors.map((selector) =>
+      selector.read(durableGroup.group)
+    ));
+
+    durableClient = createClientSnapshot(2);
+    durableGroup = createGroupSnapshot(2, 2);
+    clientCaches[0]?.publish(durableClient);
+    clientCaches[1]?.publish(durableClient);
+    groupCaches[0]?.publish(durableGroup);
+    groupCaches[1]?.publish(durableGroup);
+
+    await expect(
+      clientSelectors[2]?.read(durableClient.principal, { minStateRevision: 2 }),
+    ).resolves.toMatchObject({ status: 'found', source: 'durable' });
+    await expect(
+      groupSelectors[2]?.read(durableGroup.group, {
+        minCausalRevision: { groupRevision: 2, presenceRevision: 2 },
+      }),
+    ).resolves.toMatchObject({ status: 'found', source: 'durable' });
+    await expect(clientSelectors[2]?.read(durableClient.principal)).resolves.toMatchObject({
+      status: 'found',
+      source: 'durable',
+    });
+    await expect(groupSelectors[2]?.read(durableGroup.group)).resolves.toMatchObject({
+      status: 'found',
+      source: 'durable',
+    });
+
+    expect(clientRead).toHaveBeenCalledTimes(5);
+    expect(groupRead).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/tests/shared-server/rest-state-snapshot-read-test-fixtures.ts
+++ b/packages/tests/shared-server/rest-state-snapshot-read-test-fixtures.ts
@@ -1,0 +1,132 @@
+import { vi } from 'vitest';
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
+
+export function createClientSnapshot(stateRevision: number): ClientSnapshot {
+  const audit = createAuditStamp(stateRevision);
+  return {
+    stateRevision,
+    principal: {
+      applicationId: 'app-1',
+      workspaceId: 'workspace-1',
+      principalId: 'alice',
+      username: 'alice',
+      displayName: 'Alice',
+      avatarUrl: null,
+      authProvider: null,
+      externalSubjectId: null,
+      status: 'active',
+      disabled: null,
+      deleted: null,
+      roles: [],
+      metadata: {},
+      snapshotVersion: stateRevision,
+      profileVersion: stateRevision,
+      presenceVersion: stateRevision,
+      created: audit,
+      updated: audit,
+      lastSeenAtEpochMs: null,
+    },
+    instances: [],
+    activeSessions: [],
+    isOnline: false,
+    activeSessionCount: 0,
+    lastSeenAtEpochMs: null,
+  };
+}
+
+export function createGroupSnapshot(
+  groupRevision: number,
+  presenceRevision: number,
+): GroupSnapshot {
+  const audit = createAuditStamp(Math.max(groupRevision, presenceRevision));
+  return {
+    stateRevision: Math.max(groupRevision, presenceRevision),
+    causalRevision: { groupRevision, presenceRevision },
+    group: {
+      applicationId: 'app-1',
+      workspaceId: 'workspace-1',
+      groupId: 'group-1',
+      slug: null,
+      displayName: 'Group 1',
+      description: null,
+      kind: 'room',
+      status: 'active',
+      archived: null,
+      deleted: null,
+      joinMode: 'open',
+      maxMembers: null,
+      maxSessionsPerMember: null,
+      metadata: {},
+      snapshotVersion: groupRevision,
+      metadataVersion: groupRevision,
+      rosterVersion: groupRevision,
+      presenceVersion: presenceRevision,
+      activeMemberCount: 0,
+      ownerPrincipalId: 'alice',
+      created: audit,
+      updated: audit,
+      expiresAtEpochMs: null,
+      emptySinceEpochMs: null,
+      purgeAfterEpochMs: null,
+    },
+    members: [],
+    activeSessions: [],
+    memberCount: 0,
+    onlineMemberCount: 0,
+  };
+}
+
+export function createClientCache(initial?: ClientSnapshot) {
+  let current = initial;
+  return {
+    peek: vi.fn(() => current),
+    observe: vi.fn((snapshot: ClientSnapshot) => {
+      if (!current || snapshot.stateRevision > current.stateRevision) {
+        const outcome = current ? 'advanced' : 'inserted';
+        current = snapshot;
+        return outcome;
+      }
+      return snapshot === current ? 'duplicate' : 'stale';
+    }),
+    evictIfUnchanged: vi.fn((_ref, expected: ClientSnapshot) => {
+      if (current !== expected) return false;
+      current = undefined;
+      return true;
+    }),
+    publish(snapshot: ClientSnapshot) {
+      current = snapshot;
+    },
+    current: () => current,
+  };
+}
+
+export function createGroupCache(initial?: GroupSnapshot) {
+  let current = initial;
+  return {
+    peek: vi.fn(() => current),
+    observe: vi.fn((snapshot: GroupSnapshot) => {
+      current = snapshot;
+      return 'advanced' as const;
+    }),
+    evictIfUnchanged: vi.fn((_ref, expected: GroupSnapshot) => {
+      if (current !== expected) return false;
+      current = undefined;
+      return true;
+    }),
+    publish(snapshot: GroupSnapshot) {
+      current = snapshot;
+    },
+    current: () => current,
+  };
+}
+
+function createAuditStamp(atEpochMs: number): AuditStamp {
+  return {
+    atEpochMs,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
+}

--- a/packages/tests/shared/observable-latest-repository.test.ts
+++ b/packages/tests/shared/observable-latest-repository.test.ts
@@ -243,4 +243,45 @@ describe('ObservableLatestRepository', () => {
         ]);
         expect(repository.read('b')).toBe(2);
     });
+
+    it('deletes only the exact observed value', async () => {
+        type Snapshot = Readonly<{ revision: number }>;
+        type ConditionallyDeletable = Readonly<{
+            compareAndDelete?: (key: string, expected: Snapshot) => boolean;
+        }>;
+        const repository = new ObservableLatestRepository<string, Snapshot>();
+        const deleted = vi.fn();
+        const first = { revision: 1 };
+        const equalButDifferent = { revision: 1 };
+        const newer = { revision: 2 };
+        const conditionallyDeletable = repository as ConditionallyDeletable;
+
+        repository.onDeletedDo(deleted);
+        repository.set('room', first);
+
+        expect(
+            conditionallyDeletable.compareAndDelete?.('room', equalButDifferent)
+                ?? false,
+        ).toBe(false);
+        expect(repository.peek('room')).toBe(first);
+
+        repository.set('room', newer);
+        await repository.whenIdle();
+        expect(
+            conditionallyDeletable.compareAndDelete?.('room', first) ?? false,
+        ).toBe(false);
+        expect(repository.peek('room')).toBe(newer);
+
+        expect(
+            conditionallyDeletable.compareAndDelete?.('room', newer) ?? false,
+        ).toBe(true);
+        await repository.whenIdle();
+
+        expect(repository.peek('room')).toBeUndefined();
+        expect(deleted).toHaveBeenCalledTimes(1);
+        expect(deleted.mock.calls[0]?.[0]).toMatchObject({
+            key: 'room',
+            previous: newer,
+        });
+    });
 });

--- a/packages/tests/shared/observable-loaned-repository.test.ts
+++ b/packages/tests/shared/observable-loaned-repository.test.ts
@@ -256,6 +256,48 @@ describe('ObservableLoanedRepository', () => {
             value: 2,
         });
     });
+
+    it('deletes only the exact observed loaned value', async () => {
+        type Snapshot = Readonly<{ revision: number }>;
+        type ConditionallyDeletable = Readonly<{
+            compareAndDelete?: (key: string, expected: Snapshot) => boolean;
+        }>;
+        let current: Snapshot = { revision: 1 };
+        const repository = new ObservableLoanedRepository<string, Snapshot>(
+            async () => current,
+        );
+        const deleted = vi.fn();
+        const conditionallyDeletable = repository as ConditionallyDeletable;
+        const first = await repository.get('room');
+
+        repository.onDeletedDo(deleted);
+        expect(
+            conditionallyDeletable.compareAndDelete?.(
+                'room',
+                { revision: first.revision },
+            ) ?? false,
+        ).toBe(false);
+        expect(repository.peek('room')).toBe(first);
+
+        current = { revision: 2 };
+        const newer = await repository.refresh('room');
+        expect(
+            conditionallyDeletable.compareAndDelete?.('room', first) ?? false,
+        ).toBe(false);
+        expect(repository.peek('room')).toBe(newer);
+
+        expect(
+            conditionallyDeletable.compareAndDelete?.('room', newer) ?? false,
+        ).toBe(true);
+        await repository.whenIdle();
+
+        expect(repository.peek('room')).toBeUndefined();
+        expect(deleted).toHaveBeenCalledTimes(1);
+        expect(deleted.mock.calls[0]?.[0]).toMatchObject({
+            key: 'room',
+            previous: newer,
+        });
+    });
 });
 
 function createDeferred<T>() {

--- a/packages/tests/shared/repository-modules.test.ts
+++ b/packages/tests/shared/repository-modules.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type { OverlayInfo, RttMeasurementInfo, } from '@shared/api/api-config.ts';
-import type { ClientSession, ClientSnapshot } from '@shared/api/client-types.ts';
+import type {
+    ClientPrincipalRef,
+    ClientSession,
+    ClientSnapshot,
+} from '@shared/api/client-types.ts';
 import { readClientVersion, readGroupVersion } from '@shared/api/group-client-views.ts';
 import type {
     AuditStamp,
@@ -18,8 +22,10 @@ import {
     onClientStateSnapshotChange,
     readableClientStateSnapshotCache,
     setClientStateSnapshotByPrincipalId,
+    toClientStateSnapshotRepositoryKey,
     waitForClientStateSnapshotChangesIdle,
 } from '@shared/repository/client-state-snapshots-repository.ts';
+import * as clientSnapshotRepositoryModule from '@shared/repository/client-state-snapshots-repository.ts';
 import {
     findFirstGroupStateSnapshotRefSessionIdIsIn,
     findGroupStateSnapshotsBySessionIds,
@@ -29,8 +35,10 @@ import {
     removeGroupStateSnapshotByRef,
     setGroupStateSnapshot,
     setGroupStateSnapshots,
+    toGroupStateSnapshotRepositoryKey,
     waitForGroupStateSnapshotChangesIdle,
 } from '@shared/repository/group-state-snapshots-repository.ts';
+import * as groupSnapshotRepositoryModule from '@shared/repository/group-state-snapshots-repository.ts';
 import {
     createAndSetStarOverlays,
     findOverlayById,
@@ -84,6 +92,59 @@ describe('repository modules', () => {
         expect(findClientStateSnapshotByRef(workspaceA.principal)).toEqual(workspaceA);
         expect(findClientStateSnapshotByRef(workspaceB.principal)).toEqual(workspaceB);
         expect(getAllClientStateSnapshots()).toHaveLength(2);
+    });
+
+    it('keeps absent and explicitly empty client workspace keys distinct', () => {
+        const absentWorkspace = {
+            applicationId: 'app-1',
+            principalId: 'client-1',
+        } as ClientPrincipalRef;
+        const emptyWorkspace = {
+            ...absentWorkspace,
+            workspaceId: '',
+        };
+
+        expect(toClientStateSnapshotRepositoryKey(absentWorkspace)).not.toBe(
+            toClientStateSnapshotRepositoryKey(emptyWorkspace),
+        );
+    });
+
+    it('round-trips client snapshot keys with tagged workspace values', () => {
+        type SnapshotKeyCodec = Readonly<{
+            fromClientStateSnapshotRepositoryKey?: (
+                key: string,
+            ) => Partial<ClientPrincipalRef>;
+        }>;
+        const codec = clientSnapshotRepositoryModule as SnapshotKeyCodec;
+        const refs = [
+            {
+                applicationId: 'app|with:delimiters',
+                principalId: 'principal%2Fname',
+            } as ClientPrincipalRef,
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: '',
+                principalId: 'principal%2Fname',
+            },
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: '_',
+                principalId: 'principal%2Fname',
+            },
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: 'workspace:%25',
+                principalId: 'principal%2Fname',
+            },
+        ] satisfies readonly ClientPrincipalRef[];
+
+        const keys = refs.map(toClientStateSnapshotRepositoryKey);
+        expect(new Set(keys).size).toBe(refs.length);
+        expect(
+            keys.map((key) =>
+                codec.fromClientStateSnapshotRepositoryKey?.(key) ?? null
+            ),
+        ).toEqual(refs);
     });
 
     it('emits client snapshot changes only for accepted writes', async () => {
@@ -174,6 +235,38 @@ describe('repository modules', () => {
         expect(findClientStateSnapshotByPrincipalId('client-1')).toEqual(accepted);
         expect(() => setClientStateSnapshotByPrincipalId('client-1', conflict))
             .toThrow('Client snapshot revision conflict');
+    });
+
+    it('conditionally removes only the unchanged client snapshot identity', () => {
+        type ConditionalClientRemoval = Readonly<{
+            removeClientStateSnapshotIfUnchanged?: (
+                ref: ClientPrincipalRef,
+                expected: ClientSnapshot,
+            ) => boolean;
+        }>;
+        const conditionalRemoval =
+            clientSnapshotRepositoryModule as ConditionalClientRemoval;
+        const first = createClientSnapshot('client-1', 'session-old', 1);
+        const newer = createClientSnapshot('client-1', 'session-new', 2);
+
+        expect(setClientStateSnapshotByPrincipalId('client-1', first)).toBe(true);
+        expect(setClientStateSnapshotByPrincipalId('client-1', newer)).toBe(true);
+
+        expect(
+            conditionalRemoval.removeClientStateSnapshotIfUnchanged?.(
+                first.principal,
+                first,
+            ) ?? false,
+        ).toBe(false);
+        expect(findClientStateSnapshotByRef(first.principal)).toBe(newer);
+
+        expect(
+            conditionalRemoval.removeClientStateSnapshotIfUnchanged?.(
+                newer.principal,
+                newer,
+            ) ?? false,
+        ).toBe(true);
+        expect(findClientStateSnapshotByRef(newer.principal)).toBeUndefined();
     });
 
     it('stores group snapshots by scoped ref, keeps newer versions, and finds memberships', () => {
@@ -280,6 +373,59 @@ describe('repository modules', () => {
         );
     });
 
+    it('keeps absent and explicitly empty group workspace keys distinct', () => {
+        const absentWorkspace = {
+            applicationId: 'app-1',
+            groupId: 'group-1',
+        } as GroupSnapshot['group'];
+        const emptyWorkspace = {
+            ...absentWorkspace,
+            workspaceId: '',
+        };
+
+        expect(toGroupStateSnapshotRepositoryKey(absentWorkspace)).not.toBe(
+            toGroupStateSnapshotRepositoryKey(emptyWorkspace),
+        );
+    });
+
+    it('round-trips group snapshot keys with tagged workspace values', () => {
+        type SnapshotKeyCodec = Readonly<{
+            fromGroupStateSnapshotRepositoryKey?: (
+                key: string,
+            ) => Partial<GroupSnapshot['group']>;
+        }>;
+        const codec = groupSnapshotRepositoryModule as SnapshotKeyCodec;
+        const refs = [
+            {
+                applicationId: 'app|with:delimiters',
+                groupId: 'group%2Fname',
+            } as GroupSnapshot['group'],
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: '',
+                groupId: 'group%2Fname',
+            },
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: '_',
+                groupId: 'group%2Fname',
+            },
+            {
+                applicationId: 'app|with:delimiters',
+                workspaceId: 'workspace:%25',
+                groupId: 'group%2Fname',
+            },
+        ] satisfies readonly GroupSnapshot['group'][];
+
+        const keys = refs.map(toGroupStateSnapshotRepositoryKey);
+        expect(new Set(keys).size).toBe(refs.length);
+        expect(
+            keys.map((key) =>
+                codec.fromGroupStateSnapshotRepositoryKey?.(key) ?? null
+            ),
+        ).toEqual(refs);
+    });
+
     it('uses the full group causal tuple for cache ordering', () => {
         const first = {
             ...createGroupSnapshot('group-1', 'Alpha', 1, ['self']),
@@ -333,6 +479,48 @@ describe('repository modules', () => {
         expect(findGroupStateSnapshotByRef(accepted.group)).toEqual(accepted);
         expect(() => setGroupStateSnapshot(conflict))
             .toThrow('Group snapshot revision conflict');
+    });
+
+    it('conditionally removes only the unchanged group and session-index identity', () => {
+        type ConditionalGroupRemoval = Readonly<{
+            removeGroupStateSnapshotIfUnchanged?: (
+                ref: GroupSnapshot['group'],
+                expected: GroupSnapshot,
+            ) => boolean;
+        }>;
+        const conditionalRemoval =
+            groupSnapshotRepositoryModule as ConditionalGroupRemoval;
+        const first = createGroupSnapshot('group-1', 'Alpha', 1, [
+            'self',
+            'session-old',
+        ]);
+        const newer = createGroupSnapshot('group-1', 'Alpha', 2, [
+            'self',
+            'session-new',
+        ]);
+
+        expect(setGroupStateSnapshot(first)).toBe(true);
+        expect(setGroupStateSnapshot(newer)).toBe(true);
+
+        expect(
+            conditionalRemoval.removeGroupStateSnapshotIfUnchanged?.(
+                first.group,
+                first,
+            ) ?? false,
+        ).toBe(false);
+        expect(findGroupStateSnapshotByRef(first.group)).toBe(newer);
+        expect(findGroupStateSnapshotsBySessionIds(['self', 'session-new']))
+            .toEqual([newer]);
+
+        expect(
+            conditionalRemoval.removeGroupStateSnapshotIfUnchanged?.(
+                newer.group,
+                newer,
+            ) ?? false,
+        ).toBe(true);
+        expect(findGroupStateSnapshotByRef(newer.group)).toBeUndefined();
+        expect(findGroupStateSnapshotsBySessionIds(['self', 'session-new']))
+            .toEqual([]);
     });
 
     it('emits group snapshot changes only for accepted writes', async () => {


### PR DESCRIPTION
Implements PR 1 of `plans/rallar-rest-snapshot-read-convergence-implementation-plan.md`.

This PR owns injective in-memory snapshot keys, identity-fenced removal, cache eviction fences, scalar and causal REST selectors, durable client parity, and bounded server diagnostics. Persisted storage keys are unchanged.

Stack: 1 of 3. PR 2 targets this branch.

Exact head: `99950d02cc0142f4015a349b24fd77b4f8b9de38`
Exact tree: `dd696e197ce887e7970c2ad77d5032204365d6d7`

Validation on this exact tree:

- Focused snapshot repository/cache/selector suites: 10 files, 85 tests passed.
- `npm run check:repo-style`: passed (warning-only existing repository baseline).
- `npm run check:repo-style:changed -- origin/main`: passed with no new findings.
- `VITEST_MAX_WORKERS=4 npm run test:unit`: 685 files passed, 11 skipped; 6,219 tests passed, 18 skipped.
- `VITEST_MAX_WORKERS=4 npm run test:ci`: passed, including API/control/shared RTC Deno, browser, Recipe Console, and memory full-stack phases.
- `npm run build`: passed.
- `git diff --check origin/main...HEAD`: passed.
- [Branch Release Gate](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31208427811): passed on the exact head above.

Automatic Deno Deploy and one Cloudflare Workers preview check remain red because of external feature-branch deployment configuration; they are not the repository-owned Branch Release Gate.
