### PR TITLE
fix: retire the presence-split campaign gate from the state-write comparator

### DIFF
--- a/.agents/skills/rallar-testing/references/test-commands.md
+++ b/.agents/skills/rallar-testing/references/test-commands.md
@@ -154,9 +154,15 @@ node scripts/perf/compare-api-v1-state-write-results.mjs \
 
 The comparative result gate must pass. It validates artifact correctness,
 receipts/outbox linkage and retry exhaustion, then compares latency,
-throughput, SQL/row/byte counts, and transaction duration. Record the exact
-artifact paths and command output; do not relabel an older diagnostic artifact
-as the governed candidate.
+throughput, SQL/row/byte counts, and transaction duration. Latency and
+throughput comparisons tolerate 5% run-to-run variance; SQL and
+transaction-duration median increases require recorded regression reasons.
+Benchmark each side against a freshly migrated database — a database dirtied
+by an earlier bench run biases the later run's numbers. On noisy hosts,
+escalate to the order-balanced A-B-B-A pooling protocol
+(`pool-api-v1-state-write-results.mjs`) before concluding a regression. Record
+the exact artifact paths and command output; do not relabel an older
+diagnostic artifact as the governed candidate.
 
 ## PostgreSQL Shared-Server Integration
 

--- a/packages/tests/shared-server/group-state-server-structure-performance-policy.test.ts
+++ b/packages/tests/shared-server/group-state-server-structure-performance-policy.test.ts
@@ -183,10 +183,7 @@ describe('group-state server structure performance policy', { timeout: 120_000 }
     const errors = applyGroupStateServerStructurePerformancePolicy({
       baseline,
       candidate,
-      globalErrors: [
-        'shared throughput must improve after presence is split from the group aggregate',
-        'future comparator finding',
-      ],
+      globalErrors: ['future comparator finding'],
     });
 
     expect(errors).toEqual(['future comparator finding']);
@@ -235,11 +232,11 @@ describe('group-state server structure performance policy', { timeout: 120_000 }
 });
 
 function createArtifactPair() {
-  const baseline = createStateWritePerformanceArtifact(false, {
+  const baseline = createStateWritePerformanceArtifact({
     artifactId: 'baseline',
     measuredRuns: 18,
   });
-  const candidate = createStateWritePerformanceArtifact(true, {
+  const candidate = createStateWritePerformanceArtifact({
     artifactId: 'candidate',
     measuredRuns: 18,
   });
@@ -268,7 +265,7 @@ function createAboveBandConflictPolicy() {
   return {
     baseline,
     candidate,
-    globalErrors: [sharedImprovementError()],
+    globalErrors: [],
   };
 }
 
@@ -348,29 +345,19 @@ function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function sharedImprovementError(): string {
-  return 'shared throughput must improve after presence is split from the group aggregate';
-}
-
 function evaluatePolicy(pair: ReturnType<typeof createArtifactPair>, errors: string[]): string[] {
   return applyGroupStateServerStructurePerformancePolicy({ ...pair, globalErrors: errors });
 }
 
 function hotThroughputError(candidate: number): string {
-  return `hot throughput regressed: baseline=1, candidate=${candidate}`;
+  return `hot throughput regressed by more than 5%: baseline=1, candidate=${candidate}`;
 }
 
 function evaluateSharedThroughput(candidateThroughput: number): string[] {
   const pair = createArtifactPair();
   pair.baseline.workloads[1].summary.throughputPerSecond = 1;
   pair.candidate.workloads[1].summary.throughputPerSecond = candidateThroughput;
-  return applyGroupStateServerStructurePerformancePolicy({
-    ...pair,
-    globalErrors: [
-      `shared throughput regressed: baseline=1, candidate=${candidateThroughput}`,
-      sharedImprovementError(),
-    ],
-  });
+  return applyGroupStateServerStructurePerformancePolicy({ ...pair, globalErrors: [] });
 }
 
 function evaluateSharedRows(candidateRows: number): string[] {

--- a/packages/tests/shared-server/state-write-performance-artifact-fixture.ts
+++ b/packages/tests/shared-server/state-write-performance-artifact-fixture.ts
@@ -22,15 +22,14 @@ interface StateWritePerformanceArtifactOverrides {
 }
 
 export function createStateWritePerformanceArtifact(
-  candidate: boolean,
   overrides: StateWritePerformanceArtifactOverrides = {},
 ): any {
   const measuredRuns = overrides.measuredRuns ?? 3;
   const artifactId = overrides.artifactId ?? 'run';
   const workloads = [
-    createWorkload({ name: 'uncontended', groups: 100, candidate, measuredRuns, artifactId }),
-    createWorkload({ name: 'shared', groups: 5, candidate, measuredRuns, artifactId }),
-    createWorkload({ name: 'hot', groups: 1, candidate, measuredRuns, artifactId }),
+    createWorkload({ name: 'uncontended', groups: 100, measuredRuns, artifactId }),
+    createWorkload({ name: 'shared', groups: 5, measuredRuns, artifactId }),
+    createWorkload({ name: 'hot', groups: 1, measuredRuns, artifactId }),
   ];
   return {
     schemaVersion: STATE_WRITE_ARTIFACT_SCHEMA_VERSION,
@@ -43,19 +42,8 @@ export function createStateWritePerformanceArtifact(
       concurrency: 10,
       mutationTimingExcludes: ['setup', 'auth-session insertion', 'http', 'evidence queries'],
       tailSamplesDiscarded: false,
-      counterSources: createCounterSources(candidate),
+      counterSources: createCounterSources(),
     },
-    features: candidate
-      ? {
-          presenceSplitFromGroupAggregate: true,
-          governance: 'task10-post-remediation-candidate',
-          evidence: 'AppInbox transactional completion and final ResourceInbox effects',
-        }
-      : {
-          presenceSplitFromGroupAggregate: false,
-          governance: 'pre-remediation-baseline',
-          evidence: 'Task 0B baseline recorded before Task 1',
-        },
     regressionReasons: [],
     workloads,
   };
@@ -64,15 +52,14 @@ export function createStateWritePerformanceArtifact(
 interface CreateWorkloadInput {
   readonly name: string;
   readonly groups: number;
-  readonly candidate: boolean;
   readonly measuredRuns: number;
   readonly artifactId: string;
 }
 
 function createWorkload(input: CreateWorkloadInput): any {
-  const { name, groups, candidate, measuredRuns, artifactId } = input;
+  const { name, groups, measuredRuns, artifactId } = input;
   const samples = Array.from({ length: measuredRuns }, (_, index) =>
-    createSample(index, candidate, artifactId),
+    createSample(index, artifactId),
   );
   const workload = {
     name,
@@ -87,7 +74,7 @@ function createWorkload(input: CreateWorkloadInput): any {
   return workload;
 }
 
-function createSample(runIndex: number, candidate: boolean, artifactId: string): any {
+function createSample(runIndex: number, artifactId: string): any {
   const commands = MUTATION_MIX.flatMap((kind) =>
     Array.from({ length: 100 }, (_, ordinal) => ({
       commandId: `${artifactId}-${runIndex}:${kind}:${ordinal}`,
@@ -98,9 +85,9 @@ function createSample(runIndex: number, candidate: boolean, artifactId: string):
     })),
   );
   const latencySamplesMs = commands.map((command) => command.latencyMs);
-  const evidence = candidate ? createFinalEvidence(commands) : createLegacyEvidence(commands);
-  const attemptObservations = createAttemptObservations(commands, evidence, candidate);
-  const required = candidate ? evidence.resourceOutbox.length : evidence.outboxIntents.length;
+  const evidence = createFinalEvidence(commands);
+  const attemptObservations = createAttemptObservations(evidence);
+  const required = evidence.resourceOutbox.length;
   return {
     runIndex,
     durationMs: 100,
@@ -110,7 +97,7 @@ function createSample(runIndex: number, candidate: boolean, artifactId: string):
     commands,
     attemptObservations,
     stackCommandCounts: [350, 350],
-    ...(candidate ? { durableEvidence: evidence } : { durable: evidence }),
+    durableEvidence: evidence,
     outcomes: {
       accepted: 700,
       conflicted: 0,
@@ -132,44 +119,33 @@ function createSample(runIndex: number, candidate: boolean, artifactId: string):
     correctness: {
       acceptedCommandCount: 700,
       receiptCount: 700,
-      effectfulCommandCount: candidate ? 700 : 600,
+      effectfulCommandCount: 700,
       requiredOutboxIntentCount: required,
       outboxIntentCount: required,
-      ...(candidate ? { atomicCompletionFailures: 0 } : {}),
+      atomicCompletionFailures: 0,
       dbwFindings: [],
     },
   };
 }
 
-function createAttemptObservations(commands: any[], evidence: any, candidate: boolean): any[] {
-  return candidate
-    ? evidence.appInbox.flatMap((entry: any) =>
-        Array.from({ length: entry.attempts }, (_, index) => ({
-          commandId: entry.commandId,
-          operationId: entry.operationId,
-          attempt: index + 1,
-          outcome: index + 1 === entry.attempts ? 'accepted' : 'conflicted',
-          terminal: index + 1 === entry.attempts,
-          source: 'resource_inbox.release.telemetry',
-          retryDelayMs: 0,
-          dueAgeMs: 0,
-          selectedLane: 'fast',
-          failure:
-            index + 1 === entry.attempts
-              ? { kind: 'none' }
-              : { kind: 'retryable', code: 'runtime-state-write-conflict', name: 'Error' },
-        })),
-      )
-    : commands.flatMap((command) =>
-        operationIds(command).map((operationId) => ({
-          commandId: command.commandId,
-          operationId,
-          attempt: 1,
-          outcome: 'accepted',
-          terminal: true,
-          source: `${command.kind}.production-operation`,
-        })),
-      );
+function createAttemptObservations(evidence: any): any[] {
+  return evidence.appInbox.flatMap((entry: any) =>
+    Array.from({ length: entry.attempts }, (_, index) => ({
+      commandId: entry.commandId,
+      operationId: entry.operationId,
+      attempt: index + 1,
+      outcome: index + 1 === entry.attempts ? 'accepted' : 'conflicted',
+      terminal: index + 1 === entry.attempts,
+      source: 'resource_inbox.release.telemetry',
+      retryDelayMs: 0,
+      dueAgeMs: 0,
+      selectedLane: 'fast',
+      failure:
+        index + 1 === entry.attempts
+          ? { kind: 'none' }
+          : { kind: 'retryable', code: 'runtime-state-write-conflict', name: 'Error' },
+    })),
+  );
 }
 
 function createFinalEvidence(commands: any[]): any {
@@ -227,33 +203,6 @@ function createFinalEvidence(commands: any[]): any {
   };
 }
 
-function createLegacyEvidence(commands: any[]): any {
-  const kinds: Record<string, string[]> = {
-    'profile-instance': [
-      'client-snapshot:profile',
-      'client-event:profile',
-      'client-snapshot:instance',
-      'client-event:instance',
-    ],
-    membership: ['group-snapshot', 'group-event', 'topology-publication'],
-    'presence-connect': ['group-snapshot', 'group-event', 'topology-publication'],
-    'presence-heartbeat': [],
-    'presence-disconnect': ['group-snapshot', 'group-event', 'topology-publication'],
-    config: ['group-snapshot', 'group-event', 'topology-publication'],
-    'topology-source': ['topology-publication'],
-  };
-  return {
-    receiptCommandIds: commands.map((command) => command.commandId),
-    outboxIntents: commands.flatMap((command) =>
-      kinds[command.kind].map((intentKind, index) => ({
-        intentId: `${command.commandId}:intent:${index}`,
-        commandId: command.commandId,
-        intentKind,
-      })),
-    ),
-  };
-}
-
 function operationIds(command: any): string[] {
   return command.kind === 'profile-instance' ? ['profile', 'instance'] : ['command'];
 }
@@ -299,9 +248,7 @@ function createSummary(samples: any[]): any {
         samples.map((sample) => sample.correctness.requiredOutboxIntentCount),
       ),
       outboxIntentCount: sum(samples.map((sample) => sample.correctness.outboxIntentCount)),
-      ...(samples[0].correctness.atomicCompletionFailures === undefined
-        ? {}
-        : { atomicCompletionFailures: 0 }),
+      atomicCompletionFailures: 0,
       dbwFindings: [],
     },
   };
@@ -317,7 +264,7 @@ function toPercentiles(values: number[]): { p50: number; p95: number; p99: numbe
   return { p50: at(0.5), p95: at(0.95), p99: at(0.99) };
 }
 
-function createCounterSources(candidate: boolean): Record<string, string> {
+function createCounterSources(): Record<string, string> {
   return {
     sql: 'instrumented postgres.js',
     rowsRead: 'returned SQL rows',
@@ -332,12 +279,10 @@ function createCounterSources(candidate: boolean): Record<string, string> {
     validateTiming: 'AppInbox validate phase',
     writeTiming: 'AppInbox write phase',
     outboxTiming: 'ResourceInbox SQL',
-    attempts: candidate
-      ? 'resource_inbox.release.telemetry+app_inbox.ri_attempts reconciliation'
-      : 'legacy service timing',
+    attempts: 'resource_inbox.release.telemetry+app_inbox.ri_attempts reconciliation',
     receipts: 'same-observation mutation receipts',
-    outboxIntents: 'legacy compatibility disclosure',
-    ...(candidate ? { outbox: 'resource_inbox' } : {}),
+    outboxIntents: 'ResourceInbox effect disclosure',
+    outbox: 'resource_inbox',
   };
 }
 

--- a/packages/tests/shared-server/state-write-performance-harness.test.ts
+++ b/packages/tests/shared-server/state-write-performance-harness.test.ts
@@ -10,8 +10,8 @@ import {
 import { swapCompleteDurableResults } from './state-write-performance-result-fixture.ts';
 
 describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () => {
-  it('accepts a complete AppInbox/ResourceInbox candidate and legacy baseline', () => {
-    const candidate = createStateWritePerformanceArtifact(true);
+  it('accepts a complete AppInbox/ResourceInbox artifact for both comparison roles', () => {
+    const candidate = createStateWritePerformanceArtifact();
     expect(candidate.measurement.counterSources.outbox).toBe('resource_inbox');
     expect(candidate.measurement.counterSources.attempts).toBe(
       'resource_inbox.release.telemetry+app_inbox.ri_attempts reconciliation',
@@ -20,12 +20,40 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       [],
     );
     expect(candidate.workloads[0].samples[0].correctness.atomicCompletionFailures).toBe(0);
-    expect(validateStateWriteArtifact(createStateWritePerformanceArtifact(false))).toEqual([]);
+    expect(candidate.features).toBeUndefined();
     expect(validateStateWriteArtifact(candidate)).toEqual([]);
   });
 
+  it('tolerates equal throughput between baseline and candidate', () => {
+    expect(
+      compareStateWriteArtifacts(
+        createStateWritePerformanceArtifact(),
+        createStateWritePerformanceArtifact(),
+      ),
+    ).toEqual([]);
+  });
+
+  it('tolerates throughput variance within 5% and rejects beyond it', () => {
+    const withinTolerance = createStateWritePerformanceArtifact();
+    setThroughputAdverseRatio(withinTolerance, 0.04);
+    expect(
+      compareStateWriteArtifacts(createStateWritePerformanceArtifact(), withinTolerance),
+    ).toEqual([]);
+
+    const beyondTolerance = createStateWritePerformanceArtifact();
+    setThroughputAdverseRatio(beyondTolerance, 0.06);
+    expect(
+      compareStateWriteArtifacts(createStateWritePerformanceArtifact(), beyondTolerance),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('shared throughput regressed by more than 5%'),
+        expect.stringContaining('hot throughput regressed by more than 5%'),
+      ]),
+    );
+  });
+
   it('rejects intermediate intents and service-local attempt evidence', () => {
-    const candidate = createStateWritePerformanceArtifact(true);
+    const candidate = createStateWritePerformanceArtifact();
     const sample = candidate.workloads[0].samples[0];
     sample.durableEvidence.intermediateMutationIntents.push({ intentId: 'forbidden' });
     sample.attemptObservations[0].source = 'group-state-service.mutation.conflict';
@@ -43,7 +71,7 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       (sample: any) => sample.durableEvidence.receipts.shift(),
       (sample: any) => sample.durableEvidence.resourceOutbox.shift(),
     ]) {
-      const candidate = createStateWritePerformanceArtifact(true);
+      const candidate = createStateWritePerformanceArtifact();
       mutate(candidate.workloads[0].samples[0]);
       refreshStateWritePerformanceWorkload(candidate.workloads[0]);
       expect(validateStateWriteArtifact(candidate)).not.toEqual([]);
@@ -52,19 +80,19 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
 
   it('rejects malformed retry delay, due age, lane, and transaction evidence', () => {
     for (const field of ['retryDelayMs', 'dueAgeMs', 'transactionDurationMs'] as const) {
-      const candidate = createStateWritePerformanceArtifact(true);
+      const candidate = createStateWritePerformanceArtifact();
       candidate.workloads[0].samples[0].durableEvidence.appInbox[0][field] = -1;
       expect(validateStateWriteArtifact(candidate)).toEqual(
         expect.arrayContaining([expect.stringContaining('appInbox[0] is malformed')]),
       );
     }
-    const lane = createStateWritePerformanceArtifact(true);
+    const lane = createStateWritePerformanceArtifact();
     lane.workloads[0].samples[0].durableEvidence.appInbox[0].selectedLane = 'unknown';
     expect(validateStateWriteArtifact(lane)).not.toEqual([]);
   });
 
   it('rejects invented retry history and zero-delay nonterminal conflicts', () => {
-    const invented = createStateWritePerformanceArtifact(true);
+    const invented = createStateWritePerformanceArtifact();
     const inventedSample = invented.workloads[0].samples[0];
     inventedSample.attemptObservations.splice(1, 0, {
       ...inventedSample.attemptObservations[0],
@@ -76,7 +104,7 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       ]),
     );
 
-    const zeroDelay = createStateWritePerformanceArtifact(true);
+    const zeroDelay = createStateWritePerformanceArtifact();
     const sample = zeroDelay.workloads[0].samples[0];
     const first = sample.attemptObservations[0];
     first.outcome = 'conflicted';
@@ -97,7 +125,7 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
   });
 
   it('distinguishes typed transient retries from optimistic conflicts', () => {
-    const candidate = createStateWritePerformanceArtifact(true);
+    const candidate = createStateWritePerformanceArtifact();
     const sample = candidate.workloads[0].samples[0];
     const first = sample.attemptObservations[0];
     first.outcome = 'transient-retry';
@@ -122,13 +150,13 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
   });
 
   it('rejects malformed durable results and receipt/effect identity mismatches', () => {
-    const malformed = createStateWritePerformanceArtifact(true);
+    const malformed = createStateWritePerformanceArtifact();
     delete malformed.workloads[0].samples[0].durableEvidence.appInbox[0].durableResult;
     expect(validateStateWriteArtifact(malformed)).toEqual(
       expect.arrayContaining([expect.stringContaining('persisted durable result is malformed')]),
     );
 
-    const mismatched = createStateWritePerformanceArtifact(true);
+    const mismatched = createStateWritePerformanceArtifact();
     mismatched.workloads[0].samples[0].durableEvidence.receipts[0].outboxIds = ['invented-effect'];
     expect(validateStateWriteArtifact(mismatched)).toEqual(
       expect.arrayContaining([
@@ -136,7 +164,7 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       ]),
     );
 
-    const embeddedTamper = createStateWritePerformanceArtifact(true);
+    const embeddedTamper = createStateWritePerformanceArtifact();
     const embedded = embeddedTamper.workloads[0].samples[0].durableEvidence.appInbox.find(
       (entry: any) => entry.commandType.startsWith('GROUP_PRESENCE_'),
     );
@@ -149,7 +177,7 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       ]),
     );
 
-    const arbitraryKey = createStateWritePerformanceArtifact(true);
+    const arbitraryKey = createStateWritePerformanceArtifact();
     const client = arbitraryKey.workloads[0].samples[0].durableEvidence.appInbox.find(
       (entry: any) => entry.commandType.startsWith('CLIENT_'),
     );
@@ -158,18 +186,18 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       expect.arrayContaining([expect.stringContaining('persisted durable result is malformed')]),
     );
     for (const prefix of ['CLIENT_', 'GROUP_']) {
-      const swapped = createStateWritePerformanceArtifact(true);
+      const swapped = createStateWritePerformanceArtifact();
       swapCompleteDurableResults(swapped, prefix);
       expect(validateStateWriteArtifact(swapped)).not.toEqual([]);
     }
-    const missingTopologySibling = createStateWritePerformanceArtifact(true);
+    const missingTopologySibling = createStateWritePerformanceArtifact();
     const missingEntry =
       missingTopologySibling.workloads[0].samples[0].durableEvidence.appInbox.find(
         (entry: any) => entry.commandType === 'TOPOLOGY_CONFIG_PUT',
       );
     delete missingEntry.durableResult.config;
     expect(validateStateWriteArtifact(missingTopologySibling)).not.toEqual([]);
-    const swappedTopologySibling = createStateWritePerformanceArtifact(true);
+    const swappedTopologySibling = createStateWritePerformanceArtifact();
     const topologyEntries =
       swappedTopologySibling.workloads[0].samples[0].durableEvidence.appInbox.filter(
         (entry: any) => entry.commandType === 'TOPOLOGY_CONFIG_PUT',
@@ -189,19 +217,19 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
       (candidate: any) =>
         (candidate.workloads[0].samples[0].durableEvidence.resourceOutbox[0] = null),
     ]) {
-      const candidate = createStateWritePerformanceArtifact(true);
+      const candidate = createStateWritePerformanceArtifact();
       mutate(candidate);
       expect(() => validateStateWriteArtifact(candidate)).not.toThrow();
       expect(validateStateWriteArtifact(candidate)).not.toEqual([]);
       expect(() =>
-        compareStateWriteArtifacts(createStateWritePerformanceArtifact(false), candidate),
+        compareStateWriteArtifacts(createStateWritePerformanceArtifact(), candidate),
       ).not.toThrow();
     }
   });
 
   it('preserves scale, retry-exhaustion, latency, throughput, and resource gates', () => {
-    const baseline = createStateWritePerformanceArtifact(false);
-    const candidate = createStateWritePerformanceArtifact(true);
+    const baseline = createStateWritePerformanceArtifact();
+    const candidate = createStateWritePerformanceArtifact();
     candidate.workloads[0].scale.clients = 99;
     candidate.workloads[0].summary.latencyMs.p95 *= 2;
     candidate.workloads[1].summary.throughputPerSecond = 1;
@@ -329,3 +357,13 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
     });
   });
 });
+
+function setThroughputAdverseRatio(artifact: any, ratio: number): void {
+  for (const workload of artifact.workloads) {
+    for (const sample of workload.samples) {
+      sample.durationMs = 100 / (1 - ratio);
+      sample.throughputPerSecond = 700 / (sample.durationMs / 1000);
+    }
+    refreshStateWritePerformanceWorkload(workload);
+  }
+}

--- a/packages/tests/shared-server/state-write-performance-pooling.test.ts
+++ b/packages/tests/shared-server/state-write-performance-pooling.test.ts
@@ -145,7 +145,9 @@ describe('API-v1 state-write order-balanced pooling', { timeout: 120_000 }, () =
   it('rejects incompatible same-role metadata and duplicate raw command identities', () => {
     const metadataMismatch = createPoolingInput();
     const approvedBaseSecond = JSON.parse(metadataMismatch.sources.approvedBaseSecond.artifactText);
-    approvedBaseSecond.features.evidence = 'different evidence owner';
+    approvedBaseSecond.regressionReasons = [
+      { workload: 'shared', metric: 'sql.statements', reason: 'metadata mismatch probe fixture' },
+    ];
     metadataMismatch.sources.approvedBaseSecond.artifactText = JSON.stringify(approvedBaseSecond);
     expect(() => poolApiV1StateWriteResults(metadataMismatch)).toThrow(
       /approved-base artifact metadata must match/,
@@ -274,25 +276,21 @@ function createPoolingInput(): PoolingInput {
     expectedCandidateCommit: CANDIDATE_COMMIT,
     sources: {
       approvedBaseFirst: createSource({
-        candidate: true,
         artifactId: 'a1',
         gitCommit: APPROVED_BASE_COMMIT,
         time: '00:01:00',
       }),
       candidateFirst: createSource({
-        candidate: true,
         artifactId: 'b2',
         gitCommit: CANDIDATE_COMMIT,
         time: '00:02:00',
       }),
       candidateSecond: createSource({
-        candidate: true,
         artifactId: 'b3',
         gitCommit: CANDIDATE_COMMIT,
         time: '00:03:00',
       }),
       approvedBaseSecond: createSource({
-        candidate: true,
         artifactId: 'a4',
         gitCommit: APPROVED_BASE_COMMIT,
         time: '00:04:00',
@@ -302,17 +300,16 @@ function createPoolingInput(): PoolingInput {
 }
 
 interface CreateSourceInput {
-  readonly candidate: boolean;
   readonly artifactId: string;
   readonly gitCommit: string;
   readonly time: string;
 }
 
 function createSource(input: CreateSourceInput): PoolingSourceText {
-  const { candidate, artifactId, gitCommit, time } = input;
+  const { artifactId, gitCommit, time } = input;
   return {
     artifactText: JSON.stringify(
-      createStateWritePerformanceArtifact(candidate, {
+      createStateWritePerformanceArtifact({
         artifactId,
         generatedAt: `2026-08-01T${time}.000Z`,
         gitCommit,

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -125,7 +125,7 @@ membership, presence connect/heartbeat/disconnect, group config, and topology
 source config. Workload group counts are 100 (`uncontended`), five (`shared`),
 and one (`hot`).
 
-Artifacts use schema `rallar.api-v1.state-write.v4`. Each measured run retains
+Artifacts use schema `rallar.api-v1.state-write.v5`. Each measured run retains
 exactly 700 command records and latencies (100 of every mutation kind), balanced
 service-stack counts, and durable AppInbox attempt observations.
 It also includes latency percentiles, throughput, SQL/row/serialized-byte
@@ -139,7 +139,7 @@ reconciled exactly with durable `resource_inbox.ri_attempts` values for
 `APP_INBOX` rows. Each operation has a one-based attempt number, observed retry
 delay and due age, selected `fast`, `fairness`, or `timeout` lane, and a final
 accepted or exhausted outcome. Profile and instance remain separate operations;
-the other mutation kinds use one command operation. Candidate artifacts reject
+the other mutation kinds use one command operation. Both comparison roles reject
 service-local retry timing, invented attempt expansion, and synthetic
 prerequisite records. Every release carries the actual typed exception
 code/name, or an explicit no-failure marker for acceptance. Only recognized
@@ -179,20 +179,19 @@ node scripts/perf/compare-api-v1-state-write-results.mjs \
 ```
 
 The comparison rejects invalid artifacts, uncontended p95/p99 regressions above
-5%, shared or hot throughput regressions, unreasoned median SQL/row/byte/
-transaction increases, disallowed retry exhaustion, and any candidate receipt or
-outbox contract failure. A candidate must declare the governed Task 10
-presence-split feature with evidence and must improve shared-group throughput.
-Consequently, comparing a pre-remediation baseline with itself is expected to
-fail. A baseline correctness failure remains a failure sample and must link to a
-DBW finding; it never weakens candidate expectations. The validator recomputes
-all percentiles, throughput, outcome, attempt, median, and correctness summaries
-from raw records before applying comparison gates. Standalone validation
-preserves the immutable governed pre-remediation legacy contract. A
-non-candidate production diagnostic may retain only the exact DBW-06/DBW-12
-topology-source receipt/effect gap. Candidate comparison always applies the
-production durable contract with strict unique receipt/final-effect ID, command, and
-effect linkage; candidate DBW tags cannot waive those invariants.
+5%, shared or hot throughput regressions above 5%, unreasoned median
+SQL/row/byte/transaction increases, disallowed retry exhaustion, and any
+baseline or candidate receipt or outbox contract failure. Comparing an artifact
+with itself passes: the gate asserts no-regression within tolerance, not
+improvement. Benchmark each side against a freshly migrated database; on noisy
+hosts use the order-balanced A-B-B-A pooling protocol
+(`pool-api-v1-state-write-results.mjs`) before concluding a regression. A
+correctness failure on either side is a comparison failure. The validator
+recomputes all percentiles, throughput, outcome, attempt, median, and
+correctness summaries from raw records before applying comparison gates. Both
+roles are validated against the production durable contract with strict unique
+receipt/final-effect ID, command, and effect linkage; DBW tags cannot waive
+those invariants.
 DBW retention never waives record structure: every receipt is a nonempty raw
 command ID, every final ResourceInbox record has nonempty effect/command/topic/type
 identity and a raw-command reference, and finding IDs must match the governed `DBW-...`
@@ -206,7 +205,7 @@ All contract arrays must be dense: workloads, samples, raw commands, attempt and
 latency records, stack counts, AppInbox rows, receipts, ResourceInbox effects,
 DBW findings, mutation
 mix/exclusions, and regression reasons reject JavaScript holes before any
-iteration, equality check, derivation, or baseline waiver.
+iteration, equality check, or derivation.
 
 Resource-regression reasons contain exactly `workload`, `metric`, and `reason`.
 The workload must be uncontended, shared, or hot; the metric must be one of

--- a/scripts/perf/api-v1-state-write-concurrency-bench.ts
+++ b/scripts/perf/api-v1-state-write-concurrency-bench.ts
@@ -389,12 +389,6 @@ async function main(): Promise<void> {
           outboxIntents: 'legacy counter name retained only for governed baseline compatibility',
         },
       },
-      features: {
-         presenceSplitFromGroupAggregate: true,
-         governance: 'task10-post-remediation-candidate',
-         evidence:
-           'Transactional AppInbox completion, receipts, and direct ResourceInbox effects',
-      },
       regressionReasons: [],
       workloads,
     };

--- a/scripts/perf/compare-api-v1-state-write-results.mjs
+++ b/scripts/perf/compare-api-v1-state-write-results.mjs
@@ -7,27 +7,8 @@ import {
   validateReceiptResultBindings,
 } from './api-v1-state-write-result-binding.mjs';
 
-export const STATE_WRITE_ARTIFACT_SCHEMA_VERSION = 'rallar.api-v1.state-write.v4';
+export const STATE_WRITE_ARTIFACT_SCHEMA_VERSION = 'rallar.api-v1.state-write.v5';
 export const STATE_WRITE_COMMANDS_PER_RUN = 700;
-
-export const LEGACY_STATE_WRITE_MUTATION_CONTRACT = Object.freeze({
-  'profile-instance': Object.freeze([
-    'client-snapshot:profile',
-    'client-event:profile',
-    'client-snapshot:instance',
-    'client-event:instance',
-  ]),
-  membership: Object.freeze(['group-snapshot', 'group-event', 'topology-publication']),
-  'presence-connect': Object.freeze(['group-snapshot', 'group-event', 'topology-publication']),
-  'presence-heartbeat': Object.freeze([]),
-  'presence-disconnect': Object.freeze([
-    'group-snapshot',
-    'group-event',
-    'topology-publication',
-  ]),
-  config: Object.freeze(['group-snapshot', 'group-event', 'topology-publication']),
-  'topology-source': Object.freeze(['topology-publication']),
-});
 
 export const PRODUCTION_STATE_WRITE_MUTATION_CONTRACT = Object.freeze({
   'profile-instance': Object.freeze([
@@ -44,14 +25,12 @@ export const PRODUCTION_STATE_WRITE_MUTATION_CONTRACT = Object.freeze({
   'topology-source': Object.freeze(['rtc-topology-recompute']),
 });
 
-export const STATE_WRITE_MUTATION_CONTRACT = LEGACY_STATE_WRITE_MUTATION_CONTRACT;
-
 const WORKLOADS = new Map([
   ['uncontended', { clients: 100, groups: 100, concurrency: 10 }],
   ['shared', { clients: 100, groups: 5, concurrency: 10 }],
   ['hot', { clients: 100, groups: 1, concurrency: 10 }],
 ]);
-const MUTATION_MIX = Object.keys(LEGACY_STATE_WRITE_MUTATION_CONTRACT);
+const MUTATION_MIX = Object.keys(PRODUCTION_STATE_WRITE_MUTATION_CONTRACT);
 const TIMING_BUCKETS = ['read', 'compute', 'validate', 'write', 'transaction', 'outbox'];
 const SQL_METRICS = ['statements', 'rowsRead', 'serializedResultBytes'];
 const POSTGRES_METRICS = [
@@ -103,12 +82,9 @@ const REGRESSION_REASON_METRICS = new Set([
   'postgres.transactionDurationMs',
 ]);
 
-export function validateStateWriteArtifact(
-  artifact,
-  options = {},
-) {
+export function validateStateWriteArtifact(artifact) {
   try {
-    return validateStateWriteArtifactInternal(artifact, options);
+    return validateStateWriteArtifactInternal(artifact);
   } catch (error) {
     return [
       `artifact contains malformed nested data that could not be derived safely: ${
@@ -118,10 +94,7 @@ export function validateStateWriteArtifact(
   }
 }
 
-function validateStateWriteArtifactInternal(
-  artifact,
-  { allowDbwLinkedDurableDefects = true } = {},
-) {
+function validateStateWriteArtifactInternal(artifact) {
   const errors = [];
   if (!isObject(artifact)) {
     return ['artifact must be an object'];
@@ -142,11 +115,7 @@ function validateStateWriteArtifactInternal(
   }
 
   validateMeasurement(artifact.measurement, errors);
-  validateFeatures(artifact.features, errors);
-  const durableContract = durableContractForArtifact(artifact);
-  if (durableContract.name === 'production') {
-    validateFinalEvidenceSources(artifact.measurement, errors);
-  }
+  validateFinalEvidenceSources(artifact.measurement, errors);
 
   if (!isDenseArray(artifact.workloads)) {
     errors.push('workloads must be a dense array');
@@ -162,14 +131,7 @@ function validateStateWriteArtifactInternal(
     errors.push('workloads must contain uncontended, shared, and hot exactly once');
   }
   for (const [index, workload] of artifact.workloads.entries()) {
-    validateWorkload(
-      workload,
-      artifact.measurement,
-      `workloads[${index}]`,
-      errors,
-      allowDbwLinkedDurableDefects,
-      durableContract,
-    );
+    validateWorkload(workload, artifact.measurement, `workloads[${index}]`, errors);
   }
   validateRegressionReasons(artifact.regressionReasons, errors);
   return errors;
@@ -189,13 +151,10 @@ export function compareStateWriteArtifacts(baseline, candidate) {
 
 function compareStateWriteArtifactsInternal(baseline, candidate) {
   const baselineValidation = validateStateWriteArtifact(baseline);
-  const candidateValidation = validateStateWriteArtifact(candidate, {
-    allowDbwLinkedDurableDefects: false,
-  });
+  const candidateValidation = validateStateWriteArtifact(candidate);
   const errors = [
     ...baselineValidation.map((error) => `baseline: ${error}`),
     ...candidateValidation.map((error) => `candidate: ${error}`),
-    ...validateCandidatePresenceSplit(candidate),
   ];
   appendCorrectnessGateErrors(errors, baseline, candidate);
   if (errors.length > 0) {
@@ -222,20 +181,13 @@ function compareStateWriteArtifactsInternal(baseline, candidate) {
   );
 
   for (const name of ['shared', 'hot']) {
-    const baselineThroughput = baselineByName.get(name).throughputPerSecond;
-    const candidateThroughput = candidateByName.get(name).throughputPerSecond;
-    if (candidateThroughput < baselineThroughput) {
-      errors.push(
-        `${name} throughput regressed: baseline=${baselineThroughput}, ` +
-          `candidate=${candidateThroughput}`,
-      );
-    }
-  }
-  if (
-    candidateByName.get('shared').throughputPerSecond <=
-      baselineByName.get('shared').throughputPerSecond
-  ) {
-    errors.push('shared throughput must improve after presence is split from the group aggregate');
+    compareMinimumThroughput(
+      errors,
+      `${name} throughput`,
+      baselineByName.get(name).throughputPerSecond,
+      candidateByName.get(name).throughputPerSecond,
+      0.05,
+    );
   }
 
   for (const name of WORKLOADS.keys()) {
@@ -293,13 +245,8 @@ function appendCorrectnessGateErrors(errors, baseline, candidate) {
     if (!baselineCorrectness || !candidateCorrectness) {
       continue;
     }
-    const baselineFailures = correctnessFailures(baselineCorrectness);
-    if (baselineFailures.length > 0 && baselineCorrectness.dbwFindings.length === 0) {
-      errors.push(
-        `${name} baseline correctness already fails (${
-          baselineFailures.join(', ')
-        }) but has no DBW finding linkage`,
-      );
+    for (const failure of correctnessFailures(baselineCorrectness)) {
+      errors.push(`${name} baseline correctness failed: ${failure}`);
     }
     for (const failure of correctnessFailures(candidateCorrectness)) {
       errors.push(`${name} candidate correctness failed: ${failure}`);
@@ -369,36 +316,6 @@ function validateFinalEvidenceSources(measurement, errors) {
   }
 }
 
-function validateFeatures(features, errors) {
-  if (!isObject(features)) {
-    errors.push('features must be an object with governed presence-split metadata');
-    return;
-  }
-  if (typeof features.presenceSplitFromGroupAggregate !== 'boolean') {
-    errors.push('features.presenceSplitFromGroupAggregate must be boolean');
-  }
-  for (const field of ['governance', 'evidence']) {
-    if (typeof features[field] !== 'string' || features[field].trim().length === 0) {
-      errors.push(`features.${field} must be a non-empty string`);
-    }
-  }
-}
-
-function durableContractForArtifact(artifact) {
-  return artifact?.features?.governance === 'pre-remediation-baseline'
-    ? {
-      name: 'legacy',
-      mutations: LEGACY_STATE_WRITE_MUTATION_CONTRACT,
-      topologyDiagnostic: false,
-    }
-    : {
-      name: 'production',
-      mutations: PRODUCTION_STATE_WRITE_MUTATION_CONTRACT,
-      topologyDiagnostic:
-        artifact?.features?.governance === 'task4-production-evidence-diagnostic',
-    };
-}
-
 function validateRegressionReasons(reasons, errors) {
   if (!isDenseArray(reasons)) {
     errors.push('regressionReasons must be a dense array');
@@ -431,30 +348,7 @@ export function isSubstantiveRegressionReason(value) {
   return typeof value === 'string' && value.replaceAll(/\s/g, '').length >= 10;
 }
 
-function validateCandidatePresenceSplit(candidate) {
-  const features = candidate?.features;
-  if (
-    features?.presenceSplitFromGroupAggregate !== true ||
-    features?.governance !== 'task10-post-remediation-candidate' ||
-    typeof features?.evidence !== 'string' ||
-    features.evidence.trim().length === 0
-  ) {
-    return [
-      'candidate must declare presenceSplitFromGroupAggregate=true with ' +
-      'task10-post-remediation-candidate governance and evidence',
-    ];
-  }
-  return [];
-}
-
-function validateWorkload(
-  workload,
-  measurement,
-  path,
-  errors,
-  allowDbwLinkedDurableDefects,
-  durableContract,
-) {
+function validateWorkload(workload, measurement, path, errors) {
   if (!isObject(workload)) {
     errors.push(`${path} must be an object`);
     return;
@@ -487,17 +381,10 @@ function validateWorkload(
     );
   } else {
     for (const [index, sample] of workload.samples.entries()) {
-      validateSample(
-        sample,
-        `${path}.samples[${index}]`,
-        index,
-        errors,
-        allowDbwLinkedDurableDefects,
-        durableContract,
-      );
+      validateSample(sample, `${path}.samples[${index}]`, index, errors);
     }
     if (workload.samples.length > 0 && workload.samples.every(canDeriveWorkloadSample)) {
-      const derived = deriveWorkloadSummary(workload.samples, durableContract.mutations);
+      const derived = deriveWorkloadSummary(workload.samples);
       validateDerivedSummary(workload.summary, derived, `${path}.summary`, errors);
     } else if (workload.samples.length > 0) {
       errors.push(`${path}.summary cannot be derived from structurally malformed samples`);
@@ -505,14 +392,7 @@ function validateWorkload(
   }
 }
 
-function validateSample(
-  sample,
-  path,
-  runIndex,
-  errors,
-  allowDbwLinkedDurableDefects,
-  durableContract,
-) {
+function validateSample(sample, path, runIndex, errors) {
   validateMetrics(sample, path, errors);
   if (!isObject(sample)) {
     return;
@@ -595,15 +475,11 @@ function validateSample(
     errors.push(`${path}.stackCommandCounts does not match raw commands`);
   }
 
-  const dbwFindings = Array.isArray(sample.correctness?.dbwFindings)
-    ? sample.correctness.dbwFindings
-    : [];
   const attempts = deriveAttempts(
     sample.attemptObservations,
     commandsById,
     path,
     errors,
-    durableContract,
     sample.durableEvidence?.appInbox,
   );
   compareNumber(
@@ -641,15 +517,7 @@ function validateSample(
     errors,
     'attempt observations',
   );
-  const durable = deriveDurableCorrectness(
-    sample,
-    commandsById,
-    dbwFindings,
-    path,
-    errors,
-    allowDbwLinkedDurableDefects,
-    durableContract,
-  );
+  const durable = deriveFinalDurableCorrectness(sample, commandsById, path, errors);
   compareNumber(
     sample.correctness?.acceptedCommandCount,
     attempts.accepted,
@@ -717,7 +585,6 @@ function deriveAttempts(
   commandsById,
   path,
   errors,
-  durableContract,
   appInboxEvidence,
 ) {
   if (!isDenseArray(observations)) {
@@ -746,9 +613,7 @@ function deriveAttempts(
     if (typeof observation.source !== 'string' || observation.source.trim().length === 0) {
       errors.push(`${observationPath}.source must disclose a timing-sink source`);
     }
-    if (durableContract.name === 'production') {
-      validateAttemptFailure(observation, observationPath, errors);
-    }
+    validateAttemptFailure(observation, observationPath, errors);
     const terminalOutcome = observation.outcome === 'accepted' ||
       observation.outcome === 'exhausted';
     if (observation.terminal !== terminalOutcome) {
@@ -767,9 +632,6 @@ function deriveAttempts(
   const historiesByCommand = new Map(
     [...commandsById.keys()].map((commandId) => [commandId, []]),
   );
-  const commandOrderById = new Map(
-    [...commandsById.keys()].map((commandId, index) => [commandId, index]),
-  );
   for (const [historyKey, history] of histories) {
     const separator = historyKey.indexOf('\u0000');
     const commandId = historyKey.slice(0, separator);
@@ -782,70 +644,17 @@ function deriveAttempts(
         'state-write-command-envelope.prerequisite-exhausted:',
       );
     if (prerequisiteHistory) {
-      if (durableContract.name === 'production') {
-        errors.push(`${path}: ${commandId}/${operationId} service-local prerequisite evidence is forbidden`);
-      }
-      const prerequisite = history[0].source.slice(
-        'state-write-command-envelope.prerequisite-exhausted:'.length,
+      errors.push(
+        `${path}: ${commandId}/${operationId} service-local prerequisite evidence is forbidden`,
       );
-      const kind = commandsById.get(commandId)?.kind;
-      const validPair = prerequisite === 'membership'
-        ? kind === 'presence-connect' || kind === 'presence-heartbeat' ||
-          kind === 'presence-disconnect'
-        : prerequisite === 'presence-connect'
-        ? kind === 'presence-heartbeat' || kind === 'presence-disconnect'
-        : false;
-      if (!validPair) {
-        errors.push(`${path}: ${commandId}/${operationId} invalid prerequisite-exhausted command pair`);
-      } else {
-        const dependent = commandsById.get(commandId);
-        const identity = parseRawCommandClientIdentity(dependent);
-        const prerequisiteCommandId = identity === undefined
-          ? undefined
-          : `${identity.prefix}:${prerequisite}:${identity.clientOrdinal}`;
-        const prerequisiteCommand = prerequisiteCommandId === undefined
-          ? undefined
-          : commandsById.get(prerequisiteCommandId);
-        if (!prerequisiteCommand || prerequisiteCommand.kind !== prerequisite) {
-          errors.push(
-            `${path}: ${commandId}/${operationId} missing same-client prerequisite command`,
-          );
-        } else {
-          if (
-            (commandOrderById.get(prerequisiteCommandId) ?? Number.MAX_SAFE_INTEGER) >=
-              (commandOrderById.get(commandId) ?? -1) ||
-            MUTATION_MIX.indexOf(prerequisiteCommand.kind) >= MUTATION_MIX.indexOf(dependent.kind)
-          ) {
-            errors.push(
-              `${path}: ${commandId}/${operationId} prerequisite command must precede dependent command`,
-            );
-          }
-          if (prerequisiteCommand.status !== 'exhausted') {
-            errors.push(
-              `${path}: ${commandId}/${operationId} prerequisite command must be production-exhausted`,
-            );
-          } else {
-            const prerequisiteHistory = histories.get(
-              `${prerequisiteCommandId}\u0000command`,
-            );
-            if (!isRealGroupProductionExhaustion(prerequisiteHistory)) {
-              errors.push(
-                `${path}: ${commandId}/${operationId} prerequisite command must end in ` +
-                  'production conflict exhaustion',
-              );
-            }
-          }
-        }
-      }
     }
     const expectedFirstAttempt = 1;
     if (firstAttempt !== expectedFirstAttempt) {
       errors.push(
-        `${path}: ${commandId}/${operationId} ${durableContract.name} attempts must ` +
-          `start at ${expectedFirstAttempt}`,
+        `${path}: ${commandId}/${operationId} attempts must start at ${expectedFirstAttempt}`,
       );
     }
-    if (durableContract.name === 'production' && !prerequisiteHistory) {
+    if (!prerequisiteHistory) {
       for (const observation of history) {
         if (
           observation.source !== 'resource_inbox.release.telemetry' ||
@@ -869,7 +678,7 @@ function deriveAttempts(
         break;
       }
     }
-    if (durableContract.name === 'production' && !prerequisiteHistory) {
+    if (!prerequisiteHistory) {
       const durableAttempt = Array.isArray(appInboxEvidence)
         ? appInboxEvidence.find((entry) => entry?.commandId === commandId &&
           entry?.operationId === operationId)
@@ -1022,136 +831,6 @@ function parseRawCommandClientIdentity(command) {
     return undefined;
   }
   return { prefix, clientOrdinal };
-}
-
-function isRealGroupProductionExhaustion(history) {
-  return Array.isArray(history) && history.length >= 2 &&
-    history.slice(0, -1).every((observation) =>
-      observation.outcome === 'conflicted' && observation.terminal === false &&
-      observation.source === 'group-state-service.mutation.conflict'
-    ) &&
-    history.at(-1)?.outcome === 'exhausted' && history.at(-1)?.terminal === true &&
-    history.at(-1)?.source === 'group-state-service.mutation.conflict';
-}
-
-function deriveDurableCorrectness(
-  sample,
-  commandsById,
-  dbwFindings,
-  path,
-  errors,
-  allowDbwLinkedDurableDefects,
-  durableContract,
-) {
-  if (durableContract.name === 'production' && !durableContract.topologyDiagnostic) {
-    return deriveFinalDurableCorrectness(sample, commandsById, path, errors);
-  }
-  const receipts = sample.durable?.receiptCommandIds;
-  const intents = sample.durable?.outboxIntents;
-  const receiptIds = Array.isArray(receipts) ? receipts : [];
-  const intentRecords = Array.isArray(intents) ? intents : [];
-  if (!isDenseArray(receipts)) {
-    errors.push(`${path}.durable.receiptCommandIds must be a dense array`);
-  }
-  if (!isDenseArray(intents)) {
-    errors.push(`${path}.durable.outboxIntents must be a dense array`);
-  }
-  const canRetainLegacyBaselineDefect = durableContract.name === 'legacy' &&
-    allowDbwLinkedDurableDefects &&
-    dbwFindings.length > 0 && dbwFindings.every(isValidDbwFinding);
-  const canRetainTopologyDiagnostic = durableContract.name === 'production' &&
-    durableContract.topologyDiagnostic === true &&
-    allowDbwLinkedDurableDefects && dbwFindings.length === 2 &&
-    new Set(dbwFindings).size === 2 &&
-    dbwFindings.includes('DBW-06') && dbwFindings.includes('DBW-12');
-  const acceptedCommands = [...commandsById.values()].filter((command) =>
-    command.status === 'accepted'
-  );
-  for (const [index, receiptCommandId] of receiptIds.entries()) {
-    if (
-      typeof receiptCommandId !== 'string' || receiptCommandId.trim().length === 0 ||
-      !commandsById.has(receiptCommandId)
-    ) {
-      errors.push(
-        `${path}.durable.receiptCommandIds[${index}] must be a non-empty raw command ID`,
-      );
-    }
-  }
-  const receiptSet = new Set(receiptIds);
-  if (receiptSet.size !== receiptIds.length && !canRetainLegacyBaselineDefect) {
-    errors.push(`${path}.durable receipt command IDs must be unique`);
-  }
-  const acceptedIds = acceptedCommands.map((command) => command.commandId).sort();
-  const acceptedNonTopologyIds = acceptedCommands
-    .filter((command) => command.kind !== 'topology-source')
-    .map((command) => command.commandId)
-    .sort();
-  const exactTopologyReceiptGap = canRetainTopologyDiagnostic &&
-    sameStringArray([...receiptSet].sort(), acceptedNonTopologyIds);
-  if (
-    !sameStringArray([...receiptSet].sort(), acceptedIds) &&
-    !canRetainLegacyBaselineDefect && !exactTopologyReceiptGap
-  ) {
-    errors.push(`${path}.durable receipts must match accepted command IDs exactly`);
-  }
-
-  const intentIds = intentRecords.map((intent) => intent?.intentId);
-  if (new Set(intentIds).size !== intentIds.length && !canRetainLegacyBaselineDefect) {
-    errors.push(`${path}.durable outbox intent IDs must be unique`);
-  }
-  const expected = acceptedCommands.flatMap((command) =>
-    (durableContract.mutations[command.kind] ?? []).map((intentKind, index) =>
-      durableContract.name === 'legacy'
-        ? `${command.commandId}:intent:${index}\u0000${command.commandId}\u0000${intentKind}`
-        : `${command.commandId}\u0000${intentKind}`
-    )
-  ).sort();
-  const actual = intentRecords.map((intent, index) => {
-    if (
-      !isObject(intent) ||
-      typeof intent.intentId !== 'string' || intent.intentId.trim().length === 0 ||
-      typeof intent.commandId !== 'string' || intent.commandId.trim().length === 0 ||
-      !commandsById.has(intent.commandId) ||
-      typeof intent.intentKind !== 'string' || intent.intentKind.trim().length === 0
-    ) {
-      errors.push(
-        `${path}.durable.outboxIntents[${index}] must contain non-empty intentId, commandId, ` +
-          'and intentKind fields and reference a raw command',
-      );
-    }
-    return durableContract.name === 'legacy'
-      ? `${intent?.intentId}\u0000${intent?.commandId}\u0000${intent?.intentKind}`
-      : `${intent?.commandId}\u0000${intent?.intentKind}`;
-  }).sort();
-  const expectedWithoutTopology = acceptedCommands
-    .filter((command) => command.kind !== 'topology-source')
-    .flatMap((command) =>
-      (durableContract.mutations[command.kind] ?? []).map((intentKind) =>
-        `${command.commandId}\u0000${intentKind}`
-      )
-    ).sort();
-  const exactTopologyIntentGap = canRetainTopologyDiagnostic &&
-    sameStringArray(actual, expectedWithoutTopology);
-  if (
-    !sameStringArray(actual, expected) &&
-    !canRetainLegacyBaselineDefect && !exactTopologyIntentGap
-  ) {
-    errors.push(
-      `${path}.durable outbox intents do not match the mutation contract ` +
-        `(${durableContract.name} durable contract)`,
-    );
-  }
-  const effectfulCommandCount =
-    acceptedCommands.filter((command) =>
-      (durableContract.mutations[command.kind]?.length ?? 0) > 0
-    )
-      .length;
-  return {
-    receiptCount: receiptIds.length,
-    effectfulCommandCount,
-    requiredOutboxIntentCount: expected.length,
-    outboxIntentCount: intentRecords.length,
-  };
 }
 
 function deriveFinalDurableCorrectness(sample, commandsById, path, errors) {
@@ -1317,10 +996,6 @@ function embeddedResultReceipt(entry) {
     : undefined;
 }
 
-function hasExactKeys(value, keys) {
-  return isObject(value) && sameStringArray(Object.keys(value).toSorted(), [...keys].toSorted());
-}
-
 function deriveAtomicCompletionFailures(commands, appInbox, receipts, resourceOutbox) {
   return commands.filter((command) => {
     const expectedOperations = command.kind === 'profile-instance'
@@ -1416,14 +1091,11 @@ function canDeriveWorkloadSample(sample) {
       typeof observation.terminal === 'boolean' &&
       typeof observation.source === 'string'
     ) &&
-    ((isObject(sample.durable) &&
-      isDenseArray(sample.durable.receiptCommandIds) &&
-      isDenseArray(sample.durable.outboxIntents)) ||
-      (isObject(sample.durableEvidence) &&
-        isDenseArray(sample.durableEvidence.appInbox) &&
-        isDenseArray(sample.durableEvidence.receipts) &&
-        isDenseArray(sample.durableEvidence.resourceOutbox) &&
-        isDenseArray(sample.durableEvidence.intermediateMutationIntents))) &&
+    isObject(sample.durableEvidence) &&
+    isDenseArray(sample.durableEvidence.appInbox) &&
+    isDenseArray(sample.durableEvidence.receipts) &&
+    isDenseArray(sample.durableEvidence.resourceOutbox) &&
+    isDenseArray(sample.durableEvidence.intermediateMutationIntents) &&
     isObject(sample.correctness) &&
     isDenseArray(sample.correctness.dbwFindings) &&
     isObject(sample.sql) &&
@@ -1431,7 +1103,7 @@ function canDeriveWorkloadSample(sample) {
     isObject(sample.timingsMs);
 }
 
-function deriveWorkloadSummary(samples, mutationContract) {
+function deriveWorkloadSummary(samples) {
   const latencySamples = samples.flatMap((sample) =>
     sample.commands.map((command) => command.latencyMs)
   );
@@ -1467,14 +1139,12 @@ function deriveWorkloadSummary(samples, mutationContract) {
     timingsMs: medianObject(samples.map((sample) => sample.timingsMs)),
     correctness: {
       acceptedCommandCount: accepted,
-      receiptCount: sum(samples.map((sample) =>
-        sample.durableEvidence?.receipts?.length ?? sample.durable.receiptCommandIds.length
-      )),
+      receiptCount: sum(samples.map((sample) => sample.durableEvidence.receipts.length)),
       effectfulCommandCount: sum(
         samples.map((sample) =>
           sample.commands.filter((command) =>
             command.status === 'accepted' &&
-            mutationContract[command.kind].length > 0
+            PRODUCTION_STATE_WRITE_MUTATION_CONTRACT[command.kind].length > 0
           ).length
         ),
       ),
@@ -1482,21 +1152,17 @@ function deriveWorkloadSummary(samples, mutationContract) {
         sample.commands.reduce(
           (total, command) =>
             total + (
-              command.status === 'accepted' ? mutationContract[command.kind].length : 0
+              command.status === 'accepted'
+                ? PRODUCTION_STATE_WRITE_MUTATION_CONTRACT[command.kind].length
+                : 0
             ),
           0,
         )
       )),
-      outboxIntentCount: sum(samples.map((sample) =>
-        sample.durableEvidence?.resourceOutbox?.length ?? sample.durable.outboxIntents.length
+      outboxIntentCount: sum(samples.map((sample) => sample.durableEvidence.resourceOutbox.length)),
+      atomicCompletionFailures: sum(samples.map((sample) =>
+        sample.durableEvidence.atomicCompletionFailures ?? 0
       )),
-      ...(samples.some((sample) => sample.durableEvidence)
-        ? {
-          atomicCompletionFailures: sum(samples.map((sample) =>
-            sample.durableEvidence?.atomicCompletionFailures ?? 0
-          )),
-        }
-        : {}),
       dbwFindings,
     },
   };
@@ -1585,10 +1251,9 @@ function validateDerivedSummary(summary, derived, path, errors) {
 }
 
 function derivedWorkloads(artifact) {
-  const contract = durableContractForArtifact(artifact).mutations;
   return new Map(artifact.workloads.map((workload) => [
     workload.name,
-    deriveWorkloadSummary(workload.samples, contract),
+    deriveWorkloadSummary(workload.samples),
   ]));
 }
 
@@ -1596,12 +1261,14 @@ function correctnessFailures(correctness) {
   const failures = [];
   if (correctness.acceptedCommandCount !== correctness.receiptCount) {
     failures.push(
-      `accepted commands (${correctness.acceptedCommandCount}) != receipts (${correctness.receiptCount})`,
+      `accepted commands (${correctness.acceptedCommandCount}) != ` +
+        `receipts (${correctness.receiptCount})`,
     );
   }
   if (correctness.requiredOutboxIntentCount !== correctness.outboxIntentCount) {
     failures.push(
-      `required outbox intents (${correctness.requiredOutboxIntentCount}) != actual intents (${correctness.outboxIntentCount})`,
+      `required outbox intents (${correctness.requiredOutboxIntentCount}) != ` +
+        `actual intents (${correctness.outboxIntentCount})`,
     );
   }
   if ((correctness.atomicCompletionFailures ?? 0) !== 0) {
@@ -1637,6 +1304,16 @@ function median(values) {
 
 function compareMaximumRegression(errors, label, baseline, candidate, ratio) {
   if (candidate > baseline * (1 + ratio)) {
+    errors.push(
+      `${label} regressed by more than ${
+        ratio * 100
+      }%: baseline=${baseline}, candidate=${candidate}`,
+    );
+  }
+}
+
+function compareMinimumThroughput(errors, label, baseline, candidate, ratio) {
+  if (candidate < baseline * (1 - ratio)) {
     errors.push(
       `${label} regressed by more than ${
         ratio * 100

--- a/scripts/perf/compare-group-state-server-structure-performance.mjs
+++ b/scripts/perf/compare-group-state-server-structure-performance.mjs
@@ -19,8 +19,6 @@ const RESOURCE_METRICS = [
   { owner: 'postgres', metric: 'transactionDurationMs' },
 ];
 const WORKLOAD_NAMES = ['uncontended', 'shared', 'hot'];
-const SHARED_IMPROVEMENT_ERROR =
-  'shared throughput must improve after presence is split from the group aggregate';
 
 export function compareGroupStateServerStructurePerformance(baseline, candidate) {
   const globalErrors = compareStateWriteArtifacts(baseline, candidate);
@@ -56,6 +54,7 @@ export function applyGroupStateServerStructurePerformancePolicy(input) {
     baselineByName,
     candidateByName,
     permittedGlobalErrors,
+    childErrors,
   });
   applyResourcePolicy({
     baseline,
@@ -72,23 +71,22 @@ export function applyGroupStateServerStructurePerformancePolicy(input) {
 function applyThroughputPolicy(input) {
   const sharedBaseline = getThroughput(input.baselineByName, 'shared');
   const sharedCandidate = getThroughput(input.candidateByName, 'shared');
-  if (
-    isAdverseWithinRatio(
-      sharedBaseline,
-      sharedCandidate,
-      GROUP_STATE_SERVER_STRUCTURE_EQUIVALENCE_RATIO,
-    )
-  ) {
-    input.permittedGlobalErrors.add(SHARED_IMPROVEMENT_ERROR);
-    input.permittedGlobalErrors.add(
-      toThroughputRegressionError('shared', sharedBaseline, sharedCandidate),
+  if (sharedCandidate < sharedBaseline * (1 - GROUP_STATE_SERVER_STRUCTURE_EQUIVALENCE_RATIO)) {
+    input.childErrors.push(
+      toStructureThroughputBandError('shared', sharedBaseline, sharedCandidate),
     );
   }
 
   const hotBaseline = getThroughput(input.baselineByName, 'hot');
   const hotCandidate = getThroughput(input.candidateByName, 'hot');
-  if (isAdverseWithinRatio(hotBaseline, hotCandidate, 0.1)) {
-    input.permittedGlobalErrors.add(toThroughputRegressionError('hot', hotBaseline, hotCandidate));
+  if (hotCandidate < hotBaseline * 0.9) {
+    input.childErrors.push(toStructureThroughputBandError('hot', hotBaseline, hotCandidate));
+  } else {
+    // Must equal the global comparator's compareMinimumThroughput message exactly.
+    input.permittedGlobalErrors.add(
+      `hot throughput regressed by more than 5%: ` +
+        `baseline=${hotBaseline}, candidate=${hotCandidate}`,
+    );
   }
 }
 
@@ -170,10 +168,6 @@ function hasRegressionReason(candidate, workload, metric) {
       entry.metric === metric &&
       isSubstantiveRegressionReason(entry.reason),
   );
-}
-
-function isAdverseWithinRatio(baseline, candidate, maximumRatio) {
-  return baseline === 0 ? candidate === 0 : candidate >= baseline * (1 - maximumRatio);
 }
 
 function conflictDepth(workload) {
@@ -331,8 +325,13 @@ function toNonNegativeNumber(value) {
   return value;
 }
 
-function toThroughputRegressionError(workloadName, baseline, candidate) {
-  return `${workloadName} throughput regressed: baseline=${baseline}, candidate=${candidate}`;
+const STRUCTURE_THROUGHPUT_BANDS = { shared: '1.5%', hot: '10%' };
+
+function toStructureThroughputBandError(workloadName, baseline, candidate) {
+  return (
+    `${workloadName} throughput fell below the ${STRUCTURE_THROUGHPUT_BANDS[workloadName]} ` +
+    `structure-equivalence band: baseline=${baseline}, candidate=${candidate}`
+  );
 }
 
 function toResourceRegressionError(input) {

--- a/scripts/perf/pool-api-v1-state-write-results.mjs
+++ b/scripts/perf/pool-api-v1-state-write-results.mjs
@@ -2,7 +2,6 @@
 
 import { createHash } from 'node:crypto';
 import {
-  LEGACY_STATE_WRITE_MUTATION_CONTRACT,
   PRODUCTION_STATE_WRITE_MUTATION_CONTRACT,
   validateStateWriteArtifact,
 } from './compare-api-v1-state-write-results.mjs';
@@ -163,7 +162,6 @@ function toRoleMetadata(artifact) {
   return {
     schemaVersion: artifact.schemaVersion,
     backend: artifact.backend,
-    features: artifact.features,
     regressionReasons: artifact.regressionReasons,
     workloads: artifact.workloads.map((workload) => ({
       name: workload.name,
@@ -207,7 +205,7 @@ function poolRoleArtifacts({ sources, expectedCommit, role, environmentSha256 })
       ...structuredClone(workload),
       measuredRuns: 18,
       samples,
-      summary: summarizeSamples(samples, mutationContractForArtifact(first)),
+      summary: summarizeSamples(samples),
     };
   });
   const pooled = {
@@ -230,7 +228,7 @@ function poolRoleArtifacts({ sources, expectedCommit, role, environmentSha256 })
   return pooled;
 }
 
-function summarizeSamples(samples, mutationContract) {
+function summarizeSamples(samples) {
   const commands = samples.flatMap((sample) => sample.commands);
   const accepted = commands.filter((command) => command.status === 'accepted').length;
   const attempts = sum(samples.map((sample) => sample.attemptObservations.length));
@@ -248,44 +246,30 @@ function summarizeSamples(samples, mutationContract) {
     sql: medianObject(samples.map((sample) => sample.sql)),
     postgres: medianObject(samples.map((sample) => sample.postgres)),
     timingsMs: medianObject(samples.map((sample) => sample.timingsMs)),
-    correctness: summarizeCorrectness(samples, commands, mutationContract),
+    correctness: summarizeCorrectness(samples, commands),
   };
 }
 
-function summarizeCorrectness(samples, commands, mutationContract) {
+function summarizeCorrectness(samples, commands) {
   const acceptedCommands = commands.filter((command) => command.status === 'accepted');
   const sumSampleMetric = (name) => sum(samples.map((sample) => sample.correctness[name]));
   return {
     acceptedCommandCount: acceptedCommands.length,
-    receiptCount: sum(
-      samples.map(
-        (sample) =>
-          sample.durableEvidence?.receipts?.length ?? sample.durable.receiptCommandIds.length,
-      ),
-    ),
+    receiptCount: sum(samples.map((sample) => sample.durableEvidence.receipts.length)),
     effectfulCommandCount: acceptedCommands.filter(
-      (command) => mutationContract[command.kind].length > 0,
+      (command) => PRODUCTION_STATE_WRITE_MUTATION_CONTRACT[command.kind].length > 0,
     ).length,
     requiredOutboxIntentCount: sum(
-      acceptedCommands.map((command) => mutationContract[command.kind].length),
-    ),
-    outboxIntentCount: sum(
-      samples.map(
-        (sample) =>
-          sample.durableEvidence?.resourceOutbox?.length ?? sample.durable.outboxIntents.length,
+      acceptedCommands.map(
+        (command) => PRODUCTION_STATE_WRITE_MUTATION_CONTRACT[command.kind].length,
       ),
     ),
-    ...(samples.some((sample) => sample.durableEvidence)
-      ? { atomicCompletionFailures: sumSampleMetric('atomicCompletionFailures') }
-      : {}),
+    outboxIntentCount: sum(
+      samples.map((sample) => sample.durableEvidence.resourceOutbox.length),
+    ),
+    atomicCompletionFailures: sumSampleMetric('atomicCompletionFailures'),
     dbwFindings: [...new Set(samples.flatMap((sample) => sample.correctness.dbwFindings))],
   };
-}
-
-function mutationContractForArtifact(artifact) {
-  return artifact.features.governance === 'pre-remediation-baseline'
-    ? LEGACY_STATE_WRITE_MUTATION_CONTRACT
-    : PRODUCTION_STATE_WRITE_MUTATION_CONTRACT;
 }
 
 function countAttempts(samples, outcome) {

--- a/scripts/perf/validate-state-write-pooling-source.mjs
+++ b/scripts/perf/validate-state-write-pooling-source.mjs
@@ -3,7 +3,6 @@ import { validateApiV1StateWriteEnvironment } from './validate-api-v1-state-writ
 
 const ARTIFACT_FIELDS = [
   'backend',
-  'features',
   'generatedAt',
   'gitCommit',
   'measurement',


### PR DESCRIPTION
## What

Retires the concluded presence-split campaign machinery from the api-v1 state-write perf comparator and turns it into a steady-state no-regression gate. Net −375 lines.

- **Schema `v4` → `v5`**: the `features` governance block is gone from artifacts; the bench no longer stamps `task10-post-remediation-candidate`, and `validateCandidatePresenceSplit` (which forced every candidate to declare itself the campaign's output) is deleted.
- **Strict-improvement rule deleted**: `shared throughput must improve after presence is split from the group aggregate` (`<=` — even equal throughput failed) is gone. Shared/hot throughput now uses the same 5% tolerance the file's latency checks always had (`compareMinimumThroughput`).
- **Single durable contract**: `LEGACY_STATE_WRITE_MUTATION_CONTRACT`, the legacy `deriveDurableCorrectness` path, the `pre-remediation-baseline` / `task4-production-evidence-diagnostic` governance branches, and the baseline DBW-linked defect allowances are deleted. Both comparison roles now validate against the production contract with candidate-grade strictness — for surviving rules this is a **tightening**: a baseline correctness failure is now a plain failure instead of a DBW-excused one.
- **Structure-equivalence child gate keeps its exact strength**: `compare-group-state-server-structure-performance.mjs` used to enforce its 1.5% shared / 10% hot bands by string-filtering the global campaign errors; with those errors gone it now asserts its own band errors (and permits the new 5% global message only inside the 10% hot band). Same pass/fail outcomes for every input.
- **SQL/duration median rules unchanged**: increases still require recorded `regressionReasons` — deliberately not relaxed.
- Docs updated to match (`scripts/perf/README.md`, testing-skill `test-commands.md`, including fresh-database-per-bench guidance and the A-B-B-A escalation pointer).

## Why

The comparator was written (2026-07-18, `edf4a529`) as the acceptance gate for one remediation: splitting presence off the group aggregate. That campaign merged. Every comparison since is post-split vs post-split, so the strict-improvement rule mathematically rejected any honest no-regression pair — an A/A run of identical code failed ~half the time by coin flip, and observation-only changes could never pass. The legacy world has no remaining producer: no committed artifact carries it, the bench only emits production evidence, and the git history preserves the campaign gate at its own commits for any future archaeology.

Discovered while executing Phase 0 of the group-formation program (PR #113), whose perf pair could only be recorded failed-as-run under the campaign rules; on a clean fresh-database pair it passes even the old gate (see PR #113 comments).

## Validation

- `npx vitest run` on the five affected suites (`state-write-performance-harness`, `state-write-performance-pooling`, `group-state-server-structure-performance-policy`, `rallar-authoritative-mutation-guidance-integrity`, `rallar-group-state-owner-integrity`): **86 passed**. New pins added: equal-throughput comparison passes; ≤5% variance passes; >5% fails for shared and hot.
- `npm run test:repo-governance`: **371 passed** (skills tree touched).
- `npm run check:repo-style:changed -- origin/main HEAD`: **PASS, no new findings**.
- `node --check` on all touched `.mjs`.
- `npm run test:unit`: running; result will be posted as a comment.
- Branch Release Gate: triggered by this push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
