### PR TITLE
REST snapshot convergence: browser repair and docs

### DIFF
--- a/.agents/skills/rallar-platform/SKILL.md
+++ b/.agents/skills/rallar-platform/SKILL.md
@@ -40,6 +40,13 @@ rg --files packages/shared packages/shared-web packages/shared-server packages/s
 - Prefer adding narrow helpers beside the domain they belong to, then export through the local package barrel.
 - Treat broad `mod.ts` barrels as compatibility surfaces; avoid moving symbols in ways that break imports.
 - When editing shared contracts, inspect both browser and server consumers before changing a type.
+- REST snapshot point readers keep transport metadata in additive result
+  envelopes. Preserve body-only compatibility wrappers such as
+  `findStateGroup(...)`, and require browser success paths to validate the
+  authoritative body plus source/revision header agreement before returning.
+- Keep state-read diagnostic dimensions bounded. Application, workspace,
+  principal, group, session, and request identifiers are values for logs or
+  traces under an approved policy, not metric labels.
 
 ## Contract Shape And Compatibility
 

--- a/.agents/skills/rallar-realtime/SKILL.md
+++ b/.agents/skills/rallar-realtime/SKILL.md
@@ -106,6 +106,13 @@ rg -n "GroupRef|groupRef|groupId|roomId|createAndSwitch|createAndJoin|joinRoom|w
 - Browser RTC enables the initial connection-attempt budget by default. The
   shared service exposes `connect-exhausted`; browser facade waits report
   exhaustion as `failed` with reason `rtc-connect-attempt-budget-exhausted`.
+- Keep `rooms.refresh()` and people refresh on complete durable collections,
+  but use one exact group point read for a room session refresh. Capture the
+  current object identity before targeted, heartbeat, or collection repair and
+  remove only that unchanged observation after authoritative absence.
+- Conditional snapshot removal is a race fence, not a causal tombstone. Test
+  that a newer in-memory observation survives cleanup, and do not claim that
+  delayed stale publication cannot recreate a physically removed snapshot.
 - Game and motion traffic are reliability consumers of the realtime layer, not separate demos.
 
 ## Validation

--- a/apps/api-v1/README.md
+++ b/apps/api-v1/README.md
@@ -53,6 +53,29 @@ brokered.
 See [Production Env Hardening Checklist](../../docs/production-env-hardening-checklist.md) and
 [Environment Variables](../../docs/environment-variables.md).
 
+## REST snapshot point reads
+
+Client point reads accept one optional canonical non-negative safe-integer
+`minStateRevision`. Group point reads accept `minGroupRevision` and
+`minPresenceRevision` only as a complete pair. Malformed floors return typed
+`400` responses; authorized durable shortfall or causal incomparability returns
+typed `409 state-revision-floor-not-satisfied`. Repeated floor conflicts do not
+trip the infrastructure circuit breaker.
+
+Tokenless point reads observe durable current state. Eligible tokened reads may
+use a presence-fresh cache entry that satisfies the requested floor, while
+strict authorization always uses durable state. Group policy, floor validation,
+and the successful response reuse one durable snapshot. Graph and topology
+authority reads also use one durable current snapshot per request; mutation
+prechecks remain advisory because AppInbox revalidates before commit.
+
+Successful point responses use `Cache-Control: no-store` and authoritative
+source and revision headers. CORS exposes those Rallar headers. Client response
+metadata carries one scalar revision; group metadata carries the group and
+presence revisions, while the compatibility scalar revision remains body-only.
+See [the API reference](../../docs/rallar-api-reference.md) for exact paths,
+headers, status codes, and OpenAPI shapes.
+
 ## RTC persisted-state cutover
 
 The RTC persisted-state migration is an offline cutover. It intentionally has no legacy dual-read

