### PR TITLE
feat: add Rallar ontology vocabulary and binding contracts

### DIFF
--- a/packages/shared/ontology/mod.ts
+++ b/packages/shared/ontology/mod.ts
@@ -1,0 +1,52 @@
+export { RALLAR_RELATION_IDS } from './rallar-ontology-contracts.ts';
+export type {
+  RallarOntologyBinding,
+  RallarOntologyBindingId,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingProfileBase,
+  RallarOntologyBindingProfileId,
+  RallarOntologyBindingSetId,
+  RallarOntologyBindingStrength,
+  RallarOntologyBindingTarget,
+  RallarOntologyCompetencyQuestionId,
+  RallarOntologyId,
+  RallarOntologyIri,
+  RallarOntologyOwnerId,
+  RallarOntologyReference,
+  RallarOntologyRelationId,
+  RallarOntologyTermBase,
+  RallarOntologyTermId,
+  RallarOntologyVersion,
+  RallarOntologyVersionIri,
+  RallarOntologyVocabularyModule,
+} from './rallar-ontology-contracts.ts';
+export type { RallarDomainOntologyTerm } from './rallar-domain-ontology-term.ts';
+export type {
+  RallarMessageOntologyBindingProfile,
+  RallarMessageOntologyTerm,
+  RallarMessageRouteId,
+  RallarMessageRouteSemantics,
+  RallarMessageTargetMode,
+  RallarMessageTransportKind,
+  RallarPayloadSchemaVersionSemantics,
+  RallarPayloadValidationBinding,
+  RallarPayloadValidationSemantics,
+  RallarRealtimeOntologyBindingModule,
+  RallarRtcLaneOntologyBindingProfile,
+  RallarRtcLaneOntologyTerm,
+  RallarSenderKind,
+} from './rallar-realtime-ontology-contracts.ts';
+export type {
+  CreateRallarOntologyCatalogInput,
+  RallarOntologyCatalog,
+  RallarOntologyIssue,
+} from './rallar-ontology-registry-contracts.ts';
+export {
+  createRallarOntologyCatalog,
+  getRallarOntologyBindingProfiles,
+  getRallarOntologyBindings,
+  getRallarOntologyTerm,
+} from './rallar-ontology-registry.ts';
+export { validateRallarOntologyBindingModule } from './validate-rallar-ontology-binding-module.ts';
+export { validateRallarOntologyCatalog } from './validate-rallar-ontology-catalog.ts';
+export * from './validate-rallar-ontology-vocabulary-module.ts';

--- a/packages/shared/ontology/rallar-domain-ontology-term.ts
+++ b/packages/shared/ontology/rallar-domain-ontology-term.ts
@@ -1,0 +1,16 @@
+import type { RallarOntologyTermBase } from './rallar-ontology-contracts.ts';
+
+export interface RallarDomainOntologyTerm extends RallarOntologyTermBase {
+  readonly kind: 'domain';
+  readonly domainKind:
+    | 'scope'
+    | 'identity'
+    | 'entity'
+    | 'value-object'
+    | 'projection'
+    | 'snapshot'
+    | 'event'
+    | 'proposal';
+  readonly authority: 'authoritative' | 'derived' | 'projection' | 'proposal';
+  readonly identityFields: readonly string[];
+}

--- a/packages/shared/ontology/rallar-ontology-contracts.ts
+++ b/packages/shared/ontology/rallar-ontology-contracts.ts
@@ -1,0 +1,139 @@
+export type RallarOntologyIri =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/${string}`;
+export type RallarOntologyId = RallarOntologyIri;
+export type RallarOntologyVersionIri = `${RallarOntologyId}/version/${number}.${number}.${number}`;
+export type RallarOntologyTermId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/term/${string}`;
+export type RallarOntologyOwnerId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/owner/${string}`;
+export type RallarOntologyRelationId =
+  | `https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/${string}`
+  | 'http://www.w3.org/2004/02/skos/core#broader'
+  | 'http://www.w3.org/2004/02/skos/core#narrower'
+  | 'http://www.w3.org/2004/02/skos/core#related';
+export type RallarOntologyVersion = `${number}.${number}.${number}`;
+export type RallarOntologyCompetencyQuestionId = `CQ-${string}`;
+
+export const RALLAR_RELATION_IDS = {
+  scopedBy: 'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/scoped-by',
+  identifies:
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/identifies',
+  projects: 'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/projects',
+  identifiedBy:
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/identified-by',
+  sessionOf:
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/session-of',
+  runsOn: 'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/runs-on',
+  mayCarryScope:
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/may-carry-scope',
+  usesGroupRef:
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology/relation/uses-group-ref',
+} as const satisfies Record<string, RallarOntologyRelationId>;
+
+export interface RallarOntologyReference {
+  readonly relationId: RallarOntologyRelationId;
+  readonly targetTermId: RallarOntologyTermId;
+}
+
+export interface RallarOntologyTermBase {
+  readonly termId: RallarOntologyTermId;
+  readonly kind: string;
+  readonly label: string;
+  readonly definition: string;
+  readonly status: 'draft' | 'active' | 'deprecated';
+  readonly references: readonly RallarOntologyReference[];
+  readonly supersededBy?: RallarOntologyTermId;
+  readonly removalCondition?: string;
+}
+
+export interface RallarOntologyVocabularyModule<
+  TTerm extends RallarOntologyTermBase = RallarOntologyTermBase,
+> {
+  readonly ontologyId: RallarOntologyId;
+  readonly ownerId: RallarOntologyOwnerId;
+  readonly version: RallarOntologyVersion;
+  readonly versionIri: RallarOntologyVersionIri;
+  readonly maturity: 'experimental' | 'stable';
+  readonly compatibleWith: readonly RallarOntologyVersionIri[];
+  readonly requiredVocabularyVersionIris: readonly RallarOntologyVersionIri[];
+  readonly competencyQuestionIds: readonly RallarOntologyCompetencyQuestionId[];
+  readonly terms: readonly TTerm[];
+}
+
+export type RallarOntologyBindingId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/binding/${string}`;
+export type RallarOntologyBindingSetId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/binding-set/${string}`;
+export type RallarOntologyBindingProfileId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/binding-profile/${string}`;
+export type RallarOntologyBindingStrength = 'contractual' | 'owner' | 'implementation' | 'example';
+
+export type RallarOntologyBindingTarget =
+  | Readonly<{ kind: 'typescript-export'; modulePath: string; exportName: string }>
+  | Readonly<{
+      kind: 'wire-constant';
+      modulePath: string;
+      exportName: string;
+      propertyPath?: readonly string[];
+    }>
+  | Readonly<{ kind: 'openapi-component'; documentPath: string; componentName: string }>
+  | Readonly<{
+      kind: 'runtime-validator';
+      modulePath: string;
+      exportName: string;
+      validatorId: string;
+    }>
+  | Readonly<{ kind: 'normative-anchor'; documentPath: string; anchor: string }>
+  | Readonly<{
+      kind: 'export-property';
+      modulePath: string;
+      exportName: string;
+      propertyName: string;
+    }>
+  | Readonly<{ kind: 'package-script'; manifestPath: string; scriptName: string }>
+  | Readonly<{ kind: 'repository-owner'; ownerId: RallarOntologyOwnerId; path: string }>
+  | Readonly<{ kind: 'implementation-symbol'; path: string; symbol: string }>
+  | Readonly<{ kind: 'example'; path: string }>;
+
+export interface RallarOntologyBinding {
+  readonly bindingId: RallarOntologyBindingId;
+  readonly termId: RallarOntologyTermId;
+  readonly role:
+    | 'authoritative-contract'
+    | 'projection'
+    | 'wire-identity'
+    | 'schema'
+    | 'runtime-validation'
+    | 'authorization-owner'
+    | 'identifier'
+    | 'normative-standard'
+    | 'enforcement-owner'
+    | 'enforcement-gate'
+    | 'review-evidence'
+    | 'exception-policy'
+    | 'implementation'
+    | 'example';
+  readonly strength: RallarOntologyBindingStrength;
+  readonly target: RallarOntologyBindingTarget;
+}
+
+export interface RallarOntologyBindingProfileBase {
+  readonly profileId: RallarOntologyBindingProfileId;
+  readonly termId: RallarOntologyTermId;
+  readonly kind: string;
+}
+
+export interface RallarOntologyBindingModule<
+  TProfile extends RallarOntologyBindingProfileBase = RallarOntologyBindingProfileBase,
+> {
+  readonly bindingSetId: RallarOntologyBindingSetId;
+  readonly ontologyId: RallarOntologyId;
+  readonly vocabularyVersionIri: RallarOntologyVersionIri;
+  readonly ownerId: RallarOntologyOwnerId;
+  readonly version: RallarOntologyVersion;
+  readonly versionIri: RallarOntologyVersionIri;
+  readonly maturity: 'experimental' | 'stable';
+  readonly compatibleWith: readonly RallarOntologyVersionIri[];
+  readonly bindings: readonly RallarOntologyBinding[];
+  readonly profiles: readonly TProfile[];
+}

--- a/packages/shared/ontology/rallar-ontology-identity-validation.ts
+++ b/packages/shared/ontology/rallar-ontology-identity-validation.ts
@@ -1,0 +1,184 @@
+import type { RallarOntologyVersionIri } from './rallar-ontology-contracts.ts';
+import type { RallarOntologyIssue } from './rallar-ontology-registry-contracts.ts';
+
+const ONTOLOGY_BASE = 'https://github.com/intact-software-systems/ar-eye-hunter/ontology/';
+const canonicalVersionPattern = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+const identitySegmentPattern = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/u;
+const ontologySeriesPattern = /^(?:domain|realtime|code-standards)$/u;
+const repositoryTargetRoots = new Set(
+  (
+    '.agents .codex-plugin .github .run .superpowers .vscode apps docs examples packages plans ' +
+    'playground projects scripts tests .gitignore .prettierignore .prettierrc.json AGENTS.md ' +
+    'README.md deno.json deno.lock docker-compose.yml no-js-files-outside-dist.sh ' +
+    'package-lock.json package.json tsconfig.json vitest.config.ts'
+  ).split(' '),
+);
+const skosRelationIds = new Set([
+  'http://www.w3.org/2004/02/skos/core#broader',
+  'http://www.w3.org/2004/02/skos/core#narrower',
+  'http://www.w3.org/2004/02/skos/core#related',
+]);
+
+export function compareRallarOntologyText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function sortRallarOntologyIssues(
+  issues: readonly RallarOntologyIssue[],
+): readonly RallarOntologyIssue[] {
+  return [...issues].sort(
+    (left, right) =>
+      compareRallarOntologyText(left.path, right.path) ||
+      compareRallarOntologyText(left.code, right.code) ||
+      compareRallarOntologyText(left.message, right.message),
+  );
+}
+
+export function createRallarOntologyIssue(
+  code: RallarOntologyIssue['code'],
+  path: string,
+  message: string,
+): RallarOntologyIssue {
+  return { code, path, message };
+}
+
+export function isCanonicalRallarOntologyVersion(value: string): boolean {
+  return canonicalVersionPattern.test(value);
+}
+
+export function isValidRallarOntologyId(value: string): boolean {
+  if (!value.startsWith(ONTOLOGY_BASE)) {
+    return false;
+  }
+  const suffix = value.slice(ONTOLOGY_BASE.length);
+  if (ontologySeriesPattern.test(suffix)) {
+    return true;
+  }
+  const segments = suffix.split('/');
+  return (
+    segments.length === 3 &&
+    segments[0] === 'extension' &&
+    isIdentitySegment(segments[1]) &&
+    isIdentitySegment(segments[2])
+  );
+}
+
+export function isValidRallarOntologyOwnerId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'owner');
+}
+
+export function isValidRallarOntologyTermId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'term');
+}
+
+export function isValidRallarOntologyBindingSetId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'binding-set');
+}
+
+export function isValidRallarOntologyBindingId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'binding');
+}
+
+export function isValidRallarOntologyBindingProfileId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'binding-profile');
+}
+
+export function isValidRallarOntologyRelationId(value: string): boolean {
+  return isValidGovernedIdentity(value, 'relation') || skosRelationIds.has(value);
+}
+
+export function isVersionIriForSeries(value: string, seriesId: string): boolean {
+  const prefix = `${seriesId}/version/`;
+  return value.startsWith(prefix) && isCanonicalRallarOntologyVersion(value.slice(prefix.length));
+}
+
+export function validateCompatibleVersionIris(input: {
+  readonly seriesId: string;
+  readonly version: string;
+  readonly values: readonly RallarOntologyVersionIri[];
+  readonly path: string;
+}): readonly RallarOntologyIssue[] {
+  const issues: RallarOntologyIssue[] = [];
+  const seen = new Set<string>();
+  input.values.forEach((value, index) => {
+    const valid =
+      isVersionIriForSeries(value, input.seriesId) &&
+      compareVersions(versionFromIri(value), input.version) < 0 &&
+      !seen.has(value);
+    if (!valid) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-compatible-version-iri',
+          `${input.path}[${index}]`,
+          `Compatibility IRI must be a unique prior canonical version of ${input.seriesId}.`,
+        ),
+      );
+    }
+    seen.add(value);
+  });
+  return issues;
+}
+
+export function isRepositoryRelativeOntologyTarget(value: string): boolean {
+  if (value.length === 0 || value.startsWith('/') || value.startsWith('@')) {
+    return false;
+  }
+  if (value.includes('\\') || value.includes('://') || value.includes('%')) {
+    return false;
+  }
+  const segments = value.split('/');
+  return (
+    repositoryTargetRoots.has(segments[0]) &&
+    segments.every(
+      (segment) =>
+        segment.length > 0 &&
+        segment !== '.' &&
+        segment !== '..' &&
+        segment !== '__proto__' &&
+        segment !== 'prototype' &&
+        segment !== 'constructor' &&
+        /^[A-Za-z0-9._-]+$/u.test(segment),
+    )
+  );
+}
+
+export function isSafeOntologyPropertySegment(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value !== '__proto__' &&
+    value !== 'prototype' &&
+    value !== 'constructor' &&
+    /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(value)
+  );
+}
+
+function isValidGovernedIdentity(value: string, family: string): boolean {
+  const prefix = `${ONTOLOGY_BASE}${family}/`;
+  if (!value.startsWith(prefix)) {
+    return false;
+  }
+  const suffix = value.slice(prefix.length);
+  return !suffix.includes('/') && isIdentitySegment(suffix);
+}
+
+function isIdentitySegment(value: string | undefined): boolean {
+  return value !== undefined && identitySegmentPattern.test(value) && !value.includes('..');
+}
+
+function versionFromIri(value: string): string {
+  return value.slice(value.lastIndexOf('/') + 1);
+}
+
+function compareVersions(left: string, right: string): number {
+  if (!isCanonicalRallarOntologyVersion(left) || !isCanonicalRallarOntologyVersion(right)) {
+    return 0;
+  }
+  const leftParts = left.split('.').map(BigInt);
+  const rightParts = right.split('.').map(BigInt);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] < rightParts[index] ? -1 : 1;
+    }
+  }
+  return 0;
+}

