### PR TITLE
Group formation Phase 1: overlay precedence and bounded bootstrap

### DIFF
--- a/packages/shared-web/browser/data-caches.ts
+++ b/packages/shared-web/browser/data-caches.ts
@@ -1,11 +1,7 @@
 import { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics, ClientInfo } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
-import {
-    compareGroupCausalRevision,
-    isGroupActive,
-    isSessionInGroup,
-} from '@shared/api/group-client-views.ts';
+import { compareGroupCausalRevision } from '@shared/api/group-client-views.ts';
 import { type RallarOverlayTopologySnapshot, toOverlayInfoForSession, } from '@shared/api/overlay-topology.ts';
 import type { ClientSnapshot as ClientStateSnapshot } from '@shared/api/client-types.ts';
 import type { GroupSnapshot as GroupStateSnapshot } from '@shared/api/group-types.ts';
@@ -19,7 +15,15 @@ import { GraphInfoSnapshot } from '@shared-graph/shared-graph-types.ts';
 import * as graphsRepository from '@shared-graph/repository/graphs-repository.ts';
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
+import type { BootstrapOverlayPolicy } from '@shared/repository/overlay-bootstrap.ts';
 import * as overlaysRepository from '@shared/repository/overlays-repository.ts';
+import {
+    acceptGroupSnapshotRemoval,
+    acceptGroupSnapshotUpdate,
+    type GroupFormationPolicyInput,
+    isSameBootstrapOverlayPolicy,
+    resolveBootstrapOverlayPolicy,
+} from '@shared/services/group-snapshot-rtc-sync.ts';
 import { ObservableValueEventType } from '@shared/cache/RepositoryInterfaces.ts';
 import { WebRtcGroupManager } from '@shared/services/WebRtcGroupManager.ts';
 import type { OnMessageCallback } from '@shared/services/InboxOutboxContracts.ts';
@@ -34,11 +38,14 @@ export type StateCacheChangeListener = (
     change: StateCacheChange,
 ) => void | Promise<void>;
 
