### PR TITLE
test: fence topology churn on causal convergence

### DIFF
--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
@@ -3,11 +3,19 @@ import assert from 'node:assert/strict';
 import type { StateScope } from '@shared/api/state-types.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
+import { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
+import { PSqlQueueBox } from '@shared-server/postgres/queuebox/PSqlQueueBox.ts';
 import {
   type GroupCreateAppInboxPayload,
   type GroupPresenceConnectAppInboxPayload,
 } from '@shared-server/rallar-system/services/AppGroupInboxService.ts';
 import { AppInboxType } from '@shared-server/rallar-system/services/AppInboxService.ts';
+import { AppOutboxType } from '@shared-server/rallar-system/services/AppOutboxService.ts';
+import { GroupPresenceSummaryWork } from '@shared-server/rallar-system/services/GroupPresenceSummaryWork.ts';
+// deno-fmt-ignore: This package import exceeds the repository's 100-column checker limit.
+import {
+  APP_OUTBOX_GROUP_PRESENCE_SUMMARY_TOPIC,
+} from '@shared-server/rallar-system/services/group-state-mutations.ts';
 import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/services/authorised-ws-client-app-inbox.ts';
 import {
   type GroupStateWritten,
@@ -127,6 +135,83 @@ Deno.test('PGlite group connect conflicts when cleanup commits after lifecycle r
       (await harness.groups.readSnapshot({ ...SCOPE, groupId }))
         ?.activeSessions ?? [],
       [],
+    );
+  });
+});
+
+Deno.test('PGlite group presence completion can precede its causal summary revision', async () => {
+  await withPGliteSql(async (sql) => {
+    const harness = await createHarness(sql);
+    const groupId = 'pglite-delayed-presence-summary';
+    const groupRef = { ...SCOPE, groupId };
+    const outboxReader = new OutboxQueueReader(new PSqlQueueBox(harness.resourceInbox));
+    const summaryWork = new GroupPresenceSummaryWork({
+      runtimeRepository: harness.runtime,
+      database: sql,
+      serviceId: 'pglite-close-test',
+    });
+    outboxReader.onOutboxMessageDo(AppOutboxType.GROUP_PRESENCE_SUMMARY, {
+      onMessage: async (message, entry) => await summaryWork.processReservedEntry(message, entry),
+    });
+    outboxReader.onOutboxMessageDo(AppOutboxType.RTC_TOPOLOGY_RECOMPUTE, {
+      onMessage: () => Promise.resolve(),
+    });
+
+    await createRoom(harness, groupId, sql);
+    await processNextOutbox(outboxReader);
+    const beforeConnect = await harness.groups.readSnapshot(groupRef);
+    assert.ok(beforeConnect);
+    assert.equal(beforeConnect.onlineMemberCount, 0);
+
+    const generationId = crypto.randomUUID();
+    const connectedAtEpochMs = Date.now() - 100;
+    const pending = harness.group.processAuthenticatedEntryUntilCompletion<
+      GroupPresenceConnectAppInboxPayload,
+      GroupStateWritten
+    >({
+      type: AppInboxType.GROUP_PRESENCE_CONNECT,
+      resourceId: `presence-${generationId}`,
+      contextId: `${SCOPE.applicationId}:${SCOPE.workspaceId}:${groupId}`,
+      senderId: harness.authority.clientId,
+      data: {
+        scope: SCOPE,
+        groupId,
+        sessionId: harness.authority.sessionId,
+        request: {
+          principalId: harness.authority.clientId,
+          generationId,
+          connectedAtEpochMs,
+          lastHeartbeatAtEpochMs: connectedAtEpochMs,
+          expiresAtEpochMs: FUTURE_MS,
+          actorPrincipalId: harness.authority.clientId,
+          actorSessionId: harness.authority.sessionId,
+          requestId: `presence-${generationId}`,
+        },
+      },
+    }, harness.authority);
+    await waitForPGliteQueueRow(sql, 'APP_INBOX', 'NEW');
+    await processNext(harness.reader);
+    assert.ok((await pending).right);
+    const [queuedSummary] = await sql<{ count: string | number }[]>`
+      select count(*) as count from resource_inbox
+      where ri_type_id = 'APP_OUTBOX'
+        and ri_topic_id = ${APP_OUTBOX_GROUP_PRESENCE_SUMMARY_TOPIC}
+        and ri_status = 'NEW'
+    `;
+    assert.equal(Number(queuedSummary?.count ?? 0), 1);
+
+    const whileSummaryQueued = await harness.groups.readSnapshot(groupRef);
+    assert.ok(whileSummaryQueued);
+    assert.equal(whileSummaryQueued.onlineMemberCount, 0);
+    assert.deepEqual(whileSummaryQueued.causalRevision, beforeConnect.causalRevision);
+
+    await processNextOutbox(outboxReader);
+    const afterSummary = await harness.groups.readSnapshot(groupRef);
+    assert.ok(afterSummary);
+    assert.equal(afterSummary.onlineMemberCount, 1);
+    assert.equal(
+      afterSummary.causalRevision.presenceRevision,
+      beforeConnect.causalRevision.presenceRevision + 1,
     );
   });
 });
@@ -340,6 +425,10 @@ async function createRoom(
 
 async function processNext(reader: InboxQueueReader): Promise<void> {
   await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, toResilienceDto());
+}
+
+async function processNextOutbox(reader: OutboxQueueReader): Promise<void> {
+  await reader.dequeueOutbox(OutboxQueueReader.OUTBOX_DEQUEUE_TYPES, toResilienceDto());
 }
 
 type QueueKey = Readonly<{ topicId: string; resourceId: string; contextId: string }>;

--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
@@ -100,6 +100,8 @@ export async function createPGliteAppInboxWsCloseHarness(sql: PGliteSql) {
   );
   return {
     authority,
+    runtime,
+    resourceInbox,
     reader,
     secondReader,
     client,

--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -442,6 +442,9 @@ Stable operators:
 - `template`: render a string with placeholders
 - `concat`: concatenate string parts
 - `coalesce`: return the first non-empty value, skipping missing optional paths
+- `add` and `max`: combine a non-empty array of finite numeric values
+- `equals`: compare exactly two evaluated values
+- `if`: evaluate a condition and exactly one of the required `then` or `else` branches
 - `jsonStringify` and `jsonParse`
 - `urlEncode`
 - `number`, `string`, and `boolean`
@@ -490,6 +493,33 @@ SET transforms can use previous outputs and variables:
       "?ticket=",
       { "urlEncode": { "path": "outputs.wsTicket" } }
     ]