--- a/packages/shared/ontology/rallar-ontology-registry-contracts.ts
+++ b/packages/shared/ontology/rallar-ontology-registry-contracts.ts
@@ -1,0 +1,47 @@
+import type {
+  RallarOntologyBinding,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingProfileBase,
+  RallarOntologyTermBase,
+  RallarOntologyVocabularyModule,
+} from './rallar-ontology-contracts.ts';
+
+export interface RallarOntologyIssue {
+  readonly code:
+    | 'invalid-ontology-iri'
+    | 'invalid-version'
+    | 'invalid-version-iri'
+    | 'invalid-term-iri'
+    | 'invalid-owner-iri'
+    | 'invalid-relation-iri'
+    | 'duplicate-ontology-id'
+    | 'duplicate-version-iri'
+    | 'duplicate-term-id'
+    | 'duplicate-binding-set-id'
+    | 'duplicate-binding-id'
+    | 'duplicate-binding-profile-id'
+    | 'invalid-maturity'
+    | 'invalid-compatible-version-iri'
+    | 'invalid-binding-target'
+    | 'invalid-binding-strength'
+    | 'missing-vocabulary-import'
+    | 'binding-vocabulary-version-mismatch'
+    | 'missing-reference'
+    | 'missing-binding-term'
+    | 'invalid-deprecation';
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface CreateRallarOntologyCatalogInput {
+  readonly vocabularies: readonly RallarOntologyVocabularyModule[];
+  readonly bindingSets: readonly RallarOntologyBindingModule[];
+}
+
+export interface RallarOntologyCatalog {
+  readonly vocabularies: readonly RallarOntologyVocabularyModule[];
+  readonly bindingSets: readonly RallarOntologyBindingModule[];
+  readonly terms: readonly RallarOntologyTermBase[];
+  readonly bindings: readonly RallarOntologyBinding[];
+  readonly bindingProfiles: readonly RallarOntologyBindingProfileBase[];
+}

--- a/packages/shared/ontology/rallar-ontology-registry.ts
+++ b/packages/shared/ontology/rallar-ontology-registry.ts
@@ -1,0 +1,182 @@
+import type {
+  RallarOntologyBinding,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingProfileBase,
+  RallarOntologyTermBase,
+  RallarOntologyTermId,
+  RallarOntologyVocabularyModule,
+} from './rallar-ontology-contracts.ts';
+import type { RallarDomainOntologyTerm } from './rallar-domain-ontology-term.ts';
+import { compareRallarOntologyText } from './rallar-ontology-identity-validation.ts';
+import type {
+  CreateRallarOntologyCatalogInput,
+  RallarOntologyCatalog,
+} from './rallar-ontology-registry-contracts.ts';
+import type {
+  RallarMessageOntologyTerm,
+  RallarPayloadValidationSemantics,
+  RallarRtcLaneOntologyTerm,
+} from './rallar-realtime-ontology-contracts.ts';
+import { validateRallarOntologyCatalog } from './validate-rallar-ontology-catalog.ts';
+
+export function createRallarOntologyCatalog(
+  input: CreateRallarOntologyCatalogInput,
+): RallarOntologyCatalog {
+  const issues = validateRallarOntologyCatalog(input);
+  if (issues.length > 0) {
+    const details = issues
+      .map((issue) => `${issue.path} [${issue.code}]: ${issue.message}`)
+      .join('\n');
+    throw new TypeError(`Invalid Rallar ontology catalog:\n${details}`);
+  }
+
+  const vocabularies = [...input.vocabularies]
+    .map(copyVocabulary)
+    .sort((left, right) => compareRallarOntologyText(left.ontologyId, right.ontologyId));
+  const bindingSets = [...input.bindingSets]
+    .map(copyBindingModule)
+    .sort((left, right) => compareRallarOntologyText(left.bindingSetId, right.bindingSetId));
+  const terms = vocabularies
+    .flatMap((vocabulary) => vocabulary.terms)
+    .sort((left, right) => compareRallarOntologyText(left.termId, right.termId));
+  const bindings = bindingSets
+    .flatMap((bindingSet) => bindingSet.bindings)
+    .sort((left, right) => compareRallarOntologyText(left.bindingId, right.bindingId));
+  const bindingProfiles = bindingSets
+    .flatMap((bindingSet) => bindingSet.profiles)
+    .sort((left, right) => compareRallarOntologyText(left.profileId, right.profileId));
+
+  return { vocabularies, bindingSets, terms, bindings, bindingProfiles };
+}
+
+export function getRallarOntologyTerm(
+  catalog: RallarOntologyCatalog,
+  termId: RallarOntologyTermId,
+): RallarOntologyTermBase | undefined {
+  return catalog.terms.find((term) => term.termId === termId);
+}
+
+export function getRallarOntologyBindings(
+  catalog: RallarOntologyCatalog,
+  termId: RallarOntologyTermId,
+): readonly RallarOntologyBinding[] {
+  return catalog.bindings.filter((binding) => binding.termId === termId);
+}
+
+export function getRallarOntologyBindingProfiles(
+  catalog: RallarOntologyCatalog,
+  termId: RallarOntologyTermId,
+): readonly RallarOntologyBindingProfileBase[] {
+  return catalog.bindingProfiles.filter((profile) => profile.termId === termId);
+}
+
+function copyVocabulary(
+  vocabulary: RallarOntologyVocabularyModule,
+): RallarOntologyVocabularyModule {
+  return {
+    ...vocabulary,
+    compatibleWith: [...vocabulary.compatibleWith].sort(compareRallarOntologyText),
+    requiredVocabularyVersionIris: [...vocabulary.requiredVocabularyVersionIris].sort(
+      compareRallarOntologyText,
+    ),
+    competencyQuestionIds: [...vocabulary.competencyQuestionIds].sort(compareRallarOntologyText),
+    terms: [...vocabulary.terms]
+      .map(copyTerm)
+      .sort((left, right) => compareRallarOntologyText(left.termId, right.termId)),
+  };
+}
+
+function copyTerm(term: RallarOntologyTermBase): RallarOntologyTermBase {
+  const references = [...term.references]
+    .map((reference) => ({ ...reference }))
+    .sort(
+      (left, right) =>
+        compareRallarOntologyText(left.relationId, right.relationId) ||
+        compareRallarOntologyText(left.targetTermId, right.targetTermId),
+    );
+  if (isDomainTerm(term)) {
+    const copy: RallarDomainOntologyTerm = {
+      ...term,
+      references,
+      identityFields: [...term.identityFields],
+    };
+    return copy;
+  }
+  if (isMessageTerm(term)) {
+    const copy: RallarMessageOntologyTerm = {
+      ...term,
+      references,
+      routes: term.routes.map((route) => ({
+        ...route,
+        transports: [...route.transports],
+        targetModes: [...route.targetModes],
+      })),
+      senderKinds: [...term.senderKinds],
+      validation: copyPayloadValidation(term.validation),
+    };
+    return copy;
+  }
+  if (isRtcLaneTerm(term)) {
+    const copy: RallarRtcLaneOntologyTerm = {
+      ...term,
+      references,
+      payloadKinds: [...term.payloadKinds],
+    };
+    return copy;
+  }
+  return { ...term, references };
+}
+
+function copyBindingModule(bindingSet: RallarOntologyBindingModule): RallarOntologyBindingModule {
+  return {
+    ...bindingSet,
+    compatibleWith: [...bindingSet.compatibleWith].sort(compareRallarOntologyText),
+    bindings: [...bindingSet.bindings]
+      .map(copyBinding)
+      .sort((left, right) => compareRallarOntologyText(left.bindingId, right.bindingId)),
+    profiles: [...bindingSet.profiles]
+      .map(copyBindingProfile)
+      .sort((left, right) => compareRallarOntologyText(left.profileId, right.profileId)),
+  };
+}
+
+function copyBindingProfile(
+  profile: RallarOntologyBindingProfileBase,
+): RallarOntologyBindingProfileBase {
+  return structuredClone(profile);
+}
+
+function copyPayloadValidation(
+  validation: RallarPayloadValidationSemantics,
+): RallarPayloadValidationSemantics {
+  if (validation.kind !== 'runtime-payload') {
+    return { ...validation };
+  }
+  return { ...validation, schemaVersion: { ...validation.schemaVersion } };
+}
+
+function isDomainTerm(term: RallarOntologyTermBase): term is RallarDomainOntologyTerm {
+  return term.kind === 'domain';
+}
+
+function isMessageTerm(term: RallarOntologyTermBase): term is RallarMessageOntologyTerm {
+  return term.kind === 'message-type';
+}
+
+function isRtcLaneTerm(term: RallarOntologyTermBase): term is RallarRtcLaneOntologyTerm {
+  return term.kind === 'rtc-lane';
+}
+
+function copyBinding(binding: RallarOntologyBinding): RallarOntologyBinding {
+  if (binding.target.kind === 'wire-constant') {
+    return {
+      ...binding,
+      target: {
+        ...binding.target,
+        propertyPath:
+          binding.target.propertyPath === undefined ? undefined : [...binding.target.propertyPath],
+      },
+    };
+  }
+  return { ...binding, target: { ...binding.target } };
+}

--- a/packages/shared/ontology/rallar-realtime-ontology-contracts.ts
+++ b/packages/shared/ontology/rallar-realtime-ontology-contracts.ts
@@ -1,0 +1,99 @@
+import type {
+  RallarOntologyBindingId,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingProfileBase,
+  RallarOntologyTermBase,
+} from './rallar-ontology-contracts.ts';
+
+export type RallarMessageTransportKind = 'al-rtc' | 'al-ws';
+export type RallarMessageTargetMode = 'unicast' | 'multicast' | 'broadcast';
+export type RallarMessageRouteId =
+  `https://github.com/intact-software-systems/ar-eye-hunter/ontology/route/${string}`;
+export type RallarSenderKind = 'client-session' | 'peer-session' | 'server-node' | 'system';
+
+export interface RallarMessageRouteSemantics {
+  readonly routeId: RallarMessageRouteId;
+  readonly topicId: string;
+  readonly scope: 'room' | 'app' | 'world' | 'all' | 'system';
+  readonly transports: readonly RallarMessageTransportKind[];
+  readonly targetModes: readonly RallarMessageTargetMode[];
+  readonly requestedReliability: 'best-effort' | 'at-least-once';
+  readonly acknowledgement: 'none' | 'receiver' | 'all-logical-recipients' | 'group-leader';
+  readonly ordering: 'none' | 'al-policy' | 'al-policy-and-domain';
+  readonly deduplication: 'none' | 'al-message-id' | 'al-semantic-key' | 'domain-owned';
+  readonly supersedence: 'none' | 'al-latest-wins' | 'domain-owned';
+  readonly qosOwnership: 'sender' | 'receiver' | 'shared' | 'domain-owned';
+  readonly authorization: 'required' | 'not-applicable';
+}
+
+export type RallarPayloadSchemaVersionSemantics =
+  | Readonly<{ kind: 'wire-type-id' }>
+  | Readonly<{ kind: 'payload-field'; fieldPath: string }>
+  | Readonly<{ kind: 'external-registry'; registryId: string }>;
+
+export type RallarPayloadValidationSemantics =
+  | Readonly<{ kind: 'runtime-payload'; schemaVersion: RallarPayloadSchemaVersionSemantics }>
+  | Readonly<{ kind: 'envelope-only'; reason: string }>
+  | Readonly<{
+      kind: 'unvalidated';
+      mechanism: 'generic-assertion' | 'unknown-payload';
+      reason: string;
+    }>;
+
+export interface RallarMessageOntologyTerm extends RallarOntologyTermBase {
+  readonly kind: 'message-type';
+  readonly wireTypeId: string;
+  readonly routes: readonly RallarMessageRouteSemantics[];
+  readonly senderKinds: readonly RallarSenderKind[];
+  readonly validation: RallarPayloadValidationSemantics;
+  readonly correlation: 'message-id' | 'actions-correlation' | 'domain-owned';
+}
+
+export interface RallarRtcLaneOntologyTerm extends RallarOntologyTermBase {
+  readonly kind: 'rtc-lane';
+  readonly laneId: string;
+  readonly envelope: 'none';
+  readonly payloadKinds: readonly ('json' | 'binary')[];
+  readonly roomScopeCarrier: 'payload-room-ref-or-unique-lane';
+}
+
+export type RallarPayloadValidationBinding =
+  | Readonly<{
+      kind: 'runtime-payload';
+      schemaBindingId: RallarOntologyBindingId;
+      schemaVersionContractBindingId: RallarOntologyBindingId;
+      validatorBindingId: RallarOntologyBindingId;
+    }>
+  | Readonly<{
+      kind: 'envelope-only';
+      envelopeValidatorBindingId: RallarOntologyBindingId;
+      payloadGapOwnerBindingId: RallarOntologyBindingId;
+    }>
+  | Readonly<{
+      kind: 'unvalidated';
+      boundaryBindingId: RallarOntologyBindingId;
+      gapOwnerBindingId: RallarOntologyBindingId;
+    }>;
+
+export interface RallarMessageOntologyBindingProfile extends RallarOntologyBindingProfileBase {
+  readonly kind: 'message-bindings';
+  readonly wireTypeBindingId: RallarOntologyBindingId;
+  readonly routeBindings: readonly Readonly<{
+    routeId: RallarMessageRouteId;
+    topicBindingId: RallarOntologyBindingId;
+    authorizationBindings: readonly Readonly<{
+      transport: RallarMessageTransportKind;
+      ownerBindingIds: readonly RallarOntologyBindingId[];
+    }>[];
+  }>[];
+  readonly validation: RallarPayloadValidationBinding;
+}
+
+export interface RallarRtcLaneOntologyBindingProfile extends RallarOntologyBindingProfileBase {
+  readonly kind: 'rtc-lane-bindings';
+  readonly laneConfigBindingId: RallarOntologyBindingId;
+}
+
+export type RallarRealtimeOntologyBindingModule = RallarOntologyBindingModule<
+  RallarMessageOntologyBindingProfile | RallarRtcLaneOntologyBindingProfile
+>;

--- a/packages/shared/ontology/validate-rallar-ontology-binding-module.ts
+++ b/packages/shared/ontology/validate-rallar-ontology-binding-module.ts
@@ -1,0 +1,291 @@
+import type {
+  RallarOntologyBinding,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingTarget,
+} from './rallar-ontology-contracts.ts';
+import {
+  createRallarOntologyIssue,
+  isCanonicalRallarOntologyVersion,
+  isRepositoryRelativeOntologyTarget,
+  isSafeOntologyPropertySegment,
+  isValidRallarOntologyBindingId,
+  isValidRallarOntologyBindingProfileId,
+  isValidRallarOntologyBindingSetId,
+  isValidRallarOntologyId,
+  isValidRallarOntologyOwnerId,
+  isValidRallarOntologyTermId,
+  isVersionIriForSeries,
+  sortRallarOntologyIssues,
+  validateCompatibleVersionIris,
+} from './rallar-ontology-identity-validation.ts';
+import type { RallarOntologyIssue } from './rallar-ontology-registry-contracts.ts';
+
+const bindingStrengths = new Set(['contractual', 'owner', 'implementation', 'example']);
+
+interface AddInvalidIdentityInput {
+  readonly invalid: boolean;
+  readonly path: string;
+  readonly message: string;
+  readonly issues: RallarOntologyIssue[];
+}
+
+export function validateRallarOntologyBindingModule(
+  bindingSet: RallarOntologyBindingModule,
+): readonly RallarOntologyIssue[] {
+  const issues: RallarOntologyIssue[] = [];
+  validateBindingModuleIdentity(bindingSet, issues);
+  validateBindingModuleMetadata(bindingSet, issues);
+  validateBindings(bindingSet, issues);
+  validateProfiles(bindingSet, issues);
+  return sortRallarOntologyIssues(issues);
+}
+
+function validateBindingModuleIdentity(
+  bindingSet: RallarOntologyBindingModule,
+  issues: RallarOntologyIssue[],
+): void {
+  addInvalidIdentity({
+    invalid: !isValidRallarOntologyBindingSetId(bindingSet.bindingSetId),
+    path: 'bindingSet.bindingSetId',
+    message: 'Binding-set ID must be a literal governed binding-set IRI.',
+    issues,
+  });
+  addInvalidIdentity({
+    invalid: !isValidRallarOntologyId(bindingSet.ontologyId),
+    path: 'bindingSet.ontologyId',
+    message: 'Ontology ID must be a literal governed ontology series IRI.',
+    issues,
+  });
+  if (!isVersionIriForSeries(bindingSet.vocabularyVersionIri, bindingSet.ontologyId)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-version-iri',
+        'bindingSet.vocabularyVersionIri',
+        'Vocabulary version IRI must belong to the declared ontology series.',
+      ),
+    );
+  }
+  if (!isValidRallarOntologyOwnerId(bindingSet.ownerId)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-owner-iri',
+        'bindingSet.ownerId',
+        'Owner ID must be a literal governed owner IRI.',
+      ),
+    );
+  }
+  if (!isCanonicalRallarOntologyVersion(bindingSet.version)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-version',
+        'bindingSet.version',
+        'Version must be a canonical numeric major.minor.patch value.',
+      ),
+    );
+  }
+  if (bindingSet.versionIri !== `${bindingSet.bindingSetId}/version/${bindingSet.version}`) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-version-iri',
+        'bindingSet.versionIri',
+        'Version IRI must exactly combine bindingSetId and version.',
+      ),
+    );
+  }
+}
+
+function validateBindingModuleMetadata(
+  bindingSet: RallarOntologyBindingModule,
+  issues: RallarOntologyIssue[],
+): void {
+  if (bindingSet.maturity !== 'experimental' && bindingSet.maturity !== 'stable') {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-maturity',
+        'bindingSet.maturity',
+        'Maturity must be experimental or stable.',
+      ),
+    );
+  }
+  issues.push(
+    ...validateCompatibleVersionIris({
+      seriesId: bindingSet.bindingSetId,
+      version: bindingSet.version,
+      values: bindingSet.compatibleWith,
+      path: 'bindingSet.compatibleWith',
+    }),
+  );
+}
+
+function validateBindings(
+  bindingSet: RallarOntologyBindingModule,
+  issues: RallarOntologyIssue[],
+): void {
+  const bindingIds = new Set<string>();
+  bindingSet.bindings.forEach((binding, bindingIndex) => {
+    const path = `bindingSet.bindings[${bindingIndex}]`;
+    addInvalidIdentity({
+      invalid: !isValidRallarOntologyBindingId(binding.bindingId),
+      path: `${path}.bindingId`,
+      message: 'Binding ID must be a literal governed binding IRI.',
+      issues,
+    });
+    if (bindingIds.has(binding.bindingId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'duplicate-binding-id',
+          `${path}.bindingId`,
+          'Binding IDs must be unique.',
+        ),
+      );
+    }
+    bindingIds.add(binding.bindingId);
+    validateBindingTermAndStrength(binding, path, issues);
+    validateBindingTarget(binding.target, `${path}.target`, issues);
+  });
+}
+
+function validateBindingTermAndStrength(
+  binding: RallarOntologyBinding,
+  path: string,
+  issues: RallarOntologyIssue[],
+): void {
+  if (!isValidRallarOntologyTermId(binding.termId)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-term-iri',
+        `${path}.termId`,
+        'Binding term must be a literal governed term IRI.',
+      ),
+    );
+  }
+  if (!bindingStrengths.has(binding.strength)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-binding-strength',
+        `${path}.strength`,
+        'Binding strength must be contractual, owner, implementation, or example.',
+      ),
+    );
+  }
+}
+
+function validateProfiles(
+  bindingSet: RallarOntologyBindingModule,
+  issues: RallarOntologyIssue[],
+): void {
+  const profileIds = new Set<string>();
+  bindingSet.profiles.forEach((profile, profileIndex) => {
+    const path = `bindingSet.profiles[${profileIndex}]`;
+    addInvalidIdentity({
+      invalid: !isValidRallarOntologyBindingProfileId(profile.profileId),
+      path: `${path}.profileId`,
+      message: 'Profile ID must be a literal governed binding-profile IRI.',
+      issues,
+    });
+    if (profileIds.has(profile.profileId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'duplicate-binding-profile-id',
+          `${path}.profileId`,
+          'Binding profile IDs must be unique.',
+        ),
+      );
+    }
+    profileIds.add(profile.profileId);
+    if (!isValidRallarOntologyTermId(profile.termId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-term-iri',
+          `${path}.termId`,
+          'Profile term must be a literal governed term IRI.',
+        ),
+      );
+    }
+  });
+}
+
+function validateBindingTarget(
+  target: RallarOntologyBindingTarget,
+  path: string,
+  issues: RallarOntologyIssue[],
+): void {
+  switch (target.kind) {
+    case 'typescript-export':
+      validateTargetPath(target.modulePath, `${path}.modulePath`, issues);
+      validateTargetName(target.exportName, `${path}.exportName`, issues);
+      break;
+    case 'wire-constant':
+      validateTargetPath(target.modulePath, `${path}.modulePath`, issues);
+      validateTargetName(target.exportName, `${path}.exportName`, issues);
+      target.propertyPath?.forEach((segment, index) =>
+        validatePropertySegment(segment, `${path}.propertyPath[${index}]`, issues),
+      );
+      break;
+    case 'openapi-component':
+      validateTargetPath(target.documentPath, `${path}.documentPath`, issues);
+      validateTargetName(target.componentName, `${path}.componentName`, issues);
+      break;
+    case 'runtime-validator':
+      validateTargetPath(target.modulePath, `${path}.modulePath`, issues);
+      validateTargetName(target.exportName, `${path}.exportName`, issues);
+      validateTargetName(target.validatorId, `${path}.validatorId`, issues);
+      break;
+    case 'normative-anchor':
+      validateTargetPath(target.documentPath, `${path}.documentPath`, issues);
+      validateTargetName(target.anchor, `${path}.anchor`, issues);
+      break;
+    case 'export-property':
+      validateTargetPath(target.modulePath, `${path}.modulePath`, issues);
+      validateTargetName(target.exportName, `${path}.exportName`, issues);
+      validatePropertySegment(target.propertyName, `${path}.propertyName`, issues);
+      break;
+    case 'package-script':
+      validateTargetPath(target.manifestPath, `${path}.manifestPath`, issues);
+      validateTargetName(target.scriptName, `${path}.scriptName`, issues);
+      break;
+    case 'repository-owner':
+      if (!isValidRallarOntologyOwnerId(target.ownerId)) {
+        addTargetIssue(`${path}.ownerId`, 'Repository owner must be a governed owner IRI.', issues);
+      }
+      validateTargetPath(target.path, `${path}.path`, issues);
+      break;
+    case 'implementation-symbol':
+      validateTargetPath(target.path, `${path}.path`, issues);
+      validateTargetName(target.symbol, `${path}.symbol`, issues);
+      break;
+    case 'example':
+      validateTargetPath(target.path, `${path}.path`, issues);
+      break;
+    default:
+      addTargetIssue(`${path}.kind`, 'Binding target kind is not supported.', issues);
+  }
+}
+
+function validateTargetPath(value: string, path: string, issues: RallarOntologyIssue[]): void {
+  if (!isRepositoryRelativeOntologyTarget(value)) {
+    addTargetIssue(path, 'Target path must be safe and repository-relative.', issues);
+  }
+}
+
+function validateTargetName(value: string, path: string, issues: RallarOntologyIssue[]): void {
+  if (value.trim().length === 0) {
+    addTargetIssue(path, 'Target name must be non-empty.', issues);
+  }
+}
+
+function validatePropertySegment(value: string, path: string, issues: RallarOntologyIssue[]): void {
+  if (!isSafeOntologyPropertySegment(value)) {
+    addTargetIssue(path, 'Property segment must be a safe non-empty identifier.', issues);
+  }
+}
+
+function addInvalidIdentity(input: AddInvalidIdentityInput): void {
+  if (input.invalid) {
+    input.issues.push(createRallarOntologyIssue('invalid-ontology-iri', input.path, input.message));
+  }
+}
+
+function addTargetIssue(path: string, message: string, issues: RallarOntologyIssue[]): void {
+  issues.push(createRallarOntologyIssue('invalid-binding-target', path, message));
+}

