### PR TITLE
test: fence state-topology-churn shared-group final read on causal convergence

### DIFF
--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
@@ -416,6 +416,11 @@
                       "requestId": "presence-primary-{loop.iteration}-{sharedGroupId}-{runId}",
                       "generationId": "generation-{runId}",
                       "principalId": "{primaryClientId}"
+                    },
+                    "outputs": {
+                      "primarySharedGroupRevision": "body.causalRevision.groupRevision",
+                      "primarySharedPresenceRevision": "body.causalRevision.presenceRevision",
+                      "primarySharedOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -638,6 +643,11 @@
                       "requestId": "presence-secondary-{loop.iteration}-{sharedGroupId}-{runId}",
                       "generationId": "generation-{runId}",
                       "principalId": "{secondaryClientId}"
+                    },
+                    "outputs": {
+                      "secondarySharedGroupRevision": "body.causalRevision.groupRevision",
+                      "secondarySharedPresenceRevision": "body.causalRevision.presenceRevision",
+                      "secondarySharedOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -860,6 +870,11 @@
                       "requestId": "presence-tertiary-{loop.iteration}-{sharedGroupId}-{runId}",
                       "generationId": "generation-{runId}",
                       "principalId": "{tertiaryClientId}"
+                    },
+                    "outputs": {
+                      "tertiarySharedGroupRevision": "body.causalRevision.groupRevision",
+                      "tertiarySharedPresenceRevision": "body.causalRevision.presenceRevision",
+                      "tertiarySharedOnlineMemberCount": "body.onlineMemberCount"
                     }
                   },
                   "expect": {
@@ -1020,17 +1035,90 @@
           "presenceRevision": {
             "if": {
               "condition": {
-                "equals": [
-                  { "path": "outputs.latestChurnObservation.onlineMemberCount" },
-                  13
-                ]
+                "equals": [{ "path": "outputs.latestChurnObservation.onlineMemberCount" }, 13]
               },
               "then": { "path": "outputs.latestChurnObservation.presenceRevision" },
               "else": {
-                "add": [
-                  { "path": "outputs.latestChurnObservation.presenceRevision" },
-                  1
+                "add": [{ "path": "outputs.latestChurnObservation.presenceRevision" }, 1]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "deriveLatestSharedObservation",
+      "type": "set",
+      "output": "latestSharedObservation",
+      "transform": {
+        "value": {
+          "groupRevision": {
+            "max": [
+              { "path": "outputs.primarySharedGroupRevision" },
+              { "path": "outputs.secondarySharedGroupRevision" },
+              { "path": "outputs.tertiarySharedGroupRevision" }
+            ]
+          },
+          "presenceRevision": {
+            "max": [
+              { "path": "outputs.primarySharedPresenceRevision" },
+              { "path": "outputs.secondarySharedPresenceRevision" },
+              { "path": "outputs.tertiarySharedPresenceRevision" }
+            ]
+          },
+          "onlineMemberCount": {
+            "if": {
+              "condition": {
+                "equals": [
+                  { "path": "outputs.primarySharedPresenceRevision" },
+                  {
+                    "max": [
+                      { "path": "outputs.primarySharedPresenceRevision" },
+                      { "path": "outputs.secondarySharedPresenceRevision" },
+                      { "path": "outputs.tertiarySharedPresenceRevision" }
+                    ]
+                  }
                 ]
+              },
+              "then": { "path": "outputs.primarySharedOnlineMemberCount" },
+              "else": {
+                "if": {
+                  "condition": {
+                    "equals": [
+                      { "path": "outputs.secondarySharedPresenceRevision" },
+                      {
+                        "max": [
+                          { "path": "outputs.primarySharedPresenceRevision" },
+                          { "path": "outputs.secondarySharedPresenceRevision" },
+                          { "path": "outputs.tertiarySharedPresenceRevision" }
+                        ]
+                      }
+                    ]
+                  },
+                  "then": { "path": "outputs.secondarySharedOnlineMemberCount" },
+                  "else": { "path": "outputs.tertiarySharedOnlineMemberCount" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "deriveSharedReadFloor",
+      "type": "set",
+      "output": "sharedReadFloor",
+      "transform": {
+        "value": {
+          "groupRevision": { "path": "outputs.latestSharedObservation.groupRevision" },
+          "presenceRevision": {
+            "if": {
+              "condition": {
+                "equals": [{ "path": "outputs.latestSharedObservation.onlineMemberCount" }, 13]
+              },
+              "then": { "path": "outputs.latestSharedObservation.presenceRevision" },
+              "else": {
+                "add": [{ "path": "outputs.latestSharedObservation.presenceRevision" }, 1]
               }
             }
           }
@@ -1043,10 +1131,17 @@
       "connection": "apiTertiary",
       "request": {
         "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{sharedGroupId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{sharedGroupId}?minGroupRevision={sharedReadFloor.groupRevision}&minPresenceRevision={sharedReadFloor.presenceRevision}",
         "headers": {
           "Authorization": "{ownerAuthHeader}",
           "x-client-id": "{ownerClientId}"
+        },
+        "retry": {
+          "maxAttempts": 6,
+          "backoffMs": 250,
+          "backoffMultiplier": 2,
+          "onStatus": [409],
+          "onException": false
         },
         "outputs": {
           "sharedFinalRevision": "body.stateRevision"

--- a/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
@@ -321,6 +321,101 @@ describe('API-v1 three-server recipe semantics', () => {
         },
       },
     });
+    const allSteps = flattenRecipeSteps(recipe.steps as Array<Record<string, unknown>>);
+    for (const [connectStepName, outputPrefix] of [
+      ['connectPrimaryClientToShared{loop.iteration}', 'primaryShared'],
+      ['connectSecondaryClientToShared{loop.iteration}', 'secondaryShared'],
+      ['connectTertiaryClientToShared{loop.iteration}', 'tertiaryShared'],
+    ] as const) {
+      expect(
+        allSteps.find((step) => step.name === connectStepName),
+        connectStepName,
+      ).toMatchObject({
+        request: {
+          outputs: {
+            [`${outputPrefix}GroupRevision`]: 'body.causalRevision.groupRevision',
+            [`${outputPrefix}PresenceRevision`]: 'body.causalRevision.presenceRevision',
+            [`${outputPrefix}OnlineMemberCount`]: 'body.onlineMemberCount',
+          },
+        },
+      });
+    }
+    const latestSharedObservation = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'deriveLatestSharedObservation',
+    );
+    expect(latestSharedObservation).toMatchObject({
+      type: 'set',
+      output: 'latestSharedObservation',
+      transform: {
+        value: {
+          groupRevision: { max: expect.any(Array) },
+          presenceRevision: { max: expect.any(Array) },
+          onlineMemberCount: {
+            if: {
+              condition: { equals: expect.any(Array) },
+              then: { path: 'outputs.primarySharedOnlineMemberCount' },
+              else: {
+                if: {
+                  condition: { equals: expect.any(Array) },
+                  then: { path: 'outputs.secondarySharedOnlineMemberCount' },
+                  else: { path: 'outputs.tertiarySharedOnlineMemberCount' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const sharedFloor = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'deriveSharedReadFloor',
+    );
+    expect(sharedFloor).toMatchObject({
+      type: 'set',
+      output: 'sharedReadFloor',
+      transform: {
+        value: {
+          groupRevision: {
+            path: 'outputs.latestSharedObservation.groupRevision',
+          },
+          presenceRevision: {
+            if: {
+              condition: {
+                equals: [{ path: 'outputs.latestSharedObservation.onlineMemberCount' }, 13],
+              },
+              then: { path: 'outputs.latestSharedObservation.presenceRevision' },
+              else: {
+                add: [{ path: 'outputs.latestSharedObservation.presenceRevision' }, 1],
+              },
+            },
+          },
+        },
+      },
+    });
+    const sharedRead = (recipe.steps as Array<Record<string, unknown>>).find(
+      (step) => step.name === 'readSharedGroupThroughTertiary',
+    );
+    expect(sharedRead).toMatchObject({
+      connection: 'apiTertiary',
+      request: {
+        path: expect.stringContaining(
+          'minGroupRevision={sharedReadFloor.groupRevision}&minPresenceRevision={sharedReadFloor.presenceRevision}',
+        ),
+        retry: {
+          maxAttempts: 6,
+          backoffMs: 250,
+          backoffMultiplier: 2,
+          onStatus: [409],
+          onException: false,
+        },
+      },
+      expect: {
+        status: 200,
+        body: {
+          memberCount: 13,
+          onlineMemberCount: 13,
+        },
+      },
+    });
     expect(JSON.stringify(recipe)).toContain('disconnect');
     expect(JSON.stringify(recipe)).toContain('topology/reconfigure');
   });


### PR DESCRIPTION
## What

Fixes #159: the `api-v1-state-topology-churn` recipe's final shared-group read (`readSharedGroupThroughTertiary`) was a single-attempt HTTP GET asserting `memberCount`/`onlineMemberCount` 13 with no retry and no convergence floor, so it raced the asynchronous presence-summary expansion that refreshes the serving snapshot after a connect. In Branch Release Gate run 31449269517 it observed all 13 members but only 12 `activeSessions` — the last joiner's connect had committed through the same server ~1.6s before the read.

The churn-group read has carried a causal-revision floor plus bounded 409 retries since #116; the shared-group read had neither. This change mirrors that proven in-recipe pattern onto the shared-group read:

- the three lane `connectXxxClientToShared` steps now capture `body.causalRevision.groupRevision`, `body.causalRevision.presenceRevision`, and `body.onlineMemberCount` observations;
- new `deriveLatestSharedObservation` / `deriveSharedReadFloor` SET steps compute the floor from the max observed shared-group causal revision (with the same +1 presence bump when the latest observation had not yet seen 13 online);
- `readSharedGroupThroughTertiary` now requests `?minGroupRevision={sharedReadFloor.groupRevision}&minPresenceRevision={sharedReadFloor.presenceRevision}` with the identical bounded retry policy (`maxAttempts` 6, 250ms base, 2x backoff, retry on 409 only). The server answers 409 `state-revision-floor-not-satisfied` until the snapshot reaches the floor.

Assertions keep exactly their prior strength (status 200, `stateRevision` integer, `memberCount` 13, `onlineMemberCount` 13, exact `groupId`), and the wait stays bounded (~7.75s worst case), so a genuine convergence regression still fails. The recipe-structure test `api-v1-three-server-recipe-semantics.test.ts` now pins the shared-read fence (lane observation outputs, both derive steps, floor query, retry policy, and count assertions) with the same strength as the churn-read pins. The server-side read-your-writes option from #159 is intentionally out of scope, and the medium-scale gate's recipes, constants, operation matrix, and assertions are untouched.

Note: the race predates group-formation damping (PR #152) — it exists under both `RALLAR_GROUP_FORMATION_DAMPING` modes; damping's changed queue timing only shifted the odds. Related: #118 (cluster recipes vs background queue backlog).

## Validation

- Fresh database (`docker compose down -v`, `npm run db:up`, `npm run db:migrate`), then `npm run test:api-v1:black-box:postgres` **three consecutive runs, all green** — `api-v1-state-topology-churn` exit=0 with success=125 failure=0 each run (cluster profile 5/5, base profile 13/13, every run). Run-report evidence shows the shared read requesting real resolved floors (`?minGroupRevision=13&minPresenceRevision=25`) with the retry policy armed.
- `npx vitest run packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts` — 5/5 passed.
- `npm run test:repo-governance` — 387 passed.
- `npm run typecheck` — clean (exit 0).
- `npm run test:unit` — 7513 passed, 3 skipped, 0 failed.
- `npm run check:repo-style:changed -- origin/main HEAD` — PASS on the committed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)