### PR TITLE
Repair root-scoped Deno Deploy uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Deploy rallar-server to Deno Deploy
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-        run: deno deploy . --config apps/api-v1/deno.json --org intact-software-systems --app rallar-server --prod --json --non-interactive
+        run: deno deploy . --config deno.json --org intact-software-systems --app rallar-server --prod --json --non-interactive
 
   deploy-control-server:
     name: Deploy Black Box Control Server (Deno Deploy)
@@ -251,7 +251,7 @@ jobs:
       - name: Deploy rallar-bb-server to Deno Deploy
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-        run: deno deploy . --config apps/rallar-black-box-control-server/deno.json --org intact-software-systems --app rallar-bb-server --prod --json --non-interactive
+        run: deno deploy . --config deno.json --org intact-software-systems --app rallar-bb-server --prod --json --non-interactive
 
   deploy-relic-api:
     name: Deploy Relic API (Deno Deploy)
@@ -309,4 +309,4 @@ jobs:
       - name: Deploy relic-hunters to Deno Deploy
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-        run: deno deploy . --config apps/relic-hunter-server-v1/deno.json --org intact-software-systems --app relic-hunters --prod --json --non-interactive
+        run: deno deploy . --config deno.json --org intact-software-systems --app relic-hunters --prod --json --non-interactive

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -63,15 +63,46 @@ do not broaden the workflow or expose the token in diagnostic output.
 
 ## Deno Deploy cutover
 