--- a/packages/shared/ontology/validate-rallar-ontology-catalog.ts
+++ b/packages/shared/ontology/validate-rallar-ontology-catalog.ts
@@ -1,0 +1,351 @@
+import type {
+  RallarOntologyBindingModule,
+  RallarOntologyTermBase,
+  RallarOntologyVersionIri,
+  RallarOntologyVocabularyModule,
+} from './rallar-ontology-contracts.ts';
+import {
+  createRallarOntologyIssue,
+  sortRallarOntologyIssues,
+} from './rallar-ontology-identity-validation.ts';
+import type {
+  CreateRallarOntologyCatalogInput,
+  RallarOntologyIssue,
+} from './rallar-ontology-registry-contracts.ts';
+import { validateRallarOntologyBindingModule } from './validate-rallar-ontology-binding-module.ts';
+import * as vocabularyValidation from './validate-rallar-ontology-vocabulary-module.ts';
+
+interface OwnedTerm {
+  readonly term: RallarOntologyTermBase;
+  readonly vocabulary: RallarOntologyVocabularyModule;
+}
+
+interface AddDuplicateIssueInput {
+  readonly seen: Set<string>;
+  readonly value: string;
+  readonly code: RallarOntologyIssue['code'];
+  readonly path: string;
+  readonly issues: RallarOntologyIssue[];
+}
+
+interface ValidateDeclaredDependenciesInput {
+  readonly source: RallarOntologyVocabularyModule;
+  readonly sourceIndex: number;
+  readonly vocabularies: readonly RallarOntologyVocabularyModule[];
+  readonly issues: RallarOntologyIssue[];
+}
+
+interface ValidateTermReferenceInput {
+  readonly source: RallarOntologyVocabularyModule;
+  readonly targetTermId: string;
+  readonly path: string;
+  readonly termsById: ReadonlyMap<string, OwnedTerm>;
+  readonly issues: RallarOntologyIssue[];
+}
+
+interface AddMissingBindingTermInput {
+  readonly ownedTermIds: ReadonlySet<string>;
+  readonly termId: string;
+  readonly path: string;
+  readonly issues: RallarOntologyIssue[];
+}
+
+export function validateRallarOntologyCatalog(
+  input: CreateRallarOntologyCatalogInput,
+): readonly RallarOntologyIssue[] {
+  const issues: RallarOntologyIssue[] = [];
+  collectStandaloneIssues(input, issues);
+  validateCatalogIdentities(input, issues);
+  const termsById = toTermsById(input.vocabularies);
+  validateVocabularyDependenciesAndReferences(input.vocabularies, termsById, issues);
+  validateBindingVocabularyOwnership(input, issues);
+  return sortRallarOntologyIssues(issues);
+}
+
+function collectStandaloneIssues(
+  input: CreateRallarOntologyCatalogInput,
+  issues: RallarOntologyIssue[],
+): void {
+  input.vocabularies.forEach((vocabulary, index) => {
+    const prefix = `catalog.vocabularies[${index}]`;
+    issues.push(
+      ...vocabularyValidation.validateRallarOntologyVocabularyModule(vocabulary).map((issue) => ({
+        ...issue,
+        path: issue.path.replace(/^vocabulary/u, prefix),
+      })),
+    );
+  });
+  input.bindingSets.forEach((bindingSet, index) => {
+    const prefix = `catalog.bindingSets[${index}]`;
+    issues.push(
+      ...validateRallarOntologyBindingModule(bindingSet).map((issue) => ({
+        ...issue,
+        path: issue.path.replace(/^bindingSet/u, prefix),
+      })),
+    );
+  });
+}
+
+function validateCatalogIdentities(
+  input: CreateRallarOntologyCatalogInput,
+  issues: RallarOntologyIssue[],
+): void {
+  addVocabularyDuplicateIssues(input.vocabularies, issues);
+  addBindingDuplicateIssues(input.bindingSets, issues);
+}
+
+function addVocabularyDuplicateIssues(
+  vocabularies: readonly RallarOntologyVocabularyModule[],
+  issues: RallarOntologyIssue[],
+): void {
+  const ontologyIds = new Set<string>();
+  const versionIris = new Set<string>();
+  const termIds = new Set<string>();
+  vocabularies.forEach((vocabulary, vocabularyIndex) => {
+    addDuplicateIssue({
+      seen: ontologyIds,
+      value: vocabulary.ontologyId,
+      code: 'duplicate-ontology-id',
+      path: `catalog.vocabularies[${vocabularyIndex}].ontologyId`,
+      issues,
+    });
+    addDuplicateIssue({
+      seen: versionIris,
+      value: vocabulary.versionIri,
+      code: 'duplicate-version-iri',
+      path: `catalog.vocabularies[${vocabularyIndex}].versionIri`,
+      issues,
+    });
+    vocabulary.terms.forEach((term, termIndex) =>
+      addDuplicateIssue({
+        seen: termIds,
+        value: term.termId,
+        code: 'duplicate-term-id',
+        path: `catalog.vocabularies[${vocabularyIndex}].terms[${termIndex}].termId`,
+        issues,
+      }),
+    );
+  });
+}
+
+function addBindingDuplicateIssues(
+  bindingSets: readonly RallarOntologyBindingModule[],
+  issues: RallarOntologyIssue[],
+): void {
+  const bindingSetIds = new Set<string>();
+  const bindingIds = new Set<string>();
+  const profileIds = new Set<string>();
+  bindingSets.forEach((bindingSet, bindingSetIndex) => {
+    addDuplicateIssue({
+      seen: bindingSetIds,
+      value: bindingSet.bindingSetId,
+      code: 'duplicate-binding-set-id',
+      path: `catalog.bindingSets[${bindingSetIndex}].bindingSetId`,
+      issues,
+    });
+    bindingSet.bindings.forEach((binding, bindingIndex) =>
+      addDuplicateIssue({
+        seen: bindingIds,
+        value: binding.bindingId,
+        code: 'duplicate-binding-id',
+        path: `catalog.bindingSets[${bindingSetIndex}].bindings[${bindingIndex}].bindingId`,
+        issues,
+      }),
+    );
+    bindingSet.profiles.forEach((profile, profileIndex) =>
+      addDuplicateIssue({
+        seen: profileIds,
+        value: profile.profileId,
+        code: 'duplicate-binding-profile-id',
+        path: `catalog.bindingSets[${bindingSetIndex}].profiles[${profileIndex}].profileId`,
+        issues,
+      }),
+    );
+  });
+}
+
+function addDuplicateIssue(input: AddDuplicateIssueInput): void {
+  if (input.seen.has(input.value)) {
+    input.issues.push(
+      createRallarOntologyIssue(
+        input.code,
+        input.path,
+        `${input.value} is selected more than once.`,
+      ),
+    );
+  }
+  input.seen.add(input.value);
+}
+
+function toTermsById(
+  vocabularies: readonly RallarOntologyVocabularyModule[],
+): ReadonlyMap<string, OwnedTerm> {
+  const termsById = new Map<string, OwnedTerm>();
+  vocabularies.forEach((vocabulary) =>
+    vocabulary.terms.forEach((term) => {
+      if (!termsById.has(term.termId)) {
+        termsById.set(term.termId, { term, vocabulary });
+      }
+    }),
+  );
+  return termsById;
+}
+
+function validateVocabularyDependenciesAndReferences(
+  vocabularies: readonly RallarOntologyVocabularyModule[],
+  termsById: ReadonlyMap<string, OwnedTerm>,
+  issues: RallarOntologyIssue[],
+): void {
+  vocabularies.forEach((vocabulary, vocabularyIndex) => {
+    validateDeclaredDependencies({
+      source: vocabulary,
+      sourceIndex: vocabularyIndex,
+      vocabularies,
+      issues,
+    });
+    vocabulary.terms.forEach((term, termIndex) => {
+      const termPath = `catalog.vocabularies[${vocabularyIndex}].terms[${termIndex}]`;
+      term.references.forEach((reference, referenceIndex) =>
+        validateTermReference({
+          source: vocabulary,
+          targetTermId: reference.targetTermId,
+          path: `${termPath}.references[${referenceIndex}].targetTermId`,
+          termsById,
+          issues,
+        }),
+      );
+      if (term.supersededBy !== undefined && term.supersededBy !== term.termId) {
+        validateTermReference({
+          source: vocabulary,
+          targetTermId: term.supersededBy,
+          path: `${termPath}.supersededBy`,
+          termsById,
+          issues,
+        });
+      }
+    });
+  });
+}
+
+function validateDeclaredDependencies(input: ValidateDeclaredDependenciesInput): void {
+  input.source.requiredVocabularyVersionIris.forEach((requiredVersionIri, requirementIndex) => {
+    const seriesId = seriesFromVersionIri(requiredVersionIri);
+    const selected = input.vocabularies.find((candidate) => candidate.ontologyId === seriesId);
+    if (selected === undefined || !vocabularySatisfies(selected, requiredVersionIri)) {
+      const requirementPath =
+        `catalog.vocabularies[${input.sourceIndex}]` +
+        `.requiredVocabularyVersionIris[${requirementIndex}]`;
+      input.issues.push(
+        createRallarOntologyIssue(
+          'missing-vocabulary-import',
+          requirementPath,
+          `No selected vocabulary satisfies ${requiredVersionIri}.`,
+        ),
+      );
+    }
+  });
+}
+
+function validateTermReference(input: ValidateTermReferenceInput): void {
+  const ownedTarget = input.termsById.get(input.targetTermId);
+  if (ownedTarget === undefined) {
+    input.issues.push(
+      createRallarOntologyIssue(
+        'missing-reference',
+        input.path,
+        `Referenced term ${input.targetTermId} is not selected.`,
+      ),
+    );
+    return;
+  }
+  if (
+    ownedTarget.vocabulary.ontologyId !== input.source.ontologyId &&
+    !hasSatisfiedDependency(input.source, ownedTarget.vocabulary)
+  ) {
+    input.issues.push(
+      createRallarOntologyIssue(
+        'missing-vocabulary-import',
+        input.path,
+        `Reference to ${input.targetTermId} requires an explicit satisfied vocabulary dependency.`,
+      ),
+    );
+  }
+}
+
+function hasSatisfiedDependency(
+  source: RallarOntologyVocabularyModule,
+  target: RallarOntologyVocabularyModule,
+): boolean {
+  return source.requiredVocabularyVersionIris.some(
+    (requiredVersionIri) =>
+      seriesFromVersionIri(requiredVersionIri) === target.ontologyId &&
+      vocabularySatisfies(target, requiredVersionIri),
+  );
+}
+
+function vocabularySatisfies(
+  vocabulary: RallarOntologyVocabularyModule,
+  requiredVersionIri: RallarOntologyVersionIri,
+): boolean {
+  return (
+    vocabulary.versionIri === requiredVersionIri ||
+    vocabulary.compatibleWith.includes(requiredVersionIri)
+  );
+}
+
+function seriesFromVersionIri(versionIri: string): string {
+  const markerIndex = versionIri.lastIndexOf('/version/');
+  return markerIndex < 0 ? '' : versionIri.slice(0, markerIndex);
+}
+
+function validateBindingVocabularyOwnership(
+  input: CreateRallarOntologyCatalogInput,
+  issues: RallarOntologyIssue[],
+): void {
+  input.bindingSets.forEach((bindingSet, bindingSetIndex) => {
+    const vocabulary = input.vocabularies.find(
+      (candidate) =>
+        candidate.ontologyId === bindingSet.ontologyId &&
+        candidate.versionIri === bindingSet.vocabularyVersionIri,
+    );
+    if (vocabulary === undefined) {
+      issues.push(
+        createRallarOntologyIssue(
+          'binding-vocabulary-version-mismatch',
+          `catalog.bindingSets[${bindingSetIndex}].vocabularyVersionIri`,
+          'Binding module must select the exact ontology ID and vocabulary version IRI.',
+        ),
+      );
+      return;
+    }
+    const termIds = new Set(vocabulary.terms.map((term) => term.termId));
+    bindingSet.bindings.forEach((binding, bindingIndex) =>
+      addMissingBindingTerm({
+        ownedTermIds: termIds,
+        termId: binding.termId,
+        path: `catalog.bindingSets[${bindingSetIndex}].bindings[${bindingIndex}].termId`,
+        issues,
+      }),
+    );
+    bindingSet.profiles.forEach((profile, profileIndex) =>
+      addMissingBindingTerm({
+        ownedTermIds: termIds,
+        termId: profile.termId,
+        path: `catalog.bindingSets[${bindingSetIndex}].profiles[${profileIndex}].termId`,
+        issues,
+      }),
+    );
+  });
+}
+
+function addMissingBindingTerm(input: AddMissingBindingTermInput): void {
+  if (!input.ownedTermIds.has(input.termId)) {
+    input.issues.push(
+      createRallarOntologyIssue(
+        'missing-binding-term',
+        input.path,
+        `Binding term ${input.termId} does not belong to the selected vocabulary version.`,
+      ),
+    );
+  }
+}