+  }
+}
+```
+
+Numeric and conditional transforms can derive a bounded causal read floor
+without executing an unused branch:
+
+```json
+{
+  "type": "set",
+  "output": "presenceFloor",
+  "transform": {
+    "if": {
+      "condition": {
+        "equals": [
+          { "path": "outputs.onlineMemberCount" },
+          13
+        ]
+      },
+      "then": { "path": "outputs.presenceRevision" },
+      "else": {
+        "add": [
+          { "path": "outputs.presenceRevision" },
+          1
+        ]
+      }
+    }
   }
 }
 ```

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -496,6 +496,10 @@ function directTransformSpec(spec: Record<string, unknown>): unknown {
         'template',
         'concat',
         'coalesce',
+        'add',
+        'max',
+        'equals',
+        'if',
         'jsonStringify',
         'jsonParse',
         'urlEncode',
@@ -519,6 +523,10 @@ function isTransformOnlySpec(spec: Record<string, unknown>): boolean {
         'template',
         'concat',
         'coalesce',
+        'add',
+        'max',
+        'equals',
+        'if',
         'jsonStringify',
         'jsonParse',
         'urlEncode',
@@ -533,6 +541,9 @@ function isTransformOnlySpec(spec: Record<string, unknown>): boolean {
         'value',
         'input',
         'values',
+        'condition',
+        'then',
+        'else',
         'format',
         'secret',
         'redact',
@@ -665,6 +676,28 @@ function toTransformBoolean(value: unknown, details: any): boolean {
     });
 }
 
+function numericTransformValues(
+    spec: Record<string, unknown>,
+    operator: 'add' | 'max',
+    input: TransformEvaluationInput,
+    details: any,
+): number[] {
+    const values = Array.isArray(spec[operator])
+        ? spec[operator]
+        : Array.isArray(spec.values)
+            ? spec.values
+            : [];
+    if (values.length <= 0) {
+        return transformError(`${operator} transform requires a non-empty values array.`, details);
+    }
+    return values.map((value, index) =>
+        toTransformNumber(evaluateTransformValue(value, input), {
+            ...details,
+            index,
+        })
+    );
+}
+
 function evaluateTransformValue(value: unknown, input: TransformEvaluationInput): any {
     if (isRecord(value) && directTransformSpec(value) !== undefined) {
         return evaluateTransformSpec(value, input);
@@ -743,6 +776,46 @@ function evaluateTransformSpec(specInput: unknown, input: TransformEvaluationInp
         return transformError('Coalesce transform did not find a non-empty value.', details);
     }
 
+    if (operator === 'add') {
+        const total = numericTransformValues(spec, 'add', input, details)
+            .reduce((sum, value) => sum + value, 0);
+        return toTransformNumber(total, details);
+    }
+
+    if (operator === 'max') {
+        return Math.max(...numericTransformValues(spec, 'max', input, details));
+    }
+
+    if (operator === 'equals') {
+        const values = Array.isArray(spec.equals)
+            ? spec.equals
+            : Array.isArray(spec.values)
+                ? spec.values
+                : [];
+        if (values.length !== 2) {
+            return transformError('Equals transform requires exactly two values.', details);
+        }
+        return Object.is(
+            evaluateTransformValue(values[0], input),
+            evaluateTransformValue(values[1], input),
+        );
+    }
+
+    if (operator === 'if') {
+        const branches = isRecord(spec.if) ? spec.if : spec;
+        if (branches.condition === undefined) {
+            return transformError('If transform requires a condition.', details);
+        }
+        if (!Object.hasOwn(branches, 'then') || !Object.hasOwn(branches, 'else')) {
+            return transformError('If transform requires both then and else branches.', details);
+        }
+        const condition = toTransformBoolean(
+            evaluateTransformValue(branches.condition, input),
+            details,
+        );
+        return evaluateTransformValue(condition ? branches.then : branches.else, input);
+    }
+
     if (operator === 'jsonStringify') {
         return JSON.stringify(evaluateTransformValue(spec.jsonStringify ?? transformOperand(spec, input), input));
     }
@@ -817,6 +890,10 @@ function firstTransformOperator(spec: Record<string, unknown>): string | undefin
         'template',
         'concat',
         'coalesce',
+        'add',
+        'max',
+        'equals',
+        'if',
         'jsonStringify',
         'jsonParse',
         'urlEncode',

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -24,6 +24,12 @@ import {
 } from './rallar-remote-browser-provider.ts';
 import type { RallarBlackBoxTestCommand } from '../rallar-bb-test/types.ts';
 import { normalizeBlackBoxResponseHeaders } from './http/normalize-black-box-response-headers.ts';
+import {
+    directSafeOutputTransformSpec,
+    evaluateSafeOutputTransform,
+    isSafeOutputTransformOnlySpec,
+    SafeOutputTransformError,
+} from './scenario-transform/safe-output-transform.ts';
 const SUCCESS = 'SUCCESS';
 const FAILURE = 'FAILURE';
 declare const process: { env: Record<string, string | undefined> } | undefined;
@@ -429,20 +435,21 @@ type OutputExtraction = {
     redactAs?: string
 }
 
-type TransformEvaluationInput = {
-    context: any
-    result?: any
-    operatorPath?: string
+interface EvaluateScenarioTransformInput {
+    readonly transform: unknown
+    readonly context: any
+    readonly result?: any
+    readonly operatorPath?: string
 }
 
-class TransformEvaluationError extends Error {
-    details: any
-
-    constructor(message: string, details: any = {}) {
-        super(message)
-        this.name = 'TransformEvaluationError'
-        this.details = details
-    }
+function evaluateScenarioTransform(input: EvaluateScenarioTransformInput): any {
+    return evaluateSafeOutputTransform(input.transform, {
+        resolverRoot: toResolverRoot(input.context),
+        result: input.result,
+        operatorPath: input.operatorPath,
+        createUuid: randomUuid,
+        readTimestamp: Date.now,
+    });
 }
 
 function outputExtractions(result: any): OutputExtraction[] {
@@ -472,7 +479,7 @@ function outputExtractions(result: any): OutputExtraction[] {
                 extractions.push({
                     name,
                     path: spec.path ?? spec.from ?? spec.outputPath,
-                    transform: spec.transform ?? directTransformSpec(spec),
+                    transform: spec.transform ?? directSafeOutputTransformSpec(spec),
                     secret: spec.secret === true || spec.redact === true,
                     redactAs: typeof spec.redactAs === 'string' ? spec.redactAs : undefined,
                 });
@@ -487,422 +494,6 @@ function outputExtractions(result: any): OutputExtraction[] {
     }
 
     return extractions;
-}
-
-function directTransformSpec(spec: Record<string, unknown>): unknown {
-    return [
-        'path',
-        'from',
-        'template',
-        'concat',
-        'coalesce',
-        'add',
-        'max',
-        'equals',
-        'if',
-        'jsonStringify',
-        'jsonParse',
-        'urlEncode',
-        'number',
-        'string',
-        'boolean',
-        'uuid',
-        'timestamp',
-        'op',
-        'operator',
-    ].some(key => spec[key] !== undefined)
-        ? spec
-        : undefined;
-}
-
-function isTransformOnlySpec(spec: Record<string, unknown>): boolean {
-    const allowedKeys = new Set([
-        'path',
-        'from',
-        'outputPath',
-        'template',
-        'concat',
-        'coalesce',
-        'add',
-        'max',
-        'equals',
-        'if',
-        'jsonStringify',
-        'jsonParse',
-        'urlEncode',
-        'number',
-        'string',
-        'boolean',
-        'uuid',
-        'timestamp',
-        'op',
-        'operator',
-        'type',
-        'value',
-        'input',
-        'values',
-        'condition',
-        'then',
-        'else',
-        'format',
-        'secret',
-        'redact',
-        'redactAs',
-        'transform',
-    ]);
-    const keys = Object.keys(spec);
-    return keys.length > 0 &&
-        directTransformSpec(spec) !== undefined &&
-        keys.every(key => allowedKeys.has(key));
-}
-
-function transformError(message: string, details: any = {}): never {
-    throw new TransformEvaluationError(message, details);
-}
-
-function transformResolverRoot(context: any, result?: any): any {
-    return {
-        ...toResolverRoot(context),
-        result,
-        actual: result?.actual,
-        body: result?.actual?.body,
-    };
-}
-
-function resolveTemplateWithRoot(value: string, root: any): any {
-    const exactPlaceholderMatch = value.match(/^\{([A-Za-z_$][\w$-]*(?:\.[\w$-]+)*)\}$/u);
-
-    if (exactPlaceholderMatch) {
-        return resolvePath(exactPlaceholderMatch[1], root);
-    }
-
-    return value.replaceAll(/\{([A-Za-z_$][\w$-]*(?:\.[\w$-]+)*)\}/gu, (_match, path) => {
-        return stringifyResolvedValue(resolvePath(path, root));
-    });
-}
-
-function resolveTransformPath(path: unknown, input: TransformEvaluationInput): any {
-    if (typeof path !== 'string' || path.trim().length <= 0) {
-        return transformError('Transform path must be a non-empty string.', {
-            operator: 'path',
-            path,
-        });
-    }
-
-    const roots = [
-        input.result,
-        input.result?.actual,
-        input.result?.actual?.body,
-        transformResolverRoot(input.context, input.result),
-    ];
-
-    for (const root of roots) {
-        const resolved = tryResolvePath(path, root);
-        if (resolved.found) {
-            return resolved.value;
-        }
-    }
-
-    return transformError('Cannot resolve transform path {' + path + '}', {
-        operator: 'path',
-        path,
-    });
-}
-
-function transformOperand(spec: Record<string, unknown>, input: TransformEvaluationInput): unknown {
-    if (spec.value !== undefined) {
-        return evaluateTransformValue(spec.value, input);
-    }
-    if (spec.input !== undefined) {
-        return evaluateTransformValue(spec.input, input);
-    }
-    if (spec.from !== undefined) {
-        return resolveTransformPath(spec.from, input);
-    }
-    if (spec.path !== undefined) {
-        return resolveTransformPath(spec.path, input);
-    }
-
-    return undefined;
-}
-
-function isNonEmptyTransformValue(value: unknown): boolean {
-    if (value === undefined || value === null) {
-        return false;
-    }
-    if (typeof value === 'string') {
-        return value.length > 0;
-    }
-    if (Array.isArray(value)) {
-        return value.length > 0;
-    }
-    if (isRecord(value)) {
-        return Object.keys(value).length > 0;
-    }
-    return true;
-}
-
-function toTransformNumber(value: unknown, details: any): number {
-    const numberValue = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(numberValue)) {
-        return transformError('Transform value cannot be converted to number.', {
-            ...details,
-            input: value,
-        });
-    }
-    return numberValue;
-}
-
-function toTransformBoolean(value: unknown, details: any): boolean {
-    if (typeof value === 'boolean') {
-        return value;
-    }
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return value !== 0;
-    }
-    if (typeof value === 'string') {
-        const normalized = value.trim().toLowerCase();
-        if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
-            return true;
-        }
-        if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) {
-            return false;
-        }
-    }
-
-    return transformError('Transform value cannot be converted to boolean.', {
-        ...details,
-        input: value,
-    });
-}
-
-function numericTransformValues(
-    spec: Record<string, unknown>,
-    operator: 'add' | 'max',
-    input: TransformEvaluationInput,
-    details: any,
-): number[] {
-    const values = Array.isArray(spec[operator])
-        ? spec[operator]
-        : Array.isArray(spec.values)
-            ? spec.values
-            : [];
-    if (values.length <= 0) {
-        return transformError(`${operator} transform requires a non-empty values array.`, details);
-    }
-    return values.map((value, index) =>
-        toTransformNumber(evaluateTransformValue(value, input), {
-            ...details,
-            index,
-        })
-    );
-}
-
-function evaluateTransformValue(value: unknown, input: TransformEvaluationInput): any {
-    if (isRecord(value) && directTransformSpec(value) !== undefined) {
-        return evaluateTransformSpec(value, input);
-    }
-    if (typeof value === 'string') {
-        return resolveTemplateWithRoot(value, transformResolverRoot(input.context, input.result));
-    }
-    if (Array.isArray(value)) {
-        return value.map(item => evaluateTransformValue(item, input));
-    }
-    if (isRecord(value)) {
-        return Object.fromEntries(
-            Object.entries(value)
-                .map(([key, nested]) => [key, evaluateTransformValue(nested, input)]),
-        );
-    }
-    return value;
-}
-
-function evaluateTransformSpec(specInput: unknown, input: TransformEvaluationInput): any {
-    const spec = isRecord(specInput)
-        ? asTransformSpec(specInput)
-        : {
-            value: specInput,
-        };
-    const operator = String(spec.op ?? spec.operator ?? spec.type ?? firstTransformOperator(spec) ?? 'value');
-    const details = {
-        operator,
-        path: input.operatorPath,
-    };
-
-    if (operator === 'path' || operator === 'from' || operator === 'outputPath') {
-        return resolveTransformPath(spec.path ?? spec.from ?? spec.outputPath, input);
-    }
-
-    if (operator === 'template') {
-        if (typeof spec.template !== 'string') {
-            return transformError('Template transform requires a string template.', details);
-        }
-        return resolveTemplateWithRoot(spec.template, transformResolverRoot(input.context, input.result));
-    }
-
-    if (operator === 'concat') {
-        const parts = Array.isArray(spec.concat)
-            ? spec.concat
-            : Array.isArray(spec.values)
-                ? spec.values
-                : [];
-        if (parts.length <= 0) {
-            return transformError('Concat transform requires a non-empty values array.', details);
-        }
-        return parts
-            .map(part => stringifyResolvedValue(evaluateTransformValue(part, input)))
-            .join('');
-    }
-
-    if (operator === 'coalesce') {
-        const values = Array.isArray(spec.coalesce)
-            ? spec.coalesce
-            : Array.isArray(spec.values)
-                ? spec.values
-                : [];
-        if (values.length <= 0) {
-            return transformError('Coalesce transform requires a non-empty values array.', details);
-        }
-        for (const value of values) {
-            try {
-                const resolved = evaluateTransformValue(value, input);
-                if (isNonEmptyTransformValue(resolved)) {
-                    return resolved;
-                }
-            } catch (_error) {
-                // Missing optional values are ignored by coalesce.
-            }
-        }
-        return transformError('Coalesce transform did not find a non-empty value.', details);
-    }
-
-    if (operator === 'add') {
-        const total = numericTransformValues(spec, 'add', input, details)
-            .reduce((sum, value) => sum + value, 0);
-        return toTransformNumber(total, details);
-    }
-
-    if (operator === 'max') {
-        return Math.max(...numericTransformValues(spec, 'max', input, details));
-    }
-
-    if (operator === 'equals') {
-        const values = Array.isArray(spec.equals)
-            ? spec.equals
-            : Array.isArray(spec.values)
-                ? spec.values
-                : [];
-        if (values.length !== 2) {
-            return transformError('Equals transform requires exactly two values.', details);
-        }
-        return Object.is(
-            evaluateTransformValue(values[0], input),
-            evaluateTransformValue(values[1], input),
-        );
-    }
-
-    if (operator === 'if') {
-        const branches = isRecord(spec.if) ? spec.if : spec;
-        if (branches.condition === undefined) {
-            return transformError('If transform requires a condition.', details);
-        }
-        if (!Object.hasOwn(branches, 'then') || !Object.hasOwn(branches, 'else')) {
-            return transformError('If transform requires both then and else branches.', details);
-        }
-        const condition = toTransformBoolean(
-            evaluateTransformValue(branches.condition, input),
-            details,
-        );
-        return evaluateTransformValue(condition ? branches.then : branches.else, input);
-    }
-
-    if (operator === 'jsonStringify') {
-        return JSON.stringify(evaluateTransformValue(spec.jsonStringify ?? transformOperand(spec, input), input));
-    }
-
-    if (operator === 'jsonParse') {
-        const value = evaluateTransformValue(spec.jsonParse ?? transformOperand(spec, input), input);
-        if (typeof value !== 'string') {
-            return transformError('jsonParse transform requires a string input.', {
-                ...details,
-                input: value,
-            });
-        }
-        try {
-            return JSON.parse(value);
-        } catch (error) {
-            return transformError('jsonParse transform received invalid JSON.', {
-                ...details,
-                input: value,
-                error: error instanceof Error ? error.message : String(error),
-            });
-        }
-    }
-
-    if (operator === 'urlEncode') {
-        const value = evaluateTransformValue(spec.urlEncode ?? transformOperand(spec, input), input);
-        return encodeURIComponent(stringifyResolvedValue(value));
-    }
-
-    if (operator === 'number') {
-        return toTransformNumber(
-            evaluateTransformValue(spec.number ?? transformOperand(spec, input), input),
-            details,
-        );
-    }
-
-    if (operator === 'string') {
-        return stringifyResolvedValue(evaluateTransformValue(spec.string ?? transformOperand(spec, input), input));
-    }
-
-    if (operator === 'boolean') {
-        return toTransformBoolean(
-            evaluateTransformValue(spec.boolean ?? transformOperand(spec, input), input),
-            details,
-        );
-    }
-
-    if (operator === 'uuid') {
-        return randomUuid();
-    }
-
-    if (operator === 'timestamp') {
-        return spec.format === 'iso' ? new Date().toISOString() : Date.now();
-    }
-
-    if (spec.value !== undefined || spec.input !== undefined) {
-        return transformOperand(spec, input);
-    }
-
-    return transformError('Unsupported transform operator ' + operator + '.', details);
-}
-
-function asTransformSpec(spec: Record<string, unknown>): Record<string, unknown> {
-    return isRecord(spec.transform)
-        ? spec.transform
-        : spec;
-}
-
-function firstTransformOperator(spec: Record<string, unknown>): string | undefined {
-    return [
-        'path',
-        'from',
-        'template',
-        'concat',
-        'coalesce',
-        'add',
-        'max',
-        'equals',
-        'if',
-        'jsonStringify',
-        'jsonParse',
-        'urlEncode',
-        'number',
-        'string',
-        'boolean',
-        'uuid',
-        'timestamp',
-    ].find(key => spec[key] !== undefined);
 }
 
 function withExtractedOutputs(result: any, context: any): any {
@@ -921,7 +512,8 @@ function withExtractedOutputs(result: any, context: any): any {
     extractions.forEach(extraction => {
         try {
             const value = extraction.transform !== undefined
-                ? evaluateTransformSpec(extraction.transform, {
+                ? evaluateScenarioTransform({
+                    transform: extraction.transform,
                     context,
                     result,
                     operatorPath: `outputs.${extraction.name}`,
@@ -937,7 +529,7 @@ function withExtractedOutputs(result: any, context: any): any {
                 path: extraction.path,
                 transform: extraction.transform,
                 error: error instanceof Error ? error.message : String(error),
-                details: error instanceof TransformEvaluationError ? error.details : undefined,
+                details: error instanceof SafeOutputTransformError ? error.details : undefined,
             });
         }
     });
@@ -996,7 +588,7 @@ function resolvePlaceholders(value: any, context: any): any {
     }
 
     if (value && typeof value === 'object') {
-        if (isTransformOnlySpec(value as Record<string, unknown>)) {
+        if (isSafeOutputTransformOnlySpec(value as Record<string, unknown>)) {
             return value;
         }
 
@@ -1026,7 +618,7 @@ function resolveAssertActual(value: any, context: any, missingActualValue: any):
     }
 
     if (value && typeof value === 'object') {
-        if (isTransformOnlySpec(value as Record<string, unknown>)) {
+        if (isSafeOutputTransformOnlySpec(value as Record<string, unknown>)) {
             return value;
         }
 
@@ -1569,7 +1161,8 @@ async function executeSetInteraction(interaction: any, config: any, context: any
 
     if (transform !== undefined) {
         try {
-            value = evaluateTransformSpec(transform, {
+            value = evaluateScenarioTransform({
+                transform,
                 context,
                 operatorPath: `set.${String(output)}`,
             });
@@ -1582,7 +1175,7 @@ async function executeSetInteraction(interaction: any, config: any, context: any
                     transform,
                     transformError: {
                         message: error instanceof Error ? error.message : String(error),
-                        details: error instanceof TransformEvaluationError ? error.details : undefined,
+                        details: error instanceof SafeOutputTransformError ? error.details : undefined,
                     },
                 },
             );
@@ -1692,7 +1285,8 @@ function executeAssertInteraction(interaction: any, config: any, context: any): 
 
     const actual = interaction.response.actual !== undefined
         ? isRecord(interaction.response.actual) && interaction.response.actual.transform !== undefined
-            ? evaluateTransformSpec(interaction.response.actual.transform, {
+            ? evaluateScenarioTransform({
+                transform: interaction.response.actual.transform,
                 context,
                 operatorPath: 'assert.actual',
             })

--- a/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform-resolution.ts
+++ b/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform-resolution.ts
@@ -1,0 +1,123 @@
+// deno-lint-ignore-file no-explicit-any
+
+export interface SafeOutputTransformEvaluationInput {
+  readonly resolverRoot: Record<string, any>;
+  readonly result?: any;
+  readonly operatorPath?: string;
+  readonly createUuid: () => string;
+  readonly readTimestamp: () => number;
+}
+
+export interface SafeOutputTransformDetails {
+  readonly operator: string;
+  readonly path: any;
+  readonly [key: string]: any;
+}
+
+export class SafeOutputTransformError extends Error {
+  readonly details: SafeOutputTransformDetails;
+
+  constructor(message: string, details: SafeOutputTransformDetails) {
+    super(message);
+    this.name = 'SafeOutputTransformError';
+    this.details = details;
+  }
+}
+
+export function resolveSafeOutputTransformPath(
+  path: any,
+  input: SafeOutputTransformEvaluationInput,
+): any {
+  if (typeof path !== 'string' || path.trim().length <= 0) {
+    return rejectSafeOutputTransform('Transform path must be a non-empty string.', {
+      operator: 'path',
+      path,
+    });
+  }
+
+  const resultRoots = [input.result, input.result?.actual, input.result?.actual?.body];
+  for (const root of [...resultRoots, toTransformResolverRoot(input)]) {
+    const resolved = tryResolvePath(path, root);
+    if (resolved.found) {
+      return resolved.value;
+    }
+  }
+
+  return rejectSafeOutputTransform(`Cannot resolve transform path {${path}}`, {
+    operator: 'path',
+    path,
+  });
+}
+
+export function resolveSafeOutputTransformTemplate(
+  value: string,
+  input: SafeOutputTransformEvaluationInput,
+): any {
+  const root = toTransformResolverRoot(input);
+  const exactMatch = value.match(/^\{([A-Za-z_$][\w$-]*(?:\.[\w$-]+)*)\}$/u);
+  if (exactMatch) {
+    return resolvePath(exactMatch[1], root);
+  }
+
+  return value.replaceAll(/\{([A-Za-z_$][\w$-]*(?:\.[\w$-]+)*)\}/gu, (_match, path) =>
+    stringifySafeOutputTransformValue(resolvePath(path, root)),
+  );
+}
+
+export function stringifySafeOutputTransformValue(value: any): string {
+  if (value === undefined || value === null) {
+    return String(value);
+  }
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+export function rejectSafeOutputTransform(
+  message: string,
+  details: SafeOutputTransformDetails,
+): never {
+  throw new SafeOutputTransformError(message, details);
+}
+
+export function isSafeOutputTransformRecord(value: any): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toTransformResolverRoot(input: SafeOutputTransformEvaluationInput): any {
+  return {
+    ...input.resolverRoot,
+    result: input.result,
+    actual: input.result?.actual,
+    body: input.result?.actual?.body,
+  };
+}
+
+function resolvePath(path: string, root: any): any {
+  const resolved = path
+    .split('.')
+    .reduce(
+      (value, segment) => (value === undefined || value === null ? undefined : value[segment]),
+      root,
+    );
+  if (resolved === undefined) {
+    throw new Error(`Cannot resolve placeholder {${path}}`);
+  }
+  return resolved;
+}
+
+function tryResolvePath(path: string, root: any): { found: boolean; value?: any } {
+  const segments = path
+    .replaceAll(/\[(\d+)]/g, '.$1')
+    .split('.')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  let value = root;
+
+  for (const segment of segments) {
+    if (value === undefined || value === null) {
+      return { found: false };
+    }
+    value = value[segment];
+  }
+
+  return value === undefined ? { found: false } : { found: true, value };
+}

--- a/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform.ts
+++ b/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform.ts
@@ -1,0 +1,374 @@
+// deno-lint-ignore-file no-explicit-any
+
+import {
+  isSafeOutputTransformRecord,
+  rejectSafeOutputTransform,
+  resolveSafeOutputTransformPath,
+  resolveSafeOutputTransformTemplate,
+  type SafeOutputTransformDetails,
+  SafeOutputTransformError,
+  type SafeOutputTransformEvaluationInput,
+  stringifySafeOutputTransformValue,
+} from './safe-output-transform-resolution.ts';
+
+const DIRECT_TRANSFORM_KEYS = [
+  'path',
+  'from',
+  'template',
+  'concat',
+  'coalesce',
+  'add',
+  'max',
+  'equals',
+  'if',
+  'jsonStringify',
+  'jsonParse',
+  'urlEncode',
+  'number',
+  'string',
+  'boolean',
+  'uuid',
+  'timestamp',
+  'op',
+  'operator',
+] as const;
+
+const TRANSFORM_ONLY_KEYS = new Set([
+  ...DIRECT_TRANSFORM_KEYS,
+  'outputPath',
+  'type',
+  'value',
+  'input',
+  'values',
+  'condition',
+  'then',
+  'else',
+  'format',
+  'secret',
+  'redact',
+  'redactAs',
+  'transform',
+]);
+
+const IMPLICIT_TRANSFORM_OPERATORS = DIRECT_TRANSFORM_KEYS.filter(
+  (key) => key !== 'op' && key !== 'operator',
+);
+
+interface TransformOperatorEvaluation {
+  readonly spec: Record<string, any>;
+  readonly input: SafeOutputTransformEvaluationInput;
+  readonly details: SafeOutputTransformDetails;
+}
+
+export { SafeOutputTransformError };
+
+export function directSafeOutputTransformSpec(spec: Record<string, any>): any {
+  return DIRECT_TRANSFORM_KEYS.some((key) => spec[key] !== undefined) ? spec : undefined;
+}
+
+export function isSafeOutputTransformOnlySpec(spec: Record<string, any>): boolean {
+  const keys = Object.keys(spec);
+  return (
+    keys.length > 0 &&
+    directSafeOutputTransformSpec(spec) !== undefined &&
+    keys.every((key) => TRANSFORM_ONLY_KEYS.has(key))
+  );
+}
+
+export function evaluateSafeOutputTransform(
+  specInput: any,
+  input: SafeOutputTransformEvaluationInput,
+): any {
+  const spec = isSafeOutputTransformRecord(specInput)
+    ? asTransformSpec(specInput)
+    : { value: specInput };
+  const operator = String(
+    spec.op ?? spec.operator ?? spec.type ?? firstTransformOperator(spec) ?? 'value',
+  );
+  const details: SafeOutputTransformDetails = { operator, path: input.operatorPath };
+
+  switch (operator) {
+    case 'path':
+    case 'from':
+    case 'outputPath':
+      return resolveSafeOutputTransformPath(spec.path ?? spec.from ?? spec.outputPath, input);
+    case 'template':
+      return evaluateTemplateTransform(spec, input, details);
+    case 'concat':
+      return evaluateConcatTransform(spec, input, details);
+    case 'coalesce':
+      return evaluateCoalesceTransform(spec, input, details);
+    case 'add':
+    case 'max':
+      return evaluateNumericTransform({ spec, input, details });
+    case 'equals':
+      return evaluateEqualsTransform(spec, input, details);
+    case 'if':
+      return evaluateIfTransform(spec, input, details);
+    case 'jsonStringify':
+    case 'jsonParse':
+      return evaluateJsonTransform({ spec, input, details });
+    case 'urlEncode':
+    case 'number':
+    case 'string':
+    case 'boolean':
+      return evaluateScalarTransform({ spec, input, details });
+    case 'uuid':
+      return input.createUuid();
+    case 'timestamp':
+      return spec.format === 'iso'
+        ? new Date(input.readTimestamp()).toISOString()
+        : input.readTimestamp();
+    default:
+      return evaluateValueOrReject({ spec, input, details });
+  }
+}
+
+function evaluateTemplateTransform(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+  details: SafeOutputTransformDetails,
+): any {
+  if (typeof spec.template !== 'string') {
+    return rejectSafeOutputTransform('Template transform requires a string template.', details);
+  }
+  return resolveSafeOutputTransformTemplate(spec.template, input);
+}
+
+function evaluateConcatTransform(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+  details: SafeOutputTransformDetails,
+): string {
+  const parts = transformValues(spec, 'concat');
+  if (parts.length <= 0) {
+    return rejectSafeOutputTransform(
+      'Concat transform requires a non-empty values array.',
+      details,
+    );
+  }
+  return parts
+    .map((part) => stringifySafeOutputTransformValue(evaluateTransformValue(part, input)))
+    .join('');
+}
+
+function evaluateCoalesceTransform(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+  details: SafeOutputTransformDetails,
+): any {
+  const values = transformValues(spec, 'coalesce');
+  if (values.length <= 0) {
+    return rejectSafeOutputTransform(
+      'Coalesce transform requires a non-empty values array.',
+      details,
+    );
+  }
+  for (const value of values) {
+    try {
+      const resolved = evaluateTransformValue(value, input);
+      if (isNonEmptyTransformValue(resolved)) {
+        return resolved;
+      }
+    } catch (_error) {
+      // Missing optional values are ignored by coalesce.
+    }
+  }
+  return rejectSafeOutputTransform('Coalesce transform did not find a non-empty value.', details);
+}
+
+function evaluateNumericTransform(evaluation: TransformOperatorEvaluation): number {
+  const { spec, input, details } = evaluation;
+  const operator = details.operator as 'add' | 'max';
+  const values = transformValues(spec, operator);
+  if (values.length <= 0) {
+    return rejectSafeOutputTransform(
+      `${operator} transform requires a non-empty values array.`,
+      details,
+    );
+  }
+  const numbers = values.map((value, index) =>
+    toTransformNumber(evaluateTransformValue(value, input), { ...details, index }),
+  );
+  return operator === 'add'
+    ? toTransformNumber(
+        numbers.reduce((sum, value) => sum + value, 0),
+        details,
+      )
+    : Math.max(...numbers);
+}
+
+function evaluateEqualsTransform(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+  details: SafeOutputTransformDetails,
+): boolean {
+  const values = transformValues(spec, 'equals');
+  if (values.length !== 2) {
+    return rejectSafeOutputTransform('Equals transform requires exactly two values.', details);
+  }
+  return Object.is(
+    evaluateTransformValue(values[0], input),
+    evaluateTransformValue(values[1], input),
+  );
+}
+
+function evaluateIfTransform(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+  details: SafeOutputTransformDetails,
+): any {
+  const branches = isSafeOutputTransformRecord(spec.if) ? spec.if : spec;
+  if (branches.condition === undefined) {
+    return rejectSafeOutputTransform('If transform requires a condition.', details);
+  }
+  if (!Object.hasOwn(branches, 'then') || !Object.hasOwn(branches, 'else')) {
+    return rejectSafeOutputTransform('If transform requires both then and else branches.', details);
+  }
+  const condition = toTransformBoolean(evaluateTransformValue(branches.condition, input), details);
+  return evaluateTransformValue(condition ? branches.then : branches.else, input);
+}
+
+function evaluateJsonTransform(evaluation: TransformOperatorEvaluation): any {
+  const { spec, input, details } = evaluation;
+  const operator = details.operator as 'jsonStringify' | 'jsonParse';
+  const value = evaluateTransformValue(spec[operator] ?? transformOperand(spec, input), input);
+  if (operator === 'jsonStringify') {
+    return JSON.stringify(value);
+  }
+  if (typeof value !== 'string') {
+    return rejectSafeOutputTransform('jsonParse transform requires a string input.', {
+      ...details,
+      input: value,
+    });
+  }
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return rejectSafeOutputTransform('jsonParse transform received invalid JSON.', {
+      ...details,
+      input: value,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function evaluateScalarTransform(evaluation: TransformOperatorEvaluation): any {
+  const { spec, input, details } = evaluation;
+  const operator = details.operator as 'urlEncode' | 'number' | 'string' | 'boolean';
+  const value = evaluateTransformValue(spec[operator] ?? transformOperand(spec, input), input);
+  if (operator === 'urlEncode') {
+    return encodeURIComponent(stringifySafeOutputTransformValue(value));
+  }
+  if (operator === 'number') {
+    return toTransformNumber(value, details);
+  }
+  if (operator === 'boolean') {
+    return toTransformBoolean(value, details);
+  }
+  return stringifySafeOutputTransformValue(value);
+}
+
+function evaluateValueOrReject(evaluation: TransformOperatorEvaluation): any {
+  const { spec, input, details } = evaluation;
+  if (spec.value !== undefined || spec.input !== undefined) {
+    return transformOperand(spec, input);
+  }
+  return rejectSafeOutputTransform(`Unsupported transform operator ${details.operator}.`, details);
+}
+
+function evaluateTransformValue(value: any, input: SafeOutputTransformEvaluationInput): any {
+  if (isSafeOutputTransformRecord(value) && directSafeOutputTransformSpec(value) !== undefined) {
+    return evaluateSafeOutputTransform(value, input);
+  }
+  if (typeof value === 'string') {
+    return resolveSafeOutputTransformTemplate(value, input);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => evaluateTransformValue(item, input));
+  }
+  if (isSafeOutputTransformRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, evaluateTransformValue(nested, input)]),
+    );
+  }
+  return value;
+}
+
+function transformOperand(
+  spec: Record<string, any>,
+  input: SafeOutputTransformEvaluationInput,
+): any {
+  if (spec.value !== undefined) {
+    return evaluateTransformValue(spec.value, input);
+  }
+  if (spec.input !== undefined) {
+    return evaluateTransformValue(spec.input, input);
+  }
+  if (spec.from !== undefined) {
+    return resolveSafeOutputTransformPath(spec.from, input);
+  }
+  if (spec.path !== undefined) {
+    return resolveSafeOutputTransformPath(spec.path, input);
+  }
+  return undefined;
+}
+
+function transformValues(spec: Record<string, any>, operator: string): any[] {
+  return Array.isArray(spec[operator])
+    ? spec[operator]
+    : Array.isArray(spec.values)
+      ? spec.values
+      : [];
+}
+
+function toTransformNumber(value: any, details: SafeOutputTransformDetails): number {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return rejectSafeOutputTransform('Transform value cannot be converted to number.', {
+      ...details,
+      input: value,
+    });
+  }
+  return numberValue;
+}
+
+function toTransformBoolean(value: any, details: SafeOutputTransformDetails): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) {
+      return false;
+    }
+  }
+  return rejectSafeOutputTransform('Transform value cannot be converted to boolean.', {
+    ...details,
+    input: value,
+  });
+}
+
+function isNonEmptyTransformValue(value: any): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'string' || Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return isSafeOutputTransformRecord(value) ? Object.keys(value).length > 0 : true;
+}
+
+function asTransformSpec(spec: Record<string, any>): Record<string, any> {
+  return isSafeOutputTransformRecord(spec.transform) ? spec.transform : spec;
+}
+
+function firstTransformOperator(spec: Record<string, any>): string | undefined {
+  return IMPLICIT_TRANSFORM_OPERATORS.find((key) => spec[key] !== undefined);
+}

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
@@ -488,6 +488,11 @@
                       "requestId": "reconnect-primary-{loop.iteration}-{churnGroupId}-{runId}",
                       "generationId": "reconnect-generation-{loop.iteration}-{runId}",
                       "principalId": "{primaryClientId}"
+                    },
+                    "outputs": {
+                      "primaryChurnGroupRevision": "body.causalRevision.groupRevision",
+                      "primaryChurnPresenceRevision": "body.causalRevision.presenceRevision",
+                      "primaryChurnOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -705,6 +710,11 @@
                       "requestId": "reconnect-secondary-{loop.iteration}-{churnGroupId}-{runId}",
                       "generationId": "reconnect-generation-{loop.iteration}-{runId}",
                       "principalId": "{secondaryClientId}"
+                    },
+                    "outputs": {
+                      "secondaryChurnGroupRevision": "body.causalRevision.groupRevision",
+                      "secondaryChurnPresenceRevision": "body.causalRevision.presenceRevision",
+                      "secondaryChurnOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -922,6 +932,11 @@
                       "requestId": "reconnect-tertiary-{loop.iteration}-{churnGroupId}-{runId}",
                       "generationId": "reconnect-generation-{loop.iteration}-{runId}",
                       "principalId": "{tertiaryClientId}"
+                    },
+                    "outputs": {
+                      "tertiaryChurnGroupRevision": "body.causalRevision.groupRevision",
+                      "tertiaryChurnPresenceRevision": "body.causalRevision.presenceRevision",
+                      "tertiaryChurnOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -936,6 +951,91 @@
           ]
         }
       ]
+    },
+    {
+      "name": "deriveLatestChurnObservation",
+      "type": "set",
+      "output": "latestChurnObservation",
+      "transform": {
+        "value": {
+          "groupRevision": {
+            "max": [
+              { "path": "outputs.primaryChurnGroupRevision" },
+              { "path": "outputs.secondaryChurnGroupRevision" },
+              { "path": "outputs.tertiaryChurnGroupRevision" }
+            ]
+          },
+          "presenceRevision": {
+            "max": [
+              { "path": "outputs.primaryChurnPresenceRevision" },
+              { "path": "outputs.secondaryChurnPresenceRevision" },
+              { "path": "outputs.tertiaryChurnPresenceRevision" }
+            ]
+          },
+          "onlineMemberCount": {
+            "if": {
+              "condition": {
+                "equals": [
+                  { "path": "outputs.primaryChurnPresenceRevision" },
+                  {
+                    "max": [
+                      { "path": "outputs.primaryChurnPresenceRevision" },
+                      { "path": "outputs.secondaryChurnPresenceRevision" },
+                      { "path": "outputs.tertiaryChurnPresenceRevision" }
+                    ]
+                  }
+                ]
+              },
+              "then": { "path": "outputs.primaryChurnOnlineMemberCount" },
+              "else": {
+                "if": {
+                  "condition": {
+                    "equals": [
+                      { "path": "outputs.secondaryChurnPresenceRevision" },
+                      {
+                        "max": [
+                          { "path": "outputs.primaryChurnPresenceRevision" },
+                          { "path": "outputs.secondaryChurnPresenceRevision" },
+                          { "path": "outputs.tertiaryChurnPresenceRevision" }
+                        ]
+                      }
+                    ]
+                  },
+                  "then": { "path": "outputs.secondaryChurnOnlineMemberCount" },
+                  "else": { "path": "outputs.tertiaryChurnOnlineMemberCount" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "deriveChurnReadFloor",
+      "type": "set",
+      "output": "churnReadFloor",
+      "transform": {
+        "value": {
+          "groupRevision": { "path": "outputs.latestChurnObservation.groupRevision" },
+          "presenceRevision": {
+            "if": {
+              "condition": {
+                "equals": [
+                  { "path": "outputs.latestChurnObservation.onlineMemberCount" },
+                  13
+                ]
+              },
+              "then": { "path": "outputs.latestChurnObservation.presenceRevision" },
+              "else": {
+                "add": [
+                  { "path": "outputs.latestChurnObservation.presenceRevision" },
+                  1
+                ]
+              }
+            }
+          }
+        }
+      }
     },
     {
       "name": "readSharedGroupThroughTertiary",
@@ -970,10 +1070,17 @@
       "connection": "apiPrimary",
       "request": {
         "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{churnGroupId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{churnGroupId}?minGroupRevision={churnReadFloor.groupRevision}&minPresenceRevision={churnReadFloor.presenceRevision}",
         "headers": {
           "Authorization": "{ownerAuthHeader}",
           "x-client-id": "{ownerClientId}"
+        },
+        "retry": {
+          "maxAttempts": 6,
+          "backoffMs": 250,
+          "backoffMultiplier": 2,
+          "onStatus": [409],
+          "onException": false
         },
         "outputs": {
           "churnFinalRevision": "body.stateRevision"

--- a/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
@@ -127,6 +127,87 @@ describe('API-v1 three-server recipe semantics', () => {
     expect(new Set(finalReads.map((step) => step.connection))).toEqual(
       new Set(['apiPrimary', 'apiTertiary']),
     );
+    const latestObservation = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'deriveLatestChurnObservation',
+    );
+    expect(latestObservation).toMatchObject({
+      type: 'set',
+      output: 'latestChurnObservation',
+      transform: {
+        value: {
+          groupRevision: { max: expect.any(Array) },
+          presenceRevision: { max: expect.any(Array) },
+          onlineMemberCount: {
+            if: {
+              condition: { equals: expect.any(Array) },
+              then: { path: 'outputs.primaryChurnOnlineMemberCount' },
+              else: {
+                if: {
+                  condition: { equals: expect.any(Array) },
+                  then: { path: 'outputs.secondaryChurnOnlineMemberCount' },
+                  else: { path: 'outputs.tertiaryChurnOnlineMemberCount' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const floor = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'deriveChurnReadFloor',
+    );
+    expect(floor).toMatchObject({
+      type: 'set',
+      output: 'churnReadFloor',
+      transform: {
+        value: {
+          groupRevision: {
+            path: 'outputs.latestChurnObservation.groupRevision',
+          },
+          presenceRevision: {
+            if: {
+              condition: {
+                equals: [
+                  { path: 'outputs.latestChurnObservation.onlineMemberCount' },
+                  13,
+                ],
+              },
+              then: { path: 'outputs.latestChurnObservation.presenceRevision' },
+              else: {
+                add: [
+                  { path: 'outputs.latestChurnObservation.presenceRevision' },
+                  1,
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    const churnRead = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'readChurnGroupThroughPrimary',
+    );
+    expect(churnRead).toMatchObject({
+      connection: 'apiPrimary',
+      request: {
+        path: expect.stringContaining(
+          'minGroupRevision={churnReadFloor.groupRevision}&minPresenceRevision={churnReadFloor.presenceRevision}',
+        ),
+        retry: {
+          maxAttempts: 6,
+          backoffMs: 250,
+          backoffMultiplier: 2,
+          onStatus: [409],
+          onException: false,
+        },
+      },
+      expect: {
+        status: 200,
+        body: {
+          onlineMemberCount: 13,
+        },
+      },
+    });
     expect(JSON.stringify(recipe)).toContain('disconnect');
     expect(JSON.stringify(recipe)).toContain('topology/reconfigure');
   });

--- a/packages/tests/shared-test/scenario-black-box-config.test.ts
+++ b/packages/tests/shared-test/scenario-black-box-config.test.ts
@@ -728,6 +728,8 @@ describe('scenario-black-box CLI', () => {
                             user: {
                                 idText: '42',
                             },
+                            revision: 46,
+                            onlineMemberCount: 13,
                             enabledText: 'true',
                             payload: {
                                 roomId: 'room-1',
@@ -758,6 +760,53 @@ describe('scenario-black-box CLI', () => {
                         },
                         userId: {
                             number: { path: 'body.user.idText' },
+                        },
+                        nextRevision: {
+                            add: [
+                                { path: 'body.revision' },
+                                1,
+                            ],
+                        },
+                        maximumRevision: {
+                            max: [
+                                44,
+                                { path: 'body.revision' },
+                                45,
+                            ],
+                        },
+                        convergedRevision: {
+                            if: {
+                                condition: {
+                                    equals: [
+                                        { path: 'body.onlineMemberCount' },
+                                        13,
+                                    ],
+                                },
+                                then: { path: 'body.revision' },
+                                else: {
+                                    add: [
+                                        { path: 'body.revision' },
+                                        1,
+                                    ],
+                                },
+                            },
+                        },
+                        pendingRevision: {
+                            if: {
+                                condition: {
+                                    equals: [
+                                        { path: 'body.onlineMemberCount' },
+                                        12,
+                                    ],
+                                },
+                                then: { path: 'body.revision' },
+                                else: {
+                                    add: [
+                                        { path: 'body.revision' },
+                                        1,
+                                    ],
+                                },
+                            },
                         },
                         enabled: {
                             boolean: { path: 'body.enabledText' },
@@ -802,6 +851,10 @@ describe('scenario-black-box CLI', () => {
                         authHeader: '{authHeader}',
                         encodedToken: '{encodedToken}',
                         userId: '{userId}',
+                        nextRevision: '{nextRevision}',
+                        maximumRevision: '{maximumRevision}',
+                        convergedRevision: '{convergedRevision}',
+                        pendingRevision: '{pendingRevision}',
                         enabled: '{enabled}',
                         parsedPayload: '{parsedPayload}',
                         fallbackValue: '{fallbackValue}',
@@ -811,6 +864,10 @@ describe('scenario-black-box CLI', () => {
                             authHeader: 'Bearer secret token/123',
                             encodedToken: 'secret%20token%2F123',
                             userId: 42,
+                            nextRevision: 47,
+                            maximumRevision: 46,
+                            convergedRevision: 46,
+                            pendingRevision: 47,
                             enabled: true,
                             parsedPayload: ['room.join', true],
                             fallbackValue: 'fallback-value',
@@ -842,6 +899,10 @@ describe('scenario-black-box CLI', () => {
             authHeader: 'Bearer <redacted:accessToken>',
             encodedToken: '<redacted:encodedToken>',
             userId: 42,
+            nextRevision: 47,
+            maximumRevision: 46,
+            convergedRevision: 46,
+            pendingRevision: 47,
             enabled: true,
             parsedPayload: ['room.join', true],
             payloadJson: '{"roomId":"room-1"}',


### PR DESCRIPTION
## Decision A

This preserves the existing asynchronous group-presence response contract.
Presence mutations may return the preceding complete summary while
`GroupPresenceSummaryWork` converges downstream. The topology-churn recipe now
waits on the complete causal floor before asserting all 13 online members.

## Change

- capture each lane's final group revision, presence revision, and online member
  count without reducing churn, removing node C, or changing the 13-member
  assertion;
- associate the online count with the highest observed presence revision;
- use that revision directly when it already shows all 13 members, otherwise
  require the next presence revision;
- issue the final point read with the complete group/presence floor and retry
  only typed HTTP 409 floor conflicts, bounded to six attempts with the existing
  timeout budget;
- add bounded `add`, `max`, `equals`, and `if` transforms to the internal
  recipe runner, with tests and active recipe-guide documentation;
- extract transform evaluation and resolution into focused internal modules so
  the final tree satisfies the changed-style ratchet without suppression;
- add a deterministic PGlite regression proving that a successful presence
  mutation can precede its queued summary, retain the prior causal revision,
  and then advance exactly once when summary work runs.

No production REST route, response shape, authorization rule, timeout, or
workload size changes.

## Exact final evidence

Validated commit: `e4f3881c008394923ae0e446d709e4ec3d3f069f`.

- Branch Release Gate `31280282296`: passed on the exact head, including the
  changed-style ratchet, root CI, build, Deno checks, migrations, standard
  three-server PostgreSQL black-box profile, artifacts, and full-stack smoke;
- API v1 Medium-Scale Gate `31280284136`: passed on the same exact head;
- focused runner, recipe-matrix, and semantic tests: 87/87 passed;
- deterministic PGlite lifecycle suite: 6/6 passed;
- repository governance: 370/370 passed;
- unit gate: 708 files passed, 12 skipped; 6,476 tests passed, 22 skipped;
- exact local `npm run test:ci` passed, including 38 main browser tests,
  211 Recipe Console tests with one expected skip, and 7/7 memory full-stack;
- build, full warning-only style audit, changed-style ratchet, TypeScript check,
  Prettier check, and `git diff --check` passed;
- local isolated CRDT profile passed 22/22;
- local managed-database medium-scale profile passed 2,748/2,748;
- local single-server memory profile passed all 11 recipes.

Two clean-volume local runs of the combined standard PostgreSQL command passed
all 11 single-process recipes and the first four cluster recipes, including
topology churn 123/123 and state-write convergence 75/75, but the following
CRDT recipe was starved by state-write background queue drainage. The failures
occurred first at CRDT login and then at secondary WS-ticket issuance, both at
the unchanged 10-second request timeout. The exact-head Branch Release run
passed the same combined profile. This load/order-sensitive shared-database
isolation defect is preserved with artifacts and tracked separately in #118;
no timeout, workload, assertion, or recipe order was weakened.

The first local run before the authorized database reset also demonstrated
stale persisted test-data contamination: 47,795 inbox rows, 158,771 runtime
rows, and over 22,000 pending background items delayed presence convergence.
The local PostgreSQL test volume was deleted and recreated; those test contents
are not recoverable unless separately backed up. PostgreSQL was running before
the reset and remains running.

The standalone `npm run db:test:up` helper started PostgreSQL but could not run
migrations without an explicit `DATABASE_URL`; the black-box runner supplies
the repository local default and applied all 19 migrations successfully.

## Historical evidence

API v1 Medium-Scale run `31272960542` remains the historical first failure:
the final reconnect committed while the immediate durable read still returned
the preceding complete presence revision. This PR repairs that proof boundary;
it does not reclassify or erase the historical failure.

External Deno deployment statuses still fail and remain tracked by #98. They
are not required repository release gates and are not reclassified here.

Closes #112
