### PR TITLE
feat(realtime): group formation Phase 2 — server damping (M1, M4, M3)

### DIFF
--- a/.github/workflows/api-v1-topology-replay-gate.yml
+++ b/.github/workflows/api-v1-topology-replay-gate.yml
@@ -36,6 +36,12 @@ jobs:
           --health-retries 20
     env:
       DATABASE_URL: postgresql://app:app@localhost:5432/appdb
+      # The replay proof pins the legacy per-command publication contract: it
+      # asserts one durable topology publication per group mutation, which the
+      # damped default's coalescing and fingerprint change gate intentionally
+      # eliminate for non-topology-affecting mutations. The proof runs against
+      # the retained legacy path until it is adapted to the damped contract.
+      RALLAR_GROUP_FORMATION_DAMPING: legacy
       RALLAR_ICE_MODE: local
       RALLAR_LOGIN_USER_RATE_LIMIT: '100'
       RALLAR_STATE_STRICT_READ_AUTH: '1'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -122,6 +122,12 @@ jobs:
 
       - name: Run deterministic topology replay proof
         uses: ./.github/actions/api-v1-black-box-test
+        # The replay proof pins the legacy per-command publication contract
+        # (one durable publication per mutation), which damped coalescing and
+        # the fingerprint change gate intentionally eliminate; it runs against
+        # the retained legacy path until adapted to the damped contract.
+        env:
+          RALLAR_GROUP_FORMATION_DAMPING: legacy
         with:
           backend: postgres
           api-port: '18080'

--- a/apps/api-v1/src/main.ts
+++ b/apps/api-v1/src/main.ts
@@ -21,6 +21,9 @@ import {
   readApiRtcTopologyReplayConfig,
   shouldStartApiQueueWorkers,
 } from './runtime/rtc-topology/rtc-topology-replay-config.ts';
+import {
+  logGroupFormationDampingConfig,
+} from './runtime/group-formation/group-formation-damping-config.ts';
 
 const app: Hono = new Hono();
 addEventListener('unload', () => {
@@ -36,6 +39,7 @@ logPGliteSchemaInitConfig();
 logDatabasePubSubConfig();
 const rtcTopologyReplayConfig = readApiRtcTopologyReplayConfig();
 logRtcTopologyReplayConfig(console.log, rtcTopologyReplayConfig);
+logGroupFormationDampingConfig(console.log);
 
 const apiCors = cors(
   {

--- a/apps/api-v1/src/middleware.ts
+++ b/apps/api-v1/src/middleware.ts
@@ -96,11 +96,8 @@ import {
 } from './runtime/rtc-topology/rtc-topology-replay-config.ts';
 import {
   readApiGroupFormationDampingConfig,
+  readApiGroupFormationTopologyIntent,
 } from './runtime/group-formation/group-formation-damping-config.ts';
-import { getApiRtcTopologyServiceOptions } from './services/rtc-topology-config.ts';
-import {
-  DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
-} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
 import {
   beginMiddlewareStartupGeneration,
   registerMiddlewareBackgroundTask,
@@ -149,14 +146,7 @@ function initialise(
   setRtcTopologyOutboxWriteSink(groupFormationMetrics.topologyOutboxWritten);
   const databaseConfig = readApiV1DatabaseBackendConfig();
   const pubSubConfig = readApiV1DatabasePubSubConfig(Deno.env, databaseConfig);
-  const rtcTopologyReplayConfig = readApiRtcTopologyReplayConfig(
-    Deno.env,
-    databaseConfig,
-  );
-  const groupFormationDamping = readApiGroupFormationDampingConfig().damping;
-  const topologyRecomputeDebounceMs =
-    getApiRtcTopologyServiceOptions().topologyRecomputeDebounceMs ??
-      DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS;
+  const rtcTopologyReplayConfig = readApiRtcTopologyReplayConfig(Deno.env, databaseConfig);
   const groupSnapshotReadThroughCache = createGroupStateSnapshotReadThroughCache({
     groupsRepository,
   });
@@ -273,9 +263,10 @@ function initialise(
       outboxQueueReader,
       wakeQueueEngine,
     }) => {
+      const topologyIntent = readApiGroupFormationTopologyIntent(outboxQueueReader);
       const durable = createGroupStateService({
         runtimeRepository: runtimeStateRepository,
-        formationDamping: groupFormationDamping,
+        formationDamping: topologyIntent.damping,
         authSessionRepository,
         createGroupStateEventStore: createGroupStateEventRepository,
         serviceId: myServerId,
@@ -287,13 +278,7 @@ function initialise(
       });
       const presenceSummary = new GroupPresenceSummaryWork({
         runtimeRepository: runtimeStateRepository,
-        topologyIntent: groupFormationDamping === 'damped'
-          ? {
-            damping: 'damped',
-            outboxQueueReader,
-            recomputeDebounceMs: topologyRecomputeDebounceMs,
-          }
-          : { damping: 'legacy' },
+        topologyIntent,
         database: postgresSql,
         serviceId: myServerId,
         wakeQueue: wakeQueueEngine,
@@ -325,7 +310,7 @@ function initialise(
       const clientStateService = createCachedClientStateService({
         durable: createClientStateService({
           runtimeRepository: runtimeStateRepository,
-          formationDamping: groupFormationDamping,
+          formationDamping: readApiGroupFormationDampingConfig().damping,
           createClientStateEventStore: createClientStateEventRepository,
           serviceId: myServerId,
           timing,

--- a/apps/api-v1/src/middleware.ts
+++ b/apps/api-v1/src/middleware.ts
@@ -325,6 +325,7 @@ function initialise(
       const clientStateService = createCachedClientStateService({
         durable: createClientStateService({
           runtimeRepository: runtimeStateRepository,
+          formationDamping: groupFormationDamping,
           createClientStateEventStore: createClientStateEventRepository,
           serviceId: myServerId,
           timing,

--- a/apps/api-v1/src/middleware.ts
+++ b/apps/api-v1/src/middleware.ts
@@ -275,6 +275,7 @@ function initialise(
     }) => {
       const durable = createGroupStateService({
         runtimeRepository: runtimeStateRepository,
+        formationDamping: groupFormationDamping,
         authSessionRepository,
         createGroupStateEventStore: createGroupStateEventRepository,
         serviceId: myServerId,

--- a/apps/api-v1/src/middleware.ts
+++ b/apps/api-v1/src/middleware.ts
@@ -95,6 +95,13 @@ import {
   readApiRtcTopologyReplayConfig,
 } from './runtime/rtc-topology/rtc-topology-replay-config.ts';
 import {
+  readApiGroupFormationDampingConfig,
+} from './runtime/group-formation/group-formation-damping-config.ts';
+import { getApiRtcTopologyServiceOptions } from './services/rtc-topology-config.ts';
+import {
+  DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
+} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import {
   beginMiddlewareStartupGeneration,
   registerMiddlewareBackgroundTask,
   shutdownMiddlewareBackgroundTasks,
@@ -146,6 +153,10 @@ function initialise(
     Deno.env,
     databaseConfig,
   );
+  const groupFormationDamping = readApiGroupFormationDampingConfig().damping;
+  const topologyRecomputeDebounceMs =
+    getApiRtcTopologyServiceOptions().topologyRecomputeDebounceMs ??
+      DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS;
   const groupSnapshotReadThroughCache = createGroupStateSnapshotReadThroughCache({
     groupsRepository,
   });
@@ -275,6 +286,13 @@ function initialise(
       });
       const presenceSummary = new GroupPresenceSummaryWork({
         runtimeRepository: runtimeStateRepository,
+        topologyIntent: groupFormationDamping === 'damped'
+          ? {
+            damping: 'damped',
+            outboxQueueReader,
+            recomputeDebounceMs: topologyRecomputeDebounceMs,
+          }
+          : { damping: 'legacy' },
         database: postgresSql,
         serviceId: myServerId,
         wakeQueue: wakeQueueEngine,

--- a/apps/api-v1/src/runtime/group-formation/group-formation-damping-config.ts
+++ b/apps/api-v1/src/runtime/group-formation/group-formation-damping-config.ts
@@ -1,4 +1,12 @@
+import type { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
+import type {
+  GroupPresenceSummaryTopologyIntent,
+} from '@shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts';
+import {
+  DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
+} from '@shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts';
 import type { EnvReader } from '../../db/database-config.ts';
+import { readApiTopologyRecomputeDebounceMs } from '../../services/rtc-topology-config.ts';
 
 export const GROUP_FORMATION_DAMPING_MODES = ['damped', 'legacy'] as const;
 
@@ -24,6 +32,21 @@ export function readApiGroupFormationDampingConfig(
       GROUP_FORMATION_DAMPING_MODES.join(', ')
     }. Received: ${value}`,
   );
+}
+
+export function readApiGroupFormationTopologyIntent(
+  outboxQueueReader: OutboxQueueReader,
+  env: EnvReader = Deno.env,
+): GroupPresenceSummaryTopologyIntent {
+  if (readApiGroupFormationDampingConfig(env).damping === 'legacy') {
+    return { damping: 'legacy' };
+  }
+  return {
+    damping: 'damped',
+    outboxQueueReader,
+    recomputeDebounceMs: readApiTopologyRecomputeDebounceMs(env) ??
+      DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
+  };
 }
 
 export function groupFormationDampingStartupLogLine(

--- a/apps/api-v1/src/runtime/group-formation/group-formation-damping-config.ts
+++ b/apps/api-v1/src/runtime/group-formation/group-formation-damping-config.ts
@@ -1,0 +1,40 @@
+import type { EnvReader } from '../../db/database-config.ts';
+
+export const GROUP_FORMATION_DAMPING_MODES = ['damped', 'legacy'] as const;
+
+export type GroupFormationDampingMode = typeof GROUP_FORMATION_DAMPING_MODES[number];
+
+export interface ApiGroupFormationDampingConfig {
+  readonly damping: GroupFormationDampingMode;
+}
+
+const GROUP_FORMATION_DAMPING_ENV = 'RALLAR_GROUP_FORMATION_DAMPING';
+
+export function readApiGroupFormationDampingConfig(
+  env: EnvReader = Deno.env,
+): ApiGroupFormationDampingConfig {
+  const raw = env.get(GROUP_FORMATION_DAMPING_ENV);
+  if (raw === undefined) return { damping: 'damped' };
+  const value = raw.trim();
+  if ((GROUP_FORMATION_DAMPING_MODES as readonly string[]).includes(value)) {
+    return { damping: value as GroupFormationDampingMode };
+  }
+  throw new Error(
+    `${GROUP_FORMATION_DAMPING_ENV} must be one of ${
+      GROUP_FORMATION_DAMPING_MODES.join(', ')
+    }. Received: ${value}`,
+  );
+}
+
+export function groupFormationDampingStartupLogLine(
+  config: ApiGroupFormationDampingConfig,
+): string {
+  return `Rallar API-v1 group formation damping: ${config.damping}`;
+}
+
+export function logGroupFormationDampingConfig(
+  log: (message: string) => void = console.log,
+  config: ApiGroupFormationDampingConfig = readApiGroupFormationDampingConfig(),
+): void {
+  log(groupFormationDampingStartupLogLine(config));
+}

--- a/apps/api-v1/src/services/client-state-service.ts
+++ b/apps/api-v1/src/services/client-state-service.ts
@@ -8,6 +8,9 @@ import {
 } from '@shared-server/rallar-system/services/client-state-service.ts';
 import { myServerId } from '../runtime/runtime-identity.ts';
 import {
+  readApiGroupFormationDampingConfig,
+} from '../runtime/group-formation/group-formation-damping-config.ts';
+import {
   createClientStateEventRepository,
   createRuntimeStateRepository,
 } from '../repository/createStateRepositories.ts';
@@ -27,6 +30,7 @@ export function getClientStateService(): ClientStateService {
 
   return createClientStateService({
     runtimeRepository,
+    formationDamping: readApiGroupFormationDampingConfig().damping,
     createClientStateEventStore: createClientStateEventRepository,
     serviceId: myServerId,
     timing: getApiTimingSink(),

--- a/apps/api-v1/src/services/group-state-service.ts
+++ b/apps/api-v1/src/services/group-state-service.ts
@@ -11,6 +11,9 @@ import {
   createRuntimeStateRepository,
 } from '../repository/createStateRepositories.ts';
 import { getApiTimingSink } from './timing-service.ts';
+import {
+  readApiGroupFormationDampingConfig,
+} from '../runtime/group-formation/group-formation-damping-config.ts';
 
 export { createGroupStateService, type GroupStateService, type GroupStateServiceDependencies };
 
@@ -23,6 +26,7 @@ export function getGroupStateService(): ApiGroupStateService {
   const runtimeRepository = createRuntimeStateRepository();
   const durable = createGroupStateService({
     runtimeRepository,
+    formationDamping: readApiGroupFormationDampingConfig().damping,
     authSessionRepository: createAuthSessionRepository(runtimeRepository),
     createGroupStateEventStore: createGroupStateEventRepository,
     serviceId: myServerId,

--- a/apps/api-v1/src/services/rtc-topology-config.ts
+++ b/apps/api-v1/src/services/rtc-topology-config.ts
@@ -20,6 +20,10 @@ export function getApiRtcTopologyServiceOptions(
       env,
       'RALLAR_RTC_TOPOLOGY_RTT_REBUILD_DEBOUNCE_MS',
     ),
+    topologyRecomputeDebounceMs: readNonNegativeIntegerEnv(
+      env,
+      'RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS',
+    ),
   });
 }
 

--- a/apps/api-v1/src/services/rtc-topology-config.ts
+++ b/apps/api-v1/src/services/rtc-topology-config.ts
@@ -20,11 +20,13 @@ export function getApiRtcTopologyServiceOptions(
       env,
       'RALLAR_RTC_TOPOLOGY_RTT_REBUILD_DEBOUNCE_MS',
     ),
-    topologyRecomputeDebounceMs: readNonNegativeIntegerEnv(
-      env,
-      'RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS',
-    ),
   });
+}
+
+export function readApiTopologyRecomputeDebounceMs(
+  env: EnvReader = Deno.env,
+): number | undefined {
+  return readNonNegativeIntegerEnv(env, 'RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS');
 }
 
 function compactOptions(

--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
@@ -146,6 +146,7 @@ Deno.test('PGlite group presence completion can precede its causal summary revis
     const groupRef = { ...SCOPE, groupId };
     const outboxReader = new OutboxQueueReader(new PSqlQueueBox(harness.resourceInbox));
     const summaryWork = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: harness.runtime,
       database: sql,
       serviceId: 'pglite-close-test',

--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
@@ -49,6 +49,7 @@ export async function createPGliteAppInboxWsCloseHarness(sql: PGliteSql) {
   const groupEvents = createGroupStateEventRepository(runtime);
   const clientState = createClientStateService({
     runtimeRepository: runtime,
+    formationDamping: 'damped',
     createClientStateEventStore: createClientStateEventRepository,
     serviceId: 'pglite-close-test',
   });

--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-test-harness.ts
@@ -54,6 +54,7 @@ export async function createPGliteAppInboxWsCloseHarness(sql: PGliteSql) {
   });
   const groupState = createGroupStateService({
     runtimeRepository: runtime,
+    formationDamping: 'damped',
     createGroupStateEventStore: createGroupStateEventRepository,
     authSessionRepository: authSessions,
     serviceId: 'pglite-close-test',

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -72,6 +72,9 @@ import {
   groupStatePresenceSessionStorageKey,
 } from '@shared-server/rallar-system/group-state-storage-keys.ts';
 import { CoalescedAppOutboxWorkService } from '@shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts';
+import {
+  computeCoalescedRtcTopologyGroupRevisionWork,
+} from '@shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts';
 import { AppOutboxType } from '@shared-server/rallar-system/services/AppOutboxService.ts';
 import {
   ClientStateEventCollisionError,
@@ -4926,6 +4929,134 @@ Deno.test('transaction-bound APP_OUTBOX coalescing revives finished work in plac
     assert.equal(staleExpected.action, 'successor');
     assert.equal((await repository.findByKey(first.key))?.resource, revivedEntry.resource);
     assert.equal((await repository.findByKey(successor.key))?.resource, successor.resource);
+  });
+});
+
+Deno.test('PGlite topology gates skip unchanged coalesced group-revision rebuilds and fail open', async () => {
+  await withPGliteSql(async (sql) => {
+    const nowEpochMs = await readPGliteDatabaseEpochMs(sql);
+    const groupRef = {
+      applicationId: 'fingerprint-gate',
+      workspaceId: 'atomic-work',
+      groupId: 'room',
+    };
+    let currentSnapshot = topologyGroupSnapshotWithSessionIds(
+      groupRef,
+      ['session-a', 'session-b'],
+      nowEpochMs,
+    );
+    const runtimeRepository = new PSqlRuntimeStateRepository(sql);
+    const topologyService = new RallarRtcTopologyService({ now: () => nowEpochMs });
+    const topologyManagement = new GroupTopologyManagementService({
+      findGroupSnapshotByRef: () => currentSnapshot,
+      topologyService,
+      topologySnapshotRepository: new RtcTopologySnapshotRepository(runtimeRepository),
+      processRttReader: () => [],
+      now: () => nowEpochMs,
+    });
+    const executionRepository = new RtcTopologyExecutionRepository(
+      runtimeRepository,
+      60_000,
+      () => nowEpochMs,
+    );
+    const resourceInbox = new ResourceInboxRepository(sql);
+    const queue = new PSqlQueueBox(resourceInbox);
+    const coalescedService = new CoalescedAppOutboxWorkService(
+      new OutboxQueueReader(queue),
+      'fingerprint-gate-worker',
+      () => nowEpochMs,
+    );
+    const handler = createRtcTopologyWorkHandler({
+      runtime: createRtcTopologyOutboxPublisher({
+        outboxQueueReader: new OutboxQueueReader(queue),
+        senderId: 'fingerprint-gate-worker',
+        now: () => nowEpochMs,
+      }),
+      database: sql,
+      topologyManagement,
+      executionRepository,
+    });
+    const toCoalescedComputed = (snapshot: GroupSnapshot, previousEntry: ResourceEntry | null) =>
+      computeCoalescedRtcTopologyGroupRevisionWork({
+        aggregateRef: groupRef,
+        groupSnapshot: snapshot,
+        requestedAtEpochMs: nowEpochMs,
+        expireAtEpochMs: FUTURE_MS,
+        recomputeDebounceMs: 0,
+        senderId: 'fingerprint-gate-worker',
+        previousEntry,
+      });
+    const coalescedKey = toCoalescedComputed(currentSnapshot, null).entry.key;
+    const runCoalescedIntent = async (snapshot: GroupSnapshot) => {
+      currentSnapshot = snapshot;
+      const previousEntry = (await queue.getItem(coalescedKey)) ?? null;
+      const computed = toCoalescedComputed(snapshot, previousEntry);
+      await sql.begin(async (transaction) => await coalescedService.write(transaction, computed));
+      await sql`
+        update resource_inbox
+        set ri_status = 'RESERVED', ri_attempts = ri_attempts + 1,
+            start_ts = now() at time zone 'UTC', end_ts = null, next_ts = null
+        where ri_topic_id = ${coalescedKey.topicId}
+          and ri_resource_id = ${coalescedKey.resourceId}
+          and fk_ext_bank_id = ${coalescedKey.contextId}
+      `;
+      const reserved = await resourceInbox.findAnyByKey(coalescedKey);
+      assert.ok(reserved);
+      await handler.onMessage(JSON.parse(reserved.resource) as ALMessage, reserved);
+      return reserved.key;
+    };
+
+    const firstKey = await runCoalescedIntent(currentSnapshot);
+    assert.equal((await resourceInbox.findAnyByKey(firstKey))?.status, EntityStatus.COMPLETED);
+    let metrics = topologyService.readMetrics();
+    assert.equal(metrics.topologyPublishedCount, 1);
+    assert.equal(metrics.topologyRebuildSkippedFingerprintCount, 0);
+    assert.ok(await executionRepository.readTopologyInputFingerprint(groupRef));
+
+    await runCoalescedIntent(currentSnapshot);
+    metrics = topologyService.readMetrics();
+    assert.equal(metrics.topologyRebuildSkippedFingerprintCount, 1);
+    assert.equal(metrics.topologyPublishedCount, 1);
+    assert.equal(metrics.topologyUpdateCount, 1);
+
+    const mismatchedFingerprint = `sha256:${'0'.repeat(64)}`;
+    await sql.begin(async (transaction) =>
+      await executionRepository.writeTopologyInputFingerprint(
+        transaction,
+        groupRef,
+        mismatchedFingerprint,
+      )
+    );
+    await runCoalescedIntent(currentSnapshot);
+    metrics = topologyService.readMetrics();
+    assert.equal(metrics.topologyRebuildSkippedFingerprintCount, 1);
+    assert.equal(metrics.topologyPublishSkippedUnchangedCount, 1);
+    assert.equal(metrics.topologyPublishedCount, 1);
+    assert.equal(metrics.topologyUpdateCount, 2);
+    assert.notEqual(
+      await executionRepository.readTopologyInputFingerprint(groupRef),
+      mismatchedFingerprint,
+    );
+
+    await runCoalescedIntent(currentSnapshot);
+    metrics = topologyService.readMetrics();
+    assert.equal(metrics.topologyRebuildSkippedFingerprintCount, 2);
+    assert.equal(metrics.topologyUpdateCount, 2);
+
+    const grownSnapshot = topologyGroupSnapshotWithSessionIds(
+      groupRef,
+      ['session-a', 'session-b', 'session-c'],
+      nowEpochMs,
+    );
+    await runCoalescedIntent({
+      ...grownSnapshot,
+      stateRevision: 5,
+      causalRevision: { groupRevision: 2, presenceRevision: 3 },
+      group: { ...grownSnapshot.group, presenceVersion: 3 },
+    });
+    metrics = topologyService.readMetrics();
+    assert.equal(metrics.topologyPublishedCount, 2);
+    assert.equal(metrics.topologyUpdateCount, 3);
   });
 });
 

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -338,6 +338,11 @@ Deno.test('PGlite AppGroup commits group mutation and summary fan-out through fe
       },
     );
     const summaryWork = new GroupPresenceSummaryWork({
+      topologyIntent: {
+        damping: 'damped',
+        outboxQueueReader: outboxReader,
+        recomputeDebounceMs: 0,
+      },
       runtimeRepository: runtime,
       database: sql,
       serviceId: 'pglite-group-service',
@@ -553,6 +558,7 @@ Deno.test('PGlite summary reservation fence rolls back CAS and every downstream 
     const repository = new GroupStateRepository(runtime);
     const summaryBefore = await repository.findPresenceSummaryEntry(ref);
     const work = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: runtime,
       database: sql,
       serviceId: 'pglite-summary-fence',
@@ -4853,6 +4859,73 @@ Deno.test('transaction-bound APP_OUTBOX coalescing fences generation and reserve
         error instanceof ResourceInboxInvariantCorruptionError &&
         error.code === 'resource-inbox-invariant-corruption',
     );
+  });
+});
+
+Deno.test('transaction-bound APP_OUTBOX coalescing revives finished work in place', async () => {
+  await withPGliteSql(async (sql) => {
+    const repository = new ResourceInboxRepository(sql);
+    const queue = new PSqlQueueBox(repository);
+    const service = new CoalescedAppOutboxWorkService(
+      new OutboxQueueReader(queue),
+      'rallar-server',
+      () => 500,
+    );
+    const first = (await service.enqueue({
+      type: AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,
+      topicId: 'app-outbox.rtc-topology',
+      resourceId: 'revive-overlay',
+      contextId: 'revive-room',
+      data: { overlayId: 'revive-overlay', revision: 1 },
+    })).entry;
+    const reserved = await queue.reserveEntries(
+      new Set([first.typeId]),
+      new Set([EntityStatus.NEW]),
+      { maxToReserve: 1, maxAttempts: 20 },
+    );
+    const observedReserved = [...reserved.values()][0];
+    assert.ok(observedReserved);
+    assert.ok(
+      await repository.finishReserved(
+        observedReserved.key,
+        observedReserved.dequeueAudit.attempts,
+        EntityStatus.COMPLETED,
+        new Date(600),
+      ),
+    );
+    const finished = await repository.findAnyByKey(first.key);
+    assert.equal(finished?.status, EntityStatus.COMPLETED);
+
+    const revivedEntry = advanceCoalescedGeneration({ ...first, resource: finished!.resource }, 2);
+    const successor = createResourceEntry('revive-successor', {
+      topicId: first.key.topicId,
+      contextId: first.key.contextId,
+      typeId: first.typeId,
+      payload: { generation: 2, kind: 'successor' },
+    });
+    const revived = await sql.begin(async (transaction) =>
+      await service.write(transaction, {
+        expectedEntry: finished!,
+        entry: revivedEntry,
+        successorEntry: successor,
+      })
+    );
+    assert.equal(revived.action, 'updated');
+    const stored = await repository.findByKey(first.key);
+    assert.equal(stored?.status, EntityStatus.NEW);
+    assert.equal(stored?.resource, revivedEntry.resource);
+    assert.equal(stored?.dequeueAudit.attempts, 0);
+
+    const staleExpected = await sql.begin(async (transaction) =>
+      await service.write(transaction, {
+        expectedEntry: finished!,
+        entry: revivedEntry,
+        successorEntry: successor,
+      })
+    );
+    assert.equal(staleExpected.action, 'successor');
+    assert.equal((await repository.findByKey(first.key))?.resource, revivedEntry.resource);
+    assert.equal((await repository.findByKey(successor.key))?.resource, successor.resource);
   });
 });
 

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -74,7 +74,7 @@ import {
 import { CoalescedAppOutboxWorkService } from '@shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts';
 import {
   computeCoalescedRtcTopologyGroupRevisionWork,
-} from '@shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts';
+} from '@shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts';
 import { AppOutboxType } from '@shared-server/rallar-system/services/AppOutboxService.ts';
 import {
   ClientStateEventCollisionError,

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -726,6 +726,7 @@ Deno.test('PGlite client write commits state, event, and ResourceInbox rows in o
     const repository = new ClientStateRepository(runtime, { events });
     const service = createClientStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createClientStateEventStore: () => events,
       serviceId: 'pglite-client-service',
     });
@@ -761,6 +762,7 @@ Deno.test('PGlite client write commits state, event, and ResourceInbox rows in o
           eventId: `${commandId}-event`,
           attemptCount: 1,
           expireAtEpochMs: FUTURE_MS,
+          formationDamping: 'damped',
         },
         toClientMutationIssuedSessionAuthority(authority, scope, 'upsertPrincipal'),
       );
@@ -820,6 +822,7 @@ async function createPGliteClientEventCollisionFixture(
   const repository = new ClientStateRepository(runtime, { events });
   const service = createClientStateService({
     runtimeRepository: runtime,
+    formationDamping: 'damped',
     createClientStateEventStore: () => events,
     serviceId: 'pglite-client-service',
   });
@@ -852,6 +855,7 @@ async function createPGliteClientEventCollisionFixture(
         eventId,
         attemptCount: 1,
         expireAtEpochMs: FUTURE_MS,
+        formationDamping: 'damped',
       },
       toClientMutationIssuedSessionAuthority(authority, scope, operation),
     );

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -319,6 +319,7 @@ Deno.test('PGlite AppGroup commits group mutation and summary fan-out through fe
     await authSessions.putSession(authority);
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-group-service',
@@ -477,6 +478,7 @@ Deno.test('PGlite summary reservation fence rolls back CAS and every downstream 
     await authSessions.putSession(authority);
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-summary-fence',
@@ -1556,6 +1558,7 @@ Deno.test('PGlite AppGroup retries cross-target topology CAS conflicts through R
     });
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-topology-cross-target',
@@ -1699,6 +1702,7 @@ Deno.test('PGlite AppGroup reuses the first durable topology command and rejects
     for (const member of snapshot.members) await groupRepository.putMember(member);
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-app-inbox-topology',
@@ -2235,6 +2239,7 @@ Deno.test('PGlite topology route preserves structured AppInbox terminal and unav
     for (const member of snapshot.members) await groupRepository.putMember(member);
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-topology-route-errors',
@@ -2448,6 +2453,7 @@ Deno.test('PGlite AppGroup rereads lifecycle after a retryable topology conflict
     );
     const groupState = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: authSessions,
       serviceId: 'pglite-topology-retry',
@@ -3433,6 +3439,7 @@ Deno.test('PGlite group-state reads reject complete-contract corruption across p
       const runtime = new PSqlRuntimeStateRepository(sql);
       const service = createGroupStateService({
         runtimeRepository: runtime,
+        formationDamping: 'damped',
         createGroupStateEventStore: createGroupStateEventRepository,
         authSessionRepository: {
           findBySessionId: (sessionId) =>
@@ -3780,6 +3787,7 @@ Deno.test('PGlite group event collision rolls back the authoritative mutation tr
     const persistedAuthority = await toPersistedAuthSessionFixture(authority);
     const service = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: {
         findBySessionId: (sessionId) =>
@@ -3865,6 +3873,7 @@ Deno.test('PGlite group summary outbox collision rolls back state event and rece
     const persistedAuthority = await toPersistedAuthSessionFixture(authority);
     const service = createGroupStateService({
       runtimeRepository: runtime,
+      formationDamping: 'damped',
       createGroupStateEventStore: createGroupStateEventRepository,
       authSessionRepository: {
         findBySessionId: (sessionId) =>

--- a/apps/api-v1/test/services/group-state-service.test.ts
+++ b/apps/api-v1/test/services/group-state-service.test.ts
@@ -1601,6 +1601,7 @@ function createTestGroupStateService(
 > {
   const runtime = createTestGroupStateRuntime({
     runtimeRepository: new FakeRuntimeStateRepository(),
+    formationDamping: 'damped',
     syncPublisher,
     now: () => 1_000,
     serviceId: 'test-service',

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -75,6 +75,21 @@ for some Rallar Black Box runs.
 | `RALLAR_LOGIN_IP_RATE_LIMIT`   | No       | `30`     | Login attempts per client IP per 60 seconds. Must be a positive integer.                                                             |
 | `RALLAR_LOGIN_USER_RATE_LIMIT` | No       | `5`      | Login attempts per client IP plus username per 60 seconds. Must be a positive integer. Root memory-mode scripts raise this to `100`. |
 
+### Realtime Topology And Group Formation
+
+| Variable                                     | Required | Default   | Usage                                                                                                                                                                                                        |
+| -------------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RALLAR_GROUP_FORMATION_DAMPING`             | No       | `damped`  | Server damping for group formation. `damped` coalesces group-revision topology recomputes, gates rebuilds/publications on changed inputs, separates heartbeat lease renewals from presence revisions, and scopes principal state-sync audiences. `legacy` retains the pre-damping engine wholesale for rollback. |
+| `RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS`  | No       | `500`     | Debounce for coalesced group-revision topology recomputes. Non-negative integer; `0` makes coalesced work due immediately.                                                                                    |
+| `RALLAR_RTC_TOPOLOGY_RTT_REBUILD_DEBOUNCE_MS`| No       | `250`     | Debounce for RTT-driven topology rebuilds and the global-graph RTT recompute. Non-negative integer.                                                                                                          |
+| `RALLAR_RTC_TOPOLOGY_DEGREE_LIMIT`           | No       | `5`       | Maximum per-session degree used by topology planning. Positive integer.                                                                                                                                      |
+| `RALLAR_RTC_RTT_REPORTING_DEGREE_LIMIT`      | No       | Derived from the degree limit | Maximum peers per session for RTT reporting admission. Positive integer.                                                                                                                 |
+| `RALLAR_RTC_TOPOLOGY_TREE_MIN_SIZE`          | No       | `5`       | Smallest active-session count planned as a tree instead of a star. Positive integer.                                                                                                                         |
+| `RALLAR_RTC_TOPOLOGY_MESH_MIN_SIZE`          | No       | `16`      | Smallest active-session count planned as a mesh instead of a tree. Positive integer.                                                                                                                         |
+| `RALLAR_RTC_TOPOLOGY_MESH_PARAM_K`           | No       | `2`       | Mesh construction K parameter. Positive integer.                                                                                                                                                             |
+| `RALLAR_RTC_TOPOLOGY_REPLAY`                 | No       | `enabled` | Durable topology replay lane. Supported values: `enabled`, `disabled`.                                                                                                                                       |
+| `RALLAR_API_QUEUE_WORKERS`                   | No       | `enabled` | Queue workers on this process. `disabled` requires `RALLAR_SQL_BACKEND=postgres`.                                                                                                                            |
+
 ### Black Box Operator Tokens
 
 | Variable                                      | Required | Default      | Usage                                                                                                                                                         |

--- a/packages/shared-server/postgres/resource-inbox/ResourceInboxRepository.ts
+++ b/packages/shared-server/postgres/resource-inbox/ResourceInboxRepository.ts
@@ -1,12 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { Either } from '@shared/resilience/Either.ts';
-import {
-    COMPLETED_STATUSES,
-    EntityStatus,
-    isFailed,
-    type Key,
-    type ResourceEntry,
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type Key, type ResourceEntry, } from '@shared/queuebox/ResourceEntry.ts';
 import { DEFAULT_RESOURCE_INBOX_RETRY_POLICY } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import {
@@ -288,75 +282,6 @@ export class ResourceInboxRepository {
             );
         }
         return updated;
-    }
-
-    async replaceFinishedIfMatch(
-        expected: ResourceEntry,
-        next: ResourceEntry,
-        expectedGeneration: number,
-    ): Promise<ResourceEntry | null> {
-        if (
-            expected.key.topicId !== next.key.topicId ||
-            expected.key.resourceId !== next.key.resourceId ||
-            expected.key.contextId !== next.key.contextId ||
-            expected.typeId !== next.typeId ||
-            !(COMPLETED_STATUSES.has(expected.status) || isFailed(expected.status)) ||
-            ![EntityStatus.NEW, EntityStatus.RETRY].includes(next.status) ||
-            next.dequeueAudit.attempts !== 0 ||
-            !Number.isSafeInteger(expectedGeneration) ||
-            expectedGeneration < 1
-        ) {
-            throw new ResourceInboxInvariantCorruptionError(
-                next.key,
-                'Resource inbox finished replacement identity or lifecycle differs',
-            );
-        }
-
-        const rows = await this.sql<ResourceInboxRow[]>`
-            update resource_inbox
-            set ri_resource = ${next.resource},
-                ri_status = ${next.status},
-                next_ts = ${next.dequeueAudit.nextTs
-                    ? toPgTimestamp(next.dequeueAudit.nextTs)
-                    : null},
-                ri_attempts = 0,
-                start_ts = null,
-                end_ts = null,
-                expire_ts = ${toPgTimestamp(next.audit.expiryTs)}
-            where ri_topic_id = ${expected.key.topicId}
-              and ri_resource_id = ${expected.key.resourceId}
-              and fk_ext_bank_id = ${expected.key.contextId}
-              and ri_type_id = ${expected.typeId}
-              and ri_status = ${expected.status}
-              and ri_resource = ${expected.resource}
-              and (((ri_resource::jsonb #>> '{payload,resource}')::jsonb
-                    #>> '{data,__rallarCoalescedWork,generation}')::bigint) =
-                  ${expectedGeneration}
-            returning *
-        `;
-
-        if (rows.length === 0) {
-            return null;
-        }
-        if (rows.length !== 1) {
-            throw new ResourceInboxInvariantCorruptionError(
-                next.key,
-                'Resource inbox finished replacement returned an unexpected row count',
-            );
-        }
-
-        const revived = toDomain(rows[0]);
-        if (
-            revived.resource !== next.resource ||
-            revived.status !== next.status ||
-            revived.typeId !== next.typeId
-        ) {
-            throw new ResourceInboxInvariantCorruptionError(
-                next.key,
-                'Resource inbox finished replacement returned different content',
-            );
-        }
-        return revived;
     }
 
     async replace(entry: ResourceEntry): Promise<ResourceEntry> {

--- a/packages/shared-server/postgres/resource-inbox/ResourceInboxRepository.ts
+++ b/packages/shared-server/postgres/resource-inbox/ResourceInboxRepository.ts
@@ -1,6 +1,12 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { Either } from '@shared/resilience/Either.ts';
-import { EntityStatus, type Key, type ResourceEntry, } from '@shared/queuebox/ResourceEntry.ts';
+import {
+    COMPLETED_STATUSES,
+    EntityStatus,
+    isFailed,
+    type Key,
+    type ResourceEntry,
+} from '@shared/queuebox/ResourceEntry.ts';
 import { DEFAULT_RESOURCE_INBOX_RETRY_POLICY } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import {
@@ -282,6 +288,75 @@ export class ResourceInboxRepository {
             );
         }
         return updated;
+    }
+
+    async replaceFinishedIfMatch(
+        expected: ResourceEntry,
+        next: ResourceEntry,
+        expectedGeneration: number,
+    ): Promise<ResourceEntry | null> {
+        if (
+            expected.key.topicId !== next.key.topicId ||
+            expected.key.resourceId !== next.key.resourceId ||
+            expected.key.contextId !== next.key.contextId ||
+            expected.typeId !== next.typeId ||
+            !(COMPLETED_STATUSES.has(expected.status) || isFailed(expected.status)) ||
+            ![EntityStatus.NEW, EntityStatus.RETRY].includes(next.status) ||
+            next.dequeueAudit.attempts !== 0 ||
+            !Number.isSafeInteger(expectedGeneration) ||
+            expectedGeneration < 1
+        ) {
+            throw new ResourceInboxInvariantCorruptionError(
+                next.key,
+                'Resource inbox finished replacement identity or lifecycle differs',
+            );
+        }
+
+        const rows = await this.sql<ResourceInboxRow[]>`
+            update resource_inbox
+            set ri_resource = ${next.resource},
+                ri_status = ${next.status},
+                next_ts = ${next.dequeueAudit.nextTs
+                    ? toPgTimestamp(next.dequeueAudit.nextTs)
+                    : null},
+                ri_attempts = 0,
+                start_ts = null,
+                end_ts = null,
+                expire_ts = ${toPgTimestamp(next.audit.expiryTs)}
+            where ri_topic_id = ${expected.key.topicId}
+              and ri_resource_id = ${expected.key.resourceId}
+              and fk_ext_bank_id = ${expected.key.contextId}
+              and ri_type_id = ${expected.typeId}
+              and ri_status = ${expected.status}
+              and ri_resource = ${expected.resource}
+              and (((ri_resource::jsonb #>> '{payload,resource}')::jsonb
+                    #>> '{data,__rallarCoalescedWork,generation}')::bigint) =
+                  ${expectedGeneration}
+            returning *
+        `;
+
+        if (rows.length === 0) {
+            return null;
+        }
+        if (rows.length !== 1) {
+            throw new ResourceInboxInvariantCorruptionError(
+                next.key,
+                'Resource inbox finished replacement returned an unexpected row count',
+            );
+        }
+
+        const revived = toDomain(rows[0]);
+        if (
+            revived.resource !== next.resource ||
+            revived.status !== next.status ||
+            revived.typeId !== next.typeId
+        ) {
+            throw new ResourceInboxInvariantCorruptionError(
+                next.key,
+                'Resource inbox finished replacement returned different content',
+            );
+        }
+        return revived;
     }
 
     async replace(entry: ResourceEntry): Promise<ResourceEntry> {

--- a/packages/shared-server/postgres/resource-inbox/resource-inbox-finished-replacement.ts
+++ b/packages/shared-server/postgres/resource-inbox/resource-inbox-finished-replacement.ts
@@ -1,0 +1,90 @@
+import {
+    COMPLETED_STATUSES,
+    EntityStatus,
+    isFailed,
+    type ResourceEntry,
+} from '@shared/queuebox/ResourceEntry.ts';
+import type { PSqlTransactionSql } from '../PostgresSqlClient.ts';
+import { ResourceInboxInvariantCorruptionError } from './ResourceInboxRepository.ts';
+import { type ResourceInboxRow, toDomain, toPgTimestamp } from './repository-utils.ts';
+
+export interface ReplaceFinishedResourceEntryInput {
+    readonly expected: ResourceEntry;
+    readonly next: ResourceEntry;
+    readonly expectedGeneration: number;
+}
+
+/**
+ * Revives a terminally finished coalesced APP_OUTBOX row in place: an exact
+ * content, status, and stored-generation compare-and-set that resets the
+ * dequeue lifecycle to a fresh attempt. A miss returns null so the caller can
+ * fall back to a successor queue identity.
+ */
+export async function replaceFinishedResourceEntryIfMatch(
+    sql: PSqlTransactionSql,
+    input: ReplaceFinishedResourceEntryInput,
+): Promise<ResourceEntry | null> {
+    const { expected, next, expectedGeneration } = input;
+    if (
+        expected.key.topicId !== next.key.topicId ||
+        expected.key.resourceId !== next.key.resourceId ||
+        expected.key.contextId !== next.key.contextId ||
+        expected.typeId !== next.typeId ||
+        !(COMPLETED_STATUSES.has(expected.status) || isFailed(expected.status)) ||
+        ![EntityStatus.NEW, EntityStatus.RETRY].includes(next.status) ||
+        next.dequeueAudit.attempts !== 0 ||
+        !Number.isSafeInteger(expectedGeneration) ||
+        expectedGeneration < 1
+    ) {
+        throw new ResourceInboxInvariantCorruptionError(
+            next.key,
+            'Resource inbox finished replacement identity or lifecycle differs',
+        );
+    }
+
+    const rows = await sql<ResourceInboxRow[]>`
+        update resource_inbox
+        set ri_resource = ${next.resource},
+            ri_status = ${next.status},
+            next_ts = ${next.dequeueAudit.nextTs
+                ? toPgTimestamp(next.dequeueAudit.nextTs)
+                : null},
+            ri_attempts = 0,
+            start_ts = null,
+            end_ts = null,
+            expire_ts = ${toPgTimestamp(next.audit.expiryTs)}
+        where ri_topic_id = ${expected.key.topicId}
+          and ri_resource_id = ${expected.key.resourceId}
+          and fk_ext_bank_id = ${expected.key.contextId}
+          and ri_type_id = ${expected.typeId}
+          and ri_status = ${expected.status}
+          and ri_resource = ${expected.resource}
+          and (((ri_resource::jsonb #>> '{payload,resource}')::jsonb
+                #>> '{data,__rallarCoalescedWork,generation}')::bigint) =
+              ${expectedGeneration}
+        returning *
+    `;
+
+    if (rows.length === 0) {
+        return null;
+    }
+    if (rows.length !== 1) {
+        throw new ResourceInboxInvariantCorruptionError(
+            next.key,
+            'Resource inbox finished replacement returned an unexpected row count',
+        );
+    }
+
+    const revived = toDomain(rows[0]);
+    if (
+        revived.resource !== next.resource ||
+        revived.status !== next.status ||
+        revived.typeId !== next.typeId
+    ) {
+        throw new ResourceInboxInvariantCorruptionError(
+            next.key,
+            'Resource inbox finished replacement returned different content',
+        );
+    }
+    return revived;
+}

--- a/packages/shared-server/rallar-system/client-state/client-state-service-contracts.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service-contracts.ts
@@ -59,6 +59,7 @@ export type ClientStateWritten = Readonly<{
 
 export type ClientStateService = Readonly<{
   sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
+  formationDamping: 'damped' | 'legacy';
   listSnapshots(scope: ClientScope): Promise<readonly ClientSnapshot[]>;
   readSnapshot(ref: ClientPrincipalRef): Promise<ClientSnapshot | undefined>;
   readPresenceSnapshot(ref: ClientPrincipalRef): Promise<ClientPresenceSnapshot | undefined>;
@@ -95,6 +96,7 @@ export type ClientStateMutationService = Pick<
 
 export type ClientStateServiceDependencies = Readonly<{
   runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike;
+  formationDamping: 'damped' | 'legacy';
   createClientStateEventStore?: (
     runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike,
   ) => ClientStateEventStore;

--- a/packages/shared-server/rallar-system/client-state/client-state-service.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service.ts
@@ -30,6 +30,7 @@ export function createClientStateService(
     });
   const service: ClientStateService = {
     sessionGenerationLifecycle: createWsSessionGenerationLifecycleService(runtimeRepository),
+    formationDamping: dependencies.formationDamping,
     listSnapshots: async (scope) => await repositoryFor(runtimeRepository).listSnapshots(scope),
     readSnapshot: async (ref) => await repositoryFor(runtimeRepository).readSnapshot(ref),
     readPresenceSnapshot: async (ref) =>

--- a/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
@@ -81,6 +81,7 @@ export class AppClientInboxService extends AppInboxService {
       snapshotObserver: clientStateService,
       transactionWriter: this.transactionWriter,
       serviceId,
+      formationDamping: clientStateService.formationDamping,
     });
     this.registerClientStateMessages();
   }

--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -46,6 +46,7 @@ export interface ClientStateInboxHandlerDependencies {
   readonly snapshotObserver: Pick<ClientStateService, 'observeSnapshot'>;
   readonly transactionWriter: AppInboxMutationTransactionWriter;
   readonly serviceId: string;
+  readonly formationDamping: 'damped' | 'legacy';
 }
 
 export interface ClientStateInboxAfterCommitResult {
@@ -213,7 +214,7 @@ export class ClientStateInboxHandler {
   ): Promise<ClientMutationCommand> {
     return await toClientMutationCommand(
       input,
-      toClientMutationPersistedFacts(context, input.commandId, this.dependencies.serviceId),
+      toClientMutationPersistedFacts(context, input.commandId, this.dependencies),
       readClientMutationAuthority(context.enqueue.authority, input.operation),
     );
   }
@@ -347,11 +348,11 @@ export class ClientStateInboxHandler {
 function toClientMutationPersistedFacts(
   context: AppInboxMessageContext,
   commandId: string,
-  serviceId: string,
+  dependencies: Pick<ClientStateInboxHandlerDependencies, 'serviceId' | 'formationDamping'>,
 ): Omit<ClientMutationPersistedFacts, 'commandHash'> {
   return {
     nowEpochMs: context.message.id.ts,
-    serviceId,
+    serviceId: dependencies.serviceId,
     eventId: `client-event:${JSON.stringify([
       context.entry.key.contextId,
       context.entry.key.topicId,
@@ -359,6 +360,7 @@ function toClientMutationPersistedFacts(
     ])}`,
     attemptCount: context.entry.dequeueAudit.attempts,
     expireAtEpochMs: Number(context.entry.audit.expiryTs.epochMilliseconds),
+    formationDamping: dependencies.formationDamping,
   };
 }
 

--- a/packages/shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts
@@ -215,6 +215,7 @@ export type ClientMutationFacts = Readonly<{
   commandHash: string;
   attemptCount: number;
   expireAtEpochMs: number;
+  formationDamping: 'damped' | 'legacy';
 }>;
 
 export type ClientMutationCommandInput = ClientMutationCommand extends infer Command

--- a/packages/shared-server/rallar-system/client-state/mutation/command-validation/validate-client-mutation-command.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/command-validation/validate-client-mutation-command.ts
@@ -41,7 +41,15 @@ export function validateClientMutationFacts(facts: unknown): void {
   const value = requirePlainRecord(facts, 'Client mutation facts');
   requireExactKeys(
     value,
-    ['nowEpochMs', 'serviceId', 'eventId', 'commandHash', 'attemptCount', 'expireAtEpochMs'],
+    [
+      'nowEpochMs',
+      'serviceId',
+      'eventId',
+      'commandHash',
+      'attemptCount',
+      'expireAtEpochMs',
+      'formationDamping',
+    ],
     'Client mutation facts',
   );
   requireTimestamp(value.nowEpochMs, 'Client mutation facts.nowEpochMs');
@@ -50,6 +58,9 @@ export function validateClientMutationFacts(facts: unknown): void {
   requireSha256(value.commandHash, 'Client mutation facts.commandHash');
   requirePositiveSafeInteger(value.attemptCount, 'Client mutation facts.attemptCount');
   requireTimestamp(value.expireAtEpochMs, 'Client mutation facts.expireAtEpochMs');
+  if (value.formationDamping !== 'damped' && value.formationDamping !== 'legacy') {
+    rejectClientMutation('Client mutation facts.formationDamping is invalid');
+  }
   if ((value.expireAtEpochMs as number) <= (value.nowEpochMs as number)) {
     rejectClientMutation('Client mutation facts.expireAtEpochMs must follow nowEpochMs');
   }

--- a/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-mutation-result.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-mutation-result.ts
@@ -50,7 +50,11 @@ export function computeClientMutationResult(
   });
   const stateSync = toClientStateSync(command, snapshot, event);
   const outboxEntries = stateSync.flatMap((computed) =>
-    computeClientStateSyncEntries(computed, facts.serviceId),
+    computeClientStateSyncEntries(
+      computed,
+      facts.serviceId,
+      facts.formationDamping === 'damped' ? 'principal' : 'world',
+    ),
   );
   const receipt = toAppliedClientMutationReceipt({
     command,

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
@@ -127,7 +127,11 @@ function validateClientMutationOutbox(
   computed: Extract<ClientMutationComputed, { outcome: 'write' }>,
 ): void {
   const expectedOutboxEntries = computed.stateSync.flatMap((stateSync) =>
-    computeClientStateSyncEntries(stateSync, command.facts.serviceId),
+    computeClientStateSyncEntries(
+      stateSync,
+      command.facts.serviceId,
+      command.facts.formationDamping === 'damped' ? 'principal' : 'world',
+    ),
   );
   if (
     JSON.stringify(expectedOutboxEntries) !== JSON.stringify(computed.outboxEntries) ||

--- a/packages/shared-server/rallar-system/group-state/group-mutation-authority.ts
+++ b/packages/shared-server/rallar-system/group-state/group-mutation-authority.ts
@@ -41,6 +41,7 @@ export interface GroupMutationAuthorityDependencies {
   readonly now: () => number;
   readonly randomId: () => string;
   readonly serviceId: string;
+  readonly formationDamping: 'damped' | 'legacy';
   readonly readCausalRevision: (ref: GroupRef) => Promise<GroupStateCausalRevision | undefined>;
 }
 
@@ -91,6 +92,7 @@ export async function prepareGroupMutation(
     resolvedJoinCode,
     joinCodeVerifier: await toJoinCodeVerifier(resolvedJoinCode),
     internalAuthority: 'none',
+    formationDamping: dependencies.formationDamping,
     authenticatedAuthority: {
       principalId: verified.session.clientId,
       sessionId: verified.session.sessionId,

--- a/packages/shared-server/rallar-system/group-state/group-state-service-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/group-state-service-contracts.ts
@@ -192,6 +192,7 @@ export type GroupStateRuntime = Readonly<{
 
 export type GroupStateServiceDependencies = Readonly<{
   runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike;
+  formationDamping: 'damped' | 'legacy';
   createGroupStateEventStore?: (
     runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike,
   ) => GroupStateEventStore;

--- a/packages/shared-server/rallar-system/group-state/group-state-service.ts
+++ b/packages/shared-server/rallar-system/group-state/group-state-service.ts
@@ -115,6 +115,7 @@ function createAuthorityDependencies(
     now,
     randomId,
     serviceId: dependencies.serviceId,
+    formationDamping: dependencies.formationDamping,
     readCausalRevision: async (ref) =>
       await repositoryFor(dependencies.runtimeRepository).readCausalRevision(ref),
   };
@@ -135,6 +136,7 @@ function createInternalMutationPreparer(
       resolvedJoinCode: null,
       joinCodeVerifier: null,
       internalAuthority,
+      formationDamping: dependencies.formationDamping,
       authenticatedAuthority: null,
     };
     const causalToken = await sha256CanonicalJson({ command, facts });

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
@@ -72,9 +72,8 @@ export class GroupStateInboxHandler {
         sessionGenerationLifecycle: this.dependencies.sessionGenerationLifecycle,
       });
       if (outcome.status === 'inactive') {
-        const durableResult = await this.dependencies.transactionWriter.writeMutation(
-          context,
-          () => Promise.resolve(outcome),
+        const durableResult = await this.dependencies.transactionWriter.writeMutation(context, () =>
+          Promise.resolve(outcome),
         );
         this.recordGroupMutation(command, 'rejected');
         return durableResult;

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
@@ -91,6 +91,7 @@ export function computeCreate(
     initialPresenceSummary: toInitialGroupPresenceSummaryCandidate(summary, read.presenceSummary),
     presenceAdmission: null,
     eventType: 'group-created',
+    presenceSummaryWork: 'enqueue',
   });
 }
 
@@ -235,6 +236,7 @@ function groupWrite(input: GroupWriteInput): GroupMutationComputed {
     members: [],
     initialPresenceSummary: null,
     eventType,
+    presenceSummaryWork: 'enqueue',
   });
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -235,6 +235,7 @@ export type GroupMutationFacts = Readonly<{
   resolvedJoinCode: string | null;
   joinCodeVerifier: string | null;
   internalAuthority: 'none' | 'expiry' | 'session-cleanup';
+  formationDamping: 'damped' | 'legacy';
   authenticatedAuthority: Readonly<{
     principalId: string;
     sessionId: string;
@@ -300,7 +301,7 @@ export type GroupMutationComputed =
       event: GroupEvent;
       receipt: GroupMutationReceipt;
       idempotency: GroupMutationIdempotencyRecord | null;
-      outboxEntries: readonly [ResourceEntry];
+      outboxEntries: readonly ResourceEntry[];
     }>;
 
 export type GroupMutationComputedWrite = Extract<GroupMutationComputed, { outcome: 'write' }>;

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
@@ -20,6 +20,7 @@ import type {
   GroupMutationCommand,
   GroupMutationComputed,
   GroupMutationFacts,
+  GroupMutationIdempotencyRecord,
   GroupMutationRead,
   GroupMutationReceipt,
   PresenceAdmissionCandidate,
@@ -43,6 +44,7 @@ export interface GroupMutationWriteInput {
   readonly presenceAdmission?: PresenceAdmissionCandidate | null;
   readonly eventType: GroupEventType;
   readonly eventGroup?: Group;
+  readonly presenceSummaryWork: 'enqueue' | 'none';
 }
 
 export interface RejectedGroupMutationInput {
@@ -89,18 +91,23 @@ export function computeGroupMutationWriteResult(
     command,
     facts,
   });
-  const outboxEntry = computeGroupPresenceSummaryEntry(
-    {
-      effectKind: 'group-presence-summary',
-      aggregateRef: command.aggregateRef,
-      commandId: command.commandId,
-      createdAtEpochMs: facts.nowEpochMs,
-      expireAtEpochMs: facts.expireAtEpochMs,
-      acceptedCausalRevision: causalRevision,
-      event,
-    },
-    facts.serviceId,
-  );
+  const outboxEntries =
+    input.presenceSummaryWork === 'none'
+      ? []
+      : [
+          computeGroupPresenceSummaryEntry(
+            {
+              effectKind: 'group-presence-summary',
+              aggregateRef: command.aggregateRef,
+              commandId: command.commandId,
+              createdAtEpochMs: facts.nowEpochMs,
+              expireAtEpochMs: facts.expireAtEpochMs,
+              acceptedCausalRevision: causalRevision,
+              event,
+            },
+            facts.serviceId,
+          ),
+        ];
   const receipt = receiptFor(command, facts, {
     outcome: 'applied',
     causalRevision,
@@ -108,18 +115,9 @@ export function computeGroupMutationWriteResult(
     acceptedStorageRevision:
       input.guard.operation === 'insert' ? 0 : input.guard.expectedRevision + 1,
     eventId: event.eventId,
-    outboxIds: [outboxEntry.key.resourceId],
+    outboxIds: outboxEntries.map((outboxEntry) => outboxEntry.key.resourceId),
     rejection: null,
   });
-  const idempotency =
-    command.requestId === null
-      ? null
-      : {
-          aggregateRef: command.aggregateRef,
-          requestId: command.requestId,
-          commandHash: facts.commandHash,
-          receipt,
-        };
   return {
     outcome: 'write',
     guard: input.guard,
@@ -128,8 +126,22 @@ export function computeGroupMutationWriteResult(
     presenceAdmission: input.presenceAdmission ?? null,
     event,
     receipt,
-    idempotency,
-    outboxEntries: [outboxEntry],
+    idempotency: toGroupMutationIdempotency(command, facts, receipt),
+    outboxEntries,
+  };
+}
+
+function toGroupMutationIdempotency(
+  command: GroupMutationCommand,
+  facts: GroupMutationFacts,
+  receipt: GroupMutationReceipt,
+): GroupMutationIdempotencyRecord | null {
+  if (command.requestId === null) return null;
+  return {
+    aggregateRef: command.aggregateRef,
+    requestId: command.requestId,
+    commandHash: facts.commandHash,
+    receipt,
   };
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts
@@ -121,6 +121,7 @@ export function validateFacts(facts: GroupMutationFacts): void {
       'resolvedJoinCode',
       'joinCodeVerifier',
       'internalAuthority',
+      'formationDamping',
       'authenticatedAuthority',
       'attemptCount',
     ],
@@ -140,6 +141,9 @@ export function validateFacts(facts: GroupMutationFacts): void {
   }
   if (!['none', 'expiry', 'session-cleanup'].includes(facts.internalAuthority)) {
     throw new TypeError('Group mutation internal authority is invalid');
+  }
+  if (!['damped', 'legacy'].includes(facts.formationDamping)) {
+    throw new TypeError('Group mutation formation damping is invalid');
   }
   validateAuthenticatedAuthority(facts.authenticatedAuthority);
   validateResolvedJoinCodePair(facts);

--- a/packages/shared-server/rallar-system/group-state/mutation/presence/compute-group-presence-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/presence/compute-group-presence-mutation.ts
@@ -226,7 +226,29 @@ export function computeHeartbeatPresence(
     session,
     operation: 'update',
     eventType: 'session-heartbeat',
+    presenceSummaryWork: isPureLeaseRenewalHeartbeat(command, read, facts) ? 'none' : 'enqueue',
   });
+}
+
+/**
+ * A pure lease renewal keeps the session row, event, and receipt but must not
+ * expand a presence summary: the session is already listed by the stored
+ * summary and its lease had not lapsed at read time, so no online/offline
+ * transition can be observed. Anything not provably pure — including a
+ * lapsed-lease revival — expands as before. Legacy mode never classifies.
+ */
+export function isPureLeaseRenewalHeartbeat(
+  command: Extract<GroupMutationCommand, { operation: 'heartbeatPresence' }>,
+  read: GroupMutationRead,
+  facts: GroupMutationFacts,
+): boolean {
+  if (facts.formationDamping !== 'damped') return false;
+  const existing = read.targetPresence;
+  return (
+    existing !== null &&
+    existing.value.expiresAtEpochMs > facts.nowEpochMs &&
+    (read.presenceSummary?.value.activeSessionIds ?? []).includes(command.sessionId)
+  );
 }
 
 export function computeDisconnectPresence(
@@ -304,6 +326,7 @@ interface PresenceWriteInput {
   readonly eventType: GroupEventType;
   readonly presenceAdmission?:
     import('../group-mutation-contracts.ts').PresenceAdmissionCandidate | null;
+  readonly presenceSummaryWork?: 'enqueue' | 'none';
 }
 
 function presenceWrite({
@@ -314,6 +337,7 @@ function presenceWrite({
   operation,
   eventType,
   presenceAdmission = null,
+  presenceSummaryWork = 'enqueue',
 }: PresenceWriteInput): GroupMutationComputed {
   const stored = requireGroup(read, command.aggregateRef);
   const guard =
@@ -345,6 +369,7 @@ function presenceWrite({
     eventType,
     eventGroup: stored.value,
     presenceAdmission,
+    presenceSummaryWork,
   });
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation-write.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation-write.ts
@@ -15,6 +15,10 @@ import {
   resolveGroupMutationTargetPrincipalId,
   resolveGroupMutationTargetSessionId,
 } from '../orchestration/resolve-group-mutation-target-identity.ts';
+// prettier-ignore
+import {
+  isPureLeaseRenewalHeartbeat,
+} from '../presence/compute-group-presence-mutation.ts';
 import {
   validateGroupMutationIdempotencyRecord,
   validateMutationReceipt,
@@ -53,7 +57,7 @@ export function validateComputedWrite(input: ValidateComputedWriteInput): void {
   validateComputedInitialPresenceSummary(input);
   validateComputedPresenceAdmission(input);
   validateComputedEventAndReceipt(input);
-  validateComputedOutboxEntries(input.command, input.facts, input.computed);
+  validateComputedOutboxEntries(input);
 }
 
 function validateComputedGuard({
@@ -304,12 +308,20 @@ function expectedMutationMemberPrincipalIds(
   }
 }
 
-export function validateComputedOutboxEntries(
-  command: GroupMutationCommand,
-  facts: GroupMutationFacts,
-  computed: Extract<GroupMutationComputed, { outcome: 'write' }>,
-): void {
-  if (!Array.isArray(computed.outboxEntries) || computed.outboxEntries.length !== 1) {
+export function validateComputedOutboxEntries(input: ValidateComputedWriteInput): void {
+  const { command, read, facts, computed } = input;
+  if (!Array.isArray(computed.outboxEntries)) {
+    throw new TypeError('Group mutation computed outbox entries must be an array');
+  }
+  const pureLeaseRenewal =
+    command.operation === 'heartbeatPresence' && isPureLeaseRenewalHeartbeat(command, read, facts);
+  if (pureLeaseRenewal) {
+    if (computed.outboxEntries.length !== 0 || computed.receipt.outboxIds.length !== 0) {
+      throw new TypeError('A pure lease renewal must not expand a presence summary');
+    }
+    return;
+  }
+  if (computed.outboxEntries.length !== 1) {
     throw new TypeError('Group mutation must compute one presence-summary outbox entry');
   }
   const expected = computeGroupPresenceSummaryEntry(

--- a/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-group-mutation-result.ts
@@ -201,7 +201,7 @@ function validateAppliedReceipt({
   }
   requirePositiveSafeInteger(receipt.snapshotVersion, `${label} applied snapshotVersion`);
   requirePositiveSafeInteger(causalRevision.groupRevision, `${label} applied groupRevision`);
-  if (outboxIds.length !== 1) {
+  if (outboxIds.length > 1) {
     throw new TypeError(`${label} outboxIds differs from applied outcome`);
   }
 }

--- a/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation.ts
@@ -61,7 +61,12 @@ export function validateGroupMutation(
     if (input.computed.presenceAdmission) {
       validatePresenceAdmission(input.computed.presenceAdmission.value);
     }
-    validateComputedOutboxEntries(input.command, input.facts, input.computed);
+    validateComputedOutboxEntries({
+      command: input.command,
+      read: input.read,
+      facts: input.facts,
+      computed: input.computed,
+    });
     if (input.computed.event.eventId !== receipt.eventId) {
       throw new TypeError('Group mutation receipt event differs from write event');
     }

--- a/packages/shared-server/rallar-system/group-state/mutation/write/compute-group-membership-write.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/compute-group-membership-write.ts
@@ -56,6 +56,7 @@ export function computeGroupMembershipWrite({
     initialPresenceSummary: null,
     presenceAdmission: computeMemberPresenceAdmission({ read, members, facts }),
     eventType,
+    presenceSummaryWork: 'enqueue',
   });
 }
 

--- a/packages/shared-server/rallar-system/group-state/persistence/assemble-group-state-snapshot.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/assemble-group-state-snapshot.ts
@@ -19,6 +19,14 @@ export type GroupStateSnapshotAssemblyInput = Readonly<{
   authoritativeSessions: readonly GroupPresenceSession[];
   groupRevision: number;
   observedAtEpochMs: number;
+  /**
+   * 'authoritative' carries the liveness plane without revision movement:
+   * emitted sessions take lastHeartbeatAtEpochMs/expiresAtEpochMs from the
+   * authoritative rows, so a summary frozen at the last transition stays
+   * truthful between transitions. 'summary-frozen' reproduces the stored
+   * summary copies bit-for-bit.
+   */
+  sessionLeaseFields: 'summary-frozen' | 'authoritative';
 }>;
 
 export interface GroupStateScopeSnapshotRead {
@@ -107,18 +115,33 @@ function readActiveSessions(
   const authoritativeSessionsById = new Map(
     input.authoritativeSessions.map((session) => [session.sessionId, session]),
   );
-  return toActiveSessions(input.summary?.activeSessions ?? [], input.observedAtEpochMs)
+  const summarySessions =
+    input.sessionLeaseFields === 'authoritative'
+      ? (input.summary?.activeSessions ?? [])
+      : toActiveSessions(input.summary?.activeSessions ?? [], input.observedAtEpochMs);
+  return summarySessions
     .filter((session) => activeMemberIds.has(session.principalId))
-    .filter((session) => {
+    .flatMap((session) => {
       const authoritative = authoritativeSessionsById.get(session.sessionId);
-      return (
-        authoritative !== undefined &&
-        authoritative.principalId === session.principalId &&
-        authoritative.generationId === session.generationId &&
-        authoritative.generationVersion === session.generationVersion &&
-        authoritative.disconnectedAtEpochMs === null &&
-        isLogicallyActiveSession(authoritative.expiresAtEpochMs, input.observedAtEpochMs)
-      );
+      if (
+        authoritative === undefined ||
+        authoritative.principalId !== session.principalId ||
+        authoritative.generationId !== session.generationId ||
+        authoritative.generationVersion !== session.generationVersion ||
+        authoritative.disconnectedAtEpochMs !== null ||
+        session.disconnectedAtEpochMs !== null ||
+        !isLogicallyActiveSession(authoritative.expiresAtEpochMs, input.observedAtEpochMs)
+      ) {
+        return [];
+      }
+      if (input.sessionLeaseFields === 'summary-frozen') return [session];
+      return [
+        {
+          ...session,
+          lastHeartbeatAtEpochMs: authoritative.lastHeartbeatAtEpochMs,
+          expiresAtEpochMs: authoritative.expiresAtEpochMs,
+        },
+      ];
     });
 }
 

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-snapshot-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-snapshot-repository.ts
@@ -87,6 +87,7 @@ export abstract class GroupStateSnapshotRepository extends RuntimeStateJsonStore
           authoritativeSessions: read.sessionsByGroupId.get(stored.value.groupId) ?? [],
           groupRevision: stored.value.snapshotVersion,
           observedAtEpochMs,
+          sessionLeaseFields: 'authoritative',
         });
       }),
     );
@@ -173,6 +174,7 @@ export abstract class GroupStateSnapshotRepository extends RuntimeStateJsonStore
           authoritativeSessions: candidate.sessions,
           groupRevision: after.value.snapshotVersion,
           observedAtEpochMs,
+          sessionLeaseFields: 'authoritative',
         });
       }),
     );
@@ -255,6 +257,7 @@ export abstract class GroupStateSnapshotRepository extends RuntimeStateJsonStore
           ),
           groupRevision: stored.value.snapshotVersion,
           observedAtEpochMs,
+          sessionLeaseFields: 'authoritative',
         }),
         authorityGuard: toGroupStateAuthorityGuard(ref, stored),
       };
@@ -278,6 +281,7 @@ export abstract class GroupStateSnapshotRepository extends RuntimeStateJsonStore
           authoritativeSessions: presence.sessions,
           groupRevision: stored.value.snapshotVersion,
           observedAtEpochMs,
+          sessionLeaseFields: 'authoritative',
         }),
         authorityGuard: toGroupStateAuthorityGuard(ref, stored),
       }),

--- a/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
@@ -7,6 +7,7 @@ import type {
   GroupRef,
 } from '@shared/api/group-types.ts';
 import { compareGroupCausalRevision } from '@shared/api/group-client-views.ts';
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
 import { jsonEquals } from '@shared/repository/state-utils.ts';
 import {
@@ -40,6 +41,7 @@ export type GroupPresenceSummaryRead = Readonly<{
   admissions: readonly RuntimeStateEntryValue<GroupPresenceAdmission>[];
   presenceSessions: readonly RuntimeStateEntryValue<GroupPresenceSession>[];
   current: RuntimeStateEntryValue<GroupPresenceSummary> | null;
+  coalescedTopologyEntry: ResourceEntry | null;
 }>;
 
 export type GroupPresenceSummaryComputed =
@@ -117,12 +119,12 @@ export function validateGroupPresenceSummary(
   requireJsonSafe(computed, 'Group presence summary computed result');
   assertExactKeys(
     read,
-    ['group', 'members', 'admissions', 'presenceSessions', 'current'],
+    ['group', 'members', 'admissions', 'presenceSessions', 'current', 'coalescedTopologyEntry'],
     'Group presence summary read',
   );
   assertRequiredKeys(
     read,
-    ['group', 'members', 'admissions', 'presenceSessions', 'current'],
+    ['group', 'members', 'admissions', 'presenceSessions', 'current', 'coalescedTopologyEntry'],
     'Group presence summary read',
   );
   validateRuntimeEntryValue(read.group, 'Stored summary group', groupStateGroupStorageKey(ref));

--- a/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
@@ -66,6 +66,7 @@ interface GroupPresenceSummaryValidation {
   readonly groupRevision: number;
   readonly current: GroupPresenceSummary | undefined;
   readonly expectedNoOp: boolean;
+  readonly formationDamping: 'damped' | 'legacy';
 }
 
 export function computeGroupPresenceSummary(
@@ -73,9 +74,10 @@ export function computeGroupPresenceSummary(
     ref: GroupRef;
     read: GroupPresenceSummaryRead;
     nowEpochMs: number;
+    formationDamping: 'damped' | 'legacy';
   }>,
 ): GroupPresenceSummaryComputed {
-  const { ref, read, nowEpochMs } = input;
+  const { ref, read, nowEpochMs, formationDamping } = input;
   const content = deriveGroupPresenceSummaryContent(read, nowEpochMs);
   const groupRevision = read.group.value.snapshotVersion;
   const current = read.current?.value;
@@ -83,7 +85,10 @@ export function computeGroupPresenceSummary(
     current &&
     (current.causalRevision.groupRevision > groupRevision ||
       (current.causalRevision.groupRevision === groupRevision &&
-        jsonEquals(summaryContent(current), content)))
+        jsonEquals(
+          toComparableSummaryContent(summaryContent(current), formationDamping),
+          toComparableSummaryContent(content, formationDamping),
+        )))
   ) {
     return { outcome: 'no-op', evaluatedAtEpochMs: nowEpochMs, summary: current };
   }
@@ -112,6 +117,7 @@ export function validateGroupPresenceSummary(
     ref: GroupRef;
     read: GroupPresenceSummaryRead;
     computed: GroupPresenceSummaryComputed;
+    formationDamping: 'damped' | 'legacy';
   }>,
 ): void {
   const { ref, read, computed } = input;
@@ -138,14 +144,18 @@ export function validateGroupPresenceSummary(
     );
     validatePresenceSummaryValue(read.current.value, ref);
   }
-  validateGroupPresenceSummaryCandidate(ref, read, computed);
+  validateGroupPresenceSummaryCandidate(input);
 }
 
 function validateGroupPresenceSummaryCandidate(
-  ref: GroupRef,
-  read: GroupPresenceSummaryRead,
-  computed: GroupPresenceSummaryComputed,
+  input: Readonly<{
+    ref: GroupRef;
+    read: GroupPresenceSummaryRead;
+    computed: GroupPresenceSummaryComputed;
+    formationDamping: 'damped' | 'legacy';
+  }>,
 ): void {
+  const { ref, read, computed, formationDamping } = input;
   validatePresenceSummaryValue(computed.summary, ref);
   requirePositiveSafeInteger(
     computed.evaluatedAtEpochMs,
@@ -158,7 +168,10 @@ function validateGroupPresenceSummaryCandidate(
     current !== undefined &&
     (current.causalRevision.groupRevision > groupRevision ||
       (current.causalRevision.groupRevision === groupRevision &&
-        jsonEquals(summaryContent(current), expectedContent)));
+        jsonEquals(
+          toComparableSummaryContent(summaryContent(current), formationDamping),
+          toComparableSummaryContent(expectedContent, formationDamping),
+        )));
   const validation = {
     ref,
     read,
@@ -167,6 +180,7 @@ function validateGroupPresenceSummaryCandidate(
     groupRevision,
     current,
     expectedNoOp,
+    formationDamping,
   };
   validateGroupPresenceSummaryOutcome(validation);
   validateGroupPresenceSummaryCausalRevision(validation);
@@ -227,8 +241,14 @@ function validateGroupPresenceSummaryCausalRevision(
   if (
     comparison === 'equal' &&
     !jsonEquals(
-      summaryContent(validation.computed.summary),
-      summaryContent(validation.read.current.value),
+      toComparableSummaryContent(
+        summaryContent(validation.computed.summary),
+        validation.formationDamping,
+      ),
+      toComparableSummaryContent(
+        summaryContent(validation.read.current.value),
+        validation.formationDamping,
+      ),
     )
   ) {
     throw new TypeError('Equal group presence summary tuple has different content');
@@ -297,6 +317,27 @@ function summaryContent(summary: GroupPresenceSummary): Readonly<{
     activeSessions: summary.activeSessions,
     activePrincipalCount: summary.activePrincipalCount,
     activeSessionCount: summary.activeSessionCount,
+  };
+}
+
+/**
+ * Under damped formation the session lease fields are liveness, not content:
+ * a renewed lease over an identical session set must compare equal so a pure
+ * renewal never advances presenceRevision. Legacy keeps full-session content
+ * so heartbeats keep rewriting the summary exactly as before.
+ */
+function toComparableSummaryContent(
+  content: ReturnType<typeof summaryContent>,
+  formationDamping: 'damped' | 'legacy',
+): ReturnType<typeof summaryContent> {
+  if (formationDamping === 'legacy') return content;
+  return {
+    ...content,
+    activeSessions: content.activeSessions.map((session) => ({
+      ...session,
+      lastHeartbeatAtEpochMs: 0,
+      expiresAtEpochMs: 0,
+    })),
   };
 }
 

--- a/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
@@ -7,7 +7,6 @@ import type {
   GroupRef,
 } from '@shared/api/group-types.ts';
 import { compareGroupCausalRevision } from '@shared/api/group-client-views.ts';
-import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
 import { jsonEquals } from '@shared/repository/state-utils.ts';
 import {
@@ -41,7 +40,6 @@ export type GroupPresenceSummaryRead = Readonly<{
   admissions: readonly RuntimeStateEntryValue<GroupPresenceAdmission>[];
   presenceSessions: readonly RuntimeStateEntryValue<GroupPresenceSession>[];
   current: RuntimeStateEntryValue<GroupPresenceSummary> | null;
-  coalescedTopologyEntry: ResourceEntry | null;
 }>;
 
 export type GroupPresenceSummaryComputed =
@@ -125,12 +123,12 @@ export function validateGroupPresenceSummary(
   requireJsonSafe(computed, 'Group presence summary computed result');
   assertExactKeys(
     read,
-    ['group', 'members', 'admissions', 'presenceSessions', 'current', 'coalescedTopologyEntry'],
+    ['group', 'members', 'admissions', 'presenceSessions', 'current'],
     'Group presence summary read',
   );
   assertRequiredKeys(
     read,
-    ['group', 'members', 'admissions', 'presenceSessions', 'current', 'coalescedTopologyEntry'],
+    ['group', 'members', 'admissions', 'presenceSessions', 'current'],
     'Group presence summary read',
   );
   validateRuntimeEntryValue(read.group, 'Stored summary group', groupStateGroupStorageKey(ref));

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
@@ -154,6 +154,7 @@ export class GroupPresenceSummaryWork {
       ref: work.aggregateRef,
       read,
       nowEpochMs: this.now(),
+      formationDamping: this.options.topologyIntent.damping,
     });
     const snapshot = assembleGroupStateSnapshot(
       {
@@ -163,6 +164,8 @@ export class GroupPresenceSummaryWork {
         authoritativeSessions: read.presenceSessions.map((session) => session.value),
         groupRevision: summary.summary.causalRevision.groupRevision,
         observedAtEpochMs: summary.summary.computedAtEpochMs,
+        sessionLeaseFields:
+          this.options.topologyIntent.damping === 'damped' ? 'authoritative' : 'summary-frozen',
       },
       (storageKey, message) => new Error(`${message}: ${storageKey}`),
     );
@@ -212,6 +215,7 @@ export class GroupPresenceSummaryWork {
       ref: work.aggregateRef,
       read,
       computed: computed.summary,
+      formationDamping: this.options.topologyIntent.damping,
     });
     if (
       work.event.applicationId !== work.aggregateRef.applicationId ||

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
@@ -46,7 +46,7 @@ import {
 import {
   computeCoalescedRtcTopologyGroupRevisionWork,
   toRtcTopologyCoalescedGroupRevisionResourceId,
-} from '../../services/rtc-topology-coalesced-group-revision-work.ts';
+} from '../../topology/replay/rtc-topology-coalesced-group-revision-work.ts';
 import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '../../services/rtc-topology-outbox-entry.ts';
 import { toAppQueueKey } from '../../services/app-inbox-queue-key.ts';
 import { groupStateGroupStorageKey } from '../persistence/group-state-storage-keys.ts';

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
@@ -78,6 +78,11 @@ export type GroupPresenceSummaryWorkOptions = Readonly<{
   formationMetrics?: GroupFormationPresenceSummarySink;
 }>;
 
+export type GroupPresenceSummaryWorkRead = Readonly<{
+  presence: GroupPresenceSummaryRead;
+  coalescedTopologyEntry: ResourceEntry | null;
+}>;
+
 export type GroupPresenceSummaryComputedWork = Readonly<{
   work: GroupPresenceSummaryWorkData;
   summary: GroupPresenceSummaryComputed;
@@ -111,7 +116,7 @@ export class GroupPresenceSummaryWork {
         : null;
   }
 
-  async read(work: GroupPresenceSummaryWorkData): Promise<GroupPresenceSummaryRead> {
+  async read(work: GroupPresenceSummaryWorkData): Promise<GroupPresenceSummaryWorkRead> {
     const repository = new GroupStateRepository(this.options.runtimeRepository);
     const [group, members, admissions, presenceSessions, current, coalescedTopologyEntry] =
       await Promise.all([
@@ -126,11 +131,13 @@ export class GroupPresenceSummaryWork {
       throw new TypeError(`Group not found for presence summary: ${work.aggregateRef.groupId}`);
     }
     return {
-      group,
-      members,
-      admissions,
-      presenceSessions,
-      current: current ?? null,
+      presence: {
+        group,
+        members,
+        admissions,
+        presenceSessions,
+        current: current ?? null,
+      },
       coalescedTopologyEntry,
     };
   }
@@ -148,20 +155,20 @@ export class GroupPresenceSummaryWork {
 
   compute(
     work: GroupPresenceSummaryWorkData,
-    read: GroupPresenceSummaryRead,
+    read: GroupPresenceSummaryWorkRead,
   ): GroupPresenceSummaryComputedWork {
     const summary = computeGroupPresenceSummary({
       ref: work.aggregateRef,
-      read,
+      read: read.presence,
       nowEpochMs: this.now(),
       formationDamping: this.options.topologyIntent.damping,
     });
     const snapshot = assembleGroupStateSnapshot(
       {
-        group: read.group.value,
-        members: read.members.map((member) => member.value),
+        group: read.presence.group.value,
+        members: read.presence.members.map((member) => member.value),
         summary: summary.summary,
-        authoritativeSessions: read.presenceSessions.map((session) => session.value),
+        authoritativeSessions: read.presence.presenceSessions.map((session) => session.value),
         groupRevision: summary.summary.causalRevision.groupRevision,
         observedAtEpochMs: summary.summary.computedAtEpochMs,
         sessionLeaseFields:
@@ -205,7 +212,7 @@ export class GroupPresenceSummaryWork {
 
   validate(
     work: GroupPresenceSummaryWorkData,
-    read: GroupPresenceSummaryRead,
+    read: GroupPresenceSummaryWorkRead,
     computed: GroupPresenceSummaryComputedWork,
   ): void {
     if (computed.work !== work) {
@@ -213,7 +220,7 @@ export class GroupPresenceSummaryWork {
     }
     validateGroupPresenceSummary({
       ref: work.aggregateRef,
-      read,
+      read: read.presence,
       computed: computed.summary,
       formationDamping: this.options.topologyIntent.damping,
     });

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
@@ -1,4 +1,5 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 // prettier-ignore
 import type {
@@ -9,6 +10,7 @@ import {
   toCanonicalGroupTopologyConfigPatch,
 } from '@shared/api/group-topology-config-canonical.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import type { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
 import { requireConditionalWrite } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 // prettier-ignore
 import type {
@@ -36,6 +38,18 @@ import {
   type StateSyncAudience,
 } from '../../state-sync-publisher.ts';
 import { computeRtcTopologyEntry } from '../../services/RtcTopologyOutboxWork.ts';
+import {
+  CoalescedAppOutboxWorkService,
+  type ComputedCoalescedAppOutboxWork,
+} from '../../services/CoalescedAppOutboxWorkService.ts';
+// prettier-ignore
+import {
+  computeCoalescedRtcTopologyGroupRevisionWork,
+  toRtcTopologyCoalescedGroupRevisionResourceId,
+} from '../../services/rtc-topology-coalesced-group-revision-work.ts';
+import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '../../services/rtc-topology-outbox-entry.ts';
+import { toAppQueueKey } from '../../services/app-inbox-queue-key.ts';
+import { groupStateGroupStorageKey } from '../persistence/group-state-storage-keys.ts';
 // prettier-ignore
 import type {
   GroupFormationPresenceSummarySink,
@@ -45,8 +59,17 @@ import {
   decodeCanonicalGroupPresenceSummaryWork,
 } from './decode-canonical-group-presence-summary-work.ts';
 
+export type GroupPresenceSummaryTopologyIntent =
+  | Readonly<{
+      damping: 'damped';
+      outboxQueueReader: OutboxQueueReader;
+      recomputeDebounceMs: number;
+    }>
+  | Readonly<{ damping: 'legacy' }>;
+
 export type GroupPresenceSummaryWorkOptions = Readonly<{
   runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike;
+  topologyIntent: GroupPresenceSummaryTopologyIntent;
   database?: PSqlSql;
   now?: () => number;
   serviceId: string;
@@ -60,6 +83,7 @@ export type GroupPresenceSummaryComputedWork = Readonly<{
   summary: GroupPresenceSummaryComputed;
   snapshot: GroupSnapshot;
   downstreamOutboxEntries: readonly ResourceEntry[];
+  coalescedTopologyWork: ComputedCoalescedAppOutboxWork | null;
 }>;
 
 interface ComputeGroupPresenceSummaryOutboxInput {
@@ -68,24 +92,36 @@ interface ComputeGroupPresenceSummaryOutboxInput {
   readonly snapshot: GroupSnapshot;
   readonly audience: StateSyncAudience;
   readonly serviceId: string;
+  readonly includePerCommandTopologyEntry: boolean;
 }
 
 export class GroupPresenceSummaryWork {
   private readonly now: () => number;
+  private readonly coalescedTopologyWorkService: CoalescedAppOutboxWorkService | null;
 
   constructor(private readonly options: GroupPresenceSummaryWorkOptions) {
     this.now = options.now ?? (() => Date.now());
+    this.coalescedTopologyWorkService =
+      options.topologyIntent.damping === 'damped'
+        ? new CoalescedAppOutboxWorkService(
+            options.topologyIntent.outboxQueueReader,
+            options.serviceId,
+            this.now,
+          )
+        : null;
   }
 
   async read(work: GroupPresenceSummaryWorkData): Promise<GroupPresenceSummaryRead> {
     const repository = new GroupStateRepository(this.options.runtimeRepository);
-    const [group, members, admissions, presenceSessions, current] = await Promise.all([
-      repository.findGroupEntry(work.aggregateRef),
-      repository.listMemberEntries(work.aggregateRef),
-      repository.listPresenceAdmissionEntries(work.aggregateRef),
-      repository.listPresenceSessionEntries(work.aggregateRef),
-      repository.findPresenceSummaryEntry(work.aggregateRef),
-    ]);
+    const [group, members, admissions, presenceSessions, current, coalescedTopologyEntry] =
+      await Promise.all([
+        repository.findGroupEntry(work.aggregateRef),
+        repository.listMemberEntries(work.aggregateRef),
+        repository.listPresenceAdmissionEntries(work.aggregateRef),
+        repository.listPresenceSessionEntries(work.aggregateRef),
+        repository.findPresenceSummaryEntry(work.aggregateRef),
+        this.readCoalescedTopologyEntry(work.aggregateRef),
+      ]);
     if (!group) {
       throw new TypeError(`Group not found for presence summary: ${work.aggregateRef.groupId}`);
     }
@@ -95,7 +131,19 @@ export class GroupPresenceSummaryWork {
       admissions,
       presenceSessions,
       current: current ?? null,
+      coalescedTopologyEntry,
     };
+  }
+
+  private async readCoalescedTopologyEntry(ref: GroupRef): Promise<ResourceEntry | null> {
+    const intent = this.options.topologyIntent;
+    if (intent.damping !== 'damped') return null;
+    const key = toAppQueueKey({
+      topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
+      resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(toScopedOverlayId(ref)),
+      contextId: groupStateGroupStorageKey(ref),
+    });
+    return (await intent.outboxQueueReader.outbox.getItem(key)) ?? null;
   }
 
   compute(
@@ -124,6 +172,7 @@ export class GroupPresenceSummaryWork {
       workspaceId: work.aggregateRef.workspaceId,
       resourceId: work.aggregateRef.groupId,
     };
+    const intent = this.options.topologyIntent;
     return {
       work,
       summary,
@@ -134,7 +183,20 @@ export class GroupPresenceSummaryWork {
         snapshot,
         audience,
         serviceId: this.options.serviceId,
+        includePerCommandTopologyEntry: intent.damping === 'legacy',
       }),
+      coalescedTopologyWork:
+        intent.damping === 'damped'
+          ? computeCoalescedRtcTopologyGroupRevisionWork({
+              aggregateRef: work.aggregateRef,
+              groupSnapshot: snapshot,
+              requestedAtEpochMs: summary.summary.computedAtEpochMs,
+              expireAtEpochMs: work.expireAtEpochMs,
+              recomputeDebounceMs: intent.recomputeDebounceMs,
+              senderId: this.options.serviceId,
+              previousEntry: read.coalescedTopologyEntry,
+            })
+          : null,
     };
   }
 
@@ -181,6 +243,12 @@ export class GroupPresenceSummaryWork {
     for (const entry of computed.downstreamOutboxEntries) {
       await outbox.writeIfAbsentOrMatch(entry);
     }
+    if (computed.coalescedTopologyWork !== null) {
+      if (this.coalescedTopologyWorkService === null) {
+        throw new TypeError('Coalesced topology work requires the damped topology intent');
+      }
+      await this.coalescedTopologyWorkService.write(transaction, computed.coalescedTopologyWork);
+    }
   }
 
   async processReservedEntry(message: ALMessage, entry: ResourceEntry): Promise<void> {
@@ -206,9 +274,10 @@ export class GroupPresenceSummaryWork {
     this.options.wakeQueue?.();
     try {
       this.options.formationMetrics?.({
-        downstreamTopicIds: computed.downstreamOutboxEntries.map(
-          (outboxEntry) => outboxEntry.key.topicId,
-        ),
+        downstreamTopicIds: [
+          ...computed.downstreamOutboxEntries.map((outboxEntry) => outboxEntry.key.topicId),
+          ...(computed.coalescedTopologyWork !== null ? [APP_OUTBOX_RTC_TOPOLOGY_TOPIC] : []),
+        ],
       });
     } catch {
       // Recording must never affect presence-summary behavior.
@@ -261,6 +330,9 @@ function computeGroupPresenceSummaryOutboxEntries(
     },
     serviceId,
   );
+  if (!input.includePerCommandTopologyEntry) {
+    return [...eventEntries, ...snapshotEntries];
+  }
   const topologyEntry = computeGroupPresenceTopologyOutboxEntry(input);
   return [...eventEntries, ...snapshotEntries, topologyEntry];
 }

--- a/packages/shared-server/rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts
+++ b/packages/shared-server/rallar-system/group-state/snapshot/group-rest-snapshot-read-selector.ts
@@ -6,19 +6,14 @@ import type {
   StateSnapshotReadResult,
   StateSnapshotReadSource,
 } from '@shared/api/state-snapshot-read.ts';
-import type {
-  GroupRef,
-  GroupSnapshot,
-  GroupStateCausalRevision,
-} from '@shared/api/group-types.ts';
+import type { GroupRef, GroupSnapshot, GroupStateCausalRevision } from '@shared/api/group-types.ts';
 import {
   compareGroupCausalRevision,
   readGroupCausalRevision,
 } from '@shared/api/group-client-views.ts';
 import type { StateSnapshotObservation } from '@shared/repository/state-snapshot-revision.ts';
 
-export interface GroupRestSnapshotReadRequest
-  extends GroupStateSnapshotReadOptions {
+export interface GroupRestSnapshotReadRequest extends GroupStateSnapshotReadOptions {
   readonly strictMode?: boolean;
 }
 
@@ -50,11 +45,8 @@ interface GroupRestSnapshotReadContext {
   source: StateSnapshotReadSource;
 }
 
-class GroupRestSnapshotReadSelectorOwner
-  implements GroupRestSnapshotReadSelector {
-  public constructor(
-    private readonly dependencies: GroupRestSnapshotReadSelectorDependencies,
-  ) {}
+class GroupRestSnapshotReadSelectorOwner implements GroupRestSnapshotReadSelector {
+  public constructor(private readonly dependencies: GroupRestSnapshotReadSelectorDependencies) {}
 
   public async read(
     ref: GroupRef,
@@ -105,10 +97,7 @@ class GroupRestSnapshotReadSelectorOwner
       context.requestedFloor === undefined ||
       context.strictMode ||
       observed === undefined ||
-      !satisfiesGroupFloor(
-        readGroupCausalRevision(observed),
-        context.requestedFloor,
-      )
+      !satisfiesGroupFloor(readGroupCausalRevision(observed), context.requestedFloor)
     ) {
       return undefined;
     }
@@ -128,10 +117,7 @@ class GroupRestSnapshotReadSelectorOwner
     this.dependencies.cache.observe(snapshot);
     if (
       context.requestedFloor !== undefined &&
-      !satisfiesGroupFloor(
-        readGroupCausalRevision(snapshot),
-        context.requestedFloor,
-      )
+      !satisfiesGroupFloor(readGroupCausalRevision(snapshot), context.requestedFloor)
     ) {
       this.emit(context, {
         source: 'durable',
@@ -163,9 +149,7 @@ class GroupRestSnapshotReadSelectorOwner
     this.emit(context, {
       source: 'durable',
       result: 'not-found',
-      floorOutcome: context.requestedFloor === undefined
-        ? 'not-requested'
-        : 'not-satisfied',
+      floorOutcome: context.requestedFloor === undefined ? 'not-requested' : 'not-satisfied',
       cleanupOutcome,
       strictMode: context.strictMode,
     });

--- a/packages/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.ts
+++ b/packages/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.ts
@@ -116,15 +116,8 @@ export class GroupStateSnapshotReadThroughCache {
     await this.snapshots.whenIdle();
   }
 
-  public evictIfUnchanged(
-    ref: GroupRef,
-    expected: GroupSnapshot,
-  ): boolean {
-    const latestRemoved = removeGroupStateSnapshotIfUnchanged(
-      ref,
-      expected,
-      this.options.manager,
-    );
+  public evictIfUnchanged(ref: GroupRef, expected: GroupSnapshot): boolean {
+    const latestRemoved = removeGroupStateSnapshotIfUnchanged(ref, expected, this.options.manager);
     const loanedRemoved = this.snapshots.compareAndDelete(
       toGroupStateSnapshotRepositoryKey(ref),
       expected,
@@ -187,8 +180,7 @@ export function createGroupStateSnapshotReadThroughCache(
 }
 
 function toGroupRef(key: string): GroupRef {
-  const { applicationId, workspaceId, groupId } =
-    fromGroupStateSnapshotRepositoryKey(key);
+  const { applicationId, workspaceId, groupId } = fromGroupStateSnapshotRepositoryKey(key);
 
   return {
     applicationId,

--- a/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
+++ b/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
@@ -1,6 +1,7 @@
 import { type ALMessage, readALTargetGroupRef } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
 import { isSameGroupScope } from '@shared/api/api-type-utils.ts';
+import { compareGroupCausalRevision, readGroupCausalRevision } from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type {
   WsServerResolvedRecipient,
@@ -8,7 +9,10 @@ import type {
 } from '@shared/services/WsQueueBoxServerService.ts';
 import { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 import { isClientSnapshotSessionLive, isGroupSnapshotSessionLive } from '../snapshot-presence.ts';
-import { resolveStateSyncRecipients } from '../state-sync-routing.ts';
+import {
+  readGroupSnapshotStateSyncPayload,
+  resolveStateSyncRecipients,
+} from '../state-sync-routing.ts';
 import type { RallarGroupSnapshotResolverOptions } from './rallar-middleware-options.ts';
 
 export function createWsServerTargetResolver(
@@ -24,11 +28,37 @@ export function createWsServerTargetResolver(
     const scopedSnapshot = groupRef
       ? options.findGroupSnapshotByRef?.(groupRef, message)
       : undefined;
-    if (scopedSnapshot) return scopedSnapshot;
+    const knownSnapshot = scopedSnapshot ?? resolveGroupSnapshotById(groupId, groupRef);
+    // A group-snapshot row carries its own authoritative membership; when a
+    // process-local cache lags the row (no storm keeps caches warm under
+    // damped formation), the causally newest snapshot resolves the audience.
+    const payloadSnapshot = readGroupSnapshotPayloadForGroup(groupId, message);
+    if (!payloadSnapshot) return knownSnapshot;
+    if (!knownSnapshot) return payloadSnapshot;
+    return compareGroupCausalRevision(
+        readGroupCausalRevision(payloadSnapshot),
+        readGroupCausalRevision(knownSnapshot),
+      ) === 'dominated'
+      ? knownSnapshot
+      : payloadSnapshot;
+  };
+  const resolveGroupSnapshotById = (
+    groupId: string,
+    groupRef: ReturnType<typeof readALTargetGroupRef>,
+  ): GroupSnapshot | undefined => {
     const byIdSnapshot = options.findGroupSnapshotById?.(groupId);
     if (!byIdSnapshot) return undefined;
     return groupRef === undefined || isSameGroupScope(byIdSnapshot.group, groupRef)
       ? byIdSnapshot
+      : undefined;
+  };
+  const readGroupSnapshotPayloadForGroup = (
+    groupId: string,
+    message: ALMessage,
+  ): GroupSnapshot | undefined => {
+    const payloadSnapshot = readGroupSnapshotStateSyncPayload(message);
+    return payloadSnapshot && payloadSnapshot.group.groupId === groupId
+      ? payloadSnapshot
       : undefined;
   };
   const resolveGroupRecipients = (

--- a/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
+++ b/packages/shared-server/rallar-system/middleware/ws-server-target-resolver.ts
@@ -1,7 +1,10 @@
 import { type ALMessage, readALTargetGroupRef } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
 import { isSameGroupScope } from '@shared/api/api-type-utils.ts';
-import { compareGroupCausalRevision, readGroupCausalRevision } from '@shared/api/group-client-views.ts';
+import {
+  compareGroupCausalRevision,
+  readGroupCausalRevision,
+} from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type {
   WsServerResolvedRecipient,
@@ -9,10 +12,8 @@ import type {
 } from '@shared/services/WsQueueBoxServerService.ts';
 import { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 import { isClientSnapshotSessionLive, isGroupSnapshotSessionLive } from '../snapshot-presence.ts';
-import {
-  readGroupSnapshotStateSyncPayload,
-  resolveStateSyncRecipients,
-} from '../state-sync-routing.ts';
+import { readGroupSnapshotStateSyncPayload } from '../state-sync/state-sync-payload.ts';
+import { resolveStateSyncRecipients } from '../state-sync-routing.ts';
 import type { RallarGroupSnapshotResolverOptions } from './rallar-middleware-options.ts';
 
 export function createWsServerTargetResolver(

--- a/packages/shared-server/rallar-system/repositories/RtcTopologyExecutionRepository.ts
+++ b/packages/shared-server/rallar-system/repositories/RtcTopologyExecutionRepository.ts
@@ -18,6 +18,9 @@ import {
     RtcTopologySnapshotRepository,
 } from './RtcTopologySnapshotRepository.ts';
 import {
+    RtcTopologyInputFingerprintRepository,
+} from '../topology/replay/rtc-topology-input-fingerprint.ts';
+import {
     computeTopologyMutation,
     type RtcTopologyMutationComputed,
     type RtcTopologyMutationRead,
@@ -71,6 +74,21 @@ export class RtcTopologyExecutionRepository {
     ): Promise<RallarOverlayTopologySnapshot | undefined> {
         return await new RtcTopologySnapshotRepository(this.runtimeRepository)
             .findSnapshot(groupRef);
+    }
+
+    async readTopologyInputFingerprint(groupRef: GroupRef): Promise<string | null> {
+        return await new RtcTopologyInputFingerprintRepository(this.runtimeRepository)
+            .findFingerprint(groupRef);
+    }
+
+    async writeTopologyInputFingerprint(
+        transaction: PSqlTransactionSql,
+        groupRef: GroupRef,
+        fingerprint: string,
+    ): Promise<void> {
+        await new RtcTopologyInputFingerprintRepository(
+            new PSqlRuntimeStateRepository(transaction),
+        ).putFingerprint(groupRef, fingerprint);
     }
 
     async readTopologyMutation(

--- a/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
+++ b/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
@@ -6,9 +6,16 @@ import {
 } from '@shared/al-contracts/al-contract.ts';
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import {
-    COMPLETED_STATUSES,
+    COALESCED_APP_OUTBOX_WORK_FIELD,
+    type CoalescedAppOutboxWorkData,
+    type CoalescedAppOutboxWorkEnvelope,
+    type CoalescedAppOutboxWorkMetadata,
+    isMutableCoalescedStatus,
+    isTerminalCoalescedStatus,
+    tryReadCoalescedAppOutboxWorkEnvelope,
+} from '@shared/queuebox/coalesced-app-outbox-work-envelope.ts';
+import {
     EntityStatus,
-    isFailed,
     type Key,
     type ResourceEntry,
 } from '@shared/queuebox/ResourceEntry.ts';
@@ -24,29 +31,15 @@ import {
     replaceFinishedResourceEntryIfMatch,
 } from '../../postgres/resource-inbox/resource-inbox-finished-replacement.ts';
 
-export const COALESCED_APP_OUTBOX_WORK_FIELD = '__rallarCoalescedWork';
-
-export type CoalescedAppOutboxWorkMetadata = Readonly<{
-    generation: number;
-    requestedAtEpochMs: number;
-    dueAtEpochMs: number;
-    reasons: readonly string[];
-}>;
-
-export type CoalescedAppOutboxWorkData<T extends object> =
-    & T
-    & Readonly<{
-    [COALESCED_APP_OUTBOX_WORK_FIELD]: CoalescedAppOutboxWorkMetadata;
-}>;
-
-export type CoalescedAppOutboxWorkEnvelope<T extends object> = Readonly<{
-    type: string;
-    topicId: string;
-    resourceId: string;
-    contextId: string;
-    senderId: string;
-    data: CoalescedAppOutboxWorkData<T>;
-}>;
+export {
+    COALESCED_APP_OUTBOX_WORK_FIELD,
+    type CoalescedAppOutboxWorkData,
+    type CoalescedAppOutboxWorkEnvelope,
+    type CoalescedAppOutboxWorkMetadata,
+    isMutableCoalescedStatus,
+    isTerminalCoalescedStatus,
+    tryReadCoalescedAppOutboxWorkEnvelope,
+};
 
 export type CoalescedAppOutboxWorkMerge<T extends object> = (
     existing: CoalescedAppOutboxWorkData<T>,
@@ -227,7 +220,7 @@ export class CoalescedAppOutboxWorkService {
 
                 return {
                     ...this.toScheduledEntry(
-                        nextEntry,
+                        this.toLifecyclePreservingEntry(nextEntry, previous),
                         nextEnvelope.data[COALESCED_APP_OUTBOX_WORK_FIELD]
                             .dueAtEpochMs,
                         now,
@@ -321,6 +314,32 @@ export class CoalescedAppOutboxWorkService {
         );
     }
 
+    /**
+     * A merge keeps the predecessor row's entry audit, so the persisted
+     * message must keep the predecessor's creation and expiry identity or the
+     * merged entry stops satisfying the canonical work contract that release
+     * idempotency checks. The latest request and due times live in the
+     * coalesced metadata, not the message identity.
+     */
+    private toLifecyclePreservingEntry(
+        entry: ResourceEntry,
+        previous: ResourceEntry,
+    ): ResourceEntry {
+        const message = JSON.parse(entry.resource) as ALMessage;
+        const previousMessage = JSON.parse(previous.resource) as ALMessage;
+        const identityPreserved: ALMessage = {
+            ...message,
+            id: { ...message.id, ts: previousMessage.id.ts },
+            ...(previousMessage.constraints === undefined
+                ? {}
+                : { constraints: previousMessage.constraints }),
+            ...(previousMessage.audit === undefined
+                ? {}
+                : { audit: previousMessage.audit }),
+        };
+        return { ...entry, resource: JSON.stringify(identityPreserved) };
+    }
+
     private toScheduledEntry(
         entry: ResourceEntry,
         dueAtEpochMs: number,
@@ -346,53 +365,8 @@ export class CoalescedAppOutboxWorkService {
     }
 }
 
-export function tryReadCoalescedAppOutboxWorkEnvelope<T extends object>(
-    entry: ResourceEntry,
-): CoalescedAppOutboxWorkEnvelope<T> | undefined {
-    try {
-        const message = JSON.parse(entry.resource) as ALMessage;
-        const envelope = JSON.parse(
-            message.payload.resource,
-        ) as CoalescedAppOutboxWorkEnvelope<T>;
-        return isCoalescedEnvelope(envelope) ? envelope : undefined;
-    } catch {
-        return undefined;
-    }
-}
-
 function sameKey(left: Key, right: Key): boolean {
     return left.topicId === right.topicId &&
         left.resourceId === right.resourceId &&
         left.contextId === right.contextId;
-}
-
-export function isTerminalCoalescedStatus(status: EntityStatus): boolean {
-    return COMPLETED_STATUSES.has(status) || isFailed(status);
-}
-
-export function isMutableCoalescedStatus(status: EntityStatus): boolean {
-    return status === EntityStatus.NEW || status === EntityStatus.RETRY;
-}
-
-function isCoalescedEnvelope(
-    value: unknown,
-): value is CoalescedAppOutboxWorkEnvelope<object> {
-    if (!value || typeof value !== 'object') {
-        return false;
-    }
-
-    const maybe = value as Partial<CoalescedAppOutboxWorkEnvelope<object>>;
-    const data = maybe.data as Record<string, unknown> | undefined;
-    const metadata = data?.[COALESCED_APP_OUTBOX_WORK_FIELD] as
-        | Partial<CoalescedAppOutboxWorkMetadata>
-        | undefined;
-
-    return typeof maybe.type === 'string' &&
-        typeof maybe.topicId === 'string' &&
-        typeof maybe.resourceId === 'string' &&
-        typeof maybe.contextId === 'string' &&
-        typeof maybe.senderId === 'string' &&
-        typeof metadata?.generation === 'number' &&
-        typeof metadata.requestedAtEpochMs === 'number' &&
-        typeof metadata.dueAtEpochMs === 'number';
 }

--- a/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
+++ b/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
@@ -116,6 +116,22 @@ export class CoalescedAppOutboxWorkService {
                 'Coalesced APP_OUTBOX write must advance exactly one generation',
             );
         }
+        if (isTerminalCoalescedStatus(expected.status)) {
+            const revived = await repository.replaceFinishedIfMatch(
+                expected,
+                computed.entry,
+                expectedGeneration,
+            );
+            if (revived !== null) {
+                return {
+                    action: 'updated',
+                    entry: revived,
+                    previous: expected,
+                    blockedByReserved: false,
+                };
+            }
+            return await this.writeSuccessor(repository, computed, expected);
+        }
         if (!isMutableCoalescedStatus(expected.status)) {
             return await this.writeSuccessor(repository, computed, expected);
         }
@@ -323,15 +339,21 @@ export class CoalescedAppOutboxWorkService {
     private tryReadEnvelope<T extends object>(
         entry: ResourceEntry,
     ): CoalescedAppOutboxWorkEnvelope<T> | undefined {
-        try {
-            const message = this.readMessage(entry);
-            const envelope = JSON.parse(
-                message.payload.resource,
-            ) as CoalescedAppOutboxWorkEnvelope<T>;
-            return isCoalescedEnvelope(envelope) ? envelope : undefined;
-        } catch {
-            return undefined;
-        }
+        return tryReadCoalescedAppOutboxWorkEnvelope<T>(entry);
+    }
+}
+
+export function tryReadCoalescedAppOutboxWorkEnvelope<T extends object>(
+    entry: ResourceEntry,
+): CoalescedAppOutboxWorkEnvelope<T> | undefined {
+    try {
+        const message = JSON.parse(entry.resource) as ALMessage;
+        const envelope = JSON.parse(
+            message.payload.resource,
+        ) as CoalescedAppOutboxWorkEnvelope<T>;
+        return isCoalescedEnvelope(envelope) ? envelope : undefined;
+    } catch {
+        return undefined;
     }
 }
 
@@ -341,11 +363,11 @@ function sameKey(left: Key, right: Key): boolean {
         left.contextId === right.contextId;
 }
 
-function isTerminalCoalescedStatus(status: EntityStatus): boolean {
+export function isTerminalCoalescedStatus(status: EntityStatus): boolean {
     return COMPLETED_STATUSES.has(status) || isFailed(status);
 }
 
-function isMutableCoalescedStatus(status: EntityStatus): boolean {
+export function isMutableCoalescedStatus(status: EntityStatus): boolean {
     return status === EntityStatus.NEW || status === EntityStatus.RETRY;
 }
 

--- a/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
+++ b/packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts
@@ -20,6 +20,9 @@ import {
 } from './app-inbox-queue-key.ts';
 import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
 import { ResourceInboxRepository } from '../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import {
+    replaceFinishedResourceEntryIfMatch,
+} from '../../postgres/resource-inbox/resource-inbox-finished-replacement.ts';
 
 export const COALESCED_APP_OUTBOX_WORK_FIELD = '__rallarCoalescedWork';
 
@@ -117,11 +120,11 @@ export class CoalescedAppOutboxWorkService {
             );
         }
         if (isTerminalCoalescedStatus(expected.status)) {
-            const revived = await repository.replaceFinishedIfMatch(
+            const revived = await replaceFinishedResourceEntryIfMatch(transaction, {
                 expected,
-                computed.entry,
+                next: computed.entry,
                 expectedGeneration,
-            );
+            });
             if (revived !== null) {
                 return {
                     action: 'updated',

--- a/packages/shared-server/rallar-system/services/group-topology-management-service.ts
+++ b/packages/shared-server/rallar-system/services/group-topology-management-service.ts
@@ -239,6 +239,10 @@ export class GroupTopologyManagementService {
         this.options.topologyService.recordTopologyPublishResult(published);
     }
 
+    recordTopologyRebuildSkippedFingerprint(): void {
+        this.options.topologyService.recordTopologyRebuildSkippedFingerprint();
+    }
+
     isPlatformAdmin(principalId: string): boolean {
         return this.options.adminPrincipalIds?.has(principalId) ?? false;
     }

--- a/packages/shared-server/rallar-system/services/group-topology-management-service.ts
+++ b/packages/shared-server/rallar-system/services/group-topology-management-service.ts
@@ -38,6 +38,10 @@ import {
     readGroupMemberSessionIds,
 } from '@shared/api/group-client-views.ts';
 import { GroupStateSnapshotIncomparableError } from '@shared/repository/group-state-snapshots-repository.ts';
+// prettier-ignore
+import {
+    isTuplePreservingGroupLivenessReduction,
+} from '@shared/repository/group-state-snapshot-revision.ts';
 import { StateSnapshotRevisionConflictError } from '@shared/repository/state-snapshot-revision.ts';
 import {
     GroupTopologyServerOptions,
@@ -1246,70 +1250,6 @@ function selectTopologyPlanningGroup(
         );
     }
     return currentGroup;
-}
-
-function isTuplePreservingGroupLivenessReduction(
-    currentGroup: GroupSnapshot,
-    knownGroup: GroupSnapshot,
-): boolean {
-    const {
-        activeSessions: currentSessions,
-        onlineMemberCount: _currentOnlineMemberCount,
-        ...currentAuthority
-    } = currentGroup;
-    const {
-        activeSessions: knownSessions,
-        onlineMemberCount: _knownOnlineMemberCount,
-        ...knownAuthority
-    } = knownGroup;
-    if (
-        !rtcTopologySemanticEqual(currentAuthority, knownAuthority) ||
-        !hasConsistentGroupOnlineMemberCount(currentGroup) ||
-        !hasConsistentGroupOnlineMemberCount(knownGroup)
-    ) {
-        return false;
-    }
-
-    const knownSessionsById = new Map(
-        knownSessions.map((session, index) => [
-            session.sessionId,
-            { index, session },
-        ]),
-    );
-    if (
-        knownSessionsById.size !== knownSessions.length ||
-        new Set(currentSessions.map((session) => session.sessionId)).size !==
-            currentSessions.length
-    ) {
-        return false;
-    }
-    let previousKnownIndex = -1;
-    for (const currentSession of currentSessions) {
-        const known = knownSessionsById.get(currentSession.sessionId);
-        if (
-            !known ||
-            known.index <= previousKnownIndex ||
-            !rtcTopologySemanticEqual(currentSession, known.session)
-        ) {
-            return false;
-        }
-        previousKnownIndex = known.index;
-    }
-    return true;
-}
-
-function hasConsistentGroupOnlineMemberCount(snapshot: GroupSnapshot): boolean {
-    const activePrincipalIds = new Set(
-        snapshot.activeSessions.map((session) => session.principalId),
-    );
-    return (
-        snapshot.onlineMemberCount ===
-        snapshot.members.filter(
-            (member) =>
-                member.status === 'active' &&
-                activePrincipalIds.has(member.principalId),
-        ).length
-    );
 }
 
 function canonicalGroupRef(ref: GroupRef): GroupRef {

--- a/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
+++ b/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
@@ -8,6 +8,10 @@ import {
     type RallarRtcTopologyKind,
 } from '@shared/api/overlay-topology.ts';
 import { rtcTopologySemanticEqual } from '../rtc-topology-semantic-equality.ts';
+import {
+    emptyTopologyMetrics,
+    type RallarRtcTopologyMetrics,
+} from '../topology/rallar-rtc-topology-metrics.ts';
 import { normalizeRttReportingDegreeLimit } from '@shared/rtc/rtt-reporting-policy.ts';
 import {
     compareRtcTopologyIdentifiers,
@@ -43,43 +47,7 @@ export type RallarRtcTopologyServiceOptions = Readonly<{
     meshMinSize?: number;
     meshParamK?: number;
     rttRebuildDebounceMs?: number;
-    topologyRecomputeDebounceMs?: number;
     now?: () => number;
-}>;
-
-export type RallarRtcTopologyMetrics = Readonly<{
-    topologyUpdateCount: number;
-    topologyChangedCount: number;
-    topologyUnchangedCount: number;
-    updatesWithRttMeasurementCount: number;
-    updatesWithoutRttMeasurementCount: number;
-    starPlanCount: number;
-    starPlanDurationMs: number;
-    noRttTreePlanCount: number;
-    noRttTreePlanDurationMs: number;
-    noRttMeshPlanCount: number;
-    noRttMeshPlanDurationMs: number;
-    weightedPlanCount: number;
-    weightedPlanDurationMs: number;
-    weightedRoomGraphBuildCount: number;
-    weightedRoomGraphBuildDurationMs: number;
-    weightedRoomGraphSparseFallbackCount: number;
-    rttQueueRequestCount: number;
-    rttQueueNewCount: number;
-    rttQueueCoalescedCount: number;
-    rttQueueImmediateCount: number;
-    rttFlushAttemptCount: number;
-    rttFlushSkippedCount: number;
-    rttFlushExecutedCount: number;
-    topologyPublishAttemptCount: number;
-    topologyPublishedCount: number;
-    topologyPublishSkippedUnchangedCount: number;
-    topologyRebuildSkippedFingerprintCount: number;
-    topologyRemovalRequestCount: number;
-    topologyRemovedCount: number;
-    topologyRemoveMissCount: number;
-    topologySnapshotCount: number;
-    pendingRttUpdateCount: number;
 }>;
 
 export type RallarRtcTopologyUpdateResult = Readonly<{
@@ -160,47 +128,6 @@ const DEFAULT_TREE_MIN_SIZE = 5;
 const DEFAULT_MESH_MIN_SIZE = 16;
 const DEFAULT_MESH_PARAM_K = 2;
 const DEFAULT_RTT_REBUILD_DEBOUNCE_MS = 250;
-export const DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS = 500;
-
-type MutableRallarRtcTopologyMetrics = {
-    -readonly [K in keyof Omit<
-        RallarRtcTopologyMetrics,
-        'pendingRttUpdateCount' | 'topologySnapshotCount'
-    >]: number;
-};
-
-const emptyTopologyMetrics = (): MutableRallarRtcTopologyMetrics => ({
-    topologyUpdateCount: 0,
-    topologyChangedCount: 0,
-    topologyUnchangedCount: 0,
-    updatesWithRttMeasurementCount: 0,
-    updatesWithoutRttMeasurementCount: 0,
-    starPlanCount: 0,
-    starPlanDurationMs: 0,
-    noRttTreePlanCount: 0,
-    noRttTreePlanDurationMs: 0,
-    noRttMeshPlanCount: 0,
-    noRttMeshPlanDurationMs: 0,
-    weightedPlanCount: 0,
-    weightedPlanDurationMs: 0,
-    weightedRoomGraphBuildCount: 0,
-    weightedRoomGraphBuildDurationMs: 0,
-    weightedRoomGraphSparseFallbackCount: 0,
-    rttQueueRequestCount: 0,
-    rttQueueNewCount: 0,
-    rttQueueCoalescedCount: 0,
-    rttQueueImmediateCount: 0,
-    rttFlushAttemptCount: 0,
-    rttFlushSkippedCount: 0,
-    rttFlushExecutedCount: 0,
-    topologyPublishAttemptCount: 0,
-    topologyPublishedCount: 0,
-    topologyPublishSkippedUnchangedCount: 0,
-    topologyRebuildSkippedFingerprintCount: 0,
-    topologyRemovalRequestCount: 0,
-    topologyRemovedCount: 0,
-    topologyRemoveMissCount: 0,
-});
 
 export class RallarRtcTopologyService {
     private readonly snapshotsByOverlayId = new Map<
@@ -475,14 +402,6 @@ export class RallarRtcTopologyService {
 
     readRttRebuildDebounceMs(): number {
         return this.rttRebuildDebounceMs();
-    }
-
-    readTopologyRecomputeDebounceMs(): number {
-        return Math.max(
-            0,
-            this.options.topologyRecomputeDebounceMs ??
-                DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
-        );
     }
 
     readNowEpochMs(): number {

--- a/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
+++ b/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
@@ -43,6 +43,7 @@ export type RallarRtcTopologyServiceOptions = Readonly<{
     meshMinSize?: number;
     meshParamK?: number;
     rttRebuildDebounceMs?: number;
+    topologyRecomputeDebounceMs?: number;
     now?: () => number;
 }>;
 
@@ -158,6 +159,7 @@ const DEFAULT_TREE_MIN_SIZE = 5;
 const DEFAULT_MESH_MIN_SIZE = 16;
 const DEFAULT_MESH_PARAM_K = 2;
 const DEFAULT_RTT_REBUILD_DEBOUNCE_MS = 250;
+export const DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS = 500;
 
 type MutableRallarRtcTopologyMetrics = {
     -readonly [K in keyof Omit<
@@ -467,6 +469,14 @@ export class RallarRtcTopologyService {
 
     readRttRebuildDebounceMs(): number {
         return this.rttRebuildDebounceMs();
+    }
+
+    readTopologyRecomputeDebounceMs(): number {
+        return Math.max(
+            0,
+            this.options.topologyRecomputeDebounceMs ??
+                DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS,
+        );
     }
 
     readNowEpochMs(): number {

--- a/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
+++ b/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
@@ -74,6 +74,7 @@ export type RallarRtcTopologyMetrics = Readonly<{
     topologyPublishAttemptCount: number;
     topologyPublishedCount: number;
     topologyPublishSkippedUnchangedCount: number;
+    topologyRebuildSkippedFingerprintCount: number;
     topologyRemovalRequestCount: number;
     topologyRemovedCount: number;
     topologyRemoveMissCount: number;
@@ -195,6 +196,7 @@ const emptyTopologyMetrics = (): MutableRallarRtcTopologyMetrics => ({
     topologyPublishAttemptCount: 0,
     topologyPublishedCount: 0,
     topologyPublishSkippedUnchangedCount: 0,
+    topologyRebuildSkippedFingerprintCount: 0,
     topologyRemovalRequestCount: 0,
     topologyRemovedCount: 0,
     topologyRemoveMissCount: 0,
@@ -255,6 +257,10 @@ export class RallarRtcTopologyService {
         } else {
             this.metrics.topologyPublishSkippedUnchangedCount += 1;
         }
+    }
+
+    recordTopologyRebuildSkippedFingerprint(): void {
+        this.metrics.topologyRebuildSkippedFingerprintCount += 1;
     }
 
     updateGroupTopology(

--- a/packages/shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts
+++ b/packages/shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts
@@ -1,0 +1,251 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+import { EnqueuedType } from '@shared/api/api-config.ts';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { validateAuthoritativeGroupSnapshot } from '@shared/api/authoritative-state-validation.ts';
+import { readGroupCausalRevision, readGroupStateRevision } from '@shared/api/group-client-views.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+import { groupStateGroupStorageKey } from '../group-state-storage-keys.ts';
+import { AppOutboxType } from './AppOutboxService.ts';
+import { toAppQueueCreatedBy, toAppQueueKey } from './app-inbox-queue-key.ts';
+import {
+  COALESCED_APP_OUTBOX_WORK_FIELD,
+  type CoalescedAppOutboxWorkData,
+  type CoalescedAppOutboxWorkEnvelope,
+  type ComputedCoalescedAppOutboxWork,
+  isMutableCoalescedStatus,
+  tryReadCoalescedAppOutboxWorkEnvelope,
+} from './CoalescedAppOutboxWorkService.ts';
+import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from './rtc-topology-outbox-entry.ts';
+import type { RtcTopologyGroupRevisionWork } from './RtcTopologyOutboxWork.ts';
+
+export interface RtcTopologyCoalescedGroupRevisionInput {
+  readonly aggregateRef: GroupRef;
+  readonly groupSnapshot: GroupSnapshot;
+  readonly requestedAtEpochMs: number;
+  readonly expireAtEpochMs: number;
+  readonly recomputeDebounceMs: number;
+  readonly senderId: string;
+  readonly previousEntry: ResourceEntry | null;
+}
+
+export function toRtcTopologyCoalescedGroupRevisionResourceId(overlayId: string): string {
+  return `${overlayId}:group-revision`;
+}
+
+export function computeCoalescedRtcTopologyGroupRevisionWork(
+  input: RtcTopologyCoalescedGroupRevisionInput,
+): ComputedCoalescedAppOutboxWork {
+  validateCoalescedGroupRevisionInput(input);
+  const overlayId = toScopedOverlayId(input.aggregateRef);
+  const incoming: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork> = {
+    kind: 'group-revision',
+    overlayId,
+    groupSnapshot: input.groupSnapshot,
+    sourceGroupStateRevision: readGroupStateRevision(input.groupSnapshot),
+    requestedAtEpochMs: input.requestedAtEpochMs,
+    requestOptions: toCanonicalGroupTopologyConfigPatch({}),
+    publish: true,
+    [COALESCED_APP_OUTBOX_WORK_FIELD]: {
+      generation: 1,
+      requestedAtEpochMs: input.requestedAtEpochMs,
+      dueAtEpochMs: input.requestedAtEpochMs + input.recomputeDebounceMs,
+      reasons: ['group-revision'],
+    },
+  };
+  const successorEntry = toCoalescedGroupRevisionEntry({
+    input,
+    resourceId: toRtcTopologyCoalescedGroupRevisionSuccessorResourceId(
+      overlayId,
+      incoming.sourceGroupStateRevision,
+    ),
+    data: incoming,
+    dequeueAudit: { attempts: 0 },
+    entryAudit: null,
+  });
+  if (input.previousEntry === null) {
+    return {
+      expectedEntry: null,
+      entry: toCoalescedGroupRevisionEntry({
+        input,
+        resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(overlayId),
+        data: incoming,
+        dequeueAudit: { attempts: 0 },
+        entryAudit: null,
+      }),
+      successorEntry,
+    };
+  }
+  const previous = readPreviousCoalescedGroupRevisionEnvelope(input.previousEntry);
+  const previousGeneration = previous.data[COALESCED_APP_OUTBOX_WORK_FIELD].generation;
+  const merged = isMutableCoalescedStatus(input.previousEntry.status)
+    ? mergeRtcTopologyGroupRevisionWork(previous.data, incoming)
+    : incoming;
+  const nextData: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork> = {
+    ...merged,
+    [COALESCED_APP_OUTBOX_WORK_FIELD]: {
+      ...merged[COALESCED_APP_OUTBOX_WORK_FIELD],
+      generation: previousGeneration + 1,
+      requestedAtEpochMs: input.requestedAtEpochMs,
+    },
+  };
+  const carriesPreviousLifecycle = isMutableCoalescedStatus(input.previousEntry.status);
+  return {
+    expectedEntry: input.previousEntry,
+    entry: toCoalescedGroupRevisionEntry({
+      input,
+      resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(overlayId),
+      data: nextData,
+      dequeueAudit: {
+        attempts: carriesPreviousLifecycle ? input.previousEntry.dequeueAudit.attempts : 0,
+      },
+      entryAudit: carriesPreviousLifecycle ? input.previousEntry.audit : null,
+    }),
+    successorEntry,
+  };
+}
+
+export function mergeRtcTopologyGroupRevisionWork(
+  existing: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>,
+  incoming: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>,
+): CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork> {
+  const previous = existing[COALESCED_APP_OUTBOX_WORK_FIELD];
+  const next = incoming[COALESCED_APP_OUTBOX_WORK_FIELD];
+  const selected =
+    existing.sourceGroupStateRevision > incoming.sourceGroupStateRevision ? existing : incoming;
+  return {
+    ...incoming,
+    groupSnapshot: selected.groupSnapshot,
+    sourceGroupStateRevision: selected.sourceGroupStateRevision,
+    requestedAtEpochMs: Math.max(existing.requestedAtEpochMs, incoming.requestedAtEpochMs),
+    [COALESCED_APP_OUTBOX_WORK_FIELD]: {
+      ...next,
+      dueAtEpochMs: Math.max(previous.dueAtEpochMs, next.dueAtEpochMs),
+      reasons: [...new Set([...previous.reasons, ...next.reasons])],
+    },
+  };
+}
+
+function toRtcTopologyCoalescedGroupRevisionSuccessorResourceId(
+  overlayId: string,
+  stateRevision: number,
+): string {
+  return `${overlayId}:group-revision:r${stateRevision}`;
+}
+
+function readPreviousCoalescedGroupRevisionEnvelope(
+  previousEntry: ResourceEntry,
+): CoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork> {
+  const envelope =
+    tryReadCoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork>(previousEntry);
+  if (!envelope || envelope.data.kind !== 'group-revision') {
+    throw new TypeError(
+      `Coalesced group-revision predecessor is not coalesced topology work: ${previousEntry.key.resourceId}`,
+    );
+  }
+  return envelope;
+}
+
+interface ToCoalescedGroupRevisionEntryInput {
+  readonly input: RtcTopologyCoalescedGroupRevisionInput;
+  readonly resourceId: string;
+  readonly data: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>;
+  readonly dequeueAudit: Readonly<{ attempts: number }>;
+  readonly entryAudit: ResourceEntry['audit'] | null;
+}
+
+function toCoalescedGroupRevisionEntry(
+  entryInput: ToCoalescedGroupRevisionEntryInput,
+): ResourceEntry {
+  const { input, resourceId, data } = entryInput;
+  const createdBy = toAppQueueCreatedBy(input.senderId);
+  const contextId = groupStateGroupStorageKey(input.aggregateRef);
+  const key = toAppQueueKey({
+    topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
+    resourceId,
+    contextId,
+  });
+  const metadata = data[COALESCED_APP_OUTBOX_WORK_FIELD];
+  const messageId = `${resourceId}:g${metadata.generation}`;
+  const envelope: CoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork> = {
+    type: AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,
+    topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
+    resourceId,
+    contextId,
+    senderId: createdBy,
+    data,
+  };
+  const causalRevision = readGroupCausalRevision(data.groupSnapshot);
+  const message: ALMessage = {
+    id: {
+      v: 2,
+      msgId: messageId,
+      ts: input.requestedAtEpochMs,
+      senderId: createdBy,
+    },
+    route: key,
+    constraints: { expiresAtMs: input.expireAtEpochMs },
+    ordering: {
+      orderingKey: key.contextId,
+      epoch: causalRevision.groupRevision,
+      seq: causalRevision.presenceRevision,
+    },
+    delivery: {
+      ownership: 'exclusive',
+      reliability: 'at-least-once',
+      ack: 'none',
+    },
+    payload: {
+      typeId: AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,
+      contentType: 'application/json',
+      resource: JSON.stringify(envelope),
+    },
+    audit: {
+      createdBy,
+      createdTs: input.requestedAtEpochMs,
+    },
+  };
+  const isDue = metadata.dueAtEpochMs <= input.requestedAtEpochMs;
+  const createdTs = Temporal.Instant.fromEpochMilliseconds(input.requestedAtEpochMs)
+    .toZonedDateTimeISO('UTC')
+    .toPlainDateTime();
+  return {
+    key,
+    resource: JSON.stringify(message),
+    typeId: EnqueuedType.APP_OUTBOX,
+    status: isDue ? EntityStatus.NEW : EntityStatus.RETRY,
+    audit: entryInput.entryAudit ?? {
+      date: createdTs.toPlainTime(),
+      createdBy,
+      createdTs,
+      expiryTs: Temporal.Instant.fromEpochMilliseconds(input.expireAtEpochMs),
+    },
+    dequeueAudit: {
+      attempts: entryInput.dequeueAudit.attempts,
+      nextTs: isDue ? undefined : Temporal.Instant.fromEpochMilliseconds(metadata.dueAtEpochMs),
+    },
+  };
+}
+
+function validateCoalescedGroupRevisionInput(input: RtcTopologyCoalescedGroupRevisionInput): void {
+  const snapshot = input.groupSnapshot;
+  validateAuthoritativeGroupSnapshot(snapshot);
+  if (
+    input.senderId.length === 0 ||
+    !Number.isSafeInteger(input.requestedAtEpochMs) ||
+    !Number.isSafeInteger(input.expireAtEpochMs) ||
+    !Number.isSafeInteger(input.recomputeDebounceMs) ||
+    input.requestedAtEpochMs < 0 ||
+    input.recomputeDebounceMs < 0 ||
+    input.expireAtEpochMs <= input.requestedAtEpochMs ||
+    input.aggregateRef.applicationId !== snapshot.group.applicationId ||
+    input.aggregateRef.workspaceId !== snapshot.group.workspaceId ||
+    input.aggregateRef.groupId !== snapshot.group.groupId
+  ) {
+    throw new TypeError('Coalesced RTC topology group-revision facts are invalid');
+  }
+}

--- a/packages/shared-server/rallar-system/state-sync-publisher.ts
+++ b/packages/shared-server/rallar-system/state-sync-publisher.ts
@@ -12,12 +12,6 @@ import type {
     GroupSnapshot,
     GroupStateCausalRevision,
 } from '@shared/api/group-types.ts';
-import {
-    validateAuthoritativeClientEvent,
-    validateAuthoritativeClientSnapshot,
-    validateAuthoritativeGroupEvent,
-    validateAuthoritativeGroupSnapshot,
-} from '@shared/api/authoritative-state-validation.ts';
 import { newALBroadcastMessage, newALEventRoute } from '@shared/al-contracts/al-contract.ts';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import type { ALOutboundEnqueueResult } from '@shared/alm/ALOutboundMessageRuntime.ts';
@@ -35,6 +29,12 @@ import {
     toAppQueueCreatedBy,
     toAppQueueKey,
 } from './services/app-inbox-queue-key.ts';
+import {
+    isValidGroupCausalRevision,
+    validateClientStateSyncEffect,
+    validateComputedStateSyncFacts,
+    validateGroupStateSyncEffect,
+} from './state-sync/validate-state-sync.ts';
 
 export type StateSyncAudience = Readonly<{
     kind: 'principal' | 'group';
@@ -297,160 +297,6 @@ function toStateSyncEntry(input: ToStateSyncEntryInput): ResourceEntry {
         },
         dequeueAudit: { attempts: 0 },
     };
-}
-
-function validateComputedStateSyncFacts(
-    computed: ComputedStateSync,
-    senderId: string,
-): void {
-    if (
-        typeof computed !== 'object' ||
-        computed === null ||
-        typeof computed.commandId !== 'string' ||
-        computed.commandId.length === 0 ||
-        typeof senderId !== 'string' ||
-        senderId.length === 0 ||
-        !Number.isSafeInteger(computed.createdAtEpochMs) ||
-        !Number.isSafeInteger(computed.expireAtEpochMs) ||
-        computed.createdAtEpochMs < 0 ||
-        computed.expireAtEpochMs <= computed.createdAtEpochMs ||
-        !Array.isArray(computed.effects) ||
-        computed.effects.length === 0 ||
-        typeof computed.aggregateRef !== 'object' ||
-        computed.aggregateRef === null ||
-        typeof computed.aggregateRef.applicationId !== 'string' ||
-        computed.aggregateRef.applicationId.length === 0 ||
-        typeof computed.aggregateRef.workspaceId !== 'string' ||
-        computed.aggregateRef.workspaceId.length === 0 ||
-        typeof computed.audience !== 'object' ||
-        computed.audience === null ||
-        !['principal', 'group'].includes(computed.audience.kind) ||
-        typeof computed.audience.applicationId !== 'string' ||
-        computed.audience.applicationId.length === 0 ||
-        typeof computed.audience.workspaceId !== 'string' ||
-        computed.audience.workspaceId.length === 0 ||
-        typeof computed.audience.resourceId !== 'string' ||
-        computed.audience.resourceId.length === 0 ||
-        computed.audience.applicationId !== computed.aggregateRef.applicationId ||
-        computed.audience.workspaceId !== computed.aggregateRef.workspaceId
-    ) {
-        throw new TypeError('Computed state sync facts are invalid');
-    }
-    if (
-        ('principalId' in computed.aggregateRef &&
-            (
-                computed.audience.kind !== 'principal' ||
-                computed.audience.resourceId !== computed.aggregateRef.principalId
-            )) ||
-        ('groupId' in computed.aggregateRef &&
-            (
-                computed.audience.kind !== 'group' ||
-                computed.audience.resourceId !== computed.aggregateRef.groupId
-            ))
-    ) {
-        throw new TypeError('Computed state sync audience differs from aggregate');
-    }
-}
-
-function validateClientStateSyncEffect(
-    computed: ComputedClientStateSync,
-    effect: ComputedClientStateSyncEffect,
-): void {
-    if (
-        typeof effect !== 'object' ||
-        effect === null ||
-        effect.effectKind !== 'principal-state'
-    ) {
-        throw new TypeError('Computed client state sync effect kind is invalid');
-    }
-    if (effect.payloadKind === 'snapshot') {
-        validateAuthoritativeClientSnapshot(effect.payload, computed.aggregateRef);
-        if (
-            !sameClientRef(computed.aggregateRef, effect.payload) ||
-            effect.payload.stateRevision !== computed.acceptedCausalRevision
-        ) {
-            throw new TypeError(
-                'Computed client state sync snapshot differs from accepted authority',
-            );
-        }
-        return;
-    }
-    if (effect.payloadKind === 'event') {
-        validateAuthoritativeClientEvent(effect.payload, computed.aggregateRef);
-        if (
-            !sameClientRef(computed.aggregateRef, effect.payload) ||
-            effect.payload.snapshotVersion !== computed.acceptedCausalRevision
-        ) {
-            throw new TypeError(
-                'Computed client state sync event differs from accepted authority',
-            );
-        }
-        return;
-    }
-    throw new TypeError('Computed client state sync payload kind is invalid');
-}
-
-function validateGroupStateSyncEffect(
-    computed: ComputedGroupStateSync,
-    effect: ComputedGroupStateSyncEffect,
-): void {
-    if (typeof effect !== 'object' || effect === null) {
-        throw new TypeError('Computed group state sync effect is invalid');
-    }
-    if (effect.payloadKind === 'snapshot') {
-        if (
-            effect.effectKind !== 'member-state' &&
-            effect.effectKind !== 'scope-directory'
-        ) {
-            throw new TypeError('Computed group state sync effect kind is invalid');
-        }
-        validateAuthoritativeGroupSnapshot(effect.payload, computed.aggregateRef);
-    } else if (effect.payloadKind === 'event') {
-        if (effect.effectKind !== 'member-state') {
-            throw new TypeError('Computed group state sync effect kind is invalid');
-        }
-        validateAuthoritativeGroupEvent(effect.payload, computed.aggregateRef);
-    } else {
-        throw new TypeError('Computed group state sync payload kind is invalid');
-    }
-    if (
-        !sameGroupRef(computed.aggregateRef, effect.payload) ||
-        effect.payload.causalRevision.groupRevision !==
-            computed.acceptedCausalRevision.groupRevision ||
-        effect.payload.causalRevision.presenceRevision !==
-            computed.acceptedCausalRevision.presenceRevision
-    ) {
-        throw new TypeError('Computed group state sync differs from accepted authority');
-    }
-}
-
-function sameClientRef(
-    ref: ClientPrincipalRef,
-    value: ClientSnapshot | ClientEvent,
-): boolean {
-    const candidate = 'principal' in value ? value.principal : value;
-    return ref.applicationId === candidate.applicationId &&
-        ref.workspaceId === candidate.workspaceId &&
-        ref.principalId === candidate.principalId;
-}
-
-function sameGroupRef(
-    ref: GroupRef,
-    value: GroupSnapshot | GroupEvent,
-): boolean {
-    const candidate = 'group' in value ? value.group : value;
-    return ref.applicationId === candidate.applicationId &&
-        ref.workspaceId === candidate.workspaceId &&
-        ref.groupId === candidate.groupId;
-}
-
-function isValidGroupCausalRevision(
-    revision: GroupStateCausalRevision,
-): boolean {
-    return Number.isSafeInteger(revision.groupRevision) &&
-        revision.groupRevision >= 0 &&
-        Number.isSafeInteger(revision.presenceRevision) &&
-        revision.presenceRevision >= 0;
 }
 
 export type StateSyncPublisher = Readonly<{

--- a/packages/shared-server/rallar-system/state-sync-publisher.ts
+++ b/packages/shared-server/rallar-system/state-sync-publisher.ts
@@ -90,6 +90,7 @@ export type ComputedGroupStateSync = Readonly<{
 export function computeClientStateSyncEntries(
     computed: ComputedClientStateSync,
     senderId: string,
+    principalAudienceScope: 'principal' | 'world',
 ): readonly ResourceEntry[] {
     validateComputedStateSyncFacts(computed, senderId);
     if (
@@ -102,16 +103,17 @@ export function computeClientStateSyncEntries(
         validateClientStateSyncEffect(computed, effect);
     }
     return computed.effects.map((effect) =>
-        toStateSyncEntry(
+        toStateSyncEntry({
             computed,
             effect,
             senderId,
-            AppTopics[effect.payloadKind === 'snapshot'
+            topicId: AppTopics[effect.payloadKind === 'snapshot'
                 ? 'clientStateSnapshot'
                 : 'clientStateEvent'],
-            computed.acceptedCausalRevision,
-            0,
-        )
+            sequence: computed.acceptedCausalRevision,
+            epoch: 0,
+            principalAudienceScope,
+        })
     );
 }
 
@@ -132,23 +134,31 @@ export function computeGroupStateSyncEntries(
             : effect.effectKind === 'scope-directory'
             ? AppTopics.groupDirectorySnapshot
             : AppTopics.groupStateSnapshot;
-        return toStateSyncEntry(
+        return toStateSyncEntry({
             computed,
             effect,
             senderId,
             topicId,
-            computed.acceptedCausalRevision.presenceRevision,
-            computed.acceptedCausalRevision.groupRevision,
-        );
+            sequence: computed.acceptedCausalRevision.presenceRevision,
+            epoch: computed.acceptedCausalRevision.groupRevision,
+            principalAudienceScope: 'world',
+        });
     });
 }
 
 export async function writeClientStateSync(
     transaction: PSqlTransactionSql,
     computed: ComputedClientStateSync,
-    senderId: string,
+    write: Readonly<{
+        senderId: string;
+        principalAudienceScope: 'principal' | 'world';
+    }>,
 ): Promise<readonly ResourceEntry[]> {
-    const entries = computeClientStateSyncEntries(computed, senderId);
+    const entries = computeClientStateSyncEntries(
+        computed,
+        write.senderId,
+        write.principalAudienceScope,
+    );
     await writeStateSyncEntries(transaction, entries);
     return entries;
 }
@@ -181,14 +191,18 @@ type ComputedStateSyncEffect =
     | ComputedClientStateSyncEffect
     | ComputedGroupStateSyncEffect;
 
-function toStateSyncEntry(
-    computed: ComputedStateSync,
-    effect: ComputedStateSyncEffect,
-    senderId: string,
-    topicId: string,
-    sequence: number,
-    epoch: number,
-): ResourceEntry {
+interface ToStateSyncEntryInput {
+    readonly computed: ComputedStateSync;
+    readonly effect: ComputedStateSyncEffect;
+    readonly senderId: string;
+    readonly topicId: string;
+    readonly sequence: number;
+    readonly epoch: number;
+    readonly principalAudienceScope: 'principal' | 'world';
+}
+
+function toStateSyncEntry(input: ToStateSyncEntryInput): ResourceEntry {
+    const { computed, effect, senderId, topicId, sequence, epoch } = input;
     const causalIdentity = typeof computed.acceptedCausalRevision === 'number'
         ? `revision=${computed.acceptedCausalRevision}`
         : `group=${computed.acceptedCausalRevision.groupRevision};presence=${computed.acceptedCausalRevision.presenceRevision}`;
@@ -225,6 +239,16 @@ function toStateSyncEntry(
                     applicationId: computed.audience.applicationId,
                     workspaceId: computed.audience.workspaceId,
                     groupId: computed.audience.resourceId,
+                },
+            }
+            : input.principalAudienceScope === 'principal'
+            ? {
+                mode: 'broadcast',
+                scope: 'principal',
+                principalRef: {
+                    applicationId: computed.audience.applicationId,
+                    workspaceId: computed.audience.workspaceId,
+                    principalId: computed.audience.resourceId,
                 },
             }
             : {

--- a/packages/shared-server/rallar-system/state-sync-routing.ts
+++ b/packages/shared-server/rallar-system/state-sync-routing.ts
@@ -34,6 +34,20 @@ export type StateSyncRoutingOptions = Readonly<{
     now?: RallarSnapshotPresenceClock;
 }>;
 
+/**
+ * The authoritative group snapshot carried by a state-sync row, when the row
+ * is a group or group-directory snapshot for that exact group. Delivery-time
+ * audience resolution may use it when a process-local cache lags the row.
+ */
+export function readGroupSnapshotStateSyncPayload(
+    message: ALMessage,
+): GroupSnapshot | undefined {
+    const payload = parseStateSyncPayload(message);
+    return payload && (payload.kind === 'group' || payload.kind === 'group-directory')
+        ? payload.snapshot
+        : undefined;
+}
+
 export function resolveStateSyncRecipients(
     webSocketServer: JsonWebSocketServer,
     message: ALMessage,

--- a/packages/shared-server/rallar-system/state-sync-routing.ts
+++ b/packages/shared-server/rallar-system/state-sync-routing.ts
@@ -1,15 +1,9 @@
+import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import {
-    type ALMessage,
     readALPrincipalBroadcastTarget,
-} from '@shared/al-contracts/al-contract.ts';
-import { AppTopics } from '@shared/api/api-config.ts';
-import type {
-    ClientEvent,
-    ClientPrincipalRef,
-    ClientSnapshot,
-} from '@shared/api/client-types.ts';
-import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
-import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+} from '@shared/al-contracts/read-al-principal-broadcast-target.ts';
+import type { ClientPrincipalRef, ClientSnapshot } from '@shared/api/client-types.ts';
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { ConnectionContext, JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 import type { WsServerResolvedRecipient } from '@shared/services/WsQueueBoxServerService.ts';
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
@@ -20,11 +14,11 @@ import {
     isGroupSnapshotSessionLive,
     type RallarSnapshotPresenceClock,
 } from './snapshot-presence.ts';
-
-type StateSyncScope = Readonly<{
-    applicationId: string;
-    workspaceId: string;
-}>;
+import {
+    parseStateSyncPayload,
+    sameScope,
+    type StateSyncScope,
+} from './state-sync/state-sync-payload.ts';
 
 export type StateSyncRoutingOptions = Readonly<{
     findGroupSnapshotByRef?: (ref: GroupRef) => GroupSnapshot | undefined;
@@ -33,20 +27,6 @@ export type StateSyncRoutingOptions = Readonly<{
     readGroupSnapshots?: () => readonly GroupSnapshot[];
     now?: RallarSnapshotPresenceClock;
 }>;
-
-/**
- * The authoritative group snapshot carried by a state-sync row, when the row
- * is a group or group-directory snapshot for that exact group. Delivery-time
- * audience resolution may use it when a process-local cache lags the row.
- */
-export function readGroupSnapshotStateSyncPayload(
-    message: ALMessage,
-): GroupSnapshot | undefined {
-    const payload = parseStateSyncPayload(message);
-    return payload && (payload.kind === 'group' || payload.kind === 'group-directory')
-        ? payload.snapshot
-        : undefined;
-}
 
 export function resolveStateSyncRecipients(
     webSocketServer: JsonWebSocketServer,
@@ -264,206 +244,6 @@ function toOpenClientSessionRecipients(
             peerId: snapshot.principal.principalId,
             connectionId: session.sessionId,
         }));
-}
-
-function parseStateSyncPayload(message: ALMessage):
-    | Readonly<{
-    kind: 'client';
-    scope: StateSyncScope;
-    snapshot?: ClientSnapshot;
-}>
-    | Readonly<{
-    kind: 'group';
-    snapshot: GroupSnapshot;
-}>
-    | Readonly<{
-    kind: 'group-directory';
-    snapshot: GroupSnapshot;
-}>
-    | Readonly<{
-    kind: 'group-event';
-    scope: StateSyncScope;
-    groupId: string;
-}>
-    | Readonly<{
-    kind: 'invalid';
-}>
-    | undefined {
-    try {
-        switch (message.payload.typeId) {
-            case AppTopics.clientStateSnapshot: {
-                const snapshot = JSON.parse(message.payload.resource);
-                if (!isClientSnapshot(snapshot)) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'client',
-                    scope: snapshot.principal,
-                    snapshot,
-                };
-            }
-            case AppTopics.clientStateEvent: {
-                const event = JSON.parse(message.payload.resource);
-                if (!isClientEvent(event)) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'client',
-                    scope: event,
-                };
-            }
-            case AppTopics.groupStateSnapshot: {
-                const snapshot = JSON.parse(message.payload.resource);
-                if (
-                    !isGroupSnapshot(snapshot) ||
-                    !hasMatchingExplicitGroupAudience(message, snapshot.group)
-                ) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'group',
-                    snapshot,
-                };
-            }
-            case AppTopics.groupDirectorySnapshot: {
-                const snapshot = JSON.parse(message.payload.resource);
-                if (
-                    !isGroupSnapshot(snapshot) ||
-                    !hasMatchingExplicitGroupAudience(message, snapshot.group)
-                ) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'group-directory',
-                    snapshot,
-                };
-            }
-            case AppTopics.groupStateEvent: {
-                const event = JSON.parse(message.payload.resource);
-                if (
-                    !isGroupEvent(event) ||
-                    !hasMatchingExplicitGroupAudience(message, event)
-                ) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'group-event',
-                    scope: event,
-                    groupId: event.groupId,
-                };
-            }
-            case AppTopics.overlayTopology: {
-                const snapshot = JSON.parse(message.payload.resource);
-                if (
-                    !isOverlayTopologySnapshot(snapshot) ||
-                    !hasMatchingExplicitGroupAudience(message, snapshot.groupRef)
-                ) {
-                    return { kind: 'invalid' };
-                }
-                return {
-                    kind: 'group-event',
-                    scope: snapshot.groupRef,
-                    groupId: snapshot.groupRef.groupId,
-                };
-            }
-            default:
-                return undefined;
-        }
-    } catch {
-        return isStateSyncTopic(message.payload.typeId)
-            ? { kind: 'invalid' }
-            : undefined;
-    }
-}
-
-function hasMatchingExplicitGroupAudience(
-    message: ALMessage,
-    groupRef: GroupRef,
-): boolean {
-    const targets = message.targets;
-    const targetRef = targets?.mode === 'multicast'
-        ? targets.groupRef
-        : targets?.mode === 'broadcast' && targets.groupRef !== undefined
-        ? targets.groupRef
-        : undefined;
-    return targetRef === undefined ||
-        (
-            targetRef.applicationId === groupRef.applicationId &&
-            targetRef.workspaceId === groupRef.workspaceId &&
-            targetRef.groupId === groupRef.groupId
-        );
-}
-
-function sameScope(
-    left: StateSyncScope,
-    right: StateSyncScope,
-): boolean {
-    return left.applicationId === right.applicationId &&
-        (left.workspaceId ?? '') === (right.workspaceId ?? '');
-}
-
-function isStateSyncTopic(typeId: string): boolean {
-    return typeId === AppTopics.clientStateSnapshot ||
-        typeId === AppTopics.clientStateEvent ||
-        typeId === AppTopics.groupStateSnapshot ||
-        typeId === AppTopics.groupDirectorySnapshot ||
-        typeId === AppTopics.groupStateEvent ||
-        typeId === AppTopics.overlayTopology;
-}
-
-function isOverlayTopologySnapshot(
-    value: unknown,
-): value is RallarOverlayTopologySnapshot {
-    if (!isRecord(value) || !isRecord(value.groupRef)) {
-        return false;
-    }
-
-    const groupRef = value.groupRef;
-    return typeof groupRef.groupId === 'string' &&
-        hasStateSyncScope(groupRef) &&
-        typeof value.overlayId === 'string' &&
-        typeof value.topology === 'string' &&
-        isRecord(value.nextHopsBySessionId);
-}
-
-function isClientSnapshot(value: unknown): value is ClientSnapshot {
-    return isRecord(value) &&
-        isRecord(value.principal) &&
-        typeof value.principal.principalId === 'string' &&
-        hasStateSyncScope(value.principal) &&
-        Array.isArray(value.activeSessions);
-}
-
-function isClientEvent(value: unknown): value is ClientEvent {
-    return isRecord(value) &&
-        typeof value.principalId === 'string' &&
-        typeof value.snapshotVersion === 'number' &&
-        hasStateSyncScope(value);
-}
-
-function isGroupSnapshot(value: unknown): value is GroupSnapshot {
-    return isRecord(value) &&
-        isRecord(value.group) &&
-        typeof value.group.groupId === 'string' &&
-        hasStateSyncScope(value.group) &&
-        Array.isArray(value.members) &&
-        Array.isArray(value.activeSessions);
-}
-
-function isGroupEvent(value: unknown): value is GroupEvent {
-    return isRecord(value) &&
-        typeof value.groupId === 'string' &&
-        typeof value.snapshotVersion === 'number' &&
-        hasStateSyncScope(value);
-}
-
-function hasStateSyncScope(value: Record<string, unknown>): value is StateSyncScope {
-    return typeof value.applicationId === 'string' &&
-        (value.workspaceId === undefined || typeof value.workspaceId === 'string');
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
 }
 
 function dedupRecipients(

--- a/packages/shared-server/rallar-system/state-sync-routing.ts
+++ b/packages/shared-server/rallar-system/state-sync-routing.ts
@@ -1,6 +1,13 @@
-import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import {
+    type ALMessage,
+    readALPrincipalBroadcastTarget,
+} from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
-import type { ClientEvent, ClientSnapshot } from '@shared/api/client-types.ts';
+import type {
+    ClientEvent,
+    ClientPrincipalRef,
+    ClientSnapshot,
+} from '@shared/api/client-types.ts';
 import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ConnectionContext, JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
@@ -23,6 +30,7 @@ export type StateSyncRoutingOptions = Readonly<{
     findGroupSnapshotByRef?: (ref: GroupRef) => GroupSnapshot | undefined;
     findGroupSnapshotById?: (groupId: string) => GroupSnapshot | undefined;
     readClientSnapshots?: () => readonly ClientSnapshot[];
+    readGroupSnapshots?: () => readonly GroupSnapshot[];
     now?: RallarSnapshotPresenceClock;
 }>;
 
@@ -31,6 +39,10 @@ export function resolveStateSyncRecipients(
     message: ALMessage,
     options: StateSyncRoutingOptions = {},
 ): readonly WsServerResolvedRecipient[] | undefined {
+    const principalTarget = readALPrincipalBroadcastTarget(message);
+    if (principalTarget) {
+        return resolvePrincipalRecipients(webSocketServer, principalTarget, options);
+    }
     const payload = parseStateSyncPayload(message);
     if (!payload) {
         return undefined;
@@ -107,6 +119,41 @@ export function sendStateSyncMessage(
     }
 
     return sent;
+}
+
+/**
+ * Scope 'principal' resolves at delivery time to the principal's own live
+ * sessions plus live sessions of groups the principal is an active member of.
+ * It never falls through to every open connection, unlike the legacy
+ * world-broadcast rows whose payload sniffing this branch bypasses.
+ */
+function resolvePrincipalRecipients(
+    webSocketServer: JsonWebSocketServer,
+    principalRef: ClientPrincipalRef,
+    options: StateSyncRoutingOptions,
+): readonly WsServerResolvedRecipient[] {
+    const clientSnapshots = options.readClientSnapshots?.() ??
+        clientStateSnapshotsRepository.getAllClientStateSnapshots();
+    const ownRecipients = clientSnapshots
+        .filter((snapshot) =>
+            sameScope(snapshot.principal, principalRef) &&
+            snapshot.principal.principalId === principalRef.principalId
+        )
+        .flatMap((snapshot) =>
+            toOpenClientSessionRecipients(webSocketServer, snapshot, options)
+        );
+    const groupSnapshots = options.readGroupSnapshots?.() ??
+        groupStateSnapshotsRepository.getAllGroupStateSnapshots();
+    const coGroupRecipients = groupSnapshots
+        .filter((snapshot) =>
+            sameScope(snapshot.group, principalRef) &&
+            snapshot.members.some((member) =>
+                member.principalId === principalRef.principalId &&
+                member.status === 'active'
+            )
+        )
+        .flatMap((snapshot) => resolveGroupRecipients(webSocketServer, snapshot, options));
+    return dedupRecipients([...ownRecipients, ...coGroupRecipients]);
 }
 
 function resolveScopeRecipients(

--- a/packages/shared-server/rallar-system/state-sync/state-sync-payload.ts
+++ b/packages/shared-server/rallar-system/state-sync/state-sync-payload.ts
@@ -1,0 +1,225 @@
+import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import { AppTopics } from '@shared/api/api-config.ts';
+import type { ClientEvent, ClientSnapshot } from '@shared/api/client-types.ts';
+import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+export type StateSyncScope = Readonly<{
+    applicationId: string;
+    workspaceId: string;
+}>;
+
+export type StateSyncPayload =
+    | Readonly<{
+    kind: 'client';
+    scope: StateSyncScope;
+    snapshot?: ClientSnapshot;
+}>
+    | Readonly<{
+    kind: 'group';
+    snapshot: GroupSnapshot;
+}>
+    | Readonly<{
+    kind: 'group-directory';
+    snapshot: GroupSnapshot;
+}>
+    | Readonly<{
+    kind: 'group-event';
+    scope: StateSyncScope;
+    groupId: string;
+}>
+    | Readonly<{
+    kind: 'invalid';
+}>;
+
+/**
+ * The authoritative group snapshot carried by a state-sync row, when the row
+ * is a group or group-directory snapshot for that exact group. Delivery-time
+ * audience resolution may use it when a process-local cache lags the row.
+ */
+export function readGroupSnapshotStateSyncPayload(
+    message: ALMessage,
+): GroupSnapshot | undefined {
+    const payload = parseStateSyncPayload(message);
+    return payload && (payload.kind === 'group' || payload.kind === 'group-directory')
+        ? payload.snapshot
+        : undefined;
+}
+
+export function parseStateSyncPayload(message: ALMessage): StateSyncPayload | undefined {
+    try {
+        switch (message.payload.typeId) {
+            case AppTopics.clientStateSnapshot: {
+                const snapshot = JSON.parse(message.payload.resource);
+                if (!isClientSnapshot(snapshot)) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'client',
+                    scope: snapshot.principal,
+                    snapshot,
+                };
+            }
+            case AppTopics.clientStateEvent: {
+                const event = JSON.parse(message.payload.resource);
+                if (!isClientEvent(event)) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'client',
+                    scope: event,
+                };
+            }
+            case AppTopics.groupStateSnapshot: {
+                const snapshot = JSON.parse(message.payload.resource);
+                if (
+                    !isGroupSnapshot(snapshot) ||
+                    !hasMatchingExplicitGroupAudience(message, snapshot.group)
+                ) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'group',
+                    snapshot,
+                };
+            }
+            case AppTopics.groupDirectorySnapshot: {
+                const snapshot = JSON.parse(message.payload.resource);
+                if (
+                    !isGroupSnapshot(snapshot) ||
+                    !hasMatchingExplicitGroupAudience(message, snapshot.group)
+                ) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'group-directory',
+                    snapshot,
+                };
+            }
+            case AppTopics.groupStateEvent: {
+                const event = JSON.parse(message.payload.resource);
+                if (
+                    !isGroupEvent(event) ||
+                    !hasMatchingExplicitGroupAudience(message, event)
+                ) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'group-event',
+                    scope: event,
+                    groupId: event.groupId,
+                };
+            }
+            case AppTopics.overlayTopology: {
+                const snapshot = JSON.parse(message.payload.resource);
+                if (
+                    !isOverlayTopologySnapshot(snapshot) ||
+                    !hasMatchingExplicitGroupAudience(message, snapshot.groupRef)
+                ) {
+                    return { kind: 'invalid' };
+                }
+                return {
+                    kind: 'group-event',
+                    scope: snapshot.groupRef,
+                    groupId: snapshot.groupRef.groupId,
+                };
+            }
+            default:
+                return undefined;
+        }
+    } catch {
+        return isStateSyncTopic(message.payload.typeId)
+            ? { kind: 'invalid' }
+            : undefined;
+    }
+}
+
+export function sameScope(
+    left: StateSyncScope,
+    right: StateSyncScope,
+): boolean {
+    return left.applicationId === right.applicationId &&
+        (left.workspaceId ?? '') === (right.workspaceId ?? '');
+}
+
+function hasMatchingExplicitGroupAudience(
+    message: ALMessage,
+    groupRef: GroupRef,
+): boolean {
+    const targets = message.targets;
+    const targetRef = targets?.mode === 'multicast'
+        ? targets.groupRef
+        : targets?.mode === 'broadcast' && targets.groupRef !== undefined
+        ? targets.groupRef
+        : undefined;
+    return targetRef === undefined ||
+        (
+            targetRef.applicationId === groupRef.applicationId &&
+            targetRef.workspaceId === groupRef.workspaceId &&
+            targetRef.groupId === groupRef.groupId
+        );
+}
+
+function isStateSyncTopic(typeId: string): boolean {
+    return typeId === AppTopics.clientStateSnapshot ||
+        typeId === AppTopics.clientStateEvent ||
+        typeId === AppTopics.groupStateSnapshot ||
+        typeId === AppTopics.groupDirectorySnapshot ||
+        typeId === AppTopics.groupStateEvent ||
+        typeId === AppTopics.overlayTopology;
+}
+
+function isOverlayTopologySnapshot(
+    value: unknown,
+): value is RallarOverlayTopologySnapshot {
+    if (!isRecord(value) || !isRecord(value.groupRef)) {
+        return false;
+    }
+
+    const groupRef = value.groupRef;
+    return typeof groupRef.groupId === 'string' &&
+        hasStateSyncScope(groupRef) &&
+        typeof value.overlayId === 'string' &&
+        typeof value.topology === 'string' &&
+        isRecord(value.nextHopsBySessionId);
+}
+
+function isClientSnapshot(value: unknown): value is ClientSnapshot {
+    return isRecord(value) &&
+        isRecord(value.principal) &&
+        typeof value.principal.principalId === 'string' &&
+        hasStateSyncScope(value.principal) &&
+        Array.isArray(value.activeSessions);
+}
+
+function isClientEvent(value: unknown): value is ClientEvent {
+    return isRecord(value) &&
+        typeof value.principalId === 'string' &&
+        typeof value.snapshotVersion === 'number' &&
+        hasStateSyncScope(value);
+}
+
+function isGroupSnapshot(value: unknown): value is GroupSnapshot {
+    return isRecord(value) &&
+        isRecord(value.group) &&
+        typeof value.group.groupId === 'string' &&
+        hasStateSyncScope(value.group) &&
+        Array.isArray(value.members) &&
+        Array.isArray(value.activeSessions);
+}
+
+function isGroupEvent(value: unknown): value is GroupEvent {
+    return isRecord(value) &&
+        typeof value.groupId === 'string' &&
+        typeof value.snapshotVersion === 'number' &&
+        hasStateSyncScope(value);
+}
+
+function hasStateSyncScope(value: Record<string, unknown>): value is StateSyncScope {
+    return typeof value.applicationId === 'string' &&
+        (value.workspaceId === undefined || typeof value.workspaceId === 'string');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}

--- a/packages/shared-server/rallar-system/state-sync/validate-state-sync.ts
+++ b/packages/shared-server/rallar-system/state-sync/validate-state-sync.ts
@@ -1,0 +1,177 @@
+import type {
+    ClientEvent,
+    ClientPrincipalRef,
+    ClientSnapshot,
+} from '@shared/api/client-types.ts';
+import type {
+    GroupEvent,
+    GroupRef,
+    GroupSnapshot,
+    GroupStateCausalRevision,
+} from '@shared/api/group-types.ts';
+import {
+    validateAuthoritativeClientEvent,
+    validateAuthoritativeClientSnapshot,
+    validateAuthoritativeGroupEvent,
+    validateAuthoritativeGroupSnapshot,
+} from '@shared/api/authoritative-state-validation.ts';
+import type {
+    ComputedClientStateSync,
+    ComputedClientStateSyncEffect,
+    ComputedGroupStateSync,
+    ComputedGroupStateSyncEffect,
+} from '../state-sync-publisher.ts';
+
+export function validateComputedStateSyncFacts(
+    computed: ComputedClientStateSync | ComputedGroupStateSync,
+    senderId: string,
+): void {
+    if (
+        typeof computed !== 'object' ||
+        computed === null ||
+        typeof computed.commandId !== 'string' ||
+        computed.commandId.length === 0 ||
+        typeof senderId !== 'string' ||
+        senderId.length === 0 ||
+        !Number.isSafeInteger(computed.createdAtEpochMs) ||
+        !Number.isSafeInteger(computed.expireAtEpochMs) ||
+        computed.createdAtEpochMs < 0 ||
+        computed.expireAtEpochMs <= computed.createdAtEpochMs ||
+        !Array.isArray(computed.effects) ||
+        computed.effects.length === 0 ||
+        typeof computed.aggregateRef !== 'object' ||
+        computed.aggregateRef === null ||
+        typeof computed.aggregateRef.applicationId !== 'string' ||
+        computed.aggregateRef.applicationId.length === 0 ||
+        typeof computed.aggregateRef.workspaceId !== 'string' ||
+        computed.aggregateRef.workspaceId.length === 0 ||
+        typeof computed.audience !== 'object' ||
+        computed.audience === null ||
+        !['principal', 'group'].includes(computed.audience.kind) ||
+        typeof computed.audience.applicationId !== 'string' ||
+        computed.audience.applicationId.length === 0 ||
+        typeof computed.audience.workspaceId !== 'string' ||
+        computed.audience.workspaceId.length === 0 ||
+        typeof computed.audience.resourceId !== 'string' ||
+        computed.audience.resourceId.length === 0 ||
+        computed.audience.applicationId !== computed.aggregateRef.applicationId ||
+        computed.audience.workspaceId !== computed.aggregateRef.workspaceId
+    ) {
+        throw new TypeError('Computed state sync facts are invalid');
+    }
+    if (
+        ('principalId' in computed.aggregateRef &&
+            (
+                computed.audience.kind !== 'principal' ||
+                computed.audience.resourceId !== computed.aggregateRef.principalId
+            )) ||
+        ('groupId' in computed.aggregateRef &&
+            (
+                computed.audience.kind !== 'group' ||
+                computed.audience.resourceId !== computed.aggregateRef.groupId
+            ))
+    ) {
+        throw new TypeError('Computed state sync audience differs from aggregate');
+    }
+}
+
+export function validateClientStateSyncEffect(
+    computed: ComputedClientStateSync,
+    effect: ComputedClientStateSyncEffect,
+): void {
+    if (
+        typeof effect !== 'object' ||
+        effect === null ||
+        effect.effectKind !== 'principal-state'
+    ) {
+        throw new TypeError('Computed client state sync effect kind is invalid');
+    }
+    if (effect.payloadKind === 'snapshot') {
+        validateAuthoritativeClientSnapshot(effect.payload, computed.aggregateRef);
+        if (
+            !sameClientRef(computed.aggregateRef, effect.payload) ||
+            effect.payload.stateRevision !== computed.acceptedCausalRevision
+        ) {
+            throw new TypeError(
+                'Computed client state sync snapshot differs from accepted authority',
+            );
+        }
+        return;
+    }
+    if (effect.payloadKind === 'event') {
+        validateAuthoritativeClientEvent(effect.payload, computed.aggregateRef);
+        if (
+            !sameClientRef(computed.aggregateRef, effect.payload) ||
+            effect.payload.snapshotVersion !== computed.acceptedCausalRevision
+        ) {
+            throw new TypeError(
+                'Computed client state sync event differs from accepted authority',
+            );
+        }
+        return;
+    }
+    throw new TypeError('Computed client state sync payload kind is invalid');
+}
+
+export function validateGroupStateSyncEffect(
+    computed: ComputedGroupStateSync,
+    effect: ComputedGroupStateSyncEffect,
+): void {
+    if (typeof effect !== 'object' || effect === null) {
+        throw new TypeError('Computed group state sync effect is invalid');
+    }
+    if (effect.payloadKind === 'snapshot') {
+        if (
+            effect.effectKind !== 'member-state' &&
+            effect.effectKind !== 'scope-directory'
+        ) {
+            throw new TypeError('Computed group state sync effect kind is invalid');
+        }
+        validateAuthoritativeGroupSnapshot(effect.payload, computed.aggregateRef);
+    } else if (effect.payloadKind === 'event') {
+        if (effect.effectKind !== 'member-state') {
+            throw new TypeError('Computed group state sync effect kind is invalid');
+        }
+        validateAuthoritativeGroupEvent(effect.payload, computed.aggregateRef);
+    } else {
+        throw new TypeError('Computed group state sync payload kind is invalid');
+    }
+    if (
+        !sameGroupRef(computed.aggregateRef, effect.payload) ||
+        effect.payload.causalRevision.groupRevision !==
+            computed.acceptedCausalRevision.groupRevision ||
+        effect.payload.causalRevision.presenceRevision !==
+            computed.acceptedCausalRevision.presenceRevision
+    ) {
+        throw new TypeError('Computed group state sync differs from accepted authority');
+    }
+}
+
+export function isValidGroupCausalRevision(
+    revision: GroupStateCausalRevision,
+): boolean {
+    return Number.isSafeInteger(revision.groupRevision) &&
+        revision.groupRevision >= 0 &&
+        Number.isSafeInteger(revision.presenceRevision) &&
+        revision.presenceRevision >= 0;
+}
+
+function sameClientRef(
+    ref: ClientPrincipalRef,
+    value: ClientSnapshot | ClientEvent,
+): boolean {
+    const candidate = 'principal' in value ? value.principal : value;
+    return ref.applicationId === candidate.applicationId &&
+        ref.workspaceId === candidate.workspaceId &&
+        ref.principalId === candidate.principalId;
+}
+
+function sameGroupRef(
+    ref: GroupRef,
+    value: GroupSnapshot | GroupEvent,
+): boolean {
+    const candidate = 'group' in value ? value.group : value;
+    return ref.applicationId === candidate.applicationId &&
+        ref.workspaceId === candidate.workspaceId &&
+        ref.groupId === candidate.groupId;
+}

--- a/packages/shared-server/rallar-system/topology/rallar-rtc-topology-metrics.ts
+++ b/packages/shared-server/rallar-system/topology/rallar-rtc-topology-metrics.ts
@@ -1,0 +1,74 @@
+export type RallarRtcTopologyMetrics = Readonly<{
+    topologyUpdateCount: number;
+    topologyChangedCount: number;
+    topologyUnchangedCount: number;
+    updatesWithRttMeasurementCount: number;
+    updatesWithoutRttMeasurementCount: number;
+    starPlanCount: number;
+    starPlanDurationMs: number;
+    noRttTreePlanCount: number;
+    noRttTreePlanDurationMs: number;
+    noRttMeshPlanCount: number;
+    noRttMeshPlanDurationMs: number;
+    weightedPlanCount: number;
+    weightedPlanDurationMs: number;
+    weightedRoomGraphBuildCount: number;
+    weightedRoomGraphBuildDurationMs: number;
+    weightedRoomGraphSparseFallbackCount: number;
+    rttQueueRequestCount: number;
+    rttQueueNewCount: number;
+    rttQueueCoalescedCount: number;
+    rttQueueImmediateCount: number;
+    rttFlushAttemptCount: number;
+    rttFlushSkippedCount: number;
+    rttFlushExecutedCount: number;
+    topologyPublishAttemptCount: number;
+    topologyPublishedCount: number;
+    topologyPublishSkippedUnchangedCount: number;
+    topologyRebuildSkippedFingerprintCount: number;
+    topologyRemovalRequestCount: number;
+    topologyRemovedCount: number;
+    topologyRemoveMissCount: number;
+    topologySnapshotCount: number;
+    pendingRttUpdateCount: number;
+}>;
+
+export type MutableRallarRtcTopologyMetrics = {
+    -readonly [K in keyof Omit<
+        RallarRtcTopologyMetrics,
+        'pendingRttUpdateCount' | 'topologySnapshotCount'
+    >]: number;
+};
+
+export const emptyTopologyMetrics = (): MutableRallarRtcTopologyMetrics => ({
+    topologyUpdateCount: 0,
+    topologyChangedCount: 0,
+    topologyUnchangedCount: 0,
+    updatesWithRttMeasurementCount: 0,
+    updatesWithoutRttMeasurementCount: 0,
+    starPlanCount: 0,
+    starPlanDurationMs: 0,
+    noRttTreePlanCount: 0,
+    noRttTreePlanDurationMs: 0,
+    noRttMeshPlanCount: 0,
+    noRttMeshPlanDurationMs: 0,
+    weightedPlanCount: 0,
+    weightedPlanDurationMs: 0,
+    weightedRoomGraphBuildCount: 0,
+    weightedRoomGraphBuildDurationMs: 0,
+    weightedRoomGraphSparseFallbackCount: 0,
+    rttQueueRequestCount: 0,
+    rttQueueNewCount: 0,
+    rttQueueCoalescedCount: 0,
+    rttQueueImmediateCount: 0,
+    rttFlushAttemptCount: 0,
+    rttFlushSkippedCount: 0,
+    rttFlushExecutedCount: 0,
+    topologyPublishAttemptCount: 0,
+    topologyPublishedCount: 0,
+    topologyPublishSkippedUnchangedCount: 0,
+    topologyRebuildSkippedFingerprintCount: 0,
+    topologyRemovalRequestCount: 0,
+    topologyRemovedCount: 0,
+    topologyRemoveMissCount: 0,
+});

--- a/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
@@ -1,30 +1,22 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import {
   fromCanonicalGroupTopologyConfigPatch,
+  isPreserveOnlyCanonicalGroupTopologyConfigPatch,
 } from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/InboxOutboxContracts.ts';
 
-import type {
-  PSqlSql,
-  PSqlTransactionSql,
-} from '../../../postgres/PostgresSqlClient.ts';
-import {
-  ResourceInboxRepository,
-} from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import type { PSqlSql, PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
+import { ResourceInboxRepository } from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import { runInTransaction } from '../../../postgres/run-in-transaction.ts';
-import {
-  RuntimeStateWriteConflictError,
-} from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import {
   hashRtcTopologyExecutionCommand,
   type RtcTopologyPublication,
   toRtcTopologyPublicationId,
 } from '../../repositories/RtcTopologyPublicationRepository.ts';
-import type {
-  RtcTopologyExecutionRepository,
-} from '../../repositories/RtcTopologyExecutionRepository.ts';
+import type { RtcTopologyExecutionRepository } from '../../repositories/RtcTopologyExecutionRepository.ts';
 import type { RtcTopologyDeliveryAppendPort } from './rtc-topology-delivery-append-port.ts';
 import { RtcTopologyDeliveryLeaseLostError } from './rtc-topology-delivery-stream-service.ts';
 import {
@@ -44,6 +36,8 @@ import {
 } from '../../services/rtc-topology-mutations.ts';
 import { writeRtcTopologyPublicationOutbox } from '../../services/rtc-topology-ws-outbox-entry.ts';
 import type { RtcTopologyWorkRuntime } from '../../services/RtcTopologyOutboxWork.ts';
+import { COALESCED_APP_OUTBOX_WORK_FIELD } from '../../services/CoalescedAppOutboxWorkService.ts';
+import { computeRtcTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
 import {
   type PersistedRtcTopologyWork,
   readRtcTopologyWorkEnvelope,
@@ -75,12 +69,26 @@ interface RtcTopologyWorkHandlerOptions {
   readonly serviceId?: string;
 }
 
-interface AcceptedRtcTopologyWork {
-  readonly work: PersistedRtcTopologyWork;
-  readonly group: GroupSnapshot;
-  readonly computed: AcceptedRtcTopologyMutation;
-  readonly publication: RtcTopologyPublication | null;
-}
+type AcceptedRtcTopologyWork =
+  | Readonly<{
+      decision: 'accepted';
+      work: PersistedRtcTopologyWork;
+      group: GroupSnapshot;
+      computed: AcceptedRtcTopologyMutation;
+      publication: RtcTopologyPublication | null;
+      inputFingerprint: string;
+    }>
+  | Readonly<{
+      decision: 'skipped-fingerprint';
+      work: PersistedRtcTopologyWork;
+      group: GroupSnapshot;
+    }>
+  | Readonly<{
+      decision: 'skipped-unchanged';
+      work: PersistedRtcTopologyWork;
+      group: GroupSnapshot;
+      inputFingerprint: string;
+    }>;
 
 type RtcTopologyExecutionRead = Awaited<
   ReturnType<RtcTopologyExecutionRepository['readTopologyMutation']>
@@ -175,10 +183,26 @@ async function computeAcceptedRtcTopologyWork(
     work.groupSnapshot,
     work.kind === 'group-revision',
   );
+  const inputFingerprint = await computeRtcTopologyInputFingerprint({
+    group: authority.group,
+    effectiveConfig: authority.config.effective,
+  });
+  const changeGated = isChangeGatedGroupRevisionWork(work);
+  if (changeGated && read.snapshot?.value.state === 'active') {
+    const storedFingerprint = await options.executionRepository.readTopologyInputFingerprint(
+      authority.group.group,
+    );
+    if (storedFingerprint === inputFingerprint) {
+      return { decision: 'skipped-fingerprint', work, group: authority.group };
+    }
+  }
   const computedTopology = options.topologyManagement.computeTopologyFromAuthority(
     authority,
     read.snapshot?.value,
   );
+  if (changeGated && read.snapshot !== null && !computedTopology.changed) {
+    return { decision: 'skipped-unchanged', work, group: authority.group, inputFingerprint };
+  }
   const publicationExpireAtTimestamp = work.publish
     ? options.executionRepository.publicationExpireAtTimestamp()
     : null;
@@ -226,7 +250,22 @@ async function computeAcceptedRtcTopologyWork(
   if (computed.outcome === 'loaded') {
     throw new TypeError('RTC topology publication claim appeared on a claim-miss path');
   }
-  return { work, group: authority.group, computed, publication };
+  return {
+    decision: 'accepted',
+    work,
+    group: authority.group,
+    computed,
+    publication,
+    inputFingerprint,
+  };
+}
+
+function isChangeGatedGroupRevisionWork(work: PersistedRtcTopologyWork): boolean {
+  return (
+    work.kind === 'group-revision' &&
+    work[COALESCED_APP_OUTBOX_WORK_FIELD] !== undefined &&
+    isPreserveOnlyCanonicalGroupTopologyConfigPatch(work.requestOptions)
+  );
 }
 
 async function writeAcceptedRtcTopologyWork(
@@ -234,6 +273,23 @@ async function writeAcceptedRtcTopologyWork(
   entry: ResourceEntry,
   accepted: AcceptedRtcTopologyWork,
 ): Promise<void> {
+  if (accepted.decision === 'skipped-fingerprint') {
+    await finishRtcTopologyWork(options.database, entry);
+    options.topologyManagement.recordTopologyRebuildSkippedFingerprint();
+    return;
+  }
+  if (accepted.decision === 'skipped-unchanged') {
+    await runInTransaction(options.database, async (transaction) => {
+      await options.executionRepository.writeTopologyInputFingerprint(
+        transaction,
+        accepted.group.group,
+        accepted.inputFingerprint,
+      );
+      await finishRtcTopologyReservation(transaction, entry);
+    });
+    options.topologyManagement.recordTopologyPublication(false);
+    return;
+  }
   const computed = accepted.computed;
   if (computed.outcome === 'superseded') {
     await finishRtcTopologyWork(options.database, entry);
@@ -242,6 +298,13 @@ async function writeAcceptedRtcTopologyWork(
   }
   await writeRtcTopologyPublicationTransaction(options, entry, async (transaction) => {
     await options.executionRepository.writeTopologyMutation(transaction, computed);
+    if (computed.outcome === 'write') {
+      await options.executionRepository.writeTopologyInputFingerprint(
+        transaction,
+        accepted.group.group,
+        accepted.inputFingerprint,
+      );
+    }
     if (accepted.publication) {
       await writePublicationDelivery(transaction, accepted.publication, options.topologyDelivery);
     }

--- a/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
@@ -1,22 +1,28 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import {
   fromCanonicalGroupTopologyConfigPatch,
-  isPreserveOnlyCanonicalGroupTopologyConfigPatch,
 } from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/InboxOutboxContracts.ts';
 
 import type { PSqlSql, PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
-import { ResourceInboxRepository } from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import { runInTransaction } from '../../../postgres/run-in-transaction.ts';
-import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import {
+  RuntimeStateWriteConflictError,
+} from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import {
   hashRtcTopologyExecutionCommand,
   type RtcTopologyPublication,
   toRtcTopologyPublicationId,
 } from '../../repositories/RtcTopologyPublicationRepository.ts';
-import type { RtcTopologyExecutionRepository } from '../../repositories/RtcTopologyExecutionRepository.ts';
+import type {
+  RtcTopologyExecutionRepository,
+} from '../../repositories/RtcTopologyExecutionRepository.ts';
+import {
+  finishRtcTopologyReservation,
+  finishRtcTopologyWork,
+} from './finish-rtc-topology-work.ts';
 import type { RtcTopologyDeliveryAppendPort } from './rtc-topology-delivery-append-port.ts';
 import { RtcTopologyDeliveryLeaseLostError } from './rtc-topology-delivery-stream-service.ts';
 import {
@@ -36,7 +42,9 @@ import {
 } from '../../services/rtc-topology-mutations.ts';
 import { writeRtcTopologyPublicationOutbox } from '../../services/rtc-topology-ws-outbox-entry.ts';
 import type { RtcTopologyWorkRuntime } from '../../services/RtcTopologyOutboxWork.ts';
-import { COALESCED_APP_OUTBOX_WORK_FIELD } from '../../services/CoalescedAppOutboxWorkService.ts';
+import {
+  isChangeGatedGroupRevisionWork,
+} from './rtc-topology-coalesced-group-revision-work.ts';
 import { computeRtcTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
 import {
   type PersistedRtcTopologyWork,
@@ -260,14 +268,6 @@ async function computeAcceptedRtcTopologyWork(
   };
 }
 
-function isChangeGatedGroupRevisionWork(work: PersistedRtcTopologyWork): boolean {
-  return (
-    work.kind === 'group-revision' &&
-    work[COALESCED_APP_OUTBOX_WORK_FIELD] !== undefined &&
-    isPreserveOnlyCanonicalGroupTopologyConfigPatch(work.requestOptions)
-  );
-}
-
 async function writeAcceptedRtcTopologyWork(
   options: RtcTopologyWorkHandlerOptions,
   entry: ResourceEntry,
@@ -360,27 +360,6 @@ async function writePublicationDelivery(
     throw new RtcTopologyDeliveryLeaseLostError(
       `RTC topology publisher stream ${delivery.publisherStreamId} lost its lease`,
     );
-  }
-}
-
-async function finishRtcTopologyWork(database: PSqlSql, entry: ResourceEntry): Promise<void> {
-  await runInTransaction(database, async (transaction) => {
-    await finishRtcTopologyReservation(transaction, entry);
-  });
-}
-
-async function finishRtcTopologyReservation(
-  transaction: PSqlTransactionSql,
-  entry: ResourceEntry,
-): Promise<void> {
-  const finished = await new ResourceInboxRepository(transaction).finishReserved(
-    entry.key,
-    entry.dequeueAudit.attempts,
-    EntityStatus.COMPLETED,
-    new Date(),
-  );
-  if (!finished) {
-    throw new RuntimeStateWriteConflictError();
   }
 }
 

--- a/packages/shared-server/rallar-system/topology/replay/finish-rtc-topology-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/finish-rtc-topology-work.ts
@@ -1,0 +1,34 @@
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql, PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
+import {
+  ResourceInboxRepository,
+} from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import { runInTransaction } from '../../../postgres/run-in-transaction.ts';
+import {
+  RuntimeStateWriteConflictError,
+} from '../../../runtime-state/optimistic-runtime-state-write.ts';
+
+export async function finishRtcTopologyWork(
+  database: PSqlSql,
+  entry: ResourceEntry,
+): Promise<void> {
+  await runInTransaction(database, async (transaction) => {
+    await finishRtcTopologyReservation(transaction, entry);
+  });
+}
+
+export async function finishRtcTopologyReservation(
+  transaction: PSqlTransactionSql,
+  entry: ResourceEntry,
+): Promise<void> {
+  const finished = await new ResourceInboxRepository(transaction).finishReserved(
+    entry.key,
+    entry.dequeueAudit.attempts,
+    EntityStatus.COMPLETED,
+    new Date(),
+  );
+  if (!finished) {
+    throw new RuntimeStateWriteConflictError();
+  }
+}

--- a/packages/shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts
@@ -72,6 +72,7 @@ export function computeCoalescedRtcTopologyGroupRevisionWork(
     data: incoming,
     dequeueAudit: { attempts: 0 },
     entryAudit: null,
+    messageIdentity: null,
   });
   if (input.previousEntry === null) {
     return {
@@ -82,6 +83,7 @@ export function computeCoalescedRtcTopologyGroupRevisionWork(
         data: incoming,
         dequeueAudit: { attempts: 0 },
         entryAudit: null,
+        messageIdentity: null,
       }),
       successorEntry,
     };
@@ -109,9 +111,26 @@ export function computeCoalescedRtcTopologyGroupRevisionWork(
       dequeueAudit: {
         attempts: carriesPreviousLifecycle ? input.previousEntry.dequeueAudit.attempts : 0,
       },
-      entryAudit: carriesPreviousLifecycle ? input.previousEntry.audit : null,
+      entryAudit: input.previousEntry.audit,
+      messageIdentity: readPreviousMessageIdentity(input.previousEntry),
     }),
     successorEntry,
+  };
+}
+
+/**
+ * A stored coalesced row never rewrites its created-audit columns — both the
+ * pending merge and the terminal revival compare-and-set update the resource
+ * and lifecycle only. Every later generation must therefore keep the original
+ * message creation and expiry identity, or the row stops satisfying the
+ * canonical work contract that release idempotency checks. The latest request
+ * and due times live in the coalesced metadata, not the message identity.
+ */
+function readPreviousMessageIdentity(previousEntry: ResourceEntry): CoalescedMessageIdentity {
+  const message = JSON.parse(previousEntry.resource) as ALMessage;
+  return {
+    tsEpochMs: message.id.ts,
+    expiresAtEpochMs: message.constraints?.expiresAtMs ?? null,
   };
 }
 
@@ -170,12 +189,18 @@ function readPreviousCoalescedGroupRevisionEnvelope(
   return envelope;
 }
 
+interface CoalescedMessageIdentity {
+  readonly tsEpochMs: number;
+  readonly expiresAtEpochMs: number | null;
+}
+
 interface ToCoalescedGroupRevisionEntryInput {
   readonly input: RtcTopologyCoalescedGroupRevisionInput;
   readonly resourceId: string;
   readonly data: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>;
   readonly dequeueAudit: Readonly<{ attempts: number }>;
   readonly entryAudit: ResourceEntry['audit'] | null;
+  readonly messageIdentity: CoalescedMessageIdentity | null;
 }
 
 function toCoalescedGroupRevisionEntry(
@@ -191,6 +216,10 @@ function toCoalescedGroupRevisionEntry(
   });
   const metadata = data[COALESCED_APP_OUTBOX_WORK_FIELD];
   const messageId = `${resourceId}:g${metadata.generation}`;
+  const messageTsEpochMs = entryInput.messageIdentity?.tsEpochMs ?? input.requestedAtEpochMs;
+  const messageExpiresAtEpochMs = entryInput.messageIdentity
+    ? entryInput.messageIdentity.expiresAtEpochMs
+    : input.expireAtEpochMs;
   const envelope: CoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork> = {
     type: AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,
     topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
@@ -204,11 +233,13 @@ function toCoalescedGroupRevisionEntry(
     id: {
       v: 2,
       msgId: messageId,
-      ts: input.requestedAtEpochMs,
+      ts: messageTsEpochMs,
       senderId: createdBy,
     },
     route: key,
-    constraints: { expiresAtMs: input.expireAtEpochMs },
+    ...(messageExpiresAtEpochMs === null
+      ? {}
+      : { constraints: { expiresAtMs: messageExpiresAtEpochMs } }),
     ordering: {
       orderingKey: key.contextId,
       epoch: causalRevision.groupRevision,
@@ -226,11 +257,11 @@ function toCoalescedGroupRevisionEntry(
     },
     audit: {
       createdBy,
-      createdTs: input.requestedAtEpochMs,
+      createdTs: messageTsEpochMs,
     },
   };
   const isDue = metadata.dueAtEpochMs <= input.requestedAtEpochMs;
-  const createdTs = Temporal.Instant.fromEpochMilliseconds(input.requestedAtEpochMs)
+  const createdTs = Temporal.Instant.fromEpochMilliseconds(messageTsEpochMs)
     .toZonedDateTimeISO('UTC')
     .toPlainDateTime();
   return {

--- a/packages/shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts
@@ -4,14 +4,17 @@ import { EnqueuedType } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { validateAuthoritativeGroupSnapshot } from '@shared/api/authoritative-state-validation.ts';
 import { readGroupCausalRevision, readGroupStateRevision } from '@shared/api/group-client-views.ts';
-import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import {
+  isPreserveOnlyCanonicalGroupTopologyConfigPatch,
+  toCanonicalGroupTopologyConfigPatch,
+} from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
-import { groupStateGroupStorageKey } from '../group-state-storage-keys.ts';
-import { AppOutboxType } from './AppOutboxService.ts';
-import { toAppQueueCreatedBy, toAppQueueKey } from './app-inbox-queue-key.ts';
+import { groupStateGroupStorageKey } from '../../group-state-storage-keys.ts';
+import { AppOutboxType } from '../../services/AppOutboxService.ts';
+import { toAppQueueCreatedBy, toAppQueueKey } from '../../services/app-inbox-queue-key.ts';
 import {
   COALESCED_APP_OUTBOX_WORK_FIELD,
   type CoalescedAppOutboxWorkData,
@@ -19,9 +22,12 @@ import {
   type ComputedCoalescedAppOutboxWork,
   isMutableCoalescedStatus,
   tryReadCoalescedAppOutboxWorkEnvelope,
-} from './CoalescedAppOutboxWorkService.ts';
-import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from './rtc-topology-outbox-entry.ts';
-import type { RtcTopologyGroupRevisionWork } from './RtcTopologyOutboxWork.ts';
+} from '../../services/CoalescedAppOutboxWorkService.ts';
+import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '../../services/rtc-topology-outbox-entry.ts';
+import type { RtcTopologyGroupRevisionWork } from '../../services/RtcTopologyOutboxWork.ts';
+import type { PersistedRtcTopologyWork } from './rtc-topology-work-codec.ts';
+
+export const DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS = 500;
 
 export interface RtcTopologyCoalescedGroupRevisionInput {
   readonly aggregateRef: GroupRef;
@@ -109,6 +115,19 @@ export function computeCoalescedRtcTopologyGroupRevisionWork(
   };
 }
 
+/**
+ * The M3 change gate applies only to coalesced group-revision recomputes whose
+ * request carries a preserve-only topology-config patch; explicit reconfigures
+ * and legacy per-command work always rebuild.
+ */
+export function isChangeGatedGroupRevisionWork(work: PersistedRtcTopologyWork): boolean {
+  return (
+    work.kind === 'group-revision' &&
+    work[COALESCED_APP_OUTBOX_WORK_FIELD] !== undefined &&
+    isPreserveOnlyCanonicalGroupTopologyConfigPatch(work.requestOptions)
+  );
+}
+
 export function mergeRtcTopologyGroupRevisionWork(
   existing: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>,
   incoming: CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork>,
@@ -144,7 +163,8 @@ function readPreviousCoalescedGroupRevisionEnvelope(
     tryReadCoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork>(previousEntry);
   if (!envelope || envelope.data.kind !== 'group-revision') {
     throw new TypeError(
-      `Coalesced group-revision predecessor is not coalesced topology work: ${previousEntry.key.resourceId}`,
+      'Coalesced group-revision predecessor is not coalesced topology work: ' +
+        previousEntry.key.resourceId,
     );
   }
   return envelope;

--- a/packages/shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts
+++ b/packages/shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts
@@ -1,0 +1,89 @@
+import { readGroupDisplayName, readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
+import type { EffectiveGroupTopologyConfig } from '@shared/api/graph-topology-management-types.ts';
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
+
+import { compareRtcTopologyIdentifiers } from '../../rtc-topology-identifiers.ts';
+import { groupStateGroupStorageKey } from '../../group-state-storage-keys.ts';
+import { sha256CanonicalJson } from '../../group-state/mutation/group-state-crypto.ts';
+import { RuntimeStateJsonStore } from '../../../runtime-state/RuntimeStateJsonStore.ts';
+import type { RuntimeStateRepositoryLike } from '../../../runtime-state/RuntimeStateRepository.ts';
+
+export const RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE = 'rtc-topology:input-fingerprints';
+
+export interface RtcTopologyInputFingerprintFacts {
+  readonly group: GroupSnapshot;
+  readonly effectiveConfig: EffectiveGroupTopologyConfig;
+}
+
+interface StoredRtcTopologyInputFingerprint {
+  readonly groupRef: GroupRef;
+  readonly fingerprint: string;
+}
+
+export async function computeRtcTopologyInputFingerprint(
+  facts: RtcTopologyInputFingerprintFacts,
+): Promise<string> {
+  const digest = await sha256CanonicalJson({
+    activeSessionIds: [...readGroupMemberSessionIds(facts.group)].sort(
+      compareRtcTopologyIdentifiers,
+    ),
+    displayName: readGroupDisplayName(facts.group),
+    effectiveConfig: {
+      topologyKind: facts.effectiveConfig.topologyKind,
+      degreeLimit: facts.effectiveConfig.degreeLimit,
+      treeMinSize: facts.effectiveConfig.treeMinSize,
+      meshMinSize: facts.effectiveConfig.meshMinSize,
+      meshParamK: facts.effectiveConfig.meshParamK,
+    },
+  });
+  return `sha256:${digest}`;
+}
+
+export class RtcTopologyInputFingerprintRepository extends RuntimeStateJsonStore {
+  constructor(readonly runtimeRepository: RuntimeStateRepositoryLike) {
+    super(runtimeRepository);
+  }
+
+  /**
+   * Absent, foreign-scope, or malformed rows read as null so the fingerprint
+   * gate fails open into a normal rebuild instead of a wrong skip.
+   */
+  async findFingerprint(ref: GroupRef): Promise<string | null> {
+    const stored = await this.getValue<StoredRtcTopologyInputFingerprint>(
+      RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE,
+      groupStateGroupStorageKey(ref),
+    );
+    if (
+      !stored ||
+      typeof stored.fingerprint !== 'string' ||
+      !/^sha256:[0-9a-f]{64}$/.test(stored.fingerprint) ||
+      stored.groupRef?.applicationId !== ref.applicationId ||
+      stored.groupRef?.workspaceId !== ref.workspaceId ||
+      stored.groupRef?.groupId !== ref.groupId
+    ) {
+      return null;
+    }
+    return stored.fingerprint;
+  }
+
+  async putFingerprint(ref: GroupRef, fingerprint: string): Promise<void> {
+    if (!/^sha256:[0-9a-f]{64}$/.test(fingerprint)) {
+      throw new TypeError('RTC topology input fingerprint is invalid');
+    }
+    const stored: StoredRtcTopologyInputFingerprint = {
+      groupRef: {
+        applicationId: ref.applicationId,
+        workspaceId: ref.workspaceId,
+        groupId: ref.groupId,
+      },
+      fingerprint,
+    };
+    await this.putValue(
+      RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE,
+      groupStateGroupStorageKey(ref),
+      stored,
+      NEVER_EXPIRE_AT_TIMESTAMP,
+    );
+  }
+}

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-rtc-topology-convergence.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-rtc-topology-convergence.json
@@ -619,13 +619,13 @@
       ]
     },
     {
-      "name": "waitForBothRevisionsOnPrimary",
+      "name": "waitForBothRevisionSnapshotsOnPrimary",
       "type": "ws.wait",
       "connection": "wsPrimary",
       "request": {
         "outputs": {
-          "primaryFirstTopologyPayload": "matchedMessages.0.matchedMessage.data.payload.resource",
-          "primarySecondTopologyPayload": "matchedMessages.1.matchedMessage.data.payload.resource"
+          "primaryFirstSnapshotPayload": "matchedMessages.0.matchedMessage.data.payload.resource",
+          "primarySecondSnapshotPayload": "matchedMessages.1.matchedMessage.data.payload.resource"
         }
       },
       "expect": {
@@ -635,36 +635,32 @@
         "ordered": false,
         "messages": [
           {
-            "targets": { "minSnapshotVersion": "{roleMutationRevision}" },
             "route": {
-              "topicId": "overlay.topology",
-              "contextId": "{groupId}"
+              "topicId": "group-state.snapshot"
             },
             "payload": {
-              "typeId": "overlay.topology"
+              "typeId": "group-state.snapshot"
             }
           },
           {
-            "targets": { "minSnapshotVersion": "{groupMutationRevision}" },
             "route": {
-              "topicId": "overlay.topology",
-              "contextId": "{groupId}"
+              "topicId": "group-state.snapshot"
             },
             "payload": {
-              "typeId": "overlay.topology"
+              "typeId": "group-state.snapshot"
             }
           }
         ]
       }
     },
     {
-      "name": "waitForBothRevisionsOnTertiary",
+      "name": "waitForBothRevisionSnapshotsOnTertiary",
       "type": "ws.wait",
       "connection": "wsTertiary",
       "request": {
         "outputs": {
-          "tertiaryFirstTopologyPayload": "matchedMessages.0.matchedMessage.data.payload.resource",
-          "tertiarySecondTopologyPayload": "matchedMessages.1.matchedMessage.data.payload.resource"
+          "tertiaryFirstSnapshotPayload": "matchedMessages.0.matchedMessage.data.payload.resource",
+          "tertiarySecondSnapshotPayload": "matchedMessages.1.matchedMessage.data.payload.resource"
         }
       },
       "expect": {
@@ -674,65 +670,61 @@
         "ordered": false,
         "messages": [
           {
-            "targets": { "minSnapshotVersion": "{roleMutationRevision}" },
             "route": {
-              "topicId": "overlay.topology",
-              "contextId": "{groupId}"
+              "topicId": "group-state.snapshot"
             },
             "payload": {
-              "typeId": "overlay.topology"
+              "typeId": "group-state.snapshot"
             }
           },
           {
-            "targets": { "minSnapshotVersion": "{groupMutationRevision}" },
             "route": {
-              "topicId": "overlay.topology",
-              "contextId": "{groupId}"
+              "topicId": "group-state.snapshot"
             },
             "payload": {
-              "typeId": "overlay.topology"
+              "typeId": "group-state.snapshot"
             }
           }
         ]
       }
     },
     {
-      "name": "parsePrimaryFirstTopology",
+      "name": "parsePrimaryFirstSnapshot",
       "type": "set",
-      "output": "primaryFirstTopology",
+      "output": "primaryFirstSnapshot",
       "transform": {
         "jsonParse": {
-          "path": "outputs.primaryFirstTopologyPayload"
+          "path": "outputs.primaryFirstSnapshotPayload"
         }
       }
     },
     {
-      "name": "parsePrimarySecondTopology",
+      "name": "parsePrimarySecondSnapshot",
       "type": "set",
-      "output": "primarySecondTopology",
+      "output": "primarySecondSnapshot",
       "transform": {
         "jsonParse": {
-          "path": "outputs.primarySecondTopologyPayload"
+          "path": "outputs.primarySecondSnapshotPayload"
         }
       }
     },
     {
-      "name": "parseTertiaryFirstTopology",
+      "name": "parseTertiaryFirstSnapshot",
       "type": "set",
-      "output": "tertiaryFirstTopology",
+      "output": "tertiaryFirstSnapshot",
       "transform": {
         "jsonParse": {
-          "path": "outputs.tertiaryFirstTopologyPayload"
+          "path": "outputs.tertiaryFirstSnapshotPayload"
         }
       }
     },
     {
-      "name": "parseTertiarySecondTopology",
+      "name": "parseTertiarySecondSnapshot",
       "type": "set",
-      "output": "tertiarySecondTopology",
+      "output": "tertiarySecondSnapshot",
       "transform": {
         "jsonParse": {
-          "path": "outputs.tertiarySecondTopologyPayload"
+          "path": "outputs.tertiarySecondSnapshotPayload"
         }
       }
     },
@@ -740,8 +732,8 @@
       "name": "assertPrimaryExactRevisions",
       "type": "assert",
       "actual": {
-        "firstRevision": "{primaryFirstTopology.sourceGroupStateCausalRevision.groupRevision}",
-        "secondRevision": "{primarySecondTopology.sourceGroupStateCausalRevision.groupRevision}"
+        "firstRevision": "{primaryFirstSnapshot.causalRevision.groupRevision}",
+        "secondRevision": "{primarySecondSnapshot.causalRevision.groupRevision}"
       },
       "expect": {
         "anyOf": [
@@ -760,8 +752,8 @@
       "name": "assertTertiaryExactRevisions",
       "type": "assert",
       "actual": {
-        "firstRevision": "{tertiaryFirstTopology.sourceGroupStateCausalRevision.groupRevision}",
-        "secondRevision": "{tertiarySecondTopology.sourceGroupStateCausalRevision.groupRevision}"
+        "firstRevision": "{tertiaryFirstSnapshot.causalRevision.groupRevision}",
+        "secondRevision": "{tertiarySecondSnapshot.causalRevision.groupRevision}"
       },
       "expect": {
         "anyOf": [
@@ -777,71 +769,59 @@
       }
     },
     {
-      "name": "assertTopologyPayloadsAcrossPrimaryAndTertiary",
+      "name": "assertSnapshotPayloadsAcrossPrimaryAndTertiary",
       "type": "assert",
       "actual": {
-        "primaryFirst": "{primaryFirstTopology}",
-        "primarySecond": "{primarySecondTopology}",
-        "tertiaryFirst": "{tertiaryFirstTopology}",
-        "tertiarySecond": "{tertiarySecondTopology}"
+        "primaryFirst": "{primaryFirstSnapshot}",
+        "primarySecond": "{primarySecondSnapshot}",
+        "tertiaryFirst": "{tertiaryFirstSnapshot}",
+        "tertiarySecond": "{tertiarySecondSnapshot}"
       },
       "expect": {
         "body": {
           "primaryFirst": {
-            "sourceGroupStateCausalRevision": {
+            "causalRevision": {
               "groupRevision": "integer",
               "presenceRevision": "integer"
             },
-            "state": "active",
-            "version": "integer",
-            "groupRef": {
+            "group": {
               "applicationId": "{applicationId}",
               "workspaceId": "{workspaceId}",
               "groupId": "{groupId}"
-            },
-            "activeSessionIds": ["{aliceSessionId}", "{bobSessionId}"]
+            }
           },
           "primarySecond": {
-            "sourceGroupStateCausalRevision": {
+            "causalRevision": {
               "groupRevision": "integer",
               "presenceRevision": "integer"
             },
-            "state": "active",
-            "version": "integer",
-            "groupRef": {
+            "group": {
               "applicationId": "{applicationId}",
               "workspaceId": "{workspaceId}",
               "groupId": "{groupId}"
-            },
-            "activeSessionIds": ["{aliceSessionId}", "{bobSessionId}"]
+            }
           },
           "tertiaryFirst": {
-            "sourceGroupStateCausalRevision": {
+            "causalRevision": {
               "groupRevision": "integer",
               "presenceRevision": "integer"
             },
-            "state": "active",
-            "version": "integer",
-            "groupRef": {
+            "group": {
               "applicationId": "{applicationId}",
               "workspaceId": "{workspaceId}",
               "groupId": "{groupId}"
-            },
-            "activeSessionIds": ["{aliceSessionId}", "{bobSessionId}"]
+            }
           },
           "tertiarySecond": {
-            "sourceGroupStateCausalRevision": {
+            "causalRevision": {
               "groupRevision": "integer",
               "presenceRevision": "integer"
             },
-            "state": "active",
-            "version": "integer",
-            "groupRef": {
+            "group": {
               "applicationId": "{applicationId}",
               "workspaceId": "{workspaceId}",
               "groupId": "{groupId}"
-            },
-            "activeSessionIds": ["{aliceSessionId}", "{bobSessionId}"]
+            }
           }
         }
       }

--- a/packages/shared/al-contracts/al-contract.ts
+++ b/packages/shared/al-contracts/al-contract.ts
@@ -44,12 +44,7 @@ export type ALTargets =
     mode: 'broadcast';
     scope: 'room' | 'world' | 'all' | 'principal';
     groupRef?: GroupRef;
-    /**
-     * Server-resolved audience identity for scope 'principal': the principal's
-     * own live sessions plus live sessions of groups the principal is an
-     * active member of. Never resolves to every open connection.
-     */
-    principalRef?: ClientPrincipalRef;
+    principalRef?: ClientPrincipalRef; // scope 'principal': own + co-group live sessions only
     exceptPeerIds?: readonly string[];
     minSnapshotVersion?: number;
     /** Immutable logical audience captured by authoritative server work. */
@@ -338,9 +333,7 @@ export function toALGroupTargetKey(group: string | GroupRef): string {
     ]);
 }
 
-export function readALMulticastTargetGroupRef(
-    message: ALMessage,
-): GroupRef | undefined {
+export function readALMulticastTargetGroupRef(message: ALMessage): GroupRef | undefined {
     const targets = message.targets;
     if (targets?.mode !== 'multicast') {
         return undefined;
@@ -349,31 +342,7 @@ export function readALMulticastTargetGroupRef(
     return toALGroupRef(targets.groupRef);
 }
 
-export function readALPrincipalBroadcastTarget(
-    message: ALMessage,
-): ClientPrincipalRef | undefined {
-    const targets = message.targets;
-    if (
-        targets?.mode !== 'broadcast' ||
-        targets.scope !== 'principal' ||
-        targets.principalRef === undefined ||
-        typeof targets.principalRef.applicationId !== 'string' ||
-        typeof targets.principalRef.workspaceId !== 'string' ||
-        typeof targets.principalRef.principalId !== 'string'
-    ) {
-        return undefined;
-    }
-
-    return {
-        applicationId: targets.principalRef.applicationId,
-        workspaceId: targets.principalRef.workspaceId,
-        principalId: targets.principalRef.principalId,
-    };
-}
-
-export function readALTargetGroupRef(
-    message: ALMessage,
-): GroupRef | undefined {
+export function readALTargetGroupRef(message: ALMessage): GroupRef | undefined {
     const targets = message.targets;
     if (targets?.mode === 'multicast') {
         return toALGroupRef(targets.groupRef);

--- a/packages/shared/al-contracts/al-contract.ts
+++ b/packages/shared/al-contracts/al-contract.ts
@@ -1,4 +1,5 @@
 import type { ALQosPolicyRequest } from './al-policy.ts';
+import type { ClientPrincipalRef } from '../api/client-types.ts';
 import type { GroupRef } from '../api/group-types.ts';
 
 // -------------------------------------------------------
@@ -41,8 +42,14 @@ export type ALTargets =
 }>
     | Readonly<{
     mode: 'broadcast';
-    scope: 'room' | 'world' | 'all';
+    scope: 'room' | 'world' | 'all' | 'principal';
     groupRef?: GroupRef;
+    /**
+     * Server-resolved audience identity for scope 'principal': the principal's
+     * own live sessions plus live sessions of groups the principal is an
+     * active member of. Never resolves to every open connection.
+     */
+    principalRef?: ClientPrincipalRef;
     exceptPeerIds?: readonly string[];
     minSnapshotVersion?: number;
     /** Immutable logical audience captured by authoritative server work. */
@@ -340,6 +347,28 @@ export function readALMulticastTargetGroupRef(
     }
 
     return toALGroupRef(targets.groupRef);
+}
+
+export function readALPrincipalBroadcastTarget(
+    message: ALMessage,
+): ClientPrincipalRef | undefined {
+    const targets = message.targets;
+    if (
+        targets?.mode !== 'broadcast' ||
+        targets.scope !== 'principal' ||
+        targets.principalRef === undefined ||
+        typeof targets.principalRef.applicationId !== 'string' ||
+        typeof targets.principalRef.workspaceId !== 'string' ||
+        typeof targets.principalRef.principalId !== 'string'
+    ) {
+        return undefined;
+    }
+
+    return {
+        applicationId: targets.principalRef.applicationId,
+        workspaceId: targets.principalRef.workspaceId,
+        principalId: targets.principalRef.principalId,
+    };
 }
 
 export function readALTargetGroupRef(

--- a/packages/shared/al-contracts/read-al-principal-broadcast-target.ts
+++ b/packages/shared/al-contracts/read-al-principal-broadcast-target.ts
@@ -1,0 +1,29 @@
+import type { ClientPrincipalRef } from '../api/client-types.ts';
+import type { ALMessage } from './al-contract.ts';
+
+/**
+ * Reads the server-resolved principal audience from a broadcast target with
+ * scope 'principal': the principal's own live sessions plus live sessions of
+ * groups the principal is an active member of. Never a world broadcast.
+ */
+export function readALPrincipalBroadcastTarget(
+    message: ALMessage,
+): ClientPrincipalRef | undefined {
+    const targets = message.targets;
+    if (
+        targets?.mode !== 'broadcast' ||
+        targets.scope !== 'principal' ||
+        targets.principalRef === undefined ||
+        typeof targets.principalRef.applicationId !== 'string' ||
+        typeof targets.principalRef.workspaceId !== 'string' ||
+        typeof targets.principalRef.principalId !== 'string'
+    ) {
+        return undefined;
+    }
+
+    return {
+        applicationId: targets.principalRef.applicationId,
+        workspaceId: targets.principalRef.workspaceId,
+        principalId: targets.principalRef.principalId,
+    };
+}

--- a/packages/shared/api/group-topology-config-canonical.ts
+++ b/packages/shared/api/group-topology-config-canonical.ts
@@ -37,6 +37,16 @@ export function toCanonicalGroupTopologyConfigPatch(
     };
 }
 
+export function isPreserveOnlyCanonicalGroupTopologyConfigPatch(
+    patch: CanonicalGroupTopologyConfigPatch,
+): boolean {
+    return patch.topologyKind.action === 'preserve' &&
+        patch.degreeLimit.action === 'preserve' &&
+        patch.treeMinSize.action === 'preserve' &&
+        patch.meshMinSize.action === 'preserve' &&
+        patch.meshParamK.action === 'preserve';
+}
+
 export function readCanonicalGroupTopologyConfigPatch(
     value: unknown,
 ): CanonicalGroupTopologyConfigPatch {

--- a/packages/shared/queuebox/QueueBoxTypes.ts
+++ b/packages/shared/queuebox/QueueBoxTypes.ts
@@ -9,6 +9,10 @@ import {
     isCanonicalGroupPresenceSummaryEntry,
 } from './GroupPresenceSummaryEntryContract.ts';
 import { isCanonicalRtcTopologyWorkEntry } from './RtcTopologyWorkEntryContract.ts';
+import {
+    COALESCED_APP_OUTBOX_WORK_FIELD,
+    tryReadCoalescedAppOutboxWorkEnvelope,
+} from './coalesced-app-outbox-work-envelope.ts';
 
 export type { PersistenceProvider } from '../persistence/PersistenceProvider.ts';
 
@@ -105,6 +109,9 @@ export function isIdempotentHandlerFinalizedRelease(
     disposition: ResourceInboxReleaseDisposition,
 ): boolean {
     try {
+        if (isCoalescedRevivalAfterHandlerFinalization(current, reserved, disposition)) {
+            return true;
+        }
         const remoteDeliveryRequeue =
             disposition.status === Resource.EntityStatus.COMPLETED &&
             disposition.delayMs === null &&
@@ -146,6 +153,40 @@ export function isIdempotentHandlerFinalizedRelease(
     } catch {
         return false;
     }
+}
+
+/**
+ * A coalesced APP_OUTBOX row may be revived in place after a handler finalized
+ * the reserved work: the revival compare-and-set matches only terminal
+ * statuses, so a same-key row whose coalesced generation advanced past the
+ * reserved entry's with a reset dequeue lifecycle proves the reservation was
+ * finalized first and then legitimately superseded. Releasing that
+ * reservation as completed is idempotent, not a lost reservation.
+ */
+function isCoalescedRevivalAfterHandlerFinalization(
+    current: ResourceEntry,
+    reserved: ResourceEntry,
+    disposition: ResourceInboxReleaseDisposition,
+): boolean {
+    if (
+        disposition.status !== Resource.EntityStatus.COMPLETED ||
+        disposition.delayMs !== null ||
+        reserved.status !== Resource.EntityStatus.RESERVED ||
+        reserved.typeId !== EnqueuedType.APP_OUTBOX ||
+        current.typeId !== EnqueuedType.APP_OUTBOX ||
+        !Resource.isKeysEqual(current.key, reserved.key) ||
+        (current.status !== Resource.EntityStatus.NEW &&
+            current.status !== Resource.EntityStatus.RETRY) ||
+        current.dequeueAudit.attempts !== 0
+    ) {
+        return false;
+    }
+    const reservedWork = tryReadCoalescedAppOutboxWorkEnvelope(reserved);
+    const currentWork = tryReadCoalescedAppOutboxWorkEnvelope(current);
+    return reservedWork !== undefined &&
+        currentWork !== undefined &&
+        currentWork.data[COALESCED_APP_OUTBOX_WORK_FIELD].generation >
+            reservedWork.data[COALESCED_APP_OUTBOX_WORK_FIELD].generation;
 }
 
 export function toResourceInboxReservationOptions(

--- a/packages/shared/queuebox/coalesced-app-outbox-work-envelope.ts
+++ b/packages/shared/queuebox/coalesced-app-outbox-work-envelope.ts
@@ -1,0 +1,76 @@
+import type { ALMessage } from '../al-contracts/al-contract.ts';
+import {
+    COMPLETED_STATUSES,
+    EntityStatus,
+    isFailed,
+    type ResourceEntry,
+} from './ResourceEntry.ts';
+
+export const COALESCED_APP_OUTBOX_WORK_FIELD = '__rallarCoalescedWork';
+
+export type CoalescedAppOutboxWorkMetadata = Readonly<{
+    generation: number;
+    requestedAtEpochMs: number;
+    dueAtEpochMs: number;
+    reasons: readonly string[];
+}>;
+
+export type CoalescedAppOutboxWorkData<T extends object> =
+    & T
+    & Readonly<{
+    [COALESCED_APP_OUTBOX_WORK_FIELD]: CoalescedAppOutboxWorkMetadata;
+}>;
+
+export type CoalescedAppOutboxWorkEnvelope<T extends object> = Readonly<{
+    type: string;
+    topicId: string;
+    resourceId: string;
+    contextId: string;
+    senderId: string;
+    data: CoalescedAppOutboxWorkData<T>;
+}>;
+
+export function isTerminalCoalescedStatus(status: EntityStatus): boolean {
+    return COMPLETED_STATUSES.has(status) || isFailed(status);
+}
+
+export function isMutableCoalescedStatus(status: EntityStatus): boolean {
+    return status === EntityStatus.NEW || status === EntityStatus.RETRY;
+}
+
+export function tryReadCoalescedAppOutboxWorkEnvelope<T extends object>(
+    entry: ResourceEntry,
+): CoalescedAppOutboxWorkEnvelope<T> | undefined {
+    try {
+        const message = JSON.parse(entry.resource) as ALMessage;
+        const envelope = JSON.parse(
+            message.payload.resource,
+        ) as CoalescedAppOutboxWorkEnvelope<T>;
+        return isCoalescedEnvelope(envelope) ? envelope : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function isCoalescedEnvelope(
+    value: unknown,
+): value is CoalescedAppOutboxWorkEnvelope<object> {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const maybe = value as Partial<CoalescedAppOutboxWorkEnvelope<object>>;
+    const data = maybe.data as Record<string, unknown> | undefined;
+    const metadata = data?.[COALESCED_APP_OUTBOX_WORK_FIELD] as
+        | Partial<CoalescedAppOutboxWorkMetadata>
+        | undefined;
+
+    return typeof maybe.type === 'string' &&
+        typeof maybe.topicId === 'string' &&
+        typeof maybe.resourceId === 'string' &&
+        typeof maybe.contextId === 'string' &&
+        typeof maybe.senderId === 'string' &&
+        typeof metadata?.generation === 'number' &&
+        typeof metadata.requestedAtEpochMs === 'number' &&
+        typeof metadata.dueAtEpochMs === 'number';
+}

--- a/packages/shared/repository/group-state-snapshot-revision.ts
+++ b/packages/shared/repository/group-state-snapshot-revision.ts
@@ -1,38 +1,114 @@
-import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { GroupPresenceSession, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import {
-    compareGroupCausalRevision,
-    readGroupCausalRevision,
+  compareGroupCausalRevision,
+  readGroupCausalRevision,
 } from '@shared/api/group-client-views.ts';
 import { jsonEquals } from './state-utils.ts';
 import {
-    type StateSnapshotRevisionDecision,
-    StateSnapshotRevisionConflictError,
+  type StateSnapshotRevisionDecision,
+  StateSnapshotRevisionConflictError,
 } from './state-snapshot-revision.ts';
 
 export class GroupStateSnapshotIncomparableError extends Error {
-    constructor(readonly groupRef: GroupRef) {
-        super('Group snapshot causal tuple is incomparable');
-        this.name = 'GroupStateSnapshotIncomparableError';
-    }
+  constructor(readonly groupRef: GroupRef) {
+    super('Group snapshot causal tuple is incomparable');
+    this.name = 'GroupStateSnapshotIncomparableError';
+  }
 }
 
 export function decideGroupSnapshotCausalRevision(
-    current: GroupSnapshot | undefined,
-    incoming: GroupSnapshot,
+  current: GroupSnapshot | undefined,
+  incoming: GroupSnapshot,
 ): StateSnapshotRevisionDecision {
-    if (!current) return 'inserted';
+  if (!current) return 'inserted';
 
-    const order = compareGroupCausalRevision(
-        readGroupCausalRevision(incoming),
-        readGroupCausalRevision(current),
-    );
-    if (order === 'dominates') return 'advanced';
-    if (order === 'dominated') return 'stale';
-    if (order === 'incomparable') return 'incomparable';
-    if (jsonEquals(current, incoming)) return 'duplicate';
+  const order = compareGroupCausalRevision(
+    readGroupCausalRevision(incoming),
+    readGroupCausalRevision(current),
+  );
+  if (order === 'dominates') return 'advanced';
+  if (order === 'dominated') return 'stale';
+  if (order === 'incomparable') return 'incomparable';
+  if (
+    jsonEquals(toLeaseInsensitiveSnapshot(current), toLeaseInsensitiveSnapshot(incoming)) ||
+    isTuplePreservingGroupLivenessReduction(incoming, current) ||
+    isTuplePreservingGroupLivenessReduction(current, incoming)
+  ) {
+    return 'duplicate';
+  }
 
-    throw new StateSnapshotRevisionConflictError(
-        'Group',
-        incoming.stateRevision,
-    );
+  throw new StateSnapshotRevisionConflictError('Group', incoming.stateRevision);
+}
+
+/**
+ * Session lease fields are the liveness plane, not snapshot content: two
+ * assemblies at one causal tuple may legitimately differ only in
+ * lastHeartbeatAtEpochMs/expiresAtEpochMs (and in read-time expiry filtering,
+ * which the reduction predicate below covers).
+ */
+export function isTuplePreservingGroupLivenessReduction(
+  reduced: GroupSnapshot,
+  full: GroupSnapshot,
+): boolean {
+  const {
+    activeSessions: reducedSessions,
+    onlineMemberCount: _reducedOnlineMemberCount,
+    ...reducedAuthority
+  } = toLeaseInsensitiveSnapshot(reduced);
+  const {
+    activeSessions: fullSessions,
+    onlineMemberCount: _fullOnlineMemberCount,
+    ...fullAuthority
+  } = toLeaseInsensitiveSnapshot(full);
+  if (
+    !jsonEquals(reducedAuthority, fullAuthority) ||
+    !hasConsistentGroupOnlineMemberCount(reduced) ||
+    !hasConsistentGroupOnlineMemberCount(full)
+  ) {
+    return false;
+  }
+
+  const fullSessionsById = new Map(
+    fullSessions.map((session, index) => [session.sessionId, { index, session }]),
+  );
+  if (
+    fullSessionsById.size !== fullSessions.length ||
+    new Set(reducedSessions.map((session) => session.sessionId)).size !== reducedSessions.length
+  ) {
+    return false;
+  }
+  let previousFullIndex = -1;
+  for (const reducedSession of reducedSessions) {
+    const full = fullSessionsById.get(reducedSession.sessionId);
+    if (!full || full.index <= previousFullIndex || !jsonEquals(reducedSession, full.session)) {
+      return false;
+    }
+    previousFullIndex = full.index;
+  }
+  return true;
+}
+
+function toLeaseInsensitiveSnapshot(snapshot: GroupSnapshot): GroupSnapshot {
+  return {
+    ...snapshot,
+    activeSessions: snapshot.activeSessions.map(toLeaseInsensitiveSession),
+  };
+}
+
+function toLeaseInsensitiveSession(session: GroupPresenceSession): GroupPresenceSession {
+  return {
+    ...session,
+    lastHeartbeatAtEpochMs: 0,
+    expiresAtEpochMs: 0,
+  };
+}
+
+function hasConsistentGroupOnlineMemberCount(snapshot: GroupSnapshot): boolean {
+  const activePrincipalIds = new Set(snapshot.activeSessions.map((session) => session.principalId));
+  return (
+    snapshot.onlineMemberCount ===
+    snapshot.members.filter(
+      (member) => member.status === 'active' && activePrincipalIds.has(member.principalId),
+    ).length
+  );
 }

--- a/packages/shared/services/ws-queue-box-server-contracts.ts
+++ b/packages/shared/services/ws-queue-box-server-contracts.ts
@@ -37,7 +37,7 @@ export type WsServerTargetResolver = Readonly<{
         message: ALMessage,
     ) => readonly WsServerResolvedRecipient[];
     resolveBroadcastRecipients?: (
-        scope: 'room' | 'world' | 'all',
+        scope: 'room' | 'world' | 'all' | 'principal',
         message: ALMessage,
     ) => readonly WsServerResolvedRecipient[];
     resolvePeerIdForConnection?: (

--- a/packages/tests/repo/auth-mutation-validation-ownership.test.ts
+++ b/packages/tests/repo/auth-mutation-validation-ownership.test.ts
@@ -53,7 +53,9 @@ const directValidationImportOwners = [
 ] as const;
 
 describe('auth mutation validation ownership', () => {
-  it('keeps validation helpers out of the public package root', async () => {
+  // Importing the whole package root can exceed the default timeout under a
+  // fully parallel suite run; the ownership assertion itself is instant.
+  it('keeps validation helpers out of the public package root', { timeout: 20_000 }, async () => {
     const packageRoot = await import(absolute('packages/shared-server/mod.ts'));
 
     for (const name of privateValidationExports) {

--- a/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
+++ b/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
@@ -181,7 +181,7 @@ export const authNavigationStageLabels = [
 ] as const;
 
 export const authNavigationSourceSnapshot: readonly AuthNavigationSourceSnapshot[] = [
-  navigationSource('apps/api-v1/src/middleware.ts', '77b20cd6d40709d4db521d50acdb636a5a474c5f', [
+  navigationSource('apps/api-v1/src/middleware.ts', 'fbda2f9e63a6120b29b41b676a5ec7e5a8be99ec', [
     'initialise',
   ]),
   navigationSource(

--- a/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
+++ b/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
@@ -181,7 +181,7 @@ export const authNavigationStageLabels = [
 ] as const;
 
 export const authNavigationSourceSnapshot: readonly AuthNavigationSourceSnapshot[] = [
-  navigationSource('apps/api-v1/src/middleware.ts', '1275fe06a9ed67f33b72066e69d9b4408b5b24f1', [
+  navigationSource('apps/api-v1/src/middleware.ts', '1a6e621b519f09b57d61c9fec53e73b1aa7ca320', [
     'initialise',
   ]),
   navigationSource(

--- a/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
+++ b/packages/tests/repo/auth-server-reviewed-source-snapshot.ts
@@ -181,7 +181,7 @@ export const authNavigationStageLabels = [
 ] as const;
 
 export const authNavigationSourceSnapshot: readonly AuthNavigationSourceSnapshot[] = [
-  navigationSource('apps/api-v1/src/middleware.ts', '1a6e621b519f09b57d61c9fec53e73b1aa7ca320', [
+  navigationSource('apps/api-v1/src/middleware.ts', '77b20cd6d40709d4db521d50acdb636a5a474c5f', [
     'initialise',
   ]),
   navigationSource(

--- a/packages/tests/repo/group-state-server-source-ratchet-inventory.ts
+++ b/packages/tests/repo/group-state-server-source-ratchet-inventory.ts
@@ -69,6 +69,7 @@ export const expectedGroupStateTestTree = [
   'mutation/write-group-state-mutation-equivalence.test.ts',
   'mutation/write-group-state-mutation-presence.test.ts',
   'mutation/write-group-state-mutation.test.ts',
+  'persistence/assemble-group-state-snapshot-lease.test.ts',
   'persistence/group-state-authority-fence.test.ts',
   'persistence/group-state-repository-corruption.test.ts',
   'persistence/group-state-repository-dispatch.test.ts',

--- a/packages/tests/repo/group-state-test-structure.test.ts
+++ b/packages/tests/repo/group-state-test-structure.test.ts
@@ -106,7 +106,7 @@ describe('group-state test structure', () => {
   });
 
   it('keeps the independently written persistence fixture evidence cohort', () => {
-    expect(countSemanticLiterals(persistenceFixtureLiteralPaths)).toBe(508);
+    expect(countSemanticLiterals(persistenceFixtureLiteralPaths)).toBe(511);
     expect(countNamedCalls(persistenceFixtureCasePaths, new Set(['it', 'test']))).toBe(16);
     expect(countNamedCalls(persistenceFixtureCasePaths, new Set(['expect']))).toBe(31);
   });

--- a/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
+++ b/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
@@ -244,6 +244,7 @@ describe('AppInbox expired row replacement', () => {
         });
         const groupState = createGroupStateService({
             runtimeRepository: runtime,
+            formationDamping: 'damped',
             createGroupStateEventStore: () => database.groupEventStore,
             serviceId: 'expired-group-service',
             now: () => nowEpochMs,

--- a/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
+++ b/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
@@ -84,6 +84,7 @@ export async function createAppInboxWsCloseHarness(options: Readonly<{
   });
   const clientState = createClientStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createClientStateEventStore: () => database.clientEventStore,
     serviceId: 'server-12345678',
   });

--- a/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
+++ b/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
@@ -76,6 +76,7 @@ export async function createAppInboxWsCloseHarness(options: Readonly<{
   await authSessions.putSession(authSession);
   const groupState = createGroupStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     authSessionRepository: authSessions,
     createGroupStateEventStore: () => database.groupEventStore,
     serviceId: 'server-12345678',

--- a/packages/tests/shared-server/client-state/app-client-inbox-authentication.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authentication.test.ts
@@ -35,6 +35,7 @@ describe('AppClientInbox authentication', () => {
     await authSessions.putSession(mallory);
     const service = createClientStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       serviceId: 'server-12345678',
     });
     const command = await toClientMutationCommand(
@@ -56,6 +57,7 @@ describe('AppClientInbox authentication', () => {
         eventId: 'direct-mallory-targets-alice-event',
         attemptCount: 1,
         expireAtEpochMs: Date.now() + 60_000,
+        formationDamping: 'damped',
       },
       toClientMutationIssuedSessionAuthority(mallory, SCOPE, 'upsertPrincipal'),
     );
@@ -85,6 +87,7 @@ describe('AppClientInbox authentication', () => {
       database,
       createClientStateService({
         runtimeRepository,
+        formationDamping: 'damped',
         createClientStateEventStore: () => new InMemoryClientStateEventStore(),
         serviceId: 'server-12345678',
       }),
@@ -188,6 +191,7 @@ async function createRevokedAuthorityRetryHarness() {
     database,
     createClientStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       createClientStateEventStore: () => new InMemoryClientStateEventStore(),
       serviceId: 'server-12345678',
     }),

--- a/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
@@ -258,6 +258,7 @@ function createAuthorisedWsService(input: CreateAuthorisedWsServiceInput): AppCl
     input.database,
     createClientStateService({
       runtimeRepository: input.runtimeRepository,
+      formationDamping: 'damped',
       createClientStateEventStore: () => input.database.clientEventStore,
       serviceId: SERVICE_ID,
     }),

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
@@ -55,6 +55,7 @@ it(
     const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
     const clientStateService = createClientStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       createClientStateEventStore: () => database.clientEventStore,
       serviceId: 'server-12345678',
     });
@@ -343,6 +344,7 @@ async function waitForQueueEntryCount(
 function createClientStateServiceStub(overrides: Partial<ClientStateService>): ClientStateService {
   return {
     sessionGenerationLifecycle: {} as never,
+    formationDamping: 'damped',
     listSnapshots: vi.fn(),
     readSnapshot: vi.fn(),
     readPresenceSnapshot: vi.fn(),

--- a/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
@@ -232,6 +232,7 @@ export function createClientStateServiceStub(
   overrides: Partial<ClientStateService>,
 ): ClientStateService {
   return {
+    formationDamping: 'damped',
     listSnapshots: vi.fn(),
     readSnapshot: vi.fn(),
     readPresenceSnapshot: vi.fn(),
@@ -257,6 +258,7 @@ export function createAutoAuthorizingClientStateService(
   const authSessions = new AuthSessionRepository(runtimeRepository);
   const durable = createClientStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createClientStateEventStore: () => eventStore,
     serviceId: 'server-12345678',
   });

--- a/packages/tests/shared-server/client-state/app-client-inbox-operation-matrix.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-operation-matrix.test.ts
@@ -60,6 +60,7 @@ describe('AppClientInbox operation matrix', () => {
 function createClientInboxServiceForRegistration(): AppClientInboxService {
   const registrationService = {
     sessionGenerationLifecycle: {} as ClientStateService['sessionGenerationLifecycle'],
+    formationDamping: 'damped' as const,
   };
   return new AppClientInboxService(
     {} as InboxQueueReader,

--- a/packages/tests/shared-server/client-state/client-mutation-command-and-request.test.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-command-and-request.test.ts
@@ -110,6 +110,7 @@ describe('client mutation command and request projection', () => {
       eventId: 'event-1',
       attemptCount: 1,
       expireAtEpochMs: 10_000,
+      formationDamping: 'damped',
     };
 
     const command = await toClientMutationCommand(input, facts, authority);

--- a/packages/tests/shared-server/client-state/client-mutation-compute-test-fixtures.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-compute-test-fixtures.ts
@@ -251,6 +251,7 @@ async function command(
       eventId: `event:${input.commandId}`,
       attemptCount: 1,
       expireAtEpochMs: 20_000,
+      formationDamping: 'damped',
     },
     authority,
   );

--- a/packages/tests/shared-server/client-state/client-mutation-concurrency-test-runtime.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-concurrency-test-runtime.ts
@@ -178,6 +178,7 @@ export function createService(
 ) {
   return createClientStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     syncPublisher,
     now: () => nowEpochMs,
     randomId: (() => {

--- a/packages/tests/shared-server/client-state/client-mutation-concurrency.test.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-concurrency.test.ts
@@ -61,6 +61,7 @@ describe('client mutation stable-read concurrency', () => {
         eventId: 'stable-client-read-event',
         attemptCount: 1,
         expireAtEpochMs: session.expiresAtEpochMs + 60_000,
+        formationDamping: 'damped',
       },
       toClientMutationSystemAuthority('client-service'),
     );

--- a/packages/tests/shared-server/client-state/client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-transaction-boundary-fixture.ts
@@ -88,6 +88,7 @@ export async function createHandlerHarness(
       },
     },
     sessionGenerationLifecycle: {} as never,
+    formationDamping: 'damped',
     expiryCandidates: { listExpiredSessionCandidates: async () => [] },
     snapshotObserver: {
       observeSnapshot: async (snapshot) => {

--- a/packages/tests/shared-server/client-state/client-mutation-validation-test-fixtures.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-validation-test-fixtures.ts
@@ -105,6 +105,7 @@ export function validFacts(): ClientMutationFacts {
     commandHash: `sha256:${'a'.repeat(64)}`,
     attemptCount: 1,
     expireAtEpochMs: 10_000,
+    formationDamping: 'damped',
   };
 }
 

--- a/packages/tests/shared-server/client-state/client-mutation-validation.test.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-validation.test.ts
@@ -172,6 +172,7 @@ function validFacts() {
     commandHash: `sha256:${'0'.repeat(64)}`,
     attemptCount: 1,
     expireAtEpochMs: 2_000,
+    formationDamping: 'damped',
   };
 }
 

--- a/packages/tests/shared-server/client-state/client-state-service-timing.test.ts
+++ b/packages/tests/shared-server/client-state/client-state-service-timing.test.ts
@@ -88,6 +88,7 @@ const TIMED_COMMAND = {
     commandHash: `sha256:${'a'.repeat(64)}`,
     attemptCount: 1,
     expireAtEpochMs: 2,
+    formationDamping: 'damped',
   },
   input: {},
 } as never as ClientMutationCommand;
@@ -116,6 +117,7 @@ function createTimedClientStateServiceFixture(): TimedClientStateServiceFixture 
   const writeFailure = new Error('write failure must propagate');
   const service: ClientStateService = {
     sessionGenerationLifecycle: {} as never,
+    formationDamping: 'damped',
     listSnapshots: async () => [],
     readSnapshot: async () => undefined,
     readPresenceSnapshot: async () => undefined,

--- a/packages/tests/shared-server/client-state/client-state-test-runtime.ts
+++ b/packages/tests/shared-server/client-state/client-state-test-runtime.ts
@@ -75,6 +75,7 @@ export function createClientStatePhaseTestDriver(
   const serviceId = options.serviceId ?? 'client-service';
   const service = createClientStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createClientStateEventStore: () => eventStore,
     serviceId,
     timing: options.timing,
@@ -148,6 +149,7 @@ async function computeClientStateTestMutation(
       eventId: `test-client-event:${input.commandId}:${context.nextSequence()}`,
       attemptCount: attempt,
       expireAtEpochMs: TEST_AUTH_EXPIRES_AT_EPOCH_MS,
+      formationDamping: 'damped',
     },
     authority,
   );

--- a/packages/tests/shared-server/client-state/postgres-client-mutation-test-driver.ts
+++ b/packages/tests/shared-server/client-state/postgres-client-mutation-test-driver.ts
@@ -109,6 +109,7 @@ function createPostgresClientMutationExecutor(
           eventId: `postgres-client-event:${commandInput.commandId}`,
           attemptCount: attempt,
           expireAtEpochMs: options.atEpochMs + 24 * 60 * 60 * 1_000,
+          formationDamping: 'damped',
         },
         commandInput.operation === 'expireSession'
           ? toClientMutationSystemAuthority(options.serviceId)

--- a/packages/tests/shared-server/direct-resource-outbox.test.ts
+++ b/packages/tests/shared-server/direct-resource-outbox.test.ts
@@ -50,11 +50,11 @@ describe('direct resource outbox writes', () => {
     } as unknown as ClientEvent;
 
     const computed = createComputedClientEventStateSync(incomplete);
-    expect(() => computeClientStateSyncEntries(computed, 'server-1')).toThrow();
+    expect(() => computeClientStateSyncEntries(computed, 'server-1', 'world')).toThrow();
     const database = createResourceInboxDatabase();
     await expect(
       runInTransaction(database.sql, async (transaction) => {
-        await writeClientStateSync(transaction, computed, 'server-1');
+        await writeClientStateSync(transaction, computed, { senderId: 'server-1', principalAudienceScope: 'world' });
       }),
     ).rejects.toThrow();
     expect(database.rows.size).toBe(0);
@@ -69,11 +69,11 @@ describe('direct resource outbox writes', () => {
     const incomplete = { ...snapshot, principal };
 
     const computed = createComputedClientSnapshotStateSync(incomplete);
-    expect(() => computeClientStateSyncEntries(computed, 'server-1')).toThrow();
+    expect(() => computeClientStateSyncEntries(computed, 'server-1', 'world')).toThrow();
     const database = createResourceInboxDatabase();
     await expect(
       runInTransaction(database.sql, async (transaction) => {
-        await writeClientStateSync(transaction, computed, 'server-1');
+        await writeClientStateSync(transaction, computed, { senderId: 'server-1', principalAudienceScope: 'world' });
       }),
     ).rejects.toThrow();
     expect(database.rows.size).toBe(0);
@@ -122,7 +122,7 @@ describe('direct resource outbox writes', () => {
       effects: [{ ...computed.effects[0], effectKind: 'forged-state' }],
     } as unknown as ComputedClientStateSync;
 
-    expect(() => computeClientStateSyncEntries(forged, 'server-1')).toThrow();
+    expect(() => computeClientStateSyncEntries(forged, 'server-1', 'world')).toThrow();
   });
 
   it('replays all canonical state-sync payload families identically', () => {
@@ -133,11 +133,11 @@ describe('direct resource outbox writes', () => {
     const groupEvent = createComputedGroupEventStateSync(createGroupEvent());
     const groupSnapshot = createComputedGroupStateSync(createGroupSnapshot());
 
-    expect(computeClientStateSyncEntries(clientEvent, 'server-1')).toEqual(
-      computeClientStateSyncEntries(clientEvent, 'server-1'),
+    expect(computeClientStateSyncEntries(clientEvent, 'server-1', 'world')).toEqual(
+      computeClientStateSyncEntries(clientEvent, 'server-1', 'world'),
     );
-    expect(computeClientStateSyncEntries(clientSnapshot, 'server-1')).toEqual(
-      computeClientStateSyncEntries(clientSnapshot, 'server-1'),
+    expect(computeClientStateSyncEntries(clientSnapshot, 'server-1', 'world')).toEqual(
+      computeClientStateSyncEntries(clientSnapshot, 'server-1', 'world'),
     );
     expect(computeGroupStateSyncEntries(groupEvent, 'server-1')).toEqual(
       computeGroupStateSyncEntries(groupEvent, 'server-1'),
@@ -229,9 +229,12 @@ describe('direct resource outbox writes', () => {
           writeClientStateSync as unknown as (
             transaction: PSqlTransactionSql,
             computed: ComputedClientStateSync,
-            senderId: string,
+            write: Readonly<{
+              senderId: string;
+              principalAudienceScope: 'principal' | 'world';
+            }>,
           ) => Promise<readonly ResourceEntry[]>
-        )(transaction, client, 'server-1'),
+        )(transaction, client, { senderId: 'server-1', principalAudienceScope: 'world' }),
     );
     const groupEntries = await runInTransaction(
       database.sql,
@@ -246,7 +249,7 @@ describe('direct resource outbox writes', () => {
     );
 
     expect(clientEntries).toEqual(
-      computeClientStateSyncEntries(client, 'server-1'),
+      computeClientStateSyncEntries(client, 'server-1', 'world'),
     );
     expect(groupEntries).toEqual(
       computeGroupStateSyncEntries(group, 'server-1'),
@@ -256,9 +259,9 @@ describe('direct resource outbox writes', () => {
         writeClientStateSync as unknown as (
           transaction: PSqlTransactionSql,
           computed: ComputedClientStateSync,
-          senderId: string,
+          write: Readonly<{ senderId: string; principalAudienceScope: 'principal' | 'world' }>,
         ) => Promise<readonly ResourceEntry[]>
-      )(transaction, client, 'server-1');
+      )(transaction, client, { senderId: 'server-1', principalAudienceScope: 'world' });
       await (
         writeGroupStateSync as unknown as (
           transaction: PSqlTransactionSql,
@@ -297,7 +300,7 @@ describe('direct resource outbox writes', () => {
       ],
     };
 
-    const [entry] = computeClientStateSyncEntries(computed, 'server-1');
+    const [entry] = computeClientStateSyncEntries(computed, 'server-1', 'world');
 
     expect(entry.typeId).toBe(EnqueuedType.WS_OUTBOX);
     const message = JSON.parse(entry.resource);
@@ -313,7 +316,7 @@ describe('direct resource outbox writes', () => {
     });
     const database = createResourceInboxDatabase();
     await runInTransaction(database.sql, async (transaction) => {
-      await writeClientStateSync(transaction, computed, 'server-1');
+      await writeClientStateSync(transaction, computed, { senderId: 'server-1', principalAudienceScope: 'world' });
     });
     expect(database.rows.get(toRowKey(entry))?.ri_resource).toBe(
       entry.resource,

--- a/packages/tests/shared-server/fixtures/postgres-app-inbox-worker-services.ts
+++ b/packages/tests/shared-server/fixtures/postgres-app-inbox-worker-services.ts
@@ -60,6 +60,7 @@ export function createPostgresAppInboxWorkerServices(
   const waitOptions = createPostgresAppInboxWorkerWaitOptions(input.atEpochMs);
   const clientState = createClientStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createClientStateEventStore: createClientStateEventRepository,
     serviceId: input.serviceId,
   });

--- a/packages/tests/shared-server/fixtures/postgres-app-inbox-worker-services.ts
+++ b/packages/tests/shared-server/fixtures/postgres-app-inbox-worker-services.ts
@@ -66,6 +66,7 @@ export function createPostgresAppInboxWorkerServices(
   });
   const groupState = createGroupStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createGroupStateEventStore: createGroupStateEventRepository,
     authSessionRepository: authSessions,
     now: () => input.atEpochMs,

--- a/packages/tests/shared-server/fixtures/postgres-expiry-worker.ts
+++ b/packages/tests/shared-server/fixtures/postgres-expiry-worker.ts
@@ -282,6 +282,7 @@ async function runClientMutation(
       eventId: `postgres-client-event:${requestId}`,
       attemptCount: entry.dequeueAudit.attempts,
       expireAtEpochMs: Number(entry.audit.expiryTs.epochMilliseconds),
+      formationDamping: 'damped',
     },
     toClientMutationIssuedSessionAuthority(
       authoritySession,

--- a/packages/tests/shared-server/group-state/group-state-concurrency-test-fixtures.ts
+++ b/packages/tests/shared-server/group-state/group-state-concurrency-test-fixtures.ts
@@ -208,6 +208,7 @@ export function createMutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: {
       principalId: 'alice',
       sessionId: 'alice-session',

--- a/packages/tests/shared-server/group-state/group-state-service-idempotency.test.ts
+++ b/packages/tests/shared-server/group-state/group-state-service-idempotency.test.ts
@@ -22,6 +22,7 @@ describe('GroupStateService command idempotency', () => {
     const timingEvents: RallarTimingEvent[] = [];
     const service = createGroupStateService({
       runtimeRepository: new FakeRuntimeStateRepository(),
+      formationDamping: 'damped',
       syncPublisher: createPublisher(),
       now: () => 1_000,
       serviceId: 'group-service',
@@ -59,6 +60,7 @@ describe('GroupStateService command idempotency', () => {
     const publisher = createPublisher();
     const service = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       syncPublisher: publisher,
       now: () => 1_000,
       serviceId: 'group-service',
@@ -155,6 +157,7 @@ describe('GroupStateService command idempotency', () => {
     const runtimeRepository = new FakeRuntimeStateRepository();
     const service = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       syncPublisher: createPublisher(),
       now: () => 1_000,
       serviceId: 'group-service',
@@ -195,6 +198,7 @@ describe('GroupStateService command idempotency', () => {
     const runtimeRepository = new FakeRuntimeStateRepository();
     const service = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       syncPublisher: createPublisher(),
       now: () => 1_000,
       serviceId: 'group-service',
@@ -237,6 +241,7 @@ describe('GroupStateService command idempotency', () => {
     const publisher = createPublisher();
     const service = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       syncPublisher: publisher,
       now: () => 2_000,
       serviceId: 'group-service',
@@ -284,6 +289,7 @@ describe('GroupStateService command idempotency', () => {
     const publisher = createPublisher();
     const service = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       syncPublisher: publisher,
       now: () => 3_000,
       serviceId: 'group-service',

--- a/packages/tests/shared-server/group-state/group-state-test-mutation-executor.ts
+++ b/packages/tests/shared-server/group-state/group-state-test-mutation-executor.ts
@@ -100,6 +100,7 @@ export class GroupStateTestMutationExecutor {
         resolvedJoinCode: null,
         joinCodeVerifier: null,
         internalAuthority: authority,
+        formationDamping: 'legacy',
         authenticatedAuthority: null,
       };
       const mutation =

--- a/packages/tests/shared-server/group-state/group-state-test-runtime.ts
+++ b/packages/tests/shared-server/group-state/group-state-test-runtime.ts
@@ -81,6 +81,7 @@ export function createTestGroupStateRuntime(
   const randomId = dependencies.randomId ?? (() => crypto.randomUUID());
   const durable = createGroupStateService({
     runtimeRepository: dependencies.runtimeRepository,
+    formationDamping: 'damped',
     createGroupStateEventStore: dependencies.createGroupStateEventStore,
     now: dependencies.now,
     randomId: dependencies.randomId,

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-authority.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-authority.test.ts
@@ -43,7 +43,6 @@ describe('AppGroupInboxService authenticated authority', () => {
   it('fails closed before a direct user mutation can read or write without authority', async () => {
     const harness = await createAuthorityHarness(['owner']);
     await createRoom(harness, 'direct-missing-authority', 'Before');
-
     expect(Reflect.get(harness.groupStateService, 'updateGroup')).toBeUndefined();
     expect(
       (
@@ -181,6 +180,7 @@ describe('AppGroupInboxService authenticated authority', () => {
     const results = new TestResourceInboxResults();
     const groupStateService = createGroupStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       serviceId: 'server-12345678',
       now: () => nowEpochMs,
       authSessionRepository: authSessions,

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-retry.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-retry.test.ts
@@ -83,6 +83,7 @@ describe('AppGroupInboxService authenticated authority', { timeout: 30_000 }, ()
           resolvedJoinCode: null,
           joinCodeVerifier: null,
           internalAuthority: 'none',
+          formationDamping: 'legacy',
           authenticatedAuthority: {
             principalId: 'owner',
             sessionId: 'owner-session',

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-test-runtime.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-test-runtime.ts
@@ -250,14 +250,13 @@ export async function createAuthorityHarness(
   const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
   const groupStateService = createGroupStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createGroupStateEventStore: () => database.groupEventStore,
     serviceId: 'server-12345678',
     now: () => nowEpochMs,
     authSessionRepository: authSessions,
   } as Parameters<typeof createGroupStateService>[0] &
-    Readonly<{
-      authSessionRepository: AuthSessionRepository;
-    }>);
+    Readonly<{ authSessionRepository: AuthSessionRepository }>);
   return {
     nowEpochMs,
     runtimeRepository,

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -338,6 +338,7 @@ function inactiveConnectContext() {
           resolvedJoinCode: null,
           joinCodeVerifier: null,
           internalAuthority: 'none',
+          formationDamping: 'legacy',
           authenticatedAuthority: { principalId: 'owner', sessionId: 'inactive-session' },
         },
         causalToken: 'causal-token',

--- a/packages/tests/shared-server/group-state/inbox/group-state-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-transaction-boundary-fixture.ts
@@ -149,6 +149,7 @@ async function createTransactionBoundaryGroupStateService(
   await authSessions.putSession(authority);
   const groupStateService = createGroupStateService({
     runtimeRepository: storage.runtimeRepository,
+    formationDamping: 'damped',
     createGroupStateEventStore: () => storage.database.groupEventStore,
     serviceId: 'server-12345678',
     now: () => NOW_EPOCH_MS,

--- a/packages/tests/shared-server/group-state/mutation/group-aggregate-mutation.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-aggregate-mutation.test.ts
@@ -198,6 +198,7 @@ function createMutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: {
       principalId: 'alice',
       sessionId: 'alice-session',

--- a/packages/tests/shared-server/group-state/mutation/group-mutation-result.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-mutation-result.test.ts
@@ -366,6 +366,7 @@ function createMutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: {
       principalId: 'alice',
       sessionId: 'alice-session',

--- a/packages/tests/shared-server/group-state/mutation/group-presence-mutation.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-presence-mutation.test.ts
@@ -13,6 +13,7 @@ import {
   groupSessionStorageKey,
   groupStorageKey,
   presenceFor,
+  storagePart,
   storedEntry,
 } from './group-mutation-test-runtime.ts';
 
@@ -52,6 +53,7 @@ describe('group presence mutation computation', () => {
     const facts: GroupMutationFacts = {
       ...createMutationFacts(),
       internalAuthority: 'session-cleanup',
+      formationDamping: 'legacy',
       authenticatedAuthority: null,
     };
     const appointment = createMutationCommand({
@@ -81,6 +83,136 @@ describe('group presence mutation computation', () => {
     ).toThrow(/target presence principal.*command|command slot identity/i);
   });
 });
+
+describe('heartbeat lease renewal classification', () => {
+  const heartbeat = () =>
+    createMutationCommand({
+      operation: 'heartbeatPresence',
+      sessionId: 'alice-session',
+      input: {
+        actorPrincipalId: 'alice',
+        actorSessionId: 'alice-session',
+        reason: null,
+        traceId: null,
+        principalId: 'alice',
+        generationId: 'generation-1',
+        lastHeartbeatAtEpochMs: 1_500,
+        expiresAtEpochMs: 12_000,
+      },
+    } as Partial<GroupMutationCommand>);
+
+  it('renews the lease with no presence-summary work under damped formation', () => {
+    const computed = computeGroupMutation({
+      command: heartbeat(),
+      read: createHeartbeatRead(),
+      facts: { ...createMutationFacts(), formationDamping: 'damped' },
+    });
+
+    expect(computed.outcome).toBe('write');
+    if (computed.outcome !== 'write') return;
+    expect(computed.outboxEntries).toEqual([]);
+    expect(computed.receipt.outboxIds).toEqual([]);
+    expect(computed.guard.value).toMatchObject({
+      lastHeartbeatAtEpochMs: 1_500,
+      expiresAtEpochMs: 12_000,
+    });
+    expect(computed.event.eventType).toBe('session-heartbeat');
+  });
+
+  it('expands a lapsed-lease revival as an online transition under damped formation', () => {
+    const read = createHeartbeatRead();
+    const lapsed: GroupMutationRead = {
+      ...read,
+      targetPresence: storedEntry(groupSessionStorageKey('alice-session'), {
+        ...read.targetPresence!.value,
+        expiresAtEpochMs: 1_800,
+      }),
+    };
+
+    const computed = computeGroupMutation({
+      command: heartbeat(),
+      read: lapsed,
+      facts: { ...createMutationFacts(), formationDamping: 'damped' },
+    });
+
+    expect(computed.outcome).toBe('write');
+    if (computed.outcome !== 'write') return;
+    expect(computed.outboxEntries).toHaveLength(1);
+    expect(computed.receipt.outboxIds).toHaveLength(1);
+  });
+
+  it('expands when the stored summary does not list the session under damped formation', () => {
+    const read = createHeartbeatRead();
+    const unlisted: GroupMutationRead = {
+      ...read,
+      presenceSummary: storedEntry(groupStorageKey(), {
+        ...read.presenceSummary!.value,
+        activeSessionIds: [],
+        activeSessions: [],
+        activePrincipalIds: [],
+        activePrincipalCount: 0,
+        activeSessionCount: 0,
+      }),
+    };
+
+    const computed = computeGroupMutation({
+      command: heartbeat(),
+      read: unlisted,
+      facts: { ...createMutationFacts(), formationDamping: 'damped' },
+    });
+
+    expect(computed.outcome).toBe('write');
+    if (computed.outcome !== 'write') return;
+    expect(computed.outboxEntries).toHaveLength(1);
+  });
+
+  it('keeps the legacy expansion for every heartbeat under legacy formation', () => {
+    const computed = computeGroupMutation({
+      command: heartbeat(),
+      read: createHeartbeatRead(),
+      facts: { ...createMutationFacts(), formationDamping: 'legacy' },
+    });
+
+    expect(computed.outcome).toBe('write');
+    if (computed.outcome !== 'write') return;
+    expect(computed.outboxEntries).toHaveLength(1);
+    expect(computed.receipt.outboxIds).toHaveLength(1);
+  });
+});
+
+function createHeartbeatRead(): GroupMutationRead {
+  const base = createMutationRead();
+  const session = presenceFor('alice', 'alice-session', 'generation-1');
+  return {
+    ...base,
+    targetMember: base.actorMember,
+    targetMemberEntry: base.actorMemberEntry,
+    targetPresence: storedEntry(groupSessionStorageKey('alice-session'), session),
+    targetAdmission: storedEntry(`${groupStorageKey()}:${storagePart('principal', 'alice')}`, {
+      ...groupRef('pure-room'),
+      principalId: 'alice',
+      admittedSessions: [
+        {
+          sessionId: 'alice-session',
+          generationId: 'generation-1',
+          generationVersion: 1_000,
+          connectedAtEpochMs: 1_000,
+        },
+      ],
+      updatedAtEpochMs: 1_000,
+    }),
+    presenceSummary: storedEntry(groupStorageKey(), {
+      ...groupRef('pure-room'),
+      causalRevision: { groupRevision: 1, presenceRevision: 1 },
+      activePrincipalIds: ['alice'],
+      activeSessionIds: ['alice-session'],
+      activeSessions: [session],
+      activePrincipalCount: 1,
+      activeSessionCount: 1,
+      computedAtEpochMs: 1_000,
+    }),
+  } as GroupMutationRead;
+}
 
 function createMutationCommand(
   overrides: Partial<GroupMutationCommand> = {},
@@ -196,6 +328,7 @@ function createMutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: {
       principalId: 'alice',
       sessionId: 'alice-session',

--- a/packages/tests/shared-server/group-state/persistence/assemble-group-state-snapshot-lease.test.ts
+++ b/packages/tests/shared-server/group-state/persistence/assemble-group-state-snapshot-lease.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AuditStamp,
+  Group,
+  GroupMember,
+  GroupPresenceSession,
+  GroupPresenceSummary,
+} from '@shared/api/group-types.ts';
+import {
+  assembleGroupStateSnapshot,
+  type GroupStateSnapshotAssemblyInput,
+} from '@shared-server/rallar-system/group-state/persistence/assemble-group-state-snapshot.ts';
+import { canSendRoomMessage } from '@shared-server/rallar-system/group-policy.ts';
+import { isGroupSnapshotPresenceFresh } from '@shared-server/rallar-system/snapshot-presence.ts';
+
+const REF = {
+  applicationId: 'app-1',
+  workspaceId: 'workspace-1',
+  groupId: 'room-1',
+} as const;
+const TRANSITION_AT_EPOCH_MS = 1_000;
+const FROZEN_LEASE_EXPIRES_AT_EPOCH_MS = TRANSITION_AT_EPOCH_MS + 120_000;
+const IDLE_OBSERVED_AT_EPOCH_MS = TRANSITION_AT_EPOCH_MS + 600_000;
+
+describe('assembleGroupStateSnapshot session lease fields', () => {
+  it('carries authoritative leases so an idle group stays live, fresh, and send-authorized', () => {
+    const snapshot = assembleGroupStateSnapshot(
+      createAssemblyInput({
+        sessionLeaseFields: 'authoritative',
+        authoritativeLeaseExpiresAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS + 60_000,
+      }),
+      (storageKey, message) => new Error(`${message}: ${storageKey}`),
+    );
+
+    expect(snapshot.activeSessions).toHaveLength(1);
+    expect(snapshot.activeSessions[0]).toMatchObject({
+      lastHeartbeatAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS - 10_000,
+      expiresAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS + 60_000,
+    });
+    expect(snapshot.onlineMemberCount).toBe(1);
+    expect(isGroupSnapshotPresenceFresh(snapshot, IDLE_OBSERVED_AT_EPOCH_MS)).toBe(true);
+    expect(
+      canSendRoomMessage({
+        snapshot,
+        senderSessionId: 'session-alice',
+        actor: { principalId: 'alice' },
+        nowEpochMs: IDLE_OBSERVED_AT_EPOCH_MS,
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it('drops the session under summary-frozen leases once the frozen lease lapses', () => {
+    const snapshot = assembleGroupStateSnapshot(
+      createAssemblyInput({
+        sessionLeaseFields: 'summary-frozen',
+        authoritativeLeaseExpiresAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS + 60_000,
+      }),
+      (storageKey, message) => new Error(`${message}: ${storageKey}`),
+    );
+
+    expect(snapshot.activeSessions).toHaveLength(0);
+    expect(snapshot.onlineMemberCount).toBe(0);
+  });
+
+  it('drops the session under authoritative leases once the authoritative lease lapses', () => {
+    const snapshot = assembleGroupStateSnapshot(
+      createAssemblyInput({
+        sessionLeaseFields: 'authoritative',
+        authoritativeLeaseExpiresAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS - 1,
+      }),
+      (storageKey, message) => new Error(`${message}: ${storageKey}`),
+    );
+
+    expect(snapshot.activeSessions).toHaveLength(0);
+    expect(snapshot.onlineMemberCount).toBe(0);
+  });
+});
+
+function createAssemblyInput(
+  input: Readonly<{
+    sessionLeaseFields: GroupStateSnapshotAssemblyInput['sessionLeaseFields'];
+    authoritativeLeaseExpiresAtEpochMs: number;
+  }>,
+): GroupStateSnapshotAssemblyInput {
+  const frozenSession = createSession({
+    lastHeartbeatAtEpochMs: TRANSITION_AT_EPOCH_MS,
+    expiresAtEpochMs: FROZEN_LEASE_EXPIRES_AT_EPOCH_MS,
+  });
+  const authoritativeSession = createSession({
+    lastHeartbeatAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS - 10_000,
+    expiresAtEpochMs: input.authoritativeLeaseExpiresAtEpochMs,
+  });
+  const summary: GroupPresenceSummary = {
+    ...REF,
+    causalRevision: { groupRevision: 1, presenceRevision: 1 },
+    activePrincipalIds: ['alice'],
+    activeSessionIds: ['session-alice'],
+    activeSessions: [frozenSession],
+    activePrincipalCount: 1,
+    activeSessionCount: 1,
+    computedAtEpochMs: TRANSITION_AT_EPOCH_MS,
+  };
+  return {
+    group: createGroup(),
+    members: [createMember()],
+    summary,
+    authoritativeSessions: [authoritativeSession],
+    groupRevision: 1,
+    observedAtEpochMs: IDLE_OBSERVED_AT_EPOCH_MS,
+    sessionLeaseFields: input.sessionLeaseFields,
+  };
+}
+
+function createSession(
+  lease: Readonly<{ lastHeartbeatAtEpochMs: number; expiresAtEpochMs: number }>,
+): GroupPresenceSession {
+  return {
+    ...REF,
+    principalId: 'alice',
+    sessionId: 'session-alice',
+    generationId: 'generation-alice',
+    generationVersion: 1,
+    status: 'active',
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+    connectedAtEpochMs: TRANSITION_AT_EPOCH_MS,
+    lastHeartbeatAtEpochMs: lease.lastHeartbeatAtEpochMs,
+    expiresAtEpochMs: lease.expiresAtEpochMs,
+  };
+}
+
+function createGroup(): Group {
+  const audit = createAuditStamp();
+  return {
+    ...REF,
+    slug: null,
+    displayName: 'Room 1',
+    description: null,
+    kind: 'room',
+    status: 'active',
+    archived: null,
+    deleted: null,
+    joinMode: 'open',
+    maxMembers: null,
+    maxSessionsPerMember: null,
+    metadata: {},
+    activeMemberCount: 1,
+    ownerPrincipalId: 'alice',
+    snapshotVersion: 1,
+    metadataVersion: 1,
+    rosterVersion: 1,
+    presenceVersion: 1,
+    created: audit,
+    updated: audit,
+    expiresAtEpochMs: null,
+    emptySinceEpochMs: null,
+    purgeAfterEpochMs: null,
+  };
+}
+
+function createMember(): GroupMember {
+  const audit = createAuditStamp();
+  return {
+    ...REF,
+    principalId: 'alice',
+    role: 'owner',
+    status: 'active',
+    joined: audit,
+    updated: audit,
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+    left: null,
+    removed: null,
+    banned: null,
+  };
+}
+
+function createAuditStamp(): AuditStamp {
+  return {
+    atEpochMs: 1,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
+}

--- a/packages/tests/shared-server/group-state/persistence/group-state-repository-corruption.test.ts
+++ b/packages/tests/shared-server/group-state/persistence/group-state-repository-corruption.test.ts
@@ -382,6 +382,7 @@ function createMutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: { principalId: 'alice', sessionId: 'alice-session' },
   };
 }

--- a/packages/tests/shared-server/group-state/persistence/group-state-repository-identity.test.ts
+++ b/packages/tests/shared-server/group-state/persistence/group-state-repository-identity.test.ts
@@ -190,13 +190,14 @@ describe('GroupStateRepository persistence', () => {
         },
       ],
       [
-        'applied receipt without its authoritative outbox effect',
+        'applied receipt with more than one outbox effect',
         {
           ...valid,
           receipt: {
             ...valid.receipt,
             outcome: 'applied',
             eventId: 'event-1',
+            outboxIds: ['outbox-1', 'outbox-2'],
           },
         },
       ],

--- a/packages/tests/shared-server/group-state/persistence/group-state-repository-write-integrity.test.ts
+++ b/packages/tests/shared-server/group-state/persistence/group-state-repository-write-integrity.test.ts
@@ -144,6 +144,7 @@ describe('convergent group and presence state', () => {
     const internalFacts: GroupMutationFacts = {
       ...publicFacts,
       internalAuthority: 'session-cleanup',
+      formationDamping: 'legacy',
       authenticatedAuthority: null,
     };
 

--- a/packages/tests/shared-server/group-state/presence/group-presence-concurrency.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-concurrency.test.ts
@@ -326,6 +326,7 @@ describe('group presence concurrency', () => {
       expect(admission?.value.admittedSessions).toEqual([]);
 
       const work = new GroupPresenceSummaryWork({
+        topologyIntent: { damping: 'legacy' },
         runtimeRepository: runtime,
         now: () => BASE_EPOCH_MS + 3_000,
         serviceId: 'summary-worker',

--- a/packages/tests/shared-server/group-state/presence/group-presence-connect-decision.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-connect-decision.test.ts
@@ -256,6 +256,7 @@ function connectCommand(): GroupStateMutationCommand {
       resolvedJoinCode: null,
       joinCodeVerifier: null,
       internalAuthority: 'none',
+      formationDamping: 'legacy',
       authenticatedAuthority: { principalId: 'owner', sessionId: 'session-1' },
     },
   };

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-evaluation-time.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-evaluation-time.test.ts
@@ -47,6 +47,7 @@ describe('group presence summary evaluation time', () => {
       ref: REF,
       read,
       nowEpochMs: 2_000,
+      formationDamping: 'legacy',
     });
 
     expect(computed).toEqual({
@@ -108,12 +109,12 @@ describe('group presence summary evaluation time', () => {
       admissions: [],
       presenceSessions: [],
       current,
-      coalescedTopologyEntry: null,
     };
     const canonical = computeGroupPresenceSummary({
       ref: groupRef('pure-room'),
       read,
       nowEpochMs: 2_000,
+      formationDamping: 'legacy',
     });
     expect(canonical).toEqual({ outcome: 'no-op', evaluatedAtEpochMs: 2_000, summary: base });
     expect(() =>
@@ -121,6 +122,7 @@ describe('group presence summary evaluation time', () => {
         ref: groupRef('pure-room'),
         read,
         computed: canonical,
+        formationDamping: 'legacy',
       }),
     ).not.toThrow();
     const staleSession = presenceFor('alice', 'stale-session', 'stale-generation');
@@ -144,6 +146,7 @@ describe('group presence summary evaluation time', () => {
       ref: groupRef('pure-room'),
       read: divergent,
       nowEpochMs: 2_000,
+      formationDamping: 'legacy',
     });
     expect(write).toMatchObject({
       outcome: 'write',
@@ -156,6 +159,7 @@ describe('group presence summary evaluation time', () => {
         ref: groupRef('pure-room'),
         read: divergent,
         computed: write,
+        formationDamping: 'legacy',
       }),
     ).not.toThrow();
     const aheadValue = {
@@ -174,6 +178,7 @@ describe('group presence summary evaluation time', () => {
       ref: groupRef('pure-room'),
       read: ahead,
       nowEpochMs: 2_000,
+      formationDamping: 'legacy',
     });
     expect(concurrent).toEqual({
       outcome: 'no-op',
@@ -185,6 +190,7 @@ describe('group presence summary evaluation time', () => {
         ref: groupRef('pure-room'),
         read: ahead,
         computed: concurrent,
+        formationDamping: 'legacy',
       }),
     ).not.toThrow();
     expect(() =>
@@ -235,7 +241,6 @@ function createExpiryCrossingRead(): GroupPresenceSummaryRead {
       ),
     ],
     current: stored(groupStatePresenceSummaryStorageKey(REF), current),
-    coalescedTopologyEntry: null,
   };
 }
 

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-evaluation-time.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-evaluation-time.test.ts
@@ -108,6 +108,7 @@ describe('group presence summary evaluation time', () => {
       admissions: [],
       presenceSessions: [],
       current,
+      coalescedTopologyEntry: null,
     };
     const canonical = computeGroupPresenceSummary({
       ref: groupRef('pure-room'),
@@ -234,6 +235,7 @@ function createExpiryCrossingRead(): GroupPresenceSummaryRead {
       ),
     ],
     current: stored(groupStatePresenceSummaryStorageKey(REF), current),
+    coalescedTopologyEntry: null,
   };
 }
 

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-formation-metrics.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-formation-metrics.test.ts
@@ -33,6 +33,7 @@ describe('GroupPresenceSummaryWork formation metrics', () => {
     const formationEvents: Array<Readonly<{ downstreamTopicIds: readonly string[] }>> = [];
     const wakeQueue = vi.fn();
     const worker = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: new FakeRuntimeStateRepository(),
       database: database as never,
       serviceId: 'summary-handler',
@@ -77,6 +78,7 @@ describe('GroupPresenceSummaryWork formation metrics', () => {
     );
     const formationMetrics = vi.fn();
     const worker = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: new FakeRuntimeStateRepository(),
       database: database as never,
       serviceId: 'summary-handler',
@@ -106,6 +108,7 @@ function createComputedWorkWithDownstreamTopics(topicIds: readonly string[]) {
         contextId: 'summary-context',
       },
     })),
+    coalescedTopologyWork: null,
   } as never;
 }
 

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-storage-revision.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-storage-revision.test.ts
@@ -233,6 +233,7 @@ function mutationFacts(): GroupMutationFacts {
     resolvedJoinCode: null,
     joinCodeVerifier: null,
     internalAuthority: 'none',
+    formationDamping: 'legacy',
     authenticatedAuthority: {
       principalId: 'member',
       sessionId: 'member-session',

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-validation.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-validation.test.ts
@@ -57,6 +57,7 @@ describe('group presence summary validation', () => {
     });
 
     const summaryWork = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: runtime,
       now: () => BASE_EPOCH_MS + 3_000,
       serviceId: 'summary-worker',
@@ -129,6 +130,7 @@ describe('group presence summary validation', () => {
     runtime.resetGuards();
 
     const summaryWork = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: runtime,
       now: () => BASE_EPOCH_MS + 3_000,
       serviceId: 'summary-worker',

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-work.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-work.test.ts
@@ -139,6 +139,7 @@ describe('GroupPresenceSummaryWork canonical persisted command', () => {
     const begin = vi.fn();
     const wakeQueue = vi.fn();
     const worker = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: new FakeRuntimeStateRepository(),
       database: Object.assign(async () => undefined, { begin }) as never,
       serviceId: 'summary-handler',
@@ -165,6 +166,7 @@ describe('GroupPresenceSummaryWork canonical persisted command', () => {
 
   it('exposes single-attempt presence-summary phases for a queue-owned transaction', () => {
     const work = new GroupPresenceSummaryWork({
+      topologyIntent: { damping: 'legacy' },
       runtimeRepository: new GroupBarrierRepository(),
       now: () => BASE_EPOCH_MS,
       serviceId: 'summary-worker',

--- a/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
@@ -229,6 +229,7 @@ async function convergePresenceSummaryForCacheTest(
     acceptedCausalRevision,
   });
   const work = new GroupPresenceSummaryWork({
+    topologyIntent: { damping: 'legacy' },
     runtimeRepository: runtime,
     now: () => 2_001,
     serviceId: 'cache-convergence-test',

--- a/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
@@ -175,10 +175,7 @@ describe('GroupStateSnapshotReadThroughCache', () => {
 
   it('evicts only identities that have not advanced in either cache layer', async () => {
     type ConditionallyEvictable = Readonly<{
-      evictIfUnchanged?: (
-        ref: GroupRef,
-        expected: GroupSnapshot,
-      ) => boolean;
+      evictIfUnchanged?: (ref: GroupRef, expected: GroupSnapshot) => boolean;
     }>;
     configureTestCacheRepositories();
     const repository = new GroupStateRepository(new FakeRuntimeStateRepository());
@@ -194,14 +191,10 @@ describe('GroupStateSnapshotReadThroughCache', () => {
     expect(cache.observe(newer)).toBe('advanced');
     const conditionallyEvictable = cache as ConditionallyEvictable;
 
-    expect(
-      conditionallyEvictable.evictIfUnchanged?.(loaded.group, loaded) ?? false,
-    ).toBe(true);
+    expect(conditionallyEvictable.evictIfUnchanged?.(loaded.group, loaded) ?? false).toBe(true);
     expect(cache.peek(newer.group)).toBe(newer);
 
-    expect(
-      conditionallyEvictable.evictIfUnchanged?.(newer.group, newer) ?? false,
-    ).toBe(true);
+    expect(conditionallyEvictable.evictIfUnchanged?.(newer.group, newer) ?? false).toBe(true);
     expect(cache.peek(newer.group)).toBeUndefined();
   });
 });

--- a/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest';
+
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { toGroupSnapshotStateRevision } from '@shared/api/group-client-views.ts';
+import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { AppOutboxType } from '@shared-server/rallar-system/services/AppOutboxService.ts';
+import {
+  COALESCED_APP_OUTBOX_WORK_FIELD,
+  type CoalescedAppOutboxWorkData,
+} from '@shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts';
+import {
+  computeCoalescedRtcTopologyGroupRevisionWork,
+  mergeRtcTopologyGroupRevisionWork,
+  toRtcTopologyCoalescedGroupRevisionResourceId,
+} from '@shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts';
+import type { RtcTopologyGroupRevisionWork } from '@shared-server/rallar-system/services/RtcTopologyOutboxWork.ts';
+import {
+  parsePersistedRtcTopologyALMessage,
+  readRtcTopologyWorkEnvelope,
+  toRtcTopologyExecutionId,
+} from '@shared-server/rallar-system/topology/replay/rtc-topology-work-codec.ts';
+
+const GROUP_REF = {
+  applicationId: 'app-1',
+  workspaceId: 'workspace-1',
+  groupId: 'room-1',
+} as const;
+const OVERLAY_ID = toScopedOverlayId(GROUP_REF);
+const BASE_EPOCH_MS = 1_000_000;
+const EXPIRE_AT_EPOCH_MS = BASE_EPOCH_MS + 3_600_000;
+const DEBOUNCE_MS = 500;
+
+describe('computeCoalescedRtcTopologyGroupRevisionWork', () => {
+  it('creates a per-group coalesced entry with debounce scheduling on first intent', () => {
+    const computed = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+
+    expect(computed.expectedEntry).toBeNull();
+    expect(computed.entry.status).toBe(EntityStatus.RETRY);
+    expect(computed.entry.dequeueAudit.nextTs?.epochMilliseconds).toBe(BASE_EPOCH_MS + DEBOUNCE_MS);
+
+    const envelope = readPersistedEnvelope(computed.entry);
+    expect(envelope.resourceId).toBe(toRtcTopologyCoalescedGroupRevisionResourceId(OVERLAY_ID));
+    expect(envelope.resourceId).toBe(`${OVERLAY_ID}:group-revision`);
+    expect(envelope.data.kind).toBe('group-revision');
+    expect(envelope.data[COALESCED_APP_OUTBOX_WORK_FIELD]).toMatchObject({
+      generation: 1,
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      dueAtEpochMs: BASE_EPOCH_MS + DEBOUNCE_MS,
+      reasons: ['group-revision'],
+    });
+    expect(toRtcTopologyExecutionId(envelope)).toContain(':1');
+  });
+
+  it('is due immediately with a zero debounce', () => {
+    const computed = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: 0,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+
+    expect(computed.entry.status).toBe(EntityStatus.NEW);
+    expect(computed.entry.dequeueAudit.nextTs).toBeUndefined();
+  });
+
+  it('merges onto a pending predecessor: max revision, sliding due, one generation up', () => {
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const second = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 5),
+      requestedAtEpochMs: BASE_EPOCH_MS + 200,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: first.entry,
+    });
+
+    expect(second.expectedEntry).toBe(first.entry);
+    const envelope = readPersistedEnvelope(second.entry);
+    expect(envelope.data[COALESCED_APP_OUTBOX_WORK_FIELD]).toMatchObject({
+      generation: 2,
+      dueAtEpochMs: BASE_EPOCH_MS + 200 + DEBOUNCE_MS,
+    });
+    expect(envelope.data.sourceGroupStateRevision).toBe(toGroupSnapshotStateRevision(4, 5));
+    expect(second.entry.status).toBe(EntityStatus.RETRY);
+    expect(second.entry.dequeueAudit.attempts).toBe(first.entry.dequeueAudit.attempts);
+  });
+
+  it('keeps the newer predecessor snapshot when the incoming revision is older', () => {
+    const newer = createCoalescedData(createGroupSnapshot(4, 6), BASE_EPOCH_MS + 100);
+    const older = createCoalescedData(createGroupSnapshot(4, 5), BASE_EPOCH_MS + 300);
+
+    const merged = mergeRtcTopologyGroupRevisionWork(newer, older);
+
+    expect(merged.sourceGroupStateRevision).toBe(toGroupSnapshotStateRevision(4, 6));
+    expect(merged.groupSnapshot).toBe(newer.groupSnapshot);
+    expect(merged.requestedAtEpochMs).toBe(BASE_EPOCH_MS + 300);
+    expect(merged[COALESCED_APP_OUTBOX_WORK_FIELD].dueAtEpochMs).toBe(
+      BASE_EPOCH_MS + 300 + DEBOUNCE_MS,
+    );
+  });
+
+  it('replaces without merging over a completed predecessor and resets lifecycle', () => {
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const completed: ResourceEntry = {
+      ...first.entry,
+      status: EntityStatus.COMPLETED,
+      dequeueAudit: { attempts: 3 },
+    };
+
+    const revived = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(5, 5),
+      requestedAtEpochMs: BASE_EPOCH_MS + 60_000,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS + 60_000,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: completed,
+    });
+
+    const envelope = readPersistedEnvelope(revived.entry);
+    expect(envelope.data[COALESCED_APP_OUTBOX_WORK_FIELD]).toMatchObject({
+      generation: 2,
+      dueAtEpochMs: BASE_EPOCH_MS + 60_000 + DEBOUNCE_MS,
+      reasons: ['group-revision'],
+    });
+    expect(envelope.data.sourceGroupStateRevision).toBe(toGroupSnapshotStateRevision(5, 5));
+    expect(revived.entry.dequeueAudit.attempts).toBe(0);
+  });
+
+  it('always carries a deterministic per-revision successor identity', () => {
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const reserved: ResourceEntry = { ...first.entry, status: EntityStatus.RESERVED };
+
+    const blocked = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 5),
+      requestedAtEpochMs: BASE_EPOCH_MS + 1_000,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: reserved,
+    });
+
+    const stateRevision = toGroupSnapshotStateRevision(4, 5);
+    const successorEnvelope = readPersistedEnvelope(blocked.successorEntry);
+    expect(successorEnvelope.resourceId).toBe(`${OVERLAY_ID}:group-revision:r${stateRevision}`);
+    expect(successorEnvelope.data[COALESCED_APP_OUTBOX_WORK_FIELD].generation).toBe(1);
+    expect(successorEnvelope.data.sourceGroupStateRevision).toBe(stateRevision);
+    const mainEnvelope = readPersistedEnvelope(blocked.entry);
+    expect(mainEnvelope.data[COALESCED_APP_OUTBOX_WORK_FIELD].generation).toBe(2);
+  });
+
+  it('fails closed when the predecessor is not coalesced topology work', () => {
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: BASE_EPOCH_MS,
+      expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const corrupted: ResourceEntry = { ...first.entry, resource: '{"not":"a message"}' };
+
+    expect(() =>
+      computeCoalescedRtcTopologyGroupRevisionWork({
+        aggregateRef: GROUP_REF,
+        groupSnapshot: createGroupSnapshot(4, 5),
+        requestedAtEpochMs: BASE_EPOCH_MS + 1_000,
+        expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+        recomputeDebounceMs: DEBOUNCE_MS,
+        senderId: 'server-1',
+        previousEntry: corrupted,
+      }),
+    ).toThrow(/not coalesced topology work/);
+  });
+});
+
+function readPersistedEnvelope(entry: ResourceEntry) {
+  return readRtcTopologyWorkEnvelope(
+    parsePersistedRtcTopologyALMessage(entry.resource),
+    AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,
+  );
+}
+
+function createCoalescedData(
+  groupSnapshot: GroupSnapshot,
+  requestedAtEpochMs: number,
+): CoalescedAppOutboxWorkData<RtcTopologyGroupRevisionWork> {
+  return {
+    kind: 'group-revision',
+    overlayId: OVERLAY_ID,
+    groupSnapshot,
+    sourceGroupStateRevision: groupSnapshot.stateRevision,
+    requestedAtEpochMs,
+    requestOptions: {},
+    publish: true,
+    [COALESCED_APP_OUTBOX_WORK_FIELD]: {
+      generation: 1,
+      requestedAtEpochMs,
+      dueAtEpochMs: requestedAtEpochMs + DEBOUNCE_MS,
+      reasons: ['group-revision'],
+    },
+  };
+}
+
+function createGroupSnapshot(groupRevision: number, presenceRevision: number): GroupSnapshot {
+  const audit = createAuditStamp();
+  return {
+    stateRevision: toGroupSnapshotStateRevision(groupRevision, presenceRevision),
+    causalRevision: { groupRevision, presenceRevision },
+    group: {
+      ...GROUP_REF,
+      slug: null,
+      displayName: 'Room 1',
+      description: null,
+      kind: 'room',
+      status: 'active',
+      archived: null,
+      deleted: null,
+      joinMode: 'open',
+      maxMembers: null,
+      maxSessionsPerMember: null,
+      metadata: {},
+      activeMemberCount: 1,
+      ownerPrincipalId: 'alice',
+      snapshotVersion: groupRevision,
+      metadataVersion: groupRevision,
+      rosterVersion: groupRevision,
+      presenceVersion: presenceRevision,
+      created: audit,
+      updated: audit,
+      expiresAtEpochMs: null,
+      emptySinceEpochMs: null,
+      purgeAfterEpochMs: null,
+    },
+    members: [
+      {
+        ...GROUP_REF,
+        principalId: 'alice',
+        role: 'owner',
+        status: 'active',
+        joined: audit,
+        updated: audit,
+        invitedByPrincipalId: null,
+        invitationExpiresAtEpochMs: null,
+        left: null,
+        removed: null,
+        banned: null,
+      },
+    ],
+    activeSessions: [
+      {
+        ...GROUP_REF,
+        principalId: 'alice',
+        sessionId: 'session-alice',
+        generationId: 'generation-alice',
+        generationVersion: 1,
+        status: 'active',
+        disconnectedAtEpochMs: null,
+        disconnectReason: null,
+        connectedAtEpochMs: 1,
+        lastHeartbeatAtEpochMs: 1,
+        expiresAtEpochMs: EXPIRE_AT_EPOCH_MS,
+      },
+    ],
+    memberCount: 1,
+    onlineMemberCount: 1,
+  };
+}
+
+function createAuditStamp(): AuditStamp {
+  return {
+    atEpochMs: 1,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
+}

--- a/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { toGroupSnapshotStateRevision } from '@shared/api/group-client-views.ts';
 import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
+import { isIdempotentHandlerFinalizedRelease } from '@shared/queuebox/QueueBoxTypes.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { isCanonicalRtcTopologyWorkEntry } from '@shared/queuebox/RtcTopologyWorkEntryContract.ts';
 import { AppOutboxType } from '@shared-server/rallar-system/services/AppOutboxService.ts';
 import {
   COALESCED_APP_OUTBOX_WORK_FIELD,
@@ -105,6 +107,94 @@ describe('computeCoalescedRtcTopologyGroupRevisionWork', () => {
     expect(envelope.data.sourceGroupStateRevision).toBe(toGroupSnapshotStateRevision(4, 5));
     expect(second.entry.status).toBe(EntityStatus.RETRY);
     expect(second.entry.dequeueAudit.attempts).toBe(first.entry.dequeueAudit.attempts);
+  });
+
+  it('keeps merged generations canonical so handler-finalized releases stay idempotent', () => {
+    const unexpiredBaseEpochMs = 1_800_000_000_000;
+    const unexpiredExpireAtEpochMs = unexpiredBaseEpochMs + 3_600_000;
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: unexpiredBaseEpochMs,
+      expireAtEpochMs: unexpiredExpireAtEpochMs,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const second = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 5),
+      requestedAtEpochMs: unexpiredBaseEpochMs + 200,
+      expireAtEpochMs: unexpiredExpireAtEpochMs + 200,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: first.entry,
+    });
+    const merged = JSON.parse(second.entry.resource) as {
+      id: { ts: number };
+      audit: { createdTs: number };
+      constraints: { expiresAtMs: number };
+    };
+
+    expect(merged.id.ts).toBe(unexpiredBaseEpochMs);
+    expect(merged.audit.createdTs).toBe(unexpiredBaseEpochMs);
+    expect(merged.constraints.expiresAtMs).toBe(unexpiredExpireAtEpochMs);
+    expect(isCanonicalRtcTopologyWorkEntry(second.entry)).toBe(true);
+
+    const reserved: ResourceEntry = {
+      ...second.entry,
+      status: EntityStatus.RESERVED,
+      dequeueAudit: { attempts: 1 },
+    };
+    const finalized: ResourceEntry = {
+      ...second.entry,
+      status: EntityStatus.COMPLETED,
+      dequeueAudit: { attempts: 1 },
+    };
+    expect(
+      isIdempotentHandlerFinalizedRelease(finalized, reserved, {
+        status: EntityStatus.COMPLETED,
+        delayMs: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the original message identity through a terminal revival', () => {
+    const unexpiredBaseEpochMs = 1_800_000_000_000;
+    const unexpiredExpireAtEpochMs = unexpiredBaseEpochMs + 3_600_000;
+    const first = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 3),
+      requestedAtEpochMs: unexpiredBaseEpochMs,
+      expireAtEpochMs: unexpiredExpireAtEpochMs,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: null,
+    });
+    const completedFirst: ResourceEntry = {
+      ...first.entry,
+      status: EntityStatus.COMPLETED,
+      dequeueAudit: { attempts: 1 },
+    };
+    const revived = computeCoalescedRtcTopologyGroupRevisionWork({
+      aggregateRef: GROUP_REF,
+      groupSnapshot: createGroupSnapshot(4, 5),
+      requestedAtEpochMs: unexpiredBaseEpochMs + 5_000,
+      expireAtEpochMs: unexpiredExpireAtEpochMs + 5_000,
+      recomputeDebounceMs: DEBOUNCE_MS,
+      senderId: 'server-1',
+      previousEntry: completedFirst,
+    });
+    const revivedMessage = JSON.parse(revived.entry.resource) as {
+      id: { ts: number };
+      constraints: { expiresAtMs: number };
+    };
+
+    expect(revived.entry.dequeueAudit.attempts).toBe(0);
+    expect(revivedMessage.id.ts).toBe(unexpiredBaseEpochMs);
+    expect(revivedMessage.constraints.expiresAtMs).toBe(unexpiredExpireAtEpochMs);
+    expect(revived.entry.audit).toEqual(first.entry.audit);
+    expect(isCanonicalRtcTopologyWorkEntry(revived.entry)).toBe(true);
   });
 
   it('keeps the newer predecessor snapshot when the incoming revision is older', () => {

--- a/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
@@ -13,7 +13,7 @@ import {
   computeCoalescedRtcTopologyGroupRevisionWork,
   mergeRtcTopologyGroupRevisionWork,
   toRtcTopologyCoalescedGroupRevisionResourceId,
-} from '@shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts';
+} from '@shared-server/rallar-system/topology/replay/rtc-topology-coalesced-group-revision-work.ts';
 import type { RtcTopologyGroupRevisionWork } from '@shared-server/rallar-system/services/RtcTopologyOutboxWork.ts';
 import { computeRtcTopologyInputFingerprint } from '@shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts';
 import {

--- a/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-coalesced-group-revision-work.test.ts
@@ -15,6 +15,7 @@ import {
   toRtcTopologyCoalescedGroupRevisionResourceId,
 } from '@shared-server/rallar-system/services/rtc-topology-coalesced-group-revision-work.ts';
 import type { RtcTopologyGroupRevisionWork } from '@shared-server/rallar-system/services/RtcTopologyOutboxWork.ts';
+import { computeRtcTopologyInputFingerprint } from '@shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts';
 import {
   parsePersistedRtcTopologyALMessage,
   readRtcTopologyWorkEnvelope,
@@ -313,5 +314,88 @@ function createAuditStamp(): AuditStamp {
     reason: null,
     traceId: null,
     requestId: null,
+  };
+}
+
+describe('computeRtcTopologyInputFingerprint', () => {
+  const EFFECTIVE_CONFIG = {
+    topologyKind: 'auto',
+    degreeLimit: 5,
+    treeMinSize: 5,
+    meshMinSize: 16,
+    meshParamK: 2,
+  } as const;
+
+  it('is deterministic and insensitive to session order', async () => {
+    const forward = await computeRtcTopologyInputFingerprint({
+      group: withSessions(createGroupSnapshot(4, 3), ['session-a', 'session-b']),
+      effectiveConfig: EFFECTIVE_CONFIG,
+    });
+    const reversed = await computeRtcTopologyInputFingerprint({
+      group: withSessions(createGroupSnapshot(4, 3), ['session-b', 'session-a']),
+      effectiveConfig: EFFECTIVE_CONFIG,
+    });
+
+    expect(forward).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(reversed).toBe(forward);
+  });
+
+  it('changes when sessions, display name, or effective config change', async () => {
+    const base = await computeRtcTopologyInputFingerprint({
+      group: withSessions(createGroupSnapshot(4, 3), ['session-a', 'session-b']),
+      effectiveConfig: EFFECTIVE_CONFIG,
+    });
+    const grownSessions = await computeRtcTopologyInputFingerprint({
+      group: withSessions(createGroupSnapshot(4, 3), ['session-a', 'session-b', 'session-c']),
+      effectiveConfig: EFFECTIVE_CONFIG,
+    });
+    const renamedGroup = createGroupSnapshot(4, 3);
+    const renamed = await computeRtcTopologyInputFingerprint({
+      group: {
+        ...renamedGroup,
+        group: { ...renamedGroup.group, displayName: 'Renamed room' },
+      },
+      effectiveConfig: EFFECTIVE_CONFIG,
+    });
+    const reconfigured = await computeRtcTopologyInputFingerprint({
+      group: createGroupSnapshot(4, 3),
+      effectiveConfig: { ...EFFECTIVE_CONFIG, degreeLimit: 4 },
+    });
+
+    expect(new Set([base, grownSessions, renamed, reconfigured]).size).toBe(4);
+  });
+
+  it('ignores lease-only differences between identical session sets', async () => {
+    const snapshot = createGroupSnapshot(4, 3);
+    const renewed: GroupSnapshot = {
+      ...snapshot,
+      activeSessions: snapshot.activeSessions.map((session) => ({
+        ...session,
+        lastHeartbeatAtEpochMs: session.lastHeartbeatAtEpochMs + 30_000,
+        expiresAtEpochMs: session.expiresAtEpochMs + 30_000,
+      })),
+    };
+
+    expect(
+      await computeRtcTopologyInputFingerprint({
+        group: renewed,
+        effectiveConfig: EFFECTIVE_CONFIG,
+      }),
+    ).toBe(
+      await computeRtcTopologyInputFingerprint({
+        group: snapshot,
+        effectiveConfig: EFFECTIVE_CONFIG,
+      }),
+    );
+  });
+});
+
+function withSessions(snapshot: GroupSnapshot, sessionIds: readonly string[]): GroupSnapshot {
+  return {
+    ...snapshot,
+    activeSessions: sessionIds.map((sessionId) => ({
+      ...snapshot.activeSessions[0]!,
+      sessionId,
+    })),
   };
 }

--- a/packages/tests/shared-server/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-outbox-work.test.ts
@@ -40,6 +40,13 @@ describe('RTC topology APP_OUTBOX work', () => {
       ),
       'utf8',
     );
+    const completionSource = readFileSync(
+      new URL(
+        '../../shared-server/rallar-system/topology/replay/finish-rtc-topology-work.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
     const handlerStart = source.indexOf('export function createRtcTopologyWorkHandler');
     const handler = source.slice(handlerStart);
 
@@ -49,11 +56,23 @@ describe('RTC topology APP_OUTBOX work', () => {
     expect(handler).toMatch(/runInTransaction/);
     expect(handler).toMatch(/writeTopologyMutation\(\s*transaction/);
     expect(handler).toMatch(/appendOrValidate\(\s*transaction/);
-    expect(handler).toMatch(/new ResourceInboxRepository\(transaction\)\.finishReserved/);
+    expect(handler).toMatch(/finishRtcTopologyReservation\(transaction, entry\)/);
     expect(handler.indexOf('writeTopologyMutation')).toBeLessThan(
       handler.indexOf('appendOrValidate'),
     );
-    expect(handler.indexOf('appendOrValidate')).toBeLessThan(handler.indexOf('finishReserved'));
+    const fencedTransaction = handler.slice(
+      handler.indexOf('async function writeRtcTopologyPublicationTransaction'),
+    );
+    expect(fencedTransaction.indexOf('await write(transaction)')).toBeGreaterThanOrEqual(0);
+    expect(fencedTransaction.indexOf('await write(transaction)')).toBeLessThan(
+      fencedTransaction.indexOf('finishRtcTopologyReservation(transaction, entry)'),
+    );
+    expect(completionSource).not.toMatch(/waitForRuntimeStateWriteRetry/);
+    expect(completionSource).not.toMatch(/\bfor\s*\([^)]*attempt/);
+    expect(completionSource).toMatch(
+      /new ResourceInboxRepository\(transaction\)\.finishReserved/,
+    );
+    expect(completionSource).toMatch(/throw new RuntimeStateWriteConflictError\(\)/);
   });
 
   it('keeps each committed group revision as an immutable queue entry', async () => {

--- a/packages/tests/shared-server/state-sync-event-replay-characterization.test.ts
+++ b/packages/tests/shared-server/state-sync-event-replay-characterization.test.ts
@@ -22,6 +22,7 @@ describe('state sync event replay characterization', () => {
         let now = 1_000;
         const service = createGroupStateService({
             runtimeRepository,
+            formationDamping: 'damped',
             syncPublisher: createPublisher(),
             now: () => now,
             serviceId: 'group-service',

--- a/packages/tests/shared-server/state-sync-event-replay-characterization.test.ts
+++ b/packages/tests/shared-server/state-sync-event-replay-characterization.test.ts
@@ -63,6 +63,7 @@ describe('state sync event replay characterization', () => {
         let now = 1_000;
         const service = createClientStateService({
             runtimeRepository,
+            formationDamping: 'damped',
             syncPublisher: createPublisher(),
             now: () => now,
             serviceId: 'client-service',

--- a/packages/tests/shared-server/state-sync-principal-audience.test.ts
+++ b/packages/tests/shared-server/state-sync-principal-audience.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
+import { computeClientStateSyncEntries } from '@shared-server/rallar-system/state-sync-publisher.ts';
+import { resolveStateSyncRecipients } from '@shared-server/rallar-system/state-sync-routing.ts';
+import type { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
+
+const NOW_EPOCH_MS = 1_800_000_000_000;
+
+describe('principal state-sync audience', () => {
+  it('stamps principal-audience rows with the principal scope under damped formation', () => {
+    const [entry] = computeClientStateSyncEntries(
+      createComputedClientSnapshotStateSync(createClientSnapshot('alice', ['alice-session-1'])),
+      'server-1',
+      'principal',
+    );
+    const message = JSON.parse(entry!.resource) as ALMessage;
+
+    expect(message.targets).toEqual({
+      mode: 'broadcast',
+      scope: 'principal',
+      principalRef: {
+        applicationId: 'app-1',
+        workspaceId: 'workspace-1',
+        principalId: 'alice',
+      },
+    });
+  });
+
+  it('keeps the legacy world stamp for principal-audience rows under legacy formation', () => {
+    const [entry] = computeClientStateSyncEntries(
+      createComputedClientSnapshotStateSync(createClientSnapshot('alice', ['alice-session-1'])),
+      'server-1',
+      'world',
+    );
+    const message = JSON.parse(entry!.resource) as ALMessage;
+
+    expect(message.targets).toEqual({ mode: 'broadcast', scope: 'world' });
+  });
+
+  it('resolves principal rows to own sessions plus co-group sessions, never strangers', () => {
+    const message = toPrincipalStampedMessage('alice', ['alice-session-1', 'alice-session-2']);
+    const webSocketServer = createOpenConnections([
+      'alice-session-1',
+      'alice-session-2',
+      'bob-session',
+      'carol-session',
+    ]);
+
+    const recipients = resolveStateSyncRecipients(webSocketServer, message, {
+      readClientSnapshots: () => [
+        createClientSnapshot('alice', ['alice-session-1', 'alice-session-2']),
+        createClientSnapshot('bob', ['bob-session']),
+        createClientSnapshot('carol', ['carol-session']),
+      ],
+      readGroupSnapshots: () => [
+        createGroupSnapshot(['alice', 'bob'], {
+          alice: 'alice-session-1',
+          bob: 'bob-session',
+        }),
+      ],
+      now: () => NOW_EPOCH_MS,
+    });
+
+    expect(recipients).toBeDefined();
+    expect([...new Set(recipients!.map((recipient) => recipient.connectionId))].sort()).toEqual([
+      'alice-session-1',
+      'alice-session-2',
+      'bob-session',
+    ]);
+  });
+
+  it('never falls through to every open connection, even for an unknown payload type', () => {
+    const message = toPrincipalStampedMessage('alice', ['alice-session-1']);
+    const forged: ALMessage = {
+      ...message,
+      payload: { ...message.payload, typeId: 'unknown.topic.v1' },
+    };
+    const webSocketServer = createOpenConnections(['alice-session-1', 'carol-session']);
+
+    const recipients = resolveStateSyncRecipients(webSocketServer, forged, {
+      readClientSnapshots: () => [
+        createClientSnapshot('alice', ['alice-session-1']),
+        createClientSnapshot('carol', ['carol-session']),
+      ],
+      readGroupSnapshots: () => [],
+      now: () => NOW_EPOCH_MS,
+    });
+
+    expect(recipients).toBeDefined();
+    expect(recipients!.map((recipient) => recipient.connectionId)).toEqual(['alice-session-1']);
+  });
+});
+
+function toPrincipalStampedMessage(principalId: string, sessionIds: readonly string[]): ALMessage {
+  const [entry] = computeClientStateSyncEntries(
+    createComputedClientSnapshotStateSync(createClientSnapshot(principalId, sessionIds)),
+    'server-1',
+    'principal',
+  );
+  return JSON.parse(entry!.resource) as ALMessage;
+}
+
+function createOpenConnections(connectionIds: readonly string[]): JsonWebSocketServer {
+  return {
+    connections: new Map(connectionIds.map((id) => [id, { id, isOpen: true }])),
+  } as unknown as JsonWebSocketServer;
+}
+
+function createComputedClientSnapshotStateSync(snapshot: ClientSnapshot) {
+  return {
+    commandId: `command-${snapshot.principal.principalId}`,
+    aggregateRef: snapshot.principal,
+    acceptedCausalRevision: snapshot.stateRevision,
+    audience: {
+      kind: 'principal' as const,
+      applicationId: snapshot.principal.applicationId,
+      workspaceId: snapshot.principal.workspaceId,
+      resourceId: snapshot.principal.principalId,
+    },
+    createdAtEpochMs: NOW_EPOCH_MS,
+    expireAtEpochMs: NOW_EPOCH_MS + 60_000,
+    effects: [
+      {
+        effectKind: 'principal-state' as const,
+        payloadKind: 'snapshot' as const,
+        payload: snapshot,
+      },
+    ],
+  };
+}
+
+function createClientSnapshot(principalId: string, sessionIds: readonly string[]): ClientSnapshot {
+  const audit = createAuditStamp();
+  return {
+    stateRevision: 5,
+    principal: {
+      applicationId: 'app-1',
+      workspaceId: 'workspace-1',
+      principalId,
+      username: principalId,
+      displayName: principalId,
+      avatarUrl: null,
+      authProvider: null,
+      externalSubjectId: null,
+      status: 'active',
+      disabled: null,
+      deleted: null,
+      roles: [],
+      metadata: {},
+      snapshotVersion: 5,
+      profileVersion: 5,
+      presenceVersion: 1,
+      created: audit,
+      updated: audit,
+      lastSeenAtEpochMs: null,
+    },
+    instances: sessionIds.map((sessionId) => ({
+      applicationId: 'app-1',
+      workspaceId: 'workspace-1',
+      principalId,
+      clientInstanceId: `${sessionId}-instance`,
+      platform: 'web' as const,
+      deviceLabel: null,
+      appVersion: null,
+      userAgent: null,
+      capabilities: [],
+      registered: audit,
+      updated: audit,
+      status: 'active' as const,
+      revoked: null,
+    })),
+    activeSessions: sessionIds.map((sessionId) => ({
+      applicationId: 'app-1',
+      workspaceId: 'workspace-1',
+      principalId,
+      clientInstanceId: `${sessionId}-instance`,
+      sessionId,
+      generationId: `generation-${sessionId}`,
+      generationVersion: 1,
+      presenceState: 'online' as const,
+      transport: 'ws' as const,
+      connectionId: sessionId,
+      authenticatedAtEpochMs: NOW_EPOCH_MS - 1_000,
+      connectedAtEpochMs: NOW_EPOCH_MS - 1_000,
+      lastHeartbeatAtEpochMs: NOW_EPOCH_MS,
+      expiresAtEpochMs: NOW_EPOCH_MS + 60_000,
+      status: 'active' as const,
+      disconnectedAtEpochMs: null,
+      disconnectReason: null,
+    })),
+    isOnline: sessionIds.length > 0,
+    activeSessionCount: sessionIds.length,
+    lastSeenAtEpochMs: sessionIds.length > 0 ? NOW_EPOCH_MS : null,
+  } as unknown as ClientSnapshot;
+}
+
+function createGroupSnapshot(
+  principalIds: readonly string[],
+  sessionByPrincipalId: Readonly<Record<string, string>>,
+): GroupSnapshot {
+  const audit = createAuditStamp();
+  const ref = {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId: 'room-1',
+  };
+  return {
+    stateRevision: 3,
+    causalRevision: { groupRevision: 2, presenceRevision: 1 },
+    group: {
+      ...ref,
+      slug: null,
+      displayName: 'Room 1',
+      description: null,
+      kind: 'room',
+      status: 'active',
+      archived: null,
+      deleted: null,
+      joinMode: 'open',
+      maxMembers: null,
+      maxSessionsPerMember: null,
+      metadata: {},
+      activeMemberCount: principalIds.length,
+      ownerPrincipalId: principalIds[0]!,
+      snapshotVersion: 2,
+      metadataVersion: 2,
+      rosterVersion: 2,
+      presenceVersion: 1,
+      created: audit,
+      updated: audit,
+      expiresAtEpochMs: null,
+      emptySinceEpochMs: null,
+      purgeAfterEpochMs: null,
+    },
+    members: principalIds.map((principalId, index) => ({
+      ...ref,
+      principalId,
+      role: index === 0 ? 'owner' : 'member',
+      status: 'active',
+      joined: audit,
+      updated: audit,
+      invitedByPrincipalId: null,
+      invitationExpiresAtEpochMs: null,
+      left: null,
+      removed: null,
+      banned: null,
+    })),
+    activeSessions: principalIds.map((principalId) => ({
+      ...ref,
+      principalId,
+      sessionId: sessionByPrincipalId[principalId]!,
+      generationId: `generation-${principalId}`,
+      generationVersion: 1,
+      status: 'active',
+      disconnectedAtEpochMs: null,
+      disconnectReason: null,
+      connectedAtEpochMs: NOW_EPOCH_MS - 1_000,
+      lastHeartbeatAtEpochMs: NOW_EPOCH_MS,
+      expiresAtEpochMs: NOW_EPOCH_MS + 60_000,
+    })),
+    memberCount: principalIds.length,
+    onlineMemberCount: principalIds.length,
+  } as GroupSnapshot;
+}
+
+function createAuditStamp(): AuditStamp {
+  return {
+    atEpochMs: 1,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
+}

--- a/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
@@ -82,7 +82,9 @@ describe('API-v1 three-server recipe semantics', () => {
     expect(allSteps.find((step) => step.name === 'updateGroupThroughSecondary')).toMatchObject({
       connection: 'apiSecondary',
     });
-    expect(allSteps.find((step) => step.name === 'waitForBothRevisionsOnTertiary')).toMatchObject({
+    expect(
+      allSteps.find((step) => step.name === 'waitForBothRevisionSnapshotsOnTertiary'),
+    ).toMatchObject({
       type: 'ws.wait',
       connection: 'wsTertiary',
     });
@@ -147,20 +149,57 @@ describe('API-v1 three-server recipe semantics', () => {
       },
     });
 
-    for (const stepName of ['waitForBothRevisionsOnPrimary', 'waitForBothRevisionsOnTertiary']) {
+    for (const [stepName, firstOutput, secondOutput] of [
+      [
+        'waitForBothRevisionSnapshotsOnPrimary',
+        'primaryFirstSnapshotPayload',
+        'primarySecondSnapshotPayload',
+      ],
+      [
+        'waitForBothRevisionSnapshotsOnTertiary',
+        'tertiaryFirstSnapshotPayload',
+        'tertiarySecondSnapshotPayload',
+      ],
+    ] as const) {
       expect(allSteps.find((step) => step.name === stepName)).toMatchObject({
+        request: {
+          outputs: {
+            [firstOutput]: 'matchedMessages.0.matchedMessage.data.payload.resource',
+            [secondOutput]: 'matchedMessages.1.matchedMessage.data.payload.resource',
+          },
+        },
         expect: {
+          consume: true,
           ordered: false,
           messages: [
             {
-              targets: { minSnapshotVersion: '{roleMutationRevision}' },
-              route: { topicId: 'overlay.topology', contextId: '{groupId}' },
-              payload: { typeId: 'overlay.topology' },
+              route: { topicId: 'group-state.snapshot' },
+              payload: { typeId: 'group-state.snapshot' },
             },
             {
-              targets: { minSnapshotVersion: '{groupMutationRevision}' },
-              route: { topicId: 'overlay.topology', contextId: '{groupId}' },
-              payload: { typeId: 'overlay.topology' },
+              route: { topicId: 'group-state.snapshot' },
+              payload: { typeId: 'group-state.snapshot' },
+            },
+          ],
+        },
+      });
+    }
+    for (const [assertName, firstActual] of [
+      ['assertPrimaryExactRevisions', '{primaryFirstSnapshot.causalRevision.groupRevision}'],
+      ['assertTertiaryExactRevisions', '{tertiaryFirstSnapshot.causalRevision.groupRevision}'],
+    ] as const) {
+      expect(allSteps.find((step) => step.name === assertName)).toMatchObject({
+        type: 'assert',
+        actual: { firstRevision: firstActual },
+        expect: {
+          anyOf: [
+            {
+              firstRevision: '{roleMutationRevision}',
+              secondRevision: '{groupMutationRevision}',
+            },
+            {
+              firstRevision: '{groupMutationRevision}',
+              secondRevision: '{roleMutationRevision}',
             },
           ],
         },

--- a/packages/tests/shared-test/state-write-recipe-evidence.test.ts
+++ b/packages/tests/shared-test/state-write-recipe-evidence.test.ts
@@ -46,7 +46,7 @@ describe('API-v1 state-write recipe evidence', () => {
         const terminalNames = [
             'assertPrimaryExactRevisions',
             'assertTertiaryExactRevisions',
-            'assertTopologyPayloadsAcrossPrimaryAndTertiary',
+            'assertSnapshotPayloadsAcrossPrimaryAndTertiary',
             'closeAliceWebSocket',
             'closeBobWebSocket',
             'logoutAliceThroughPrimary',
@@ -58,25 +58,23 @@ describe('API-v1 state-write recipe evidence', () => {
 
         const assertionSteps = recipe.steps.slice(-terminalNames.length, -4);
         expect(assertionSteps[0].actual).toEqual({
-            firstRevision: '{primaryFirstTopology.sourceGroupStateCausalRevision.groupRevision}',
-            secondRevision: '{primarySecondTopology.sourceGroupStateCausalRevision.groupRevision}',
+            firstRevision: '{primaryFirstSnapshot.causalRevision.groupRevision}',
+            secondRevision: '{primarySecondSnapshot.causalRevision.groupRevision}',
         });
-        const groupRef = {
+        const group = {
             applicationId: 'app', workspaceId: 'workspace', groupId: 'group',
         };
-        const topology = (groupRevision: number, presenceRevision: number) => ({
-            sourceGroupStateCausalRevision: { groupRevision, presenceRevision },
-            state: 'active', version: 3, groupRef,
-            activeSessionIds: ['alice-session', 'bob-session'],
+        const snapshot = (groupRevision: number, presenceRevision: number) => ({
+            causalRevision: { groupRevision, presenceRevision },
+            group,
         });
         const variables = {
             applicationId: 'app', workspaceId: 'workspace', groupId: 'group',
-            aliceSessionId: 'alice-session', bobSessionId: 'bob-session',
             roleMutationRevision: 3, groupMutationRevision: 4,
-            primaryFirstTopology: topology(3, 4),
-            primarySecondTopology: topology(4, 5),
-            tertiaryFirstTopology: topology(4, 5),
-            tertiarySecondTopology: topology(3, 4),
+            primaryFirstSnapshot: snapshot(3, 7),
+            primarySecondSnapshot: snapshot(4, 8),
+            tertiaryFirstSnapshot: snapshot(4, 8),
+            tertiarySecondSnapshot: snapshot(3, 7),
         };
         const interactions = [
             ...assertionSteps.map((step, index) => ({

--- a/packages/tests/shared/coalesced-revival-release-contract.test.ts
+++ b/packages/tests/shared/coalesced-revival-release-contract.test.ts
@@ -1,0 +1,172 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { describe, expect, it } from 'vitest';
+
+import { EnqueuedType } from '@shared/api/api-config.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { isIdempotentHandlerFinalizedRelease } from '@shared/queuebox/QueueBoxTypes.ts';
+
+const KEY = {
+  topicId: 'app-outbox.rtc-topology',
+  resourceId: 'overlay-1:group-revision',
+  contextId: 'group-context-1',
+};
+
+interface CoalescedEntryInput {
+  readonly generation: number;
+  readonly status: EntityStatus;
+  readonly attempts: number;
+  readonly typeId?: EnqueuedType;
+  readonly coalesced?: boolean;
+}
+
+function toCoalescedEntry(input: CoalescedEntryInput): ResourceEntry {
+  const envelope = {
+    type: 'rtc-topology-recompute',
+    topicId: KEY.topicId,
+    resourceId: KEY.resourceId,
+    contextId: KEY.contextId,
+    senderId: 'server-a',
+    data: {
+      kind: 'group-revision',
+      ...(input.coalesced === false ? {} : {
+        __rallarCoalescedWork: {
+          generation: input.generation,
+          requestedAtEpochMs: 1_000 + input.generation,
+          dueAtEpochMs: 1_500 + input.generation,
+          reasons: ['group-revision'],
+        },
+      }),
+    },
+  };
+  const message = {
+    id: { v: 2, msgId: `${KEY.resourceId}:g${input.generation}`, ts: 1_000, senderId: 'server-a' },
+    route: KEY,
+    payload: {
+      typeId: 'rtc-topology-recompute',
+      contentType: 'application/json',
+      resource: JSON.stringify(envelope),
+    },
+    audit: { createdBy: 'server-a', createdTs: 1_000 },
+  };
+  const createdTs = Temporal.Instant.fromEpochMilliseconds(1_000)
+    .toZonedDateTimeISO('UTC')
+    .toPlainDateTime();
+  return {
+    key: KEY,
+    resource: JSON.stringify(message),
+    typeId: input.typeId ?? EnqueuedType.APP_OUTBOX,
+    status: input.status,
+    audit: {
+      date: createdTs.toPlainTime(),
+      createdBy: 'server-a',
+      createdTs,
+      expiryTs: Temporal.Instant.fromEpochMilliseconds(9_000_000_000_000),
+    },
+    dequeueAudit: { attempts: input.attempts },
+  };
+}
+
+const COMPLETED_DISPOSITION = { status: EntityStatus.COMPLETED, delayMs: null } as const;
+
+describe('coalesced revival release contract', () => {
+  it('accepts a release whose reserved coalesced work was finalized and revived in place', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+    });
+    const revived = toCoalescedEntry({ generation: 3, status: EntityStatus.NEW, attempts: 0 });
+
+    expect(isIdempotentHandlerFinalizedRelease(revived, reserved, COMPLETED_DISPOSITION)).toBe(
+      true,
+    );
+  });
+
+  it('accepts a revived successor scheduled as RETRY for a later due time', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+    });
+    const revived = toCoalescedEntry({ generation: 3, status: EntityStatus.RETRY, attempts: 0 });
+
+    expect(isIdempotentHandlerFinalizedRelease(revived, reserved, COMPLETED_DISPOSITION)).toBe(
+      true,
+    );
+  });
+
+  it('rejects a same-generation rewrite: no proof the reserved work was finalized first', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+    });
+    const rewritten = toCoalescedEntry({ generation: 2, status: EntityStatus.NEW, attempts: 0 });
+
+    expect(isIdempotentHandlerFinalizedRelease(rewritten, reserved, COMPLETED_DISPOSITION)).toBe(
+      false,
+    );
+  });
+
+  it('rejects a revived row whose dequeue lifecycle was not reset', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+    });
+    const revived = toCoalescedEntry({ generation: 3, status: EntityStatus.NEW, attempts: 1 });
+
+    expect(isIdempotentHandlerFinalizedRelease(revived, reserved, COMPLETED_DISPOSITION)).toBe(
+      false,
+    );
+  });
+
+  it('rejects non-coalesced rows: the generation proof requires both envelopes', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+      coalesced: false,
+    });
+    const revived = toCoalescedEntry({ generation: 3, status: EntityStatus.NEW, attempts: 0 });
+
+    expect(isIdempotentHandlerFinalizedRelease(revived, reserved, COMPLETED_DISPOSITION)).toBe(
+      false,
+    );
+  });
+
+  it('rejects a retry disposition: revival proof only confirms completions', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+    });
+    const revived = toCoalescedEntry({ generation: 3, status: EntityStatus.NEW, attempts: 0 });
+
+    expect(
+      isIdempotentHandlerFinalizedRelease(revived, reserved, {
+        status: EntityStatus.RETRY,
+        delayMs: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects WS_OUTBOX rows: revival is an APP_OUTBOX coalesced-work contract', () => {
+    const reserved = toCoalescedEntry({
+      generation: 2,
+      status: EntityStatus.RESERVED,
+      attempts: 1,
+      typeId: EnqueuedType.WS_OUTBOX,
+    });
+    const revived = toCoalescedEntry({
+      generation: 3,
+      status: EntityStatus.NEW,
+      attempts: 0,
+      typeId: EnqueuedType.WS_OUTBOX,
+    });
+
+    expect(isIdempotentHandlerFinalizedRelease(revived, reserved, COMPLETED_DISPOSITION)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/tests/shared/group-state-snapshot-revision.test.ts
+++ b/packages/tests/shared/group-state-snapshot-revision.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
+import {
+  decideGroupSnapshotCausalRevision,
+  isTuplePreservingGroupLivenessReduction,
+} from '@shared/repository/group-state-snapshot-revision.ts';
+import { StateSnapshotRevisionConflictError } from '@shared/repository/state-snapshot-revision.ts';
+
+describe('decideGroupSnapshotCausalRevision', () => {
+  it('orders snapshots by causal tuple', () => {
+    const current = createGroupSnapshot({ presenceRevision: 3 });
+
+    expect(decideGroupSnapshotCausalRevision(undefined, current)).toBe('inserted');
+    expect(
+      decideGroupSnapshotCausalRevision(current, createGroupSnapshot({ presenceRevision: 4 })),
+    ).toBe('advanced');
+    expect(
+      decideGroupSnapshotCausalRevision(current, createGroupSnapshot({ presenceRevision: 2 })),
+    ).toBe('stale');
+  });
+
+  it('treats lease-only differences at an equal tuple as duplicates', () => {
+    const current = createGroupSnapshot({ presenceRevision: 3 });
+    const renewed = createGroupSnapshot({
+      presenceRevision: 3,
+      leaseOffsetMs: 30_000,
+    });
+
+    expect(decideGroupSnapshotCausalRevision(current, renewed)).toBe('duplicate');
+    expect(decideGroupSnapshotCausalRevision(renewed, current)).toBe('duplicate');
+  });
+
+  it('treats a tuple-preserving liveness reduction as a duplicate in both directions', () => {
+    const full = createGroupSnapshot({ presenceRevision: 3 });
+    const reduced: GroupSnapshot = {
+      ...full,
+      activeSessions: full.activeSessions.slice(0, 1),
+      onlineMemberCount: 1,
+    };
+
+    expect(decideGroupSnapshotCausalRevision(full, reduced)).toBe('duplicate');
+    expect(decideGroupSnapshotCausalRevision(reduced, full)).toBe('duplicate');
+  });
+
+  it('still fails closed on genuine equal-tuple content divergence', () => {
+    const current = createGroupSnapshot({ presenceRevision: 3 });
+    const divergent: GroupSnapshot = {
+      ...current,
+      activeSessions: current.activeSessions.map((session, index) =>
+        index === 0 ? { ...session, generationId: 'other-generation' } : session,
+      ),
+    };
+
+    expect(() => decideGroupSnapshotCausalRevision(current, divergent)).toThrow(
+      StateSnapshotRevisionConflictError,
+    );
+  });
+});
+
+describe('isTuplePreservingGroupLivenessReduction', () => {
+  it('accepts an order-preserving lease-insensitive session subset', () => {
+    const full = createGroupSnapshot({ presenceRevision: 3 });
+    const reduced: GroupSnapshot = {
+      ...full,
+      activeSessions: [{ ...full.activeSessions[1]!, expiresAtEpochMs: 99 }],
+      onlineMemberCount: 1,
+    };
+
+    expect(isTuplePreservingGroupLivenessReduction(reduced, full)).toBe(true);
+  });
+
+  it('rejects a reordered or foreign session set', () => {
+    const full = createGroupSnapshot({ presenceRevision: 3 });
+    const reordered: GroupSnapshot = {
+      ...full,
+      activeSessions: [...full.activeSessions].reverse(),
+    };
+    const foreign: GroupSnapshot = {
+      ...full,
+      activeSessions: [{ ...full.activeSessions[0]!, sessionId: 'session-x' }],
+      onlineMemberCount: 1,
+    };
+
+    expect(isTuplePreservingGroupLivenessReduction(reordered, full)).toBe(false);
+    expect(isTuplePreservingGroupLivenessReduction(foreign, full)).toBe(false);
+  });
+});
+
+function createGroupSnapshot(
+  input: Readonly<{ presenceRevision: number; leaseOffsetMs?: number }>,
+): GroupSnapshot {
+  const audit = createAuditStamp();
+  const leaseOffsetMs = input.leaseOffsetMs ?? 0;
+  const ref = {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId: 'room-1',
+  };
+  const member = (principalId: string) => ({
+    ...ref,
+    principalId,
+    role: principalId === 'alice' ? ('owner' as const) : ('member' as const),
+    status: 'active' as const,
+    joined: audit,
+    updated: audit,
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+    left: null,
+    removed: null,
+    banned: null,
+  });
+  const session = (principalId: string, sessionId: string) => ({
+    ...ref,
+    principalId,
+    sessionId,
+    generationId: `generation-${sessionId}`,
+    generationVersion: 1,
+    status: 'active' as const,
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+    connectedAtEpochMs: 1,
+    lastHeartbeatAtEpochMs: 1_000 + leaseOffsetMs,
+    expiresAtEpochMs: 120_000 + leaseOffsetMs,
+  });
+  return {
+    stateRevision: 4 + input.presenceRevision,
+    causalRevision: { groupRevision: 4, presenceRevision: input.presenceRevision },
+    group: {
+      ...ref,
+      slug: null,
+      displayName: 'Room 1',
+      description: null,
+      kind: 'room',
+      status: 'active',
+      archived: null,
+      deleted: null,
+      joinMode: 'open',
+      maxMembers: null,
+      maxSessionsPerMember: null,
+      metadata: {},
+      activeMemberCount: 2,
+      ownerPrincipalId: 'alice',
+      snapshotVersion: 4,
+      metadataVersion: 4,
+      rosterVersion: 4,
+      presenceVersion: input.presenceRevision,
+      created: audit,
+      updated: audit,
+      expiresAtEpochMs: null,
+      emptySinceEpochMs: null,
+      purgeAfterEpochMs: null,
+    },
+    members: [member('alice'), member('bob')],
+    activeSessions: [session('alice', 'session-alice'), session('bob', 'session-bob')],
+    memberCount: 2,
+    onlineMemberCount: 2,
+  };
+}
+
+function createAuditStamp(): AuditStamp {
+  return {
+    atEpochMs: 1,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
+}

--- a/plans/rallar-group-formation-phase2-server-damping-plan.md
+++ b/plans/rallar-group-formation-phase2-server-damping-plan.md
@@ -320,6 +320,16 @@ retained path they were authored against; the durable replay machinery itself
 to the damped contract (fingerprint-affecting drivers, revision-exact
 correlation) is a recorded follow-up issue.
 
+Recorded delta (implementation): coalesced work generations must preserve the
+original persisted-message creation and expiry identity, because queue rows
+never rewrite their created-audit columns and the release-idempotency
+predicate proves handler finalization through the canonical work contract.
+The first M1 cut stamped each generation with the latest request time, which
+wedged the APP_OUTBOX worker in lost-reservation retry loops from generation
+2 onward (caught post-gate by the full-stack WS quick test; fixed in the
+compute builder, the coalesced service merge path, and with a revival-aware
+release-idempotency arm; details in the phase-2 results document).
+
 Recorded delta (implementation): the branch-CI changed-style gate rejects
 worsened file-length and layout findings, so the damping additions that had
 grown pre-existing large files were extracted into feature modules instead:

--- a/plans/rallar-group-formation-phase2-server-damping-plan.md
+++ b/plans/rallar-group-formation-phase2-server-damping-plan.md
@@ -1,0 +1,395 @@
+# Rallar Group Formation Phase 2: Server Damping (M1, M4, M3)
+
+Status: in progress. Plan checkpoint; implementation follows in the same
+draft PR. Base: `main` at `1e5f5e55` (recorded for plan revalidation).
+
+Phase 2 of
+[the group formation implementation plan](../playground/rtc-design/2026-08-08-group-formation-implementation-plan.md):
+a join burst produces ~1 recompute, an idle group produces ~0 work. Baseline
+evidence:
+[Phase 0 formation-burst baseline](../playground/rtc-design/baselines/2026-08-08-formation-burst-baseline.md)
+and
+[Phase 1 overlay-precedence results](../playground/rtc-design/baselines/2026-08-09-phase1-overlay-precedence-results.md)
+(20,000 WS deliveries/min at an idle N=50 group; recomputes triggered ≈
+executed ≈ published; `topologyPublishSkippedUnchangedCount == 0`
+everywhere).
+
+## Context: the measured storm engine (file-level)
+
+One causal chain produces every steady-state number in the baseline:
+
+1. **Every group mutation — including `heartbeatPresence` — enqueues one
+   presence-summary expansion.** `computeGroupMutationWriteResult`
+   (`packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts:92`)
+   unconditionally emits a `GROUP_PRESENCE_SUMMARY` APP_OUTBOX entry keyed
+   per `commandId`.
+2. **Heartbeats always change summary content.** The summary content
+   comparison (`compute-group-presence-summary.ts:84`, `summaryContent`)
+   includes full `GroupPresenceSession` objects, so a moved
+   `lastHeartbeatAtEpochMs`/`expiresAtEpochMs` forces `outcome: 'write'`
+   with `presenceRevision + 1`.
+3. **Every expansion fans out three WS rows and one topology entry.**
+   `GroupPresenceSummaryWork.compute`
+   (`group-state/presence/group-presence-summary-work.ts:219-287`) emits
+   event + snapshot + directory WS_OUTBOX rows and one
+   `RTC_TOPOLOGY_RECOMPUTE` APP_OUTBOX entry via the legacy
+   `computeRtcTopologyEntry` overload whose identity is
+   `deriveRtcTopologyEntryResourceId` — per `commandId` + causal tuple
+   (`services/rtc-topology-outbox-entry.ts:210-222`). No two entries ever
+   coalesce.
+4. **Every recompute publishes, even for identical graphs.** The work
+   handler (`topology/replay/create-rtc-topology-work-handler.ts:182-197`)
+   builds a publication whenever `work.publish` is true — before and
+   regardless of the planner's own `changed` result
+   (`planRallarRtcTopologySnapshot`,
+   `services/rallar-rtc-topology-service.ts:105-137`, which already
+   computes `changed` and even returns the previous snapshot object when
+   the graph is identical). `decideTopologySnapshot` then observes
+   `'advanced'`/`'duplicate'`, but the publication is already built and is
+   written and delivered either way.
+5. **Client principal snapshots are stamped world-scope.**
+   `toStateSyncEntry` (`state-sync-publisher.ts:230-233`) writes
+   `{mode: 'broadcast', scope: 'world'}` for principal audiences. Delivery
+   re-derives the audience per process by payload sniffing
+   (`state-sync-routing.ts:39`, `ws-server-target-resolver.ts:95-104`);
+   an unrecognized payload typeId falls through to *every open connection
+   on the process*.
+
+The coalescing infrastructure already exists and is proven on the RTT lane:
+`CoalescedAppOutboxWorkService` (generation-CAS `write(transaction,
+computed)`, due-time scheduling, successor identities;
+`services/CoalescedAppOutboxWorkService.ts`) and the topology work codec
+already accepts coalesced `group-revision` envelopes
+(`topology/replay/rtc-topology-work-codec.ts:145,191`) with the coalescing
+generation folded into the execution id (`toRtcTopologyExecutionId`).
+Phase 2 wires the storm path onto that machinery and adds the two gates.
+
+## Decisions
+
+### Decision 1 — flag surface: one server damping mode, default `damped`
+
+`RALLAR_GROUP_FORMATION_DAMPING` ∈ `['damped', 'legacy']`, default
+`'damped'`, parsed in a new `apps/api-v1/src/services/`
+`group-formation-damping-config.ts` following the exact
+`rtc-topology-replay-config.ts` convention (mode const, typed union,
+throw-on-invalid reader, startup log line from `main.ts`). The mode is
+threaded explicitly (constructor/options/facts — no module state) into the
+group mutation facts, `GroupPresenceSummaryWork`, the topology work
+handler, snapshot assembly, and the state-sync publisher/resolver.
+`legacy` retains today's engine wholesale (per-command topology entries,
+heartbeat-driven expansions, publish-on-advanced, world-scope stamps).
+Rationale: matches the server-side flag convention the repo already uses
+(`RALLAR_RTC_TOPOLOGY_REPLAY`, `RALLAR_API_QUEUE_WORKERS`) and mirrors
+Phase 1's default-on-with-legacy-rollback posture (`groupFormationMode:
+'bounded-bootstrap' | 'legacy-star'`). Default-on means every existing
+suite exercises the damped path; targeted unit tests pin the legacy path.
+
+The debounce is config, not flag:
+`RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS` → new
+`topologyRecomputeDebounceMs` option beside `rttRebuildDebounceMs`
+(default **500 ms**, non-negative, 0 = due immediately), parsed in
+`apps/api-v1/src/services/rtc-topology-config.ts` and defaulted in
+`rallar-rtc-topology-service.ts`. Both env vars get documented in
+`docs/environment-variables.md` (the existing `RALLAR_RTC_TOPOLOGY_*`
+family is undocumented there today; this change documents the new ones and
+backfills the family).
+
+### Decision 2 — M1 identity: one coalesced work item per group
+
+The presence-summary expansion stops writing per-command topology entries.
+Under `damped`, `GroupPresenceSummaryWork` routes the topology intent
+through `CoalescedAppOutboxWorkService.write(transaction, computed)` with:
+
+- **Key**: same topic (`app-outbox.rtc-topology`) and context (group
+  storage key); `resourceId = ${overlayId}:group-revision` — constant per
+  group. (The RTT lane already owns `resourceId = ${overlayId}`; the
+  suffix keeps the two lanes' queue identities disjoint.)
+- **Envelope**: the existing `RtcTopologyGroupRevisionWork` shape plus the
+  coalescing metadata field the codec already accepts. Merge keeps the
+  max-`sourceGroupStateRevision` snapshot (same selection rule as
+  `mergeRtcTopologyRttWork`), unions reasons, and slides
+  `dueAtEpochMs = max(previous, now + debounceMs)` — the same sliding-due
+  semantics the RTT merge uses. Starvation is bounded because under M4
+  only transitions enqueue.
+- **Read/compute/write discipline**: the expansion's `read` phase
+  additionally reads the current coalesced entry via the outbox reader
+  (new explicit `outboxQueueReader` dependency wired at
+  `apps/api-v1/src/middleware.ts:276`, where it is already in scope);
+  `compute` builds `{expectedEntry, entry, successorEntry}` purely;
+  `write(transaction, computed)` performs the generation-CAS inside the
+  expansion's existing transaction. A reserved/raced predecessor falls to
+  the successor identity `${overlayId}:group-revision:r${revision}` —
+  insert-if-absent, deterministic, self-coalescing. AppInbox doctrine is
+  untouched: the service write still receives the transaction and never
+  opens or retries one; conflicts stay typed values.
+
+Out of M1 scope (unchanged trigger sites, all rare/operator-driven): the
+explicit reconfigure path (`group-topology-management-service.ts:543`,
+resource `:explicit`), topology config mutations (`:1096`), RTT recompute
+intents (`rtc-rtt-mutation-service.ts:101`), and the scalar-recompute
+migration worker (`init-api-rtc-topology-scalar-recompute-worker.ts`).
+
+### Decision 3 — M3 gates discriminate on the coalesced envelope
+
+Both gates run in `computeAcceptedRtcTopologyWork`
+(`create-rtc-topology-work-handler.ts`) and apply **only** to work that
+carries the coalescing metadata field with kind `group-revision` and an
+empty canonical request patch — i.e. exactly the storm path M1 creates.
+Explicit reconfigure, config-mutation, RTT-refresh, and migration work
+keep today's semantics, which preserves the medium-scale gate's
+`assertFinalTopologyEffectsConverged` /
+`assertPublishedTopologyEffectsMatchReceipts` behavior (those assert
+explicit-reconfigure publications).
+
+- **Input fingerprint (skip rebuilds).** A pure
+  `computeRtcTopologyInputFingerprint` hashes the canonical topology
+  input: sorted active session ids from the group snapshot, the resolved
+  effective config projection (topology kind selection inputs, degree
+  limit, tree/mesh thresholds, mesh K), and the group display name (it
+  participates in the planner's `changed`). SHA-256 over canonical JSON —
+  the same deterministic-fingerprint idea the activation design defines
+  for `group_batch` (`topologyInputHash`). The fingerprint of the inputs
+  that produced the committed snapshot is stored in a new runtime-state
+  entry beside the overlay snapshot, written in the same
+  `writeTopologyMutation` transaction by **every** accepting path (so
+  explicit/RTT rebuilds refresh it), and read in the execution read.
+  Fingerprint equal + stored snapshot `active` → finish the entry
+  completed with no plan, no snapshot write, no publication; count a new
+  `topologyRebuildSkippedFingerprintCount` metric. Absent or mismatched
+  fingerprint fails open into a normal rebuild — a stale fingerprint can
+  only cause an extra rebuild, never a wrong skip.
+- **Publication gated on `changed`.** The publication is built only when
+  the plan result's `changed` is true or no durable snapshot exists.
+  Unchanged plans finish without a snapshot write or publication and
+  record `recordTopologyPublishResult(false)` →
+  `topologyPublishSkippedUnchangedCount` finally moves off zero. Late
+  joiners are covered because their own presence connect is a transition
+  that changes the input fingerprint and the planned graph; reconnecting
+  sessions are covered by the durable topology replay/hydration lane
+  (PRs #143/#146/#148), which replays the last publication.
+
+### Decision 4 — M4 heartbeat separation: the audit and the dual-plane cut
+
+**Audit of every consumer of heartbeat-advanced `presenceRevision` and
+heartbeat-refreshed lease fields** (the risk the program plan flags):
+
+| # | Consumer | Site | Today | Under damped M4 |
+| --- | --- | --- | --- | --- |
+| 1 | Summary content comparison | `compute-group-presence-summary.ts:84` (`summaryContent` includes full sessions) | every heartbeat → content change → `presenceRevision+1` → broadcast + recompute | lease fields excluded from the comparison; renewals compare equal (see cut below) |
+| 2 | Snapshot assembly session values | `assemble-group-state-snapshot.ts:110` (`readActiveSessions`) | snapshot sessions are the **summary-frozen** copies; authoritative rows only filter (identity, generation, disconnect, expiry) | frozen lease values would lapse ~TTL (browser default 120 s, `DEFAULT_STATE_HEARTBEAT_TTL_MSECS`) after the last transition → assembly must override `lastHeartbeatAtEpochMs`/`expiresAtEpochMs` from the authoritative row |
+| 3 | Room-send authorization | `group-policy.ts:397-407` (`canSendRoomMessage` requires `isLiveSession(snapshot session, now)`) | kept live by the heartbeat→summary rewrite | **breaks without #2** (idle groups would deny sends after TTL); fixed by #2 |
+| 4 | Read-through cache freshness | `group-state-snapshot-read-through-cache.ts:162` → `isGroupSnapshotPresenceFresh` (`snapshot-presence.ts:35`: every session lease in the future) | kept fresh the same way | **breaks without #2** (`findOrLoad` would return `undefined` for idle-but-alive groups — WS authorization and topology reads fail); fixed by #2, cache TTL 60 s re-loads fresh values |
+| 5 | Equal-tuple content equality | `shared/repository/group-state-snapshot-revision.ts:32` (`jsonEquals`); server carve-out `isTuplePreservingGroupLivenessReduction` (`group-topology-management-service.ts:1247`) | content per tuple is deterministic **except** read-time expiry filtering (a pre-existing, storm-masked GET-vs-broadcast conflict window) | with #2, same-tuple assemblies legitimately differ in lease values → the shared decide treats lease fields as liveness, not content, and adopts the tuple-preserving liveness-reduction carve-out (predicate moves to the shared layer; the management service imports it) |
+| 6 | `minSnapshotVersion` freshness gates | `ws-topic-room-authorizer.ts:56-83`, `ws-topic-router.ts:715,762-765`, read-through caches (`minSnapshotVersion`/`minCausalRevision`/`minStateRevision`), `canSendRoomMessage:383` | all compare `group.snapshotVersion` (groupRevision) or a receipt-derived tuple; heartbeat receipts already return the **pre-expansion** revision (`group-mutation-result.ts:83-84` reads the stored summary; the `+1` never appears in a receipt) | **no consumer waits on a heartbeat-driven bump — no change needed** |
+| 7 | Overlay causal tuples | `sourceGroupStateCausalRevision` ordering (Phase 1 admission, stale-publication guard, replay decisions) | strictly monotonic | still strictly monotonic — transitions bump the tuple; unchanged graphs are not republished at all |
+| 8 | Presence-expiry machinery | sweeper `enqueueExpiredPresenceSessions` (rows), TTL, generation fencing | reads **authoritative rows**, which heartbeats keep updating | unchanged, by design; the sweeper's expiry-disconnect remains the sole offline-transition authority and bumps the tuple when it fires |
+| 9 | Client plane (`rallar.people` `lastSeenAtEpochMs`, client snapshot freshness) | client sessions/snapshots | separate mutation family | out of Phase 2 scope: client heartbeats are untouched (the formation recipes drive only group-presence heartbeats; idle-tier targets do not require client-plane separation) |
+
+**Recommendation (recorded per the program plan's risk #1): adopt the
+dual-plane transition now, with no revision-advancing shim.** Concretely:
+
+- (a) **Mutation-level gate**: `computeHeartbeatPresence` classifies a
+  heartbeat as a *pure lease renewal* when the stored summary lists the
+  session (`read.presenceSummary.activeSessionIds` contains it) **and**
+  the existing row was still unexpired at read time
+  (`expiresAtEpochMs > now`). Pure renewals still write the session row,
+  the durable event, and the receipt — but emit **no** presence-summary
+  work (`outboxEntries: []`, mirrored in the receipt's `outboxIds` and in
+  the deterministic write validator). Anything not provably pure —
+  including a lapsed-lease revival, which is an offline→online transition
+  — emits summary work as today.
+- (b) **Snapshots carry the liveness plane without revision movement**:
+  assembly overrides the two lease fields from the authoritative row
+  (audit #2), keeping authorization, cache freshness, and
+  `isGroupSnapshotSessionLive` truthful between transitions.
+- (c) **Lease fields become non-content**: the summary content comparison
+  (audit #1) and the shared equal-tuple snapshot equality (audit #5)
+  exclude `lastHeartbeatAtEpochMs`/`expiresAtEpochMs`; the equal-tuple
+  liveness-reduction carve-out moves into the shared decide, which also
+  closes the pre-existing storm-masked conflict window.
+- (d) **Revisions advance on transition events only** — join/leave,
+  connect/disconnect, admission changes, expiry-disconnects from the
+  unchanged sweeper. Because audit #6 found no consumer that requires
+  heartbeat-driven advancement, no dual-write compatibility period is
+  needed; `legacy` mode retains the old engine wholesale for rollback.
+
+### Decision 5 — audience fix: honest scope + co-group narrowing, flagged
+
+`toStateSyncEntry` stops stamping principal-audience rows as
+world-broadcast. An additive `'principal'` member joins the broadcast
+scope union in `ALTargets` (`packages/shared/al-contracts/al-contract.ts:31-50`),
+carried with the aggregate's principal identity; persistence validation
+accepts it; `newALBroadcastMessage` semantics for existing scopes are
+unchanged (no public API break — additive union member, server-resolved).
+The server resolver maps `scope: 'principal'` to: the principal's own live
+sessions ∪ live sessions of groups where the principal is an active
+member — resolved at delivery time per the after-commit dynamic-audience
+doctrine — and **never** falls through to all open connections
+(the `'world'` fallback blast radius flagged in
+`ws-server-target-resolver.ts:47-58` does not apply to the new scope).
+Legacy `'world'` rows (old producers, in-flight rows) resolve exactly as
+today.
+
+Deliberate tradeoff, recorded: today every live session in the
+(application, workspace) scope receives every principal's client snapshot
+(`state-sync-routing.ts:112-131`), and the browser people directory
+(`rallar-runtime/state-store.ts:99-109`, `rallar-people-facade.ts`)
+depends on receiving *other* principals' snapshots. Narrowing to co-group
+sessions preserves the directory for the peers that share a group with the
+observer (the realtime-relevant set) while stopping workspace-wide
+strangers from receiving each other's client state. In every black-box
+recipe all clients share one group, so recipe-visible behavior is
+identical. Under `legacy` the world stamp and workspace fanout are
+retained bit-for-bit.
+
+### Decision 6 — single draft PR (review-pressure record)
+
+Estimated footprint: ~25 production modules across `packages/shared`,
+`packages/shared-server`, `apps/api-v1`, plus tests and docs — under the
+100-file / 10,000-line / 20-production-module thresholds is *not* certain
+(module count may cross 20), so the written decision is recorded here:
+**one PR**. The four mechanisms form one invariant ("a heartbeat is not a
+topology event; an unchanged topology is not a publication") verified by
+one measurement harness; the flag couples them operationally; and the
+tier reruns validate them only in combination. The PR body carries a
+read-first map ordered by entry owners (mutation compute → expansion →
+work handler → resolver) per the large-PR rule.
+
+## Scope (implementation slices)
+
+Each slice lands with its unit/service tests; focused validation runs per
+slice, tier + gate validation at the end.
+
+1. **Config + flag plumbing** — damping-mode config file (api-v1), the
+   `topologyRecomputeDebounceMs` option + env parsing, startup log,
+   `docs/environment-variables.md` rows, threading into the composition
+   roots (`create-rallar-server.ts`, `middleware.ts`).
+2. **M1 coalesced recompute** — `GroupPresenceSummaryWork` read/compute/
+   write changes, per-group identity + successor identity, merge function
+   beside the RTT merge, wiring of the outbox reader dependency; tests
+   for merge selection, generation CAS, reserved→successor, debounce due
+   scheduling, and legacy-mode per-command retention.
+3. **M3 gates** — fingerprint helper + storage read/write in the
+   execution repository transaction, both gates in
+   `computeAcceptedRtcTopologyWork`, `topologyRebuildSkippedFingerprintCount`
+   metric, `recordTopologyPublishResult(false)` on unchanged; tests for
+   skip/fail-open/changed-gate/exemption-of-explicit-and-RTT work.
+4. **M4 heartbeat separation** — pure-renewal gate in
+   `computeHeartbeatPresence` + write-result/receipt/validator mirroring;
+   lease exclusion in `summaryContent` + validator; assembly lease
+   override (`sessionLeaseFields: 'summary-frozen' | 'authoritative'`
+   required input, all call sites updated); shared lease-insensitive
+   equal-tuple equality + liveness-reduction carve-out relocation; tests
+   for renewal-vs-transition classification (incl. lapsed-lease revival),
+   equal-tuple decisions, authorization and cache freshness on idle
+   groups, sweeper interplay.
+5. **Audience fix** — `ALTargets` `'principal'` scope + validation,
+   publisher stamp under damped, resolver branch + co-group resolution,
+   no-fallback guarantee; tests for scope resolution (own sessions,
+   co-group sessions, no-blast on unknown typeId), legacy compatibility.
+6. **Validation + results** — tier reruns (memory, postgres,
+   formation-large), medium-scale gate, state-write perf comparison
+   (fresh DB per side), results document beside the baselines, final
+   completion gates.
+
+Recipes: no step or assertion changes are expected — the formation-burst
+recipes capture whole metrics objects (new counters appear automatically)
+and assert liveness only; convergence polls (4 × 1 s + 5 s `ws.wait`)
+comfortably cover the 500 ms debounce. If any capture path proves
+incompatible, the recipe change ships in the same slice that caused it.
+
+Out of scope (later phases per the program plan): delta dissemination and
+read-through (Phase 3), join admission control (Phase 3), incremental
+planning/hysteresis (Phase 4), RTT threshold refinement (Phase 4, M8),
+formation epochs (Phase 5), client-plane heartbeat separation (audit #9 —
+follow-up issue if idle client-plane rows matter operationally),
+`orderingKey` dequeue honoring (Phase 6).
+
+## Validation matrix
+
+Targets (from the program plan and the Phase 2 task):
+
+- **Idle steady state (T2−T1, per minute), every tier**: expansions ≈ 0,
+  recomputes triggered/executed/published ≈ 0, presence-summary WS rows ≈
+  0, deliveries ≈ 0 (vs 20,000/min at N=50 today). Group mutations remain
+  2N (heartbeats still write leases).
+- **Burst window (T1−T0)**: recomputes executed/published in the low
+  single digits per server (vs ≈ N today);
+  `topologyPublishSkippedUnchangedCount > 0` over the run; every join
+  succeeds; full membership visible (`memberCount == N+1`,
+  `onlineMemberCount == N`); every client receives ≥ 1 `overlay.topology`
+  (existing hard assertions unchanged).
+- **No liveness regressions**: room sends authorized on idle groups
+  (audit #3), read-through caches serve idle groups (audit #4).
+
+Commands (fresh DB per the established procedure for every postgres run:
+`docker compose down -v && npm run db:up && DATABASE_URL=… npm run
+db:migrate`; queue tables truncated before capture runs, matching the
+baseline methodology):
+
+- `npm run test:api-v1:black-box:memory` (13 recipes incl. small+medium
+  tiers)
+- `npm run test:api-v1:black-box:postgres` (13 + 5 cluster)
+- `npm run test:api-v1:black-box:postgres:formation-large` (N=50)
+- `npm run test:api-v1:black-box:postgres:medium-scale` — constants,
+  operation matrix, and assertions untouched (this plan changes none of
+  its recipe files; Decision 3 keeps explicit-reconfigure publication
+  semantics it asserts)
+- State-write perf comparison gate: `npm run perf:api-v1:state-write`
+  baseline on `main`@`1e5f5e55` and candidate on this branch (each
+  against a freshly migrated database), then
+  `node scripts/perf/compare-api-v1-state-write-results.mjs baseline
+  candidate`. Expected direction: heartbeat-heavy workloads write fewer
+  outbox rows; any waiver follows the comparator's waiver contract.
+- Focused suites: `packages/tests/shared-server` (presence summary,
+  coalesced work, topology handler, policy), `packages/tests/shared`
+  (al-contracts, repository decides), api-v1 `deno task check` + group
+  state route tests, `npx vitest run
+  packages/tests/rallar-black-box-headless/` +
+  `npm --workspace @ar-eye-hunter/shared-web run check:browser-bundles`
+  (shared bundle ratchets), `npm run check:repo-style:changed -- origin/main HEAD`.
+- Completion gates: final tree passes `npm run test:unit`,
+  `npm run test:ci`, `npm run build`; **Branch Release Gate** green on the
+  final feature-branch commit; **Run Hetzner Supported Distributed
+  Manifests** green on the resulting default-branch commit (recorded by
+  exact SHA).
+
+Results document: committed beside the baselines as
+`playground/rtc-design/baselines/<date>-phase2-server-damping-results.md`
+with the same tier × backend tables, reading rules, and provenance.
+
+## Risks and mitigations
+
+1. **Lease-aware equality misses a comparison site.** Mitigation: the
+   change lands in the single shared decide all stores use
+   (`group-state-snapshots-repository.ts:232` is its only caller) plus
+   the one server carve-out site; a grep-audit for `jsonEquals` over
+   `GroupSnapshot` is part of slice 4 review.
+2. **Coalesced entry starvation under sustained churn** (sliding due).
+   Bounded: only transitions enqueue under M4; a stuck-reserved
+   predecessor falls to the successor identity. Watched via queue-depth
+   captures in the tier reruns.
+3. **Fingerprint skip hides a needed rebuild.** The gate fails open on
+   absent/mismatched fingerprints, applies only to empty-patch coalesced
+   work, and every accepting path refreshes the stored fingerprint in the
+   same transaction. Wrong-skip would require a fingerprint collision on
+   different canonical inputs (SHA-256).
+4. **Mixed-version window during rollout** (old browser bundles with
+   strict `jsonEquals` vs new servers emitting lease-fresh snapshots at
+   an unmoved tuple). Exposure is transient and self-heals on the next
+   transition ('advanced' replaces the entry); the same window exists
+   today via read-time expiry filtering. Rollback: `legacy` mode.
+5. **Medium-scale/perf gate sensitivity to changed outbox counts.**
+   Heartbeat receipts legitimately report `outboxIds: []` under damped;
+   the medium-scale recipe asserts outbox ids only on topology-config
+   receipts (unchanged paths). The perf comparator sees fewer SQL
+   statements on heartbeat paths — an improvement, not a waiverable
+   regression.
+
+## Draft Pull Request Record
+
+Maintained in the PR body from the first checkpoint: written-plan link,
+milestone checklist mirroring the six slices, current behavior +
+incomplete areas, exact passed/failed/skipped validation, follow-up
+issues, default-branch base (`1e5f5e55`) and latest revalidation outcome,
+and the Decision 6 single-PR record with the read-first map.

--- a/plans/rallar-group-formation-phase2-server-damping-plan.md
+++ b/plans/rallar-group-formation-phase2-server-damping-plan.md
@@ -298,6 +298,15 @@ and assert liveness only; convergence polls (4 × 1 s + 5 s `ws.wait`)
 comfortably cover the 500 ms debounce. If any capture path proves
 incompatible, the recipe change ships in the same slice that caused it.
 
+Recorded delta (implementation): one cluster recipe,
+`api-v1-rtc-topology-convergence`, asserted a topology publication per
+concurrent group revision. A role promotion plus a metadata update leave the
+topology-input fingerprint unchanged, so the damped server correctly plans
+nothing; the recipe now observes cross-server convergence of both revisions
+on the state plane (both `group-state.snapshot` broadcasts on both servers),
+which damping preserves per transition. The medium-scale gate's recipe files
+are untouched. Details in the phase-2 results document.
+
 Out of scope (later phases per the program plan): delta dissemination and
 read-through (Phase 3), join admission control (Phase 3), incremental
 planning/hysteresis (Phase 4), RTT threshold refinement (Phase 4, M8),

--- a/plans/rallar-group-formation-phase2-server-damping-plan.md
+++ b/plans/rallar-group-formation-phase2-server-damping-plan.md
@@ -307,6 +307,34 @@ on the state plane (both `group-state.snapshot` broadcasts on both servers),
 which damping preserves per transition. The medium-scale gate's recipe files
 are untouched. Details in the phase-2 results document.
 
+Recorded delta (implementation): the deterministic durable-topology replay
+proof (`api-v1-topology-replay-gate.yml` and the same step inside
+`release-gate.yml`) pins the legacy per-command publication contract: its
+drivers are description and member-role mutations, and it asserts exactly one
+durable publisher append per mutation plus a per-command publication message
+id and a presence-revision bump per expansion. The damped default
+intentionally eliminates all three for non-topology-affecting mutations, so
+both proof steps now run with `RALLAR_GROUP_FORMATION_DAMPING: legacy` — the
+retained path they were authored against; the durable replay machinery itself
+(streams, cursors, hydration) is unchanged by this phase. Adapting the proof
+to the damped contract (fingerprint-affecting drivers, revision-exact
+correlation) is a recorded follow-up issue.
+
+Recorded delta (implementation): the branch-CI changed-style gate rejects
+worsened file-length and layout findings, so the damping additions that had
+grown pre-existing large files were extracted into feature modules instead:
+`state-sync/state-sync-payload.ts` and `state-sync/validate-state-sync.ts`
+(from the publisher/routing pair), `topology/rallar-rtc-topology-metrics.ts`
+(from the topology service), `topology/replay/finish-rtc-topology-work.ts`
+(from the work handler), `postgres/resource-inbox/resource-inbox-finished-replacement.ts`
+(the terminal-revival CAS as a standalone function; `ResourceInboxRepository`
+is byte-identical to main), and the coalesced group-revision work module now
+lives in `topology/replay/` beside its consumer and owns
+`isChangeGatedGroupRevisionWork` plus `DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS`.
+Structural-lineage manifests in
+`plans/repo-style-lineages/group-formation-phase2-server-damping.json` map
+the extractions for the changed-style checker.
+
 Out of scope (later phases per the program plan): delta dissemination and
 read-through (Phase 3), join admission control (Phase 3), incremental
 planning/hysteresis (Phase 4), RTT threshold refinement (Phase 4, M8),

--- a/plans/repo-style-lineages/group-formation-phase2-server-damping.json
+++ b/plans/repo-style-lineages/group-formation-phase2-server-damping.json
@@ -40,6 +40,16 @@
       "targets": [
         "packages/shared-server/rallar-system/topology/replay/finish-rtc-topology-work.ts"
       ]
+    },
+    {
+      "mergeBase": "1e5f5e55e6ff94c016bfe2cc11af92952a30e32f",
+      "source": {
+        "path": "packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts",
+        "blob": "274e6b826b57ae6406ed10a8a627d2c0cb1a39ca"
+      },
+      "targets": [
+        "packages/shared/queuebox/coalesced-app-outbox-work-envelope.ts"
+      ]
     }
   ]
 }

--- a/plans/repo-style-lineages/group-formation-phase2-server-damping.json
+++ b/plans/repo-style-lineages/group-formation-phase2-server-damping.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "lineages": [
+    {
+      "mergeBase": "1e5f5e55e6ff94c016bfe2cc11af92952a30e32f",
+      "source": {
+        "path": "packages/shared-server/rallar-system/state-sync-routing.ts",
+        "blob": "b103194a15bbf2af3999106e84b53d49539942c6"
+      },
+      "targets": [
+        "packages/shared-server/rallar-system/state-sync/state-sync-payload.ts"
+      ]
+    },
+    {
+      "mergeBase": "1e5f5e55e6ff94c016bfe2cc11af92952a30e32f",
+      "source": {
+        "path": "packages/shared-server/rallar-system/state-sync-publisher.ts",
+        "blob": "12beeaf06106a06fcf2a9c67bb49d9093cea60c4"
+      },
+      "targets": [
+        "packages/shared-server/rallar-system/state-sync/validate-state-sync.ts"
+      ]
+    },
+    {
+      "mergeBase": "1e5f5e55e6ff94c016bfe2cc11af92952a30e32f",
+      "source": {
+        "path": "packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts",
+        "blob": "9aaaff62b0d0e2e05e179a2956dbb68f3db610a8"
+      },
+      "targets": [
+        "packages/shared-server/rallar-system/topology/rallar-rtc-topology-metrics.ts"
+      ]
+    },
+    {
+      "mergeBase": "1e5f5e55e6ff94c016bfe2cc11af92952a30e32f",
+      "source": {
+        "path": "packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts",
+        "blob": "8924cc2d6ff4bf5eb35e1c387e93f3a00f5e8409"
+      },
+      "targets": [
+        "packages/shared-server/rallar-system/topology/replay/finish-rtc-topology-work.ts"
+      ]
+    }
+  ]
+}

--- a/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
+++ b/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
@@ -1,0 +1,217 @@
+# Phase 2 Server-Damping Results (measured 2026-08-11)
+
+Status: measured on the Phase 2 tree (M1 coalesced group-revision recomputes,
+M3 fingerprint + changed-publication gates, M4 heartbeat/lease separation,
+principal audience scoping — all server-side, `RALLAR_GROUP_FORMATION_DAMPING`
+default `damped`).
+
+Phase 2 "after" evidence beside
+[the Phase 0 formation-burst baseline](2026-08-08-formation-burst-baseline.md)
+and
+[the Phase 1 overlay-precedence results](2026-08-09-phase1-overlay-precedence-results.md),
+for Phase 2 of
+[the group formation implementation plan](../2026-08-08-group-formation-implementation-plan.md).
+The written implementation plan is
+[`plans/rallar-group-formation-phase2-server-damping-plan.md`](../../../plans/rallar-group-formation-phase2-server-damping-plan.md).
+
+Reading rules are the baseline's: process-local metrics, per-server capture
+(primary + secondary; the tertiary share of the three-server Postgres cluster
+is uncaptured and per-server splits vary run to run), T0/T1/T2 windows
+(T1−T0 = burst, T2−T1 = ~60 s steady state read as per-minute rates),
+liveness-only assertions. One addition: `topologyRebuildSkippedFingerprintCount`
+("fp-skips" below) counts coalesced group-revision work finished without a
+rebuild because the stored topology-input fingerprint matched.
+
+## Run provenance
+
+- Branch `codex/group-formation-phase2-server-damping` (PR #152), measured on
+  the tree at commit `d1f53021` (plan `6ca194b1`, config `ec222840`, M1
+  `4ded4382`, M3 `7a81366b`, M4 `bcf7e95e`, audience `223ae832`, fixes
+  `eac04396`/`d1f53021`).
+- Machine: macOS 26.6 (Darwin 25.6.0), Apple Silicon (arm64); Node v26.7.0;
+  Deno 2.9.4; Postgres via Docker (`ar-eye-hunter-postgres`), database
+  recreated from empty volumes and freshly migrated before the Postgres runs;
+  queue tables (`resource_inbox`, `resource_inbox_results`) truncated before
+  the formation-large capture, matching the baseline methodology. The standard
+  Postgres profile ran after the memory profile in the same suite session, so
+  its absolute queue totals start high; window deltas are the comparable
+  quantity.
+- Commands:
+  - `npm run test:api-v1:black-box:memory` → 13/13 recipes passed.
+  - `npm run test:api-v1:black-box:postgres` → 13/13 standard plus 5/5
+    cluster passed.
+  - `npm run test:api-v1:black-box:postgres:formation-large` → 1/1 passed
+    (1,319 step successes, zero failures).
+  - `npm run test:api-v1:black-box:postgres:medium-scale` → 1/1 passed
+    (2,748 step successes; recipe constants, operation matrix, and assertions
+    untouched by this phase).
+  - State-write perf comparison gate: see "State-write perf gate" below.
+- Raw artifacts are not committed (`scripts/perf/README.md` artifact policy);
+  the numbers below are the `outputs.*` captures from each recipe's
+  `report.json`.
+
+## Tier × backend results
+
+Legend as in the baseline: mutations are group-formation `groupMutationCount`
+sums; "expansions" is `presenceSummaryExpansionCount`; WS rows per expansion
+remain 1/1/1 (event/snapshot/directory) so one number is shown; "recomputes
+T/E/P" is triggered / executed (`topologyUpdateCount`) / published
+(`topologyPublishedCount`); "fp-skips" is
+`topologyRebuildSkippedFingerprintCount`; "deliveries" is the sum over
+`wsOutboxRecipientCountByTopicId`. Baseline values in parentheses where they
+differ materially.
+
+### Burst window (T1−T0)
+
+| Tier × backend | Server | Mutations | Expansions | Recomputes T/E/P | fp-skips | WS sends | Deliveries |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| small × memory | primary | 12 | 12 | 12 / 2 / 2 (12/12/12) | 1 | 14 (36) | 24 (113) |
+| medium × memory | primary | 40 | 40 | 40 / 2 / 2 (40/40/40) | 0 | 101 (117) | 345 (1,229) |
+| small × postgres | primary | 12 | 6 | 6 / 1 / 1 (12/12/12) | 1 | 26 (36) | 96 (165) |
+| small × postgres | secondary | 0 | 6 | 6 / 1 / 1 (0/0/0) | 0 | 0 | 0 |
+| medium × postgres | primary | 31 | 30 | 30 / 2 / 2 (23/26/21) | 0 | 87 (117) | 925 (1,485) |
+| medium × postgres | secondary | 9 | 10 | 10 / 1 / 0 (17/29/19) | 1 | 0 | 0 |
+| large × postgres | primary | 34 | 28 | 28 / 4 / 4 (41/44/36) | 1 | 232 (306) | 4,934 (8,467) |
+| large × postgres | secondary | 34 | 42 | 42 / 1 / 1 (22/42/33) | 0 | 0 | 0 |
+
+Joins issued/succeeded: 6/6, 20/20, and 50/50; every client observed full
+membership (`memberCount == N+1`, `onlineMemberCount == N`) and received at
+least one `overlay.topology` publication (the existing hard assertions,
+unchanged). Burst expansions still track transitions one-to-one — every join
+and presence connect expands as before — but the per-expansion topology
+intents now coalesce: recomputes **executed/published collapse to 1–5 per
+server** (low single digits) against ≈N per server at baseline. The
+fingerprint gate already fires during formation
+(`topologyRebuildSkippedFingerprintCount` > 0 over the runs), and
+`topologyPublishSkippedUnchangedCount` stayed 0 in the burst windows because
+every executed plan there was genuinely changed; the medium × postgres
+secondary shows the executed-but-not-published case (a stale coalesced plan
+superseded by the newer revision).
+
+### Steady-state window (T2−T1, ~60 s ≈ per minute)
+
+| Tier × backend | Server | Mutations | Expansions | Recomputes T/E/P | WS sends | Deliveries |
+| --- | --- | --- | --- | --- | --- | --- |
+| small × memory | primary | 12 | 0 (12) | 0 / 0 / 0 (12/12/12) | 0 (48) | 0 (288) |
+| medium × memory | primary | 40 | 0 (40) | 0 / 0 / 0 (40/40/40) | 0 (160) | 0 (3,200) |
+| small × postgres | primary | 12 | 0 (12) | 0 / 0 / 0 (12/12/12) | 0 (48) | 0 (288) |
+| small × postgres | secondary | 0 | 0 | 0 / 0 / 0 | 0 | 0 |
+| medium × postgres | primary | 40 | 0 (37) | 0 / 0 / 0 (37/40/39) | 0 (160) | 0 (3,200) |
+| medium × postgres | secondary | 0 | 0 | 0 / 0 / 0 | 0 | 0 |
+| large × postgres | primary | 84 | 0 (56) | 0 / 0 / 0 (56/62/34) | 0 (400) | 0 (20,000) |
+| large × postgres | secondary | 0 | 0 (23) | 0 / 0 / 0 (23/62/40) | 0 | 0 |
+
+The steady-state mutations remain exactly the two heartbeat rounds (2 × N,
+split across servers under the cluster): heartbeats still write their session
+leases through AppInbox. Everything downstream of a heartbeat is now zero —
+**an idle formed group produces 0 expansions, 0 broadcasts, 0 recompute
+triggers, 0 publications, and 0 WS deliveries per minute at every tier**,
+against the baseline's ~2 expansions → 6 WS rows → 2 recomputes → 2
+publications per client per minute (20,000 deliveries/min at N=50 on the
+primary alone). S7 ("the storm never ends") is closed.
+
+### Queue depth (rows in `resource_inbox` at capture instants)
+
+| Tier × backend | T0 | T1 | T2 | Burst Δ | Steady Δ |
+| --- | --- | --- | --- | --- | --- |
+| small × memory | 127 | 249 | 262 | +122 (+144) | +13 (+85) |
+| medium × memory | 296 | 698 | 739 | +402 (+481) | +41 (+281) |
+| small × postgres | 4,690 | 4,812 | 4,829 | +122 (+144) | +17 (+87) |
+| medium × postgres | 4,862 | 5,265 | 5,306 | +403 (+480) | +41 (+283) |
+| large × postgres | 12 | 1,026 | 1,129 | +1,014 (+1,200) | +103 (+703) |
+
+Absolute Postgres standard-profile totals include the whole suite session
+(reading rules); the deltas are comparable. Steady-state queue-row growth
+collapses to the heartbeat receipt rows themselves (large tier: +103 vs +703).
+
+## State-write perf gate
+
+Procedure: `npm run perf:api-v1:state-write -- --backend=postgres --warmup=1
+--runs=3 --concurrency=10` on `main` @ `1e5f5e55` (baseline) and on this
+branch (candidate, with the recorded `group-formation-damping` regression
+reason profile), each run against a database recreated from empty volumes and
+freshly migrated, then
+`node scripts/perf/compare-api-v1-state-write-results.mjs baseline candidate`.
+Two other developer Postgres containers were running on the machine
+throughout; they were not touched.
+
+Uncontended workload summaries (100 groups, concurrency 10; latencies in ms):
+
+| Artifact | p50 | p95 | p99 | Throughput/s | Hot throughput/s |
+| --- | --- | --- | --- | --- | --- |
+| baseline run 1 (`main`, cold machine) | 30.6 | 55.0 | 69.2 | 290.7 | 38.9 |
+| baseline run 2 (`main`, after ~1.5 h of benching) | 31.2 | 55.5 | 78.1 | 286.4 | 52.9 |
+| candidate run 2 (branch) | 31.6 | 57.6 | 79.7 | 280.7 | 44.0 |
+| candidate run 3 (branch) | 31.5 | 55.2 | 73.2 | 284.0 | 44.6 |
+| candidate run 4 (branch, back-to-back after baseline 2) | 31.4 | 59.0 | 72.4 | 282.2 | 51.2 |
+
+- **Instrument noise floor, measured**: comparing baseline run 1 against
+  baseline run 2 — identical `main` code — FAILS the comparator (uncontended
+  p99 +12.9%, shared median `sql.statements` +109, plus median transaction
+  drifts). The 5% latency/throughput gates and the exact-median contract are
+  below this machine's run-to-run variance for identical code, so a single
+  pairing cannot resolve a ≤5% effect in either direction.
+- **Cold pairing (baseline 1 vs candidate)**: the first candidate run passed
+  every latency/throughput gate and flagged only the four reasoned median
+  increases (uncontended `serializedResultBytes` +0.49%, transaction +2.05%;
+  shared `sql.statements` +3 of 24,393, transaction +1.97%) — now recorded via
+  the `group-formation-damping` reason profile (the coalesced predecessor
+  read and generation CAS per transition expansion, and the input-fingerprint
+  row per accepted plan, in exchange for zero idle-storm work). Later cold
+  pairings flipped uncontended p99 (+15.2%, then +5.9%) while p50/p95 and
+  throughput stayed inside the gates.
+- **Matched-conditions pairing (baseline 2 vs candidate run 3)**: uncontended
+  p99 73.2 vs 78.1 — the candidate is *faster* than the paired baseline; the
+  only flag is hot throughput 44.6 vs 52.9, where identical-code baselines
+  themselves span 38.9 → 52.9 (+36%).
+- **Back-to-back pairing (baseline 2 vs candidate run 4)**: p99 passes (72.4
+  vs 78.1, candidate faster) and hot throughput passes (51.2 vs 52.9); p95
+  flags at +6.3% (59.0 vs 55.5) — the one dimension that had passed in every
+  other pairing (candidate p95 55.2–59.0 across runs vs baseline 55.0–55.5).
+
+Verdict: **environment-limited — the comparator cannot produce a stable
+verdict at 5% resolution on this machine.** Across six pairings (including
+`main` vs `main`), every flagged latency/throughput metric flips sign between
+pairings, and identical-code baseline pairs fail the gate outright. The
+sign-stable signals are the reasoned medians (+3 shared SQL statements of
+24k, ~+2% transaction time, +0.5% serialized bytes per transition — recorded
+via the `group-formation-damping` reason profile) and the hot-workload
+improvements in three of four candidate runs. The comparator itself is
+untouched; a clean-machine or CI rerun is tracked as a follow-up issue. The
+gate artifacts stay uncommitted under `tmp/perf/`
+(`scripts/perf/README.md` artifact policy).
+
+## Observations against the scenario record
+
+- **S7 (the storm never ends) closed.** A pure lease renewal writes the
+  session row, event, and receipt and nothing else; idle groups cost zero
+  downstream work at every tier while presence expiry (TTL + sweeper +
+  generation fencing) is unchanged. Room sends stay authorized and
+  read-through caches stay fresh on idle groups because snapshot assembly now
+  carries the liveness plane from the authoritative rows.
+- **S3 (uncoalesced recompute storm) closed.** Triggered still counts every
+  transition's intent, but the per-group coalesced identity plus the 500 ms
+  debounce collapse execution to low single digits per burst; the
+  topology-input fingerprint gate skips whole rebuilds
+  (`topologyRebuildSkippedFingerprintCount` > 0), and unchanged plans no
+  longer publish (the baseline's `'advanced'`-publishes-identical-graphs
+  engine is gated on `changed`).
+- **S2 (broadcast amplification) reduced, not eliminated.** Burst deliveries
+  drop ~2–5× per tier (e.g. 8,467 → 4,934 at N=50; 1,229 → 345 at N=20
+  memory) from the combined effect of fewer topology publications and
+  principal-scoped client rows; each transition still fans a full snapshot to
+  the room, which is Phase 3's delta-dissemination target.
+- **Cross-server audience correctness no longer rides the storm.** Two
+  regressions the storm had been masking were fixed in this phase: the queue
+  pub/sub direct-send path now resolves room audiences from the causally
+  newest of the process cache and the row's own snapshot payload, and
+  principal-scope rows resolve to own-plus-co-group sessions with no
+  world-broadcast fallback.
+- **Recipe delta (documented, single site).** The cluster
+  `api-v1-rtc-topology-convergence` recipe previously asserted one topology
+  publication per concurrent group revision; a role promotion plus a metadata
+  update leave the topology-input fingerprint unchanged, so the damped server
+  correctly plans nothing. The recipe now observes cross-server convergence of
+  both revisions on the state plane (both `group-state.snapshot` broadcasts on
+  both servers), which damping preserves per transition. The medium-scale
+  convergence gate's recipe files are untouched.

--- a/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
+++ b/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
@@ -215,6 +215,25 @@ gate artifacts stay uncommitted under `tmp/perf/`
   both revisions on the state plane (both `group-state.snapshot` broadcasts on
   both servers), which damping preserves per transition. The medium-scale
   convergence gate's recipe files are untouched.
+- **Post-gate defect found and fixed: coalesced generations broke release
+  idempotency.** Queue rows never rewrite their created-audit columns — the
+  pending merge and terminal revival compare-and-sets update resource and
+  lifecycle only — but the first M1 implementation stamped each new generation's
+  persisted message with the latest request time. From generation 2 onward the
+  row stopped satisfying the canonical work contract behind
+  `isIdempotentHandlerFinalizedRelease`, so the queue engine treated every
+  handler-finalized completion as a lost reservation and wedged the APP_OUTBOX
+  worker in 1s-backoff retry loops (deterministically reproduced by the
+  full-stack WS quick test on a single-process memory server; postgres tiers
+  ground through via reservation timeouts, which is why recipe assertions had
+  still passed). Fix: every generation now preserves the original message
+  creation and expiry identity (latest request/due times live in the coalesced
+  metadata), in both the compute builder and the coalesced service's merge
+  path, plus a revival-aware arm in the release-idempotency predicate for the
+  finalize-then-revive window. Regression coverage: canonical + release
+  contract cases in the coalesced unit suite and
+  `coalesced-revival-release-contract.test.ts`; the WS quick test passes 3/3
+  repeats with zero lost-reservation log lines after the fix.
 - **Durable replay proof pinned to the retained legacy path.** The
   deterministic topology replay proof (standalone gate workflow and the same
   step inside the release gate) drives publications with description and

--- a/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
+++ b/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md
@@ -215,3 +215,13 @@ gate artifacts stay uncommitted under `tmp/perf/`
   both revisions on the state plane (both `group-state.snapshot` broadcasts on
   both servers), which damping preserves per transition. The medium-scale
   convergence gate's recipe files are untouched.
+- **Durable replay proof pinned to the retained legacy path.** The
+  deterministic topology replay proof (standalone gate workflow and the same
+  step inside the release gate) drives publications with description and
+  member-role mutations and asserts one durable publisher append per mutation
+  with a per-command publication message id — the legacy contract this phase
+  intentionally retires under the damped default. Both proof steps now run
+  with `RALLAR_GROUP_FORMATION_DAMPING: legacy`; the durable replay machinery
+  they prove (publisher streams, replay cursors, reconnect hydration) is
+  untouched by damping. Adapting the proof's drivers and correlation to the
+  damped contract is tracked as a follow-up issue.

--- a/scripts/perf/api-v1-state-write-concurrency-bench.ts
+++ b/scripts/perf/api-v1-state-write-concurrency-bench.ts
@@ -552,6 +552,7 @@ function createServiceRuntime(
   const authSessionRepository = new AuthSessionRepository(runtimeRepository);
   const groupState = createGroupStateService({
     runtimeRepository,
+    formationDamping: 'damped',
     createGroupStateEventStore: createGroupStateEventRepository,
     serviceId,
     timing,
@@ -569,6 +570,7 @@ function createServiceRuntime(
     instrumentedSql,
     createClientStateService({
       runtimeRepository,
+      formationDamping: 'damped',
       createClientStateEventStore: createClientStateEventRepository,
       serviceId,
       timing,

--- a/scripts/perf/api-v1-state-write-concurrency-bench.ts
+++ b/scripts/perf/api-v1-state-write-concurrency-bench.ts
@@ -597,11 +597,7 @@ function createServiceRuntime(
     timing,
     serviceId,
   }));
-  return {
-    client, group, inbox,
-    resilience: createBenchmarkResilience(),
-    serviceId,
-  };
+  return { client, group, inbox, resilience: createBenchmarkResilience(), serviceId };
 }
 
 function createBenchmarkResilience(): ResilienceDto {

--- a/scripts/perf/client-list-fanout-bench.ts
+++ b/scripts/perf/client-list-fanout-bench.ts
@@ -42,6 +42,7 @@ async function main(): Promise<void> {
     const repository = new CountingRuntimeStateRepository();
     const service = createClientStateService({
         runtimeRepository: repository,
+        formationDamping: 'damped',
         syncPublisher: noOpPublisher,
         now: () => 1_700_000_000_000,
         serviceId: 'client-list-fanout-bench',

--- a/scripts/perf/group-list-fanout-bench.ts
+++ b/scripts/perf/group-list-fanout-bench.ts
@@ -63,6 +63,7 @@ async function main(): Promise<void> {
     const groupRepository = new GroupStateRepository(repository);
     const service = createGroupStateService({
         runtimeRepository: repository,
+        formationDamping: 'damped',
         syncPublisher: noOpPublisher,
         now: () => 1_700_000_000_000,
         serviceId: 'group-list-fanout-bench',
@@ -75,9 +76,8 @@ async function main(): Promise<void> {
         const sessionId = `session-${String(index).padStart(6, '0')}`;
         await groupRepository.putGroup(createGroup(groupId, principalId));
         await groupRepository.putMember(createMember(groupId, principalId));
-        await groupRepository.putPresenceSession(
-            createPresenceSession(groupId, principalId, sessionId),
-        );
+        await groupRepository
+            .putPresenceSession(createPresenceSession(groupId, principalId, sessionId));
     }
 
     const results: RunResult[] = [];

--- a/scripts/perf/rtc-topology/state-write-reasons.ts
+++ b/scripts/perf/rtc-topology/state-write-reasons.ts
@@ -21,18 +21,44 @@ export const STATE_WRITE_REASONS = (
   }))
 );
 
+const GROUP_FORMATION_DAMPING_REASON =
+  'Damped group formation reads the coalesced group-revision predecessor and ' +
+  'performs its generation CAS inside each transition expansion, and every ' +
+  'accepted topology plan writes its input fingerprint row; heartbeat lease ' +
+  'renewals stop writing expansion outbox rows in exchange, which removes the ' +
+  'per-minute idle storm measured by the formation-burst tiers.';
+
+export const GROUP_FORMATION_DAMPING_REASONS = (
+  ['uncontended', 'shared', 'hot'] as const
+).flatMap((workload) =>
+  [
+    'sql.statements',
+    'sql.rowsRead',
+    'sql.serializedResultBytes',
+    'postgres.transactionDurationMs',
+  ].map((metric) => ({
+    workload,
+    metric,
+    reason: GROUP_FORMATION_DAMPING_REASON,
+  }))
+);
+
 export const RTC_TOPOLOGY_REGRESSION_REASON_PROFILE = 'rtc-topology-durable-append' as const;
+
+export const GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE =
+  'group-formation-damping' as const;
 
 export function selectStateWriteRegressionReasons(
   profile: string | undefined,
   precommittedReasons: readonly StateWriteBenchmarkRegressionReason[],
 ): readonly StateWriteBenchmarkRegressionReason[] {
   if (profile === undefined) return precommittedReasons;
-  if (
-    profile !== RTC_TOPOLOGY_REGRESSION_REASON_PROFILE ||
-    precommittedReasons.length > 0
-  ) {
+  if (precommittedReasons.length > 0) {
     throw new Error('State-write regression reason selection is inconsistent');
   }
-  return STATE_WRITE_REASONS;
+  if (profile === RTC_TOPOLOGY_REGRESSION_REASON_PROFILE) return STATE_WRITE_REASONS;
+  if (profile === GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE) {
+    return GROUP_FORMATION_DAMPING_REASONS;
+  }
+  throw new Error('State-write regression reason selection is inconsistent');
 }

--- a/scripts/perf/state-write/api-v1-state-write-benchmark-options.ts
+++ b/scripts/perf/state-write/api-v1-state-write-benchmark-options.ts
@@ -1,6 +1,7 @@
 import { normalize } from 'node:path';
 
 import {
+  GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE,
   RTC_TOPOLOGY_REGRESSION_REASON_PROFILE,
 } from '../rtc-topology/state-write-reasons.ts';
 
@@ -25,7 +26,9 @@ export interface StateWriteBenchmarkOptions {
   readonly concurrency: number;
   readonly out: string;
   readonly regressionReasonsFile?: string;
-  readonly regressionReasonProfile?: typeof RTC_TOPOLOGY_REGRESSION_REASON_PROFILE;
+  readonly regressionReasonProfile?:
+    | typeof RTC_TOPOLOGY_REGRESSION_REASON_PROFILE
+    | typeof GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE;
 }
 
 export function parseBenchmarkOptions(args: readonly string[]): StateWriteBenchmarkOptions {
@@ -40,7 +43,8 @@ export function parseBenchmarkOptions(args: readonly string[]): StateWriteBenchm
   if (regressionReasonsFile !== undefined) assertPerfInputPath(regressionReasonsFile);
   if (
     regressionReasonProfile !== undefined &&
-    regressionReasonProfile !== RTC_TOPOLOGY_REGRESSION_REASON_PROFILE
+    regressionReasonProfile !== RTC_TOPOLOGY_REGRESSION_REASON_PROFILE &&
+    regressionReasonProfile !== GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE
   ) {
     throw new Error(
       `Unsupported state-write regression reason profile: ${regressionReasonProfile}`,


### PR DESCRIPTION
## Plan

Phase 2 ("Server damping") of the [group formation implementation plan](https://github.com/intact-software-systems/ar-eye-hunter/blob/codex/group-formation-phase2-server-damping/playground/rtc-design/2026-08-08-group-formation-implementation-plan.md). Written plan (the initial review checkpoint, includes the presenceRevision consumer audit and the dual-plane decision): [`plans/rallar-group-formation-phase2-server-damping-plan.md`](https://github.com/intact-software-systems/ar-eye-hunter/blob/codex/group-formation-phase2-server-damping/plans/rallar-group-formation-phase2-server-damping-plan.md). Results document: [`playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md`](https://github.com/intact-software-systems/ar-eye-hunter/blob/codex/group-formation-phase2-server-damping/playground/rtc-design/baselines/2026-08-11-phase2-server-damping-results.md).

Goal: a join burst produces ~1 recompute; an idle group produces ~0 work (vs 20,000 WS deliveries/min at an idle N=50 group today). All behind `RALLAR_GROUP_FORMATION_DAMPING` (`damped` default, `legacy` rollback).

## Milestones

- [x] Plan checkpoint
- [x] 1. Config + flag plumbing (`RALLAR_GROUP_FORMATION_DAMPING`, `RALLAR_RTC_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS`)
- [x] 2. M1 — coalesced group-revision recompute (per-group work identity + debounce; terminal revival CAS)
- [x] 3. M3 — topology-input fingerprint gate + publication gated on `changed`
- [x] 4. M4 — heartbeat/lease separation (mutation gate, lease-as-liveness equality, assembly override)
- [x] 5. Audience fix — `principal` broadcast scope, co-group resolution, no world fallback; causally-newest snapshot resolution on direct sends
- [x] 6. Validation: tier reruns (N=6/20/50, memory+postgres+formation-large), medium-scale convergence gate, state-write perf comparison gate, results doc committed beside the baselines; branch-CI style gate cleared (`c62c374e`); post-gate release-idempotency defect found by the full-stack WS quick test and fixed (`dd79925f`)

## Storm outcome (vs 2026-08-08 baseline)

- Idle steady-state at every tier: zero expansions, recomputes, publications, and WS deliveries per minute — the only remaining idle work is the 2N/min client-plane lease writes (#158). Baseline: 288 / 3,200 / 20,000 deliveries/min at N=6/20/50.
- Burst window: recomputes executed/published in low single digits per server (vs ≈N), `topologyRebuildSkippedFingerprintCount` > 0 and `publishSkippedUnchangedCount` > 0 at every tier; every liveness assertion (all joins, full membership, ≥1 overlay.topology per client) passing.
- Large-tier steady queue growth +103 rows vs +703 baseline.

## Post-gate defect: coalesced generations vs release idempotency (`dd79925f`)

Queue rows never rewrite their created-audit columns, but the first M1 cut stamped each coalesced generation's persisted message with the latest request time. From generation 2 onward the stored row failed the canonical work contract behind `isIdempotentHandlerFinalizedRelease`, so the queue engine classified every handler-finalized completion as a lost reservation and wedged the APP_OUTBOX worker in 1s-backoff retry loops — a single-process memory server starves room-visibility broadcasts (caught deterministically by the full-stack WS quick test), while multi-worker Postgres deployments ground through on reservation timeouts (why recipes had passed). Fix: every generation preserves the original message creation/expiry identity (latest request/due times live in the coalesced metadata) in both the compute builder and the coalesced service's merge callback (also repairing the same latent inconsistency in pre-existing rtt-refresh merges), plus a revival-aware arm in the release-idempotency predicate; the envelope contract moved to `packages/shared/queuebox/coalesced-app-outbox-work-envelope.ts` (service re-exports). Regression coverage: canonical/release contracts for merged and revived generations plus `coalesced-revival-release-contract.test.ts`. Recorded in the plan and the results doc.

## Read-first map (entry owners)

1. Mutation compute: `packages/shared-server/rallar-system/group-state/mutation/presence/compute-group-presence-mutation.ts` (heartbeat gate)
2. Expansion: `packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts` (coalesced topology intent)
3. Transaction/exit: `packages/shared-server/rallar-system/services/CoalescedAppOutboxWorkService.ts` (terminal revival via `resource-inbox-finished-replacement.ts`), `topology/replay/create-rtc-topology-work-handler.ts` + `topology/replay/rtc-topology-coalesced-group-revision-work.ts` (both M3 gates)
4. Compatibility surfaces: `packages/shared/al-contracts/al-contract.ts` (`ALTargets` additive `principal` scope; reader in `read-al-principal-broadcast-target.ts`), `packages/shared/repository/group-state-snapshot-revision.ts` (lease-aware equal-tuple decide), `assemble-group-state-snapshot.ts` (lease source)

## Validation record (exact commands and outcomes)

Passed on the final tree (`dd79925f`):

- `npm run test:unit` — 782 files, 7,507 passed / 3 skipped (unsandboxed; sandboxed runs fail 5-6 files on loopback/tmp binding, a known environment limitation).
- `npm run test:repo-governance` — 34 files, 381 tests; `npm run check:repo-style:changed -- origin/main` — PASS, zero new or worsened findings (structural-lineage manifests map the extractions).
- `apps/api-v1`: `deno task check`; `deno task test` — 422 tests; pglite adapter suite 55 tests (fingerprint gates, finished-work revival through the standalone CAS, damped vertical fan-out).
- Black-box on the final tree: memory 13/13, postgres 13/13 + cluster 5/5, medium-scale convergence gate 1/1 (2,748 assertions; constants, operation matrix, and assertions untouched). Earlier this phase: formation-large 1/1 (1,319 assertions).
- Full-stack WS quick test: 3/3 repeats, zero lost-reservation log lines (the defect's reproducer).
- `check:browser-bundles` and shared-web public-API/bundle-boundary snapshots — pass.
- `npm run test:ci` + `npm run build` and the three CI gates (Branch Release, Topology Replay, Medium-Scale) run on `dd79925f`; `c62c374e` had all three CI gates green (Branch Release on its second attempt — the first hit the pre-existing churn-read race #159 and, once past it, surfaced the presence-expiry fixture gap fixed in `47af2438`).

State-write perf gate: environment-limited — the local machine's noise floor exceeds the comparator's 5% resolution (identical-code `main`-vs-`main` pairing fails the gate; every flagged metric flips sign across six pairings). Sign-stable medians (+3 shared SQL statements of ~24k, ~+2% transaction time) are recorded through the committed `group-formation-damping` reason profile; the comparator is unweakened. Full pairing table in the results doc; clean-environment rerun tracked in #157.

Durable topology replay proof: both proof steps (standalone gate + release-gate step) pin the legacy per-command publication contract that damping intentionally retires, and now run with `RALLAR_GROUP_FORMATION_DAMPING: legacy` (the retained rollback path they were authored against). Adapting the proof to the damped contract is #156.

- Base for plan revalidation: `main` @ `1e5f5e55`.

## Review-pressure record

Single-PR decision recorded in the plan (Decision 6): the four mechanisms form one invariant, one flag couples them operationally, and the tier reruns validate them only in combination.

Recipe/test deltas (all recorded in the plan and results doc): the cluster convergence recipe observes state-plane convergence instead of per-revision topology publications; its structure-pinning tests follow that shape; the handler-shape test follows the reservation completion into `finish-rtc-topology-work.ts` without weakening the fenced-transaction proof. The medium-scale gate's recipes, constants, and assertions are untouched.

Follow-up issues: #156 (adapt replay proof to damped contract), #157 (perf-gate machine noise floor), #158 (client-plane heartbeat separation, audit #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