--- a/packages/shared/ontology/validate-rallar-ontology-vocabulary-module.ts
+++ b/packages/shared/ontology/validate-rallar-ontology-vocabulary-module.ts
@@ -1,0 +1,202 @@
+import {
+  RALLAR_RELATION_IDS,
+  type RallarOntologyVocabularyModule,
+} from './rallar-ontology-contracts.ts';
+import {
+  createRallarOntologyIssue,
+  isCanonicalRallarOntologyVersion,
+  isValidRallarOntologyId,
+  isValidRallarOntologyOwnerId,
+  isValidRallarOntologyRelationId,
+  isValidRallarOntologyTermId,
+  isVersionIriForSeries,
+  sortRallarOntologyIssues,
+  validateCompatibleVersionIris,
+} from './rallar-ontology-identity-validation.ts';
+import type { RallarOntologyIssue } from './rallar-ontology-registry-contracts.ts';
+
+const skosRelationIds = [
+  'http://www.w3.org/2004/02/skos/core#broader',
+  'http://www.w3.org/2004/02/skos/core#narrower',
+  'http://www.w3.org/2004/02/skos/core#related',
+] as const;
+const controlledRelationIds = new Set<string>([
+  ...Object.values(RALLAR_RELATION_IDS),
+  ...skosRelationIds,
+]);
+
+export function validateRallarOntologyVocabularyModule(
+  vocabulary: RallarOntologyVocabularyModule,
+): readonly RallarOntologyIssue[] {
+  const issues: RallarOntologyIssue[] = [];
+  validateVocabularyIdentity(vocabulary, issues);
+  validateVocabularyMetadata(vocabulary, issues);
+  validateVocabularyTerms(vocabulary, issues);
+  return sortRallarOntologyIssues(issues);
+}
+
+function validateVocabularyIdentity(
+  vocabulary: RallarOntologyVocabularyModule,
+  issues: RallarOntologyIssue[],
+): void {
+  if (!isValidRallarOntologyId(vocabulary.ontologyId)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-ontology-iri',
+        'vocabulary.ontologyId',
+        'Ontology ID must be a literal governed ontology series IRI.',
+      ),
+    );
+  }
+  if (!isValidRallarOntologyOwnerId(vocabulary.ownerId)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-owner-iri',
+        'vocabulary.ownerId',
+        'Owner ID must be a literal governed owner IRI.',
+      ),
+    );
+  }
+  if (!isCanonicalRallarOntologyVersion(vocabulary.version)) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-version',
+        'vocabulary.version',
+        'Version must be a canonical numeric major.minor.patch value.',
+      ),
+    );
+  }
+  if (vocabulary.versionIri !== `${vocabulary.ontologyId}/version/${vocabulary.version}`) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-version-iri',
+        'vocabulary.versionIri',
+        'Version IRI must exactly combine ontologyId and version.',
+      ),
+    );
+  }
+}
+
+function validateVocabularyMetadata(
+  vocabulary: RallarOntologyVocabularyModule,
+  issues: RallarOntologyIssue[],
+): void {
+  if (vocabulary.maturity !== 'experimental' && vocabulary.maturity !== 'stable') {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-maturity',
+        'vocabulary.maturity',
+        'Maturity must be experimental or stable.',
+      ),
+    );
+  }
+  issues.push(
+    ...validateCompatibleVersionIris({
+      seriesId: vocabulary.ontologyId,
+      version: vocabulary.version,
+      values: vocabulary.compatibleWith,
+      path: 'vocabulary.compatibleWith',
+    }),
+  );
+  vocabulary.requiredVocabularyVersionIris.forEach((versionIri, index) => {
+    const ownerSeries = versionIri.slice(0, versionIri.lastIndexOf('/version/'));
+    if (!isValidRallarOntologyId(ownerSeries) || !isVersionIriForSeries(versionIri, ownerSeries)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-version-iri',
+          `vocabulary.requiredVocabularyVersionIris[${index}]`,
+          'Required vocabulary version must be an exact governed version IRI.',
+        ),
+      );
+    }
+  });
+}
+
+function validateVocabularyTerms(
+  vocabulary: RallarOntologyVocabularyModule,
+  issues: RallarOntologyIssue[],
+): void {
+  const termIds = new Set<string>();
+  vocabulary.terms.forEach((term, termIndex) => {
+    const path = `vocabulary.terms[${termIndex}]`;
+    if (!isValidRallarOntologyTermId(term.termId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-term-iri',
+          `${path}.termId`,
+          'Term ID must be a literal governed term IRI.',
+        ),
+      );
+    }
+    if (termIds.has(term.termId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'duplicate-term-id',
+          `${path}.termId`,
+          'Term IDs must be unique.',
+        ),
+      );
+    }
+    termIds.add(term.termId);
+    validateTermReferences(term, path, issues);
+    validateTermDeprecation(term, path, issues);
+  });
+}
+
+function validateTermReferences(
+  term: RallarOntologyVocabularyModule['terms'][number],
+  termPath: string,
+  issues: RallarOntologyIssue[],
+): void {
+  term.references.forEach((reference, referenceIndex) => {
+    const path = `${termPath}.references[${referenceIndex}]`;
+    if (
+      !isValidRallarOntologyRelationId(reference.relationId) ||
+      !controlledRelationIds.has(reference.relationId)
+    ) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-relation-iri',
+          `${path}.relationId`,
+          'Relation ID must be one of the controlled Rallar or SKOS relations.',
+        ),
+      );
+    }
+    if (!isValidRallarOntologyTermId(reference.targetTermId)) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-term-iri',
+          `${path}.targetTermId`,
+          'Reference target must be a literal governed term IRI.',
+        ),
+      );
+    }
+  });
+}
+
+function validateTermDeprecation(
+  term: RallarOntologyVocabularyModule['terms'][number],
+  termPath: string,
+  issues: RallarOntologyIssue[],
+): void {
+  if (term.status === 'deprecated' && !term.removalCondition?.trim()) {
+    issues.push(
+      createRallarOntologyIssue(
+        'invalid-deprecation',
+        `${termPath}.removalCondition`,
+        'A deprecated term requires a non-empty removal condition.',
+      ),
+    );
+  }
+  if (term.supersededBy !== undefined) {
+    if (!isValidRallarOntologyTermId(term.supersededBy) || term.supersededBy === term.termId) {
+      issues.push(
+        createRallarOntologyIssue(
+          'invalid-deprecation',
+          `${termPath}.supersededBy`,
+          'A superseding term must be a different valid governed term IRI.',
+        ),
+      );
+    }
+  }
+}