--- a/docs/rallar-api-reference.md
+++ b/docs/rallar-api-reference.md
@@ -179,7 +179,10 @@ await rallar.auth.registerAndLogin({
 
 `rooms.list()` returns room summaries.
 
-`rooms.refresh(input?)` fetches current room and client snapshots from the API and updates local caches.
+`rooms.refresh(input?)` fetches complete current room and client snapshot
+collections from the API and updates local caches. A room session's
+`refresh()` performs one group point read for that exact `roomRef`, without a
+revision-floor query, and updates only that room.
 
 `rooms.create(input)` creates a group/room, joins it, and makes it current.
 `input` can be a display name string or an object. It does not leave the
@@ -292,6 +295,35 @@ REST errors keep the existing `{ error }` shape and may also include `code`,
 `message`, and `details`. Browser workflows preserve the parsed response on
 `ApiHttpError`, so apps can branch on stable policy reason codes without string
 matching `error`.
+
+Client and group point reads support optional convergence floors:
+
+- `readStateClientSnapshot(principalId, scope, { minStateRevision? })` returns
+  `{ snapshot, source, stateRevision }`.
+- `readStateGroupSnapshot(groupId, scope, { minCausalRevision? })` returns
+  `{ snapshot, source, groupRevision, presenceRevision }`.
+- `findStateGroup(...)` remains the body-only compatibility wrapper and returns
+  `Promise<GroupSnapshot>`.
+
+Floors are non-negative safe integers. Group callers provide both components
+through `minCausalRevision`; the REST query sends both `minGroupRevision` and
+`minPresenceRevision`. Malformed or partial floors return `400`. An authorized
+durable snapshot that does not satisfy the requested floor returns `409` with
+code `state-revision-floor-not-satisfied`; this is distinct from an
+infrastructure `503`.
+
+A point read without a floor observes durable state. An eligible floor-bearing
+read may be served from a process cache. Successful responses include
+`Cache-Control: no-store`, `rallar-state-source`, and the applicable
+`rallar-state-revision` or `rallar-group-revision` plus
+`rallar-presence-revision` headers. The browser readers validate the
+authoritative body, requested identity, required headers, and header/body
+revision agreement before returning.
+
+`setBrowserStateReadDiagnosticsSink(...)` installs an optional browser sink for
+bounded point, heartbeat, and collection outcomes. Events expose only feature,
+operation, result, source when known, and duration. Do not add application,
+workspace, principal, group, session, or request identifiers as metric labels.
 
 The group state routes for the policy workflows are:
 

--- a/docs/rallar-convergent-state-and-rtc-topology.md
+++ b/docs/rallar-convergent-state-and-rtc-topology.md
@@ -206,10 +206,14 @@ application inbox service publishes WS or topology work. Every snapshot and
 idempotent result must carry `stateRevision`; revisionless compatibility is not
 supported.
 
-Reads use asynchronous read-through caching. Authorization, REST, admin,
-statistics, and topology paths use these shared services. Synchronous `peek`
-is restricted to best-effort local routing where a cache miss can safely
-produce no local recipients.
+General reads use asynchronous read-through caching. Point-read convergence has
+a narrower rule: reads without a revision floor use the durable current
+snapshot, while an eligible floor-bearing read may return a causally sufficient
+cache entry. Strict authorization and graph/topology authority reads use the
+same durable current snapshot used for the request decision; stale cached state
+is never authorization authority. Synchronous `peek` is restricted to
+best-effort local routing where a cache miss can safely produce no local
+recipients.
 
 Client cache keys contain the complete principal identity:
 
@@ -424,6 +428,21 @@ only the revision probe.
 
 ## Browser Convergence
 
+Browser point readers expose the response source and authoritative revision
+metadata. They reject malformed authoritative bodies, missing or invalid
+metadata headers, and header/body revision disagreement. A room session refresh
+uses one exact group point read without a floor; top-level room and people
+refreshes continue to use complete durable collections.
+
+Before targeted, heartbeat, or complete collection reads, browser repair
+captures the observed snapshot identity. An authoritative `404`, heartbeat
+absence, or successful complete collection omission removes that value only if
+the repository still contains the identical observation. Failed, aborted,
+malformed, or partial collection reads do not reconcile absence. This is a
+race fence for physical cleanup, not a deletion tombstone: a delayed stale
+publication can reinsert a removed client or group snapshot until causal
+tombstones exist.
+
 `RallarOverlayTopologySnapshot` and `OverlayInfo` require
 `sourceGroupStateRevision` and `state`. Browser overlay repositories use the
 same revision ordering rule as server state caches:
@@ -459,8 +478,9 @@ that is safe because the publication and browser observation are idempotent.
 The architecture guarantees that a returned durable group/client snapshot is
 revision-consistent, process caches do not regress, outbox-accepted topology
 output is atomic with its publication index, a work retry reuses the same
-publication, and room authorization observes durable revision movement on the
-next message.
+publication, strict read authorization does not trust cached snapshots, and an
+eligible floor-bearing point read never returns below its requested scalar or
+causal floor.
 
 It does not yet guarantee lossless cluster publication replay. PostgreSQL
 notifications are ephemeral, so a server disconnected after publication commit
@@ -468,6 +488,13 @@ can miss the wake-up. The durable record remains correct, but no ordered cursor
 drain currently discovers it. The follow-up architecture should maintain a
 durable ordered publication log with per-process replay cursors and treat
 notifications only as wake-ups.
+
+Browser client/group absence repair also does not guarantee resurrection
+safety. Conditional physical deletion protects a newer observation already in
+the repository, but it cannot prevent a delayed stale publication from
+recreating an absent entry. Causal tombstones remain separate work. The overlay
+tombstones described above are a different feature and do not provide state
+snapshot deletion authority.
 
 ## Performance Bounds
 
@@ -477,6 +504,9 @@ notifications only as wake-ups.
   and one exact-key aggregate validation batch.
 - Warm room authorization performs one durable aggregate revision probe; the
   stable snapshot reader runs only after revision movement.
+- An eligible point-read cache hit performs zero durable snapshot reads.
+  Tokenless reads, misses, floor fallback, and strict group point reads perform
+  one full durable snapshot read for the selected feature.
 - Topology planning is outside the transaction. Current execution performs a
   fresh read and one conditional write transaction per accepted attempt;
   conflicts re-enter the complete read/compute/validate path.
@@ -515,10 +545,12 @@ The cluster-notification cutover requires a coordinated deployment of API
 nodes. Older nodes do not subscribe to topology publication notifications and
 cannot fan out publications to their locally connected sessions.
 
-REST route and request shapes, database schema, generated manifests, and
-browser runtime import paths are unchanged. The required response fields and
-the two-work-type topology queue contract are intentional breaking contract
-changes and require a coordinated deployment.
+Existing REST paths, database schema, generated manifests, and browser runtime
+import paths remain compatible. Point-read floor queries, authoritative
+response headers, and metadata-bearing browser readers are additive;
+`findStateGroup(...)` preserves its body-only return shape. The required
+response fields and the two-work-type topology queue contract remain the
+intentional coordinated-deployment boundary described by this architecture.
 
 ## Source Map
 

--- a/docs/rallar-troubleshooting-checklist.md
+++ b/docs/rallar-troubleshooting-checklist.md
@@ -27,6 +27,10 @@ Use this checklist when Rallar behavior is surprising in a browser or server int
   previous membership.
 - `leaveCurrent` behavior is intentional when joining another room.
 - Multi-workspace code passes `roomRef` instead of only `roomId`.
+- `rooms.session(room).refresh()` is expected to make one exact group point
+  read; `rooms.refresh()` is the complete room/client collection refresh.
+- A room-session refresh `404` is rethrown after conditional local cleanup. A
+  newer snapshot racing that response is preserved.
 - `rooms.waitForPresence(...)` uses the right expectation for the flow:
   `{ min, max? }`, `{ exact }`, or `{ sessionIds, allowExtras? }`.
 - Room event subscriptions use the correct `scope`, `roomId`, `roomRef`, and `eventTypes`.
@@ -38,6 +42,25 @@ Use this checklist when Rallar behavior is surprising in a browser or server int
 - Client events are not assumed to arrive while disconnected unless replay is used.
 - Server websocket lifecycle cleanup is installed.
 - Server presence expiry reconciliation is initialized.
+
+## REST Snapshot Reads
+
+- Client floors use one canonical `minStateRevision`; group floors provide
+  both `minGroupRevision` and `minPresenceRevision`.
+- `400` means the floor query is malformed. Authorized `409` with
+  `state-revision-floor-not-satisfied` means durable state has not reached or
+  does not dominate the requested floor. Treat `503` as infrastructure or
+  stable-snapshot-read failure instead.
+- Successful point responses include `Cache-Control: no-store`,
+  `rallar-state-source`, and revision headers that agree with the body.
+- Browser point readers validate authoritative body and response metadata. A
+  malformed success response is rejected and is not reconciled into caches.
+- Collection omission and heartbeat/point `404` cleanup is conditional on the
+  originally observed object identity. It is physical deletion, not a
+  tombstone; delayed stale publication can reinsert the snapshot.
+- Browser diagnostics use `setBrowserStateReadDiagnosticsSink(...)`. Keep
+  dimensions bounded and never add tenant, entity, session, or request IDs as
+  metric labels.
 
 ## WebSocket
 

--- a/packages/shared-server/rallar-system/client-state/README.md
+++ b/packages/shared-server/rallar-system/client-state/README.md
@@ -85,12 +85,22 @@ AppInbox owners directly.
 
 - [`createCachedClientStateService` and explicit committed-snapshot observation](./snapshot/cached-client-state-service.ts)
 - [`ClientStateSnapshotReadThroughCache` and durable read-through refresh](./snapshot/client-state-snapshot-read-through-cache.ts)
+- [`ClientRestSnapshotReadSelector` and REST scalar-floor selection](./snapshot/client-rest-snapshot-read-selector.ts)
 
 The legacy `services/cached-client-state-service.ts` and
 `services/client-state-snapshot-read-through-cache.ts` paths remain direct
 named compatibility exports for API-v1 and deep consumers. The package
 `mod.ts` exports both canonical snapshot owners directly. The cache remains a
 latest-value projection; durable client-state repositories remain authoritative.
+
+`ClientRestSnapshotReadSelector` keeps REST policy separate from the general
+cache API. Tokenless and strict reads load durable current state. A tokened
+non-strict read may return a presence-fresh cache entry only when its scalar
+revision satisfies `minStateRevision`; otherwise it performs exactly one
+durable-current read. Durable shortfall returns the typed floor-conflict result.
+Durable absence conditionally removes only the unchanged cached observation,
+which is a race fence rather than a tombstone. Its optional diagnostics report
+only bounded source, result, floor, cleanup, strict-mode, and duration fields.
 
 ## Compatibility paths and removal conditions
 

--- a/packages/shared-server/rallar-system/group-state/README.md
+++ b/packages/shared-server/rallar-system/group-state/README.md
@@ -279,6 +279,17 @@ re-thrown. The common mutation path observes only the committed snapshot after
 its AppInbox transaction returns, so cache observation never decides durable
 mutation success.
 
+[GroupRestSnapshotReadSelector](./snapshot/group-rest-snapshot-read-selector.ts)
+owns REST point-read policy for the complete group causal pair. Tokenless and
+strict reads load durable current state. A tokened non-strict read may use a
+presence-fresh cache entry only when its group and presence revisions equal or
+dominate the requested pair; domination and incomparability fall back to one
+durable-current read. Durable shortfall or incomparability returns the typed
+floor-conflict result. Strict route authorization reuses that same durable
+snapshot for policy, floor validation, and response construction. Durable
+absence conditionally removes only the unchanged cache identity; it is not a
+tombstone. Optional diagnostics keep only bounded dimensions.
+
 ## Family Inventory And Scope
 
 - Aggregate and membership operations share the authenticated AppInbox family.

--- a/packages/shared-web/browser/api-integration.ts
+++ b/packages/shared-web/browser/api-integration.ts
@@ -1,5 +1,7 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { readApiBaseUrl } from './api-client-config.ts';
+import { ApiHttpError, type ApiHttpMethod } from './api/http-error.ts';
+import { readStateGroupSnapshot } from './state-read/point-read.ts';
 import { readSession } from '@shared/api/auth.ts';
 import {
     validateAuthoritativeClientEventList,
@@ -69,7 +71,6 @@ import {
     type RotateGroupJoinCodeRequest,
     type SetGroupMemberRoleRequest,
     type StateScope,
-    type StateErrorResponse,
     type TransferGroupOwnershipRequest,
     type UnbanGroupMemberRequest,
     type UpdateGroupRequest,
@@ -95,7 +96,18 @@ export type ApiRequestOptions = Readonly<{
     authSession?: AuthSession | null;
 }>;
 
-export type ApiHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export { ApiHttpError, readApiPolicyError } from './api/http-error.ts';
+export type { ApiHttpMethod } from './api/http-error.ts';
+export {
+    readStateClientSnapshot,
+    readStateGroupSnapshot,
+} from './state-read/point-read.ts';
+export type {
+    ReadStateClientSnapshotOptions,
+    ReadStateGroupSnapshotOptions,
+    StateClientSnapshotRead,
+    StateGroupSnapshotRead,
+} from './state-read/point-read.ts';
 
 export type StateEventListRequestOptions<TEventType extends string> =
     & ApiRequestOptions
@@ -133,32 +145,6 @@ export type GroupStateEventListRequestOptions =
 
 export type ClientStateEventListRequestOptions =
     StateEventListRequestOptions<ClientEventType>;
-
-export class ApiHttpError extends Error {
-    public readonly policyError?: StateErrorResponse & Readonly<{ code: string }>;
-
-    public constructor(
-        public readonly method: ApiHttpMethod,
-        public readonly path: string,
-        public readonly status: number,
-        public readonly bodyText: string,
-        public readonly headers?: Headers,
-    ) {
-        super(`API ${method} ${path} failed: ${status} ${bodyText}`);
-        this.name = 'ApiHttpError';
-        this.policyError = parseApiPolicyError(bodyText);
-    }
-}
-
-export function readApiPolicyError(
-    error: unknown,
-): (StateErrorResponse & Readonly<{ code: string }>) | undefined {
-    if (error instanceof ApiHttpError) {
-        return error.policyError;
-    }
-
-    return undefined;
-}
 
 export type WebSocketTicketBackoffState = Readonly<
     | {
@@ -421,44 +407,6 @@ async function createWebSocketTicketThroughCircuitBreaker(
     );
 }
 
-async function readTextOrElse(
-    res: Response,
-    orElse: () => string,
-): Promise<string> {
-    try {
-        return await res.text();
-    } catch {
-        return orElse();
-    }
-}
-
-function parseApiPolicyError(
-    bodyText: string,
-): (StateErrorResponse & Readonly<{ code: string }>) | undefined {
-    try {
-        const value = JSON.parse(bodyText);
-        if (!isRecord(value)) {
-            return undefined;
-        }
-        if (typeof value.error !== 'string' || typeof value.code !== 'string') {
-            return undefined;
-        }
-
-        return {
-            error: value.error,
-            code: value.code,
-            message: typeof value.message === 'string' ? value.message : undefined,
-            details: isRecord(value.details) ? value.details : undefined,
-        };
-    } catch {
-        return undefined;
-    }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
-}
-
 async function executeHttpRequest<TReq, TRes>(
     baseUrl: string,
     path: string,
@@ -467,25 +415,20 @@ async function executeHttpRequest<TReq, TRes>(
     options: ApiRequestOptions = {},
     requestHeaders: Readonly<Record<string, string>> = {},
 ): Promise<TRes> {
-    const url = `${baseUrl}${path}`;
-
     const init: RequestInit = {
         method,
         headers: { 'content-type': 'application/json', ...requestHeaders },
         signal: options.signal,
     };
-
     const session = options.authSession === undefined
         ? readSession()
         : options.authSession;
-
     if (session) {
         const headers = new Headers(init.headers);
         headers.set('authorization', `Bearer ${session.accessToken}`);
         headers.set('x-client-id', session.clientId);
         init.headers = headers;
     }
-
     if (method === 'POST' || method === 'PUT') {
         if (body === undefined) {
             throw new Error(`${method} ${path} requires a body`);
@@ -494,16 +437,25 @@ async function executeHttpRequest<TReq, TRes>(
     } else if (method === 'DELETE' && body !== undefined) {
         init.body = JSON.stringify(body);
     }
-
-    const res = await fetch(url, init);
-
-    if (!res.ok) {
-        const txt = await readTextOrElse(res, () => '');
-
-        throw new ApiHttpError(method, path, res.status, txt, res.headers);
+    const response = await fetch(`${baseUrl}${path}`, init);
+    if (!response.ok) {
+        throw new ApiHttpError(
+            method,
+            path,
+            response.status,
+            await readErrorBody(response),
+            response.headers,
+        );
     }
+    return (await response.json()) as TRes;
+}
 
-    return (await res.json()) as TRes;
+async function readErrorBody(response: Response): Promise<string> {
+    try {
+        return await response.text();
+    } catch {
+        return '';
+    }
 }
 
 export async function readApiConfig(
@@ -734,13 +686,7 @@ export async function findStateGroup(
     scope: StateScope = defaultStateScope(),
     options?: ApiRequestOptions,
 ): Promise<GroupStateSnapshot> {
-    return await executeHttpRequest<void, GroupStateSnapshot>(
-        readApiBaseUrl(),
-        `${toStateScopePath(scope)}/groups/${encodeURIComponent(groupId)}`,
-        'GET',
-        undefined,
-        options,
-    );
+    return (await readStateGroupSnapshot(groupId, scope, options)).snapshot;
 }
 
 export async function listStateGroupEvents(

--- a/packages/shared-web/browser/api-workflows.ts
+++ b/packages/shared-web/browser/api-workflows.ts
@@ -3,9 +3,7 @@ import type { ClientSnapshot as ClientStateSnapshot } from '@shared/api/client-t
 import type { GroupSnapshot as GroupStateSnapshot } from '@shared/api/group-types.ts';
 import {
   validateAuthoritativeClientSnapshot,
-  validateAuthoritativeClientSnapshotList,
   validateAuthoritativeGroupSnapshot,
-  validateAuthoritativeGroupSnapshotList,
 } from '@shared/api/authoritative-state-validation.ts';
 import type {
   RevokeGroupInviteRequest,
@@ -28,8 +26,6 @@ import {
   findStateGroup,
   heartbeatStateClientSession,
   heartbeatStateGroupPresenceSession,
-  listStateClients,
-  listStateGroups,
   revokeStateGroupInvite as revokeStateGroupInviteApi,
   rotateStateGroupJoinCode as rotateStateGroupJoinCodeApi,
   updateStateGroup,
@@ -41,6 +37,9 @@ import {
   toStateWorkflowRequestId,
 } from '@shared-web/browser/state-workflow-support.ts';
 import type { StateGroupWorkflowValue } from '@shared-web/browser/rooms/room-group-state-workflows.ts';
+import {
+  refreshCompleteStateSnapshotCollections,
+} from '@shared-web/browser/state-read/collection-refresh.ts';
 
 export {
   createAndJoinStateGroup,
@@ -96,30 +95,13 @@ export type RefreshStateHeartbeatResult = Readonly<{
   expiresAtEpochMs: number;
 }>;
 
-type StateSnapshotsKey = 'clients' | 'groups';
-
 type StateHeartbeatKey = 'client' | `group:${string}`;
 
 export async function refreshStateSnapshots(
   scope: StateScope = defaultStateScope(),
   policies: CommandsOrchestratorPolicies<StateSnapshotsWorkflowValue> = {},
 ): Promise<StateSnapshots> {
-  const flow = CommandsOrchestrator.withPolicies<StateSnapshotsKey, StateSnapshotsWorkflowValue>(
-    policies,
-  );
-
-  const results = await flow
-    .parallel(
-      flow.commandStep('clients', (signal) => listStateClients(scope, { signal })),
-      flow.commandStep('groups', (signal) => listStateGroups(scope, { signal })),
-    )
-    .run();
-
-  const clients: unknown = requireStateWorkflowResult(results, 'clients');
-  const groups: unknown = requireStateWorkflowResult(results, 'groups');
-  validateAuthoritativeClientSnapshotList(clients, scope);
-  validateAuthoritativeGroupSnapshotList(groups, scope);
-  return { clients, groups };
+  return await refreshCompleteStateSnapshotCollections(scope, policies);
 }
 
 export async function appointStateGroupDirector(

--- a/packages/shared-web/browser/api/http-error.ts
+++ b/packages/shared-web/browser/api/http-error.ts
@@ -1,0 +1,54 @@
+import type { StateErrorResponse } from '@shared/api/state-types.ts';
+
+export type ApiHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export class ApiHttpError extends Error {
+  public readonly policyError?: StateErrorResponse & Readonly<{ code: string }>;
+
+  public constructor(
+    public readonly method: ApiHttpMethod,
+    public readonly path: string,
+    public readonly status: number,
+    public readonly bodyText: string,
+    public readonly headers?: Headers,
+  ) {
+    super(`API ${method} ${path} failed: ${status} ${bodyText}`);
+    this.name = 'ApiHttpError';
+    this.policyError = parseApiPolicyError(bodyText);
+  }
+}
+
+export function readApiPolicyError<T>(
+  error: T,
+): (StateErrorResponse & Readonly<{ code: string }>) | undefined {
+  return error instanceof ApiHttpError ? error.policyError : undefined;
+}
+
+function parseApiPolicyError(
+  bodyText: string,
+): (StateErrorResponse & Readonly<{ code: string }>) | undefined {
+  try {
+    const value = JSON.parse(bodyText);
+    if (!isRecord(value) || typeof value.error !== 'string' || typeof value.code !== 'string') {
+      return undefined;
+    }
+    return {
+      error: value.error,
+      code: value.code,
+      message: typeof value.message === 'string' ? value.message : undefined,
+      details: isRecord(value.details) ? value.details : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord<T>(value: T): value is T & JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonRecord;
+
+interface JsonRecord {
+  readonly [key: string]: JsonValue;
+}

--- a/packages/shared-web/browser/heartbeat.ts
+++ b/packages/shared-web/browser/heartbeat.ts
@@ -11,6 +11,7 @@ import {
     refreshStateHeartbeat,
     type StateHeartbeatWorkflowValue,
 } from '@shared-web/browser/api-workflows.ts';
+import { emitBrowserStateReadDiagnostic } from '@shared-web/browser/state-read/diagnostics.ts';
 
 const intervalMsecs = 20000;
 const retryIntervalMsecs = 5000;
@@ -123,7 +124,17 @@ async function refreshHeartbeat(
 
     groupStateSnapshotsRepository.setGroupStateSnapshots(refreshed.groups);
     for (const missingGroup of refreshed.missingGroups) {
-        groupStateSnapshotsRepository.removeGroupStateSnapshotByRef(missingGroup.group);
+        const removed = groupStateSnapshotsRepository.removeGroupStateSnapshotIfUnchanged(
+            missingGroup.group,
+            missingGroup,
+        );
+        emitBrowserStateReadDiagnostic({
+            name: 'rallar.browser.state-read',
+            feature: 'group',
+            operation: 'heartbeat',
+            result: removed ? 'removed' : 'preserved',
+            durationMs: 0,
+        });
     }
 
     await Promise.all([

--- a/packages/shared-web/browser/rooms/browser-rallar-rooms.ts
+++ b/packages/shared-web/browser/rooms/browser-rallar-rooms.ts
@@ -1,8 +1,14 @@
 import * as apiWorkflows from '@shared-web/browser/api-workflows.ts';
+import {
+  ApiHttpError,
+  readStateGroupSnapshot,
+} from '@shared-web/browser/api-integration.ts';
+import type { StateGroupSnapshotRead } from '@shared-web/browser/api-integration.ts';
 import type { ApiMiddleware } from '@shared-web/browser/app-context.ts';
 import type { RallarRefreshOptions } from '@shared-web/browser/rallar-connection-facade.ts';
 import type { RallarMessagesFacade } from '@shared-web/browser/rallar-messages-facade.ts';
 import {
+  toRallarCommandOptions,
   toRallarWorkflowPolicies,
   type RallarOperationOptions,
 } from '@shared-web/browser/rallar-operation-options.ts';
@@ -14,8 +20,12 @@ import type {
   RallarUnsubscribe,
 } from '@shared-web/browser/rallar-shared-contracts.ts';
 import type { AuthSession } from '@shared/api/api-config.ts';
-import { toGroupRefFromScope } from '@shared/api/api-type-utils.ts';
+import { toGroupRefFromScope, toStateScope } from '@shared/api/api-type-utils.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import { Command } from '@shared/cache/Command.ts';
+import * as groupStateSnapshotsRepository
+  from '@shared/repository/group-state-snapshots-repository.ts';
+import { emitBrowserStateReadDiagnostic } from '@shared-web/browser/state-read/diagnostics.ts';
 
 import { createAndJoinRoom, createAndSwitchRoom } from './create-and-join-room.ts';
 import { enterRoom, joinRoom } from './join-room.ts';
@@ -87,7 +97,7 @@ export function createBrowserRallarRooms(
       messages: input.messages,
       realtime: input.realtime,
       leaveRoom: async (leaveInput) => await leaveRoom({ ...input, input: leaveInput }),
-      refreshRooms: refresh,
+      refreshRoom: async (roomRef, options) => await refreshRoom(input, roomRef, options),
     });
 
   return {
@@ -219,6 +229,48 @@ async function refreshRooms(
     );
     await input.acceptSnapshots(context, clients, groups, scope);
     return input.stateStore.state();
+  });
+}
+
+async function refreshRoom(
+  input: CreateBrowserRallarRoomsInput,
+  roomRef: GroupRef,
+  refreshInput: RallarRefreshOptions = {},
+): Promise<void> {
+  await input.runAuthAwareOperation(async () => {
+    const scope = toStateScope(roomRef);
+    const operationOptions = input.resolveOperationOptions({
+      ...refreshInput,
+      scope,
+    });
+    const context = await input.connect(operationOptions);
+    const observed = groupStateSnapshotsRepository.findGroupStateSnapshotByRef(roomRef);
+    try {
+      const response = await new Command<StateGroupSnapshotRead>(
+        (signal) => readStateGroupSnapshot(roomRef.groupId, scope, {
+          signal,
+          authSession: input.requireSession(),
+        }),
+        toRallarCommandOptions(operationOptions),
+      ).run();
+      await input.acceptSnapshots(context, [], [response.snapshot], scope);
+    } catch (error) {
+      if (error instanceof ApiHttpError && error.status === 404 && observed) {
+        const removed = groupStateSnapshotsRepository.removeGroupStateSnapshotIfUnchanged(
+          roomRef,
+          observed,
+        );
+        emitBrowserStateReadDiagnostic({
+          name: 'rallar.browser.state-read',
+          feature: 'group',
+          operation: 'point',
+          result: removed ? 'removed' : 'preserved',
+          durationMs: 0,
+        });
+        await groupStateSnapshotsRepository.waitForGroupStateSnapshotChangesIdle();
+      }
+      throw error;
+    }
   });
 }
 

--- a/packages/shared-web/browser/rooms/room-session.ts
+++ b/packages/shared-web/browser/rooms/room-session.ts
@@ -26,7 +26,10 @@ export interface CreateRoomSessionInput {
   readonly leaveRoom: (
     input?: string | RallarLeaveRoomOptions,
   ) => Promise<GroupSnapshot | undefined>;
-  readonly refreshRooms: (input?: RallarRefreshOptions) => Promise<unknown>;
+  readonly refreshRoom: (
+    roomRef: GroupRef,
+    input?: RallarRefreshOptions,
+  ) => Promise<unknown>;
 }
 
 export function createRoomSession(input: CreateRoomSessionInput): RallarRoomSession {
@@ -44,7 +47,10 @@ export function createRoomSession(input: CreateRoomSessionInput): RallarRoomSess
         scope: options.scope ?? toStateScope(input.roomRef),
       }),
     refresh: async (options = {}) => {
-      await input.refreshRooms({ ...options, scope: options.scope ?? toStateScope(input.roomRef) });
+      await input.refreshRoom(input.roomRef, {
+        ...options,
+        scope: options.scope ?? toStateScope(input.roomRef),
+      });
       return createRoomSession(input);
     },
     realtime: <T>(options?: RallarRoomSessionRealtimeInput) =>

--- a/packages/shared-web/browser/state-read/collection-refresh.ts
+++ b/packages/shared-web/browser/state-read/collection-refresh.ts
@@ -1,0 +1,47 @@
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+import {
+  validateAuthoritativeClientSnapshotList,
+  validateAuthoritativeGroupSnapshotList,
+} from '@shared/api/authoritative-state-validation.ts';
+import type { StateScope } from '@shared/api/state-types.ts';
+import {
+  CommandsOrchestrator,
+  type CommandsOrchestratorPolicies,
+} from '@shared/cache/CommandsOrchestrator.ts';
+
+import { listStateClients, listStateGroups } from '../api-integration.ts';
+import { requireStateWorkflowResult } from '../state-workflow-support.ts';
+import {
+  captureStateSnapshotCollectionObservations,
+  reconcileCompleteStateSnapshotCollections,
+} from './reconciliation.ts';
+
+type CollectionSnapshot = ClientSnapshot[] | GroupSnapshot[];
+
+export interface CompleteStateSnapshotCollections {
+  readonly clients: ClientSnapshot[];
+  readonly groups: GroupSnapshot[];
+}
+
+export async function refreshCompleteStateSnapshotCollections(
+  scope: StateScope,
+  policies: CommandsOrchestratorPolicies<CollectionSnapshot>,
+): Promise<CompleteStateSnapshotCollections> {
+  const observations = captureStateSnapshotCollectionObservations(scope);
+  const flow = CommandsOrchestrator.withPolicies<'clients' | 'groups', CollectionSnapshot>(
+    policies,
+  );
+  const results = await flow
+    .parallel(
+      flow.commandStep('clients', (signal) => listStateClients(scope, { signal })),
+      flow.commandStep('groups', (signal) => listStateGroups(scope, { signal })),
+    )
+    .run();
+  const clients = requireStateWorkflowResult(results, 'clients');
+  const groups = requireStateWorkflowResult(results, 'groups');
+  validateAuthoritativeClientSnapshotList(clients, scope);
+  validateAuthoritativeGroupSnapshotList(groups, scope);
+  reconcileCompleteStateSnapshotCollections(observations, clients, groups);
+  return { clients, groups };
+}

--- a/packages/shared-web/browser/state-read/diagnostics.ts
+++ b/packages/shared-web/browser/state-read/diagnostics.ts
@@ -1,0 +1,33 @@
+import type { StateSnapshotReadSource } from '@shared/api/state-snapshot-read.ts';
+
+export type BrowserStateReadDiagnosticEvent = Readonly<{
+  name: 'rallar.browser.state-read';
+  feature: 'client' | 'group';
+  operation: 'point' | 'heartbeat' | 'collection';
+  result: 'found' | 'not-found' | 'error' | 'removed' | 'preserved';
+  source?: StateSnapshotReadSource;
+  durationMs: number;
+}>;
+
+export type BrowserStateReadDiagnosticsSink = (
+  event: BrowserStateReadDiagnosticEvent,
+) => void;
+
+// One process-wide sink keeps the public surface additive and opt-in.
+let diagnosticsSink: BrowserStateReadDiagnosticsSink | undefined;
+
+export function setBrowserStateReadDiagnosticsSink(
+  sink: BrowserStateReadDiagnosticsSink | undefined,
+): void {
+  diagnosticsSink = sink;
+}
+
+export function emitBrowserStateReadDiagnostic(
+  event: BrowserStateReadDiagnosticEvent,
+): void {
+  try {
+    diagnosticsSink?.(event);
+  } catch {
+    // Diagnostics must never change state-read behavior.
+  }
+}

--- a/packages/shared-web/browser/state-read/point-read.ts
+++ b/packages/shared-web/browser/state-read/point-read.ts
@@ -1,0 +1,239 @@
+import { readSession } from '@shared/api/auth.ts';
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import {
+  readClientStateRevision,
+  readGroupCausalRevision,
+} from '@shared/api/group-client-views.ts';
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+import {
+  parseAuthoritativeClientSnapshot,
+  parseAuthoritativeGroupSnapshot,
+} from '@shared/api/authoritative-state-validation.ts';
+import type {
+  ClientStateSnapshotReadOptions,
+  GroupStateSnapshotReadOptions,
+  StateSnapshotReadSource,
+} from '@shared/api/state-snapshot-read.ts';
+import type { StateScope } from '@shared/api/state-types.ts';
+
+import { readApiBaseUrl } from '../api-client-config.ts';
+import { ApiHttpError } from '../api/http-error.ts';
+import type { ApiRequestOptions } from '../api-integration.ts';
+import { emitBrowserStateReadDiagnostic } from './diagnostics.ts';
+
+export type ReadStateClientSnapshotOptions =
+  & ApiRequestOptions
+  & ClientStateSnapshotReadOptions;
+
+export type ReadStateGroupSnapshotOptions =
+  & ApiRequestOptions
+  & GroupStateSnapshotReadOptions;
+
+export interface StateClientSnapshotRead {
+  readonly snapshot: ClientSnapshot;
+  readonly source: StateSnapshotReadSource;
+  readonly stateRevision: number;
+}
+
+export interface StateGroupSnapshotRead {
+  readonly snapshot: GroupSnapshot;
+  readonly source: StateSnapshotReadSource;
+  readonly groupRevision: number;
+  readonly presenceRevision: number;
+}
+
+interface PointReadInput<T> {
+  readonly feature: 'client' | 'group';
+  readonly path: string;
+  readonly options: ApiRequestOptions;
+  readonly readResult: (
+    serialized: string,
+    source: StateSnapshotReadSource,
+    headers: Headers,
+  ) => T;
+}
+
+interface PointPathInput {
+  readonly scope: StateScope;
+  readonly collection: 'clients' | 'groups';
+  readonly id: string;
+  readonly floors: readonly (readonly [name: string, value: number | undefined])[];
+}
+
+interface EmitDiagnosticInput {
+  readonly feature: 'client' | 'group';
+  readonly result: 'found' | 'not-found' | 'error';
+  readonly startedAt: number;
+  readonly source?: StateSnapshotReadSource;
+}
+
+export async function readStateClientSnapshot(
+  principalId: string,
+  scope: StateScope,
+  options: ReadStateClientSnapshotOptions = {},
+): Promise<StateClientSnapshotRead> {
+  return await readPointSnapshot({
+    feature: 'client',
+    path: pointPath({
+      scope,
+      collection: 'clients',
+      id: principalId,
+      floors: [['minStateRevision', options.minStateRevision]],
+    }),
+    options,
+    readResult: (serialized, source, headers) => {
+      const snapshot = parseAuthoritativeClientSnapshot(serialized, scope);
+      if (snapshot.principal.principalId !== principalId) {
+        throw new Error('Client snapshot response principal does not match the request.');
+      }
+      const stateRevision = readRevisionHeader(headers, 'rallar-state-revision');
+      if (stateRevision !== readClientStateRevision(snapshot)) {
+        throw new Error('Client snapshot response header revision does not match the body.');
+      }
+      return { snapshot, source, stateRevision };
+    },
+  });
+}
+
+export async function readStateGroupSnapshot(
+  groupId: string,
+  scope: StateScope,
+  options: ReadStateGroupSnapshotOptions = {},
+): Promise<StateGroupSnapshotRead> {
+  return await readPointSnapshot({
+    feature: 'group',
+    path: pointPath({
+      scope,
+      collection: 'groups',
+      id: groupId,
+      floors: [
+        ['minGroupRevision', options.minCausalRevision?.groupRevision],
+        ['minPresenceRevision', options.minCausalRevision?.presenceRevision],
+      ],
+    }),
+    options,
+    readResult: (serialized, source, headers) => {
+      const snapshot = parseAuthoritativeGroupSnapshot(serialized, scope);
+      if (snapshot.group.groupId !== groupId) {
+        throw new Error('Group snapshot response group does not match the request.');
+      }
+      const groupRevision = readRevisionHeader(headers, 'rallar-group-revision');
+      const presenceRevision = readRevisionHeader(headers, 'rallar-presence-revision');
+      const bodyRevision = readGroupCausalRevision(snapshot);
+      if (
+        groupRevision !== bodyRevision.groupRevision ||
+        presenceRevision !== bodyRevision.presenceRevision
+      ) {
+        throw new Error('Group snapshot response header revisions do not match the body.');
+      }
+      return { snapshot, source, groupRevision, presenceRevision };
+    },
+  });
+}
+
+async function readPointSnapshot<T>(input: PointReadInput<T>): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    const headers = new Headers({ 'content-type': 'application/json' });
+    const session = input.options.authSession === undefined
+      ? readSession()
+      : input.options.authSession;
+    if (session) {
+      headers.set('authorization', `Bearer ${session.accessToken}`);
+      headers.set('x-client-id', session.clientId);
+    }
+    const response = await fetch(`${readApiBaseUrl()}${input.path}`, {
+      method: 'GET',
+      headers,
+      signal: input.options.signal,
+    });
+    if (!response.ok) {
+      throw new ApiHttpError(
+        'GET',
+        input.path,
+        response.status,
+        await readErrorBody(response),
+        response.headers,
+      );
+    }
+    const source = readSource(response.headers);
+    assertNoStore(response.headers);
+    const result = input.readResult(await response.text(), source, response.headers);
+    emitDiagnostic({ feature: input.feature, result: 'found', startedAt, source });
+    return result;
+  } catch (error) {
+    emitDiagnostic({
+      feature: input.feature,
+      result: error instanceof ApiHttpError && error.status === 404 ? 'not-found' : 'error',
+      startedAt,
+    });
+    throw error;
+  }
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function emitDiagnostic(input: EmitDiagnosticInput): void {
+  emitBrowserStateReadDiagnostic({
+    name: 'rallar.browser.state-read',
+    feature: input.feature,
+    operation: 'point',
+    result: input.result,
+    source: input.source,
+    durationMs: performance.now() - input.startedAt,
+  });
+}
+
+function pointPath(input: PointPathInput): string {
+  const query = new URLSearchParams();
+  for (const [name, value] of input.floors) {
+    if (value !== undefined) {
+      query.set(name, canonicalRevision(value));
+    }
+  }
+  const path = `/api/state/apps/${encodeURIComponent(input.scope.applicationId)}` +
+    `/workspaces/${encodeURIComponent(input.scope.workspaceId)}` +
+    `/${input.collection}/${encodeURIComponent(input.id)}`;
+  return query.size === 0 ? path : `${path}?${query}`;
+}
+
+function canonicalRevision(value: number): string {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError('State revision floors must be non-negative safe integers.');
+  }
+  return String(value);
+}
+
+function readSource(headers: Headers): StateSnapshotReadSource {
+  const source = headers.get('rallar-state-source');
+  if (source !== 'cache' && source !== 'durable') {
+    throw new Error('State snapshot response has an invalid or missing source header.');
+  }
+  return source;
+}
+
+function readRevisionHeader(headers: Headers, name: string): number {
+  const value = headers.get(name);
+  if (value === null || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw new Error(`State snapshot response has an invalid or missing ${name} header.`);
+  }
+  const revision = Number(value);
+  if (!Number.isSafeInteger(revision)) {
+    throw new Error(`State snapshot response has an unsafe ${name} header.`);
+  }
+  return revision;
+}
+
+function assertNoStore(headers: Headers): void {
+  const noStore = headers.get('cache-control')?.toLowerCase().split(',')
+    .some((directive) => directive.trim() === 'no-store');
+  if (!noStore) {
+    throw new Error('State snapshot response is missing Cache-Control: no-store.');
+  }
+}

--- a/packages/shared-web/browser/state-read/reconciliation.ts
+++ b/packages/shared-web/browser/state-read/reconciliation.ts
@@ -1,0 +1,81 @@
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+import type { StateScope } from '@shared/api/state-types.ts';
+import * as clientSnapshots from '@shared/repository/client-state-snapshots-repository.ts';
+import * as groupSnapshots from '@shared/repository/group-state-snapshots-repository.ts';
+
+import { emitBrowserStateReadDiagnostic } from './diagnostics.ts';
+
+export type StateSnapshotCollectionObservations = Readonly<{
+  clients: readonly ClientSnapshot[];
+  groups: readonly GroupSnapshot[];
+}>;
+
+export function captureStateSnapshotCollectionObservations(
+  scope: StateScope,
+): StateSnapshotCollectionObservations {
+  return {
+    clients: readConfiguredSnapshots(clientSnapshots.getAllClientStateSnapshots).filter(
+      (snapshot) => isScope(snapshot.principal, scope),
+    ),
+    groups: readConfiguredSnapshots(groupSnapshots.getAllGroupStateSnapshots).filter((snapshot) =>
+      isScope(snapshot.group, scope)
+    ),
+  };
+}
+
+function readConfiguredSnapshots<T>(read: () => T[]): T[] {
+  try {
+    return read();
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Repository not found:')) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export function reconcileCompleteStateSnapshotCollections(
+  observations: StateSnapshotCollectionObservations,
+  currentClients: readonly ClientSnapshot[],
+  currentGroups: readonly GroupSnapshot[],
+): void {
+  const currentClientIds = new Set(
+    currentClients.map((snapshot) => snapshot.principal.principalId),
+  );
+  for (const observed of observations.clients) {
+    if (!currentClientIds.has(observed.principal.principalId)) {
+      emitReconciliation(
+        'client',
+        clientSnapshots.removeClientStateSnapshotIfUnchanged(observed.principal, observed),
+      );
+    }
+  }
+
+  const currentGroupIds = new Set(currentGroups.map((snapshot) => snapshot.group.groupId));
+  for (const observed of observations.groups) {
+    if (!currentGroupIds.has(observed.group.groupId)) {
+      emitReconciliation(
+        'group',
+        groupSnapshots.removeGroupStateSnapshotIfUnchanged(observed.group, observed),
+      );
+    }
+  }
+}
+
+function emitReconciliation(feature: 'client' | 'group', removed: boolean): void {
+  emitBrowserStateReadDiagnostic({
+    name: 'rallar.browser.state-read',
+    feature,
+    operation: 'collection',
+    result: removed ? 'removed' : 'preserved',
+    durationMs: 0,
+  });
+}
+
+function isScope(
+  ref: Readonly<{ applicationId: string; workspaceId?: string }>,
+  scope: StateScope,
+): boolean {
+  return ref.applicationId === scope.applicationId && ref.workspaceId === scope.workspaceId;
+}

--- a/packages/shared-web/mod.ts
+++ b/packages/shared-web/mod.ts
@@ -1,5 +1,6 @@
 export * from './browser/api-client-config.ts';
 export * from './browser/api-integration.ts';
+export * from './browser/state-read/diagnostics.ts';
 export {
     appointStateGroupDirector as appointStateGroupDirectorWorkflow,
     archiveStateGroup,

--- a/packages/tests/rallar-black-box-headless/headless-bundle-boundary.test.ts
+++ b/packages/tests/rallar-black-box-headless/headless-bundle-boundary.test.ts
@@ -41,7 +41,8 @@ describe('rallar-black-box-headless bundle boundary', () => {
       );
     }
 
-    expect(result.brotliKiB).toBeLessThan(192);
+    // Validated snapshot point reads and race-fenced repair add a bounded browser cost.
+    expect(result.brotliKiB).toBeLessThan(194);
   });
 });
 

--- a/packages/tests/repo/group-state-navigation-map-integrity.test.ts
+++ b/packages/tests/repo/group-state-navigation-map-integrity.test.ts
@@ -208,6 +208,11 @@ const navigationSourceLinks = [
     declaration: 'export class GroupStateSnapshotReadThroughCache',
   },
   {
+    symbol: 'GroupRestSnapshotReadSelector',
+    sourcePath: './snapshot/group-rest-snapshot-read-selector.ts',
+    declaration: 'export interface GroupRestSnapshotReadSelector',
+  },
+  {
     symbol: 'canReadGroupSnapshot',
     sourcePath: '../group-policy.ts',
     declaration: 'export function canReadGroupSnapshot',

--- a/packages/tests/shared-web/api-workflows.test.ts
+++ b/packages/tests/shared-web/api-workflows.test.ts
@@ -662,7 +662,7 @@ describe('state API workflows', () => {
         };
         stubFetch(({ url, method }) => {
             if (method === 'GET' && url.endsWith('/groups/group-1')) {
-                return jsonResponse(existing);
+                return groupPointResponse(existing);
             }
 
             if (method === 'PUT' && url.endsWith('/groups/group-1')) {
@@ -1778,6 +1778,19 @@ function jsonResponse(body: unknown, status = 200): Response {
     return new Response(JSON.stringify(body), {
         status,
         headers: { 'content-type': 'application/json' },
+    });
+}
+
+function groupPointResponse(body: GroupSnapshot): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: {
+            'cache-control': 'no-store',
+            'content-type': 'application/json',
+            'rallar-state-source': 'durable',
+            'rallar-group-revision': String(body.causalRevision.groupRevision),
+            'rallar-presence-revision': String(body.causalRevision.presenceRevision),
+        },
     });
 }
 

--- a/packages/tests/shared-web/heartbeat.test.ts
+++ b/packages/tests/shared-web/heartbeat.test.ts
@@ -129,6 +129,49 @@ describe('browser heartbeat', () => {
         ).toBeUndefined();
     });
 
+    it('preserves a newer group publication that races an authoritative heartbeat 404', async () => {
+        const observed = groupSnapshot(
+            'stale-room',
+            'ar-eye-hunter',
+            'default',
+            authSession.clientId,
+            authSession.sessionId,
+        );
+        const newer = {
+            ...observed,
+            stateRevision: observed.stateRevision + 1,
+            causalRevision: {
+                groupRevision: observed.causalRevision.groupRevision + 1,
+                presenceRevision: observed.causalRevision.presenceRevision,
+            },
+        };
+        groupStateSnapshotsRepository.setGroupStateSnapshots([observed]);
+        stubFetch(({ url, method }) => {
+            if (method === 'POST' && url.includes('/clients/principal-1/')) {
+                return jsonResponse(clientSnapshot('principal-1'));
+            }
+            if (method === 'POST' && url.includes('/groups/stale-room/')) {
+                groupStateSnapshotsRepository.setGroupStateSnapshots([newer]);
+                return textResponse('Group presence session not found: session-1', 404);
+            }
+            return textResponse('unexpected', 500);
+        });
+
+        const handle = await initHeartbeat(clientData, {
+            authSession,
+            scope: { applicationId: 'ar-eye-hunter', workspaceId: 'default' },
+        });
+        await vi.waitFor(() => {
+            expect(fetchCalls.filter((call) => call.url.includes('/heartbeat'))).toHaveLength(2);
+        });
+        handle.stop();
+        await groupStateSnapshotsRepository.waitForGroupStateSnapshotChangesIdle();
+
+        expect(groupStateSnapshotsRepository.findGroupStateSnapshotByRef(observed.group)).toBe(
+            newer,
+        );
+    });
+
     it('stops and reports auth invalidation after a single client heartbeat 401', async () => {
         const onAuthInvalid = vi.fn();
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/tests/shared-web/rooms/room-group-state-mutation-workflows.test.ts
+++ b/packages/tests/shared-web/rooms/room-group-state-mutation-workflows.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureApiClient } from '@shared-web/browser/api-client-config.ts';
 import * as legacyWorkflows from '@shared-web/browser/api-workflows.ts';
 import * as mutationWorkflows from '@shared-web/browser/rooms/room-group-state-mutation-workflows.ts';
+import { readGroupCausalRevision } from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { createGroupSnapshotFixture } from '../authoritative-group-fixtures.ts';
@@ -46,13 +47,12 @@ describe.each(workflowPaths)(
         keep: true,
         rallarDirector: { old: true },
       });
-      stubFetch(fetchCalls, ({ method }) =>
-        jsonResponse(
-          method === 'GET'
-            ? current
-            : roomSnapshot('group-1', { keep: true, rallarDirector: { next: true } }),
-        ),
-      );
+      stubFetch(fetchCalls, ({ method }) => {
+        const body = method === 'GET'
+          ? current
+          : roomSnapshot('group-1', { keep: true, rallarDirector: { next: true } });
+        return method === 'GET' ? groupPointResponse(body) : jsonResponse(body);
+      });
 
       await workflows.updateStateGroupMetadata(
         'group-1',
@@ -271,5 +271,19 @@ function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { 'content-type': 'application/json' },
+  });
+}
+
+function groupPointResponse(body: GroupSnapshot): Response {
+  const revision = readGroupCausalRevision(body);
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+      'rallar-state-source': 'durable',
+      'rallar-group-revision': String(revision.groupRevision),
+      'rallar-presence-revision': String(revision.presenceRevision),
+    },
   });
 }

--- a/packages/tests/shared-web/rooms/room-session.test.ts
+++ b/packages/tests/shared-web/rooms/room-session.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, expect, it } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
 import { isRallarValidationError } from '@shared/api/rallar-validation.ts';
+import { configureApiClient } from '@shared-web/browser/api-client-config.ts';
+import { ApiHttpError } from '@shared-web/browser/api-integration.ts';
 
 import {
   createRoomSnapshot,
@@ -9,6 +11,7 @@ import {
 } from './room-workflow-test-runtime.ts';
 
 beforeEach(resetRoomWorkflowTestRuntime);
+afterEach(() => vi.unstubAllGlobals());
 
 it('exposes the owning room session operation', async () => {
   const { createRoomSession } = await import('@shared-web/browser/rooms/room-session.ts');
@@ -46,4 +49,90 @@ it('reports a structured validation issue when no room session can be resolved',
       },
     ],
   });
+});
+
+it('refreshes a bound room with one tokenless durable point read', async () => {
+  const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+  configureApiClient({ apiBaseUrl: 'https://api.example.test' });
+  const observed = createRoomSnapshot('room-1', ['session-1']);
+  const current = {
+    ...observed,
+    stateRevision: observed.stateRevision + 1,
+    group: {
+      ...observed.group,
+      snapshotVersion: observed.group.snapshotVersion + 1,
+    },
+    causalRevision: {
+      groupRevision: observed.causalRevision.groupRevision + 1,
+      presenceRevision: observed.causalRevision.presenceRevision,
+    },
+  };
+  seedRoomSnapshots([observed]);
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify(current), {
+    status: 200,
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'application/json',
+      'rallar-state-source': 'durable',
+      'rallar-group-revision': String(current.causalRevision.groupRevision),
+      'rallar-presence-revision': String(current.causalRevision.presenceRevision),
+    },
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+
+  const refreshed = await createRallarFacade().rooms.session(observed.group).refresh();
+
+  expect(fetchMock).toHaveBeenCalledOnce();
+  expect(fetchMock.mock.calls[0]?.[0]).toBe(
+    'https://api.example.test/api/state/apps/app-1/workspaces/workspace-1/groups/room-1',
+  );
+  const request = fetchMock.mock.calls[0]?.[1];
+  const headers = new Headers(request?.headers);
+  expect(headers.get('authorization')).toBe('Bearer token-1');
+  expect(headers.get('x-client-id')).toBe('principal-1');
+  expect(refreshed.snapshot()).toEqual(current);
+});
+
+it('conditionally cleans a targeted 404 and rethrows the original HTTP error', async () => {
+  const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+  configureApiClient({ apiBaseUrl: 'https://api.example.test' });
+  const observed = createRoomSnapshot('room-1', ['session-1']);
+  seedRoomSnapshots([observed]);
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('missing', { status: 404 })));
+
+  const session = createRallarFacade().rooms.session(observed.group);
+  let thrown: unknown;
+  try {
+    await session.refresh();
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(ApiHttpError);
+  expect((thrown as ApiHttpError).status).toBe(404);
+  expect(session.snapshot()).toBeUndefined();
+});
+
+it('preserves a newer publication that races targeted 404 cleanup', async () => {
+  const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+  configureApiClient({ apiBaseUrl: 'https://api.example.test' });
+  const observed = createRoomSnapshot('room-1', ['session-1']);
+  const newer = {
+    ...observed,
+    stateRevision: observed.stateRevision + 1,
+    causalRevision: {
+      groupRevision: observed.causalRevision.groupRevision + 1,
+      presenceRevision: observed.causalRevision.presenceRevision,
+    },
+  };
+  seedRoomSnapshots([observed]);
+  vi.stubGlobal('fetch', vi.fn(async () => {
+    seedRoomSnapshots([newer]);
+    return new Response('missing', { status: 404 });
+  }));
+
+  const session = createRallarFacade().rooms.session(observed.group);
+  await expect(session.refresh()).rejects.toBeInstanceOf(ApiHttpError);
+
+  expect(session.snapshot()).toBe(newer);
 });

--- a/packages/tests/shared-web/rooms/room-workflow-test-runtime.ts
+++ b/packages/tests/shared-web/rooms/room-workflow-test-runtime.ts
@@ -200,6 +200,15 @@ vi.mock('@shared/repository/group-state-snapshots-repository.ts', () => ({
     roomWorkflowMocks.groupSnapshots.find((snapshot) => isSameRoomRef(snapshot.group, roomRef)),
   ),
   getAllGroupStateSnapshots: vi.fn(() => [...roomWorkflowMocks.groupSnapshots]),
+  removeGroupStateSnapshotIfUnchanged: vi.fn((roomRef: GroupRef, expected: GroupSnapshot) => {
+    const index = roomWorkflowMocks.groupSnapshots.findIndex((snapshot) =>
+      snapshot === expected && isSameRoomRef(snapshot.group, roomRef)
+    );
+    if (index < 0) return false;
+    roomWorkflowMocks.groupSnapshots.splice(index, 1);
+    return true;
+  }),
+  waitForGroupStateSnapshotChangesIdle: vi.fn(async () => undefined),
 }));
 
 export function readRoomWorkflowMocks(): typeof roomWorkflowMocks {

--- a/packages/tests/shared-web/shared-web-public-api-snapshots.test.ts
+++ b/packages/tests/shared-web/shared-web-public-api-snapshots.test.ts
@@ -600,6 +600,29 @@ const PUBLIC_SURFACES: readonly PublicSurfaceSnapshot[] = [
         },
     },
     {
+        filePath: 'packages/shared-web/browser/state-read/point-read.ts',
+        expected: {
+            values: ['readStateClientSnapshot', 'readStateGroupSnapshot'],
+            types: [
+                'ReadStateClientSnapshotOptions',
+                'ReadStateGroupSnapshotOptions',
+                'StateClientSnapshotRead',
+                'StateGroupSnapshotRead',
+            ],
+            starExports: [],
+            namespaceExports: [],
+        },
+    },
+    {
+        filePath: 'packages/shared-web/browser/state-read/diagnostics.ts',
+        expected: {
+            values: ['emitBrowserStateReadDiagnostic', 'setBrowserStateReadDiagnosticsSink'],
+            types: ['BrowserStateReadDiagnosticEvent', 'BrowserStateReadDiagnosticsSink'],
+            starExports: [],
+            namespaceExports: [],
+        },
+    },
+    {
         filePath: 'packages/shared-web/mod.ts',
         expected: {
             values: [
@@ -644,6 +667,7 @@ const PUBLIC_SURFACES: readonly PublicSurfaceSnapshot[] = [
                 './browser/resilience-config.ts',
                 './browser/rtc-engine.ts',
                 './browser/rtc-message-router.ts',
+                './browser/state-read/diagnostics.ts',
                 './browser/ws-message-router.ts',
                 './game/mod.ts',
             ],

--- a/packages/tests/shared-web/state-snapshot-collection-refresh.test.ts
+++ b/packages/tests/shared-web/state-snapshot-collection-refresh.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as clientSnapshots from '@shared/repository/client-state-snapshots-repository.ts';
+import * as groupSnapshots from '@shared/repository/group-state-snapshots-repository.ts';
+import { configureApiClient } from '@shared-web/browser/api-client-config.ts';
+import { refreshStateSnapshots } from '@shared-web/browser/api-workflows.ts';
+
+import { configureTestCacheRepositories } from '../cache-repository-config.ts';
+import {
+  createClientSnapshotFixture,
+  createGroupSnapshotFixture,
+} from './authoritative-group-fixtures.ts';
+
+vi.mock('@shared/api/auth.ts', () => ({ readSession: () => undefined }));
+
+const scope = { applicationId: 'app-1', workspaceId: 'workspace-1' };
+
+describe('browser complete collection refresh', () => {
+  beforeEach(() => {
+    configureApiClient({ apiBaseUrl: '' });
+    configureTestCacheRepositories();
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reconciles omissions only after both complete collections validate', async () => {
+    const client = createClientSnapshotFixture({ ...scope, principalId: 'alice' });
+    const group = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    clientSnapshots.setClientStateSnapshots([client]);
+    groupSnapshots.setGroupStateSnapshots([group]);
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse([])));
+
+    await refreshStateSnapshots(scope);
+
+    expect(clientSnapshots.findClientStateSnapshotByRef(client.principal)).toBeUndefined();
+    expect(groupSnapshots.findGroupStateSnapshotByRef(group.group)).toBeUndefined();
+  });
+
+  it.each([
+    ['failed', () => new Response('unavailable', { status: 503 })],
+    ['malformed', () => jsonResponse({ partial: true })],
+  ])('does not reconcile after a %s group collection', async (_label, groupResponse) => {
+    const client = createClientSnapshotFixture({ ...scope, principalId: 'alice' });
+    const group = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    clientSnapshots.setClientStateSnapshots([client]);
+    groupSnapshots.setGroupStateSnapshots([group]);
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) =>
+      String(url).endsWith('/clients') ? jsonResponse([]) : groupResponse()
+    ));
+
+    await expect(refreshStateSnapshots(scope)).rejects.toThrow();
+
+    expect(clientSnapshots.findClientStateSnapshotByRef(client.principal)).toBe(client);
+    expect(groupSnapshots.findGroupStateSnapshotByRef(group.group)).toBe(group);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/packages/tests/shared-web/state-snapshot-point-read.test.ts
+++ b/packages/tests/shared-web/state-snapshot-point-read.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { configureApiClient } from '@shared-web/browser/api-client-config.ts';
+import {
+  findStateGroup,
+  readStateClientSnapshot,
+  readStateGroupSnapshot,
+} from '@shared-web/browser/api-integration.ts';
+import {
+  setBrowserStateReadDiagnosticsSink,
+  type BrowserStateReadDiagnosticEvent,
+} from '@shared-web/browser/state-read/diagnostics.ts';
+
+import {
+  createClientSnapshotFixture,
+  createGroupSnapshotFixture,
+} from './authoritative-group-fixtures.ts';
+
+const scope = { applicationId: 'app-1', workspaceId: 'workspace-1' };
+
+describe('browser state snapshot point reads', () => {
+  beforeEach(() => {
+    configureApiClient({ apiBaseUrl: 'https://api.example.test' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setBrowserStateReadDiagnosticsSink(undefined);
+  });
+
+  it('returns client metadata and sends one canonical scalar floor', async () => {
+    const snapshot = createClientSnapshotFixture({ ...scope, principalId: 'alice' });
+    const fetchMock = vi.fn(async () => jsonSnapshotResponse(snapshot, {
+      'rallar-state-source': 'cache',
+      'rallar-state-revision': '1',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(readStateClientSnapshot('alice', scope, {
+      authSession: null,
+      minStateRevision: 1,
+    })).resolves
+      .toEqual({ snapshot, source: 'cache', stateRevision: 1 });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://api.example.test/api/state/apps/app-1/workspaces/workspace-1/clients/alice?minStateRevision=1',
+    );
+  });
+
+  it('returns group causal metadata while preserving the body-only wrapper', async () => {
+    const snapshot = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    const fetchMock = vi.fn(async () => jsonSnapshotResponse(snapshot, {
+      'rallar-state-source': 'durable',
+      'rallar-group-revision': '1',
+      'rallar-presence-revision': '0',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(readStateGroupSnapshot('room-1', scope, {
+      authSession: null,
+      minCausalRevision: { groupRevision: 1, presenceRevision: 0 },
+    })).resolves.toEqual({
+      snapshot,
+      source: 'durable',
+      groupRevision: 1,
+      presenceRevision: 0,
+    });
+    await expect(findStateGroup('room-1', scope, { authSession: null })).resolves.toEqual(snapshot);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(
+      '?minGroupRevision=1&minPresenceRevision=0',
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).not.toContain('?');
+  });
+
+  it('rejects malformed authoritative bodies and header/body disagreement', async () => {
+    const snapshot = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(jsonSnapshotResponse({ ...snapshot, members: null }, {
+        'rallar-state-source': 'durable',
+        'rallar-group-revision': '1',
+        'rallar-presence-revision': '0',
+      }))
+      .mockResolvedValueOnce(jsonSnapshotResponse(snapshot, {
+        'rallar-state-source': 'durable',
+        'rallar-group-revision': '2',
+        'rallar-presence-revision': '0',
+      })));
+
+    await expect(readStateGroupSnapshot('room-1', scope, { authSession: null })).rejects.toThrow();
+    await expect(readStateGroupSnapshot('room-1', scope, { authSession: null })).rejects.toThrow(
+      'header revisions do not match the body',
+    );
+  });
+
+  it('emits only bounded diagnostics dimensions', async () => {
+    const events: BrowserStateReadDiagnosticEvent[] = [];
+    const snapshot = createClientSnapshotFixture({ ...scope, principalId: 'alice' });
+    setBrowserStateReadDiagnosticsSink((event) => events.push(event));
+    vi.stubGlobal('fetch', vi.fn(async () => jsonSnapshotResponse(snapshot, {
+      'rallar-state-source': 'durable',
+      'rallar-state-revision': '1',
+    })));
+
+    await readStateClientSnapshot('alice', scope, { authSession: null });
+
+    expect(events).toHaveLength(1);
+    expect(Object.keys(events[0] ?? {}).sort()).toEqual([
+      'durationMs', 'feature', 'name', 'operation', 'result', 'source',
+    ]);
+    expect(JSON.stringify(events[0])).not.toContain('alice');
+    expect(JSON.stringify(events[0])).not.toContain('app-1');
+  });
+});
+
+function jsonSnapshotResponse(
+  body: unknown,
+  headers: Readonly<Record<string, string>>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store', ...headers },
+  });
+}

--- a/packages/tests/shared-web/state-snapshot-reconciliation.test.ts
+++ b/packages/tests/shared-web/state-snapshot-reconciliation.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import * as clientSnapshots from '@shared/repository/client-state-snapshots-repository.ts';
+import * as groupSnapshots from '@shared/repository/group-state-snapshots-repository.ts';
+import {
+  captureStateSnapshotCollectionObservations,
+  reconcileCompleteStateSnapshotCollections,
+} from '@shared-web/browser/state-read/reconciliation.ts';
+
+import { configureTestCacheRepositories } from '../cache-repository-config.ts';
+import {
+  createClientSnapshotFixture,
+  createGroupSnapshotFixture,
+} from './authoritative-group-fixtures.ts';
+
+const scope = { applicationId: 'app-1', workspaceId: 'workspace-1' };
+
+describe('browser complete snapshot reconciliation', () => {
+  beforeEach(() => configureTestCacheRepositories());
+
+  it('removes authoritative omissions only when the captured identity is unchanged', () => {
+    const oldClient = createClientSnapshotFixture({ ...scope, principalId: 'alice' });
+    const oldGroup = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    clientSnapshots.setClientStateSnapshots([oldClient]);
+    groupSnapshots.setGroupStateSnapshots([oldGroup]);
+    const observations = captureStateSnapshotCollectionObservations(scope);
+
+    const newerClient = { ...oldClient, stateRevision: 2 };
+    const newerGroup = {
+      ...oldGroup,
+      stateRevision: 2,
+      causalRevision: { groupRevision: 2, presenceRevision: 0 },
+    };
+    clientSnapshots.setClientStateSnapshots([newerClient]);
+    groupSnapshots.setGroupStateSnapshots([newerGroup]);
+
+    reconcileCompleteStateSnapshotCollections(observations, [], []);
+
+    expect(clientSnapshots.findClientStateSnapshotByRef(oldClient.principal)).toBe(newerClient);
+    expect(groupSnapshots.findGroupStateSnapshotByRef(oldGroup.group)).toBe(newerGroup);
+  });
+
+  it('physically removes unchanged omissions and allows delayed stale publication to reinsert', () => {
+    const observed = createGroupSnapshotFixture({ ...scope, groupId: 'room-1', sessionIds: [] });
+    groupSnapshots.setGroupStateSnapshots([observed]);
+
+    reconcileCompleteStateSnapshotCollections(
+      captureStateSnapshotCollectionObservations(scope),
+      [],
+      [],
+    );
+    expect(groupSnapshots.findGroupStateSnapshotByRef(observed.group)).toBeUndefined();
+
+    groupSnapshots.setGroupStateSnapshots([observed]);
+    expect(groupSnapshots.findGroupStateSnapshotByRef(observed.group)).toBe(observed);
+  });
+});

--- a/plans/rallar-rest-snapshot-read-convergence-implementation-plan.md
+++ b/plans/rallar-rest-snapshot-read-convergence-implementation-plan.md
@@ -1,734 +1,165 @@
-# Rallar REST Snapshot Read Convergence Implementation Plan
+# Revised REST Snapshot Read Convergence Plan
 
-> **Status:** Revalidated against current `main`; review-ready, not approved and not
-> implementation-complete.
->
-> **Implementation workflow:** Use `superpowers:executing-plans` or
-> `superpowers:subagent-driven-development` only after the human architecture
-> decisions in Task 0 are recorded. Use the repo-local `rallar-code-writing`,
-> `rallar-platform`, `rallar-realtime`, `rallar-testing`, and
-> `publishing-plan-progress` skills throughout implementation.
+## Summary
 
-**Goal:** Give REST point-snapshot reads an explicit convergence contract that
-matches the current revision domains:
+Implement scalar client and two-component group point-read floors without using
+stale state for authorization. Tokenless point reads observe durable state;
+eligible tokened reads may use cache. Browser repair uses race-fenced physical
+cleanup and explicitly does not claim tombstone or resurrection safety.
 
-- client point reads use the scalar, entity-local `stateRevision`;
-- group point reads use the authoritative
-  `GroupStateCausalRevision { groupRevision, presenceRevision }`;
-- an omitted minimum reads a durable snapshot;
-- a supplied minimum may use a presence-fresh process cache only when it equals
-  or dominates the caller's floor;
-- strict authorization always uses current durable authority;
-- browser refresh and collection reconciliation converge without claiming that
-  a physical delete is a causal tombstone.
+Deliver the work as three stacked PRs. Persisted client-key migration, durable
+invalidation replay, projection tables, tombstones, and numeric latency SLOs
+remain separate work.
 
-## Revalidation Against Main
+## Public Contracts
 
-### Reviewed baseline
+- Client point query: optional `minStateRevision`, parsed as one canonical
+  non-negative safe integer.
+- Group point query: `minGroupRevision` and `minPresenceRevision`, either both
+  absent or both present.
+- Valid unsatisfied floors return typed
+  `409 state-revision-floor-not-satisfied`; malformed floors return typed
+  `400`.
+- Successful client responses expose source and scalar revision; successful
+  group responses expose source, group revision, and presence revision. Group
+  scalar revision remains body-only compatibility data.
+- Add metadata-bearing `readStateClientSnapshot` and
+  `readStateGroupSnapshot` shared-web functions. Preserve
+  `findStateGroup(): Promise<GroupSnapshot>` as a wrapper.
+- Successful browser responses must pass authoritative body validation and
+  header/body agreement before return.
+- Add an optional low-cardinality browser state-read diagnostics sink. No
+  application, workspace, principal, group, session, or request IDs may become
+  metric labels.
 
-| Item | Exact value |
-|---|---|
-| Review date | 2026-07-27 |
-| Current branch | `main` |
-| Reviewed `HEAD` | `6d87fcbe9b7812b366d0c91f45b27a1179c878e4` |
-| Local `origin/main` after `git fetch origin main` | `6d87fcbe9b7812b366d0c91f45b27a1179c878e4` |
-| `FETCH_HEAD` after fetch | `6d87fcbe9b7812b366d0c91f45b27a1179c878e4` |
-| Status | `## main...origin/main`; clean index and working tree; no untracked files |
-| User changes present before review | No |
-| Original plan commit | `f38cf81627f3e91a5f5c09460fa69ce4718d4bec`, 2026-07-20 |
+## PR 1 — Foundations
 
-The fetched remote-tracking ref, `FETCH_HEAD`, and checked-out `HEAD` agree.
-This checkout therefore represented current remote `main` at the review
-boundary. Any implementation session must repeat this baseline check because
-the conclusion is SHA-specific.
+Base `codex/rallar-rest-snapshot-foundations` on the freshly revalidated
+default branch.
 
-### Important architectural changes and corrections
+- Replace absent/empty aliases in client and group in-memory snapshot repository
+  keys with a tagged typed projection. Do not modify persisted storage keys.
+- Add identity-based conditional deletion to latest and loaned repositories;
+  expose conditional client/group snapshot removal while preserving observers
+  and the group session index.
+- Add race-fenced `evictIfUnchanged` behavior to canonical client/group
+  snapshot caches.
+- Add separate feature-owned client-scalar and group-causal REST selectors
+  under their canonical snapshot trees. Share transport/result contracts only;
+  do not create a generic cross-feature service owner.
+- Add client durable-current parity; preserve the existing group
+  durable-current implementation.
+- Add server diagnostic events for source, result, floor outcome, cleanup
+  outcome, strict mode, and duration.
+- Unit-test scalar eligibility, causal equality/dominance/domination/
+  incomparability, presence freshness, not-found races, exact durable-read
+  counts, and three logical caches over one durable fake.
 
-| Change or corrected assumption | Classification | Current evidence and plan consequence |
+## PR 2 — Server/API Contract and Proof
+
+Base `codex/rallar-rest-snapshot-server-api` on PR 1.
+
+- Add strict reusable floor parsers and wire the selectors through current
+  client routes and canonical group read registration.
+- Keep client self-auth durable and strict group authorization durable. Reuse
+  the same durable group snapshot for floor validation, authorization, and
+  response.
+- Replace graph/topology cache-permitting authority reads with one durable
+  current snapshot per request. Mutation prechecks remain advisory; AppInbox
+  revalidates.
+- Return `409` for authorized durable shortfall/incomparability. Ensure repeated
+  `409`s do not affect the circuit breaker.
+- Emit `Cache-Control: no-store` and authoritative source/revision headers.
+  Expose the Rallar headers through CORS.
+- Update OpenAPI for `400/401/403/404/409/429` and infrastructure `503`,
+  keeping floor conflicts distinct from service unavailability.
+- Extend black-box recipe schemas, normalized results, reports, redaction, and
+  assertions with an allow-listed lowercase response-header map.
+- Add a two-process convergence recipe to `api-v1-black-box-cluster`; retain
+  the existing medium-scale profile unchanged.
+- Add `scripts/perf/api-v1-state-snapshot-read-bench.ts` with tokenless,
+  eligible-cache, fallback, strict-auth, and concurrency scenarios. Record
+  operation counts and p50/p95/p99 artifacts under `tmp/perf/`; set no numeric
+  SLO.
+- Add a path-scoped/manual **API v1 Medium-Scale Gate** workflow using the
+  existing composite action and profile, with exact-SHA artifact upload.
+
+## PR 3 — Browser Convergence and Documentation
+
+Base `codex/rallar-rest-snapshot-browser` on PR 2.
+
+- Extract focused point-response transport/validation code instead of enlarging
+  `api-integration.ts`.
+- Implement additive metadata-bearing point readers and preserve body-only
+  compatibility wrappers.
+- Change `rallar.rooms.room(ref).refresh()` to one tokenless durable group point
+  read. Keep top-level rooms and people refresh on complete durable collections.
+- Capture scoped observations before targeted, heartbeat, and collection
+  requests. Conditionally remove only unchanged identities after authoritative
+  `404` or complete successful omission.
+- Do not reconcile after failed, aborted, malformed, or partial collection
+  reads. Rethrow the original targeted `ApiHttpError` after conditional `404`
+  cleanup.
+- Preserve group causal monotonicity and existing incomparable recovery.
+  Characterize delayed stale-publication reinsertion as allowed until tombstones
+  exist.
+- Emit browser refresh/reconciliation diagnostics through the optional sink.
+- Update public API snapshots, browser bundle boundaries, feature READMEs, API
+  reference, consistency guide, troubleshooting guidance, and only the affected
+  skills.
+
+## Verification and Traceability
+
+| Guarantee | Implementation owner | Required proof |
 |---|---|---|
-| Group authority is a two-component causal revision; scalar `stateRevision` is only a compatibility projection. | Contradicted by the old plan; already implemented before the old plan | `packages/shared/api/group-types.ts:166-169,203-213`; `packages/shared/api/group-client-views.ts:68-109`; `packages/shared/repository/group-state-snapshots-repository.ts:224-269`. Replace every group scalar floor with a complete causal floor and define incomparable behavior. |
-| Group presence uses per-session guards and no longer advances the group row for every presence write. | Old runtime map obsolete; already implemented | `packages/shared-server/rallar-system/services/group-state-guarded-batch.ts:118-136`; `packages/shared-server/rallar-system/repositories/GroupStateRepository.ts:620-660`. Remove the old contention premise. |
-| Presence summaries are hints; durable assembly revalidates group lifecycle, active membership, session identity/generation, connectivity, expiry, and one captured observation time. | Already implemented | `packages/shared-server/rallar-system/repositories/group-state-snapshot-assembly.ts:13-100`; `packages/shared-server/rallar-system/repositories/GroupStateRepository.ts:331-421,810-871`. Keep this as a non-regression invariant, not new work. |
-| AppInbox owns incoming mutation transactions and retry attempts. Services perform named `read`, `compute`, `validate`, and `write(transaction, computed)` phases. | Old companion-plan dependency obsolete; already implemented | `packages/shared-server/rallar-system/services/app-inbox-transaction-writer.ts:47-82,126-152`; `packages/shared-server/rallar-system/services/AppClientInboxService.ts:424-446`; `packages/shared-server/rallar-system/services/AppGroupInboxService.ts:957-1076`. This read plan must not create a mutation bypass or a second transaction/retry boundary. |
-| The intermediate mutation outbox was removed. Final resource outbox rows are written in the received transaction. | Old follow-up obsolete; already implemented | Commit `f5e10b2bbf23092c2c98c501fb20ee17fb8583d8`; `packages/shared-server/rallar-system/services/client-state-service.ts:238-282`; `packages/shared-server/rallar-system/services/group-state-guarded-batch.ts:118-179`; `packages/shared-server/rallar-system/services/GroupPresenceSummaryWork.ts:178-222`. Remove every proposed intermediate-outbox dependency. |
-| Group point REST reads already call a full durable snapshot read. | Old READ-02 obsolete; already implemented | `apps/api-v1/src/routes/group-state-routes.ts:151-169`; `packages/shared-server/rallar-system/services/cached-group-state-service.ts:56-59`. Do not reimplement this behavior. |
-| Client point REST reads and strict self-collection reads still call cached `readSnapshot`. | Missing required work | `apps/api-v1/src/routes/client-state-routes.ts:72-110`; production injection in `apps/api-v1/src/create-rallar-server.ts:337-349` and cached-service requirement in `apps/api-v1/src/middleware-contract.ts:20-33`. Add an explicit durable current-client method and use it for tokenless reads. |
-| Group point and event authorization are durable, but graph/topology policy can use cached `readSnapshot`. | Partially implemented; missing security work | `apps/api-v1/src/routes/group-state-routes.ts:151-169,941-985`; `apps/api-v1/src/routes/graph-topology-routes.ts:350-377`; cached production injection at `apps/api-v1/src/create-rallar-server.ts:350-363`. Require a durable current read in graph/topology policy paths. |
-| Group cache services and browser repositories already compare causal tuples and reject incomparable observations. | Already implemented | `packages/shared-server/rallar-system/services/group-state-snapshot-read-through-cache.ts:33-39,150-170`; `packages/shared/repository/group-state-snapshots-repository.ts:251-269`; `packages/shared-web/browser/data-caches.ts:258-297`. Reuse these semantics. |
-| OpenAPI already requires client `stateRevision` and group `stateRevision` plus `causalRevision`. | Old READ-10 obsolete in part; already implemented | `apps/api-v1/resources/api-v1-openapi.yaml:3898-3930,4322-4367`; `apps/api-v1/test/swagger-routes.test.ts:107-132`. Add transport parameters, headers, and errors only; preserve required arrays. |
-| The browser already has a 20-second state heartbeat with a 5-second retry, authoritative collection refresh, group-404 removal during heartbeat, and an incomparable-group forced reread. | Old anti-entropy inventory incomplete | `packages/shared-web/browser/heartbeat.ts:15-16,60-90,98-137`; `packages/shared-web/browser/api-workflows.ts:128-155`; `packages/shared-web/browser/data-caches.ts:258-297`. Do not add a second random 5–10 request cadence. |
-| Room-session refresh still delegates to the full collection refresh; people refresh also reads both collections. | Partially correct; room work remains | `packages/shared-web/browser/rallar-runtime/rooms.ts:194-217,416-435`; `packages/shared-web/browser/rallar-runtime/people.ts:41-67`. Make room-session refresh a targeted durable point read; retain top-level durable collection refresh. |
-| Browser collection hydration is merge-only, so an entity omitted after deletion or authorization filtering may remain locally visible. | Missing required work | `packages/shared-web/browser/data-caches.ts:240-256`; `packages/shared-web/browser/rallar-runtime/state-store.ts:290-299`. Add scoped, race-fenced reconciliation after a complete successful collection response. |
-| Current storage/cache key projections are not uniformly injective over presence and value. | Missing required work | `packages/shared-server/rallar-system/client-state-storage-keys.ts:7-30` aliases absent workspace with explicit `_`; `packages/shared/repository/client-state-snapshots-repository.ts:203-210` and `packages/shared/repository/group-state-snapshots-repository.ts:402-407` alias absent workspace with explicit empty string. Key hardening and bounded migration are prerequisites for exact scoped eviction. |
-| Mutation-result cache hydration exists but is not a correctness boundary. | Still correct with updated context | `packages/shared-server/rallar-system/state-sync-cache-hydration.ts:22-57`; `apps/api-v1/src/routes/client-state-routes.ts:461-506`; `packages/shared-server/rallar-system/services/AppClientInboxService.ts:424-446`; `packages/shared-server/rallar-system/services/AppGroupInboxService.ts:987-1076`. Retain it as a latency optimization; convergence must rely on revision checks and durable fallback. |
-| The API-v1 black-box runner supports a primary and optional secondary server, not a tertiary server. | Old Task 7 unsupported and unnecessary | `packages/shared-test/black-box-runner/api-v1-black-box-run.mts:7-16,93-126,195-216`; `packages/shared-test/package.json` scripts `bb:api-v1:postgres` and `bb:api-v1:postgres:medium-scale`. Use deterministic three-logical-cache unit tests plus the existing two-process Postgres gate. |
-| The black-box execution report does not currently retain response headers needed for source/revision assertions. | Missing required work | `packages/shared-test/black-box-runner/execute-black-box.ts:1142`. Extend the report contract before recipes assert convergence headers. |
-| The old plan names a publish-failure characterization test. | Obsolete | That test was deleted with commit `f5e10b2bbf23092c2c98c501fb20ee17fb8583d8`. Use current cache, route, and `state-sync-event-replay-characterization` tests instead. |
-| The authoritative TypeScript standard is `repo-code-style.md`. | Old style reference obsolete | `.agents/skills/rallar-code-writing/references/repo-code-style.md`; `docs/repo-human-style-guide.md`. New plain object contracts use `interface`; modules should remain under the 400-line target or receive an explicit human exception. |
-
-### Current-main inconsistency outside this read implementation
-
-The replacement `AGENTS.md` requires final `APP_OUTBOX`/`WS_OUTBOX` insertion to
-be insert-only and says a collision rolls back without loading a winner.
-Current writers call `ResourceInboxRepository.writeIfAbsentOrMatch`
-(`packages/shared-server/rallar-system/services/client-state-service.ts:277-281`,
-`packages/shared-server/rallar-system/services/group-state-guarded-batch.ts:174-179`,
-and
-`packages/shared-server/rallar-system/services/GroupPresenceSummaryWork.ts:193-196`).
-The implementation of that helper can accept an exact existing row
-(`packages/shared-server/postgres/resource-inbox/ResourceInboxRepository.ts:105-218`).
-
-This plan must not copy, expand, or bless that behavior. Resolving the
-source-versus-`AGENTS.md` collision policy is a separate mutation remediation
-decision because this plan adds no database mutation. It remains an explicit
-repository issue and prevents describing the mutation architecture as wholly
-closed.
-
-## Audit Of The Original Plan
-
-### Original findings
-
-| Original item | Classification | Revised disposition |
-|---|---|---|
-| READ-01: internal caches accept `minStateRevision` | Partially correct | Client scalar semantics remain. Group scalar semantics are compatibility-only; use `minCausalRevision`. REST still exposes neither floor. |
-| READ-02: group current read probes a durable head then cache | Obsolete | It already performs one full durable `readSnapshot`; remove the proposed rewrite. |
-| READ-03: client lacks current-read parity | Still correct | Add `readCurrentSnapshot`/REST read parity to the process-owned cached client service. |
-| READ-04: cache presence freshness cannot prove completeness | Still correct for caches; durable side already implemented | Retain the limitation and do not call a presence-fresh cache globally current. |
-| READ-05: acknowledged revision followed by stale GET | Historical claim unverifiable from source alone | Preserve only as incident motivation. The new contract makes returning below a supplied floor an explicit failure. |
-| READ-06: receiving-node hydration does not prove Node C | Still correct | Test three logical caches deterministically; do not require a third API process. |
-| READ-07: aggregate/children stable assembly | Partially correct | Update for batched authority reads, one captured time, presence summary validation, and group causal tuples. |
-| READ-08: browser monotonic cache but no anti-entropy | Partially obsolete | Browser group caches are causal and heartbeat/collection repair already exists. Replace random request cadence with targeted room refresh and scoped collection reconciliation. |
-| READ-09: wakeups are not durable replay | Still correct | Keep durable invalidation/replay as a deferred alternative. |
-| READ-10: OpenAPI omits required revision fields | Already implemented | Preserve current required arrays; add query/header/error contracts and client minimum validation. |
-| READ-11: group point response snapshot might authorize stale data | Already implemented for group point/events; missing for graph/topology | Keep the durable authority rule and harden the graph/topology dependency. |
-| READ-12: room-session refresh reads the full collection | Still correct | Replace only the room-session path with targeted durable point refresh. |
-
-### Original tasks, files, commands, and criteria
-
-| Original area | Classification | Action in this revision |
-|---|---|---|
-| Task 0 human review | Still required | Expanded to include the group query shape, conditional absence handling, key migration, and feature-branch publication boundary. |
-| Task 1 shared scalar selector | Partially correct for clients; contradicted for groups | Replace with separate client-scalar and group-causal interfaces and explicit incomparable handling. |
-| Task 2 symmetric cached services | Partially implemented | Group current and causal-at-least methods already exist. Add client current parity, REST selection, production composition, and race-fenced eviction. |
-| Task 3 routes | Partially implemented | Preserve group durable point behavior, add separate query parsers, fix strict client collection and graph/topology authority, and expose headers. |
-| Task 4 random browser cadence | Replaced | Use targeted tokenless room-session refresh plus existing heartbeat; add scoped collection reconciliation and conditional absence removal. |
-| Task 5 required OpenAPI fields | Already implemented in part | Do not rewrite required fields; add transport details and parity tests. |
-| Task 6 deleted publish-failure test | Obsolete | Replace with current cache/service/route characterization tests. |
-| Task 7 three-process runner/workflow expansion | Rejected | Current runner is two-process. A third process does not deterministically prove a missed wakeup without fault suppression and is unnecessary for the selected contract. |
-| Task 8 old runtime/outbox docs | Partially obsolete | Document current AppInbox, causal tuple, liveness, and selected REST contract. |
-| Task 9 skill changes | Partially redundant | Skills already contain AppInbox/causal rules; add only the new read contract and real commands, then run skill integrity tests. |
-| Task 10 validation | Incomplete in old plan | Add repo style, unit, CI, build, medium-scale, draft PR, Branch Release Gate, and Hetzner default-branch evidence. |
-| `state-sync-publish-failure-characterization.test.ts` | Obsolete path | Removed from all tasks and commands. |
-| Three-process Postgres command/workflow | Unverifiable/nonexistent | Removed. Existing two-process scripts remain authoritative. |
-| Per-task `git commit` commands | Unsafe on the reviewed `main` checkout | Replace with feature-branch-only checkpoints. Plan review never authorizes any commit. |
-| Scalar group acceptance criteria | Contradicted | Replace with causal equality/dominance and incomparable handling. |
-| Fifth-through-tenth browser probe criterion | Obsolete design | Replace with explicit targeted refresh plus the existing 20-second heartbeat. |
-| “Caches never regress” plus unconditional 404 delete | Internally contradicted | Require compare-and-remove fences; state that physical deletion is not resurrection-safe without tombstones. |
-
-All previously proposed `Create` artifacts were absent as expected. Every
-existing path retained below was checked at the reviewed SHA. Every new path is
-explicitly labelled **Create**.
-
-## Current Contract And Invariants
-
-### Revision domains
-
-1. `ClientSnapshot.stateRevision` is a non-negative, entity-local scalar.
-   It is not a workspace revision. A client cache is eligible when its scalar
-   revision is greater than or equal to the caller's scalar floor.
-2. `GroupSnapshot.causalRevision` is authoritative. A group cache is eligible
-   only when both components equal or exceed the requested components.
-   `incomparable` is not an eligible result.
-3. `GroupSnapshot.stateRevision` remains a compatibility/diagnostic projection
-   and must not be accepted as an external group freshness floor.
-4. Client and group collection reads contain independently revisioned entities.
-   There is no collection-wide revision domain, so collection routes accept no
-   minimum token.
-
-### Proposed REST surface
-
-| Route | No minimum | Minimum | Cache eligibility | Strict authorization |
-|---|---|---|---|---|
-| `GET /api/state/apps/:applicationId/workspaces/:workspaceId/clients/:principalId` | Full durable client snapshot read | `minStateRevision=<safe non-negative integer>` | Presence-fresh client snapshot with scalar revision at least the floor | Existing durable auth-session identity; response selection may use cache after authorization |
-| `GET /api/state/apps/:applicationId/workspaces/:workspaceId/groups/:groupId` | Full durable group snapshot read | Both `minGroupRevision=<safe non-negative integer>` and `minPresenceRevision=<safe non-negative integer>` | Presence-fresh group snapshot whose causal tuple equals or dominates the floor | When strict read auth is enabled, perform one durable current group read, authorize and respond from it, and validate the floor against it; never authorize from the response cache |
-
-Supplying only one group component is `400 invalid-group-causal-revision`.
-Repeated, blank, signed, decimal, exponential, non-finite, negative, or unsafe
-integer values are `400`. A durable observation dominated by the requested
-floor, or incomparable with it, is retryable `503` with `Retry-After: 1`.
-
-Successful point responses set:
-
-- `Rallar-State-Source: cache|durable`;
-- client: `Rallar-State-Revision`;
-- group: `Rallar-Group-Revision` and `Rallar-Presence-Revision`;
-- `Cache-Control: no-store`.
-
-The group response may retain `Rallar-State-Revision` only as a labelled
-compatibility projection. It must not be used to satisfy the causal floor.
-All new headers must be exposed by CORS.
-
-### Selection results
-
-**Create** `packages/shared/api/state-snapshot-read.ts` with interfaces for
-plain object contracts:
-
-```ts
-export interface ClientStateSnapshotReadOptions {
-    readonly minStateRevision?: number;
-}
-
-export interface GroupStateSnapshotReadOptions {
-    readonly minCausalRevision?: GroupStateCausalRevision;
-}
-
-export type StateSnapshotReadSource = 'cache' | 'durable';
-
-export interface StateSnapshotReadFound<T> {
-    readonly status: 'found';
-    readonly source: StateSnapshotReadSource;
-    readonly snapshot: T;
-}
-
-export interface StateSnapshotReadNotFound {
-    readonly status: 'not-found';
-    readonly source: 'durable';
-}
-
-export type StateSnapshotReadResult<T> =
-    | StateSnapshotReadFound<T>
-    | StateSnapshotReadNotFound;
-```
-
-Use separate client and group selectors. Do not build a generic numeric
-`revisionOf` abstraction that erases the group partial order.
-
-### Absence, eviction, and tombstones
-
-An authoritative tokenless `404` proves absence at that durable observation.
-It does not supply a causal deletion revision. Unconditional deletion is
-race-unsafe:
-
-1. a durable not-found read begins;
-2. a newer positive snapshot is observed;
-3. the older not-found result deletes the newer entry.
-
-The selected near-term behavior is compare-and-remove:
-
-- capture the exact scoped cache observation before the durable read;
-- after durable not-found, remove only if the current entry is still identical
-  to the captured revision and content;
-- if the entry advanced, changed, or appeared after the read began, keep it;
-- return the authoritative `404` to the caller regardless of whether cleanup
-  won the race.
-
-This improves presentation convergence but does **not** prevent a delayed stale
-publication from recreating a positive entry. A causal tombstone is required
-for resurrection safety and for durable/distributed negative-cache convergence.
-The plan therefore rejects claims that simple deletion is equivalent to a
-tombstone.
-
-### AppInbox, CAS, and liveness boundaries
-
-- This plan adds no database mutation and no new transaction, retry loop,
-  mutation outbox, or final-outbox writer.
-- Incoming mutations continue through AppInbox. Every conflict returns to a
-  fresh `read`, `compute`, `validate`, and AppInbox-owned transaction.
-- Snapshot reads keep existing key/value/scope validation and stable assembly.
-- Group presence summaries remain hints. Durable snapshots keep one captured
-  observation time and revalidate current group, membership, and session
-  authority before reporting live presence.
-- Strict authorization, policy, capacity, lifecycle, and governance never use
-  a caller's stale-tolerant preference.
-- Mutation-result hydration remains a best-effort latency optimization. It is
-  not required for tokenless or at-least correctness.
-
-## Architecture Proposal Review
-
-| Proposal | Problem solved | Guarantee provided | Guarantee not provided | Current-architecture interaction | Security, performance, and compatibility | Recommendation |
-|---|---|---|---|---|---|---|
-| Tokenless durable point reads | Warm process cache can lag durable state | Reads a stable durable snapshot/absence at one observation boundary | No promise that another commit cannot occur after the read | Read-only; uses current repository assembly and does not enter AppInbox/CAS | More database work; strongest simple policy/auth basis; backward-compatible for existing group point behavior and a client behavior change | **Selected** |
-| Tokened at-least cache reads | Caller knows a committed revision but wants a cheap eligible read | Never returns below a client scalar floor or outside group causal equality/dominance | Does not promise newest durable state or presence completeness | Reuses process caches and current group tuple comparison; durable fallback remains read-only | Strict group auth bypasses cache; query additions are compatible; cache hits reduce read load | **Selected**, client scalar and group causal pair |
-| Periodic browser authoritative probes | Normal use can otherwise keep reusing eligible old cache data | Would bound convergence by calls if every scoped entity keeps being read | Does not cover idle entities and duplicates existing timer repair | Existing browser heartbeat already runs every 20 seconds and top-level refresh is durable | Random cadence adds hidden state, off-by-one risk, and inconsistent facade semantics | **Replaced** by explicit targeted room refresh, existing heartbeat, and scoped collection reconciliation |
-| Durable revision-head reads | Avoids assembling a full snapshot when checking a cache | Can reject a cache known below a canonical head | A head and later snapshot are not one atomic observation; still needs full read on miss | Group has two heads and liveness-filtered projections; adds another read before common paths | Extra database round trip; can encourage stale auth if misused | **Rejected** as default |
-| Latest-snapshot projection tables | Reduce multi-row assembly cost | Can provide one-row reads if projection is transactionally authoritative | Does not solve lag when populated asynchronously; does not remove tombstone needs | Would be an additional AppInbox/CAS write target and must use current causal tuple | Migration, write amplification, hot-presence contention, and compatibility cost require measurement | **Deferred** |
-| Durable invalidation/replay | Repair missed wakeups across API processes | Cursor replay plus anti-entropy can converge process caches after missed notifications | Does not by itself make browser caches current or authorize stale data | Must use final resource outbox truth or a separately approved durable source; no intermediate mutation outbox | Requires cursor ownership, retention, compaction, poison handling, and metrics | **Deferred** |
-| Tombstones | Prevent stale positives from resurrecting after deletion | Causal negative state can dominate earlier positives | Does not make authorization optional or remove retention policy | Requires authoritative deletion revision and transactionally consistent publication | Contract/storage migration and retention cost; necessary before claiming negative-cache convergence | **Deferred**, while compare-and-remove is selected as bounded cleanup |
-| Structured causal group revisions | Correctly represents independent group and presence progress | Equality/dominance/incomparability without scalar aliasing | Does not provide a workspace-wide collection revision | Already the authoritative model in source and caches | Two query/header fields add transport surface but preserve response compatibility | **Selected and already implemented internally** |
-| Convergence metrics and service-level targets | Make cache effectiveness and fallback behavior observable | Counters/histograms show source, fallback, shortfall, incomparable, and cleanup races | Metrics alone provide no consistency guarantee; percentile targets need a measured baseline | Add read-path instrumentation only; no mutation changes | Low compatibility risk; avoid high-cardinality IDs | **Selected metrics; latency SLOs deferred until baseline measurement** |
-
-Required metrics:
-
-- point reads by entity kind, source, strict-auth mode, and result;
-- cache floor hit, cache floor miss, durable fallback, durable shortfall, and
-  group incomparable counts;
-- durable snapshot latency by client/group and list-versus-point;
-- conditional absence cleanup applied/skipped because the cache advanced;
-- browser targeted refresh result and scoped collection reconciliation counts.
-
-Do not label a value `latest` unless it means latest observed at a named
-boundary. Do not define p95/p99 service-level targets until representative
-baseline results are recorded.
-
-## Implementation Tasks
-
-Every task below is future implementation work. This plan review authorizes
-none of it.
-
-### Task 0: Record architecture and feature-branch gates
-
-**Evidence:** This plan and `AGENTS.md`.
-
-- [ ] Recheck branch, full `HEAD`, full `origin/main`, `git status`, and user
-  changes.
-- [ ] Record the human choice of client scalar plus group causal pair:
-  `minStateRevision` for clients and the all-or-none
-  `minGroupRevision`/`minPresenceRevision` pair for groups.
-- [ ] Record acceptance of compare-and-remove as bounded cleanup without
-  resurrection safety, or split tombstone design into an approved prerequisite.
-- [ ] Record the bounded migration approach for non-injective client and shared
-  snapshot keys.
-- [ ] Confirm no scalar collection floor, no policy decision from stale cache,
-  and no new mutation path.
-- [ ] Before implementation edits, create or switch to
-  `codex/rallar-rest-snapshot-read-convergence`. Never implement task commits
-  on `main`, `master`, or another default branch.
-- [ ] Plan review or Task 0 approval is not commit, push, merge, rebase, or PR
-  permission. The future publication workflow applies only on the feature
-  branch; default-branch operations require the separate just-in-time
-  disclosures and permissions in `AGENTS.md`.
-
-No feature-branch checkpoint is created for the review gate alone.
-
-### Task 1: Make scoped keys and absence cleanup race-safe
-
-**Modify:**
-
-- `packages/shared-server/rallar-system/client-state-storage-keys.ts`
-- `packages/shared-server/rallar-system/repositories/ClientStateRepository.ts`
-- `packages/shared/repository/client-state-snapshots-repository.ts`
-- `packages/shared/repository/group-state-snapshots-repository.ts`
-- `packages/shared/cache/ObservableLatestRepository.ts`
-- `packages/shared/cache/ObservableLoanedRepository.ts`
-- `packages/shared-server/rallar-system/services/client-state-snapshot-read-through-cache.ts`
-- `packages/shared-server/rallar-system/services/group-state-snapshot-read-through-cache.ts`
-- `packages/tests/shared/observable-latest-repository.test.ts`
-- `packages/tests/shared/observable-loaned-repository.test.ts`
-
-**Create:**
-
-- `packages/tests/shared-server/client-state-storage-keys.test.ts`
-
-**Verify:**
-
-- `packages/tests/shared-server/client-state-snapshot-read-through-cache.test.ts`
-- `packages/tests/shared-server/group-state-snapshot-read-through-cache.test.ts`
-- `packages/tests/shared-web/data-caches.test.ts`
-
-Steps:
-
-- [ ] Add failing key tests covering field name, string value, type/presence,
-  absent workspace, explicit `_`, explicit empty string, delimiters, percent
-  sequences, child keys, prefix/list boundaries, and repository round trips.
-- [ ] Replace sentinel/empty-string aliases with a canonical typed projection.
-  Do not treat URI escaping alone as absence encoding.
-- [ ] For persisted client state, migrate a legacy row only after validating its
-  stored identity proves the intended scope and conditionally claiming the new
-  key. Do not fan one row into two scopes or add an unbounded dual-read.
-- [ ] Add conditional repository deletion that succeeds only when the current
-  value is the expected exact observation. Preserve observer and session-index
-  behavior.
-- [ ] Add `evictIfUnchanged` to both snapshot read-through caches and cover the
-  not-found/newer-positive race.
-- [ ] Keep new modules/interfaces within repo style limits; split implementation
-  helpers instead of growing an already oversized module without approval.
-- [ ] Run:
-  `npx vitest run packages/tests/shared/observable-latest-repository.test.ts packages/tests/shared/observable-loaned-repository.test.ts packages/tests/shared-server/client-state-storage-keys.test.ts packages/tests/shared-server/client-state-snapshot-read-through-cache.test.ts packages/tests/shared-server/group-state-snapshot-read-through-cache.test.ts packages/tests/shared-web/data-caches.test.ts`.
-
-**Feature-branch checkpoint only:** `fix: make snapshot cache identity and absence cleanup causal-safe`.
-
-### Task 2: Add separate client and group REST read selectors
-
-**Create:**
-
-- `packages/shared/api/state-snapshot-read.ts`
-- `packages/shared-server/rallar-system/services/rest-state-snapshot-reader.ts`
-- `packages/tests/shared-server/rest-state-snapshot-reader.test.ts`
-
-**Modify:**
-
-- `packages/shared-server/rallar-system/services/cached-client-state-service.ts`
-- `packages/shared-server/rallar-system/services/cached-group-state-service.ts`
-- `packages/shared-server/rallar-system/services/client-state-snapshot-read-through-cache.ts`
-- `packages/shared-server/rallar-system/services/group-state-snapshot-read-through-cache.ts`
-- `packages/shared-server/mod.ts`
-- `apps/api-v1/src/middleware-contract.ts`
-- `apps/api-v1/src/middleware.ts`
-
-**Verify:**
-
-- `packages/tests/shared-server/cached-state-services.test.ts`
-- `packages/tests/shared-server/client-state-snapshot-read-through-cache.test.ts`
-- `packages/tests/shared-server/group-state-snapshot-read-through-cache.test.ts`
-- `packages/tests/shared-server/state-sync-cache-hydration.test.ts`
-
-Steps:
-
-- [ ] Write failing client tests: tokenless performs one full durable read;
-  an eligible scalar cache answers tokened reads; an ineligible cache falls back
-  to durable; durable below the floor yields a typed retryable shortfall.
-- [ ] Write failing group tests with equality, dominance, domination, and
-  incomparability. Never project the tuple to a scalar for eligibility.
-- [ ] Add a typed found/not-found result with explicit `cache|durable` source.
-- [ ] Add client `readCurrentSnapshot` parity and separate REST selector
-  methods to the process-owned services wired through middleware.
-- [ ] Preserve current group `readCurrentSnapshot` as a direct durable read.
-  Do not add a revision-head probe.
-- [ ] On durable not-found, invoke `evictIfUnchanged` with the observation
-  captured before the read. Return not-found even when cleanup loses a race.
-- [ ] Do not turn a liveness-filtered group projection into stronger canonical
-  authority than its preserved causal tuple. Continue to reject incomparable
-  cache observation.
-- [ ] Add a deterministic three-logical-cache test over one durable fake:
-  warm A/B/C, commit through B, hydrate A/B only, prove C's client scalar and
-  group causal floor miss falls back to durable, and prove C tokenless always
-  reads durable.
-- [ ] Keep current mutation-result hydration tests as optimization tests.
-- [ ] Run:
-  `npx vitest run packages/tests/shared-server/rest-state-snapshot-reader.test.ts packages/tests/shared-server/cached-state-services.test.ts packages/tests/shared-server/client-state-snapshot-read-through-cache.test.ts packages/tests/shared-server/group-state-snapshot-read-through-cache.test.ts packages/tests/shared-server/state-sync-cache-hydration.test.ts`.
-
-**Feature-branch checkpoint only:** `feat: add scalar client and causal group REST snapshot readers`.
-
-### Task 3: Expose the contract without weakening authorization
-
-**Create:**
-
-- `apps/api-v1/src/routes/state-snapshot-read.ts`
-- `apps/api-v1/test/routes/state-snapshot-read.test.ts`
-
-**Modify:**
-
-- `apps/api-v1/src/routes/client-state-routes.ts`
-- `apps/api-v1/src/routes/group-state-routes.ts`
-- `apps/api-v1/src/routes/graph-topology-routes.ts`
-- `apps/api-v1/src/create-rallar-server.ts`
-- `apps/api-v1/src/main.ts`
-- `apps/api-v1/test/routes/state-api-routes-hardening.test.ts`
-- `apps/api-v1/test/routes/graph-topology-routes.test.ts`
-
-Steps:
-
-- [ ] Add table-driven parser tests for blank, whitespace, signed, negative,
-  decimal, exponential, `NaN`, `Infinity`, unsafe, and repeated values.
-- [ ] Require both group causal query components or neither.
-- [ ] Route client tokenless point and strict self-collection reads through the
-  durable current-client method.
-- [ ] Route non-policy-sensitive client tokened reads through the scalar
-  selector.
-- [ ] Preserve group tokenless direct durable behavior.
-- [ ] In non-strict mode, allow a group causal cache hit. In strict mode,
-  perform one durable current group read, check the requested causal floor,
-  authorize, and return that same snapshot.
-- [ ] Replace graph/topology's cache-permitting `readSnapshot` authority
-  dependency with `readCurrentSnapshot`; avoid duplicate durable reads within
-  one request by passing the obtained snapshot through existence and policy
-  checks.
-- [ ] Keep mutation route prechecks advisory only; AppInbox must still rerun
-  complete durable authorization and validation on every attempt.
-- [ ] Emit source/revision/no-store headers on `200`; emit `Retry-After: 1` on
-  shortfall/incomparable `503`; expose all headers in CORS.
-- [ ] Add assertions that serializers return all required authoritative fields.
-- [ ] Run:
-  `cd apps/api-v1 && deno test --allow-env --allow-read test/routes/state-snapshot-read.test.ts test/routes/state-api-routes-hardening.test.ts test/routes/graph-topology-routes.test.ts`.
-- [ ] Run: `cd apps/api-v1 && deno task check`.
-
-**Feature-branch checkpoint only:** `feat: expose causal snapshot floors in API v1`.
-
-### Task 4: Make browser refresh authoritative and scope-reconciling
-
-**Create:**
-
-- `packages/tests/shared-web/api-integration-state-snapshot-read.test.ts`
-- `packages/tests/shared-web/state-snapshot-read-reconciliation.test.ts`
-
-**Modify:**
-
-- `packages/shared-web/browser/api-integration.ts`
-- `packages/shared-web/browser/api-workflows.ts`
-- `packages/shared-web/browser/data-caches.ts`
-- `packages/shared-web/browser/rallar-runtime/contracts.ts`
-- `packages/shared-web/browser/rallar-runtime/state-store.ts`
-- `packages/shared-web/browser/rallar-runtime/rooms.ts`
-- `packages/shared-web/browser/rallar-runtime/people.ts`
-- `packages/shared-web/browser/rallar-runtime/composition.ts`
-- `packages/shared-web/mod.ts`
-- `packages/tests/shared-web/rallar-rooms-facade.test.ts`
-- `packages/tests/shared-web/rallar-people-facade.test.ts`
-- `packages/tests/shared-web/rallar-rooms-people-state.test.ts`
-- `packages/tests/shared-web/shared-web-public-api-snapshots.test.ts`
-- `packages/tests/shared-web/shared-web-browser-bundle-boundaries.test.ts`
-
-Steps:
-
-- [ ] Add a client point function with scalar options and group point options
-  using the causal pair. Successful HTTP metadata must expose the response
-  source/revisions without weakening authoritative body validation.
-- [ ] Change `rallar.rooms.room(ref).refresh()` to one targeted tokenless group
-  point read. Keep `rallar.rooms.refresh()` and `rallar.people.refresh()` on
-  complete durable collection reads.
-- [ ] Do not add random 5–10-call state. The existing heartbeat remains the
-  background repair mechanism for the current client and joined groups.
-- [ ] On targeted `404`, compare-and-remove only the exact unchanged scoped
-  browser observation and rethrow the original `ApiHttpError`.
-- [ ] After a successful complete collection read, reconcile that scope:
-  remove a previously visible entity omitted from the result only when the
-  cached observation has not advanced since the request began.
-- [ ] Preserve group causal monotonicity and the current incomparable recovery
-  path. Never accept the compatibility scalar as group authority.
-- [ ] State in tests and public docs that physical removal can be followed by
-  stale-publication reinsertion until a future tombstone design lands.
-- [ ] Keep low-level point functions stateless. Callers explicitly choose
-  tokenless or tokened reads.
-- [ ] Update public API snapshots and browser bundle-boundary checks for every
-  new export.
-- [ ] Run:
-  `npx vitest run packages/tests/shared-web/api-integration-state-snapshot-read.test.ts packages/tests/shared-web/state-snapshot-read-reconciliation.test.ts packages/tests/shared-web/rallar-rooms-facade.test.ts packages/tests/shared-web/rallar-people-facade.test.ts packages/tests/shared-web/rallar-rooms-people-state.test.ts packages/tests/shared-web/shared-web-public-api-snapshots.test.ts packages/tests/shared-web/shared-web-browser-bundle-boundaries.test.ts`.
-- [ ] Run: `npm --workspace @ar-eye-hunter/shared-web run check:browser-bundles`.
-
-**Feature-branch checkpoint only:** `feat: converge browser snapshot refresh and scoped absence`.
-
-### Task 5: Align OpenAPI, Swagger, and successful contracts
-
-**Modify:**
-
-- `apps/api-v1/resources/api-v1-openapi.yaml`
-- `apps/api-v1/test/swagger-routes.test.ts`
-- `packages/shared-test/black-box-runner/tests/api-v1/api-v1-openapi-topology-auth.json`
-
-Steps:
-
-- [ ] Add client `minStateRevision` and the all-or-none group causal query pair
-  to point operations only.
-- [ ] Add `400`, `404`, and retryable `503` response schemas and the source,
-  revision, `Retry-After`, and no-store header contracts.
-- [ ] Preserve required `ClientSnapshot.stateRevision`,
-  `GroupSnapshot.stateRevision`, and `GroupSnapshot.causalRevision`.
-- [ ] Add `minimum: 0` consistently to client revision fields and confirm all
-  successful required arrays, serializers, TypeScript contracts, and tests
-  agree.
-- [ ] Add Swagger and recipe assertions that collection/event/presence routes
-  do not advertise one entity floor.
-- [ ] Run:
-  `cd apps/api-v1 && deno test --allow-env --allow-read test/swagger-routes.test.ts`.
-- [ ] Run:
-  `npm run test:api-v1:black-box:memory`.
-
-**Feature-branch checkpoint only:** `docs: specify scalar client and causal group snapshot reads`.
-
-### Task 6: Prove logical and real multi-process convergence
-
-**Create:**
-
-- `packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-read-convergence.json`
-
-**Modify:**
-
-- `packages/shared-test/black-box-runner/execute-black-box.ts`
-- `packages/shared-test/black-box-runner/recipe-matrix.json`
-- `packages/tests/shared-test/rallar-bb-test.test.ts`
-- `packages/tests/shared-test/api-v1-black-box-run.test.ts`
-- `packages/tests/shared-server/state-sync-event-replay-characterization.test.ts`
-- `apps/api-v1/test/routes/state-api-routes-hardening.test.ts`
-
-Steps:
-
-- [ ] Extend black-box HTTP result/report data to retain a normalized,
-  allow-listed response-header map; cover redaction and serialization before
-  recipes assert headers.
-- [ ] Add a two-process Postgres recipe that warms one process, mutates through
-  the other, captures the committed client scalar/group causal revision, and
-  proves:
-  - tokenless reads are durable;
-  - eligible floors may use cache;
-  - stale floors fall back to durable;
-  - no response is below a client scalar floor;
-  - group equality/dominance succeeds and incomparable/dominated durable
-    observations fail with the typed `503`;
-  - source and revision headers match the response body;
-  - strict group and graph/topology policy use durable current authority.
-- [ ] Keep the deterministic three-logical-cache unit test from Task 2 as the
-  proof that a cache missing all hydration/wakeup observations converges.
-- [ ] Do not add a tertiary API process. Current two-process integration plus
-  deterministic logical isolation proves the selected contract without
-  nondeterministic queue claimant or PostgreSQL wakeup behavior.
-- [ ] Run:
-  `npx vitest run packages/tests/shared-test/rallar-bb-test.test.ts packages/tests/shared-test/api-v1-black-box-run.test.ts packages/tests/shared-server/state-sync-event-replay-characterization.test.ts`.
-- [ ] Run:
-  `npm run test:api-v1:black-box:postgres`.
-- [ ] Run the mandatory unweakened gate:
-  `npm run test:api-v1:black-box:postgres:medium-scale`.
-- [ ] If local PostgreSQL is unavailable, report each command as skipped and
-  require exact CI evidence on the same feature commit; a skip does not satisfy
-  completion.
-
-**Feature-branch checkpoint only:** `test: prove two-process causal snapshot convergence`.
-
-### Task 7: Publish the current mental model in docs and skills
-
-**Create:**
-
-- `docs/rallar-state-snapshot-consistency.md`
-
-**Modify:**
-
-- `docs/README.md`
-- `docs/rallar-api-reference.md`
-- `docs/rallar-convergent-state-and-rtc-topology.md`
-- `docs/rallar-groups-report.md`
-- `docs/rallar-troubleshooting-checklist.md`
-- `packages/shared-server/rallar-server-repositories.md`
-- `.agents/skills/rallar-realtime/SKILL.md`
-- `.agents/skills/rallar-platform/SKILL.md`
-- `.agents/skills/rallar-testing/SKILL.md`
-- `.agents/skills/rallar-testing/references/test-commands.md`
-
-Steps:
-
-- [ ] Define internal consistency, client scalar monotonicity, group causal
-  partial order, presence completeness limits, durable authority, and
-  post-read commit races.
-- [ ] Describe current AppInbox transaction/retry ownership, direct final
-  resource outbox rows, per-session presence guards, summary revalidation, and
-  captured observation time. Do not describe them as future work.
-- [ ] Document the two point-route query shapes, headers, validation, typed
-  errors, and strict-auth exception.
-- [ ] Document targeted room refresh, existing 20-second heartbeat, scoped
-  collection reconciliation, compare-and-remove races, and why a physical
-  delete is not a tombstone.
-- [ ] Remove stale durable-head-probe, shared group-row presence contention,
-  future causal-split, intermediate mutation-outbox, package-code-style, random
-  cadence, and three-process claims.
-- [ ] Add only real focused commands to the testing skill.
-- [ ] Run:
-  `npx vitest run packages/tests/repo/rallar-skill-integrity.test.ts packages/tests/repo/repo-code-style-integrity.test.ts packages/tests/repo/repo-style-check.test.ts`.
-- [ ] Run: `npm run check:repo-style`.
-
-**Feature-branch checkpoint only:** `docs: publish causal REST snapshot consistency`.
-
-### Task 8: Final verification, publication, and review handoff
-
-**Verify the exact final feature-branch tree after all edits:**
-
-- [ ] Run focused commands from Tasks 1–7 and record exact results.
-- [ ] Run `npm run check:repo-style`.
-- [ ] Run `npm run test:unit`.
-- [ ] Run `npm run test:ci`.
-- [ ] Run `npm run build`.
-- [ ] Run `npm run test:api-v1:black-box:postgres:medium-scale`.
-- [ ] Run `git diff --check`.
-- [ ] Confirm every authoritative TypeScript/OpenAPI/serializer/test contract
-  remains aligned.
-- [ ] Confirm no incoming mutation bypasses AppInbox, no service owns a new
-  transaction/retry loop, and no intermediate mutation outbox was introduced.
-- [ ] Confirm no generated artifacts under `.artifacts/` or `tmp/` are staged.
-- [ ] Confirm the current branch is the feature branch before every checkpoint.
-
-Any change after a successful final `test:unit`, `test:ci`, or `build` result
-invalidates that result and requires rerunning the command.
-
-**Publication requirements:**
-
-- [ ] On the non-default feature branch, commit only reviewed in-scope files,
-  push the branch, and keep a draft PR current with the plan link, milestones,
-  exact passed/failed/skipped validation, and incomplete decisions.
-- [ ] Record the final feature-branch commit SHA.
-- [ ] Require **Branch Release Gate** to pass for that exact final
-  feature-branch SHA. The workflow is defined in
-  `.github/workflows/branch-release-gate.yml:1-14`.
-- [ ] After a separately authorized integration to the default branch, record
-  the resulting default-branch SHA.
-- [ ] Require **Run Hetzner Supported Distributed Manifests** to pass for that
-  exact default-branch SHA. The workflow is defined in
-  `.github/workflows/hetzner-supported-distributed-manifests.yml:1-50`.
-- [ ] Do not infer either result from a workflow attached to older code.
-- [ ] Do not mark the plan approved or implementation-complete while a command,
-  draft PR update, workflow, or exact-SHA evidence is pending, skipped, failed,
-  or prohibited.
-
-**Final feature-branch checkpoint only:** `feat: complete REST snapshot read convergence`.
-
-## Acceptance Criteria
-
-- Client point GET without a minimum performs a full durable read.
-- Group point GET without a minimum preserves the already-durable current read.
-- Client tokened reads never return below `minStateRevision`.
-- Group tokened reads return cache only when the causal tuple equals or
-  dominates the complete requested pair; incomparable is never accepted.
-- A cache miss/ineligible value falls back to durable. A durable value below or
-  incomparable with the requested floor returns typed retryable `503`.
-- Collections accept no entity minimum. Strict self-client collection is
-  durable; group collections remain durable and policy-filter current
-  snapshots.
-- Strict group point/event/graph/topology authorization uses durable current
-  authority and never a stale-tolerant response candidate.
-- Presence summaries remain hints; durable assembly revalidates lifecycle,
-  membership, session identity/generation, connectivity, and expiry at one
-  captured time while preserving `GroupStateCausalRevision`.
-- Mutation-result hydration remains operational but is not required for
-  correctness.
-- A logical Node C that missed hydration and wakeups still converges through
-  tokenless or at-least durable fallback.
-- Room-session refresh is a targeted tokenless durable point read. Top-level
-  rooms/people refresh remains a durable collection read.
-- Successful collection refresh reconciles unchanged omitted entries in the
-  requested scope; it never deletes an entry that advanced during the request.
-- Authoritative not-found cleanup is compare-and-remove. Documentation and
-  tests do not claim resurrection safety without a causal tombstone.
-- Client and group storage/cache keys are injective over field, value,
-  type/presence, delimiters, percent sequences, and child/prefix boundaries.
-- TypeScript authoritative fields, serializers, OpenAPI `required` arrays,
-  Swagger, browser validation, and tests remain aligned.
-- Response source/revision headers, CORS exposure, no-store policy, and
-  retryable errors match the selected contract.
-- Focused tests, repo style, `test:unit`, `test:ci`, `build`, ordinary Postgres
-  black-box, and the unweakened two-process medium-scale gate have exact
-  recorded results.
-- The draft PR is current; Branch Release Gate is green on the final feature
-  SHA; Hetzner supported manifests are green on the resulting default-branch
-  SHA.
-
-## Explicit Non-Goals
-
-- Claiming globally latest state at response receipt.
-- Inventing a scalar group causal floor or a workspace collection revision.
-- Replacing runtime-state snapshot assembly with projection tables in this
-  implementation.
-- Adding durable cache-invalidation replay in this implementation.
-- Claiming physical cache deletion is a tombstone.
-- Adding a third API-v1 process to the black-box runner.
-- Adding a second random browser probe cadence beside the existing heartbeat.
-- Changing AppInbox mutation ownership, CAS retry boundaries, or final resource
-  outbox behavior.
-- Resolving the current final-outbox collision-policy mismatch noted in the
-  revalidation ledger.
-- Weakening authorization, policy, lifecycle, capacity, or governance for cache
-  hit rate.
-
-## Human Decisions Still Required
-
-1. Approve or revise the external group query shape:
-   `minGroupRevision` plus `minPresenceRevision`, both required together.
-2. Accept compare-and-remove as bounded near-term absence cleanup, with causal
-   tombstones deferred and resurrection safety explicitly unclaimed.
-3. Approve the bounded migration for the current non-injective client and shared
-   snapshot key projections, or split it into a prerequisite plan before exact
-   scoped eviction ships.
-4. Decide whether to retain a group `Rallar-State-Revision` header as a clearly
-   labelled compatibility projection; it cannot satisfy the causal contract.
-5. Assign separate ownership for the current source-versus-`AGENTS.md`
-   final-outbox collision-policy mismatch.
-6. Approve implementation only on a feature branch. This plan review never
-   grants permission for a default-branch commit or push.
-
-After production measurement, separately review projection tables, durable
-replay, causal tombstone retention, and numeric latency service-level targets.
+| Tokenless client reads are durable | PR1 selector; PR2 route | Selector durable-call count, client route test, two-process recipe |
+| Tokened client reads never return below the scalar floor | PR1 client selector | Eligible hit, below-floor fallback, durable shortfall `409`, three-cache test |
+| Group reads use the complete causal pair | PR1 group selector; PR2 parser | Equality/dominance success; domination/incomparability fallback or `409`; partial pair `400` |
+| Strict authorization never trusts cache | PR2 client/group/graph routes | Strict self, member, banned/nonmember, graph/manage tests; one durable read assertion |
+| Authoritative absence cannot delete a newer observation | PR1 conditional deletion; PR3 repair | Latest/loaned CAS-delete races, session-index tests, targeted/heartbeat/collection races |
+| Physical deletion is not a tombstone | PR3 documentation/tests | Delayed stale publication may reinsert; no resurrection-safety assertion |
+| Snapshot cache keys are injective in scope | PR1 snapshot repositories | Presence/value/delimiter/percent/round-trip/scope-isolation tests |
+| REST contract is compatible and visible to browsers | PR2 routes/OpenAPI/CORS | Parser matrix, statuses, no-store, CORS, authoritative headers, Swagger tests |
+| Browser API is additive | PR3 transport/public exports | Existing `findStateGroup` shape, new envelopes, malformed body/header rejection, API snapshots |
+| Multi-process contract holds | PR2 runner/recipe | Warm A, mutate B, read A/B; cache source and body revisions agree; no result below floor |
+| Diagnostics are usable and safe | PR1/PR3 sinks | Exact event names and bounded dimensions; no tenant/entity labels |
+| Added durable I/O is bounded | PR1 selectors; PR2 benchmark | Cache hit = 0 durable reads; tokenless/miss/strict group = one full durable read |
+| Publication evidence matches code | All PRs | Exact SHA/tree, focused tests, completion gates, medium-scale artifact, Branch Release Gate |
+
+Focused verification must use current paths, including:
+
+- Snapshot repository/cache and three-logical-cache Vitest suites.
+- `apps/api-v1/test/client-state/client-state-read-routes.test.ts`.
+- `apps/api-v1/test/group-state/group-state-read-routes.test.ts`.
+- Graph/topology, resilience middleware, Swagger, and new parser/contract Deno
+  tests.
+- Browser heartbeat, data-cache, room-session, rooms facade, public API
+  snapshot, and bundle-boundary tests.
+- Shared-test runner schema/report/redaction and API black-box runner tests.
+- `npm run test:api-v1:black-box:memory`.
+- `npm run test:api-v1:black-box:postgres`.
+- Exact-SHA **API v1 Medium-Scale Gate**.
+- `npm --workspace @ar-eye-hunter/shared-web run check:browser-bundles`.
+- `npm run test:repo-governance` after docs/skill routing changes.
+
+For every stacked PR, record focused results, then run from its final tree:
+
+- `npm run check:repo-style`
+- `npm run test:unit`
+- `npm run test:ci`
+- `npm run build`
+- `git diff --check`
+- Branch Release Gate on the exact final PR SHA
+
+Rebases invalidate prior evidence. Merge only in stack order. After each
+separately authorized default-branch integration, record the resulting full SHA
+and require Run Hetzner Supported Distributed Manifests for that SHA.
+
+## Assumptions and Deferred Work
+
+- Runtime REST scopes continue to require nonempty workspace IDs.
+- Strict-read policy behavior and its default remain unchanged.
+- Persisted client-key migration is separate remediation.
+- Final-outbox collision-policy remediation remains separate.
+- Causal tombstones, durable replay, projection tables, a third API process,
+  collection-wide revisions, and numeric latency SLOs are deferred.


### PR DESCRIPTION
Implements PR 3 of `plans/rallar-rest-snapshot-read-convergence-implementation-plan.md` on top of PR #87.

This PR owns validated metadata-bearing point readers, compatibility wrappers, tokenless revision-floor room refresh, race-fenced targeted and collection repair, bounded browser diagnostics, public API and bundle checks, feature READMEs, consistency documentation, and the agreed revised implementation plan. Physical cleanup is explicitly not a tombstone and delayed stale publication may reinsert state.

Stack: 3 of 3. Base PR: #87.

Current exact head: `841c1e811d7f7f695213975f53bffe290765bb77`
Current exact tree: `f70b97eb11f24e82fd0bf5127c3e4e28ec78f08f`

The current head adds only the agreed rewrite of `plans/rallar-rest-snapshot-read-convergence-implementation-plan.md` on top of implementation commit `79e298df7b77305c51f25af1c68238b13ed64d99` (tree `a39c9c03cb99b29b4a8e2a598e2c7698ecfbc19f`).

Validation on the current tree:

- Shared-web focused suite: 86 files, 512 tests passed.
- Repository governance suite: 27 files, 292 tests passed, including the updated group-state navigation inventory.
- Shared-web browser bundle boundary: passed; facade 152.6 KiB Brotli against a `<160 KiB` budget.
- Headless bundle/status boundary: 2 files, 4 tests passed.
- `npm run check:repo-style` and `npm run check:repo-style:changed -- origin/main`: passed.
- `VITEST_MAX_WORKERS=4 npm run test:unit`: 688 files passed, 11 skipped; 6,235 tests passed, 18 skipped.
- `VITEST_MAX_WORKERS=4 npm run test:ci`: passed, including 397 API-v1 Deno tests, 211 Recipe Console Playwright tests (1 skipped), and 7 memory full-stack tests.
- `npm run build`: passed.
- `git diff --check`: passed.
- [API v1 Medium-Scale Gate](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31216269720): passed on the current exact head and uploaded exact-SHA artifacts.
- [Branch Release Gate](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31213192667): passed on the exact implementation parent. The workflow intentionally ignores `plans/**`, so GitHub did not emit a redundant run for the plan-only follow-up commit; the current code tree is unchanged.

The first sandboxed unit attempt after the plan edit was invalid because local IPC/TCP listeners were denied with `EPERM`. The unchanged command passed outside that listener-restricted sandbox; no source or test workaround was made.

Automatic Deno Deploy and Cloudflare Workers preview checks remain red because of external feature-branch deployment configuration; they are not the repository-owned Branch Release Gate.