-The Deno GitHub integration creates branch timelines and corresponding GitHub
-status contexts. The repository-controlled workflow avoids that behavior by
-deploying only from the main-only GitHub Actions workflow.
+Every push to a linked GitHub repository starts a Deno build, and each branch
+receives its own timeline. The documented application settings do not provide a
+global switch that ignores every non-default branch. `[skip deploy]` is useful
+for an exceptional commit, but it is not a durable branch policy. Disconnect the
+Deno GitHub integration from all three applications to make the main-only
+GitHub Actions workflow the only deployment owner. See Deno's documentation for
+[applications](https://docs.deno.com/deploy/reference/apps/),
+[timelines](https://docs.deno.com/deploy/reference/timelines/), and
+[`[skip deploy]`](https://docs.deno.com/deploy/changelog/).
 
 Before any database migration, the workflow verifies the token and access to
-all three applications. Each deployment uploads the repository root so
-monorepo imports under `packages/**` are present, then selects the app-specific
-`deno.json`. The checked-in `deploy.runtime` configuration fixes the entrypoint
-and working directory for each service.
+all three applications. Each deployment uploads the repository root with this
+command shape:
+
+```sh
+deno deploy . --config deno.json \
+  --org intact-software-systems \
+  --app <app-name> \
+  --prod --json --non-interactive
+```
+
+An explicit `--config` controls upload-manifest collection, so source discovery
+at the repository-root `deno.json` is required to include workspace members and
+imports under `packages/**`. The `--app` argument selects the existing target;
+the shared root config deliberately has no `deploy` target. This relies on the
+[Deno workspace upload fix](https://github.com/denoland/deno/pull/33562), which
+is present in the configured Deno v2 toolchain.
+
+App-level `deno.json` files remain authoritative for local checks and retain
+their app names and runtime metadata. Because Actions uploads use the shared
+root config, the Deno dashboard provides the runtime configuration for those
+uploads. Configure every application as a **Dynamic App** with **No Preset**,
+blank install, build, and pre-deploy commands, a five-minute build timeout, and
+3 GiB of build memory. Use these path settings:
+
+| App | App directory | Entrypoint | Runtime working directory |
+| --- | --- | --- | --- |
+| `rallar-server` | `(root)` | `apps/api-v1/src/main.ts` | Blank |
+| `rallar-bb-server` | `(root)` | `apps/rallar-black-box-control-server/src/main.ts` | Blank |
+| `relic-hunters` | `(root)` | `apps/relic-hunter-server-v1/src/main.ts` | Blank |
 
 Complete the cutover in this order:
 
@@ -79,21 +110,17 @@ Complete the cutover in this order:
    existing applications.
 2. Store it as the repository Actions secret `DENO_DEPLOY_TOKEN`. Never put the
    value in a command argument, workflow file, issue, pull request, or log.
-3. Disconnect the Deno GitHub integration for:
-   - `rallar-server`, sourced from `apps/api-v1`;
-   - `rallar-bb-server`, sourced from
-     `apps/rallar-black-box-control-server`;
-   - `relic-hunters`, sourced from `apps/relic-hunter-server-v1`.
-4. Set the repository Actions variable `DENO_DEPLOY_ACTIONS_ENABLED=true`.
-5. Manually run **Deploy Web + API** with release-gate skipping disabled.
-6. Confirm the preflight recognizes all three applications before any migration
+3. Apply the dashboard settings above to all three applications.
+4. Record each application's currently active production revision and verify
+   its production endpoint.
+5. Disconnect the Deno GitHub integration from all three applications. Confirm
+   that disconnecting does not remove or replace the recorded active revisions.
+6. Set the repository Actions variable `DENO_DEPLOY_ACTIONS_ENABLED=true`.
+7. Manually run **Deploy Web + API** with release-gate skipping disabled.
+8. Confirm the preflight recognizes all three applications before any migration
    begins.
-7. Verify all three Deno jobs deploy the exact default-branch commit and the
+9. Verify all three Deno jobs deploy the exact default-branch commit and the
    production health endpoints remain healthy.
-
-If the token is not ready, do not disconnect the integration and do not enable
-the variable. If the cutover fails, set `DENO_DEPLOY_ACTIONS_ENABLED=false`
-before deciding whether to reconnect the provider integration.
 
 The GitHub-side commands are intentionally interactive for the secret value:
 
@@ -103,8 +130,16 @@ gh variable set DENO_DEPLOY_ACTIONS_ENABLED --body true
 gh workflow run deploy.yml --ref main -f skip_release_gate=false
 ```
 
-For rollback, keep the token but disable execution with
-`gh variable set DENO_DEPLOY_ACTIONS_ENABLED --body false`.
+If a corrected CLI deployment fails, immediately set
+`DENO_DEPLOY_ACTIONS_ENABLED=false`; the previously active production revisions
+remain available. Keep the token, and disable execution with:
+
+```sh
+gh variable set DENO_DEPLOY_ACTIONS_ENABLED --body false
+```
+
+Reconnect the affected application's GitHub repository and use **Deploy Default
+Branch** only when a provider-managed replacement deployment is required.
 
 ## Human verification
 

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -92,8 +92,11 @@ describe('Deploy workflow release gate', () => {
     expect(workflow).not.toContain('pull_request:');
   });
 
-  it('stages three explicit main-only Deno Deploy applications without placeholder jobs', async () => {
+  it('uploads the root Deno workspace to three explicit main-only applications', async () => {
     const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+    const rootConfig = JSON.parse(
+      await readFile(path.join(repoRoot, 'deno.json'), 'utf8'),
+    ) as Record<string, unknown>;
 
     const expectedDeployments = [
       {
@@ -122,8 +125,9 @@ describe('Deploy workflow release gate', () => {
       expect(jobBlock).toContain(deployDenoAfterPreflightCondition);
       expect(jobBlock).toContain('DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}');
       expect(jobBlock).toContain(
-        `deno deploy . --config ${deployment.configPath} --org intact-software-systems --app ${deployment.appName} --prod --json --non-interactive`,
+        `deno deploy . --config deno.json --org intact-software-systems --app ${deployment.appName} --prod --json --non-interactive`,
       );
+      expect(jobBlock).not.toMatch(/deno deploy \. --config apps\//u);
 
       const config = JSON.parse(
         await readFile(path.join(repoRoot, deployment.configPath), 'utf8'),
@@ -148,6 +152,7 @@ describe('Deploy workflow release gate', () => {
       });
     }
 
+    expect(rootConfig).not.toHaveProperty('deploy');
     expect(workflow).not.toContain('deploy-in-memory-api:');
     expect(workflow).not.toContain('Deno Deploy auto-deploys from GitHub main branch');
   });
@@ -192,6 +197,11 @@ describe('Deploy workflow release gate', () => {
       'Production branch: `main`',
       'Builds for non-production branches: disabled',
       'Disconnect the Deno GitHub integration',
+      'Every push to a linked GitHub repository starts a Deno build',
+      'source discovery at the repository-root `deno.json`',
+      'App-level `deno.json` files remain authoritative for local checks',
+      '`DENO_DEPLOY_ACTIONS_ENABLED=false`',
+      'Deploy Default Branch',
       '`DENO_DEPLOY_TOKEN`',
       '`DENO_DEPLOY_ACTIONS_ENABLED=true`',
       'Branch Release Gate',


### PR DESCRIPTION
## Summary

- upload the repository-root Deno workspace for all three production applications
- keep `--app` as the deployment-target selector
- add regression coverage preventing nested `--config apps/...` commands or a shared root deploy target
- document dashboard runtime settings, GitHub integration disconnect, rollback, and provider fallback

The feature-branch commit includes Deno's one-off `[skip deploy]` directive so publishing this branch does not create another provider branch timeline before the GitHub integrations are disconnected. This is not the durable branch policy.

## Validation

- [x] `npx vitest run packages/tests/hetzner/deploy-release-gate.test.ts`
- [x] `npm run check:repo-style` (exit 0; existing warning-only findings)
- [x] `npm run test:unit` — 711 files / 6,514 tests
- [x] `npm run test:ci`
- [x] `npm run build`
- [x] [Branch Release Gate](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31318218242) passed for exact feature commit `0f697055db30550fa5430786e612e5a61c348313`

## Provider rollout before merge

Apply to all three Deno applications:

| App | App directory | Entrypoint | Runtime working directory |
| --- | --- | --- | --- |
| `rallar-server` | `(root)` | `apps/api-v1/src/main.ts` | Blank |
| `rallar-bb-server` | `(root)` | `apps/rallar-black-box-control-server/src/main.ts` | Blank |
| `relic-hunters` | `(root)` | `apps/relic-hunter-server-v1/src/main.ts` | Blank |

Use Dynamic App, No Preset, blank install/build/pre-deploy commands, five-minute build timeout, and 3 GiB build memory.

- [ ] Record each active production revision
- [ ] Apply the dashboard settings above
- [ ] Disconnect the linked GitHub repository from all three apps
- [ ] Confirm active production revisions were not removed or replaced
- [ ] Confirm this feature branch has no Deno Deploy status context or branch timeline

## Post-merge verification

- [ ] **Deploy Web + API** succeeds for the exact resulting `main` SHA
- [ ] Release Gate and Deno preflight succeed
- [ ] Prisma migrations finish before API deployment
- [ ] all three Deno deploy jobs succeed without missing `packages/**` modules
- [ ] each production revision corresponds to the exact `main` SHA
- [ ] existing production endpoints respond successfully
- [ ] **Run Hetzner Supported Distributed Manifests** succeeds for that exact `main` SHA

Rollback remains `DENO_DEPLOY_ACTIONS_ENABLED=false`. Reconnect an affected app and use **Deploy Default Branch** only if a provider-managed replacement deployment is needed.