--- a/packages/tests/repo/repo-style-layout-rules.test.ts
+++ b/packages/tests/repo/repo-style-layout-rules.test.ts
@@ -11,11 +11,9 @@ import {
 const repoRoot = path.resolve('/repo');
 describe('repository layout rules', () => {
   it('uses the exact TypeScript projection and defensively ignores JavaScript', () => {
-    expect(isLayoutTypeScriptFile('/repo/feature/value.ts')).toBe(true);
-    expect(isLayoutTypeScriptFile('/repo/feature/value.tsx')).toBe(true);
-    expect(isLayoutTypeScriptFile('/repo/feature/value.mts')).toBe(true);
-    expect(isLayoutTypeScriptFile('/repo/feature/value.cts')).toBe(true);
-    expect(isLayoutTypeScriptFile('/repo/feature/value.d.ts')).toBe(true);
+    for (const suffix of ['ts', 'tsx', 'mts', 'cts', 'd.ts']) {
+      expect(isLayoutTypeScriptFile(`/repo/feature/value.${suffix}`)).toBe(true);
+    }
     expect(isLayoutTypeScriptFile('/repo/feature/value.mjs')).toBe(false);
     const result = scanFiles({ 'feature/value.mjs': 'export const value = 1;' });
     expect(result.findings).toEqual([]);
@@ -70,16 +68,18 @@ describe('repository layout rules', () => {
   it('groups exact filename, generic-name, tool-name, and mod-boundary cases', () => {
     const result = scan(
       sourceList(
-        'feature/ThingService.ts feature/thingService.ts feature/thing-service.ts ' +
-          'feature/vite.config.ts feature/types.ts feature/group-state-types.ts ' +
-          'feature/helpers.ts feature/group-state-helpers.ts packages/shared/mod.ts ' +
-          'packages/shared/feature/mod.ts',
+        'feature/ThingService.ts feature/thingService.ts packages/shared/mod.ts ' +
+          'feature/thing-service.ts feature/vite.config.ts packages/shared/feature/mod.ts ' +
+          'feature/types.ts feature/group-state-types.ts packages/shared/ontology/nested/mod.ts ' +
+          'feature/helpers.ts feature/group-state-helpers.ts packages/shared/ontology/mod.ts',
       ),
     );
     expect(result.counts[rules.filenameStyle]).toBe(2);
     expect(findingsFor(result, rules.filenameStyle)).toHaveLength(1);
     expect(result.counts[rules.genericFilename]).toBe(2);
-    expect(result.counts[rules.unapprovedMod]).toBe(1);
+    const unapprovedModCount = (file: string) => scan(sourceList(file)).counts[rules.unapprovedMod];
+    expect(unapprovedModCount('packages/shared/ontology/mod.ts')).toBe(0);
+    expect(unapprovedModCount('packages/shared/ontology/nested/mod.ts')).toBe(1);
   });
   it('parses exported route registration functions instead of matching text', () => {
     const result = scanFiles(

--- a/packages/tests/shared/rallar-ontology-binding-validation.test.ts
+++ b/packages/tests/shared/rallar-ontology-binding-validation.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  RallarOntologyBinding,
+  RallarOntologyBindingModule,
+  RallarOntologyBindingTarget,
+} from '@shared/ontology/rallar-ontology-contracts.ts';
+import { validateRallarOntologyBindingModule } from '@shared/ontology/validate-rallar-ontology-binding-module.ts';
+
+import {
+  createRallarOntologyBindingModuleFixture,
+  ONTOLOGY_BASE,
+  TEST_BINDING_ID,
+  TEST_BINDING_SET_ID,
+  TEST_BINDING_SET_VERSION_IRI,
+  TEST_ONTOLOGY_ID,
+  TEST_ONTOLOGY_VERSION_IRI,
+  TEST_OWNER_ID,
+  TEST_PARENT_TERM_ID,
+  TEST_PROFILE_ID,
+} from './rallar-ontology-test-fixtures.ts';
+
+function bindingFixture(
+  target: RallarOntologyBindingTarget,
+  overrides: Partial<RallarOntologyBinding> = {},
+): RallarOntologyBinding {
+  return {
+    ...createRallarOntologyBindingModuleFixture().bindings[0],
+    target,
+    ...overrides,
+  };
+}
+
+function issueCodes(bindingSet: RallarOntologyBindingModule): readonly string[] {
+  return validateRallarOntologyBindingModule(bindingSet).map((issue) => issue.code);
+}
+
+describe('Rallar ontology binding validation', () => {
+  it('accepts the independent default binding module with canonical identities', () => {
+    const bindingSet = createRallarOntologyBindingModuleFixture();
+
+    expect(bindingSet).toMatchObject({
+      bindingSetId: TEST_BINDING_SET_ID,
+      ontologyId: TEST_ONTOLOGY_ID,
+      vocabularyVersionIri: TEST_ONTOLOGY_VERSION_IRI,
+      ownerId: TEST_OWNER_ID,
+      version: '0.1.0',
+      versionIri: TEST_BINDING_SET_VERSION_IRI,
+    });
+    expect(bindingSet.bindings[0]?.bindingId).toBe(TEST_BINDING_ID);
+    expect(bindingSet.profiles[0]?.profileId).toBe(TEST_PROFILE_ID);
+    expect(validateRallarOntologyBindingModule(bindingSet)).toEqual([]);
+  });
+
+  it.each([
+    'http://github.com/intact-software-systems/ar-eye-hunter/ontology/binding-set/acme.core',
+    'https://GITHUB.com/intact-software-systems/ar-eye-hunter/ontology/binding-set/acme.core',
+    'https://github.com.evil/intact-software-systems/ar-eye-hunter/ontology/binding-set/acme.core',
+    `${ONTOLOGY_BASE}/binding-set/../acme.core`,
+    `${ONTOLOGY_BASE}/binding-set/acme.core?x=1`,
+    `${ONTOLOGY_BASE}/binding-set/%61cme.core`,
+  ])('rejects the literal binding-set lookalike %s', (bindingSetId) => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      bindingSetId: bindingSetId as RallarOntologyBindingModule['bindingSetId'],
+    });
+
+    expect(issueCodes(bindingSet)).toContain('invalid-ontology-iri');
+  });
+
+  it('requires exact binding and vocabulary version IRIs', () => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      versionIri: `${TEST_BINDING_SET_ID}/version/0.2.0`,
+      vocabularyVersionIri: `${ONTOLOGY_BASE}/extension/acme/other/version/0.1.0`,
+    });
+
+    expect(issueCodes(bindingSet)).toEqual(
+      expect.arrayContaining(['invalid-version-iri', 'invalid-version-iri']),
+    );
+  });
+
+  it.each(['1', '1.2', '1.2.3-beta', '1.2.3+build', '01.2.3'])(
+    'rejects non-canonical binding version %s',
+    (version) => {
+      const bindingSet = createRallarOntologyBindingModuleFixture({
+        version: version as RallarOntologyBindingModule['version'],
+      });
+
+      expect(issueCodes(bindingSet)).toContain('invalid-version');
+    },
+  );
+
+  it('accepts unique prior compatible binding versions from the same series', () => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      version: '0.3.0',
+      versionIri: `${TEST_BINDING_SET_ID}/version/0.3.0`,
+      compatibleWith: [
+        `${TEST_BINDING_SET_ID}/version/0.1.0`,
+        `${TEST_BINDING_SET_ID}/version/0.2.0`,
+      ],
+    });
+
+    expect(validateRallarOntologyBindingModule(bindingSet)).toEqual([]);
+  });
+
+  it.each([
+    {
+      values: [`${TEST_BINDING_SET_ID}/version/0.1.0`, `${TEST_BINDING_SET_ID}/version/0.1.0`],
+    },
+    { values: [`${TEST_BINDING_SET_ID}/version/0.3.0`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/0.4.0`] },
+    { values: [`${ONTOLOGY_BASE}/binding-set/acme.other/version/0.1.0`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/^0.1.0`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/0.1`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/0.1.0-beta`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/0.1.0+build`] },
+    { values: [`${TEST_BINDING_SET_ID}/version/00.1.0`] },
+  ])('rejects an invalid binding compatibility declaration %#', ({ values }) => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      version: '0.3.0',
+      versionIri: `${TEST_BINDING_SET_ID}/version/0.3.0`,
+      compatibleWith: values as RallarOntologyBindingModule['compatibleWith'],
+    });
+
+    expect(issueCodes(bindingSet)).toContain('invalid-compatible-version-iri');
+  });
+
+  it('rejects invalid maturity and duplicate binding or profile identities', () => {
+    const original = createRallarOntologyBindingModuleFixture();
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      maturity: 'preview' as RallarOntologyBindingModule['maturity'],
+      bindings: [original.bindings[0], original.bindings[0]],
+      profiles: [original.profiles[0], original.profiles[0]],
+    });
+
+    expect(issueCodes(bindingSet)).toEqual(
+      expect.arrayContaining([
+        'invalid-maturity',
+        'duplicate-binding-id',
+        'duplicate-binding-profile-id',
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      kind: 'typescript-export',
+      modulePath: 'packages/shared/example.ts',
+      exportName: 'Example',
+    },
+    {
+      kind: 'wire-constant',
+      modulePath: 'packages/shared/example.ts',
+      exportName: 'EXAMPLE',
+      propertyPath: ['id'],
+    },
+    {
+      kind: 'openapi-component',
+      documentPath: 'apps/api-v1/resources/api-v1-openapi.yaml',
+      componentName: 'Example',
+    },
+    {
+      kind: 'runtime-validator',
+      modulePath: 'packages/shared/example.ts',
+      exportName: 'validateExample',
+      validatorId: 'example-v1',
+    },
+    {
+      kind: 'normative-anchor',
+      documentPath: 'docs/example.md',
+      anchor: 'example',
+    },
+    {
+      kind: 'export-property',
+      modulePath: 'packages/shared/example.ts',
+      exportName: 'example',
+      propertyName: 'id',
+    },
+    { kind: 'package-script', manifestPath: 'package.json', scriptName: 'test:unit' },
+    { kind: 'repository-owner', ownerId: TEST_OWNER_ID, path: 'packages/shared' },
+    { kind: 'implementation-symbol', path: 'packages/shared/example.ts', symbol: 'example' },
+    { kind: 'example', path: 'examples/example.ts' },
+  ] satisfies readonly RallarOntologyBindingTarget[])(
+    'accepts the $kind target contract',
+    (target) => {
+      const strengths = ['contractual', 'owner', 'implementation', 'example'] as const;
+      const bindings = strengths.map((strength, index) =>
+        bindingFixture(target, {
+          bindingId: `${ONTOLOGY_BASE}/binding/acme.target-${index}`,
+          strength,
+        }),
+      );
+
+      expect(
+        validateRallarOntologyBindingModule(createRallarOntologyBindingModuleFixture({ bindings })),
+      ).toEqual([]);
+    },
+  );
+
+  it('rejects an untrusted target with an unsupported kind at the target boundary', () => {
+    const runtimeBindingSet = JSON.parse(
+      JSON.stringify(createRallarOntologyBindingModuleFixture()),
+    );
+    runtimeBindingSet.bindings[0].target.kind = 'typescript-export-typo';
+
+    expect(validateRallarOntologyBindingModule(runtimeBindingSet)).toEqual([
+      {
+        code: 'invalid-binding-target',
+        path: 'bindingSet.bindings[0].target.kind',
+        message: 'Binding target kind is not supported.',
+      },
+    ]);
+  });
+
+  it('rejects an unscoped package specifier as a repository target path', () => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      bindings: [
+        bindingFixture({ kind: 'typescript-export', modulePath: 'lodash/fp', exportName: 'map' }),
+      ],
+    });
+
+    expect(validateRallarOntologyBindingModule(bindingSet)).toEqual([
+      {
+        code: 'invalid-binding-target',
+        path: 'bindingSet.bindings[0].target.modulePath',
+        message: 'Target path must be safe and repository-relative.',
+      },
+    ]);
+  });
+
+  it.each([
+    '/packages/shared/example.ts',
+    '../packages/shared/example.ts',
+    'packages/../shared/example.ts',
+    'https://example.test/file.ts',
+    '@shared/example.ts',
+    'packages/shared/%65xample.ts',
+    'packages/shared/__proto__/example.ts',
+    'packages/shared/prototype/example.ts',
+    'packages/shared/constructor/example.ts',
+  ])('rejects the unsafe repository target %s', (modulePath) => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      bindings: [bindingFixture({ kind: 'typescript-export', modulePath, exportName: 'Example' })],
+    });
+    const issues = validateRallarOntologyBindingModule(bindingSet);
+
+    expect(issues.map((issue) => issue.code)).toContain('invalid-binding-target');
+    expect(issues[0]?.path).toContain('bindingSet.bindings[0].target.modulePath');
+  });
+
+  it.each(['', '__proto__', 'prototype', 'constructor', 'not.valid'])(
+    'rejects unsafe property path segment %s',
+    (propertyName) => {
+      const bindingSet = createRallarOntologyBindingModuleFixture({
+        bindings: [
+          bindingFixture({
+            kind: 'wire-constant',
+            modulePath: 'packages/shared/example.ts',
+            exportName: 'EXAMPLE',
+            propertyPath: [propertyName],
+          }),
+        ],
+      });
+
+      expect(issueCodes(bindingSet)).toContain('invalid-binding-target');
+    },
+  );
+
+  it('rejects malformed governed binding identities and invalid strengths with full paths', () => {
+    const original = createRallarOntologyBindingModuleFixture();
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      bindings: [
+        {
+          ...original.bindings[0],
+          bindingId: `${ONTOLOGY_BASE}/binding/../bad`,
+          termId: `${ONTOLOGY_BASE}/term/../bad`,
+          strength: 'strong' as RallarOntologyBinding['strength'],
+        },
+      ],
+      profiles: [
+        {
+          ...original.profiles[0],
+          profileId: `${ONTOLOGY_BASE}/binding-profile/bad?x=1`,
+          termId: `${ONTOLOGY_BASE}/term/%62ad`,
+        },
+      ],
+    });
+    const issues = validateRallarOntologyBindingModule(bindingSet);
+
+    expect(issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'invalid-ontology-iri',
+        'invalid-term-iri',
+        'invalid-binding-strength',
+      ]),
+    );
+    expect(issues.every((issue) => issue.path.startsWith('bindingSet.'))).toBe(true);
+    expect(issues.some((issue) => issue.path === 'bindingSet.profiles[0].profileId')).toBe(true);
+  });
+});

--- a/packages/tests/shared/rallar-ontology-catalog-validation.test.ts
+++ b/packages/tests/shared/rallar-ontology-catalog-validation.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RALLAR_RELATION_IDS,
+  type RallarOntologyBindingModule,
+  type RallarOntologyTermBase,
+  type RallarOntologyVersion,
+  type RallarOntologyVocabularyModule,
+} from '@shared/ontology/rallar-ontology-contracts.ts';
+import { validateRallarOntologyCatalog } from '@shared/ontology/validate-rallar-ontology-catalog.ts';
+
+import {
+  createRallarOntologyBindingModuleFixture,
+  createRallarOntologyVocabularyFixture,
+  ONTOLOGY_BASE,
+  TEST_CHILD_TERM_ID,
+  TEST_ONTOLOGY_ID,
+  TEST_ONTOLOGY_VERSION_IRI,
+  TEST_PARENT_TERM_ID,
+} from './rallar-ontology-test-fixtures.ts';
+
+const DEPENDENCY_ONTOLOGY_ID = `${ONTOLOGY_BASE}/extension/acme/dependency` as const;
+const DEPENDENCY_TERM_ID = `${ONTOLOGY_BASE}/term/acme.dependency` as const;
+
+function createDependencyVocabulary(
+  version: RallarOntologyVersion = '0.1.0',
+  overrides: Partial<RallarOntologyVocabularyModule> = {},
+): RallarOntologyVocabularyModule {
+  return createRallarOntologyVocabularyFixture({
+    ontologyId: DEPENDENCY_ONTOLOGY_ID,
+    version,
+    versionIri: `${DEPENDENCY_ONTOLOGY_ID}/version/${version}`,
+    terms: [
+      {
+        termId: DEPENDENCY_TERM_ID,
+        kind: 'concept',
+        label: 'Dependency',
+        definition: 'A dependency concept.',
+        status: 'draft',
+        references: [],
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function createSourceVocabulary(
+  term: RallarOntologyTermBase,
+  requiredVocabularyVersionIris: RallarOntologyVocabularyModule['requiredVocabularyVersionIris'] = [],
+): RallarOntologyVocabularyModule {
+  return createRallarOntologyVocabularyFixture({
+    requiredVocabularyVersionIris,
+    terms: [term],
+  });
+}
+
+function sourceTerm(overrides: Partial<RallarOntologyTermBase> = {}): RallarOntologyTermBase {
+  return {
+    ...createRallarOntologyVocabularyFixture().terms[0],
+    ...overrides,
+  };
+}
+
+function codes(input: {
+  readonly vocabularies: readonly RallarOntologyVocabularyModule[];
+  readonly bindingSets: readonly RallarOntologyBindingModule[];
+}): readonly string[] {
+  return validateRallarOntologyCatalog(input).map((issue) => issue.code);
+}
+
+describe('Rallar ontology catalog validation', () => {
+  it('accepts the exact independent vocabulary and binding pair', () => {
+    expect(
+      validateRallarOntologyCatalog({
+        vocabularies: [createRallarOntologyVocabularyFixture()],
+        bindingSets: [createRallarOntologyBindingModuleFixture()],
+      }),
+    ).toEqual([]);
+  });
+
+  it('reports duplicate identities across every catalog collection', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture();
+    const bindingSet = createRallarOntologyBindingModuleFixture();
+    const duplicateTermVocabulary = createDependencyVocabulary('0.1.0', {
+      terms: [{ ...vocabulary.terms[0], termId: TEST_PARENT_TERM_ID }],
+    });
+    const duplicateBindingSet = createRallarOntologyBindingModuleFixture({
+      bindings: [bindingSet.bindings[0]],
+      profiles: [bindingSet.profiles[0]],
+    });
+    const issues = validateRallarOntologyCatalog({
+      vocabularies: [vocabulary, vocabulary, duplicateTermVocabulary],
+      bindingSets: [bindingSet, duplicateBindingSet],
+    });
+
+    expect(issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'duplicate-ontology-id',
+        'duplicate-version-iri',
+        'duplicate-term-id',
+        'duplicate-binding-set-id',
+        'duplicate-binding-id',
+        'duplicate-binding-profile-id',
+      ]),
+    );
+    expect(issues.every((issue) => issue.path.startsWith('catalog.'))).toBe(true);
+  });
+
+  it('accepts an exact selected vocabulary dependency', () => {
+    const dependency = createDependencyVocabulary();
+    const source = createSourceVocabulary(sourceTerm(), [dependency.versionIri]);
+
+    expect(
+      validateRallarOntologyCatalog({ vocabularies: [source, dependency], bindingSets: [] }),
+    ).toEqual([]);
+  });
+
+  it('accepts a newer selected dependency only with explicit prior compatibility', () => {
+    const requiredVersionIri = `${DEPENDENCY_ONTOLOGY_ID}/version/0.1.0` as const;
+    const dependency = createDependencyVocabulary('0.2.0', {
+      compatibleWith: [requiredVersionIri],
+    });
+    const source = createSourceVocabulary(sourceTerm(), [requiredVersionIri]);
+
+    expect(
+      validateRallarOntologyCatalog({ vocabularies: [source, dependency], bindingSets: [] }),
+    ).toEqual([]);
+  });
+
+  it.each([
+    { selected: [] },
+    { selected: [createDependencyVocabulary('0.2.0')] },
+    {
+      selected: [
+        createDependencyVocabulary('0.2.0', {
+          compatibleWith: [`${DEPENDENCY_ONTOLOGY_ID}/version/0.0.1`],
+        }),
+      ],
+    },
+  ])('rejects an omitted or incompatible selected dependency %#', ({ selected }) => {
+    const source = createSourceVocabulary(sourceTerm(), [
+      `${DEPENDENCY_ONTOLOGY_ID}/version/0.1.0`,
+    ]);
+
+    expect(codes({ vocabularies: [source, ...selected], bindingSets: [] })).toContain(
+      'missing-vocabulary-import',
+    );
+  });
+
+  it('accepts intra-vocabulary references without declaring a dependency', () => {
+    const source = createRallarOntologyVocabularyFixture();
+
+    expect(validateRallarOntologyCatalog({ vocabularies: [source], bindingSets: [] })).toEqual([]);
+  });
+
+  it('accepts foreign references and supersession only with a satisfied dependency', () => {
+    const dependency = createDependencyVocabulary();
+    const source = createSourceVocabulary(
+      sourceTerm({
+        status: 'deprecated',
+        removalCondition: 'Remove after dependency migration.',
+        supersededBy: DEPENDENCY_TERM_ID,
+        references: [
+          { relationId: RALLAR_RELATION_IDS.scopedBy, targetTermId: DEPENDENCY_TERM_ID },
+        ],
+      }),
+      [dependency.versionIri],
+    );
+
+    expect(
+      validateRallarOntologyCatalog({ vocabularies: [source, dependency], bindingSets: [] }),
+    ).toEqual([]);
+  });
+
+  it('distinguishes absent references from undeclared foreign references', () => {
+    const missing = createSourceVocabulary(
+      sourceTerm({
+        references: [
+          {
+            relationId: RALLAR_RELATION_IDS.scopedBy,
+            targetTermId: `${ONTOLOGY_BASE}/term/acme.absent`,
+          },
+        ],
+      }),
+    );
+    const foreign = createSourceVocabulary(
+      sourceTerm({
+        references: [
+          { relationId: RALLAR_RELATION_IDS.scopedBy, targetTermId: DEPENDENCY_TERM_ID },
+        ],
+      }),
+    );
+
+    expect(codes({ vocabularies: [missing], bindingSets: [] })).toContain('missing-reference');
+    expect(
+      codes({ vocabularies: [foreign, createDependencyVocabulary()], bindingSets: [] }),
+    ).toContain('missing-vocabulary-import');
+  });
+
+  it('requires exact binding ontology and selected vocabulary-version pairing', () => {
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      vocabularyVersionIri: `${TEST_ONTOLOGY_ID}/version/0.2.0`,
+    });
+
+    expect(
+      codes({
+        vocabularies: [createRallarOntologyVocabularyFixture()],
+        bindingSets: [bindingSet],
+      }),
+    ).toContain('binding-vocabulary-version-mismatch');
+  });
+
+  it('rejects a binding or profile term owned by another selected vocabulary', () => {
+    const original = createRallarOntologyBindingModuleFixture();
+    const bindingSet = createRallarOntologyBindingModuleFixture({
+      bindings: [{ ...original.bindings[0], termId: DEPENDENCY_TERM_ID }],
+      profiles: [{ ...original.profiles[0], termId: DEPENDENCY_TERM_ID }],
+    });
+
+    expect(
+      codes({
+        vocabularies: [createRallarOntologyVocabularyFixture(), createDependencyVocabulary()],
+        bindingSets: [bindingSet],
+      }),
+    ).toEqual(expect.arrayContaining(['missing-binding-term', 'missing-binding-term']));
+  });
+
+  it('reports every untrusted binding target failure with complete catalog paths', () => {
+    const runtimeBindingSet = JSON.parse(
+      JSON.stringify(createRallarOntologyBindingModuleFixture()),
+    );
+    const binding = runtimeBindingSet.bindings[0];
+    runtimeBindingSet.bindings = [
+      { ...binding, target: { ...binding.target, kind: 'typescript-export-typo' } },
+      {
+        ...binding,
+        bindingId: `${ONTOLOGY_BASE}/binding/acme.invalid-package-target`,
+        target: { kind: 'typescript-export', modulePath: 'lodash/fp', exportName: 'map' },
+      },
+    ];
+
+    expect(
+      validateRallarOntologyCatalog({
+        vocabularies: [createRallarOntologyVocabularyFixture()],
+        bindingSets: [runtimeBindingSet],
+      }),
+    ).toEqual([
+      {
+        code: 'invalid-binding-target',
+        path: 'catalog.bindingSets[0].bindings[0].target.kind',
+        message: 'Binding target kind is not supported.',
+      },
+      {
+        code: 'invalid-binding-target',
+        path: 'catalog.bindingSets[0].bindings[1].target.modulePath',
+        message: 'Target path must be safe and repository-relative.',
+      },
+    ]);
+  });
+
+  it('returns complete catalog paths in deterministic path, code, message order', () => {
+    const source = createSourceVocabulary(
+      sourceTerm({
+        termId: TEST_CHILD_TERM_ID,
+        references: [
+          {
+            relationId: RALLAR_RELATION_IDS.scopedBy,
+            targetTermId: `${ONTOLOGY_BASE}/term/acme.absent`,
+          },
+        ],
+      }),
+    );
+    const issues = validateRallarOntologyCatalog({
+      vocabularies: [createRallarOntologyVocabularyFixture(), source],
+      bindingSets: [
+        createRallarOntologyBindingModuleFixture({
+          vocabularyVersionIri: `${TEST_ONTOLOGY_ID}/version/0.2.0`,
+        }),
+      ],
+    });
+    const tuples = issues.map((issue) => `${issue.path}\u0000${issue.code}\u0000${issue.message}`);
+
+    expect(tuples).toEqual([...tuples].sort());
+    expect(issues.some((issue) => issue.path.includes('catalog.vocabularies[1].terms[0]'))).toBe(
+      true,
+    );
+    expect(issues.some((issue) => issue.path.includes('catalog.bindingSets[0]'))).toBe(true);
+    expect(issues.every((issue) => !/^(termId|targetTermId|modulePath)$/u.test(issue.path))).toBe(
+      true,
+    );
+    expect(TEST_ONTOLOGY_VERSION_IRI).toContain('/version/0.1.0');
+  });
+});

--- a/packages/tests/shared/rallar-ontology-registry.test.ts
+++ b/packages/tests/shared/rallar-ontology-registry.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createRallarOntologyCatalog,
+  getRallarOntologyBindingProfiles,
+  getRallarOntologyBindings,
+  getRallarOntologyTerm,
+  RALLAR_RELATION_IDS,
+  validateRallarOntologyCatalog,
+  type CreateRallarOntologyCatalogInput,
+  type RallarOntologyBindingModule,
+  type RallarDomainOntologyTerm,
+  type RallarMessageOntologyBindingProfile,
+  type RallarMessageOntologyTerm,
+  type RallarRtcLaneOntologyTerm,
+  type RallarOntologyVocabularyModule,
+} from '@shared/ontology/mod.ts';
+
+import {
+  createRallarOntologyBindingModuleFixture,
+  createRallarOntologyCustomOrderedProfileFixture,
+  createRallarOntologySpecializedCopyFixture,
+  createRallarOntologyVocabularyFixture,
+  ONTOLOGY_BASE,
+  type RallarOntologyCustomOrderedProfile,
+  TEST_BINDING_ID,
+  TEST_BINDING_SET_ID,
+  TEST_CHILD_TERM_ID,
+  TEST_ONTOLOGY_ID,
+  TEST_PARENT_TERM_ID,
+  TEST_PROFILE_ID,
+} from './rallar-ontology-test-fixtures.ts';
+
+const ALPHA_BINDING_SET_ID = `${ONTOLOGY_BASE}/binding-set/acme.alpha` as const;
+const ALPHA_BINDING_ID = `${ONTOLOGY_BASE}/binding/acme.alpha.export` as const;
+const ALPHA_PROFILE_ID = `${ONTOLOGY_BASE}/binding-profile/acme.alpha.profile` as const;
+const SECOND_BINDING_ID = `${ONTOLOGY_BASE}/binding/acme.core.second` as const;
+const SECOND_PROFILE_ID = `${ONTOLOGY_BASE}/binding-profile/acme.core.second` as const;
+
+function createUnsortedVocabulary(): RallarOntologyVocabularyModule {
+  const fixture = createRallarOntologyVocabularyFixture();
+  const domainTerm: RallarDomainOntologyTerm = {
+    ...fixture.terms[0],
+    kind: 'domain',
+    domainKind: 'identity',
+    authority: 'authoritative',
+    identityFields: ['z-authored-first', 'a-authored-second'],
+  };
+  return createRallarOntologyVocabularyFixture({
+    version: '0.3.0',
+    versionIri: `${TEST_ONTOLOGY_ID}/version/0.3.0`,
+    compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.2.0`, `${TEST_ONTOLOGY_ID}/version/0.1.0`],
+    requiredVocabularyVersionIris: [
+      `${ONTOLOGY_BASE}/code-standards/version/0.1.0`,
+      `${ONTOLOGY_BASE}/domain/version/0.1.0`,
+    ],
+    competencyQuestionIds: ['CQ-z-last', 'CQ-a-first'],
+    terms: [
+      {
+        ...fixture.terms[1],
+        references: [
+          { relationId: RALLAR_RELATION_IDS.scopedBy, targetTermId: TEST_PARENT_TERM_ID },
+          { relationId: RALLAR_RELATION_IDS.identifies, targetTermId: TEST_PARENT_TERM_ID },
+        ],
+      },
+      {
+        ...domainTerm,
+      },
+    ],
+  });
+}
+
+function createAlphaBindingSet(): RallarOntologyBindingModule {
+  const fixture = createRallarOntologyBindingModuleFixture();
+  return createRallarOntologyBindingModuleFixture({
+    bindingSetId: ALPHA_BINDING_SET_ID,
+    vocabularyVersionIri: `${TEST_ONTOLOGY_ID}/version/0.3.0`,
+    versionIri: `${ALPHA_BINDING_SET_ID}/version/0.1.0`,
+    bindings: [{ ...fixture.bindings[0], bindingId: ALPHA_BINDING_ID }],
+    profiles: [{ ...fixture.profiles[0], profileId: ALPHA_PROFILE_ID }],
+  });
+}
+
+function createRequiredVocabulary(
+  ontologyId: RallarOntologyVocabularyModule['ontologyId'],
+  termId: RallarOntologyVocabularyModule['terms'][number]['termId'],
+): RallarOntologyVocabularyModule {
+  return createRallarOntologyVocabularyFixture({
+    ontologyId,
+    versionIri: `${ontologyId}/version/0.1.0`,
+    terms: [
+      {
+        ...createRallarOntologyVocabularyFixture().terms[0],
+        termId,
+        references: [],
+      },
+    ],
+  });
+}
+
+function createUnsortedBindingSet(): RallarOntologyBindingModule {
+  const fixture = createRallarOntologyBindingModuleFixture();
+  return createRallarOntologyBindingModuleFixture({
+    vocabularyVersionIri: `${TEST_ONTOLOGY_ID}/version/0.3.0`,
+    version: '0.3.0',
+    versionIri: `${TEST_BINDING_SET_ID}/version/0.3.0`,
+    compatibleWith: [
+      `${TEST_BINDING_SET_ID}/version/0.2.0`,
+      `${TEST_BINDING_SET_ID}/version/0.1.0`,
+    ],
+    bindings: [
+      {
+        ...fixture.bindings[0],
+        bindingId: SECOND_BINDING_ID,
+        termId: TEST_CHILD_TERM_ID,
+        target: {
+          kind: 'wire-constant',
+          modulePath: 'packages/shared/example.ts',
+          exportName: 'EXAMPLE',
+          propertyPath: ['zAuthoredFirst', 'aAuthoredSecond'],
+        },
+      },
+      fixture.bindings[0],
+    ],
+    profiles: [
+      { ...fixture.profiles[0], profileId: SECOND_PROFILE_ID, termId: TEST_CHILD_TERM_ID },
+      fixture.profiles[0],
+    ],
+  });
+}
+
+function createUnsortedInput(): CreateRallarOntologyCatalogInput {
+  return {
+    vocabularies: [
+      createUnsortedVocabulary(),
+      createRequiredVocabulary(`${ONTOLOGY_BASE}/domain`, `${ONTOLOGY_BASE}/term/domain.example`),
+      createRequiredVocabulary(
+        `${ONTOLOGY_BASE}/code-standards`,
+        `${ONTOLOGY_BASE}/term/code-rule.example`,
+      ),
+    ],
+    bindingSets: [createUnsortedBindingSet(), createAlphaBindingSet()],
+  };
+}
+
+function freezeInputGraph(value: unknown): void {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return;
+  }
+  Object.values(value).forEach(freezeInputGraph);
+  Object.freeze(value);
+}
+
+function expectDetachedCopy(copied: unknown, authored: unknown): void {
+  expect(copied).toEqual(authored);
+  expect(copied).not.toBe(authored);
+}
+
+describe('Rallar ontology registry', () => {
+  it('creates the same deterministic catalog from forward and reverse module order', () => {
+    const input = createUnsortedInput();
+    const reversed = {
+      vocabularies: [...input.vocabularies].reverse(),
+      bindingSets: [...input.bindingSets].reverse(),
+    };
+
+    expect(createRallarOntologyCatalog(input)).toEqual(createRallarOntologyCatalog(reversed));
+  });
+
+  it('sorts every order-insensitive collection by raw identity ordering', () => {
+    const catalog = createRallarOntologyCatalog(createUnsortedInput());
+    const source = catalog.vocabularies.find(
+      (vocabulary) => vocabulary.ontologyId === TEST_ONTOLOGY_ID,
+    );
+
+    expect(catalog.vocabularies.map((vocabulary) => vocabulary.ontologyId)).toEqual([
+      `${ONTOLOGY_BASE}/code-standards`,
+      `${ONTOLOGY_BASE}/domain`,
+      TEST_ONTOLOGY_ID,
+    ]);
+    expect(source?.compatibleWith).toEqual([
+      `${TEST_ONTOLOGY_ID}/version/0.1.0`,
+      `${TEST_ONTOLOGY_ID}/version/0.2.0`,
+    ]);
+    expect(source?.requiredVocabularyVersionIris).toEqual([
+      `${ONTOLOGY_BASE}/code-standards/version/0.1.0`,
+      `${ONTOLOGY_BASE}/domain/version/0.1.0`,
+    ]);
+    expect(source?.competencyQuestionIds).toEqual(['CQ-a-first', 'CQ-z-last']);
+    expect(source?.terms.map((term) => term.termId)).toEqual([
+      TEST_CHILD_TERM_ID,
+      TEST_PARENT_TERM_ID,
+    ]);
+    expect(source?.terms[0]?.references.map((reference) => reference.relationId)).toEqual([
+      RALLAR_RELATION_IDS.identifies,
+      RALLAR_RELATION_IDS.scopedBy,
+    ]);
+    expect(catalog.bindingSets.map((bindingSet) => bindingSet.bindingSetId)).toEqual([
+      ALPHA_BINDING_SET_ID,
+      TEST_BINDING_SET_ID,
+    ]);
+    expect(
+      catalog.bindingSets.map((bindingSet) => bindingSet.bindings.map((item) => item.bindingId)),
+    ).toEqual([[ALPHA_BINDING_ID], [TEST_BINDING_ID, SECOND_BINDING_ID]]);
+    expect(
+      catalog.bindingSets.map((bindingSet) => bindingSet.profiles.map((item) => item.profileId)),
+    ).toEqual([[ALPHA_PROFILE_ID], [TEST_PROFILE_ID, SECOND_PROFILE_ID]]);
+    expect(catalog.bindings.map((binding) => binding.bindingId)).toEqual([
+      ALPHA_BINDING_ID,
+      TEST_BINDING_ID,
+      SECOND_BINDING_ID,
+    ]);
+    expect(catalog.bindingProfiles.map((profile) => profile.profileId)).toEqual([
+      ALPHA_PROFILE_ID,
+      TEST_PROFILE_ID,
+      SECOND_PROFILE_ID,
+    ]);
+    expect(catalog.terms.map((term) => term.termId)).toEqual(
+      [...catalog.terms.map((term) => term.termId)].sort(),
+    );
+  });
+
+  it('does not mutate caller arrays and preserves semantically ordered arrays', () => {
+    const input = createUnsortedInput();
+    const before = structuredClone(input);
+    freezeInputGraph(input);
+
+    const catalog = createRallarOntologyCatalog(input);
+    const source = catalog.vocabularies.find(
+      (vocabulary) => vocabulary.ontologyId === TEST_ONTOLOGY_ID,
+    );
+    const parent = source?.terms.find((term) => term.termId === TEST_PARENT_TERM_ID);
+    const wireBinding = catalog.bindings.find((binding) => binding.bindingId === SECOND_BINDING_ID);
+
+    expect(input).toEqual(before);
+    expect(parent).toMatchObject({
+      identityFields: ['z-authored-first', 'a-authored-second'],
+    });
+    expect(wireBinding?.target).toMatchObject({
+      propertyPath: ['zAuthoredFirst', 'aAuthoredSecond'],
+    });
+    if (wireBinding?.target.kind === 'wire-constant') {
+      const authoredWireBinding = input.bindingSets[0]?.bindings.find(
+        (binding) => binding.bindingId === SECOND_BINDING_ID,
+      );
+      expect(wireBinding.target.propertyPath).not.toBe(
+        authoredWireBinding?.target.kind === 'wire-constant'
+          ? authoredWireBinding.target.propertyPath
+          : undefined,
+      );
+    }
+  });
+
+  it('copies every known ordered value without reordering or mutating caller data', () => {
+    const fixture = createRallarOntologySpecializedCopyFixture();
+    const input = { vocabularies: [fixture.vocabulary], bindingSets: [fixture.bindingSet] };
+    const before = structuredClone(input);
+    freezeInputGraph(input);
+
+    const catalog = createRallarOntologyCatalog(input);
+    const copiedDomain = getRallarOntologyTerm(
+      catalog,
+      fixture.domainTerm.termId,
+    ) as RallarDomainOntologyTerm;
+    const copiedMessage = getRallarOntologyTerm(
+      catalog,
+      fixture.messageTerm.termId,
+    ) as RallarMessageOntologyTerm;
+    const copiedLane = getRallarOntologyTerm(
+      catalog,
+      fixture.laneTerm.termId,
+    ) as RallarRtcLaneOntologyTerm;
+    const copiedProfile = getRallarOntologyBindingProfiles(
+      catalog,
+      fixture.messageProfile.termId,
+    ).find(
+      (profile) => profile.profileId === fixture.messageProfile.profileId,
+    ) as RallarMessageOntologyBindingProfile;
+
+    expect(input).toEqual(before);
+    expectDetachedCopy(copiedDomain, fixture.domainTerm);
+    expectDetachedCopy(copiedDomain.identityFields, fixture.domainTerm.identityFields);
+    expectDetachedCopy(copiedMessage, fixture.messageTerm);
+    expectDetachedCopy(copiedMessage.routes, fixture.messageTerm.routes);
+    expectDetachedCopy(copiedMessage.routes[0], fixture.messageTerm.routes[0]);
+    expectDetachedCopy(
+      copiedMessage.routes[0].transports,
+      fixture.messageTerm.routes[0].transports,
+    );
+    expectDetachedCopy(
+      copiedMessage.routes[0].targetModes,
+      fixture.messageTerm.routes[0].targetModes,
+    );
+    expectDetachedCopy(copiedMessage.senderKinds, fixture.messageTerm.senderKinds);
+    expectDetachedCopy(copiedMessage.validation, fixture.messageTerm.validation);
+    if (
+      copiedMessage.validation.kind === 'runtime-payload' &&
+      fixture.messageTerm.validation.kind === 'runtime-payload'
+    ) {
+      expectDetachedCopy(
+        copiedMessage.validation.schemaVersion,
+        fixture.messageTerm.validation.schemaVersion,
+      );
+    }
+    expectDetachedCopy(copiedLane, fixture.laneTerm);
+    expectDetachedCopy(copiedLane.payloadKinds, fixture.laneTerm.payloadKinds);
+    expectDetachedCopy(copiedProfile, fixture.messageProfile);
+    expectDetachedCopy(copiedProfile.routeBindings, fixture.messageProfile.routeBindings);
+    const copiedRoute = copiedProfile.routeBindings[0];
+    const authoredRoute = fixture.messageProfile.routeBindings[0];
+    expectDetachedCopy(copiedRoute, authoredRoute);
+    expectDetachedCopy(copiedRoute.authorizationBindings, authoredRoute.authorizationBindings);
+    expectDetachedCopy(
+      copiedRoute.authorizationBindings[0],
+      authoredRoute.authorizationBindings[0],
+    );
+    expectDetachedCopy(
+      copiedRoute.authorizationBindings[0].ownerBindingIds,
+      authoredRoute.authorizationBindings[0].ownerBindingIds,
+    );
+    expectDetachedCopy(copiedProfile.validation, fixture.messageProfile.validation);
+    const copiedBinding = catalog.bindings[0];
+    const authoredBinding = fixture.bindingSet.bindings[0];
+    if (
+      copiedBinding.target.kind === 'wire-constant' &&
+      authoredBinding.target.kind === 'wire-constant'
+    ) {
+      expectDetachedCopy(copiedBinding.target.propertyPath, authoredBinding.target.propertyPath);
+    }
+  });
+
+  it('detaches custom profile nested ordered arrays from later caller mutation', () => {
+    const authoredSteps = ['zAuthoredFirst', 'aAuthoredSecond'];
+    const profile = createRallarOntologyCustomOrderedProfileFixture(authoredSteps);
+    const bindingSet = createRallarOntologyBindingModuleFixture({ profiles: [profile] });
+    const catalog = createRallarOntologyCatalog({
+      vocabularies: [createRallarOntologyVocabularyFixture()],
+      bindingSets: [bindingSet],
+    });
+    const copied = catalog.bindingProfiles[0] as RallarOntologyCustomOrderedProfile;
+
+    authoredSteps.reverse();
+
+    expect(copied.metadata.orderedSteps).toEqual(['zAuthoredFirst', 'aAuthoredSecond']);
+    expect(copied.metadata).not.toBe(profile.metadata);
+    expect(copied.metadata.orderedSteps).not.toBe(authoredSteps);
+  });
+
+  it('provides direct term, binding, and profile lookups with empty missing results', () => {
+    const catalog = createRallarOntologyCatalog(createUnsortedInput());
+
+    expect(getRallarOntologyTerm(catalog, TEST_PARENT_TERM_ID)?.termId).toBe(TEST_PARENT_TERM_ID);
+    expect(getRallarOntologyBindings(catalog, TEST_PARENT_TERM_ID)).toHaveLength(2);
+    expect(getRallarOntologyBindingProfiles(catalog, TEST_PARENT_TERM_ID)).toHaveLength(2);
+    const missing = `${ONTOLOGY_BASE}/term/acme.missing` as const;
+    expect(getRallarOntologyTerm(catalog, missing)).toBeUndefined();
+    expect(getRallarOntologyBindings(catalog, missing)).toEqual([]);
+    expect(getRallarOntologyBindingProfiles(catalog, missing)).toEqual([]);
+  });
+
+  it('creates an independently valid vocabulary catalog without bindings', () => {
+    const catalog = createRallarOntologyCatalog({
+      vocabularies: [createRallarOntologyVocabularyFixture()],
+      bindingSets: [],
+    });
+
+    expect(catalog.bindingSets).toEqual([]);
+    expect(catalog.bindings).toEqual([]);
+    expect(catalog.bindingProfiles).toEqual([]);
+  });
+
+  it('throws one TypeError containing every sorted validation issue', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      terms: [
+        {
+          ...createRallarOntologyVocabularyFixture().terms[0],
+          references: [
+            {
+              relationId: RALLAR_RELATION_IDS.scopedBy,
+              targetTermId: `${ONTOLOGY_BASE}/term/acme.missing`,
+            },
+          ],
+        },
+      ],
+    });
+    const input = { vocabularies: [vocabulary, vocabulary], bindingSets: [] };
+    const issues = validateRallarOntologyCatalog(input);
+
+    expect(() => createRallarOntologyCatalog(input)).toThrowError(TypeError);
+    try {
+      createRallarOntologyCatalog(input);
+    } catch (error) {
+      expect(error).toBeInstanceOf(TypeError);
+      const message = String(error);
+      issues.forEach((issue) => {
+        expect(message).toContain(`${issue.path} [${issue.code}]: ${issue.message}`);
+      });
+    }
+  });
+});

