### PR TITLE
Harden Hetzner RTC recipe lifecycle

### DIFF
--- a/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
@@ -149,6 +149,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
@@ -387,6 +387,22 @@
             }
           },
           {
+            "kind": "loop",
+            "commandId": "parity-peer-overlap-hold",
+            "durationMs": 12000,
+            "intervalMs": 1000,
+            "maxCommands": 12,
+            "metadata": {
+              "purpose": "keep-all-parity-peers-online-through-connect-readiness"
+            },
+            "commands": [
+              {
+                "kind": "health",
+                "commandId": "parity-peer-overlap-health"
+              }
+            ]
+          },
+          {
             "kind": "close",
             "commandId": "parity-close",
             "label": "Close provider parity runtime",
@@ -441,6 +457,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
@@ -205,6 +205,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
@@ -205,6 +205,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
@@ -205,6 +205,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
@@ -207,6 +207,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
@@ -207,6 +207,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
@@ -376,6 +376,10 @@
     }
   ],
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
+++ b/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
@@ -205,6 +205,10 @@
     "expectedParticipantCount": 3
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
@@ -205,6 +205,10 @@
     "expectedParticipantCount": 2
   },
   "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
   "startMode": "manual",
   "artifactPolicy": {
     "retainArtifacts": true,

--- a/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
+++ b/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
@@ -12,12 +12,14 @@ import {
 import {
     createRallarBlackBoxRtcMessagesAllPeerMulticastRecipe,
     createRallarBlackBoxRtcMessagesPrincipalMulticastRecipes,
-    createRallarBlackBoxProviderParityLiveRecipe,
     createRallarBlackBoxRtcRealtimeRecipe,
     createRallarBlackBoxRtcRealtimeStabilityRecipe,
     createRallarBlackBoxRtcSmokeRecipe,
     RALLAR_BLACK_BOX_RECIPE_FIXTURES,
 } from '@shared-test/rallar-bb-test/recipe-fixtures.ts';
+import {
+    createHetznerProviderParityRecipe,
+} from './hetzner/create-hetzner-provider-parity-recipe.ts';
 
 export const HETZNER_DISTRIBUTED_MANIFEST_GROUP: RallarBlackBoxDistributedGroupRef = {
     applicationId: 'rallar-server',
@@ -134,7 +136,7 @@ export function buildHetznerDistributedManifestCatalog(): readonly HetznerDistri
             title: 'Provider parity 2-agent',
             description: 'Broader browser-rallar provider parity check for connect, direct, multicast, broadcast, health, close, and reset.',
             distributedRunId: 'hetzner-provider-parity-2-agent',
-            recipe: createHetznerProviderParityRecipe(),
+            recipe: createHetznerProviderParityRecipe(HETZNER_DISTRIBUTED_MANIFEST_GROUP),
             agentCount: 2,
             profiles: ['rtc', 'parity'],
             live: true,
@@ -970,62 +972,4 @@ function fixtureRecipe(fixtureId: string): RallarBlackBoxTestRecipe {
         schemaVersion: 1,
         ...fixture.recipe,
     };
-}
-
-function createHetznerProviderParityRecipe(): RallarBlackBoxTestRecipe {
-    const recipe = withoutDemoCredentials(createRallarBlackBoxProviderParityLiveRecipe({
-        group: HETZNER_DISTRIBUTED_MANIFEST_GROUP,
-        readyPeerCount: 1,
-        readyTimeoutMs: 10_000,
-    }));
-    const closeIndex = recipe.commands.findIndex(command => command.kind === 'close');
-    if (closeIndex < 0) {
-        throw new Error('Provider parity recipe must close its browser runtime.');
-    }
-
-    return {
-        ...recipe,
-        commands: [
-            ...recipe.commands.slice(0, closeIndex),
-            {
-                kind: 'loop',
-                commandId: 'parity-peer-overlap-hold',
-                durationMs: 12_000,
-                intervalMs: 1_000,
-                maxCommands: 12,
-                metadata: {
-                    purpose: 'keep-all-parity-peers-online-through-connect-readiness',
-                },
-                commands: [
-                    {
-                        kind: 'health',
-                        commandId: 'parity-peer-overlap-health',
-                    },
-                ],
-            },
-            ...recipe.commands.slice(closeIndex),
-        ],
-    };
-}
-
-function withoutDemoCredentials(recipe: RallarBlackBoxTestRecipe): RallarBlackBoxTestRecipe {
-    const copy = structuredClone(recipe) as RallarBlackBoxTestRecipe;
-    for (const command of copy.commands) {
-        if (command.kind !== 'configure') {
-            continue;
-        }
-        const config = command.config as unknown;
-        if (!config || typeof config !== 'object' || Array.isArray(config)) {
-            continue;
-        }
-        const rallar = (config as { rallar?: unknown }).rallar;
-        if (!rallar || typeof rallar !== 'object' || Array.isArray(rallar)) {
-            continue;
-        }
-        delete (rallar as { username?: unknown }).username;
-        delete (rallar as { password?: unknown }).password;
-        delete (rallar as { token?: unknown }).token;
-        delete (rallar as { restoreSession?: unknown }).restoreSession;
-    }
-    return copy;
 }

--- a/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
+++ b/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
@@ -134,11 +134,7 @@ export function buildHetznerDistributedManifestCatalog(): readonly HetznerDistri
             title: 'Provider parity 2-agent',
             description: 'Broader browser-rallar provider parity check for connect, direct, multicast, broadcast, health, close, and reset.',
             distributedRunId: 'hetzner-provider-parity-2-agent',
-            recipe: withoutDemoCredentials(createRallarBlackBoxProviderParityLiveRecipe({
-                group: HETZNER_DISTRIBUTED_MANIFEST_GROUP,
-                readyPeerCount: 1,
-                readyTimeoutMs: 10_000,
-            })),
+            recipe: createHetznerProviderParityRecipe(),
             agentCount: 2,
             profiles: ['rtc', 'parity'],
             live: true,
@@ -548,7 +544,7 @@ function buildManifestEntry(input: ManifestCatalogInput): HetznerDistributedMani
         targetPolicyMode: input.targetPolicyMode ?? 'all-online-group-members',
         rolePattern: input.rolePattern ?? 'all-agents',
         ackTimeoutMs: DEFAULT_ACK_TIMEOUT_MS,
-        barrier: input.barrier
+        barrier: input.barrier || (input.live && input.agentCount >= 2)
             ? {
                   enabled: true,
                   timeoutMs: 15_000,
@@ -973,6 +969,42 @@ function fixtureRecipe(fixtureId: string): RallarBlackBoxTestRecipe {
     return {
         schemaVersion: 1,
         ...fixture.recipe,
+    };
+}
+
+function createHetznerProviderParityRecipe(): RallarBlackBoxTestRecipe {
+    const recipe = withoutDemoCredentials(createRallarBlackBoxProviderParityLiveRecipe({
+        group: HETZNER_DISTRIBUTED_MANIFEST_GROUP,
+        readyPeerCount: 1,
+        readyTimeoutMs: 10_000,
+    }));
+    const closeIndex = recipe.commands.findIndex(command => command.kind === 'close');
+    if (closeIndex < 0) {
+        throw new Error('Provider parity recipe must close its browser runtime.');
+    }
+
+    return {
+        ...recipe,
+        commands: [
+            ...recipe.commands.slice(0, closeIndex),
+            {
+                kind: 'loop',
+                commandId: 'parity-peer-overlap-hold',
+                durationMs: 12_000,
+                intervalMs: 1_000,
+                maxCommands: 12,
+                metadata: {
+                    purpose: 'keep-all-parity-peers-online-through-connect-readiness',
+                },
+                commands: [
+                    {
+                        kind: 'health',
+                        commandId: 'parity-peer-overlap-health',
+                    },
+                ],
+            },
+            ...recipe.commands.slice(closeIndex),
+        ],
     };
 }
 

--- a/apps/rallar-black-box/src/hetzner/create-hetzner-provider-parity-recipe.ts
+++ b/apps/rallar-black-box/src/hetzner/create-hetzner-provider-parity-recipe.ts
@@ -1,0 +1,74 @@
+import type {
+    RallarBlackBoxDistributedGroupRef,
+} from '@shared-test/rallar-bb-test/distributed-run.ts';
+import type { RallarBlackBoxTestRecipe } from '@shared-test/rallar-bb-test/types.ts';
+import {
+    createRallarBlackBoxProviderParityLiveRecipe,
+} from '@shared-test/rallar-bb-test/recipe-fixtures.ts';
+
+const OMITTED_DEMO_CREDENTIAL_KEYS = new Set([
+    'username',
+    'password',
+    'token',
+    'restoreSession',
+]);
+
+export function createHetznerProviderParityRecipe(
+    group: RallarBlackBoxDistributedGroupRef,
+): RallarBlackBoxTestRecipe {
+    const recipe = withoutDemoCredentials(createRallarBlackBoxProviderParityLiveRecipe({
+        group,
+        readyPeerCount: 1,
+        readyTimeoutMs: 10_000,
+    }));
+    const closeIndex = recipe.commands.findIndex(command => command.kind === 'close');
+    if (closeIndex < 0) {
+        throw new Error('Provider parity recipe must close its browser runtime.');
+    }
+
+    return {
+        ...recipe,
+        commands: [
+            ...recipe.commands.slice(0, closeIndex),
+            {
+                kind: 'loop',
+                commandId: 'parity-peer-overlap-hold',
+                durationMs: 12_000,
+                intervalMs: 1_000,
+                maxCommands: 12,
+                metadata: {
+                    purpose: 'keep-all-parity-peers-online-through-connect-readiness',
+                },
+                commands: [
+                    {
+                        kind: 'health',
+                        commandId: 'parity-peer-overlap-health',
+                    },
+                ],
+            },
+            ...recipe.commands.slice(closeIndex),
+        ],
+    };
+}
+
+function withoutDemoCredentials(recipe: RallarBlackBoxTestRecipe): RallarBlackBoxTestRecipe {
+    return {
+        ...recipe,
+        commands: recipe.commands.map(command => {
+            if (command.kind !== 'configure' || command.config.rallar === undefined) {
+                return command;
+            }
+            return {
+                ...command,
+                config: {
+                    ...command.config,
+                    rallar: Object.fromEntries(
+                        Object.entries(command.config.rallar).filter(
+                            ([key]) => !OMITTED_DEMO_CREDENTIAL_KEYS.has(key),
+                        ),
+                    ),
+                },
+            };
+        }),
+    };
+}

--- a/docs/repo-code-style-exceptions.md
+++ b/docs/repo-code-style-exceptions.md
@@ -45,6 +45,18 @@ cohesive algorithm.
   - Review or removal condition: split the catalog when it exceeds 1,200
     physical lines or when a new independently generated manifest suite is
     added.
+- Repository-relative path:
+  `packages/shared-test/rallar-bb-test/browser-adapter.ts`
+  - Exception category: parser or state-transition table
+  - Why cohesion is clearer: this adapter is the single browser-rallar command
+    dispatch and result-projection boundary. Keeping readiness result
+    projection with the command execution table makes the provider call and its
+    artifact-visible outcome traceable in one place; extracting only this small
+    projection would add a pass-through module without separating ownership.
+  - Approval date and reviewer: 2026-08-09, task requester
+  - Review or removal condition: remove the exception when browser-rallar
+    command families are decomposed into independently owned adapters, or
+    review it again if the file exceeds 3,100 physical lines.
 
 | Repository-relative path                               | Symbol      | Exception category | Why cohesion is clearer                                                                                                                                    | Approval date and reviewer                                                         | Owner                | Review or removal condition                                                                                                                                                                        |
 | ------------------------------------------------------ | ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/repo-code-style-exceptions.md
+++ b/docs/repo-code-style-exceptions.md
@@ -35,6 +35,17 @@ cohesive algorithm.
 
 ## Approved exceptions
 
+- Repository-relative path: `apps/rallar-black-box/src/hetzner-distributed-manifests.ts`
+  - Exception category: static lookup data
+  - Why cohesion is clearer: the file is the single ordered catalog for the
+    generated Hetzner manifest suite. Keeping its manifest inventory, shared
+    construction rules, and generation metadata together makes ordering and
+    cross-manifest lifecycle invariants directly reviewable.
+  - Approval date and reviewer: 2026-08-09, task requester
+  - Review or removal condition: split the catalog when it exceeds 1,200
+    physical lines or when a new independently generated manifest suite is
+    added.
+
 | Repository-relative path                               | Symbol      | Exception category | Why cohesion is clearer                                                                                                                                    | Approval date and reviewer                                                         | Owner                | Review or removal condition                                                                                                                                                                        |
 | ------------------------------------------------------ | ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scripts/perf/api-v1-state-write-concurrency-bench.ts` | Entire file | cohesive algorithm | Keep the unchanged measured orchestration together for this tooling wave while the named artifact owner is extracted; the file may not exceed 1,763 lines. | 2026-08-09; human approval of plan blob `b6fd5aebfa77ee489e65fa30fbee165e033c14f9` | Group-topology child | Remove in a separately approved benchmark-architecture child that splits measurement orchestration into cohesive owners without changing benchmark behavior, artifacts, timing, or governance.     |

--- a/docs/superpowers/plans/2026-08-09-hetzner-rtc-recipe-lifecycle-hardening.md
+++ b/docs/superpowers/plans/2026-08-09-hetzner-rtc-recipe-lifecycle-hardening.md
@@ -1,0 +1,60 @@
+# Hetzner RTC Recipe Lifecycle Hardening Plan
+
+**Goal:** Prevent live multi-agent Hetzner recipes from racing startup or
+teardown, and make RTC room-refresh behavior visible in black-box artifacts.
+
+**Architecture:** The Hetzner manifest catalog owns distributed start barriers
+and the provider-parity overlap hold. The RTC readiness coordinator owns
+bounded `refreshRoom` retries and their counters. The browser command adapter
+serializes the complete readiness evidence into command results.
+
+## Constraints
+
+- Preserve recipe IDs, all-agent provider-parity targeting, provider choice,
+  authentication behavior, and the 10-second parity readiness window.
+- Enable the existing 15-second barrier for every live multi-agent manifest;
+  preserve explicit barriers on simulated diagnostics.
+- Keep every provider-parity peer alive for 12 seconds before close/reset by
+  sampling health once per second.
+- Count refresh attempts, completed successes, and retryable failures without
+  changing retry classification or timeout/abort behavior.
+- Do not convert the other small RTC recipes to role-based recipes. Principal
+  and high-rate recipes already own their role-specific lifecycle holds.
+
+## Implementation
+
+- [x] Add failing regression tests for live barriers and parity overlap.
+- [x] Make live multi-agent barriers a catalog construction invariant.
+- [x] Insert the parity health loop immediately before close/reset and
+  regenerate checked-in manifests.
+- [x] Add failing artifact assertions for room-refresh counters.
+- [x] Add counters to `RtcConnectReadinessResult` and keep readiness functions
+  below the repository function-size threshold.
+- [ ] Serialize the counters at the browser artifact boundary after the
+  required size-exception decision in
+  [issue #142](https://github.com/intact-software-systems/ar-eye-hunter/issues/142).
+- [ ] Pass focused tests, typecheck, manifest generation check, and changed-file
+  repository-style review.
+- [ ] Pass `npm run test:unit`, `npm run test:ci`, and `npm run build` on the
+  final uncommitted tree.
+- [ ] Publish the final feature commit to one draft PR and verify Branch
+  Release Gate for its exact SHA.
+- [ ] After merge, verify Run Hetzner Supported Distributed Manifests for the
+  resulting exact default-branch SHA.
+
+## Compatibility Checkpoint
+
+Implementation started from `origin/main` at
+`726edc7c33386f9282f6594ec4b5c3c02033fbf1`. Compared with the earlier planning
+base, the intervening default-branch commits did not change manifest ownership,
+RTC readiness contracts, recipe identities, or the required validation paths.
+Outcome: **Compatible — no plan delta**.
+
+## Persistent Size Exceptions
+
+- Approved by the task requester on 2026-08-09: keep
+  `apps/rallar-black-box/src/hetzner-distributed-manifests.ts` cohesive as the
+  ordered static manifest catalog; review at 1,200 lines or a second generated
+  suite.
+- Pending in issue #142: the legacy browser command adapter must project the
+  new readiness fields but remains above 800 physical lines.

--- a/docs/superpowers/plans/2026-08-09-hetzner-rtc-recipe-lifecycle-hardening.md
+++ b/docs/superpowers/plans/2026-08-09-hetzner-rtc-recipe-lifecycle-hardening.md
@@ -30,12 +30,12 @@ serializes the complete readiness evidence into command results.
 - [x] Add failing artifact assertions for room-refresh counters.
 - [x] Add counters to `RtcConnectReadinessResult` and keep readiness functions
   below the repository function-size threshold.
-- [ ] Serialize the counters at the browser artifact boundary after the
+- [x] Serialize the counters at the browser artifact boundary after the
   required size-exception decision in
   [issue #142](https://github.com/intact-software-systems/ar-eye-hunter/issues/142).
-- [ ] Pass focused tests, typecheck, manifest generation check, and changed-file
+- [x] Pass focused tests, typecheck, manifest generation check, and changed-file
   repository-style review.
-- [ ] Pass `npm run test:unit`, `npm run test:ci`, and `npm run build` on the
+- [x] Pass `npm run test:unit`, `npm run test:ci`, and `npm run build` on the
   final uncommitted tree.
 - [ ] Publish the final feature commit to one draft PR and verify Branch
   Release Gate for its exact SHA.
@@ -56,5 +56,6 @@ Outcome: **Compatible — no plan delta**.
   `apps/rallar-black-box/src/hetzner-distributed-manifests.ts` cohesive as the
   ordered static manifest catalog; review at 1,200 lines or a second generated
   suite.
-- Pending in issue #142: the legacy browser command adapter must project the
-  new readiness fields but remains above 800 physical lines.
+- Approved by the task requester on 2026-08-09 in issue #142: keep the legacy
+  browser-rallar command dispatch and result-projection table cohesive; revisit
+  when its command families are decomposed or the file exceeds 3,100 lines.

--- a/packages/shared-test/rallar-bb-test/browser-adapter.ts
+++ b/packages/shared-test/rallar-bb-test/browser-adapter.ts
@@ -313,26 +313,14 @@ function withRtcConnectReadinessValue(
     value: unknown,
     readiness: RtcConnectReadinessResult,
 ): unknown {
-    const readinessValue = {
-        ready: readiness.ready,
-        minReadyPeers: readiness.minReadyPeers,
-        timeoutMs: readiness.timeoutMs,
-        intervalMs: readiness.intervalMs,
-        waitedMs: readiness.waitedMs,
-        readyPeerIds: readiness.readyPeerIds,
-        health: readiness.health,
-        ...(readiness.lastRefreshError !== undefined
-            ? { lastRefreshError: readiness.lastRefreshError }
-            : {}),
-    };
     return value && typeof value === 'object' && !Array.isArray(value)
         ? {
             ...(value as Record<string, unknown>),
-            readiness: readinessValue,
+            readiness,
         }
         : {
             diagnostics: value,
-            readiness: readinessValue,
+            readiness,
         };
 }
 

--- a/packages/shared-test/rallar-bb-test/browser/rtc-connect-readiness.ts
+++ b/packages/shared-test/rallar-bb-test/browser/rtc-connect-readiness.ts
@@ -23,6 +23,9 @@ export type RtcConnectReadinessResult = Readonly<{
   intervalMs: number;
   waitedMs: number;
   readyPeerIds: readonly string[];
+  roomRefreshAttempts: number;
+  roomRefreshSuccesses: number;
+  roomRefreshRetryableFailures: number;
   health?: ReadinessBoundaryValue;
   lastRefreshError?: RtcConnectReadinessError;
 }>;
@@ -38,13 +41,29 @@ type ReadinessAbortScope = Readonly<{
   cleanup(): void;
 }>;
 
-type ReadinessResultInput = Readonly<{
-  options: RtcConnectReadinessOptions;
-  startedAtEpochMs: number;
-  health: ReadinessBoundaryValue;
+interface RtcConnectReadinessState {
+  latestHealth: ReadinessBoundaryValue;
   readyPeerIds: readonly string[];
+  roomRefreshAttempts: number;
+  roomRefreshSuccesses: number;
+  roomRefreshRetryableFailures: number;
+  nextRefreshAtEpochMs: number;
   lastRefreshError?: RtcConnectReadinessError;
+}
+
+type ReadinessLoopInput = Readonly<{
+  runtime: RtcConnectReadinessRuntime;
+  options: RtcConnectReadinessOptions;
+  parentSignal?: AbortSignal;
+  abortScope: ReadinessAbortScope;
+  startedAtEpochMs: number;
+  deadlineEpochMs: number;
+  state: RtcConnectReadinessState;
 }>;
+
+type HealthPollOutcome = 'polled' | 'timed-out';
+type RoomRefreshOutcome = 'not-due' | 'refreshed' | 'timed-out';
+type ReadinessSleepOutcome = 'slept' | 'timed-out';
 
 const ROOM_REFRESH_INTERVAL_MS = 1_000;
 const READINESS_TIMEOUT_ERROR_NAME = 'RALLAR_BB_RTC_READINESS_TIMEOUT';
@@ -200,17 +219,115 @@ function createReadinessAbortScope(
   };
 }
 
-function readinessResult(input: ReadinessResultInput): RtcConnectReadinessResult {
+function readinessResult(input: ReadinessLoopInput): RtcConnectReadinessResult {
   return {
-    ready: input.readyPeerIds.length >= input.options.minReadyPeers,
+    ready: input.state.readyPeerIds.length >= input.options.minReadyPeers,
     minReadyPeers: input.options.minReadyPeers,
     timeoutMs: input.options.timeoutMs,
     intervalMs: input.options.intervalMs,
     waitedMs: Math.max(0, Date.now() - input.startedAtEpochMs),
-    readyPeerIds: input.readyPeerIds,
-    health: input.health,
-    ...(input.lastRefreshError !== undefined ? { lastRefreshError: input.lastRefreshError } : {}),
+    readyPeerIds: input.state.readyPeerIds,
+    roomRefreshAttempts: input.state.roomRefreshAttempts,
+    roomRefreshSuccesses: input.state.roomRefreshSuccesses,
+    roomRefreshRetryableFailures: input.state.roomRefreshRetryableFailures,
+    health: input.state.latestHealth,
+    ...(input.state.lastRefreshError !== undefined
+      ? { lastRefreshError: input.state.lastRefreshError }
+      : {}),
   };
+}
+
+function throwParentAbortOrError(
+  error: ReadinessBoundaryValue,
+  parentSignal?: AbortSignal,
+): never {
+  if (parentSignal?.aborted) {
+    throw toAbortError(parentSignal.reason);
+  }
+  throw error;
+}
+
+async function pollRtcConnectHealth(input: ReadinessLoopInput): Promise<HealthPollOutcome> {
+  try {
+    input.state.latestHealth = await raceWithAbort(
+      input.runtime.health(),
+      input.abortScope.signal,
+    );
+  } catch (error) {
+    if (input.abortScope.timedOut()) {
+      return 'timed-out';
+    }
+    throwParentAbortOrError(error, input.parentSignal);
+  }
+  input.state.readyPeerIds = toRtcReadyPeerIds(input.state.latestHealth);
+  return 'polled';
+}
+
+async function refreshRtcConnectRoom(input: ReadinessLoopInput): Promise<RoomRefreshOutcome> {
+  if (Date.now() < input.state.nextRefreshAtEpochMs) {
+    return 'not-due';
+  }
+
+  input.state.roomRefreshAttempts += 1;
+  const remainingMs = Math.max(0, input.deadlineEpochMs - Date.now());
+  try {
+    await raceWithAbort(
+      input.runtime.refreshRoom({ signal: input.abortScope.signal, timeoutMs: remainingMs }),
+      input.abortScope.signal,
+    );
+    input.state.roomRefreshSuccesses += 1;
+  } catch (error) {
+    if (input.abortScope.timedOut()) {
+      return 'timed-out';
+    }
+    if (input.parentSignal?.aborted || !shouldRetryRoomRefresh(error)) {
+      throwParentAbortOrError(error, input.parentSignal);
+    }
+    input.state.roomRefreshRetryableFailures += 1;
+    input.state.lastRefreshError = serializeReadinessError(error);
+  }
+  input.state.nextRefreshAtEpochMs = Date.now() + ROOM_REFRESH_INTERVAL_MS;
+  return 'refreshed';
+}
+
+async function sleepForRtcConnectPoll(input: ReadinessLoopInput): Promise<ReadinessSleepOutcome> {
+  const remainingMs = Math.max(0, input.deadlineEpochMs - Date.now());
+  try {
+    await sleep(Math.min(input.options.intervalMs, remainingMs), input.abortScope.signal);
+    return 'slept';
+  } catch (error) {
+    if (input.abortScope.timedOut()) {
+      return 'timed-out';
+    }
+    throwParentAbortOrError(error, input.parentSignal);
+  }
+}
+
+async function runRtcConnectReadinessLoop(
+  input: ReadinessLoopInput,
+): Promise<RtcConnectReadinessResult> {
+  while (true) {
+    if (await pollRtcConnectHealth(input) === 'timed-out') {
+      return readinessResult(input);
+    }
+    if (
+      input.state.readyPeerIds.length >= input.options.minReadyPeers ||
+      Date.now() >= input.deadlineEpochMs
+    ) {
+      return readinessResult(input);
+    }
+
+    const refreshOutcome = await refreshRtcConnectRoom(input);
+    if (refreshOutcome === 'timed-out') {
+      return readinessResult(input);
+    }
+    if (refreshOutcome === 'refreshed') {
+      continue;
+    }
+    if (await sleepForRtcConnectPoll(input) === 'timed-out') {
+      return readinessResult(input);
+    }
+  }
 }
 
 export async function waitForRtcConnectReadiness(
@@ -221,92 +338,25 @@ export async function waitForRtcConnectReadiness(
   const startedAtEpochMs = Date.now();
   const deadlineEpochMs = startedAtEpochMs + options.timeoutMs;
   const abortScope = createReadinessAbortScope(options.timeoutMs, parentSignal);
-  let latestHealth: ReadinessBoundaryValue;
-  let readyPeerIds: readonly string[] = [];
-  let lastRefreshError: RtcConnectReadinessError | undefined;
-  let nextRefreshAtEpochMs = startedAtEpochMs;
+  const state: RtcConnectReadinessState = {
+    latestHealth: undefined,
+    readyPeerIds: [],
+    roomRefreshAttempts: 0,
+    roomRefreshSuccesses: 0,
+    roomRefreshRetryableFailures: 0,
+    nextRefreshAtEpochMs: startedAtEpochMs,
+  };
 
   try {
-    while (true) {
-      try {
-        latestHealth = await raceWithAbort(runtime.health(), abortScope.signal);
-      } catch (error) {
-        if (abortScope.timedOut()) {
-          return readinessResult({
-            options,
-            startedAtEpochMs,
-            health: latestHealth,
-            readyPeerIds,
-            lastRefreshError,
-          });
-        }
-        if (parentSignal?.aborted) {
-          throw toAbortError(parentSignal.reason);
-        }
-        throw error;
-      }
-      readyPeerIds = toRtcReadyPeerIds(latestHealth);
-      if (readyPeerIds.length >= options.minReadyPeers || Date.now() >= deadlineEpochMs) {
-        return readinessResult({
-          options,
-          startedAtEpochMs,
-          health: latestHealth,
-          readyPeerIds,
-          lastRefreshError,
-        });
-      }
-
-      if (Date.now() >= nextRefreshAtEpochMs) {
-        const remainingMs = Math.max(0, deadlineEpochMs - Date.now());
-        try {
-          await raceWithAbort(
-            runtime.refreshRoom({
-              signal: abortScope.signal,
-              timeoutMs: remainingMs,
-            }),
-            abortScope.signal,
-          );
-        } catch (error) {
-          if (abortScope.timedOut()) {
-            return readinessResult({
-              options,
-              startedAtEpochMs,
-              health: latestHealth,
-              readyPeerIds,
-              lastRefreshError,
-            });
-          }
-          if (parentSignal?.aborted) {
-            throw toAbortError(parentSignal.reason);
-          }
-          if (!shouldRetryRoomRefresh(error)) {
-            throw error;
-          }
-          lastRefreshError = serializeReadinessError(error);
-        }
-        nextRefreshAtEpochMs = Date.now() + ROOM_REFRESH_INTERVAL_MS;
-        continue;
-      }
-
-      const remainingMs = Math.max(0, deadlineEpochMs - Date.now());
-      try {
-        await sleep(Math.min(options.intervalMs, remainingMs), abortScope.signal);
-      } catch (error) {
-        if (abortScope.timedOut()) {
-          return readinessResult({
-            options,
-            startedAtEpochMs,
-            health: latestHealth,
-            readyPeerIds,
-            lastRefreshError,
-          });
-        }
-        if (parentSignal?.aborted) {
-          throw toAbortError(parentSignal.reason);
-        }
-        throw error;
-      }
-    }
+    return await runRtcConnectReadinessLoop({
+      runtime,
+      options,
+      parentSignal,
+      abortScope,
+      startedAtEpochMs,
+      deadlineEpochMs,
+      state,
+    });
   } finally {
     abortScope.cleanup();
   }

--- a/packages/tests/rallar-black-box/browser-rallar-runtime.test.ts
+++ b/packages/tests/rallar-black-box/browser-rallar-runtime.test.ts
@@ -351,6 +351,13 @@ describe('rallar-black-box SPA browser-rallar runtime', () => {
 
         expect(result.ok).toBe(true);
         expect(refreshRoom).not.toHaveBeenCalled();
+        expect(result.value).toMatchObject({
+            readiness: {
+                roomRefreshAttempts: 0,
+                roomRefreshSuccesses: 0,
+                roomRefreshRetryableFailures: 0,
+            },
+        });
     });
 
     it('refreshes room state while waiting for an initially undiscovered RTC peer', async () => {
@@ -402,6 +409,9 @@ describe('rallar-black-box SPA browser-rallar runtime', () => {
         expect(result.value).toMatchObject({
             readiness: {
                 readyPeerIds: ['peer-a'],
+                roomRefreshAttempts: 1,
+                roomRefreshSuccesses: 1,
+                roomRefreshRetryableFailures: 0,
             },
         });
     });
@@ -449,6 +459,13 @@ describe('rallar-black-box SPA browser-rallar runtime', () => {
             expect(result.ok).toBe(false);
             expect(result.error).toMatchObject({
                 code: 'RALLAR_BB_RTC_READY_TIMEOUT',
+            });
+            expect(result.value).toMatchObject({
+                readiness: {
+                    roomRefreshAttempts: 1,
+                    roomRefreshSuccesses: 0,
+                    roomRefreshRetryableFailures: 0,
+                },
             });
             expect(signal?.aborted).toBe(true);
         } finally {
@@ -550,6 +567,9 @@ describe('rallar-black-box SPA browser-rallar runtime', () => {
             expect(result.value).toMatchObject({
                 readiness: {
                     readyPeerIds: ['peer-a'],
+                    roomRefreshAttempts: 2,
+                    roomRefreshSuccesses: 1,
+                    roomRefreshRetryableFailures: 1,
                     lastRefreshError: {
                         name: 'Error',
                         message: refreshError.message,

--- a/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
+++ b/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
@@ -75,8 +75,10 @@ type ManifestCommand = Readonly<{
         intervalMs?: number;
     }>;
     count?: number;
+    durationMs?: number;
     intervalMs?: number;
     maxInFlight?: number;
+    maxCommands?: number;
     continueOnSendFailure?: boolean;
     metadata?: Record<string, unknown>;
     thresholds?: Record<string, unknown>;
@@ -291,6 +293,20 @@ describe('Hetzner distributed manifest catalog', () => {
                 minReadyPeers: expected?.peers,
                 timeoutMs: expected?.timeoutMs,
                 intervalMs: 100,
+            });
+        }
+    });
+
+    it('synchronizes every live multi-agent Hetzner recipe before execution', () => {
+        for (const entry of buildHetznerDistributedManifestCatalog()) {
+            const hasLiveRecipe = entry.manifest.recipes.some(selection => selection.live);
+            if (!hasLiveRecipe || entry.agentCount < 2) {
+                continue;
+            }
+
+            expect(entry.manifest.barrier, entry.filePath).toEqual({
+                enabled: true,
+                timeoutMs: 15_000,
             });
         }
     });
@@ -540,6 +556,45 @@ describe('Hetzner distributed manifest catalog', () => {
             timeoutMs: 15_000,
             readiness: { timeoutMs: 10_000 },
         });
+    });
+
+    it('keeps provider parity peers alive through the readiness window before teardown', () => {
+        const parity = buildHetznerDistributedManifestCatalog().find(entry =>
+            entry.filePath === 'apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json'
+        );
+        const commands = parity?.manifest.recipes[0]?.recipe.commands as readonly ManifestCommand[] | undefined;
+        const connectIndex = commands?.findIndex(command => command.kind === 'rtc.connect') ?? -1;
+        const holdIndex = commands?.findIndex(command => command.commandId === 'parity-peer-overlap-hold') ?? -1;
+        const closeIndex = commands?.findIndex(command => command.kind === 'close') ?? -1;
+        const resetIndex = commands?.findIndex(command => command.kind === 'reset') ?? -1;
+        const connect = commands?.at(connectIndex);
+        const hold = commands?.at(holdIndex);
+
+        expect(parity?.manifest.targetPolicy.mode).toBe('all-online-group-members');
+        expect(parity?.manifest.recipes).toHaveLength(1);
+        expect(parity?.manifest.recipes[0]?.role).toBeUndefined();
+        expect(connectIndex).toBeGreaterThanOrEqual(0);
+        expect(holdIndex).toBeGreaterThanOrEqual(0);
+        expect(closeIndex).toBeGreaterThanOrEqual(0);
+        expect(resetIndex).toBeGreaterThanOrEqual(0);
+        expect(connectIndex).toBeLessThan(holdIndex);
+        expect(holdIndex).toBeLessThan(closeIndex);
+        expect(closeIndex).toBeLessThan(resetIndex);
+        expect(hold).toMatchObject({
+            kind: 'loop',
+            durationMs: 12_000,
+            intervalMs: 1_000,
+            maxCommands: 12,
+            commands: [
+                {
+                    kind: 'health',
+                    commandId: 'parity-peer-overlap-health',
+                },
+            ],
+        });
+        expect(hold?.durationMs).toBeGreaterThanOrEqual(
+            (connect?.readiness?.timeoutMs ?? 0) + 2_000,
+        );
     });
 
     it('feeds Hetzner CI artifacts into SPA monitor and RTC performance views', () => {


### PR DESCRIPTION
## Summary
- make the existing 15-second start barrier a construction invariant for every live multi-agent Hetzner manifest
- keep both provider-parity agents alive for a 12-second, 1 Hz health hold before close/reset
- make rtc.connect readiness use RallarBrowser refreshRoom while peers are not ready and publish attempt, success, and retryable-failure counters in command artifacts
- record the requester-approved browser-adapter size exception from #142

## Plan
- Implementation plan: docs/superpowers/plans/2026-08-09-hetzner-rtc-recipe-lifecycle-hardening.md
- One lifecycle PR; the manifest and readiness slices share one failure mode and validation path.

## Progress
- [x] Manifest barrier and parity-overlap slice committed
- [x] Checked-in JSON regenerated
- [x] Readiness counters serialized at the artifact boundary
- [x] Full local completion gates
- [x] Branch Release Gate for exact head cb87dba53cf01ba277b6275d01ae3b27294e5a61: https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31335100107
- [ ] After merge, Run Hetzner Supported Distributed Manifests for the resulting exact main SHA

## Runtime lifecycle trace
1. BrowserCommandAdapter is constructed with the Rallar browser runtime before its executor is registered.
2. rtc.connect connects the runtime, then waitForRtcConnectReadiness polls health under one timeout and parent-abort scope.
3. While the peer threshold is unmet, the loop calls refreshRoom at the bounded refresh interval. Attempts count before invocation; successes count resolved refreshes; retryable failures count caught retryable refresh errors.
4. Ready, timeout, and error paths retain the same abort and retry semantics. The adapter embeds the complete typed readiness result in both object and primitive diagnostics, so artifacts expose zero, success, retry, and in-flight-timeout evidence.

## Validation
- Focused Vitest: 2 files and 34 tests passed
- Hetzner manifest generation check: 60 manifests current
- npm run typecheck: all workspaces passed
- npm run check:repo-style:changed -- origin/main WORKTREE: passed
- npm run check:repo-style: full scan exited 0; 4,544 warning-only legacy findings remain. The browser adapter length is covered by the approved exception, and all other touched-file findings are pre-existing and not worsened.
- npm run test:unit: 717 files and 6,564 tests passed on the final tree
- npm run test:ci: passed; 407 API Deno, 79 control-server Deno, 146 scenario/provider Deno, 38 enabled browser, 211 recipe-console, and 7 memory full-stack tests passed. Configured skips were 46 browser and 1 recipe-console.
- npm run build: all workspaces passed; existing Vite chunk-size advisories only
- Independent final code review: no Critical, Important, or Minor findings
- Branch Release Gate: passed all phases in 31m05s for exact SHA cb87dba53cf01ba277b6275d01ae3b27294e5a61

## Base compatibility
Compatible — no plan delta. Current origin/main is 108933a97c7a40ee0831ecd185725aea243122bd. Its only change since the planning base is reviewed style-checker dispositions for three performance-harness findings. There is no touched-path overlap, the merge tree is conflict-free, and feature contracts and acceptance criteria are unchanged.

Closes #142.