### PR TITLE
test: isolate Postgres presence request IDs

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -126,4 +126,7 @@ jobs:
           npm run test:rallar:full-stack:postgres:control
 
       - name: Run Postgres presence-expiry integration tests
-        run: npm run test:postgres:presence-expiry
+        run: |
+          # The second invocation proves retained direct-outbox rows cannot contaminate a later run.
+          npm run test:postgres:presence-expiry
+          npm run test:postgres:presence-expiry

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -49,7 +49,8 @@ describe('Deploy workflow release gate', () => {
       'cd apps/rallar-black-box-control-server && deno task check',
     );
     expect(releaseGateWorkflow).toContain('npm run db:migrate');
-    expect(releaseGateWorkflow).toContain('npm run test:postgres:presence-expiry');
+    expect(releaseGateWorkflow.match(/npm run test:postgres:presence-expiry/gu))
+      .toHaveLength(2);
     expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:rest');
     expect(releaseGateWorkflow).toContain('npm run test:rallar:full-stack:postgres:control');
 

--- a/packages/tests/shared-server/fixtures/create-postgres-test-request-id-factory.ts
+++ b/packages/tests/shared-server/fixtures/create-postgres-test-request-id-factory.ts
@@ -1,0 +1,21 @@
+const MAX_REQUEST_ID_LENGTH = 128;
+
+export function createPostgresTestRequestIdFactory(
+  runNonce = crypto.randomUUID(),
+): (semanticId: string) => string {
+  const prefix = `postgres-test:${runNonce}:`;
+
+  return (semanticId) => {
+    if (semanticId.trim().length === 0) {
+      throw new Error("Postgres test request semantic id must be non-empty");
+    }
+
+    const requestId = `${prefix}${semanticId}`;
+    if (requestId.length > MAX_REQUEST_ID_LENGTH) {
+      throw new Error(
+        `Postgres test request id must not exceed ${MAX_REQUEST_ID_LENGTH} characters`,
+      );
+    }
+    return requestId;
+  };
+}

--- a/packages/tests/shared-server/integration/postgres/presence/presence-expiry-concurrency.test.ts
+++ b/packages/tests/shared-server/integration/postgres/presence/presence-expiry-concurrency.test.ts
@@ -43,6 +43,8 @@ import {
   expectWorkerOutboxLifecycleEvidence,
   type WorkerOutboxEffect,
 } from "../../../postgres-worker-outbox-evidence.ts";
+import { createPostgresTestRequestIdFactory } from
+  "../../../fixtures/create-postgres-test-request-id-factory.ts";
 
 const POSTGRES_INTEGRATION_ENABLED =
   process.env.RALLAR_POSTGRES_INTEGRATION === "1";
@@ -116,6 +118,7 @@ const STATE_MUTATION_WORKER_PATH = fileURLToPath(
 );
 
 const postgresIt = POSTGRES_INTEGRATION_ENABLED ? it : it.skip;
+const requestIdFor = createPostgresTestRequestIdFactory();
 
 describe("Postgres presence expiry concurrency", () => {
   postgresIt(
@@ -190,7 +193,7 @@ describe("Postgres presence expiry concurrency", () => {
           createdByPrincipalId: "alice",
           actorPrincipalId: "alice",
           actorSessionId: "alice-session",
-          requestId: "worker-request-id-create",
+          requestId: requestIdFor("worker-request-id-create"),
         });
         await Promise.all(inputs.map((input) =>
           writeFile(input.barrier.releaseFilePath, "release", "utf8")
@@ -254,7 +257,7 @@ describe("Postgres presence expiry concurrency", () => {
           expiresAtEpochMs: atEpochMs + 61_000 + index,
           actorPrincipalId: sessionRef.principalId,
           actorSessionId: sessionRef.sessionId,
-          requestId: `worker-client-heartbeat-${index}`,
+          requestId: requestIdFor(`worker-client-heartbeat-${index}`),
         },
       }));
       const handles: WorkerHandle[] = [];
@@ -270,9 +273,13 @@ describe("Postgres presence expiry concurrency", () => {
         const outputs = await Promise.all(handles.map((handle) => handle.done));
 
         outputs.forEach(expectCompactWorkerOutput);
-        expect(outputs.find((output) => output.requestId === "worker-client-heartbeat-1"))
+        expect(outputs.find((output) =>
+          output.requestId === requestIdFor("worker-client-heartbeat-1")
+        ))
           .toMatchObject({ domainStatus: "applied" });
-        expect(outputs.find((output) => output.requestId === "worker-client-heartbeat-0")
+        expect(outputs.find((output) =>
+          output.requestId === requestIdFor("worker-client-heartbeat-0")
+        )
           ?.domainStatus).toMatch(/^(applied|no-op)$/u);
         expect(outputs.map((output) => output.attemptCount).sort()).toEqual([1, 2]);
         const traces = await Promise.all(inputs.map((input) => readTrace(input.traceFilePath)));
@@ -332,7 +339,7 @@ describe("Postgres presence expiry concurrency", () => {
             disconnectedAtEpochMs: atEpochMs + 1_000,
             actorPrincipalId: sessionRef.principalId,
             actorSessionId: sessionRef.sessionId,
-            requestId: "worker-client-disconnect",
+            requestId: requestIdFor("worker-client-disconnect"),
           },
         },
         {
@@ -355,7 +362,7 @@ describe("Postgres presence expiry concurrency", () => {
             expiresAtEpochMs: atEpochMs + 61_001,
             actorPrincipalId: sessionRef.principalId,
             actorSessionId: sessionRef.sessionId,
-            requestId: "worker-client-reconnect",
+            requestId: requestIdFor("worker-client-reconnect"),
           },
         },
       ];
@@ -428,7 +435,7 @@ describe("Postgres presence expiry concurrency", () => {
           request: {
             actorPrincipalId: "bob",
             actorSessionId: "bob-session",
-            requestId: "worker-group-join-bob",
+            requestId: requestIdFor("worker-group-join-bob"),
           },
         },
         {
@@ -445,7 +452,7 @@ describe("Postgres presence expiry concurrency", () => {
           request: {
             actorPrincipalId: "alice",
             actorSessionId: "alice-session",
-            requestId: "worker-group-ban-carol",
+            requestId: requestIdFor("worker-group-ban-carol"),
           },
         },
       ];
@@ -469,13 +476,13 @@ describe("Postgres presence expiry concurrency", () => {
           createdByPrincipalId: "alice",
           actorPrincipalId: "alice",
           actorSessionId: "alice-session",
-          requestId: "worker-group-create",
+          requestId: requestIdFor("worker-group-create"),
         });
         await setup.upsertMember(scope, groupRef.groupId, "carol", {
           status: "active",
           actorPrincipalId: "carol",
           actorSessionId: "carol-session",
-          requestId: "worker-group-add-carol",
+          requestId: requestIdFor("worker-group-add-carol"),
         });
         handles.push(...inputs.map((input) => spawnWorker(databaseUrl, input)));
         await waitForPostgresAppInboxWorkerParticipants(
@@ -543,14 +550,14 @@ describe("Postgres presence expiry concurrency", () => {
           createdByPrincipalId: "alice",
           actorPrincipalId: "alice",
           actorSessionId: "alice-session",
-          requestId: "worker-presence-create",
+          requestId: requestIdFor("worker-presence-create"),
         });
         for (const principalId of principals) {
           await setup.upsertMember(scope, groupRef.groupId, principalId, {
             status: "active",
             actorPrincipalId: principalId,
             actorSessionId: `${principalId}-session`,
-            requestId: `worker-presence-member-${principalId}`,
+            requestId: requestIdFor(`worker-presence-member-${principalId}`),
           });
         }
 
@@ -570,7 +577,7 @@ describe("Postgres presence expiry concurrency", () => {
             expiresAtEpochMs: atEpochMs + 61_000,
             actorPrincipalId: principalId,
             actorSessionId: sessions[index],
-            requestId: `worker-presence-connect-${index}`,
+            requestId: requestIdFor(`worker-presence-connect-${index}`),
           },
         }));
         const connected = await runBarrierWorkerPair(databaseUrl, connectInputs);
@@ -596,7 +603,7 @@ describe("Postgres presence expiry concurrency", () => {
             expiresAtEpochMs: atEpochMs + 62_000,
             actorPrincipalId: principalId,
             actorSessionId: sessions[index],
-            requestId: `worker-presence-heartbeat-${index}`,
+            requestId: requestIdFor(`worker-presence-heartbeat-${index}`),
           },
         }));
         const heartbeats = await runBarrierWorkerPair(databaseUrl, heartbeatInputs);
@@ -621,7 +628,7 @@ describe("Postgres presence expiry concurrency", () => {
             disconnectedAtEpochMs: atEpochMs + 3_000,
             actorPrincipalId: principalId,
             actorSessionId: sessions[index],
-            requestId: `worker-presence-disconnect-${index}`,
+            requestId: requestIdFor(`worker-presence-disconnect-${index}`),
           },
         }));
         const disconnected = await runBarrierWorkerPair(databaseUrl, disconnectInputs);
@@ -663,7 +670,10 @@ describe("Postgres presence expiry concurrency", () => {
       const scope = uniqueScope("group-last-slot-capacity");
       const groupRef: GroupRef = { ...scope, groupId: "room-1" };
       const atEpochMs = Date.now();
-      const contenderRequestIds = ["postgres-join-bob", "postgres-join-carol"];
+      const contenderRequestIds = [
+        requestIdFor("postgres-join-bob"),
+        requestIdFor("postgres-join-carol"),
+      ];
 
       try {
         await createPostgresGroupRuntime(
@@ -677,7 +687,7 @@ describe("Postgres presence expiry concurrency", () => {
           joinMode: "open",
           maxMembers: 2,
           createdByPrincipalId: "alice",
-          requestId: "postgres-create-last-slot",
+          requestId: requestIdFor("postgres-create-last-slot"),
         });
 
         const barrier = new GroupPresenceReadBarrier(2);
@@ -777,14 +787,14 @@ describe("Postgres presence expiry concurrency", () => {
           joinMode: "open",
           maxMembers: sessionCount + 1,
           createdByPrincipalId: "alice",
-          requestId: "postgres-heartbeat-create",
+          requestId: requestIdFor("postgres-heartbeat-create"),
         });
         for (let index = 0; index < sessionCount; index += 1) {
           const principalId = `member-${index}`;
           await setup.upsertMember(scope, groupRef.groupId, principalId, {
             status: "active",
             actorPrincipalId: principalId,
-            requestId: `postgres-heartbeat-member-${index}`,
+            requestId: requestIdFor(`postgres-heartbeat-member-${index}`),
           });
           await setup.connectPresenceSession(
             scope,
@@ -797,7 +807,7 @@ describe("Postgres presence expiry concurrency", () => {
               lastHeartbeatAtEpochMs: atEpochMs,
               expiresAtEpochMs: atEpochMs + 60_000,
               actorPrincipalId: principalId,
-              requestId: `postgres-heartbeat-connect-${index}`,
+              requestId: requestIdFor(`postgres-heartbeat-connect-${index}`),
             },
           );
         }
@@ -823,7 +833,7 @@ describe("Postgres presence expiry concurrency", () => {
         });
         const heartbeatRequestIds = Array.from(
           { length: sessionCount },
-          (_, index) => `postgres-heartbeat-${index}`,
+          (_, index) => requestIdFor(`postgres-heartbeat-${index}`),
         );
         const authorities = heartbeatRequestIds.map((_, index) =>
           testAuthority(`member-${index}`, `session-${index}`)
@@ -975,7 +985,7 @@ describe("Postgres presence expiry concurrency", () => {
                 connectedAtEpochMs: atEpochMs + 1,
                 lastHeartbeatAtEpochMs: atEpochMs + 1,
                 expiresAtEpochMs: atEpochMs + 60_000,
-                requestId: "postgres-reconnect-generation-2",
+                requestId: requestIdFor("postgres-reconnect-generation-2"),
               },
             ),
         ]);
@@ -1227,7 +1237,7 @@ async function seedExpiredClientSession(
       expiresAtEpochMs: atEpochMs - 1_000,
       actorPrincipalId: sessionRef.principalId,
       actorSessionId: sessionRef.sessionId,
-      requestId: "seed-client-session",
+      requestId: requestIdFor("seed-client-session"),
     },
   );
 }
@@ -1255,7 +1265,7 @@ async function seedExpiredGroupPresenceSession(
     createdByPrincipalId: "alice",
     actorPrincipalId: "alice",
     actorSessionId: sessionId,
-    requestId: "seed-group",
+    requestId: requestIdFor("seed-group"),
   });
   await service.connectPresenceSession(scope, groupRef.groupId, sessionId, {
     generationId: "generation-1",
@@ -1265,7 +1275,7 @@ async function seedExpiredGroupPresenceSession(
     expiresAtEpochMs: atEpochMs - 1_000,
     actorPrincipalId: "alice",
     actorSessionId: sessionId,
-    requestId: "seed-group-presence-session",
+    requestId: requestIdFor("seed-group-presence-session"),
   });
 }
 
@@ -1456,7 +1466,7 @@ async function seedConnectedClientSession(
     expiresAtEpochMs: atEpochMs + 60_000,
     actorPrincipalId: sessionRef.principalId,
     actorSessionId: sessionRef.sessionId,
-    requestId: "worker-client-seed",
+    requestId: requestIdFor("worker-client-seed"),
   });
 }
 

--- a/packages/tests/shared-server/postgres-test-request-id.test.ts
+++ b/packages/tests/shared-server/postgres-test-request-id.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createPostgresTestRequestIdFactory } from
+  "./fixtures/create-postgres-test-request-id-factory.ts";
+
+const RUN_A = "00000000-0000-4000-8000-000000000001";
+const RUN_B = "00000000-0000-4000-8000-000000000002";
+
+describe("Postgres test request ids", () => {
+  it("keeps one semantic id stable within a parent test run", () => {
+    const requestIdFor = createPostgresTestRequestIdFactory(RUN_A);
+
+    expect(requestIdFor("worker-presence-heartbeat-0"))
+      .toBe(requestIdFor("worker-presence-heartbeat-0"));
+    expect(requestIdFor("worker-presence-heartbeat-0"))
+      .toMatch(/worker-presence-heartbeat-0$/u);
+  });
+
+  it("separates retained evidence from different parent test runs", () => {
+    const firstRun = createPostgresTestRequestIdFactory(RUN_A);
+    const secondRun = createPostgresTestRequestIdFactory(RUN_B);
+
+    expect(firstRun("worker-presence-heartbeat-0"))
+      .not.toBe(secondRun("worker-presence-heartbeat-0"));
+  });
+
+  it("keeps concurrent contenders distinct within one run", () => {
+    const requestIdFor = createPostgresTestRequestIdFactory(RUN_A);
+
+    expect(requestIdFor("postgres-join-bob"))
+      .not.toBe(requestIdFor("postgres-join-carol"));
+  });
+
+  it("keeps the longest current semantic id within the public request limit", () => {
+    const requestIdFor = createPostgresTestRequestIdFactory(RUN_A);
+
+    expect(requestIdFor("postgres-reconnect-generation-2")).toHaveLength(82);
+    expect(requestIdFor("postgres-reconnect-generation-2").length)
+      .toBeLessThanOrEqual(128);
+  });
+
+  it("rejects empty or over-limit semantic ids before database mutation", () => {
+    const requestIdFor = createPostgresTestRequestIdFactory(RUN_A);
+
+    expect(() => requestIdFor(" ")).toThrow("semantic id must be non-empty");
+    expect(() => requestIdFor("x".repeat(78))).toThrow("must not exceed 128");
+  });
+});


### PR DESCRIPTION
## What this fixes

The opt-in Postgres presence-expiry suite retained direct-outbox rows whose
resource IDs could collide with later Vitest invocations. Evidence lookup is
intentionally by resource ID, so reused semantic request IDs could select an
older completed or retry row instead of the current run's new row.

## Change

- generate one UUID nonce when the parent presence test module starts;
- prefix every non-null caller-supplied request ID with that nonce while
  retaining the readable semantic suffix;
- keep IDs stable across retries and spawned child workers;
- reject empty or longer-than-128-character test IDs before mutation;
- keep production queue builders and deterministic maintenance identities
  unchanged;
- run the presence suite twice against the same Postgres service in the Release
  Gate, with governance proof requiring exactly two invocations.

## Current exact-head evidence

Validated and published head: `7011ce7c3b33e768839e029ea56cb83edb26f16e`.

The branch was rebased onto `661e497597587e3803c0760a90b0a124df8af075`.
Current main later gained only PR #131's unrelated plan-file edit at
`5e892aaff06cce0d994fbf79cfbcc12b235c7e48`; a merge-tree simulation is
conflict-free, so the tested executable tree was not rewritten again.

Passed locally on the exact head:

- request-ID and workflow-governance tests: 12/12;
- repository governance: 371/371;
- changed-style gate: no new findings;
- shared Postgres integration: 4/4;
- two consecutive presence-expiry runs against one retained database: 10/10
  and 10/10, followed by another 10/10 run after shared integration;
- standalone unit gate: 712 files and 6,519 tests;
- API Deno tests: 407/0;
- control-server Deno tests: 79/0;
- shared RTC/scenario Deno tests: 146/0;
- browser E2E: 38 passed, 46 intentionally skipped;
- Recipe Console E2E: 211 passed, 1 intentionally skipped;
- memory full-stack: 7/0;
- all workspace builds;
- full repository style check (warning-only), `git diff --check`, and a clean
  worktree.

Postgres was restored to its initial stopped state without resetting persisted
test data.

Two exact `npm run test:ci` attempts stopped during their nested unit phase on
unrelated five-/fifteen-second timeouts under high local CPU load: the attempts
reached 6,512/6,519 and 6,516/6,519 unit tests respectively. Every timed-out
file passed in isolation, the standalone exact unit gate passed 6,519/6,519,
and all remaining CI phases passed directly. No timeout, worker count, workload,
or assertion was changed. The clean-runner Branch Release Gate on this exact
head remains the publication authority and is pending.

The old Branch Release Gate run 31276006641 passed on the superseded
`4b8967c8...` head and is retained only as historical evidence. Feature-branch
Deno provider deployment contexts are not release gates under the repository's
main-only deployment policy.

Closes #102