--- a/packages/tests/shared/rallar-ontology-test-fixtures.ts
+++ b/packages/tests/shared/rallar-ontology-test-fixtures.ts
@@ -1,0 +1,225 @@
+import {
+  RALLAR_RELATION_IDS,
+  type RallarOntologyBindingModule,
+  type RallarOntologyBindingProfileBase,
+  type RallarOntologyVocabularyModule,
+} from '@shared/ontology/rallar-ontology-contracts.ts';
+import type { RallarDomainOntologyTerm } from '@shared/ontology/rallar-domain-ontology-term.ts';
+import type {
+  RallarMessageOntologyBindingProfile,
+  RallarMessageOntologyTerm,
+  RallarRtcLaneOntologyTerm,
+} from '@shared/ontology/rallar-realtime-ontology-contracts.ts';
+
+export const ONTOLOGY_BASE =
+  'https://github.com/intact-software-systems/ar-eye-hunter/ontology' as const;
+export const TEST_ONTOLOGY_ID = `${ONTOLOGY_BASE}/extension/acme/core` as const;
+export const TEST_ONTOLOGY_VERSION_IRI = `${TEST_ONTOLOGY_ID}/version/0.1.0` as const;
+export const TEST_OWNER_ID = `${ONTOLOGY_BASE}/owner/acme` as const;
+export const TEST_PARENT_TERM_ID = `${ONTOLOGY_BASE}/term/acme.parent` as const;
+export const TEST_CHILD_TERM_ID = `${ONTOLOGY_BASE}/term/acme.child` as const;
+export const TEST_BINDING_SET_ID = `${ONTOLOGY_BASE}/binding-set/acme.core` as const;
+export const TEST_BINDING_SET_VERSION_IRI = `${TEST_BINDING_SET_ID}/version/0.1.0` as const;
+export const TEST_BINDING_ID = `${ONTOLOGY_BASE}/binding/acme.core.export` as const;
+export const TEST_PROFILE_ID = `${ONTOLOGY_BASE}/binding-profile/acme.core.profile` as const;
+
+export function createRallarOntologyVocabularyFixture(
+  overrides: Partial<RallarOntologyVocabularyModule> = {},
+): RallarOntologyVocabularyModule {
+  return {
+    ontologyId: TEST_ONTOLOGY_ID,
+    ownerId: TEST_OWNER_ID,
+    version: '0.1.0',
+    versionIri: TEST_ONTOLOGY_VERSION_IRI,
+    maturity: 'experimental',
+    compatibleWith: [],
+    requiredVocabularyVersionIris: [],
+    competencyQuestionIds: ['CQ-acme-core'],
+    terms: [
+      {
+        termId: TEST_PARENT_TERM_ID,
+        kind: 'concept',
+        label: 'Parent',
+        definition: 'The parent concept.',
+        status: 'draft',
+        references: [],
+      },
+      {
+        termId: TEST_CHILD_TERM_ID,
+        kind: 'concept',
+        label: 'Child',
+        definition: 'The child concept.',
+        status: 'draft',
+        references: [
+          {
+            relationId: RALLAR_RELATION_IDS.scopedBy,
+            targetTermId: TEST_PARENT_TERM_ID,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function createRallarOntologyBindingModuleFixture(
+  overrides: Partial<RallarOntologyBindingModule> = {},
+): RallarOntologyBindingModule {
+  return {
+    bindingSetId: TEST_BINDING_SET_ID,
+    ontologyId: TEST_ONTOLOGY_ID,
+    vocabularyVersionIri: TEST_ONTOLOGY_VERSION_IRI,
+    ownerId: TEST_OWNER_ID,
+    version: '0.1.0',
+    versionIri: TEST_BINDING_SET_VERSION_IRI,
+    maturity: 'experimental',
+    compatibleWith: [],
+    bindings: [
+      {
+        bindingId: TEST_BINDING_ID,
+        termId: TEST_PARENT_TERM_ID,
+        role: 'authoritative-contract',
+        strength: 'contractual',
+        target: {
+          kind: 'typescript-export',
+          modulePath: 'packages/shared/example.ts',
+          exportName: 'AcmeParent',
+        },
+      },
+    ],
+    profiles: [
+      {
+        profileId: TEST_PROFILE_ID,
+        termId: TEST_PARENT_TERM_ID,
+        kind: 'generic',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export interface RallarOntologyCustomOrderedProfile extends RallarOntologyBindingProfileBase {
+  readonly kind: 'custom-ordered';
+  readonly metadata: Readonly<{ orderedSteps: readonly string[] }>;
+}
+
+export interface RallarOntologySpecializedCopyFixture {
+  readonly vocabulary: RallarOntologyVocabularyModule;
+  readonly bindingSet: RallarOntologyBindingModule;
+  readonly domainTerm: RallarDomainOntologyTerm;
+  readonly messageTerm: RallarMessageOntologyTerm;
+  readonly laneTerm: RallarRtcLaneOntologyTerm;
+  readonly messageProfile: RallarMessageOntologyBindingProfile;
+  readonly customProfile: RallarOntologyCustomOrderedProfile;
+}
+
+export function createRallarOntologyCustomOrderedProfileFixture(
+  orderedSteps: readonly string[] = ['zAuthoredFirst', 'aAuthoredSecond'],
+): RallarOntologyCustomOrderedProfile {
+  return {
+    profileId: `${ONTOLOGY_BASE}/binding-profile/acme.custom-ordered`,
+    termId: TEST_PARENT_TERM_ID,
+    kind: 'custom-ordered',
+    metadata: { orderedSteps },
+  };
+}
+
+export function createRallarOntologySpecializedCopyFixture(): RallarOntologySpecializedCopyFixture {
+  const terms = createRallarOntologyVocabularyFixture().terms;
+  const domainTerm: RallarDomainOntologyTerm = {
+    ...terms[0],
+    kind: 'domain',
+    domainKind: 'identity',
+    authority: 'authoritative',
+    identityFields: ['zAuthoredFirst', 'aAuthoredSecond'],
+  };
+  const messageTerm: RallarMessageOntologyTerm = {
+    ...terms[1],
+    kind: 'message-type',
+    wireTypeId: 'acme.message.v1',
+    routes: [
+      {
+        routeId: `${ONTOLOGY_BASE}/route/acme.message`,
+        topicId: 'acme.message',
+        scope: 'room',
+        transports: ['al-ws', 'al-rtc'],
+        targetModes: ['broadcast', 'unicast'],
+        requestedReliability: 'best-effort',
+        acknowledgement: 'none',
+        ordering: 'none',
+        deduplication: 'none',
+        supersedence: 'none',
+        qosOwnership: 'sender',
+        authorization: 'required',
+      },
+    ],
+    senderKinds: ['server-node', 'client-session'],
+    validation: {
+      kind: 'runtime-payload',
+      schemaVersion: { kind: 'payload-field', fieldPath: '$.schemaVersion' },
+    },
+    correlation: 'message-id',
+  };
+  const laneTerm: RallarRtcLaneOntologyTerm = {
+    ...terms[0],
+    termId: `${ONTOLOGY_BASE}/term/acme.lane`,
+    kind: 'rtc-lane',
+    laneId: 'acme-lane',
+    envelope: 'none',
+    payloadKinds: ['binary', 'json'],
+    roomScopeCarrier: 'payload-room-ref-or-unique-lane',
+  };
+  const messageProfile: RallarMessageOntologyBindingProfile = {
+    profileId: `${ONTOLOGY_BASE}/binding-profile/acme.message`,
+    termId: messageTerm.termId,
+    kind: 'message-bindings',
+    wireTypeBindingId: `${ONTOLOGY_BASE}/binding/acme.wire-type`,
+    routeBindings: [
+      {
+        routeId: messageTerm.routes[0].routeId,
+        topicBindingId: `${ONTOLOGY_BASE}/binding/acme.topic`,
+        authorizationBindings: [
+          {
+            transport: 'al-ws',
+            ownerBindingIds: [
+              `${ONTOLOGY_BASE}/binding/acme.owner-z`,
+              `${ONTOLOGY_BASE}/binding/acme.owner-a`,
+            ],
+          },
+        ],
+      },
+    ],
+    validation: {
+      kind: 'unvalidated',
+      boundaryBindingId: `${ONTOLOGY_BASE}/binding/acme.boundary`,
+      gapOwnerBindingId: `${ONTOLOGY_BASE}/binding/acme.gap-owner`,
+    },
+  };
+  const customProfile = createRallarOntologyCustomOrderedProfileFixture();
+  const vocabulary = createRallarOntologyVocabularyFixture({
+    terms: [domainTerm, messageTerm, laneTerm],
+  });
+  const bindingSet = createRallarOntologyBindingModuleFixture({
+    bindings: [
+      {
+        ...createRallarOntologyBindingModuleFixture().bindings[0],
+        target: {
+          kind: 'wire-constant',
+          modulePath: 'packages/shared/example.ts',
+          exportName: 'EXAMPLE',
+          propertyPath: ['zAuthoredFirst', 'aAuthoredSecond'],
+        },
+      },
+    ],
+    profiles: [messageProfile, customProfile],
+  });
+  return {
+    vocabulary,
+    bindingSet,
+    domainTerm,
+    messageTerm,
+    laneTerm,
+    messageProfile,
+    customProfile,
+  };
+}

--- a/packages/tests/shared/rallar-ontology-vocabulary-validation.test.ts
+++ b/packages/tests/shared/rallar-ontology-vocabulary-validation.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RALLAR_RELATION_IDS,
+  type RallarOntologyVocabularyModule,
+} from '@shared/ontology/rallar-ontology-contracts.ts';
+import { validateRallarOntologyVocabularyModule } from '@shared/ontology/validate-rallar-ontology-vocabulary-module.ts';
+
+import {
+  createRallarOntologyVocabularyFixture,
+  ONTOLOGY_BASE,
+  TEST_CHILD_TERM_ID,
+  TEST_ONTOLOGY_ID,
+  TEST_OWNER_ID,
+  TEST_PARENT_TERM_ID,
+} from './rallar-ontology-test-fixtures.ts';
+
+function issueCodes(vocabulary: RallarOntologyVocabularyModule): readonly string[] {
+  return validateRallarOntologyVocabularyModule(vocabulary).map((issue) => issue.code);
+}
+
+describe('Rallar ontology vocabulary validation', () => {
+  it('accepts the independent default vocabulary without a binding module', () => {
+    expect(validateRallarOntologyVocabularyModule(createRallarOntologyVocabularyFixture())).toEqual(
+      [],
+    );
+  });
+
+  it.each([
+    `${ONTOLOGY_BASE}/domain`,
+    `${ONTOLOGY_BASE}/realtime`,
+    `${ONTOLOGY_BASE}/code-standards`,
+    `${ONTOLOGY_BASE}/extension/acme/game`,
+  ])('accepts the governed ontology series %s', (ontologyId) => {
+    const versionIri = `${ontologyId}/version/0.1.0`;
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      ontologyId: ontologyId as RallarOntologyVocabularyModule['ontologyId'],
+      versionIri: versionIri as RallarOntologyVocabularyModule['versionIri'],
+    });
+
+    expect(validateRallarOntologyVocabularyModule(vocabulary)).toEqual([]);
+  });
+
+  it('accepts canonical owner, term, relation, and version identities', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      ownerId: `${ONTOLOGY_BASE}/owner/acme`,
+      terms: [
+        {
+          termId: `${ONTOLOGY_BASE}/term/acme.entity`,
+          kind: 'concept',
+          label: 'Entity',
+          definition: 'An entity.',
+          status: 'draft',
+          references: [
+            {
+              relationId: `${ONTOLOGY_BASE}/relation/scoped-by`,
+              targetTermId: TEST_PARENT_TERM_ID,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(validateRallarOntologyVocabularyModule(vocabulary)).toEqual([]);
+  });
+
+  it.each([
+    'http://www.w3.org/2004/02/skos/core#broader',
+    'http://www.w3.org/2004/02/skos/core#narrower',
+    'http://www.w3.org/2004/02/skos/core#related',
+  ] as const)('accepts the controlled SKOS relation %s', (relationId) => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      terms: [
+        {
+          ...createRallarOntologyVocabularyFixture().terms[0],
+          references: [{ relationId, targetTermId: TEST_PARENT_TERM_ID }],
+        },
+      ],
+    });
+
+    expect(validateRallarOntologyVocabularyModule(vocabulary)).toEqual([]);
+  });
+
+  it.each([
+    'http://github.com/intact-software-systems/ar-eye-hunter/ontology/domain',
+    'https://GITHUB.com/intact-software-systems/ar-eye-hunter/ontology/domain',
+    'https://githуb.com/intact-software-systems/ar-eye-hunter/ontology/domain',
+    'https://github.com.evil/intact-software-systems/ar-eye-hunter/ontology/domain',
+    'https://github.com@evil.example/intact-software-systems/ar-eye-hunter/ontology/domain',
+    'https://github.com/intact-software-systems/ar-eye-hunter/ontology.evil/domain',
+    `${ONTOLOGY_BASE}/./domain`,
+    `${ONTOLOGY_BASE}/../domain`,
+    `${ONTOLOGY_BASE}//domain`,
+    `${ONTOLOGY_BASE}/domain?version=1`,
+    `${ONTOLOGY_BASE}/domain#version`,
+    `${ONTOLOGY_BASE}/%64omain`,
+    `${ONTOLOGY_BASE}/extension`,
+    `${ONTOLOGY_BASE}/extension/acme`,
+  ])('rejects the literal ontology lookalike %s', (ontologyId) => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      ontologyId: ontologyId as RallarOntologyVocabularyModule['ontologyId'],
+    });
+
+    expect(issueCodes(vocabulary)).toContain('invalid-ontology-iri');
+  });
+
+  it.each([
+    ['ownerId', `${ONTOLOGY_BASE}/owner/../acme`, 'invalid-owner-iri'],
+    ['ownerId', `${ONTOLOGY_BASE}/owner/acme?x=1`, 'invalid-owner-iri'],
+    ['ownerId', `${ONTOLOGY_BASE}/owner/%61cme`, 'invalid-owner-iri'],
+    ['termId', `${ONTOLOGY_BASE}/term/../acme.entity`, 'invalid-term-iri'],
+    ['termId', `${ONTOLOGY_BASE}/term/acme.entity#x`, 'invalid-term-iri'],
+    ['termId', `${ONTOLOGY_BASE}/term/%61cme.entity`, 'invalid-term-iri'],
+  ])('rejects malformed %s identities', (field, value, code) => {
+    const vocabulary = createRallarOntologyVocabularyFixture(
+      field === 'ownerId'
+        ? { ownerId: value as RallarOntologyVocabularyModule['ownerId'] }
+        : {
+            terms: [
+              {
+                ...createRallarOntologyVocabularyFixture().terms[0],
+                termId: value as RallarOntologyVocabularyModule['terms'][number]['termId'],
+              },
+            ],
+          },
+    );
+
+    expect(issueCodes(vocabulary)).toContain(code);
+  });
+
+  it.each(['1', '1.2', '1.2.3-beta', '1.2.3+build', '01.2.3', '1.02.3', '1.2.03'])(
+    'rejects the non-canonical version %s',
+    (version) => {
+      const vocabulary = createRallarOntologyVocabularyFixture({
+        version: version as RallarOntologyVocabularyModule['version'],
+      });
+
+      expect(issueCodes(vocabulary)).toContain('invalid-version');
+    },
+  );
+
+  it('requires the exact version IRI for the declared series and version', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      versionIri: `${TEST_ONTOLOGY_ID}/version/0.2.0`,
+    });
+
+    expect(issueCodes(vocabulary)).toContain('invalid-version-iri');
+  });
+
+  it('accepts unique prior compatible versions from the same series', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      version: '0.3.0',
+      versionIri: `${TEST_ONTOLOGY_ID}/version/0.3.0`,
+      compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.1.0`, `${TEST_ONTOLOGY_ID}/version/0.2.0`],
+    });
+
+    expect(validateRallarOntologyVocabularyModule(vocabulary)).toEqual([]);
+  });
+
+  it.each([
+    {
+      compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.1.0`, `${TEST_ONTOLOGY_ID}/version/0.1.0`],
+    },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.3.0`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.4.0`] },
+    { compatibleWith: [`${ONTOLOGY_BASE}/extension/acme/other/version/0.1.0`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/^0.1.0`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.1`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.1.0-beta`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/0.1.0+build`] },
+    { compatibleWith: [`${TEST_ONTOLOGY_ID}/version/00.1.0`] },
+  ])('rejects an invalid compatibility declaration %#', ({ compatibleWith }) => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      version: '0.3.0',
+      versionIri: `${TEST_ONTOLOGY_ID}/version/0.3.0`,
+      compatibleWith: compatibleWith as RallarOntologyVocabularyModule['compatibleWith'],
+    });
+
+    expect(issueCodes(vocabulary)).toContain('invalid-compatible-version-iri');
+  });
+
+  it('validates controlled relations, unique terms, maturity, and local deprecation rules', () => {
+    const parent = createRallarOntologyVocabularyFixture().terms[0];
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      maturity: 'preview' as RallarOntologyVocabularyModule['maturity'],
+      terms: [
+        parent,
+        { ...parent, termId: parent.termId },
+        {
+          ...parent,
+          termId: TEST_CHILD_TERM_ID,
+          status: 'deprecated',
+          supersededBy: TEST_CHILD_TERM_ID,
+          references: [
+            {
+              relationId:
+                `${ONTOLOGY_BASE}/relation/free-form` as typeof RALLAR_RELATION_IDS.scopedBy,
+              targetTermId: TEST_PARENT_TERM_ID,
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateRallarOntologyVocabularyModule(vocabulary);
+
+    expect(issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'invalid-maturity',
+        'duplicate-term-id',
+        'invalid-relation-iri',
+        'invalid-deprecation',
+      ]),
+    );
+    expect(issues.every((issue) => issue.path.startsWith('vocabulary.'))).toBe(true);
+    expect(issues.some((issue) => issue.path === 'vocabulary.terms[2].supersededBy')).toBe(true);
+  });
+
+  it('leaves valid reference target resolution to catalog validation', () => {
+    const vocabulary = createRallarOntologyVocabularyFixture({
+      terms: [
+        {
+          ...createRallarOntologyVocabularyFixture().terms[0],
+          references: [
+            {
+              relationId: RALLAR_RELATION_IDS.scopedBy,
+              targetTermId: `${ONTOLOGY_BASE}/term/acme.not-selected`,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(validateRallarOntologyVocabularyModule(vocabulary)).toEqual([]);
+  });
+});

--- a/scripts/repo-style-check/layout-rules.mjs
+++ b/scripts/repo-style-check/layout-rules.mjs
@@ -11,11 +11,11 @@ const ignoredLeadingFeatureTokens = toWordSet(
     'to use v1 v2 validate write',
 );
 const approvedModCompatibilityBoundaries = toWordSet(
-  'packages/relic-hunters/mod.ts packages/shared-graph/mod.ts ' +
-    'packages/shared-server/game/mod.ts packages/shared-server/mod.ts ' +
+  'packages/relic-hunters/mod.ts packages/shared-graph/mod.ts packages/shared/ontology/mod.ts ' +
+    'packages/shared-server/game/mod.ts packages/shared-server/mod.ts packages/shared/mod.ts ' +
     'packages/shared-server/rallar-ai/mod.ts packages/shared-test/rallar-bb-test/mod.ts ' +
     'packages/shared-web/game/mod.ts packages/shared-web/mod.ts packages/shared/crdt/mod.ts ' +
-    'packages/shared/mod.ts packages/shared/rallar-ai/mod.ts packages/shared/rallar-game/mod.ts ' +
+    'packages/shared/rallar-ai/mod.ts packages/shared/rallar-game/mod.ts ' +
     'packages/shared/rallar-match/mod.ts packages/shared/rallar-motion/mod.ts',
 );
 const authoritativeBrowserImports = new Map([


### PR DESCRIPTION
## Outcome

Implements only Ontology Task 1: the additive, operationally inert Rallar ontology vocabulary, binding, catalog, deterministic registry, narrow ontology compatibility surface, and focused tests.

## Publication anchors

- Implementation base: `e54d0ff06863ea9af6647eaad84bb5d3e9615740`
- Human-approved plan blob: `7e142365f9b18f59966aa440cb5b9cdd228935b0`
- Human approval: PR #80 comment `5218917814`
- Coordinator activation: merged roadmap PR #79 at `6d4b9653eda00fb0234d2dc419321dd8b7fce7a4`
- Roadmap activation blob: `c30557fbf46309835664f6794987c6d80a2413f6`
- Candidate commit: `ff9e77405b4986836272a3c48dc0659241ff5d83`
- Candidate tree: `07d58cd0936406f6ab632b6d219431fadc2605e0`

The prohibited earlier `d68d511...` prototype was not reused or transplanted.

## Exact scope

- Exactly the approved 17 paths changed: 15 new ontology source/test files plus the two existing repository-layout checker files.
- Every changed source, test, and checker file is at most 400 physical lines.
- The layout checker adds only `packages/shared/ontology/mod.ts` as an approved compatibility boundary; the nested lookalike remains rejected.
- No existing package barrel, runtime import, packet, payload, authority, routing, runtime validator, generated artifact, or Ontology Task 2-11 path changed.

## TDD and review evidence

- Vocabulary: missing-module RED; GREEN including literal governed identities, canonical versions, compatibility, references, deprecation, and all three approved SKOS relations.
- Binding: missing-validator RED; GREEN for identities, versions, strengths, targets, repository paths, and property paths.
- Catalog: missing-validator RED; GREEN for duplicates, exact dependencies, cross-vocabulary references, binding pairing, and term ownership.
- Registry: missing-registry/public-surface RED; GREEN for deterministic copying/sorting, three lookups, aggregate `TypeError`, and non-aliasing copies of Task 1-owned nested arrays/objects while preserving semantically ordered arrays.
- Layout: exact ontology boundary RED before allowlisting; GREEN after the one-path checker change.
- Final review RED/GREEN: an untrusted unknown binding-target discriminant is rejected at `.target.kind`; an unscoped package specifier such as `lodash/fp` is rejected at `.modulePath`; catalog aggregation retains both complete issue paths.
- Final review RED/GREEN: custom profile metadata is recursively detached without reordering, known ordered arrays and nested objects are detached, a second binding set proves top-level, nested, and flattened ID ordering, and frozen caller inputs remain unchanged.
- Final review RED/GREEN: the layout test now independently proves the exact ontology root `mod.ts` is allowed and a nested lookalike is rejected.
- Final focused cohort: 5 files, 159 tests passed.

## Fresh local validation on the candidate tree

- `npx tsc -p packages/shared/tsconfig.json --noEmit` — passed.
- Exact 17-path Prettier, line-count, `git diff --check`, cached diff, and scope checks — passed; all files are at most 400 lines.
- `npm run check:repo-style:changed -- e54d0ff06863ea9af6647eaad84bb5d3e9615740` — passed with zero new findings.
- `npm run test:repo-governance` — 27 files, 292 tests passed.
- `npm run test:unit` — 688 files passed (11 skipped); 6317 tests passed (18 skipped).
- Exact full `npm run test:ci` — passed outside the Codex sandbox on the unchanged candidate tree: unit passed; Deno passed; Rallar Playwright 38 passed/46 skipped; Recipe Console 211 passed/1 skipped; memory full-stack 7/7.
- `npm run build` — all workspaces passed; expected Vite chunk-size warnings only.

The initial sandboxed full-CI attempt was invalidated by three socket/IPC `EPERM` failures and four unrelated timeouts. The exact full command passed outside the sandbox without a source change. Generated dependency directories were removed before the final commit, and the committed tree is clean.

## Held boundaries

- No runtime integration or consumer activation.
- No ontology Tasks 2-11.
- No RTC instrumentation, capture, optimization, or Phase 2 work.

## Remote publication

- [x] Branch Release Gate run `31214805578`, attempt `1`, job `92985722492` passed on candidate commit `ff9e77405b4986836272a3c48dc0659241ff5d83`; the earlier successful run `31208680268` / attempt `1` / job `92965945437` validated the superseded commit only and is retained as historical evidence.
- [ ] Human merge approval remains separate.
- [ ] Resulting-main workflow evidence remains required after merge before Task 1 can be marked fully published.