+export type StateCacheGroupFormationOptions = GroupFormationPolicyInput;
+
 export type StateCacheScopeOptions = Readonly<{
     scope?: StateScope;
     rereadGroupSnapshots?: (
         scope: StateScope,
     ) => Promise<readonly GroupStateSnapshot[]>;
+    groupFormation?: StateCacheGroupFormationOptions;
 }>;
 
 export type StateCacheInboxSource = Readonly<{
@@ -56,6 +63,7 @@ let stateRepositoryObserverContext:
     webRtcGroupManager: WebRtcGroupManager;
     sessionId: string;
     scope: StateScope;
+    bootstrapOverlayPolicy: BootstrapOverlayPolicy;
     rereadGroupSnapshots?: (
         scope: StateScope,
     ) => Promise<readonly GroupStateSnapshot[]>;
@@ -303,10 +311,18 @@ function installStateRepositoryObservers(
     scope: StateScope,
     options: StateCacheScopeOptions,
 ): void {
+    const bootstrapOverlayPolicy = resolveBootstrapOverlayPolicy(
+        options.groupFormation,
+        myOwnClientData.sessionId,
+    );
     if (
         stateRepositoryObserverContext?.webRtcGroupManager === webRtcGroupManager &&
         stateRepositoryObserverContext.sessionId === myOwnClientData.sessionId &&
         isSameStateScope(stateRepositoryObserverContext.scope, scope) &&
+        isSameBootstrapOverlayPolicy(
+            stateRepositoryObserverContext.bootstrapOverlayPolicy,
+            bootstrapOverlayPolicy,
+        ) &&
         stateRepositoryObserverContext.rereadGroupSnapshots ===
             options.rereadGroupSnapshots
     ) {
@@ -318,6 +334,7 @@ function installStateRepositoryObservers(
         webRtcGroupManager,
         sessionId: myOwnClientData.sessionId,
         scope,
+        bootstrapOverlayPolicy,
         rereadGroupSnapshots: options.rereadGroupSnapshots,
     };
 
@@ -354,12 +371,12 @@ function installStateRepositoryObservers(
 
             return trackStateRepositoryObserverTask((async () => {
                 if (change.kind === ObservableValueEventType.Deleted) {
-                    await handleGroupSnapshotRemoval(snapshot, webRtcGroupManager);
+                    await acceptGroupSnapshotRemoval(snapshot, webRtcGroupManager);
                 } else {
-                    await handleGroupSnapshotUpdate(
+                    await acceptGroupSnapshotUpdate(
                         snapshot,
                         webRtcGroupManager,
-                        myOwnClientData.sessionId,
+                        bootstrapOverlayPolicy,
                     );
                 }
                 await notifyStateCacheChange({
@@ -380,44 +397,6 @@ function installStateRepositoryObservers(
             stateRepositoryObserverContext = undefined;
         }
     };
-}
-
-async function handleGroupSnapshotUpdate(
-    snapshot: GroupStateSnapshot,
-    webRtcGroupManager: WebRtcGroupManager,
-    mySessionId: string,
-): Promise<void> {
-    if (!isGroupActive(snapshot)) {
-        overlaysRepository.removeOverlayByGroupRef(snapshot.group);
-        overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
-
-        await webRtcGroupManager.delete(snapshot.group);
-        return;
-    }
-
-    if (!isSessionInGroup(snapshot, mySessionId)) {
-        overlaysRepository.removeOverlayByGroupRef(snapshot.group);
-        overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
-        if (webRtcGroupManager.has(snapshot.group)) {
-            await webRtcGroupManager.delete(snapshot.group, { retainConnections: true });
-        } else {
-            await webRtcGroupManager.ensureAllGroupsConnected();
-        }
-        return;
-    }
-
-    overlaysRepository.createAndSetStarOverlays([snapshot]);
-    await webRtcGroupManager.acceptGroupUpdate(snapshot);
-}
-
-async function handleGroupSnapshotRemoval(
-    snapshot: GroupStateSnapshot,
-    webRtcGroupManager: WebRtcGroupManager,
-): Promise<void> {
-    overlaysRepository.removeOverlayByGroupRef(snapshot.group);
-    overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
-
-    await webRtcGroupManager.delete(snapshot.group);
 }
 
 function trackStateRepositoryObserverTask(task: Promise<void>): Promise<void> {

--- a/packages/shared-web/browser/middleware.ts
+++ b/packages/shared-web/browser/middleware.ts
@@ -26,6 +26,13 @@ import { WebRtcOverlayMulticastManager } from '@shared/multicast/WebRtcOverlayMu
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
 import * as overlaysRepository from '@shared/repository/overlays-repository.ts';
+import {
+    resolveBootstrapDegree,
+} from '@shared/rtc/bootstrap-peer-selection.ts';
+import {
+    resolveRtcGroupFormationMode,
+    type RtcGroupFormationMode,
+} from '@shared/rtc/group-formation-mode.ts';
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import type { ALOutboundRuntimeDiagnosticsSink } from '@shared/alm/ALOutboundMessageRuntime.ts';
 import { pairKey } from '@shared/repository/rtt-repository.ts';
@@ -63,6 +70,8 @@ export type MiddlewareInitOptions = Readonly<{
     dataChannelLanes?: readonly RtcDataChannelLaneConfig[];
     maxPeerConnections?: number;
     rttReportingDegreeLimit?: number;
+    groupFormationMode?: RtcGroupFormationMode;
+    bootstrapDegree?: number;
     scope?: StateScope;
     onAuthInvalid?: (error: unknown) => void | Promise<void>;
     outboundDiagnostics?: ALOutboundRuntimeDiagnosticsSink;
@@ -258,6 +267,14 @@ export async function initialiseMiddleware(
             },
         );
 
+    const groupFormationMode = resolveRtcGroupFormationMode(
+        options.groupFormationMode,
+    );
+    const bootstrapDegree = resolveBootstrapDegree({
+        bootstrapDegree: options.bootstrapDegree,
+        maxPeerConnections: options.maxPeerConnections,
+    });
+
     const webRtcGroupManager = new WebRtcGroupManager(
         webRtcConnectionService,
         groupStateSnapshotsRepository.readableGroupStateSnapshotCache(),
@@ -265,6 +282,7 @@ export async function initialiseMiddleware(
         overlaysRepository.readableOverlayCache(),
         {
             maxPeerConnections: options.maxPeerConnections,
+            groupFormationMode,
             onDesiredPeerIdsChanged: refreshRttReportingPeers,
         },
     );
@@ -292,6 +310,10 @@ export async function initialiseMiddleware(
     const stateCacheOptions = {
         scope: options.scope,
         rereadGroupSnapshots,
+        groupFormation: {
+            mode: groupFormationMode,
+            bootstrapDegree,
+        },
     };
     cache.initialise(
         webSocketQueueBox,

--- a/packages/shared-web/browser/rallar-operation-options.ts
+++ b/packages/shared-web/browser/rallar-operation-options.ts
@@ -1,5 +1,6 @@
 import type { CommandOptions } from '@shared/cache/Command.ts';
 import type { CommandsOrchestratorPolicies } from '@shared/cache/CommandsOrchestrator.ts';
+import type { RtcGroupFormationMode } from '@shared/rtc/group-formation-mode.ts';
 import type { RtcDataChannelLaneConfig } from '@shared/services/WebRtcConnectionService.ts';
 
 export type RallarOperationRetryPredicate = (
@@ -15,6 +16,8 @@ export type RallarOperationOptions = Readonly<{
     dataChannelLanes?: readonly RtcDataChannelLaneConfig[];
     maxPeerConnections?: number;
     rttReportingDegreeLimit?: number;
+    groupFormationMode?: RtcGroupFormationMode;
+    bootstrapDegree?: number;
 }>;
 
 export function toRallarWorkflowPolicies<V>(
@@ -44,7 +47,9 @@ export function toRallarOperationOptions(
         options.shouldRetry === undefined &&
         options.dataChannelLanes === undefined &&
         options.maxPeerConnections === undefined &&
-        options.rttReportingDegreeLimit === undefined
+        options.rttReportingDegreeLimit === undefined &&
+        options.groupFormationMode === undefined &&
+        options.bootstrapDegree === undefined
     ) {
         return {};
     }
@@ -57,6 +62,8 @@ export function toRallarOperationOptions(
         dataChannelLanes?: readonly RtcDataChannelLaneConfig[];
         maxPeerConnections?: number;
         rttReportingDegreeLimit?: number;
+        groupFormationMode?: RtcGroupFormationMode;
+        bootstrapDegree?: number;
     } = {};
     if (options.signal) {
         normalized.signal = options.signal;
@@ -78,6 +85,12 @@ export function toRallarOperationOptions(
     }
     if (options.rttReportingDegreeLimit !== undefined) {
         normalized.rttReportingDegreeLimit = options.rttReportingDegreeLimit;
+    }
+    if (options.groupFormationMode !== undefined) {
+        normalized.groupFormationMode = options.groupFormationMode;
+    }
+    if (options.bootstrapDegree !== undefined) {
+        normalized.bootstrapDegree = options.bootstrapDegree;
     }
 
     return normalized;

--- a/packages/shared-web/browser/rallar-runtime-context.ts
+++ b/packages/shared-web/browser/rallar-runtime-context.ts
@@ -7,6 +7,7 @@ import type {
     WorkspaceId,
 } from '@shared/api/group-types.ts';
 import { DEFAULT_STATE_WORKSPACE_ID, type StateScope } from '@shared/api/state-types.ts';
+import type { RtcGroupFormationMode } from '@shared/rtc/group-formation-mode.ts';
 import type { RtcDataChannelLaneConfig } from '@shared/services/WebRtcConnectionService.ts';
 import {
     type ApiMiddleware,
@@ -38,6 +39,8 @@ export type RallarBrowserRuntimeDefaults = Readonly<{
         dataChannelLanes?: readonly RtcDataChannelLaneConfig[];
         maxPeerConnections?: number;
         rttReportingDegreeLimit?: number;
+        groupFormationMode?: RtcGroupFormationMode;
+        bootstrapDegree?: number;
     }>;
     messages?: Readonly<{
         maxPayloadBytes?: number;
@@ -208,6 +211,7 @@ export function createRallarBrowserFacadeRuntimeContext(
                 : state.defaults?.operations?.maxAttempts;
             const shouldRetry = options.shouldRetry ??
                 state.defaults?.operations?.shouldRetry;
+
             const dataChannelLanes = options.dataChannelLanes !== undefined
                 ? options.dataChannelLanes
                 : state.defaults?.rtc?.dataChannelLanes;
@@ -217,6 +221,12 @@ export function createRallarBrowserFacadeRuntimeContext(
             const rttReportingDegreeLimit = options.rttReportingDegreeLimit !== undefined
                 ? options.rttReportingDegreeLimit
                 : state.defaults?.rtc?.rttReportingDegreeLimit;
+            const groupFormationMode = options.groupFormationMode !== undefined
+                ? options.groupFormationMode
+                : state.defaults?.rtc?.groupFormationMode;
+            const bootstrapDegree = options.bootstrapDegree !== undefined
+                ? options.bootstrapDegree
+                : state.defaults?.rtc?.bootstrapDegree;
 
             if (
                 timeoutMs === undefined &&
@@ -224,7 +234,9 @@ export function createRallarBrowserFacadeRuntimeContext(
                 shouldRetry === undefined &&
                 dataChannelLanes === undefined &&
                 maxPeerConnections === undefined &&
-                rttReportingDegreeLimit === undefined
+                rttReportingDegreeLimit === undefined &&
+                groupFormationMode === undefined &&
+                bootstrapDegree === undefined
             ) {
                 return options;
             }
@@ -239,6 +251,8 @@ export function createRallarBrowserFacadeRuntimeContext(
                 ...(rttReportingDegreeLimit !== undefined
                     ? { rttReportingDegreeLimit }
                     : {}),
+                ...(groupFormationMode !== undefined ? { groupFormationMode } : {}),
+                ...(bootstrapDegree !== undefined ? { bootstrapDegree } : {}),
             };
         },
         readAuthExpiryTimer: () => state.authExpiryTimer,

--- a/packages/shared/api/api-config.ts
+++ b/packages/shared/api/api-config.ts
@@ -117,8 +117,16 @@ export type GroupId = string;
 
 export type OverlayId = string;
 
+/**
+ * Where an overlay record came from. Server overlays are authoritative and
+ * always supersede bootstrap overlays; a bootstrap overlay never replaces a
+ * server overlay (group-formation Phase 1 admission rule).
+ */
+export type OverlayProvenance = 'server' | 'bootstrap';
+
 export type OverlayInfo = {
     readonly sourceGroupStateCausalRevision: GroupStateCausalRevision;
+    readonly provenance: OverlayProvenance;
     readonly state: 'active' | 'removed';
     readonly overlayId: OverlayId;
     readonly groupRef: GroupRef;

--- a/packages/shared/api/overlay-topology.ts
+++ b/packages/shared/api/overlay-topology.ts
@@ -45,6 +45,7 @@ export function toOverlayInfoForSession(
     return {
         sourceGroupStateCausalRevision:
             snapshot.sourceGroupStateCausalRevision,
+        provenance: 'server',
         state: snapshot.state,
         overlayId: snapshot.overlayId,
         groupRef: snapshot.groupRef,

--- a/packages/shared/repository/overlay-adoption-diagnostics.ts
+++ b/packages/shared/repository/overlay-adoption-diagnostics.ts
@@ -1,0 +1,85 @@
+export type OverlayAdoptionOutcome =
+    | 'initial-set'
+    | 'adopted'
+    | 'equal'
+    | 'dominated-dropped'
+    | 'incomparable-conflict'
+    | 'server-superseded-bootstrap'
+    | 'bootstrap-dropped-over-server';
+
+export type OverlayAdoptionDiagnosticsEvent = Readonly<{
+    overlayId: string;
+    outcome: OverlayAdoptionOutcome;
+}>;
+
+export type OverlayAdoptionDiagnosticsSink = (
+    event: OverlayAdoptionDiagnosticsEvent,
+) => void;
+
+interface MutableOverlayAdoptionDiagnostics {
+    initialSetCount: number;
+    adoptedCount: number;
+    equalCount: number;
+    dominatedDroppedCount: number;
+    incomparableConflictCount: number;
+    serverSupersededBootstrapCount: number;
+    bootstrapDroppedOverServerCount: number;
+}
+
+export type RallarOverlayAdoptionDiagnostics = Readonly<MutableOverlayAdoptionDiagnostics>;
+
+// One process-wide sink and counter object keep the adoption surface additive and opt-in.
+let adoptionDiagnosticsSink: OverlayAdoptionDiagnosticsSink | undefined;
+const adoptionCounters: MutableOverlayAdoptionDiagnostics = emptyOverlayAdoptionDiagnostics();
+
+export function setOverlayAdoptionDiagnosticsSink(
+    sink: OverlayAdoptionDiagnosticsSink | undefined,
+): void {
+    adoptionDiagnosticsSink = sink;
+}
+
+export function readOverlayAdoptionDiagnostics(): RallarOverlayAdoptionDiagnostics {
+    return { ...adoptionCounters };
+}
+
+export function resetOverlayAdoptionDiagnostics(): void {
+    Object.assign(adoptionCounters, emptyOverlayAdoptionDiagnostics());
+}
+
+function emptyOverlayAdoptionDiagnostics(): MutableOverlayAdoptionDiagnostics {
+    return {
+        initialSetCount: 0,
+        adoptedCount: 0,
+        equalCount: 0,
+        dominatedDroppedCount: 0,
+        incomparableConflictCount: 0,
+        serverSupersededBootstrapCount: 0,
+        bootstrapDroppedOverServerCount: 0,
+    };
+}
+
+export function emitOverlayAdoption(
+    overlayId: string,
+    outcome: OverlayAdoptionOutcome,
+): void {
+    if (outcome === 'initial-set') {
+        adoptionCounters.initialSetCount += 1;
+    } else if (outcome === 'adopted') {
+        adoptionCounters.adoptedCount += 1;
+    } else if (outcome === 'equal') {
+        adoptionCounters.equalCount += 1;
+    } else if (outcome === 'dominated-dropped') {
+        adoptionCounters.dominatedDroppedCount += 1;
+    } else if (outcome === 'server-superseded-bootstrap') {
+        adoptionCounters.serverSupersededBootstrapCount += 1;
+    } else if (outcome === 'bootstrap-dropped-over-server') {
+        adoptionCounters.bootstrapDroppedOverServerCount += 1;
+    } else {
+        adoptionCounters.incomparableConflictCount += 1;
+    }
+    try {
+        adoptionDiagnosticsSink?.({ overlayId, outcome });
+    } catch {
+        // Recording must never affect overlay adoption behavior.
+    }
+}

--- a/packages/shared/repository/overlay-bootstrap.ts
+++ b/packages/shared/repository/overlay-bootstrap.ts
@@ -1,0 +1,126 @@
+import type { OverlayInfo } from '@shared/api/api-config.ts';
+import {
+    isOverlayForGroupRef,
+    toScopedOverlayId,
+    toWebRtcGroupKey,
+} from '@shared/api/api-type-utils.ts';
+import type { GroupRef } from '@shared/api/group-types.ts';
+import {
+    type AnyGroupPresence,
+    readGroupCausalRevision,
+    readGroupCreatedAtEpochMs,
+    readGroupCreatedByPrincipalId,
+    readGroupDisplayName,
+    readGroupMemberSessionIds,
+    readGroupUpdatedAtEpochMs,
+    readGroupVersion,
+} from '@shared/api/group-client-views.ts';
+import { readObservableLatestRepositoryValue } from '@shared/cache/LatestRepositoryHelpers.ts';
+import type { RepositoryManager } from '@shared/cache/RepositoryManager.ts';
+import type { RtcGroupFormationMode } from '@shared/rtc/group-formation-mode.ts';
+import { selectBootstrapPeers } from '@shared/rtc/bootstrap-peer-selection.ts';
+import {
+    createAndSetStarOverlays,
+    overlayRepositoryToken,
+    setOverlayById,
+} from './overlays-repository.ts';
+
+/**
+ * Resolved at the composition root: the local session identity, the rollback
+ * mode, and the effective bootstrap degree (already clamped to the peer
+ * connection budget).
+ */
+export type BootstrapOverlayPolicy = Readonly<{
+    localSessionId: string;
+    mode: RtcGroupFormationMode;
+    bootstrapDegree: number;
+}>;
+
+/**
+ * Bootstrap-overlay writer for group snapshot updates. In 'bounded-bootstrap'
+ * mode the overlay is a rendezvous-selected bounded set and is written only
+ * while no server overlay record exists for the group — a server overlay,
+ * active or removed, is authoritative and the bootstrap star must not be
+ * restamped over it. 'legacy-star' mode preserves the pre-Phase-1 behavior:
+ * an unconditional full-membership star (admission still keeps server
+ * overlays authoritative once adopted).
+ */
+export function createAndSetBootstrapOverlays(
+    groups: readonly AnyGroupPresence[],
+    policy: BootstrapOverlayPolicy,
+    manager?: RepositoryManager,
+): void {
+    if (policy.mode === 'legacy-star') {
+        createAndSetStarOverlays(groups, manager);
+        return;
+    }
+
+    for (const group of groups) {
+        if (hasServerOverlayRecordForGroup(group.group, manager)) {
+            continue;
+        }
+
+        const overlay = toBoundedBootstrapOverlay(group, policy);
+        setOverlayById(overlay.overlayId, overlay, manager);
+    }
+}
+
+export function toBoundedBootstrapOverlay(
+    group: AnyGroupPresence,
+    policy: BootstrapOverlayPolicy,
+): OverlayInfo {
+    const memberSessionIds = readGroupMemberSessionIds(group);
+    const nextHopSessionIds = selectBootstrapPeers({
+        localSessionId: policy.localSessionId,
+        memberSessionIds,
+        groupKey: toWebRtcGroupKey(group.group),
+        bootstrapDegree: policy.bootstrapDegree,
+    });
+
+    return {
+        sourceGroupStateCausalRevision: readGroupCausalRevision(group),
+        provenance: 'bootstrap',
+        state: 'active',
+        name: readGroupDisplayName(group),
+        overlayId: toScopedOverlayId(group.group),
+        groupRef: group.group,
+        topology: 'star',
+        createdByClientId: readGroupCreatedByPrincipalId(group),
+        createdAtEpochMs: readGroupCreatedAtEpochMs(group),
+        nextHopSessionIds,
+        degreeLimit: Math.max(
+            1,
+            Math.min(policy.bootstrapDegree, memberSessionIds.length - 1),
+        ),
+        overlayVersion: readGroupVersion(group),
+        updatedAtEpochMs: readGroupUpdatedAtEpochMs(group),
+    };
+}
+
+function hasServerOverlayRecordForGroup(
+    groupRef: GroupRef,
+    manager?: RepositoryManager,
+): boolean {
+    const scoped = readOverlayRecordById(toScopedOverlayId(groupRef), manager);
+    if (scoped?.provenance === 'server') {
+        return true;
+    }
+
+    const legacy = readOverlayRecordById(groupRef.groupId, manager);
+    return legacy?.provenance === 'server' &&
+        isOverlayForGroupRef(legacy, groupRef);
+}
+
+// Raw record read: a server overlay with state 'removed' still expresses
+// server authority over the group's overlay, so the bootstrap check must see
+// it even though value readers filter removed records out.
+function readOverlayRecordById(
+    overlayId: string,
+    manager?: RepositoryManager,
+): OverlayInfo | undefined {
+    return readObservableLatestRepositoryValue(
+        overlayRepositoryToken,
+        overlayId,
+        manager,
+    );
+}

--- a/packages/shared/repository/overlays-repository.ts
+++ b/packages/shared/repository/overlays-repository.ts
@@ -32,6 +32,7 @@ import {
     ObservableValueEventType,
     type ReadableKeyedValues,
 } from '@shared/cache/RepositoryInterfaces.ts';
+import { emitOverlayAdoption } from './overlay-adoption-diagnostics.ts';
 
 export type OverlayRepositoryOptions =
     & Omit<
@@ -61,78 +62,15 @@ export class OverlayRevisionConflictError extends Error {
     }
 }
 
-export type OverlayAdoptionOutcome =
-    | 'initial-set'
-    | 'adopted'
-    | 'equal'
-    | 'dominated-dropped'
-    | 'incomparable-conflict';
-
-export type OverlayAdoptionDiagnosticsEvent = Readonly<{
-    overlayId: string;
-    outcome: OverlayAdoptionOutcome;
-}>;
-
-export type OverlayAdoptionDiagnosticsSink = (
-    event: OverlayAdoptionDiagnosticsEvent,
-) => void;
-
-interface MutableOverlayAdoptionDiagnostics {
-    initialSetCount: number;
-    adoptedCount: number;
-    equalCount: number;
-    dominatedDroppedCount: number;
-    incomparableConflictCount: number;
-}
-
-export type RallarOverlayAdoptionDiagnostics = Readonly<MutableOverlayAdoptionDiagnostics>;
-
-// One process-wide sink and counter object keep the adoption surface additive and opt-in.
-let adoptionDiagnosticsSink: OverlayAdoptionDiagnosticsSink | undefined;
-const adoptionCounters: MutableOverlayAdoptionDiagnostics = emptyOverlayAdoptionDiagnostics();
-
-export function setOverlayAdoptionDiagnosticsSink(
-    sink: OverlayAdoptionDiagnosticsSink | undefined,
-): void {
-    adoptionDiagnosticsSink = sink;
-}
-
-export function readOverlayAdoptionDiagnostics(): RallarOverlayAdoptionDiagnostics {
-    return { ...adoptionCounters };
-}
-
-export function resetOverlayAdoptionDiagnostics(): void {
-    Object.assign(adoptionCounters, emptyOverlayAdoptionDiagnostics());
-}
-
-function emptyOverlayAdoptionDiagnostics(): MutableOverlayAdoptionDiagnostics {
-    return {
-        initialSetCount: 0,
-        adoptedCount: 0,
-        equalCount: 0,
-        dominatedDroppedCount: 0,
-        incomparableConflictCount: 0,
-    };
-}
-
-function emitOverlayAdoption(overlayId: string, outcome: OverlayAdoptionOutcome): void {
-    if (outcome === 'initial-set') {
-        adoptionCounters.initialSetCount += 1;
-    } else if (outcome === 'adopted') {
-        adoptionCounters.adoptedCount += 1;
-    } else if (outcome === 'equal') {
-        adoptionCounters.equalCount += 1;
-    } else if (outcome === 'dominated-dropped') {
-        adoptionCounters.dominatedDroppedCount += 1;
-    } else {
-        adoptionCounters.incomparableConflictCount += 1;
-    }
-    try {
-        adoptionDiagnosticsSink?.({ overlayId, outcome });
-    } catch {
-        // Recording must never affect overlay adoption behavior.
-    }
-}
+export {
+    type OverlayAdoptionDiagnosticsEvent,
+    type OverlayAdoptionDiagnosticsSink,
+    type OverlayAdoptionOutcome,
+    type RallarOverlayAdoptionDiagnostics,
+    readOverlayAdoptionDiagnostics,
+    resetOverlayAdoptionDiagnostics,
+    setOverlayAdoptionDiagnosticsSink,
+} from './overlay-adoption-diagnostics.ts';
 
 export const overlayRepositoryToken = newObservableLatestRepositoryToken<string, OverlayInfo>(
     'shared.repository.overlays',
@@ -286,6 +224,21 @@ export function setOverlayById(
         return;
     }
 
+    // Server overlays are authoritative over bootstrap overlays regardless of
+    // the causal tuple: a bootstrap star restamped from a newer group revision
+    // must never displace a server topology (scenario S5), and a server
+    // overlay planned against an older revision must still be adopted.
+    if (overlay.provenance === 'server' && current.provenance === 'bootstrap') {
+        emitOverlayAdoption(id, 'server-superseded-bootstrap');
+        repository.set(id, overlay);
+        return;
+    }
+
+    if (overlay.provenance === 'bootstrap' && current.provenance === 'server') {
+        emitOverlayAdoption(id, 'bootstrap-dropped-over-server');
+        return;
+    }
+
     const comparison = compareOverlayInfoTuple(overlay, current);
     if (comparison === 'dominates') {
         emitOverlayAdoption(id, 'adopted');
@@ -359,6 +312,7 @@ function toOverlayRepositoryChange(
 function toStarOverlay(group: AnyGroupPresence): OverlayInfo {
     return {
         sourceGroupStateCausalRevision: readGroupCausalRevision(group),
+        provenance: 'bootstrap',
         state: 'active',
         name: readGroupDisplayName(group),
         overlayId: toScopedOverlayId(group.group),

--- a/packages/shared/rtc/bootstrap-peer-selection.ts
+++ b/packages/shared/rtc/bootstrap-peer-selection.ts
@@ -1,0 +1,52 @@
+import { rendezvousScore } from './rendezvous-score.ts';
+import { DEFAULT_WEBRTC_MAX_PEER_CONNECTIONS } from '../services/WebRtcGroupManager.ts';
+
+export const DEFAULT_BOOTSTRAP_DEGREE = 5;
+
+export type BootstrapDegreeInput = Readonly<{
+    bootstrapDegree?: number;
+    maxPeerConnections?: number;
+}>;
+
+export type BootstrapPeerSelectionInput = Readonly<{
+    localSessionId: string;
+    memberSessionIds: readonly string[];
+    groupKey: string;
+    bootstrapDegree: number;
+}>;
+
+export function resolveBootstrapDegree(input: BootstrapDegreeInput): number {
+    const requestedDegree = toPositiveInteger(input.bootstrapDegree) ??
+        DEFAULT_BOOTSTRAP_DEGREE;
+    const maxPeerConnections = toPositiveInteger(input.maxPeerConnections) ??
+        DEFAULT_WEBRTC_MAX_PEER_CONNECTIONS;
+    return Math.min(requestedDegree, maxPeerConnections);
+}
+
+/**
+ * Deterministic bounded bootstrap set: each session ranks the group's other
+ * members by rendezvous score and keeps the first `bootstrapDegree`. The
+ * per-session asymmetric rankings make the union graph connected with high
+ * probability at small degree without any coordination; WS relay remains the
+ * correctness baseline when a bootstrap component is isolated.
+ */
+export function selectBootstrapPeers(
+    input: BootstrapPeerSelectionInput,
+): readonly string[] {
+    const candidates = [...new Set(input.memberSessionIds)]
+        .filter((sessionId) => sessionId !== input.localSessionId)
+        .sort((left, right) =>
+            rendezvousScore(input.localSessionId, left, input.groupKey)
+                .localeCompare(
+                    rendezvousScore(input.localSessionId, right, input.groupKey),
+                )
+        );
+
+    return candidates.slice(0, Math.max(0, input.bootstrapDegree));
+}
+
+function toPositiveInteger(value: number | undefined): number | undefined {
+    return value !== undefined && Number.isInteger(value) && value > 0
+        ? value
+        : undefined;
+}

--- a/packages/shared/rtc/group-formation-mode.ts
+++ b/packages/shared/rtc/group-formation-mode.ts
@@ -1,0 +1,16 @@
+/**
+ * Governs the group-formation Phase 1 behaviors that have an operational
+ * rollback: conditional bounded bootstrap overlays and the outbound dial
+ * budget. 'legacy-star' restores the unconditional full-membership star and
+ * unbounded dialing. Overlay admission precedence (server supersedes
+ * bootstrap) is not mode-dependent.
+ */
+export type RtcGroupFormationMode = 'bounded-bootstrap' | 'legacy-star';
+
+export const DEFAULT_RTC_GROUP_FORMATION_MODE: RtcGroupFormationMode = 'bounded-bootstrap';
+
+export function resolveRtcGroupFormationMode(
+    mode: RtcGroupFormationMode | undefined,
+): RtcGroupFormationMode {
+    return mode ?? DEFAULT_RTC_GROUP_FORMATION_MODE;
+}

--- a/packages/shared/rtc/rendezvous-score.ts
+++ b/packages/shared/rtc/rendezvous-score.ts
@@ -1,0 +1,22 @@
+/**
+ * Deterministic rendezvous scoring shared by RTT-reporting peer selection and
+ * bootstrap peer selection. Scores depend only on (groupKey, localSessionId,
+ * peerSessionId), so every session computes the same ranking for itself
+ * without coordination, and different sessions get de-correlated rankings.
+ */
+export function rendezvousScore(
+    localSessionId: string,
+    peerSessionId: string,
+    groupKey = '',
+): string {
+    return `${hashString(`${groupKey}:${localSessionId}:${peerSessionId}`)}`.padStart(10, '0');
+}
+
+function hashString(value: string): number {
+    let hash = 2166136261;
+    for (let i = 0; i < value.length; i++) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}

--- a/packages/shared/rtc/rtt-reporting-policy.ts
+++ b/packages/shared/rtc/rtt-reporting-policy.ts
@@ -1,3 +1,5 @@
+import { rendezvousScore } from './rendezvous-score.ts';
+
 export const DEFAULT_RTT_REPORTING_DEGREE_LIMIT = 5;
 
 export type RttReportingPeerSelectionInput = Readonly<{
@@ -60,21 +62,4 @@ export function selectRttReportingPeers(
 
 function stableUnique(values: readonly string[]): string[] {
     return [...new Set(values)];
-}
-
-function rendezvousScore(
-    localSessionId: string,
-    peerSessionId: string,
-    groupKey = '',
-): string {
-    return `${hashString(`${groupKey}:${localSessionId}:${peerSessionId}`)}`.padStart(10, '0');
-}
-
-function hashString(value: string): number {
-    let hash = 2166136261;
-    for (let i = 0; i < value.length; i++) {
-        hash ^= value.charCodeAt(i);
-        hash = Math.imul(hash, 16777619);
-    }
-    return hash >>> 0;
 }

--- a/packages/shared/services/WebRtcGroupManager.ts
+++ b/packages/shared/services/WebRtcGroupManager.ts
@@ -8,15 +8,19 @@ import {
     type AnyGroupPresence,
     readActiveClientSessionIds,
 } from '../api/group-client-views.ts';
-import {
-    isOverlayForGroupRef,
-    toScopedOverlayId,
-    toWebRtcGroupKey,
-} from '@shared/api/api-type-utils.ts';
+import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
 import {
     normalizeRttReportingDegreeLimit,
     selectRttReportingPeers,
 } from '../rtc/rtt-reporting-policy.ts';
+import { resolveRtcGroupFormationMode } from '../rtc/group-formation-mode.ts';
+import { computeOutboundDialPlan } from './webrtc-outbound-dial-plan.ts';
+import {
+    computeOverlayRttReportingDegreeLimit,
+    computeServerDesiredPeerIds,
+    readAuthoritativeOverlayForGroup,
+    readOverlayForGroup,
+} from './webrtc-group-overlay-reading.ts';
 import {
     clonePeerOwners,
     emptyGroupManagerDiagnostics,
@@ -218,7 +222,10 @@ export class WebRtcGroupManager {
     ): readonly PeerId[] {
         const degreeLimit = normalizeRttReportingDegreeLimit(
             options.degreeLimit,
-            this.overlayRttReportingDegreeLimit(),
+            computeOverlayRttReportingDegreeLimit(
+                this.overlayCache,
+                this.groups().map((group) => group.groupRef),
+            ),
         );
         const onlinePeerIds = this.onlinePeerIds();
 
@@ -270,11 +277,24 @@ export class WebRtcGroupManager {
                 (peerId) => onlinePeerIds.has(peerId),
             );
 
-            const peersToConnect = connectablePeerIds.filter(
-                (peerId) => !peerIdsWithNoReconnectableLanes.has(peerId),
-            );
+            const dialPlan = computeOutboundDialPlan({
+                mode: resolveRtcGroupFormationMode(this.options.groupFormationMode),
+                maxPeerConnections: this.maxPeerConnections(),
+                knownPeerIds,
+                desiredPeerIds,
+                connectablePeerIds: connectablePeerIds.filter(
+                    (peerId) => !peerIdsWithNoReconnectableLanes.has(peerId),
+                ),
+                serverDesiredPeerIds: computeServerDesiredPeerIds(
+                    this.overlayCache,
+                    this.groups().map((group) => group.groupRef),
+                    this.rtcQBox.input.sessionId,
+                ),
+            });
+            this.diagnostics.connectDeferredBudgetCount +=
+                dialPlan.deferredPeerIds.length;
 
-            for (const peerId of peersToConnect) {
+            for (const peerId of dialPlan.peersToConnect) {
                 this.diagnostics.connectAttemptCount += 1;
                 const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
                 if (connected.left) {
@@ -367,7 +387,7 @@ export class WebRtcGroupManager {
     }
 
     private targetPeerIdsForGroup(group: WebRtcGroupService): readonly PeerId[] {
-        const overlay = this.readOverlayForGroup(group.groupRef);
+        const overlay = readOverlayForGroup(this.overlayCache, group.groupRef);
         if (overlay) {
             return overlay.nextHopSessionIds.filter(
                 (peerId) => peerId !== this.rtcQBox.input.sessionId,
@@ -387,7 +407,10 @@ export class WebRtcGroupManager {
             .sort((left, right) => left.groupKey.localeCompare(right.groupKey));
 
         for (const group of groups) {
-            const overlay = this.readAuthoritativeOverlayForGroup(group.groupRef);
+            const overlay = readAuthoritativeOverlayForGroup(
+                this.overlayCache,
+                group.groupRef,
+            );
             const activePeerSessionIds = group.targetPeerIds()
                 .filter((peerId) => onlinePeerIds.has(peerId));
             const selection = selectRttReportingPeers({
@@ -459,7 +482,10 @@ export class WebRtcGroupManager {
         activePeerSessionIds: readonly PeerId[],
         degreeLimit: number,
     ): boolean {
-        const overlay = this.readAuthoritativeOverlayForGroup(group.groupRef);
+        const overlay = readAuthoritativeOverlayForGroup(
+            this.overlayCache,
+            group.groupRef,
+        );
         const localSelection = selectRttReportingPeers({
             localSessionId: this.rtcQBox.input.sessionId,
             degreeLimit,
@@ -486,38 +512,6 @@ export class WebRtcGroupManager {
         });
 
         return peerSelection.selectedPeerIds.includes(this.rtcQBox.input.sessionId);
-    }
-
-    private overlayRttReportingDegreeLimit(): number | undefined {
-        const limits = this.groups()
-            .map((group) => this.readOverlayForGroup(group.groupRef)?.degreeLimit)
-            .filter((value): value is number => value !== undefined);
-        return limits.length > 0 ? Math.min(...limits) : undefined;
-    }
-
-    private readOverlayForGroup(groupRef: GroupRef): OverlayInfo | undefined {
-        if (!this.overlayCache) {
-            return undefined;
-        }
-
-        const scopedOverlayId = toScopedOverlayId(groupRef);
-        const scoped = this.overlayCache.read(scopedOverlayId) ??
-            this.overlayCache.peek(scopedOverlayId);
-        if (scoped) {
-            return scoped.state === 'removed' ? undefined : scoped;
-        }
-
-        const legacy = this.overlayCache.read(groupRef.groupId) ??
-            this.overlayCache.peek(groupRef.groupId);
-        return legacy && legacy.state !== 'removed' &&
-                isOverlayForGroupRef(legacy, groupRef)
-            ? legacy
-            : undefined;
-    }
-
-    private readAuthoritativeOverlayForGroup(groupRef: GroupRef): OverlayInfo | undefined {
-        const overlay = this.readOverlayForGroup(groupRef);
-        return overlay?.degreeLimit !== undefined ? overlay : undefined;
     }
 
     private retainKnownPeersForGroup(

--- a/packages/shared/services/group-snapshot-rtc-sync.ts
+++ b/packages/shared/services/group-snapshot-rtc-sync.ts
@@ -1,0 +1,77 @@
+import { isGroupActive, isSessionInGroup } from '@shared/api/group-client-views.ts';
+import type { GroupSnapshot as GroupStateSnapshot } from '@shared/api/group-types.ts';
+import {
+    type BootstrapOverlayPolicy,
+    createAndSetBootstrapOverlays,
+} from '@shared/repository/overlay-bootstrap.ts';
+import * as overlaysRepository from '@shared/repository/overlays-repository.ts';
+import { resolveBootstrapDegree } from '@shared/rtc/bootstrap-peer-selection.ts';
+import {
+    resolveRtcGroupFormationMode,
+    type RtcGroupFormationMode,
+} from '@shared/rtc/group-formation-mode.ts';
+import type { WebRtcGroupManager } from '@shared/services/WebRtcGroupManager.ts';
+
+export type GroupFormationPolicyInput = Readonly<{
+    mode: RtcGroupFormationMode;
+    bootstrapDegree: number;
+}>;
+
+export function resolveBootstrapOverlayPolicy(
+    groupFormation: GroupFormationPolicyInput | undefined,
+    localSessionId: string,
+): BootstrapOverlayPolicy {
+    return {
+        localSessionId,
+        mode: resolveRtcGroupFormationMode(groupFormation?.mode),
+        bootstrapDegree: groupFormation?.bootstrapDegree ??
+            resolveBootstrapDegree({}),
+    };
+}
+
+export function isSameBootstrapOverlayPolicy(
+    left: BootstrapOverlayPolicy,
+    right: BootstrapOverlayPolicy,
+): boolean {
+    return left.localSessionId === right.localSessionId &&
+        left.mode === right.mode &&
+        left.bootstrapDegree === right.bootstrapDegree;
+}
+
+export async function acceptGroupSnapshotUpdate(
+    snapshot: GroupStateSnapshot,
+    webRtcGroupManager: WebRtcGroupManager,
+    bootstrapOverlayPolicy: BootstrapOverlayPolicy,
+): Promise<void> {
+    if (!isGroupActive(snapshot)) {
+        overlaysRepository.removeOverlayByGroupRef(snapshot.group);
+        overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
+
+        await webRtcGroupManager.delete(snapshot.group);
+        return;
+    }
+
+    if (!isSessionInGroup(snapshot, bootstrapOverlayPolicy.localSessionId)) {
+        overlaysRepository.removeOverlayByGroupRef(snapshot.group);
+        overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
+        if (webRtcGroupManager.has(snapshot.group)) {
+            await webRtcGroupManager.delete(snapshot.group, { retainConnections: true });
+        } else {
+            await webRtcGroupManager.ensureAllGroupsConnected();
+        }
+        return;
+    }
+
+    createAndSetBootstrapOverlays([snapshot], bootstrapOverlayPolicy);
+    await webRtcGroupManager.acceptGroupUpdate(snapshot);
+}
+
+export async function acceptGroupSnapshotRemoval(
+    snapshot: GroupStateSnapshot,
+    webRtcGroupManager: WebRtcGroupManager,
+): Promise<void> {
+    overlaysRepository.removeOverlayByGroupRef(snapshot.group);
+    overlaysRepository.removeLegacyOverlayByGroupIdIfMatches(snapshot.group);
+
+    await webRtcGroupManager.delete(snapshot.group);
+}

--- a/packages/shared/services/webrtc-group-manager-contracts.ts
+++ b/packages/shared/services/webrtc-group-manager-contracts.ts
@@ -1,4 +1,5 @@
 import { GroupId, PeerId } from '../api/api-config.ts';
+import type { RtcGroupFormationMode } from '../rtc/group-formation-mode.ts';
 
 export type WebRtcGroupManagerState = {
     readonly groupIds: readonly GroupId[];
@@ -12,6 +13,7 @@ export type WebRtcGroupManagerState = {
 
 export type WebRtcGroupManagerOptions = Readonly<{
     maxPeerConnections?: number;
+    groupFormationMode?: RtcGroupFormationMode;
     onDesiredPeerIdsChanged?: () => void;
 }>;
 
@@ -46,6 +48,7 @@ export interface MutableWebRtcGroupManagerDiagnostics {
     lastDesiredPeerCount: number;
     connectAttemptCount: number;
     connectFailureCount: number;
+    connectDeferredBudgetCount: number;
     disconnectCount: number;
     retainedEvictionCount: number;
 }
@@ -59,6 +62,7 @@ export function emptyGroupManagerDiagnostics(): MutableWebRtcGroupManagerDiagnos
         lastDesiredPeerCount: 0,
         connectAttemptCount: 0,
         connectFailureCount: 0,
+        connectDeferredBudgetCount: 0,
         disconnectCount: 0,
         retainedEvictionCount: 0,
     };

--- a/packages/shared/services/webrtc-group-overlay-reading.ts
+++ b/packages/shared/services/webrtc-group-overlay-reading.ts
@@ -1,0 +1,73 @@
+import type { OverlayInfo, PeerId } from '../api/api-config.ts';
+import type { GroupRef } from '../api/group-types.ts';
+import {
+    isOverlayForGroupRef,
+    toScopedOverlayId,
+} from '@shared/api/api-type-utils.ts';
+import type { ReadableKeyedValues } from '../cache/RepositoryInterfaces.ts';
+
+export type OverlayCacheReader = ReadableKeyedValues<string, OverlayInfo>;
+
+export function readOverlayForGroup(
+    overlayCache: OverlayCacheReader | undefined,
+    groupRef: GroupRef,
+): OverlayInfo | undefined {
+    if (!overlayCache) {
+        return undefined;
+    }
+
+    const scopedOverlayId = toScopedOverlayId(groupRef);
+    const scoped = overlayCache.read(scopedOverlayId) ??
+        overlayCache.peek(scopedOverlayId);
+    if (scoped) {
+        return scoped.state === 'removed' ? undefined : scoped;
+    }
+
+    const legacy = overlayCache.read(groupRef.groupId) ??
+        overlayCache.peek(groupRef.groupId);
+    return legacy && legacy.state !== 'removed' &&
+            isOverlayForGroupRef(legacy, groupRef)
+        ? legacy
+        : undefined;
+}
+
+export function readAuthoritativeOverlayForGroup(
+    overlayCache: OverlayCacheReader | undefined,
+    groupRef: GroupRef,
+): OverlayInfo | undefined {
+    const overlay = readOverlayForGroup(overlayCache, groupRef);
+    return overlay?.degreeLimit !== undefined ? overlay : undefined;
+}
+
+export function computeOverlayRttReportingDegreeLimit(
+    overlayCache: OverlayCacheReader | undefined,
+    groupRefs: readonly GroupRef[],
+): number | undefined {
+    const limits = groupRefs
+        .map((groupRef) => readOverlayForGroup(overlayCache, groupRef)?.degreeLimit)
+        .filter((value): value is number => value !== undefined);
+    return limits.length > 0 ? Math.min(...limits) : undefined;
+}
+
+export function computeServerDesiredPeerIds(
+    overlayCache: OverlayCacheReader | undefined,
+    groupRefs: readonly GroupRef[],
+    localSessionId: string,
+): ReadonlySet<PeerId> {
+    const serverDesiredPeerIds = new Set<PeerId>();
+
+    for (const groupRef of groupRefs) {
+        const overlay = readOverlayForGroup(overlayCache, groupRef);
+        if (overlay?.provenance !== 'server') {
+            continue;
+        }
+
+        for (const peerId of overlay.nextHopSessionIds) {
+            if (peerId !== localSessionId) {
+                serverDesiredPeerIds.add(peerId);
+            }
+        }
+    }
+
+    return serverDesiredPeerIds;
+}

--- a/packages/shared/services/webrtc-outbound-dial-plan.ts
+++ b/packages/shared/services/webrtc-outbound-dial-plan.ts
@@ -1,0 +1,62 @@
+import type { PeerId } from '../api/api-config.ts';
+import type { RtcGroupFormationMode } from '../rtc/group-formation-mode.ts';
+
+export type OutboundDialPlanInput = Readonly<{
+    mode: RtcGroupFormationMode;
+    maxPeerConnections: number;
+    knownPeerIds: ReadonlySet<PeerId>;
+    desiredPeerIds: ReadonlySet<PeerId>;
+    connectablePeerIds: readonly PeerId[];
+    serverDesiredPeerIds: ReadonlySet<PeerId>;
+}>;
+
+export type OutboundDialPlan = Readonly<{
+    peersToConnect: readonly PeerId[];
+    deferredPeerIds: readonly PeerId[];
+}>;
+
+/**
+ * Bounds outbound dialing to the same peer-connection budget inbound
+ * admission uses. Peers with an existing connection are always ensured (an
+ * ensure is idempotent, not a new dial); new dials are admitted
+ * server-overlay-desired peers first, then bootstrap-desired peers, until
+ * desired connections reach the budget. Only desired known connections count
+ * against the budget: retained (grace) connections are governed by the
+ * retained-eviction pass, which trims the overflow in the same reconcile —
+ * counting them here would let a full retained set starve required dials
+ * that the eviction pass would never unblock. Deferred peers are retried by
+ * later reconciles as slots free up. 'legacy-star' keeps the unbounded
+ * pre-Phase-1 dialing.
+ */
+export function computeOutboundDialPlan(
+    input: OutboundDialPlanInput,
+): OutboundDialPlan {
+    if (input.mode === 'legacy-star') {
+        return { peersToConnect: input.connectablePeerIds, deferredPeerIds: [] };
+    }
+
+    const alreadyKnown = input.connectablePeerIds
+        .filter((peerId) => input.knownPeerIds.has(peerId));
+    const newCandidates = input.connectablePeerIds
+        .filter((peerId) => !input.knownPeerIds.has(peerId));
+    const serverFirstCandidates = [
+        ...newCandidates.filter((peerId) => input.serverDesiredPeerIds.has(peerId)),
+        ...newCandidates.filter((peerId) => !input.serverDesiredPeerIds.has(peerId)),
+    ];
+
+    const desiredKnownCount = Array.from(input.knownPeerIds)
+        .filter((peerId) => input.desiredPeerIds.has(peerId))
+        .length;
+    const newDialBudget = Math.max(
+        0,
+        input.maxPeerConnections - desiredKnownCount,
+    );
+
+    return {
+        peersToConnect: [
+            ...alreadyKnown,
+            ...serverFirstCandidates.slice(0, newDialBudget),
+        ],
+        deferredPeerIds: serverFirstCandidates.slice(newDialBudget),
+    };
+}

--- a/packages/tests/rallar-black-box-headless/headless-bundle-boundary.test.ts
+++ b/packages/tests/rallar-black-box-headless/headless-bundle-boundary.test.ts
@@ -42,7 +42,9 @@ describe('rallar-black-box-headless bundle boundary', () => {
     }
 
     // Validated snapshot point reads and race-fenced repair add a bounded browser cost.
-    expect(result.brotliKiB).toBeLessThan(194);
+    // Group-formation Phase 1 (overlay provenance admission, bounded bootstrap
+    // selection, outbound dial plan) adds ~0.7 KiB; measured 194.61 at that change.
+    expect(result.brotliKiB).toBeLessThan(196);
   });
 });
 

--- a/packages/tests/shared-web/data-caches.test.ts
+++ b/packages/tests/shared-web/data-caches.test.ts
@@ -15,7 +15,7 @@ import {
 import { newALBroadcastMessage, newALEventRoute } from '@shared/al-contracts/al-contract.ts';
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
-import { findOverlayById } from '@shared/repository/overlays-repository.ts';
+import { findOverlayById, setOverlayById } from '@shared/repository/overlays-repository.ts';
 import * as dataCaches from '@shared-web/browser/data-caches.ts';
 import { configureTestCacheRepositories } from '../cache-repository-config.ts';
 
@@ -732,6 +732,119 @@ describe('browser data caches state scope filtering', () => {
         });
 
         unsubscribe();
+    });
+
+    it('creates a bounded bootstrap overlay for active group snapshots', async () => {
+        const manager = createWebRtcGroupManager();
+        const clientData: ClientInfo = {
+            clientId: 'alice',
+            sessionId: 'session-a',
+            isOnline: true,
+        };
+        const memberSessionIds = Array.from(
+            { length: 8 },
+            (_, index) => `session-${String.fromCharCode(97 + index)}`,
+        );
+        const group = createGroupSnapshot(
+            'room-bootstrap',
+            DEFAULT_STATE_APPLICATION_ID,
+            DEFAULT_STATE_WORKSPACE_ID,
+            memberSessionIds,
+            1,
+        );
+
+        await dataCaches.hydrateStateCaches(manager, clientData, [], [group]);
+
+        const overlay = findOverlayById(toScopedOverlayId(group.group));
+        expect(overlay).toMatchObject({
+            provenance: 'bootstrap',
+            topology: 'star',
+            degreeLimit: 5,
+        });
+        expect(overlay?.nextHopSessionIds).toHaveLength(5);
+        expect(overlay?.nextHopSessionIds).not.toContain('session-a');
+    });
+
+    it('does not restamp a bootstrap overlay over an existing server overlay', async () => {
+        const manager = createWebRtcGroupManager();
+        const clientData: ClientInfo = {
+            clientId: 'alice',
+            sessionId: 'session-a',
+            isOnline: true,
+        };
+        const group = createGroupSnapshot(
+            'room-server-owned',
+            DEFAULT_STATE_APPLICATION_ID,
+            DEFAULT_STATE_WORKSPACE_ID,
+            ['session-a', 'session-b', 'session-c'],
+            1,
+        );
+        const overlayId = toScopedOverlayId(group.group);
+        setOverlayById(overlayId, {
+            sourceGroupStateCausalRevision: {
+                groupRevision: 1,
+                presenceRevision: 1,
+            },
+            provenance: 'server',
+            state: 'active',
+            overlayId,
+            groupRef: group.group,
+            topology: 'tree',
+            name: 'room-server-owned',
+            createdByClientId: 'server',
+            createdAtEpochMs: 1,
+            nextHopSessionIds: ['session-c'],
+            degreeLimit: 5,
+            overlayVersion: 1,
+            updatedAtEpochMs: 1,
+        });
+
+        const newerGroup = createGroupSnapshot(
+            'room-server-owned',
+            DEFAULT_STATE_APPLICATION_ID,
+            DEFAULT_STATE_WORKSPACE_ID,
+            ['session-a', 'session-b', 'session-c'],
+            5,
+        );
+        await dataCaches.hydrateStateCaches(manager, clientData, [], [newerGroup]);
+
+        expect(findOverlayById(overlayId)).toMatchObject({
+            provenance: 'server',
+            topology: 'tree',
+            nextHopSessionIds: ['session-c'],
+        });
+    });
+
+    it('restores the unconditional full-membership star in legacy-star mode', async () => {
+        const manager = createWebRtcGroupManager();
+        const clientData: ClientInfo = {
+            clientId: 'alice',
+            sessionId: 'session-a',
+            isOnline: true,
+        };
+        const memberSessionIds = Array.from(
+            { length: 8 },
+            (_, index) => `session-${String.fromCharCode(97 + index)}`,
+        );
+        const group = createGroupSnapshot(
+            'room-legacy',
+            DEFAULT_STATE_APPLICATION_ID,
+            DEFAULT_STATE_WORKSPACE_ID,
+            memberSessionIds,
+            1,
+        );
+
+        await dataCaches.hydrateStateCaches(manager, clientData, [], [group], {
+            groupFormation: { mode: 'legacy-star', bootstrapDegree: 5 },
+        });
+
+        const overlay = findOverlayById(toScopedOverlayId(group.group));
+        expect(overlay).toMatchObject({
+            provenance: 'bootstrap',
+            topology: 'star',
+            degreeLimit: 7,
+        });
+        expect(overlay?.nextHopSessionIds).toEqual(memberSessionIds);
     });
 });
 

--- a/packages/tests/shared/group-formation-burst-simulation.test.ts
+++ b/packages/tests/shared/group-formation-burst-simulation.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it, vi } from 'vitest';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import type { ClientInfo } from '@shared/api/api-config.ts';
+import type {
+    AuditStamp,
+    GroupSnapshot,
+} from '@shared/api/group-types.ts';
+import {
+    type RallarOverlayTopologySnapshot,
+    toOverlayInfoForSession,
+} from '@shared/api/overlay-topology.ts';
+import { LatestRepository } from '@shared/cache/LatestRepository.ts';
+import { RepositoryManager } from '@shared/cache/RepositoryManager.ts';
+import {
+    createAndSetBootstrapOverlays,
+} from '@shared/repository/overlay-bootstrap.ts';
+import {
+    configureOverlayRepository,
+    createAndSetStarOverlays,
+    findOverlayById,
+    readableOverlayCache,
+    readOverlayAdoptionDiagnostics,
+    resetOverlayAdoptionDiagnostics,
+    setOverlayById,
+} from '@shared/repository/overlays-repository.ts';
+import { Either } from '@shared/resilience/Either.ts';
+import { WebRtcGroupManager } from '@shared/services/WebRtcGroupManager.ts';
+
+const MAX_PEER_CONNECTIONS = 10;
+const BOOTSTRAP_DEGREE = 5;
+
+// The Phase 1 tier evidence for "overlay adoption ≈ 100% and outbound dials
+// bounded": N real browser-side stacks (overlay repository semantics +
+// WebRtcGroupManager over a fake connection service) burst-join one group,
+// bootstrap with the bounded rendezvous star, then receive a server overlay
+// planned against an OLDER group revision than the bootstrap star carries —
+// the exact S5 condition under which the pre-Phase-1 tuple admission dropped
+// every server overlay. The formation-burst black-box recipes cover the
+// server side and WS delivery; this covers the browser-side logic those
+// recipes cannot reach (their clients are raw WS sockets).
+describe('group formation burst simulation', () => {
+    it.each([
+        { tier: 'small', memberCount: 6 },
+        { tier: 'medium', memberCount: 20 },
+        { tier: 'large', memberCount: 50 },
+    ])(
+        'adopts the server overlay on every client with bounded dials ($tier, N=$memberCount)',
+        async ({ memberCount }) => {
+            resetOverlayAdoptionDiagnostics();
+            const sessionIds = Array.from(
+                { length: memberCount },
+                (_, index) => `session-${index}`,
+            );
+            const group = createGroupSnapshot('burst-group', 3, sessionIds);
+            const overlayId = toScopedOverlayId(group.group);
+            const serverTopology = createRingTopologySnapshot(
+                group,
+                sessionIds,
+                { groupRevision: 2, presenceRevision: 2 },
+            );
+            const clients = sessionIds.map((sessionId) =>
+                createSimulatedClient(sessionId, sessionIds)
+            );
+
+            for (const client of clients) {
+                createAndSetBootstrapOverlays([group], {
+                    localSessionId: client.sessionId,
+                    mode: 'bounded-bootstrap',
+                    bootstrapDegree: BOOTSTRAP_DEGREE,
+                }, client.repositoryManager);
+                await client.manager.acceptGroupUpdate(group);
+            }
+
+            for (const client of clients) {
+                const bootstrapOverlay = findOverlayById(
+                    overlayId,
+                    client.repositoryManager,
+                );
+                expect(bootstrapOverlay?.provenance).toBe('bootstrap');
+                expect(bootstrapOverlay?.nextHopSessionIds.length)
+                    .toBeLessThanOrEqual(BOOTSTRAP_DEGREE);
+                expect(client.dialedPeerIds().size)
+                    .toBeLessThanOrEqual(MAX_PEER_CONNECTIONS);
+            }
+            expect(readOverlayAdoptionDiagnostics().initialSetCount)
+                .toBe(memberCount);
+
+            for (const client of clients) {
+                setOverlayById(
+                    overlayId,
+                    toOverlayInfoForSession(serverTopology, client.sessionId),
+                    client.repositoryManager,
+                );
+                await client.manager.notifyOverlayTopologyChanged();
+            }
+
+            // Belt and braces: a later legacy full-membership restamp attempt
+            // must not displace the adopted server overlay on any client.
+            for (const client of clients) {
+                createAndSetStarOverlays([group], client.repositoryManager);
+            }
+
+            const adoption = readOverlayAdoptionDiagnostics();
+            expect(adoption.serverSupersededBootstrapCount).toBe(memberCount);
+            expect(adoption.bootstrapDroppedOverServerCount).toBe(memberCount);
+            expect(adoption.incomparableConflictCount).toBe(0);
+
+            for (const client of clients) {
+                const adopted = findOverlayById(overlayId, client.repositoryManager);
+                expect(adopted?.provenance).toBe('server');
+                expect(adopted?.topology).toBe('tree');
+
+                const dialed = client.dialedPeerIds();
+                expect(dialed.size).toBeLessThanOrEqual(MAX_PEER_CONNECTIONS);
+                expect(client.manager.readDiagnostics().connectFailureCount)
+                    .toBe(0);
+            }
+        },
+    );
+
+    it('legacy-star mode reproduces the unbounded full-mesh dial storm (N=50)', async () => {
+        const sessionIds = Array.from(
+            { length: 50 },
+            (_, index) => `session-${index}`,
+        );
+        const group = createGroupSnapshot('legacy-group', 3, sessionIds);
+        const client = createSimulatedClient(sessionIds[0], sessionIds, {
+            groupFormationMode: 'legacy-star',
+        });
+
+        createAndSetBootstrapOverlays([group], {
+            localSessionId: client.sessionId,
+            mode: 'legacy-star',
+            bootstrapDegree: BOOTSTRAP_DEGREE,
+        }, client.repositoryManager);
+        await client.manager.acceptGroupUpdate(group);
+
+        expect(client.dialedPeerIds().size).toBe(49);
+    });
+});
+
+type SimulatedClient = Readonly<{
+    sessionId: string;
+    repositoryManager: RepositoryManager;
+    manager: WebRtcGroupManager;
+    dialedPeerIds: () => ReadonlySet<string>;
+}>;
+
+function createSimulatedClient(
+    sessionId: string,
+    allSessionIds: readonly string[],
+    options: Readonly<{ groupFormationMode?: 'bounded-bootstrap' | 'legacy-star' }> =
+        {},
+): SimulatedClient {
+    const repositoryManager = new RepositoryManager();
+    configureOverlayRepository({ ttlMs: 60_000 }, repositoryManager);
+
+    const groupCache = new LatestRepository<string, GroupSnapshot>();
+    const clientCache = new LatestRepository<string, ClientInfo>();
+    for (const peerSessionId of allSessionIds) {
+        clientCache.set(peerSessionId, {
+            clientId: peerSessionId,
+            sessionId: peerSessionId,
+            isOnline: true,
+        });
+    }
+
+    const dialedPeerIds = new Set<string>();
+    const knownPeerIds = new Set<string>();
+    const rtcQBox = {
+        input: { sessionId },
+        knownPeerIds: () => Array.from(knownPeerIds),
+        peerIdsWithNoReconnectableLanes: () => Array.from(knownPeerIds),
+        ensurePeerConnectionStarted: vi.fn((peerId: string) => {
+            dialedPeerIds.add(peerId);
+            knownPeerIds.add(peerId);
+            return Either.ofRight({ peerId } as never);
+        }),
+        disconnectPeer: vi.fn((peerId: string) => {
+            knownPeerIds.delete(peerId);
+        }),
+    };
+
+    const manager = new WebRtcGroupManager(
+        rtcQBox as never,
+        groupCache,
+        clientCache,
+        // The manager reads the same per-client overlay repository the
+        // admission writes go to, exactly like the browser composition root.
+        readableOverlayCache(repositoryManager),
+        {
+            maxPeerConnections: MAX_PEER_CONNECTIONS,
+            groupFormationMode: options.groupFormationMode ?? 'bounded-bootstrap',
+        },
+    );
+
+    return {
+        sessionId,
+        repositoryManager,
+        manager,
+        dialedPeerIds: () => dialedPeerIds,
+    };
+}
+
+function createRingTopologySnapshot(
+    group: GroupSnapshot,
+    sessionIds: readonly string[],
+    sourceGroupStateCausalRevision: Readonly<{
+        groupRevision: number;
+        presenceRevision: number;
+    }>,
+): RallarOverlayTopologySnapshot {
+    const nextHopsBySessionId: Record<string, readonly string[]> = {};
+    for (let index = 0; index < sessionIds.length; index++) {
+        const previous = sessionIds[(index + sessionIds.length - 1) % sessionIds.length];
+        const next = sessionIds[(index + 1) % sessionIds.length];
+        nextHopsBySessionId[sessionIds[index]] = [previous, next];
+    }
+
+    return {
+        sourceGroupStateCausalRevision,
+        state: 'active',
+        overlayId: toScopedOverlayId(group.group),
+        groupRef: group.group,
+        name: 'burst',
+        topology: 'tree',
+        activeSessionIds: sessionIds,
+        nextHopsBySessionId,
+        degreeLimit: BOOTSTRAP_DEGREE,
+        version: 1,
+        createdByClientId: 'server',
+        createdAtEpochMs: 1,
+        updatedAtEpochMs: 2,
+    };
+}
+
+function createGroupSnapshot(
+    groupId: string,
+    snapshotVersion: number,
+    sessionIds: readonly string[],
+): GroupSnapshot {
+    const applicationId = 'app-1';
+    const workspaceId = 'workspace-1';
+    const ownerPrincipalId = sessionIds[0];
+
+    return {
+        stateRevision: snapshotVersion * 2,
+        causalRevision: {
+            groupRevision: snapshotVersion,
+            presenceRevision: snapshotVersion,
+        },
+        group: {
+            applicationId,
+            workspaceId,
+            groupId,
+            slug: null,
+            displayName: groupId,
+            description: null,
+            kind: 'room',
+            status: 'active',
+            joinMode: 'open',
+            maxMembers: null,
+            maxSessionsPerMember: null,
+            metadata: {},
+            snapshotVersion,
+            metadataVersion: 1,
+            rosterVersion: 1,
+            presenceVersion: snapshotVersion,
+            created: auditStamp(1),
+            updated: auditStamp(snapshotVersion),
+            archived: null,
+            deleted: null,
+            expiresAtEpochMs: null,
+            emptySinceEpochMs: null,
+            purgeAfterEpochMs: null,
+            activeMemberCount: sessionIds.length,
+            ownerPrincipalId,
+        },
+        members: sessionIds.map((sessionId, index) => ({
+            applicationId,
+            workspaceId,
+            groupId,
+            principalId: sessionId,
+            role: index === 0 ? 'owner' : 'member',
+            status: 'active',
+            joined: auditStamp(1),
+            updated: auditStamp(snapshotVersion),
+            left: null,
+            removed: null,
+            banned: null,
+            invitedByPrincipalId: null,
+            invitationExpiresAtEpochMs: null,
+        })),
+        activeSessions: sessionIds.map((sessionId) => ({
+            applicationId,
+            workspaceId,
+            groupId,
+            sessionId,
+            principalId: sessionId,
+            generationId: `generation-${snapshotVersion}`,
+            generationVersion: snapshotVersion,
+            status: 'active',
+            connectedAtEpochMs: 1,
+            lastHeartbeatAtEpochMs: snapshotVersion,
+            expiresAtEpochMs: 60_000,
+            disconnectedAtEpochMs: null,
+            disconnectReason: null,
+        })),
+        memberCount: sessionIds.length,
+        onlineMemberCount: sessionIds.length,
+    };
+}
+
+function auditStamp(atEpochMs: number): AuditStamp {
+    return {
+        atEpochMs,
+        actor: { kind: 'service', serviceId: 'test' },
+        reason: null,
+        traceId: null,
+        requestId: null,
+    };
+}

--- a/packages/tests/shared/repository-modules.test.ts
+++ b/packages/tests/shared/repository-modules.test.ts
@@ -578,6 +578,7 @@ describe('repository modules', () => {
 
         expect(findOverlayById(overlayId)).toEqual({
             sourceGroupStateCausalRevision: group.causalRevision,
+            provenance: 'bootstrap',
             state: 'active',
             overlayId,
             groupRef: group.group,
@@ -628,6 +629,7 @@ describe('repository modules', () => {
                     groupRevision: 1,
                     presenceRevision: 1,
                 },
+                provenance: 'server',
                 state: 'active',
                 overlayId: 'group-1',
                 groupRef: {
@@ -684,6 +686,7 @@ describe('repository modules', () => {
                     groupRevision: 1,
                     presenceRevision: 1,
                 },
+                provenance: 'server',
                 state: 'active',
                 overlayId,
                 groupRef: {
@@ -740,6 +743,8 @@ describe('repository modules', () => {
                 equalCount: 1,
                 dominatedDroppedCount: 1,
                 incomparableConflictCount: 2,
+                serverSupersededBootstrapCount: 0,
+                bootstrapDroppedOverServerCount: 0,
             });
 
             setOverlayAdoptionDiagnosticsSink(() => {
@@ -760,6 +765,101 @@ describe('repository modules', () => {
         }
     });
 
+    it('admits server overlays over bootstrap overlays regardless of the causal tuple', () => {
+        const outcomes: string[] = [];
+        resetOverlayAdoptionDiagnostics();
+        setOverlayAdoptionDiagnosticsSink((event) => {
+            outcomes.push(event.outcome);
+        });
+
+        try {
+            const overlayId = 'group-provenance';
+            const bootstrap = {
+                sourceGroupStateCausalRevision: {
+                    groupRevision: 5,
+                    presenceRevision: 5,
+                },
+                provenance: 'bootstrap',
+                state: 'active',
+                overlayId,
+                groupRef: {
+                    applicationId: 'app-1',
+                    workspaceId: 'workspace-1',
+                    groupId: overlayId,
+                },
+                topology: 'star',
+                name: 'Alpha',
+                createdByClientId: 'owner',
+                createdAtEpochMs: 1,
+                nextHopSessionIds: ['peer-bootstrap'],
+                degreeLimit: 1,
+                overlayVersion: 5,
+                updatedAtEpochMs: 5,
+            } satisfies OverlayInfo;
+            const dominatedServer = {
+                ...bootstrap,
+                provenance: 'server',
+                sourceGroupStateCausalRevision: {
+                    groupRevision: 1,
+                    presenceRevision: 1,
+                },
+                nextHopSessionIds: ['peer-server'],
+                overlayVersion: 1,
+            } satisfies OverlayInfo;
+            const dominatingBootstrap = {
+                ...bootstrap,
+                sourceGroupStateCausalRevision: {
+                    groupRevision: 9,
+                    presenceRevision: 9,
+                },
+                overlayVersion: 9,
+            } satisfies OverlayInfo;
+            const newerServer = {
+                ...dominatedServer,
+                sourceGroupStateCausalRevision: {
+                    groupRevision: 2,
+                    presenceRevision: 2,
+                },
+                nextHopSessionIds: ['peer-server-2'],
+                overlayVersion: 2,
+            } satisfies OverlayInfo;
+
+            setOverlayById(overlayId, bootstrap);
+            setOverlayById(overlayId, dominatedServer);
+            expect(findOverlayById(overlayId)?.nextHopSessionIds)
+                .toEqual(['peer-server']);
+
+            setOverlayById(overlayId, dominatingBootstrap);
+            expect(findOverlayById(overlayId)?.provenance).toBe('server');
+            expect(findOverlayById(overlayId)?.nextHopSessionIds)
+                .toEqual(['peer-server']);
+
+            setOverlayById(overlayId, newerServer);
+            setOverlayById(overlayId, {
+                ...dominatedServer,
+                nextHopSessionIds: ['peer-server-stale'],
+            });
+            expect(findOverlayById(overlayId)?.nextHopSessionIds)
+                .toEqual(['peer-server-2']);
+
+            expect(outcomes).toEqual([
+                'initial-set',
+                'server-superseded-bootstrap',
+                'bootstrap-dropped-over-server',
+                'adopted',
+                'dominated-dropped',
+            ]);
+            expect(readOverlayAdoptionDiagnostics()).toMatchObject({
+                serverSupersededBootstrapCount: 1,
+                bootstrapDroppedOverServerCount: 1,
+                incomparableConflictCount: 0,
+            });
+        } finally {
+            setOverlayAdoptionDiagnosticsSink(undefined);
+            resetOverlayAdoptionDiagnostics();
+        }
+    });
+
     it('orders revisioned overlays by source group revision and retains removal tombstones', () => {
         const first = {
             overlayId: 'overlay-1',
@@ -767,6 +867,7 @@ describe('repository modules', () => {
                 groupRevision: 2,
                 presenceRevision: 2,
             },
+            provenance: 'server',
             state: 'active',
             groupRef: {
                 applicationId: 'app-1',

--- a/packages/tests/shared/rtc-bootstrap-peer-selection.test.ts
+++ b/packages/tests/shared/rtc-bootstrap-peer-selection.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_BOOTSTRAP_DEGREE,
+    resolveBootstrapDegree,
+    selectBootstrapPeers,
+} from '@shared/rtc/bootstrap-peer-selection.ts';
+
+describe('resolveBootstrapDegree', () => {
+    it('defaults to the bootstrap degree clamped by the connection budget', () => {
+        expect(resolveBootstrapDegree({})).toBe(DEFAULT_BOOTSTRAP_DEGREE);
+        expect(resolveBootstrapDegree({ bootstrapDegree: 3 })).toBe(3);
+        expect(resolveBootstrapDegree({ maxPeerConnections: 3 })).toBe(3);
+        expect(
+            resolveBootstrapDegree({ bootstrapDegree: 8, maxPeerConnections: 6 }),
+        ).toBe(6);
+        expect(
+            resolveBootstrapDegree({ bootstrapDegree: 4, maxPeerConnections: 20 }),
+        ).toBe(4);
+    });
+
+    it('ignores non-positive and non-integer inputs', () => {
+        expect(resolveBootstrapDegree({ bootstrapDegree: 0 }))
+            .toBe(DEFAULT_BOOTSTRAP_DEGREE);
+        expect(resolveBootstrapDegree({ bootstrapDegree: -2 }))
+            .toBe(DEFAULT_BOOTSTRAP_DEGREE);
+        expect(resolveBootstrapDegree({ bootstrapDegree: 2.5 }))
+            .toBe(DEFAULT_BOOTSTRAP_DEGREE);
+        expect(resolveBootstrapDegree({ maxPeerConnections: Number.NaN }))
+            .toBe(DEFAULT_BOOTSTRAP_DEGREE);
+    });
+});
+
+describe('selectBootstrapPeers', () => {
+    const memberSessionIds = [
+        'session-a',
+        'session-b',
+        'session-c',
+        'session-d',
+        'session-e',
+        'session-f',
+    ];
+
+    it('is deterministic per (groupKey, localSessionId) and self-excluding', () => {
+        const input = {
+            localSessionId: 'session-a',
+            memberSessionIds,
+            groupKey: 'app|ws|group-1',
+            bootstrapDegree: 3,
+        };
+
+        const first = selectBootstrapPeers(input);
+        const second = selectBootstrapPeers({
+            ...input,
+            memberSessionIds: [...memberSessionIds].reverse(),
+        });
+
+        expect(first).toEqual(second);
+        expect(first).toHaveLength(3);
+        expect(first).not.toContain('session-a');
+    });
+
+    it('bounds the selection and deduplicates members', () => {
+        expect(
+            selectBootstrapPeers({
+                localSessionId: 'session-a',
+                memberSessionIds: [...memberSessionIds, ...memberSessionIds],
+                groupKey: 'group',
+                bootstrapDegree: 2,
+            }),
+        ).toHaveLength(2);
+        expect(
+            selectBootstrapPeers({
+                localSessionId: 'session-a',
+                memberSessionIds: ['session-a', 'session-b'],
+                groupKey: 'group',
+                bootstrapDegree: 5,
+            }),
+        ).toEqual(['session-b']);
+        expect(
+            selectBootstrapPeers({
+                localSessionId: 'session-a',
+                memberSessionIds,
+                groupKey: 'group',
+                bootstrapDegree: 0,
+            }),
+        ).toEqual([]);
+    });
+
+    it('varies the selection across sessions and group keys', () => {
+        const bySession = new Set(
+            memberSessionIds.map((localSessionId) =>
+                selectBootstrapPeers({
+                    localSessionId,
+                    memberSessionIds,
+                    groupKey: 'group-vary',
+                    bootstrapDegree: 2,
+                }).join(',')
+            ),
+        );
+
+        expect(bySession.size).toBeGreaterThan(1);
+    });
+
+    // Program-plan risk 3: every session keeps a small rendezvous-selected
+    // set, and the undirected union over all sessions must stay connected at
+    // the black-box tiers. Deterministic inputs make this a regression test,
+    // not a probabilistic one.
+    it.each([
+        { tier: 'small', memberCount: 6 },
+        { tier: 'medium', memberCount: 20 },
+        { tier: 'large', memberCount: 50 },
+    ])(
+        'keeps the $tier tier (N=$memberCount) union bootstrap graph connected across seeds',
+        ({ memberCount }) => {
+            for (let seed = 0; seed < 100; seed++) {
+                const sessions = Array.from(
+                    { length: memberCount },
+                    (_, index) => `seed${seed}-session-${index}`,
+                );
+                const groupKey = `app|ws|group-${seed}`;
+
+                const edges = new Map<string, Set<string>>(
+                    sessions.map((session) => [session, new Set<string>()]),
+                );
+                for (const localSessionId of sessions) {
+                    const selected = selectBootstrapPeers({
+                        localSessionId,
+                        memberSessionIds: sessions,
+                        groupKey,
+                        bootstrapDegree: DEFAULT_BOOTSTRAP_DEGREE,
+                    });
+                    for (const peerId of selected) {
+                        edges.get(localSessionId)?.add(peerId);
+                        edges.get(peerId)?.add(localSessionId);
+                    }
+                }
+
+                expect(countReachableSessions(sessions[0], edges))
+                    .toBe(memberCount);
+            }
+        },
+    );
+});
+
+function countReachableSessions(
+    start: string,
+    edges: ReadonlyMap<string, ReadonlySet<string>>,
+): number {
+    const visited = new Set<string>([start]);
+    const queue = [start];
+
+    while (queue.length > 0) {
+        const current = queue.pop();
+        if (current === undefined) {
+            break;
+        }
+        for (const neighbor of edges.get(current) ?? []) {
+            if (!visited.has(neighbor)) {
+                visited.add(neighbor);
+                queue.push(neighbor);
+            }
+        }
+    }
+
+    return visited.size;
+}

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -584,6 +584,7 @@ describe('WebRtcGroupManager', () => {
             lastDesiredPeerCount: 0,
             connectAttemptCount: 0,
             connectFailureCount: 0,
+            connectDeferredBudgetCount: 0,
             disconnectCount: 0,
             retainedEvictionCount: 0,
         });
@@ -612,6 +613,77 @@ describe('WebRtcGroupManager', () => {
 
         manager.resetDiagnostics();
         expect(manager.readDiagnostics().reconcileRunCount).toBe(0);
+    });
+
+    it('caps outbound dials at the connection budget and counts deferrals', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcQBoxHarness('self');
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service as never,
+            groupCache,
+            clientCache,
+            undefined,
+            { maxPeerConnections: 5 },
+        );
+        const peerIds = Array.from({ length: 8 }, (_, index) => `peer-${index}`);
+        for (const peerId of peerIds) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+
+        await manager.acceptGroupUpdate(
+            createGroupSnapshot('group-1', 1, ['self', ...peerIds]),
+        );
+
+        expect(rtcQBox.knownPeerIds()).toHaveLength(5);
+        expect(manager.readDiagnostics().connectDeferredBudgetCount).toBe(3);
+    });
+
+    it('dials server-overlay next hops before bootstrap peers under the budget', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const overlayCache = new LatestRepository<string, OverlayInfo>();
+        const rtcQBox = createRtcQBoxHarness('self');
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service as never,
+            groupCache,
+            clientCache,
+            overlayCache,
+            { maxPeerConnections: 5 },
+        );
+        const bootstrapPeerIds = Array.from(
+            { length: 6 },
+            (_, index) => `peer-x${index + 1}`,
+        );
+        const bootstrapGroup = createGroupSnapshot('group-boot', 1, [
+            'self',
+            ...bootstrapPeerIds,
+        ]);
+        const serverGroup = createGroupSnapshot('group-server', 1, [
+            'self',
+            'peer-s1',
+        ]);
+        for (const peerId of ['peer-s1', ...bootstrapPeerIds]) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        overlayCache.set(
+            toScopedOverlayId(serverGroup.group),
+            createOverlayInfo(serverGroup, ['peer-s1']),
+        );
+
+        await manager.acceptGroupUpdate(serverGroup);
+        await manager.acceptGroupUpdate(bootstrapGroup);
+
+        // The server-overlay hop keeps its slot; the remaining budget goes to
+        // the first bootstrap peers and the rest are deferred.
+        expect(rtcQBox.knownPeerIds()).toEqual([
+            'peer-s1',
+            'peer-x1',
+            'peer-x2',
+            'peer-x3',
+            'peer-x4',
+        ]);
+        expect(manager.readDiagnostics().connectDeferredBudgetCount).toBe(2);
     });
 
     it('counts connect failures in diagnostics', async () => {
@@ -655,16 +727,23 @@ describe('WebRtcGroupManager', () => {
             undefined,
             { maxPeerConnections: 5 },
         );
-        const peerIds = ['peer-a', 'peer-b', 'peer-c', 'peer-d', 'peer-e', 'peer-f', 'peer-g'];
-        for (const peerId of peerIds) {
+        const retainedPeerIds = ['peer-a', 'peer-b', 'peer-c', 'peer-d'];
+        const replacementPeerIds = ['peer-e', 'peer-f', 'peer-g'];
+        for (const peerId of [...retainedPeerIds, ...replacementPeerIds]) {
             clientCache.set(peerId, createClientInfo(peerId, true));
         }
 
-        const group = createGroupSnapshot('group-1', 1, ['self', ...peerIds]);
-        await manager.acceptGroupUpdate(group);
-        expect(rtcQBox.knownPeerIds()).toHaveLength(7);
+        const oldGroup = createGroupSnapshot('group-1', 1, [
+            'self',
+            ...retainedPeerIds,
+        ]);
+        await manager.acceptGroupUpdate(oldGroup);
+        expect(rtcQBox.knownPeerIds()).toHaveLength(4);
+        await manager.delete(oldGroup.group, { retainConnections: true });
 
-        await manager.delete(group.group, { retainConnections: true });
+        await manager.acceptGroupUpdate(
+            createGroupSnapshot('group-2', 1, ['self', ...replacementPeerIds]),
+        );
 
         const diagnostics = manager.readDiagnostics();
         expect(diagnostics.retainedEvictionCount).toBe(2);
@@ -852,5 +931,6 @@ function createOverlayInfo(
         degreeLimit: Math.max(1, nextHopSessionIds.length),
         overlayVersion,
         updatedAtEpochMs: overlayVersion,
+        provenance: 'server',
     };
 }

--- a/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
+++ b/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { computeOutboundDialPlan } from '@shared/services/webrtc-outbound-dial-plan.ts';
+
+describe('computeOutboundDialPlan', () => {
+    it('keeps legacy-star dialing unbounded', () => {
+        const connectablePeerIds = Array.from(
+            { length: 49 },
+            (_, index) => `peer-${index}`,
+        );
+
+        expect(
+            computeOutboundDialPlan({
+                mode: 'legacy-star',
+                maxPeerConnections: 10,
+                knownPeerIds: new Set(),
+                desiredPeerIds: new Set(connectablePeerIds),
+                connectablePeerIds,
+                serverDesiredPeerIds: new Set(),
+            }),
+        ).toEqual({ peersToConnect: connectablePeerIds, deferredPeerIds: [] });
+    });
+
+    it('caps new dials at the connection budget and defers the rest', () => {
+        const connectablePeerIds = Array.from(
+            { length: 49 },
+            (_, index) => `peer-${index}`,
+        );
+
+        const plan = computeOutboundDialPlan({
+            mode: 'bounded-bootstrap',
+            maxPeerConnections: 10,
+            knownPeerIds: new Set(),
+            desiredPeerIds: new Set(connectablePeerIds),
+            connectablePeerIds,
+            serverDesiredPeerIds: new Set(),
+        });
+
+        expect(plan.peersToConnect).toHaveLength(10);
+        expect(plan.deferredPeerIds).toHaveLength(39);
+    });
+
+    it('always ensures known desired peers and only budgets new dials', () => {
+        const plan = computeOutboundDialPlan({
+            mode: 'bounded-bootstrap',
+            maxPeerConnections: 3,
+            knownPeerIds: new Set(['peer-a', 'peer-b']),
+            desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c', 'peer-d']),
+            connectablePeerIds: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
+            serverDesiredPeerIds: new Set(),
+        });
+
+        expect(plan.peersToConnect).toEqual(['peer-a', 'peer-b', 'peer-c']);
+        expect(plan.deferredPeerIds).toEqual(['peer-d']);
+    });
+
+    it('prioritizes server-overlay-desired peers over bootstrap peers', () => {
+        const plan = computeOutboundDialPlan({
+            mode: 'bounded-bootstrap',
+            maxPeerConnections: 2,
+            knownPeerIds: new Set(),
+            desiredPeerIds: new Set(['peer-boot-1', 'peer-server-1', 'peer-boot-2', 'peer-server-2']),
+            connectablePeerIds: [
+                'peer-boot-1',
+                'peer-server-1',
+                'peer-boot-2',
+                'peer-server-2',
+            ],
+            serverDesiredPeerIds: new Set(['peer-server-1', 'peer-server-2']),
+        });
+
+        expect(plan.peersToConnect).toEqual(['peer-server-1', 'peer-server-2']);
+        expect(plan.deferredPeerIds).toEqual(['peer-boot-1', 'peer-boot-2']);
+    });
+
+    it('excludes retained non-desired connections from the dial budget', () => {
+        // Four retained (known, no longer desired) connections must not starve
+        // the dial of a newly desired peer: the retained-eviction pass owns
+        // trimming that overflow.
+        const plan = computeOutboundDialPlan({
+            mode: 'bounded-bootstrap',
+            maxPeerConnections: 5,
+            knownPeerIds: new Set(['old-a', 'old-b', 'old-c', 'old-d', 'old-e']),
+            desiredPeerIds: new Set(['peer-new']),
+            connectablePeerIds: ['peer-new'],
+            serverDesiredPeerIds: new Set(),
+        });
+
+        expect(plan.peersToConnect).toEqual(['peer-new']);
+        expect(plan.deferredPeerIds).toEqual([]);
+    });
+
+    it('defers everything when desired connections already fill the budget', () => {
+        const plan = computeOutboundDialPlan({
+            mode: 'bounded-bootstrap',
+            maxPeerConnections: 2,
+            knownPeerIds: new Set(['peer-a', 'peer-b']),
+            desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c']),
+            connectablePeerIds: ['peer-a', 'peer-b', 'peer-c'],
+            serverDesiredPeerIds: new Set(),
+        });
+
+        expect(plan.peersToConnect).toEqual(['peer-a', 'peer-b']);
+        expect(plan.deferredPeerIds).toEqual(['peer-c']);
+    });
+});

--- a/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
+++ b/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
@@ -37,9 +37,9 @@ complete.
   and `5466ccca` (run 31326547901).
 - Remote gates: **Branch Release Gate** failed on `7eca6b18`/`16561c46`
   solely on the headless bundle ratchet (194.61 > 194), fixed in
-  `5466ccca`; the run on `5466ccca` is recorded in the PR record when it
-  completes. **Run Hetzner Supported Distributed Manifests** pends the
-  resulting default-branch commit after merge.
+  `5466ccca`; run 31326545612 **succeeded on `5466ccca`**. **Run Hetzner
+  Supported Distributed Manifests** pends the resulting default-branch
+  commit after merge; the plan is not complete until it is green there.
 
 ## Context
 

--- a/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
+++ b/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
@@ -1,0 +1,370 @@
+# Rallar Group Formation Phase 1: Overlay Precedence And Bounded Bootstrap
+
+Status: in progress. Branch `codex/group-formation-phase1-overlay-precedence`,
+based on `main` at `76e5a1b3`. This document is the initial review checkpoint
+for the phase; implementation proceeds on the same branch and draft PR.
+
+## Context
+
+Phase 0 (merged as `be6acbfe`, PR #113) made the formation storm observable:
+storm counters on the server (`group-formation` admin metrics family), browser
+diagnostics (`rallar.rtc.diagnostics().groupManager` / `.overlayAdoption`),
+formation-burst black-box recipes at the 6/20/50 tiers, and the committed
+baseline `playground/rtc-design/baselines/2026-08-08-formation-burst-baseline.md`.
+
+Phase 1 of
+`playground/rtc-design/2026-08-08-group-formation-implementation-plan.md`
+(mechanisms M5 + M10, root cause 1 / scenario S5) makes the server's topology
+actually take effect and stops browser full-mesh dialing. The defect chain
+today, all browser-side:
+
+1. Every group snapshot update unconditionally restamps a local full-membership
+   star overlay (`packages/shared-web/browser/data-caches.ts:409` →
+   `createAndSetStarOverlays`, builder at
+   `packages/shared/repository/overlays-repository.ts:359`) carrying the
+   group's **latest** causal revision and `overlayVersion = group version`.
+2. Overlay admission (`overlays-repository.ts:276` `setOverlayById`) orders
+   overlays by the `(sourceGroupStateCausalRevision, overlayVersion)` tuple
+   only. A server overlay planned against an older group revision is
+   `dominated` (dropped) or `incomparable` (conflict) against the freshly
+   restamped star — server topologies effectively never govern browsers.
+3. The star's `nextHopSessionIds` is **all members**, so
+   `WebRtcGroupManager.reconcileAllGroups` (connect loop at
+   `packages/shared/services/WebRtcGroupManager.ts:277-292`) dials N−1 peers
+   with no outbound cap, while inbound admission is capped at
+   `maxPeerConnections` (10) — the 49-out/10-in asymmetry.
+4. The star's `degreeLimit` is N−1, and
+   `WebRtcGroupManager.overlayRttReportingDegreeLimit()` treats the overlay
+   `degreeLimit` as the RTT-reporting fallback degree, so RTT reporting also
+   scales with N instead of ~5.
+
+Phase 1 is browser-side only: `packages/shared` (contracts, repository,
+services, rtc policy) and `packages/shared-web/browser`. No server behavior,
+route, or schema changes. Verified: `OverlayInfo` has no usage under
+`packages/shared-server` or `apps/**`; the wire contract
+(`RallarOverlayTopologySnapshot`, `packages/shared/api/overlay-topology.ts`)
+is unchanged.
+
+## Decisions for review (owner may override at this checkpoint)
+
+1. **Provenance admission is always-on; the rollback flag governs the
+   environment-dependent behaviors** (conditional star, bounded bootstrap
+   selection, outbound dial budget). Rationale: the admission rule
+   ("server supersedes bootstrap; bootstrap never overwrites server") is a
+   pure, deterministic correctness fix for S5 with exhaustive unit coverage —
+   reverting it means reverting the phase (git revert). The plausible
+   production rollback need is different: bounded bootstrap graphs or the dial
+   budget misbehaving in some environment. `legacy-star` mode therefore
+   restores the unconditional full-membership star (shape, N−1 degree,
+   unconditional restamp attempts) and unbounded dialing — the aggressive
+   legacy connectivity — while server topology, once published, still governs.
+   A restamped bootstrap star cannot displace an adopted server overlay even
+   in legacy mode; that displacement is the root-cause bug, not a behavior to
+   preserve.
+2. **Flag surface**: `groupFormationMode: 'bounded-bootstrap' | 'legacy-star'`
+   (default `'bounded-bootstrap'`) plus `bootstrapDegree?: number`, exposed
+   exactly like `maxPeerConnections` today: `RallarOperationOptions`
+   (`packages/shared-web/browser/rallar-operation-options.ts:16`),
+   `RallarBrowserRuntimeDefaults.rtc`
+   (`packages/shared-web/browser/rallar-runtime-context.ts:35-41`), resolved
+   in the runtime context and threaded through the middleware composition
+   root into `data-caches` and `WebRtcGroupManager`.
+3. **Default bootstrap degree** = `min(5, maxPeerConnections)` — 5 matches
+   `DEFAULT_RTT_REPORTING_DEGREE_LIMIT`
+   (`packages/shared/rtc/rtt-reporting-policy.ts:1`), the "server/bootstrap
+   degree (≤5-ish)" target in the program plan; the `min` keeps the bootstrap
+   set inside the connection budget when an app configures a smaller budget.
+4. **Tier evidence mapping.** The formation-burst recipes drive raw WS
+   sockets (baseline "Reading rules"), so browser adoption/dial counters
+   cannot come from those processes. Phase 1 supplies the required
+   "overlay adoption ≈ 100% and bounded outbound dials at N=6/20/50"
+   evidence from the components that actually run that logic, at exactly
+   those tiers:
+   - a new deterministic in-process formation-burst simulation test that
+     instantiates N real browser stacks (overlays/group/client repositories +
+     `WebRtcGroupManager` over a fake `WebRtcConnectionService`) at N=6/20/50,
+     bursts joins, publishes server overlays, and asserts adoption 100% and
+     dials ≤ budget per client — using the same Phase 0 diagnostics counters;
+   - the live three-browser matrix with
+     `RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR` capture, asserting the same
+     from real browsers via `rallar.rtc.diagnostics()`;
+   - the unchanged formation-burst recipes at 6/20/50 rerun against the
+     Phase 1 tree to prove the server-side storm quantities and the
+     per-client `overlay.topology` delivery assertions are not regressed
+     (Phase 1 must not change server behavior; deltas vs the baseline are
+     recorded).
+5. **Connect-first ordering stays.** The reconcile loop keeps its current
+   connect → disconnect → evict order; budget freed by disconnects becomes
+   available on the next reconcile (reconciles fire on every presence/overlay
+   change). Make-before-break and grace windows are Phase 4 (M11); reordering
+   teardown before dialing is out of scope here.
+6. **Measured-results document**: tier reruns, simulation numbers, and
+   live-rtc-3 diagnostics land in
+   `playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md`
+   beside the Phase 0 baseline, with a README row, following the same
+   raw-artifacts-not-committed policy.
+
+## Roadmap coordination
+
+The active RTC B01–B05 reservation (roadmap Section 10) reserves
+`scripts/perf/rtc-baseline/**`, the listed `scripts/perf/*` harnesses, the
+`packages/tests/repo/rtc-performance-baseline-*.test.ts` files, the baseline
+plan document, and `tmp/perf/rtc-baseline/**`. **This plan writes none of
+those paths.** Declared overlap of subject, not files: Phase 1 changes the
+behavior of `WebRtcGroupManager` and overlay admission, which are on the
+baseline program's measured workload — dial counts and RTT-reporting degree
+change by design. The human program owner sequences B01–B05 captures against
+this phase so before/after RTC baselines are not mixed within one accepted
+envelope.
+
+## Scope
+
+In scope:
+
+1. Overlay **provenance** (`'server' | 'bootstrap'`) on `OverlayInfo` and
+   provenance-aware admission in `setOverlayById`: server supersedes
+   bootstrap; bootstrap never overwrites server; same-provenance ordering
+   keeps the existing monotonic tuple. New adoption-diagnostics outcomes and
+   counters for both new branches.
+2. **Conditional local star**: the bootstrap overlay is created only when no
+   server overlay exists for the group; bootstrap-over-bootstrap restamps
+   (membership changes) still advance while no server overlay exists.
+3. **Bounded rendezvous-hash bootstrap selection**: `nextHopSessionIds` =
+   deterministic ≤ `bootstrapDegree` peers per (groupKey, sessionId), reusing
+   the FNV-1a rendezvous scoring already in `rtt-reporting-policy.ts`;
+   `degreeLimit` = effective bootstrap degree (so RTT reporting inherits ≤5).
+4. **Outbound dial budget** in the `WebRtcGroupManager` reconcile connect
+   loop: new dials capped at `maxPeerConnections − knownPeerIds.size`;
+   priority order server-overlay next hops, then bootstrap peers; deferred
+   dials counted in diagnostics.
+5. The `groupFormationMode` rollback flag and `bootstrapDegree` config,
+   threaded through the existing options/defaults surfaces.
+6. Unit tests, the N=6/20/50 in-process simulation test, public-surface
+   snapshot updates, tier recipe reruns, live-rtc-3 diagnostics capture, and
+   the committed results document.
+
+Out of scope (explicitly): all server-side damping (Phase 2 — coalescer,
+change gate, heartbeat separation, audience fix); delta dissemination and
+overlay read-through on connect (Phase 3 — `hydrateStateCaches` still does
+not pull `GET .../topology`; adoption of the first server overlay still rides
+its WS publication); incremental replans, hysteresis, retention grace windows
+(Phase 4); formation epochs (Phase 5). No changes to
+`packages/shared-server`, `apps/api-v1`, recipes, or the black-box runner.
+
+## Design
+
+### 1. Provenance and admission (`packages/shared`)
+
+- `OverlayInfo` (`packages/shared/api/api-config.ts:120`) gains required
+  `provenance: 'server' | 'bootstrap'` (house rule: required fields by
+  default; every constructor is in this change set). Type
+  `OverlayProvenance` lives beside `OverlayInfo`.
+- `toOverlayInfoForSession` (`packages/shared/api/overlay-topology.ts:41`)
+  stamps `'server'` — it is the single decoder for server
+  `overlay.topology` publications (`data-caches.ts:186-202`). The wire
+  snapshot itself is unchanged.
+- The bootstrap builder stamps `'bootstrap'`.
+- `updateNextHopSessionIds` (`overlays-repository.ts:203`, the `graphs`
+  topic path) preserves the current overlay's provenance.
+- `setOverlayById` (`overlays-repository.ts:276`) admission becomes, in
+  order: no current → initial-set (unchanged); incoming `server` over
+  current `bootstrap` → **adopt always** (new outcome
+  `server-superseded-bootstrap`); incoming `bootstrap` over current
+  `server` → **drop always** (new outcome `bootstrap-dropped-over-server`);
+  same provenance → existing tuple comparison and conflict semantics
+  unchanged. `OverlayAdoptionOutcome` union and the adoption counters gain
+  the two new members (`serverSupersededBootstrapCount`,
+  `bootstrapDroppedOverServerCount`); Phase 0 counter fields keep their
+  meaning for same-provenance flows.
+- Admission logic stays a pure decision over the two records; if the
+  file's style budget demands, the comparison moves to a sibling
+  `overlay-admission.ts` with `overlays-repository.ts` keeping the
+  repository shell.
+
+### 2. Bootstrap selection (`packages/shared/rtc`)
+
+- New `packages/shared/rtc/rendezvous-hash.ts`: the FNV-1a scoring extracted
+  verbatim from `rtt-reporting-policy.ts:65-80`; `rtt-reporting-policy.ts`
+  re-imports it (zero behavior change,
+  `packages/tests/shared/rtc-rtt-reporting-policy.test.ts` must stay green
+  unmodified).
+- New `packages/shared/rtc/bootstrap-peer-selection.ts`:
+  `selectBootstrapPeers({ localSessionId, memberSessionIds, groupKey,
+  bootstrapDegree })` → deterministic, self-excluded, ≤ degree, ordered by
+  rendezvous score. Also `resolveBootstrapDegree({ bootstrapDegree?,
+  maxPeerConnections? })` → `min(bootstrapDegree ?? 5, maxPeerConnections ??
+  10)`, guarded to positive integers.
+- Bootstrap graphs are k-out digraphs with pseudo-random asymmetric edges;
+  undirected-union connectivity at k=5 is validated by unit test across
+  N=6/20/50 and many deterministic seed sets (risk 3 of the program plan).
+  WS relay remains the correctness baseline regardless — a disconnected
+  bootstrap component degrades to relay, never to silence.
+
+### 3. Conditional bounded star (`packages/shared` repository +
+`packages/shared-web/browser`)
+
+- `overlays-repository.ts`: new
+  `createAndSetBootstrapOverlays(groups, policy, manager?)` where `policy`
+  carries `{ localSessionId, mode, bootstrapDegree, maxPeerConnections }`.
+  In `bounded-bootstrap` mode it builds the bounded overlay
+  (`nextHopSessionIds` from `selectBootstrapPeers`, `degreeLimit` =
+  effective bootstrap degree) and **skips creation entirely when a
+  server-provenance overlay already exists** for the group (checked via the
+  repository; admission also enforces it — defense in depth). In
+  `legacy-star` mode it delegates to the unchanged full-membership builder.
+  The existing `createAndSetStarOverlays` export keeps its exact legacy
+  semantics (now stamping `provenance: 'bootstrap'`).
+- `data-caches.ts:409` (`handleGroupSnapshotUpdate`) calls the new function
+  with the policy from the observer context; `StateCacheScopeOptions` gains
+  the policy input, provided by the middleware composition root
+  (`packages/shared-web/browser/middleware.ts:296-316`) so construction
+  stays visible. The policy decision (mode, degree) is made once at the
+  composition root, not inside the handler.
+
+### 4. Outbound dial budget (`packages/shared/services`)
+
+- `WebRtcGroupManagerOptions` gains `groupFormationMode?`. In
+  `bounded-bootstrap` mode `reconcileAllGroups` splits connectable desired
+  peers into already-known (always ensured — an ensure on a known peer is
+  not a new dial) and new dials; new dials are ordered server-overlay-desired
+  first (provenance read from the group's overlay via
+  `readOverlayForGroup`), then bootstrap-desired, deterministic within each
+  class, and capped at `max(0, maxPeerConnections − knownPeerIds.size)` —
+  the same budget inbound admission uses
+  (`WebRtcConnectionService.canAcceptAdditionalPeer`,
+  `packages/shared/services/WebRtcConnectionService.ts:570-590`). Deferred
+  dials increment a new `connectDeferredBudgetCount` diagnostics field.
+  `legacy-star` mode keeps today's unbounded loop.
+- The dial-plan computation is a pure function in a new sibling module
+  (`webrtc-outbound-dial-plan.ts`, verb `computeOutboundDialPlan`) so
+  `WebRtcGroupManager.ts` (608 lines) barely grows and the decision is
+  testable in isolation.
+- RTT-reporting degree needs no code change: with the bounded star,
+  `overlayRttReportingDegreeLimit()` now sees `degreeLimit ≤ 5` instead of
+  N−1, which is the plan's intended inheritance.
+
+### 5. Flag threading (`packages/shared-web/browser`)
+
+`RallarOperationOptions` (+ normalization), `RallarBrowserRuntimeDefaults.rtc`,
+the runtime-context resolution (`rallar-runtime-context.ts:214-227` pattern),
+middleware options, and the two consumers (data-caches policy,
+`WebRtcGroupManager` options). Additive public-surface change → deliberate
+snapshot updates in `shared-web-public-api-snapshots.test.ts`; bundle
+boundary checks must stay green.
+
+## Tasks
+
+### Task 1 — Shared primitives: provenance, admission, selection
+
+`OverlayProvenance` on `OverlayInfo`; stamped builders/decoder;
+provenance-aware `setOverlayById` with the two new outcomes/counters;
+`rendezvous-hash.ts` extraction; `bootstrap-peer-selection.ts`.
+Tests: admission decision table (every provenance × tuple combination,
+including conflict-path preservation), selection determinism/bounds/
+self-exclusion, union-graph connectivity at 6/20/50, RTT policy suite
+untouched and green.
+
+### Task 2 — Conditional bounded star and flag threading
+
+`createAndSetBootstrapOverlays` + policy; `data-caches.ts` switch;
+options/defaults/runtime-context/middleware threading; snapshots.
+Tests: `data-caches.test.ts` — bounded shape, conditional creation (no
+bootstrap write when server overlay present), restamp-over-server dropped,
+legacy mode bit-identical star behavior; snapshot updates.
+
+### Task 3 — Outbound dial budget
+
+`computeOutboundDialPlan` + reconcile integration + diagnostics field +
+options. Tests: budget cap, server-first priority, deferred counting,
+already-known ensures not budget-counted, legacy mode unbounded,
+`webrtc-group-manager.test.ts` extensions.
+
+### Task 4 — Tier simulation test
+
+`packages/tests/shared-web/group-formation-burst-simulation.test.ts` (exact
+home may shift to `packages/tests/shared/` if no shared-web import is
+needed): N=6/20/50, per-client isolated repositories via `RepositoryManager`
+(`packages/tests/cache-repository-config.ts` pattern), fake rtcQBox, burst
+join → assert bootstrap dials ≤ budget and bootstrap next-hops ≤ degree →
+publish server overlay per client → assert adoption 100%
+(`initialSetCount + serverSupersededBootstrapCount` accounts for every
+client, `incomparableConflictCount == 0`, every manager's effective overlay
+is server-provenance) and total connect attempts bounded.
+
+### Task 5 — Tier reruns, live diagnostics, results document
+
+Recipes unchanged: memory (small+medium), postgres (small+medium),
+postgres formation-large; deltas vs the Phase 0 baseline recorded.
+live-rtc-3 (memory mode) with diagnostics capture; verify
+`groupManager.connectAttemptCount` bounded and `overlayAdoption` shows
+server adoption without conflicts. Commit the results document + README row.
+
+## Validation
+
+Focused first:
+
+```sh
+npx tsc -p packages/shared/tsconfig.json --noEmit
+npx tsc -p packages/shared-web/tsconfig.json --noEmit
+cd apps/api-v1 && deno task check   # packages/shared is on its compile path
+npx vitest run packages/tests/shared/rtc-rtt-reporting-policy.test.ts packages/tests/shared/webrtc-group-manager.test.ts packages/tests/shared/webrtc-overlay-services.test.ts
+npx vitest run packages/tests/shared-web/data-caches.test.ts packages/tests/shared-web/shared-web-public-api-snapshots.test.ts packages/tests/shared-web/shared-web-browser-bundle-boundaries.test.ts
+npm --workspace @ar-eye-hunter/shared-web run check:browser-bundles
+```
+
+plus the new selection, admission, dial-plan, and simulation test files.
+
+Tier evidence (Decision 4 mapping):
+
+```sh
+npx vitest run packages/tests/shared-web/group-formation-burst-simulation.test.ts
+npm run test:api-v1:black-box:memory
+npm run test:api-v1:black-box:postgres
+npm run test:api-v1:black-box:postgres:formation-large
+RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR=tmp/perf/results npm run test:rallar:full-stack:memory:live-rtc-3
+```
+
+Gates that do **not** apply, with evidence to be recorded at completion: the
+api-v1 medium-scale convergence gate and the state-write perf comparison
+bind to api-v1 mutation-path/server changes; this phase's diff must contain
+no `packages/shared-server` or `apps/**` production changes (verified by
+`git diff --stat` at completion; if that ever stops being true, both gates
+become required). Postgres-backed runs follow the DB-freshness procedure
+(fresh migrate before capture; issues #119/#136).
+
+Repo style: `npm run check:repo-style:changed -- origin/main HEAD`.
+
+Completion gates (plan completion policy): from the final working tree
+`npm run test:unit`, `npm run test:ci`, `npm run build`; draft PR record
+current; **Branch Release Gate** green on the final feature-branch commit;
+**Run Hetzner Supported Distributed Manifests** green on the resulting
+default-branch commit; exact SHAs recorded here. Any change after a passing
+gate invalidates it.
+
+## Sequencing
+
+One feature branch, commits in task order (1 shared primitives → 2 star +
+threading → 3 dial budget → 4 simulation → 5 reruns + results doc), one
+draft PR for the plan-to-implementation lifecycle, kept current per
+checkpoint. Default-branch base recorded: `76e5a1b3`; plan revalidation runs
+before each published milestone.
+
+## Risks
+
+1. **Bootstrap connectivity at small degree** (program-plan risk 3):
+   validated by the connectivity unit test across tiers and seeds; WS relay
+   remains the correctness floor; `legacy-star` is the operational rollback.
+2. **Dial-budget starvation under churn**: deferred dials are retried on
+   every reconcile (presence/overlay driven); the deferred counter makes
+   starvation observable in diagnostics and live-rtc capture; rollback flag.
+3. **Public-surface churn**: additive fields on `OverlayInfo`,
+   `RallarOperationOptions`, defaults, and diagnostics; deliberate snapshot
+   updates; no removals.
+4. **Existing-file style budgets** (`WebRtcGroupManager.ts` 608 lines,
+   `data-caches.ts` 478, `overlays-repository.ts` 374): new logic lands in
+   new small pure modules; edits to existing files stay near call sites;
+   `check:repo-style:changed` is the arbiter, style-lineage declarations
+   only if unavoidable.
+5. **Interaction with PR #83** (activation design): M11-adjacent retention
+   behavior is untouched; this phase only implements M5/M10 as the program
+   plan's merge-point rules require.

--- a/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
+++ b/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
@@ -134,7 +134,8 @@ In scope:
    the FNV-1a rendezvous scoring already in `rtt-reporting-policy.ts`;
    `degreeLimit` = effective bootstrap degree (so RTT reporting inherits ≤5).
 4. **Outbound dial budget** in the `WebRtcGroupManager` reconcile connect
-   loop: new dials capped at `maxPeerConnections − knownPeerIds.size`;
+   loop: new dials capped at `maxPeerConnections − |known ∩ desired|`
+   (see the Design amendment on retained connections);
    priority order server-overlay next hops, then bootstrap peers; deferred
    dials counted in diagnostics.
 5. The `groupFormationMode` rollback flag and `bootstrapDegree` config,
@@ -229,10 +230,17 @@ its WS publication); incremental replans, hysteresis, retention grace windows
   not a new dial) and new dials; new dials are ordered server-overlay-desired
   first (provenance read from the group's overlay via
   `readOverlayForGroup`), then bootstrap-desired, deterministic within each
-  class, and capped at `max(0, maxPeerConnections − knownPeerIds.size)` —
+  class, and capped at `max(0, maxPeerConnections − |known ∩ desired|)` —
   the same budget inbound admission uses
   (`WebRtcConnectionService.canAcceptAdditionalPeer`,
-  `packages/shared/services/WebRtcConnectionService.ts:570-590`). Deferred
+  `packages/shared/services/WebRtcConnectionService.ts:570-590`).
+  **Amendment (implementation finding):** only *desired* known connections
+  count against the dial budget. Retained (grace) connections are governed
+  by the existing retained-eviction pass, which trims the overflow within
+  the same reconcile; counting them in the dial budget would let a full
+  retained set permanently starve required dials, because retained
+  eviction only fires when the retained count exceeds the leftover budget,
+  which a deferred dial never raises. Deferred
   dials increment a new `connectDeferredBudgetCount` diagnostics field.
   `legacy-star` mode keeps today's unbounded loop.
 - The dial-plan computation is a pure function in a new sibling module

--- a/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
+++ b/plans/rallar-group-formation-phase1-overlay-precedence-plan.md
@@ -1,8 +1,45 @@
 # Rallar Group Formation Phase 1: Overlay Precedence And Bounded Bootstrap
 
-Status: in progress. Branch `codex/group-formation-phase1-overlay-precedence`,
-based on `main` at `76e5a1b3`. This document is the initial review checkpoint
-for the phase; implementation proceeds on the same branch and draft PR.
+Status: implementation and local validation complete on
+`codex/group-formation-phase1-overlay-precedence` (PR #138), based on `main`
+at `76e5a1b3`; awaiting **Branch Release Gate** confirmation on the final
+build-affecting commit, human review/merge, and the post-merge **Run Hetzner
+Supported Distributed Manifests** gate before the plan can be marked
+complete.
+
+## Progress notes (2026-08-09)
+
+- Commits: plan checkpoint `2755122b`; implementation `7eca6b18` (provenance
+  admission, conditional bounded star, dial budget, flag threading, style
+  splits); tier simulation `16561c46`; measured results
+  `aebe9393`; headless bundle ratchet `5466ccca` (final build-affecting
+  commit — the Phase 1 modules add ~0.7 KiB brotli, budget 194 → 196 with
+  boundary assertions unchanged).
+- Local completion gates from the final tree at `5466ccca`:
+  `npm run test:unit` (717 files, 6,562 passed), `npm run test:ci` (exit 0;
+  unit + Deno + Playwright e2e 38 + 211 + full-stack 7), `npm run build`
+  (exit 0). `npm run check:repo-style:changed -- origin/main HEAD` passed
+  with zero findings; `check:browser-bundles` passed;
+  `apps/api-v1 deno task check` passed.
+- Tier evidence (Decision 4 mapping): simulation asserts 100%
+  server-overlay adoption, zero conflicts, dials ≤ budget at N=6/20/50 and
+  the 49-dial legacy contrast; live-rtc-3 (memory) passed with captured
+  diagnostics (zero admission conflicts, dials ≤ desired, deferrals 0);
+  recipes rerun green — memory 13/13, postgres 13/13 + 5/5 cluster,
+  formation-large 1/1 (1,324 steps, 0 failures) — with baseline-matching
+  server-side signatures. Committed record:
+  `playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md`.
+- Gates that do not bind (evidence): `git diff origin/main...HEAD` contains
+  no `packages/shared-server` or `apps/**` changes, so the api-v1
+  medium-scale convergence and state-write perf gates are not required by
+  the mutation-path rule; the PR-triggered **API v1 Medium-Scale Gate**
+  nevertheless ran and succeeded on `7eca6b18`, `16561c46`, `aebe9393`,
+  and `5466ccca` (run 31326547901).
+- Remote gates: **Branch Release Gate** failed on `7eca6b18`/`16561c46`
+  solely on the headless bundle ratchet (194.61 > 194), fixed in
+  `5466ccca`; the run on `5466ccca` is recorded in the PR record when it
+  completes. **Run Hetzner Supported Distributed Manifests** pends the
+  resulting default-branch commit after merge.
 
 ## Context
 

--- a/playground/rtc-design/README.md
+++ b/playground/rtc-design/README.md
@@ -12,6 +12,7 @@ implementation plan.
 | [2026-08-08-group-lifecycle-and-policy-model.md](2026-08-08-group-lifecycle-and-policy-model.md)       | Control plane: explicit formation lifecycle (FORMING/ESTABLISHING/ACTIVE), manager roles, and declarative policies (admission, activation criterion, data gating) as presets over the mechanisms — plus the policy-driven test scenario matrix.                                                                                    |
 | [2026-08-08-rallar-system-planes-catalog.md](2026-08-08-rallar-system-planes-catalog.md)               | Beyond formation: the system planes a distributed group communication system needs (P1–P14 — time, room log, repair, failure detection, flow control, agreement-lite, interest management, trust, evolution, governance, operational truth, and more), each with mechanisms, Rallar seeds, scenario families, and a priority view. |
 | [baselines/2026-08-08-formation-burst-baseline.md](baselines/2026-08-08-formation-burst-baseline.md)   | Phase 0 measured baseline: the storm quantities recorded by the `group-formation` admin metrics family and the 6/20/50 formation-burst black-box tiers on memory and Postgres backends — the "before" numbers for Phases 1+.                                                                                                       |
+| [baselines/2026-08-09-phase1-overlay-precedence-results.md](baselines/2026-08-09-phase1-overlay-precedence-results.md) | Phase 1 measured results: server-overlay adoption and bounded outbound dials at the 6/20/50 tiers (in-process simulation + live three-browser diagnostics), plus the recipe reruns showing server-side storm quantities unchanged vs the Phase 0 baseline.                                                                        |
 
 Relationship to other documents:
 
@@ -24,4 +25,6 @@ Relationship to other documents:
   architecture authority for causal revisions, durable publications, and
   multi-server fanout.
 
-Status: analysis and planning documents; no implementation started.
+Status: Phase 0 (storm metrics + baseline) is merged; Phase 1 (overlay
+precedence + bounded bootstrap) is in progress on PR #138. Later phases
+remain planning documents.

--- a/playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md
+++ b/playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md
@@ -1,0 +1,143 @@
+# Phase 1 Overlay-Precedence Results (measured 2026-08-09)
+
+Status: measured on the Phase 1 tree (overlay provenance admission, bounded
+bootstrap star, outbound dial budget — all browser-side).
+
+Phase 1 "after" evidence beside
+[the Phase 0 formation-burst baseline](2026-08-08-formation-burst-baseline.md),
+for Phase 1 of
+[the group formation implementation plan](../2026-08-08-group-formation-implementation-plan.md).
+Phase 1 changes no server behavior, so the recipe reruns are a
+**non-regression** check (server-side storm quantities should match the
+baseline within noise); the Phase 1 effect itself — server-overlay adoption
+and bounded outbound dials — lives in browser-side logic that the raw-WS
+recipes cannot execute, and is measured here by the in-process tier
+simulation and the live three-browser diagnostics capture.
+
+Reading rules are the baseline's: process-local metrics, per-server capture,
+T0/T1/T2 windows, liveness-only assertions.
+
+## Run provenance
+
+- Branch `codex/group-formation-phase1-overlay-precedence` (PR #138),
+  measured on the tree at commit `16561c46` (plan `2755122b`,
+  implementation `7eca6b18`, simulation `16561c46`).
+- Machine: macOS 26.6 (Darwin 25.6.0), Apple Silicon (arm64); Node v26.7.0;
+  Deno 2.9.4; Postgres via Docker (`ar-eye-hunter-postgres`); queue tables
+  (`resource_inbox`, `resource_inbox_results`) truncated before the Postgres
+  runs, matching the baseline methodology.
+- Commands:
+  - `npm run test:api-v1:black-box:memory`
+  - `npm run test:api-v1:black-box:postgres`
+  - `npm run test:api-v1:black-box:postgres:formation-large`
+  - `npx vitest run packages/tests/shared/group-formation-burst-simulation.test.ts`
+  - `RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR=tmp/perf/results npm run test:rallar:full-stack:memory:live-rtc-3`
+- Raw artifacts are not committed (`scripts/perf/README.md` artifact policy).
+
+## Browser-side tier evidence (the Phase 1 effect)
+
+In-process formation-burst simulation
+(`packages/tests/shared/group-formation-burst-simulation.test.ts`) at
+N=6/20/50: per client an isolated overlay repository + `WebRtcGroupManager`
+(budget 10, bootstrap degree 5) bursts one group, bootstraps, then receives
+a server overlay planned against an **older** group revision than the
+bootstrap star carries — the S5 condition that pre-Phase-1 admission
+dropped.
+
+| Tier | Server-overlay adoption | Incomparable conflicts | Legacy restamp displacing server | Unique outbound dials per client |
+| --- | --- | --- | --- | --- |
+| N=6 | 6/6 (100%) | 0 | 0/6 | ≤ 10 (budget) |
+| N=20 | 20/20 (100%) | 0 | 0/20 | ≤ 10 (budget) |
+| N=50 | 50/50 (100%) | 0 | 0/50 | ≤ 10 (budget) |
+| N=50 `legacy-star` | — | — | — | 49 (full mesh, rollback mode) |
+
+Deterministic rendezvous bootstrap connectivity: union bootstrap graph
+connected at every tier across 100 seeded member sets per tier at degree 5
+(`packages/tests/shared/rtc-bootstrap-peer-selection.test.ts`).
+
+Live three-browser matrix (`live-rtc-3`, memory backend) with
+`RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR` capture — real browsers through
+the full stack (spec passed in 33.5 s; direct/multicast/broadcast/NACK
+proven with real data over the established RTC edges). Per browser across
+both captured scenarios (`rallar.rtc.diagnostics()`):
+
+- `overlayAdoption`: `initialSetCount: 1` and `adoptedCount: 0–2` on every
+  browser; `incomparableConflictCount: 0`,
+  `bootstrapDroppedOverServerCount: 0`, `dominatedDroppedCount: 0` — the
+  governing overlay converged to the server lineage on every browser with
+  zero admission conflicts (the baseline's S5 mode was dominated/
+  incomparable drops of server overlays).
+- `groupManager`: `lastDesiredPeerCount: 2` (N=3),
+  `connectAttemptCount: 0–2` (≤ desired), `connectFailureCount: 0`,
+  `connectDeferredBudgetCount: 0` — dials bounded well inside the budget.
+
+## Server-side non-regression: tier × backend reruns vs baseline
+
+Legend as in the baseline (mutations / expansions / recomputes T-E-P /
+WS sends / deliveries).
+
+### Burst window (T1−T0)
+
+Baseline values in parentheses where they differ.
+
+| Tier × backend | Server | Burst wall clock | Mutations | Expansions | Recomputes T/E/P | WS sends | Deliveries |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| small × memory | primary | 2.2 s (4.6 s) | 12 | 12 | 12 / 12 / 12 | 33 (36) | 108 (113) |
+| medium × memory | primary | 3.9 s (4.8 s) | 40 | 40 | 40 / 40 / 40 | 117 | 1,210 (1,229) |
+| small × postgres | primary | 1.9 s | 12 | 12 | 12 / 12 / 12 | 36 | 164 (165) |
+| small × postgres | secondary | — | 0 | 0 | 0 / 0 / 0 | 0 | 0 |
+| medium × postgres | primary | 2.4 s | 34 (31) | 31 (23) | 31 / 33 / 33 (23/26/21) | 120 (117) | 1,659 (1,485) |
+| medium × postgres | secondary | — | 6 (9) | 6 (17) | 6 / 5 / 5 (17/29/19) | 0 | 0 |
+| large × postgres | primary | 4.2 s (6.6 s) | 53 (38) | 44 (41) | 44 / 68 / 54 (41/44/36) | 299 (306) | 8,947 (8,467) |
+| large × postgres | secondary | — | 47 (26) | 56 (22) | 56 / 61 / 46 (22/42/33) | 0 | 0 |
+
+### Steady-state window (T2−T1, ~60 s ≈ per minute)
+
+| Tier × backend | Server | Mutations | Expansions | Recomputes T/E/P | WS sends | Deliveries |
+| --- | --- | --- | --- | --- | --- | --- |
+| small × memory | primary | 12 | 12 | 12 / 12 / 12 | 48 | 288 |
+| medium × memory | primary | 40 | 40 | 40 / 40 / 40 | 160 | 3,200 |
+| small × postgres | primary | 12 | 12 | 12 / 12 / 12 | 48 | 288 |
+| medium × postgres | primary | 40 | 40 | 40 / 40 / 40 | 160 | 3,200 |
+| large × postgres | primary | 100 (57) | 93 (56) | 93 / 89 / 79 (56/62/34) | 400 | 20,000 |
+| large × postgres | secondary | 0 (28) | 3 (23) | 3 / 23 / 12 (23/62/40) | 0 | 0 |
+
+### Queue depth (rows in `resource_inbox` at capture instants)
+
+| Tier × backend | T0 | T1 | T2 |
+| --- | --- | --- | --- |
+| small × memory | 138 | 282 | 367 |
+| medium × memory | 401 | 882 | 1,163 |
+| small × postgres | 140 | 284 | 371 |
+| medium × postgres | 405 | 885 | 1,168 |
+| large × postgres | 2,109 | 3,309 | 4,012 |
+
+The large-tier absolute queue totals start higher than the baseline's
+(2,109 vs 13 at T0) because this run reused the suite session after the
+standard profile instead of a fresh truncation; the **window deltas match
+the baseline exactly**: T1−T0 = +1,200 and T2−T1 = +703 on both trees.
+
+## Observations
+
+- **Root cause 1 (S5) closed at the admission layer.** The simulation
+  reproduces the exact failure geometry — a server overlay carrying an older
+  causal tuple than the freshly restamped bootstrap star — and every client
+  at every tier adopts it (`serverSupersededBootstrapCount == N`,
+  conflicts 0). The reverse direction (`bootstrapDroppedOverServerCount ==
+  N` under a forced legacy restamp) proves a bootstrap star can no longer
+  displace a server topology.
+- **Root cause 4 (S4 dial storm) bounded.** Unique outbound dials per client
+  stay within the 10-connection budget at N=50 (bootstrap degree 5 + server
+  next hops), against 49 in `legacy-star` mode — the 49-out/10-in asymmetry
+  is gone. The bounded star also carries `degreeLimit ≤ 5`, so RTT-reporting
+  degree now inherits ~5 instead of N−1.
+- **Server side untouched, as designed.** Every tier × backend rerun shows
+  the same structural signature as the baseline: recomputes ≈ expansions ≈
+  triggered with `publishSkippedUnchanged == 0`, the ~2N-per-minute idle
+  heartbeat storm (S7: 20,000 deliveries/min at N=50), and identical
+  queue-window deltas (+1,200 burst, +703 steady at the large tier).
+  Per-server splits differ run-to-run under the three-server cluster
+  (expected; the baseline's reading rules call this out). Those storms are
+  Phase 2's targets.
+- All 13 memory recipes, 13 postgres standard + 5 cluster recipes, and the
+  formation-large recipe passed with zero step failures on the Phase 1 tree.


### PR DESCRIPTION
## Plan

Executes **Phase 1 — Overlay precedence + bootstrap set** (M5 + M10, root cause 1/S5) of
[the group-formation implementation plan](playground/rtc-design/2026-08-08-group-formation-implementation-plan.md).
Written plan: [plans/rallar-group-formation-phase1-overlay-precedence-plan.md](plans/rallar-group-formation-phase1-overlay-precedence-plan.md).
Baseline: [playground/rtc-design/baselines/2026-08-08-formation-burst-baseline.md](playground/rtc-design/baselines/2026-08-08-formation-burst-baseline.md) (Phase 0, PR #113).
Measured Phase 1 results: [playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md](playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md).

Review requested on the plan's **Decisions for review**:
1. provenance admission always-on; `legacy-star` rollback flag governs conditional star + bounded bootstrap + dial budget;
2. tier evidence mapping (raw-WS recipes → server non-regression; browser-side adoption/dials → in-process simulation at N=6/20/50 + live-rtc-3 diagnostics);
3. dial-budget amendment: only *desired* known connections count against the budget (retained grace connections stay owned by the eviction pass — counting them would deadlock required dials);
4. headless bundle ratchet 194 → 196 KiB brotli (Phase 1 modules add ~0.7 KiB; measured 194.61; boundary assertions unchanged).

## Milestones

- [x] Plan checkpoint (`2755122b`)
- [x] Task 1 — shared primitives: `OverlayInfo.provenance`, provenance-aware admission, `rendezvous-score` extraction, bounded bootstrap selection (+ tier connectivity tests)
- [x] Task 2 — conditional bounded star + `groupFormationMode`/`bootstrapDegree` threading
- [x] Task 3 — outbound dial budget (`computeOutboundDialPlan`, server-first priority, `connectDeferredBudgetCount`)
- [x] Task 4 — N=6/20/50 in-process formation-burst simulation (`16561c46`)
- [x] Task 5 — tier recipe reruns, live-rtc-3 diagnostics capture, committed results document (`aebe9393`)

Final build-affecting commit: **`5466ccca`** (headless bundle ratchet). `a7e85aa7` is a plans-only progress-notes commit (excluded from Branch Release Gate by paths-ignore).

## Validation record (final tree `5466ccca`)

- **Passed (local completion gates)**: `npm run test:unit` — 717 files / 6,562 tests; `npm run test:ci` — exit 0 (unit + Deno + Playwright e2e 38 + 211 specs + full-stack 7 specs); `npm run build` — exit 0.
- **Passed (focused)**: `tsc` shared + shared-web; `apps/api-v1 deno task check`; `check:repo-style:changed -- origin/main HEAD` (zero findings); `check:browser-bundles`.
- **Passed (tier evidence)**: simulation — 100% server-overlay adoption, 0 conflicts, dials ≤ budget at N=6/20/50; legacy-star contrast = 49 dials at N=50. live-rtc-3 (memory) — spec green 33.5 s, captured `rallar.rtc.diagnostics()` shows `incomparableConflictCount: 0`, `bootstrapDroppedOverServerCount: 0`, `connectAttemptCount ≤ desired`, `connectDeferredBudgetCount: 0` on all three browsers.
- **Passed (recipes vs baseline)**: memory 13/13; postgres 13/13 standard + 5/5 cluster; formation-large 1/1 (1,324 steps, 0 failures). Server-side signatures match the baseline (identical steady-state patterns; large-tier queue-window deltas exactly +1,200 burst / +703 steady on both trees). Queue tables truncated pre-run per baseline methodology.
- **Remote gates**: **API v1 Medium-Scale Gate** success on `5466ccca` (run 31326547901) — not required by the mutation-path rule (diff contains no `packages/shared-server` or `apps/**` changes) but green regardless. **Branch Release Gate** on `5466ccca`: run 31326545612 — **success** (the failures on `7eca6b18`/`16561c46` were only the pre-fix bundle ratchet). **Run Hetzner Supported Distributed Manifests**: pends the resulting default-branch commit after merge.
- Environment note: sandboxed local runs block loopback listens; port-binding suites were run unsandboxed and pass.

## Plan revalidation

Default-branch base: `76e5a1b3` — unchanged since branch creation (checked 2026-08-09 before this checkpoint). `Compatible — no plan delta`.

## Follow-up issues

None — no material independent discoveries; the dial-budget/retention interaction was in-scope and fixed with the plan amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
