### PR TITLE
perf(rtc): add B01 signaling baseline instrumentation

### DIFF
--- a/packages/tests/repo/rtc-performance-baseline-harnesses.test.ts
+++ b/packages/tests/repo/rtc-performance-baseline-harnesses.test.ts
@@ -1,4 +1,25 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
+
+import { runRtcPeerConnectionDiagnostics } from '../../../scripts/perf/rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts';
+import {
+  createRtcIceCandidateQueueSamples,
+  parseRtcIceCandidateQueueArguments,
+} from '../../../scripts/perf/rtc-ice-candidate-queue-bench.ts';
+import {
+  createRtcPeerConnectionDiagnosticsDependencies,
+  parseRtcPeerConnectionDiagnosticsArguments,
+  runRtcPeerConnectionDiagnosticsAcceptedSamples,
+} from '../../../scripts/perf/rtc-peer-connection-diagnostics-burst.ts';
+import {
+  createRtcPeerListenerCleanupSamples,
+  parseRtcPeerListenerCleanupArguments,
+} from '../../../scripts/perf/rtc-peer-listener-cleanup-bench.ts';
+import { createRtcBaselineEvidenceAcceptance } from '../../../scripts/perf/rtc-baseline/rtc-baseline-evidence-acceptance.ts';
+import { deriveRtcBaselineCaptureManifest } from '../../../scripts/perf/rtc-baseline/rtc-baseline-workload-manifest.ts';
 
 const featureFiles = [
   'rtc-baseline-contracts.ts',
@@ -144,5 +165,236 @@ describe('RTC baseline reservation inventory', () => {
     expect(existingTypeScriptHarnesses).not.toContain('rtc-room-graph-no-rtt-bench.ts');
     expect(existingTypeScriptHarnesses).not.toContain('rtc-rtt-group-scan-bench.ts');
     expect(existingTypeScriptHarnesses).not.toContain('rtc-topology-rtt-traffic-metrics.ts');
+  });
+});
+
+const baselineId = '20260807-0123456789ab-e1-local';
+function retainedSampleIds(caseInput: string): string[] {
+  return [1, 2, 3, 4, 5].map(
+    (inner) => `rtc-b01-${caseInput}-retained-001-${String(inner).padStart(3, '0')}`,
+  );
+}
+const burstSampleIds = retainedSampleIds('peer-connection-diagnostics-burst-pairs-500');
+const queueSampleIds = retainedSampleIds('ice-candidate-queue-candidates-25000');
+const listenerSampleIds = retainedSampleIds('peer-listener-cleanup-peers-10000');
+
+function workerArguments(caseId: string, inputKey: string, sampleIds: readonly string[]) {
+  return [
+    '--capture=worker',
+    `--baseline-id=${baselineId}`,
+    '--workload=RTC-B01',
+    `--case-id=${caseId}`,
+    `--input-key=${inputKey}`,
+    '--intended-phase=retained',
+    '--outer-ordinal=1',
+    `--sample-ids=${sampleIds.join(',')}`,
+  ];
+}
+
+const repeated = <T>(value: T): T[] => [value, value, value, value, value];
+function parseExactWorkers() {
+  return {
+    burst: parseRtcPeerConnectionDiagnosticsArguments([
+      ...workerArguments('peer-connection-diagnostics-burst', 'pairs-500', burstSampleIds),
+      '--rtc-ice-candidates-per-peer=5',
+      '--rtc-inner-runs=5',
+      '--rtc-offer-collisions-per-peer=3',
+      '--rtc-peers=500',
+    ]),
+    queue: parseRtcIceCandidateQueueArguments([
+      ...workerArguments('ice-candidate-queue', 'candidates-25000', queueSampleIds),
+      '--rtc-candidates=25000',
+      '--rtc-inner-runs=5',
+    ]),
+    listeners: parseRtcPeerListenerCleanupArguments([
+      ...workerArguments('peer-listener-cleanup', 'peers-10000', listenerSampleIds),
+      '--rtc-inner-runs=5',
+      '--rtc-peers=10000',
+    ]),
+  };
+}
+
+const zeroCleanup = {
+  pendingIceCandidateQueueLength: 0,
+  reconnectAttemptsInFlight: 0,
+  activeReconnectTimerCount: 0,
+  pendingTimerCount: 0,
+};
+const validBurstResult = {
+  durationMs: 1,
+  peerCount: 1000,
+  signalingMessagesSent: 500,
+  diagnostics: {
+    queuedIceCandidateCount: 2500,
+    flushedIceCandidateCount: 2500,
+    offerCollisionCount: 1500,
+    ignoredOfferCollisionCount: 1500,
+    reconnectAttemptCount: 500,
+    reconnectTimerAlreadyActiveCount: 500,
+    reconnectExhaustedCount: 500,
+    iceRestartCount: 500,
+  },
+  cleanup: zeroCleanup,
+};
+
+describe('RTC-B01 accepted signaling, ICE, and listener instrumentation', () => {
+  it('rejects invalid diagnostic bounds and non-frozen accepted inputs', () => {
+    expect(parseRtcPeerConnectionDiagnosticsArguments(['--peers=0'])).toMatchObject({ ok: false });
+    expect(parseRtcIceCandidateQueueArguments(['--candidates=25001'])).toMatchObject({ ok: false });
+    expect(parseRtcPeerListenerCleanupArguments(['--runs=6'])).toMatchObject({ ok: false });
+    const invalidOut = ['--out=/tmp/result.json'];
+    const rejected = { ok: false };
+    expect(parseRtcPeerConnectionDiagnosticsArguments(invalidOut)).toMatchObject(rejected);
+    expect(parseRtcIceCandidateQueueArguments(invalidOut)).toMatchObject(rejected);
+    expect(parseRtcPeerListenerCleanupArguments(invalidOut)).toMatchObject(rejected);
+    expect(
+      parseRtcPeerConnectionDiagnosticsArguments([
+        ...workerArguments('peer-connection-diagnostics-burst', 'pairs-500', burstSampleIds),
+        '--rtc-ice-candidates-per-peer=5',
+        '--rtc-inner-runs=5',
+        '--rtc-offer-collisions-per-peer=3',
+        '--rtc-peers=499',
+      ]),
+    ).toMatchObject({ ok: false });
+  });
+  it('recomputes signaling counters and exposes zero cleanup state from explicit fakes', async () => {
+    const hadPeerConnection = Object.hasOwn(globalThis, 'RTCPeerConnection');
+    const fakeRuntime = createRtcPeerConnectionDiagnosticsDependencies();
+    try {
+      const result = await runRtcPeerConnectionDiagnostics(
+        { peers: 2, iceCandidatesPerPeer: 2, offerCollisionsPerPeer: 3 },
+        fakeRuntime.dependencies,
+      );
+      expect(result).toMatchObject({
+        peerCount: 4,
+        signalingMessagesSent: 2,
+        diagnostics: {
+          queuedIceCandidateCount: 4,
+          flushedIceCandidateCount: 4,
+          offerCollisionCount: 6,
+          ignoredOfferCollisionCount: 6,
+          reconnectAttemptCount: 2,
+          reconnectTimerAlreadyActiveCount: 2,
+          reconnectExhaustedCount: 2,
+          iceRestartCount: 2,
+        },
+        cleanup: zeroCleanup,
+      });
+    } finally {
+      fakeRuntime.restore();
+    }
+    expect(Object.hasOwn(globalThis, 'RTCPeerConnection')).toBe(hadPeerConnection);
+  });
+  it('accepts exact B01 inputs and recomputes producer counters and identities', () => {
+    const { burst, queue, listeners } = parseExactWorkers();
+    if (!burst.ok || !queue.ok || !listeners.ok) throw new Error('Expected exact worker inputs.');
+    const queueSamples = createRtcIceCandidateQueueSamples({
+      worker: queue.value,
+      results: repeated({
+        durationMs: 1,
+        candidateCount: 25000,
+        addedCandidates: 25000,
+        remainingQueuedCandidates: 0,
+      }),
+    });
+    const listenerSamples = createRtcPeerListenerCleanupSamples({
+      worker: listeners.value,
+      results: repeated({
+        durationMs: 1,
+        peerCount: 10000,
+        retainedIceGatheringListeners: 0,
+        maxListenersPerPeer: 0,
+        unclearedHandlerSlots: 0,
+      }),
+    });
+    expect(
+      [...queueSamples, ...listenerSamples].every(
+        (sample) => sample.outcome === 'passed' && sample.evidenceClass === 'synthetic-path',
+      ),
+    ).toBe(true);
+  });
+  it('persists a counter failure before returning the accepted failure', async () => {
+    const { burst: worker } = parseExactWorkers();
+    if (!worker.ok) throw new Error('Expected exact worker input.');
+    const invalid = {
+      ...validBurstResult,
+      diagnostics: {
+        ...validBurstResult.diagnostics,
+        queuedIceCandidateCount: 2499,
+      },
+    };
+    let executedRuns = 0;
+    const outcomes = await runRtcPeerConnectionDiagnosticsAcceptedSamples({
+      worker: worker.value,
+      run: async () => {
+        executedRuns += 1;
+        return invalid;
+      },
+    });
+    expect(executedRuns).toBe(1);
+    expect(outcomes.map((sample) => sample.identity.sampleId)).toEqual(burstSampleIds);
+    const writes: unknown[] = [];
+    const manifest = deriveRtcBaselineCaptureManifest({
+      schema: 'rallar.rtc-baseline.capture-request.v1',
+      baselineId,
+      workloadIds: ['RTC-B01'],
+      environmentId: 'E1-local',
+      retainedSampleMultiplier: 1,
+      repeatLink: null,
+      conditionalEnvironmentDecisions: [],
+    });
+    const attempt = manifest.outerAttempts.find(
+      (value) =>
+        value.caseId === 'peer-connection-diagnostics-burst' && value.intendedPhase === 'retained',
+    )!;
+    const acceptance = createRtcBaselineEvidenceAcceptance({
+      initializeStore: async () => ({ ok: true as const, value: undefined }),
+      readManifest: async () => ({
+        ok: true as const,
+        value: { ...manifest, outerAttempts: [attempt] },
+      }),
+      writeAcceptedArtifact: async (_acceptedBaselineId, artifact) => {
+        writes.push(artifact);
+        return { ok: true as const, value: undefined };
+      },
+      readStagedJson: async () => ({ ok: false as const, issues: [] }),
+      runFreshWorker: async () => ({ outcomes }),
+      reconcileAcceptedOperation: async () => [],
+    });
+    expect(await acceptance.captureWorkload({ baselineId, workloadId: 'RTC-B01' })).toMatchObject({
+      ok: false,
+    });
+    expect(writes[0]).toMatchObject({
+      artifactKind: 'failure',
+      identity: { sampleId: burstSampleIds[0] },
+      issues: [{ code: 'counter-mismatch' }],
+    });
+  });
+  it('keeps create-new diagnostic JSON separate from accepted evidence', () => {
+    mkdirSync('tmp/perf/results', { recursive: true });
+    const directory = mkdtempSync(join('tmp/perf/results', 'rtc-b01-diagnostic-'));
+    const outputPath = join(directory, 'ice.json');
+    const command = [
+      'run',
+      '--config=apps/api-v1/deno.json',
+      '--allow-read',
+      '--allow-write',
+      'scripts/perf/rtc-ice-candidate-queue-bench.ts',
+      '--candidates=1',
+      '--runs=1',
+      `--out=${outputPath}`,
+    ];
+    try {
+      const first = spawnSync('deno', command, { encoding: 'utf8' });
+      const persisted = JSON.parse(readFileSync(outputPath, 'utf8'));
+      const second = spawnSync('deno', command, { encoding: 'utf8' });
+      expect(first.status).toBe(0);
+      expect(persisted).toMatchObject({ input: { candidateCount: 1, runs: 1 } });
+      expect(persisted).not.toHaveProperty('schema');
+      expect(persisted).not.toHaveProperty('outcome');
+      expect(second.status).not.toBe(0);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/perf/rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts
+++ b/scripts/perf/rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts
@@ -1,0 +1,322 @@
+import {
+  QRtcPeerConnection,
+  type QRtcPeerConnectionDiagnostics,
+} from '@shared/webrtc/QRtcPeerConnection.ts';
+import { QRtcSignalingType } from '@shared/webrtc/QRtcSignalingContracts.ts';
+
+export interface RtcPeerConnectionDiagnosticsInputDto {
+  readonly peers: number;
+  readonly iceCandidatesPerPeer: number;
+  readonly offerCollisionsPerPeer: number;
+}
+
+export interface RtcPeerConnectionDiagnosticsPeerInput {
+  readonly id: string;
+  readonly isPolite: boolean;
+  readonly onSend: () => void;
+}
+
+export interface RtcPeerConnectionDiagnosticsPeer {
+  connect(): void;
+  receiveIceCandidate(candidateIndex: number): Promise<void>;
+  receiveOffer(): Promise<void>;
+  beginOfferCollision(): void;
+  receiveCollidingOffer(collisionIndex: number): Promise<void>;
+  failConnection(): void;
+  reconnect(): Promise<void>;
+  drainSignaling(): Promise<void>;
+  exhaustReconnects(): Promise<void>;
+  readDiagnostics(): QRtcPeerConnectionDiagnostics;
+}
+
+export interface RtcPeerConnectionDiagnosticsDependencies {
+  createPeer(input: RtcPeerConnectionDiagnosticsPeerInput): RtcPeerConnectionDiagnosticsPeer;
+  reset(): void;
+  drainTimers(): Promise<void>;
+  getPendingTimerCount(): number;
+  monotonicNowMs(): number;
+}
+
+export interface RtcPeerConnectionDiagnosticsCleanupState {
+  readonly pendingIceCandidateQueueLength: number;
+  readonly reconnectAttemptsInFlight: number;
+  readonly activeReconnectTimerCount: number;
+  readonly pendingTimerCount: number;
+}
+
+export interface RtcPeerConnectionDiagnosticsResult {
+  readonly durationMs: number;
+  readonly peerCount: number;
+  readonly signalingMessagesSent: number;
+  readonly diagnostics: Readonly<Record<string, number>>;
+  readonly cleanup: RtcPeerConnectionDiagnosticsCleanupState;
+}
+
+interface RunRtcPeerConnectionDiagnosticsPeerInput {
+  readonly diagnosticsInput: RtcPeerConnectionDiagnosticsInputDto;
+  readonly index: number;
+  readonly onSend: () => void;
+}
+
+interface QueuedTimer {
+  readonly id: number;
+  readonly callback: () => void | Promise<void>;
+}
+
+export async function runRtcPeerConnectionDiagnostics(
+  input: RtcPeerConnectionDiagnosticsInputDto,
+  dependencies: RtcPeerConnectionDiagnosticsDependencies,
+): Promise<RtcPeerConnectionDiagnosticsResult> {
+  dependencies.reset();
+  const startedAt = dependencies.monotonicNowMs();
+  const diagnostics: Record<string, number> = {};
+  let signalingMessagesSent = 0;
+  let activeReconnectTimerCount = 0;
+
+  for (let index = 0; index < input.peers; index += 1) {
+    const onSend = () => {
+      signalingMessagesSent += 1;
+    };
+    const peerInput = { diagnosticsInput: input, index, onSend };
+    const politeDiagnostics = await runPolitePeer(peerInput, dependencies);
+    const impoliteDiagnostics = await runImpolitePeer(peerInput, dependencies);
+    addNumericDiagnostics(diagnostics, politeDiagnostics);
+    addNumericDiagnostics(diagnostics, impoliteDiagnostics);
+    activeReconnectTimerCount += Number(politeDiagnostics.hasReconnectTimer);
+    activeReconnectTimerCount += Number(impoliteDiagnostics.hasReconnectTimer);
+  }
+
+  return {
+    durationMs: dependencies.monotonicNowMs() - startedAt,
+    peerCount: input.peers * 2,
+    signalingMessagesSent,
+    diagnostics,
+    cleanup: {
+      pendingIceCandidateQueueLength: diagnostics.pendingIceCandidateQueueLength ?? 0,
+      reconnectAttemptsInFlight: diagnostics.reconnectAttemptsInFlight ?? 0,
+      activeReconnectTimerCount,
+      pendingTimerCount: dependencies.getPendingTimerCount(),
+    },
+  };
+}
+
+async function runPolitePeer(
+  input: RunRtcPeerConnectionDiagnosticsPeerInput,
+  dependencies: RtcPeerConnectionDiagnosticsDependencies,
+): Promise<QRtcPeerConnectionDiagnostics> {
+  const peer = dependencies.createPeer({
+    id: `polite-${input.index}`,
+    isPolite: true,
+    onSend: input.onSend,
+  });
+  peer.connect();
+  for (
+    let candidateIndex = 0;
+    candidateIndex < input.diagnosticsInput.iceCandidatesPerPeer;
+    candidateIndex += 1
+  ) {
+    await peer.receiveIceCandidate(candidateIndex);
+  }
+  await peer.receiveOffer();
+  return peer.readDiagnostics();
+}
+
+async function runImpolitePeer(
+  input: RunRtcPeerConnectionDiagnosticsPeerInput,
+  dependencies: RtcPeerConnectionDiagnosticsDependencies,
+): Promise<QRtcPeerConnectionDiagnostics> {
+  const peer = dependencies.createPeer({
+    id: `impolite-${input.index}`,
+    isPolite: false,
+    onSend: input.onSend,
+  });
+  peer.connect();
+  peer.beginOfferCollision();
+  for (
+    let collisionIndex = 0;
+    collisionIndex < input.diagnosticsInput.offerCollisionsPerPeer;
+    collisionIndex += 1
+  ) {
+    await peer.receiveCollidingOffer(collisionIndex);
+  }
+  peer.failConnection();
+  await peer.reconnect();
+  await peer.reconnect();
+  await dependencies.drainTimers();
+  await peer.drainSignaling();
+  await peer.exhaustReconnects();
+  return peer.readDiagnostics();
+}
+
+function addNumericDiagnostics(
+  aggregate: Record<string, number>,
+  diagnostics: QRtcPeerConnectionDiagnostics,
+): void {
+  for (const [key, value] of Object.entries(diagnostics)) {
+    if (typeof value === 'number') {
+      aggregate[key] = (aggregate[key] ?? 0) + value;
+    }
+  }
+}
+
+export function createRtcPeerConnectionDiagnosticsDependencies(): {
+  dependencies: RtcPeerConnectionDiagnosticsDependencies;
+  restore(): void;
+} {
+  const hadPeerConnection = Object.hasOwn(globalThis, 'RTCPeerConnection');
+  const originalPeerConnection = globalThis.RTCPeerConnection;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let nextTimerId = 1;
+  let timers: QueuedTimer[] = [];
+  Reflect.set(globalThis, 'RTCPeerConnection', FakeRTCPeerConnection);
+  globalThis.setTimeout = ((callback: () => void | Promise<void>) => {
+    const id = nextTimerId++;
+    timers.push({ id, callback });
+    return id;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((id: number) => {
+    timers = timers.filter((timer) => timer.id !== id);
+  }) as typeof clearTimeout;
+  return {
+    dependencies: {
+      createPeer: createPeerAdapter,
+      reset() {
+        FakeRTCPeerConnection.instances = [];
+        timers = [];
+      },
+      async drainTimers() {
+        while (timers.length > 0) {
+          const pending = timers;
+          timers = [];
+          for (const timer of pending) {
+            await timer.callback();
+          }
+        }
+      },
+      getPendingTimerCount: () => timers.length,
+      monotonicNowMs: () => performance.now(),
+    },
+    restore() {
+      if (hadPeerConnection) Reflect.set(globalThis, 'RTCPeerConnection', originalPeerConnection);
+      else Reflect.deleteProperty(globalThis, 'RTCPeerConnection');
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
+function createPeerAdapter(
+  input: RtcPeerConnectionDiagnosticsPeerInput,
+): RtcPeerConnectionDiagnosticsPeer {
+  const peer = new QRtcPeerConnection(
+    { send: async () => input.onSend() },
+    {
+      sessionId: `self-${input.id}`,
+      token: 'token',
+      peerSessionId: `peer-${input.id}`,
+      iceCandidates: { iceServers: [], expiresAtEpochMs: Date.now() + 60_000 },
+      isPolite: input.isPolite,
+    },
+  );
+  let nativePeer: FakeRTCPeerConnection | undefined;
+  const requireNativePeer = () => {
+    if (!nativePeer) {
+      throw new Error('Expected fake RTCPeerConnection instance.');
+    }
+    return nativePeer;
+  };
+  return {
+    connect() {
+      peer.connect();
+      nativePeer = FakeRTCPeerConnection.instances.at(-1);
+    },
+    receiveIceCandidate: (index) =>
+      peer.handleSignal(QRtcSignalingType.IceCandidate, {
+        description: null,
+        candidate: { candidate: `candidate-${input.id}-${index}`, sdpMid: '0', sdpMLineIndex: 0 },
+      }),
+    receiveOffer: () =>
+      peer.handleSignal(QRtcSignalingType.Offer, {
+        description: { type: 'offer', sdp: `remote-offer-${input.id}` } as RTCSessionDescription,
+        candidate: null,
+      }),
+    beginOfferCollision() {
+      peer.status.makingOffer = true;
+      requireNativePeer().signalingState = 'have-local-offer';
+    },
+    receiveCollidingOffer: (index) =>
+      peer.handleSignal(QRtcSignalingType.Offer, {
+        description: {
+          type: 'offer',
+          sdp: `colliding-offer-${input.id}-${index}`,
+        } as RTCSessionDescription,
+        candidate: null,
+      }),
+    failConnection: () => {
+      requireNativePeer().connectionState = 'failed';
+    },
+    reconnect: () => peer.handleReconnect(),
+    drainSignaling: () => readSignalingChain(peer),
+    exhaustReconnects: async () => {
+      peer.status.reconnectAttempts = 5;
+      await peer.handleReconnect();
+    },
+    readDiagnostics: () => peer.readDiagnostics(),
+  };
+}
+
+function readSignalingChain(peer: QRtcPeerConnection): Promise<void> {
+  const signalingChain = Reflect.get(peer, 'signalingChain');
+  if (!(signalingChain instanceof Promise)) {
+    throw new Error('Expected QRtcPeerConnection signaling chain.');
+  }
+  return signalingChain;
+}
+
+class FakeRTCPeerConnection {
+  static instances: FakeRTCPeerConnection[] = [];
+  connectionState: RTCPeerConnectionState = 'new';
+  signalingState: RTCSignalingState = 'stable';
+  iceConnectionState: RTCIceConnectionState = 'new';
+  iceGatheringState: RTCIceGatheringState = 'new';
+  localDescription: RTCSessionDescription | null = null;
+  remoteDescription: RTCSessionDescription | null = null;
+  onnegotiationneeded: (() => Promise<void>) | null = null;
+  onicecandidate: ((event: { candidate: RTCIceCandidateInit | null }) => Promise<void>) | null =
+    null;
+  ondatachannel: ((event: RTCDataChannelEvent) => Promise<void>) | null = null;
+  ontrack: ((event: RTCTrackEvent) => Promise<void>) | null = null;
+  oniceconnectionstatechange: (() => void) | null = null;
+  onsignalingstatechange: (() => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  constructor(_configuration: RTCConfiguration) {
+    FakeRTCPeerConnection.instances.push(this);
+  }
+  addEventListener(_type: string, _listener: (event?: Event) => void): void {}
+  removeEventListener(_type: string, _listener: (event?: Event) => void): void {}
+  getTransceivers(): Array<{ stop: () => void }> {
+    return [];
+  }
+  close(): void {
+    this.connectionState = 'closed';
+  }
+  restartIce(): void {}
+  createDataChannel(_label: string): RTCDataChannel {
+    return {} as RTCDataChannel;
+  }
+  addIceCandidate(_candidate?: RTCIceCandidateInit): Promise<void> {
+    return Promise.resolve();
+  }
+  async setRemoteDescription(description: RTCSessionDescription): Promise<void> {
+    this.remoteDescription = description;
+    this.signalingState = description.type === 'offer' ? 'have-remote-offer' : 'stable';
+  }
+  async setLocalDescription(description?: RTCSessionDescriptionInit): Promise<void> {
+    this.localDescription = (description ?? {
+      type: this.remoteDescription?.type === 'offer' ? 'answer' : 'offer',
+      sdp: this.remoteDescription?.type === 'offer' ? 'answer-sdp' : 'offer-sdp',
+    }) as RTCSessionDescription;
+    this.signalingState = this.localDescription.type === 'offer' ? 'have-local-offer' : 'stable';
+  }
+}

--- a/scripts/perf/rtc-ice-candidate-queue-bench.ts
+++ b/scripts/perf/rtc-ice-candidate-queue-bench.ts
@@ -1,97 +1,348 @@
 import { QRtcPeerConnection } from '@shared/webrtc/QRtcPeerConnection.ts';
 
-type BenchResult = Readonly<{
-    run: number;
-    durationMs: number;
-    candidateCount: number;
-    addedCandidates: number;
-    remainingQueuedCandidates: number;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineJson,
+  type RtcBaselineSampleIdentityDto,
+  type RtcBaselineSampleDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
 
-const OUT = readArg('--out') ??
-    'tmp/perf/results/rtc-ice-candidate-queue.json';
-const CANDIDATES = Number(readArg('--candidates') ?? '25000');
-const RUNS = Number(readArg('--runs') ?? '5');
+interface QueueInput {
+  readonly candidates: number;
+  readonly runs: number;
+}
+interface DiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: QueueInput;
+  readonly out: string;
+}
+interface AcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: QueueInput;
+  readonly baselineId: string;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+export interface RtcIceCandidateQueueResult {
+  readonly durationMs: number;
+  readonly candidateCount: number;
+  readonly addedCandidates: number;
+  readonly remainingQueuedCandidates: number;
+}
+interface BenchResult extends RtcIceCandidateQueueResult {
+  readonly run: number;
+}
+interface CreateRtcIceCandidateQueueSampleInput {
+  readonly identity: RtcBaselineSampleIdentityDto;
+  readonly outcome: 'passed' | 'failed' | 'not-run';
+  readonly rawEvidence: RtcIceCandidateQueueResult | null;
+  readonly issues: RtcBaselineSampleDto['issues'];
+}
 
-const writeLine = console.log.bind(console);
-console.log = () => {
-};
-console.warn = () => {
-};
+const acceptedNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-candidates',
+  'rtc-inner-runs',
+];
+
+export function parseRtcIceCandidateQueueArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['candidates', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+
+export function createRtcIceCandidateQueueSamples(input: {
+  worker: AcceptedArguments;
+  results: readonly RtcIceCandidateQueueResult[];
+}): RtcBaselineSampleDto[] {
+  let priorFailureId: string | undefined;
+  return input.worker.sampleIds.map((sampleId, index) => {
+    const identity = createIdentity(input.worker, sampleId, index + 1);
+    const result = input.results[index];
+    if (priorFailureId !== undefined || result === undefined) {
+      return createSample({
+        identity,
+        outcome: 'not-run',
+        rawEvidence: null,
+        issues: [
+          rtcBaselineIssue(
+            '$.rawEvidence',
+            'causal-not-run',
+            priorFailureId ?? 'Missing inner run.',
+          ),
+        ],
+      });
+    }
+    const issues = validateResult(input.worker.input, result);
+    if (issues.length > 0) priorFailureId = sampleId;
+    return createSample({
+      identity,
+      outcome: issues.length === 0 ? 'passed' : 'failed',
+      rawEvidence: result,
+      issues,
+    });
+  });
+}
+
+export async function runRtcIceCandidateQueueAcceptedSamples(input: {
+  worker: AcceptedArguments;
+  run: () => Promise<RtcIceCandidateQueueResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const results: RtcIceCandidateQueueResult[] = [];
+  for (let run = 0; run < input.worker.input.runs; run += 1) {
+    const result = await input.run();
+    results.push(result);
+    if (validateResult(input.worker.input, result).length > 0) break;
+  }
+  return createRtcIceCandidateQueueSamples({ worker: input.worker, results });
+}
+
+async function main(): Promise<void> {
+  const parsed = parseRtcIceCandidateQueueArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  if (parsed.value.mode === 'accepted') {
+    const samples = await runRtcIceCandidateQueueAcceptedSamples({
+      worker: parsed.value,
+      run: () => runQueue(parsed.value.input.candidates),
+    });
+    writeLine(JSON.stringify(samples));
+    return;
+  }
+  const results: BenchResult[] = [];
+  for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+    results.push({ run, ...(await runQueue(parsed.value.input.candidates)) });
+  }
+  await Deno.writeTextFile(
+    parsed.value.out,
+    JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        input: { candidateCount: parsed.value.input.candidates, runs: parsed.value.input.runs },
+        results,
+      },
+      null,
+      2,
+    ),
+    { createNew: true },
+  );
+  writeLine(`Wrote ${parsed.value.out}`);
+}
+
+async function runQueue(candidates: number): Promise<RtcIceCandidateQueueResult> {
+  const peer = new QRtcPeerConnection(
+    { send: async () => {} },
+    {
+      sessionId: 'self',
+      token: 'token',
+      peerSessionId: 'peer',
+      iceCandidates: { iceServers: [], expiresAtEpochMs: Date.now() + 60_000 },
+      isPolite: true,
+    },
+  );
+  const status = peer.status;
+  status.iceCandidateQueue = Array.from({ length: candidates }, (_value, index) => ({
+    candidate: `candidate-${index}`,
+    sdpMid: '0',
+    sdpMLineIndex: 0,
+  }));
+  const nativePeer = new FakeRTCPeerConnection();
+  const startedAt = performance.now();
+  await (
+    peer as unknown as {
+      flushIceCandidateQueue(
+        peerConnection: Pick<RTCPeerConnection, 'addIceCandidate'>,
+      ): Promise<void>;
+    }
+  ).flushIceCandidateQueue(nativePeer);
+  return {
+    durationMs: performance.now() - startedAt,
+    candidateCount: candidates,
+    addedCandidates: nativePeer.addedCandidates,
+    remainingQueuedCandidates: status.iceCandidateQueue.length,
+  };
+}
+
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const out = options.out ?? 'tmp/perf/results/rtc-ice-candidate-queue.json';
+  const outComponents = out.split('/');
+  const validOut =
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    outComponents.every((component) => component !== '' && component !== '.' && component !== '..');
+  const candidates = parseRtcBaselineBoundedInteger(
+    options.candidates ?? '25000',
+    'candidates',
+    1,
+    25000,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  if (!candidates.ok || !runs.ok || !validOut) {
+    return {
+      ok: false as const,
+      issues: [
+        ...(!candidates.ok ? candidates.issues : []),
+        ...(!runs.ok ? runs.issues : []),
+        ...(!validOut
+          ? [rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.')]
+          : []),
+      ],
+    };
+  }
+  return {
+    ok: true as const,
+    value: {
+      mode: 'diagnostic' as const,
+      input: { candidates: candidates.value, runs: runs.value },
+      out,
+    },
+  };
+}
+
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = outer.ok ? [] : [...outer.issues];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B01',
+    'case-id': 'ice-candidate-queue',
+    'input-key': 'candidates-25000',
+    'rtc-candidates': '25000',
+    'rtc-inner-runs': '5',
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
+    }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(phase === 'warmup' ? phase : 'retained', ordinal);
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { candidates: 25000, runs: 5 },
+          baselineId: options['baseline-id']!,
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
+}
+
+function createExpectedSampleIds(phase: string, outerOrdinal: number): string[] {
+  const attemptPrefix =
+    `rtc-b01-ice-candidate-queue-candidates-25000-${phase}-` +
+    String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${attemptPrefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function createIdentity(
+  worker: AcceptedArguments,
+  sampleId: string,
+  innerOrdinal: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId,
+    workloadId: 'RTC-B01' as const,
+    caseId: 'ice-candidate-queue',
+    inputKey: 'candidates-25000',
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal,
+  };
+}
+
+function createSample(sampleInput: CreateRtcIceCandidateQueueSampleInput): RtcBaselineSampleDto {
+  const { identity, outcome, rawEvidence, issues } = sampleInput;
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome,
+    evidenceClass: 'synthetic-path',
+    metrics: rawEvidence
+      ? [{ metric: 'durationMs', unit: 'ms', value: rawEvidence.durationMs }]
+      : [],
+    rawEvidence: rawEvidence === null ? null : createRawEvidence(rawEvidence),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(input: QueueInput, result: RtcIceCandidateQueueResult) {
+  const issues = [];
+  if (result.candidateCount !== input.candidates) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.candidateCount', 'counter-mismatch', 'Unexpected.'),
+    );
+  }
+  if (result.addedCandidates !== input.candidates) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.addedCandidates', 'counter-mismatch', 'Unexpected.'),
+    );
+  }
+  if (result.remainingQueuedCandidates !== 0) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.remainingQueuedCandidates', 'cleanup-nonzero', 'Expected 0.'),
+    );
+  }
+  return issues;
+}
+
+function createRawEvidence(result: RtcIceCandidateQueueResult): RtcBaselineJson {
+  return {
+    durationMs: result.durationMs,
+    candidateCount: result.candidateCount,
+    addedCandidates: result.addedCandidates,
+    remainingQueuedCandidates: result.remainingQueuedCandidates,
+  };
+}
 
 class FakeRTCPeerConnection {
-    addedCandidates = 0;
-
-    addIceCandidate(_candidate?: RTCIceCandidateInit): Promise<void> {
-        this.addedCandidates += 1;
-        return Promise.resolve();
-    }
+  addedCandidates = 0;
+  addIceCandidate(_candidate?: RTCIceCandidateInit | null): Promise<void> {
+    this.addedCandidates += 1;
+    return Promise.resolve();
+  }
 }
 
-const results: BenchResult[] = [];
-
-for (let run = 1; run <= RUNS; run++) {
-    const peer = new QRtcPeerConnection(
-        {
-            send: async () => {
-            },
-        },
-        {
-            sessionId: 'self',
-            token: 'token',
-            peerSessionId: 'peer',
-            iceCandidates: {
-                iceServers: [],
-                expiresAtEpochMs: Date.now() + 60_000,
-            },
-            isPolite: true,
-        },
-    );
-    const queuedCandidates = Array.from(
-        { length: CANDIDATES },
-        (_unused, index) => ({
-            candidate: `candidate-${index}`,
-            sdpMid: '0',
-            sdpMLineIndex: 0,
-        } satisfies RTCIceCandidateInit),
-    );
-    const status = peer.status as unknown as {
-        iceCandidateQueue: RTCIceCandidateInit[];
-    };
-    status.iceCandidateQueue = queuedCandidates;
-    const pc = new FakeRTCPeerConnection();
-    const start = performance.now();
-
-    await (peer as unknown as {
-        flushIceCandidateQueue: (
-            pc: Pick<RTCPeerConnection, 'addIceCandidate'>,
-        ) => Promise<void>;
-    }).flushIceCandidateQueue(pc);
-
-    results.push({
-        run,
-        durationMs: performance.now() - start,
-        candidateCount: CANDIDATES,
-        addedCandidates: pc.addedCandidates,
-        remainingQueuedCandidates: status.iceCandidateQueue.length,
-    });
-}
-
-await Deno.writeTextFile(
-    OUT,
-    JSON.stringify({
-        createdAt: new Date().toISOString(),
-        input: {
-            candidateCount: CANDIDATES,
-            runs: RUNS,
-        },
-        results,
-    }, null, 2),
-);
-
-writeLine(`Wrote ${OUT}`);
-
-function readArg(name: string): string | undefined {
-    return Deno.args.find((arg) => arg.startsWith(`${name}=`))
-        ?.slice(name.length + 1);
-}
+if (import.meta.main) await main();

--- a/scripts/perf/rtc-peer-connection-diagnostics-burst.ts
+++ b/scripts/perf/rtc-peer-connection-diagnostics-burst.ts
@@ -1,348 +1,368 @@
+import type {
+  RtcBaselineJson,
+  RtcBaselineSampleIdentityDto,
+  RtcBaselineSampleDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import { rtcBaselineIssue } from './rtc-baseline/rtc-baseline-contracts.ts';
 import {
-    QRtcPeerConnection,
-    type QRtcPeerConnectionDiagnostics,
-} from '@shared/webrtc/QRtcPeerConnection.ts';
-import { QRtcSignalingType } from '@shared/webrtc/QRtcSignalingContracts.ts';
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
+import {
+  createRtcPeerConnectionDiagnosticsDependencies,
+  runRtcPeerConnectionDiagnostics,
+  type RtcPeerConnectionDiagnosticsResult,
+} from './rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts';
 
-type Args = Readonly<{
-    peers: number;
-    iceCandidatesPerPeer: number;
-    offerCollisionsPerPeer: number;
-    runs: number;
-    out: string;
-}>;
+export { createRtcPeerConnectionDiagnosticsDependencies };
 
-type NumericDiagnostics = {
-    [Key in keyof QRtcPeerConnectionDiagnostics as QRtcPeerConnectionDiagnostics[Key] extends number
-        ? Key
-        : never]: number;
-};
+interface DiagnosticsInput {
+  readonly peers: number;
+  readonly iceCandidatesPerPeer: number;
+  readonly offerCollisionsPerPeer: number;
+  readonly runs: number;
+}
+interface DiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: DiagnosticsInput;
+  readonly out: string;
+}
+interface AcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: DiagnosticsInput;
+  readonly baselineId: string;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+interface BenchResult extends RtcPeerConnectionDiagnosticsResult {
+  readonly run: number;
+  readonly iceCandidatesPerPeer: number;
+  readonly offerCollisionsPerPeer: number;
+}
+interface CreateRtcPeerConnectionDiagnosticsSampleInput {
+  readonly identity: RtcBaselineSampleIdentityDto;
+  readonly outcome: 'passed' | 'failed' | 'not-run';
+  readonly rawEvidence: RtcPeerConnectionDiagnosticsResult | null;
+  readonly issues: RtcBaselineSampleDto['issues'];
+}
+const acceptedNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-ice-candidates-per-peer',
+  'rtc-inner-runs',
+  'rtc-offer-collisions-per-peer',
+  'rtc-peers',
+];
+const diagnosticNames = ['peers', 'ice-candidates', 'offer-collisions', 'runs', 'out'];
 
-type BenchResult = Readonly<{
-    run: number;
-    durationMs: number;
-    peerCount: number;
-    iceCandidatesPerPeer: number;
-    offerCollisionsPerPeer: number;
-    signalingMessagesSent: number;
-    diagnostics: NumericDiagnostics;
-}>;
+export function parseRtcPeerConnectionDiagnosticsArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : diagnosticNames,
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
 
-type QueuedTimer = Readonly<{
-    id: number;
-    callback: () => void | Promise<void>;
-}>;
+export function createRtcPeerConnectionDiagnosticsSamples(input: {
+  worker: AcceptedArguments;
+  results: readonly RtcPeerConnectionDiagnosticsResult[];
+}): RtcBaselineSampleDto[] {
+  let priorFailureId: string | undefined;
+  return input.worker.sampleIds.map((sampleId, index) => {
+    const identity = createIdentity(input.worker, sampleId, index + 1);
+    const result = input.results[index];
+    if (priorFailureId !== undefined || result === undefined) {
+      return createSample({
+        identity,
+        outcome: 'not-run',
+        rawEvidence: null,
+        issues: [
+          rtcBaselineIssue(
+            '$.rawEvidence',
+            'causal-not-run',
+            priorFailureId ?? 'Missing inner run.',
+          ),
+        ],
+      });
+    }
+    const issues = validateResult(input.worker.input, result);
+    if (issues.length > 0) priorFailureId = sampleId;
+    return createSample({
+      identity,
+      outcome: issues.length === 0 ? 'passed' : 'failed',
+      rawEvidence: result,
+      issues,
+    });
+  });
+}
 
-let nextTimerId = 1;
-let timers: QueuedTimer[] = [];
+export async function runRtcPeerConnectionDiagnosticsAcceptedSamples(input: {
+  worker: AcceptedArguments;
+  run: () => Promise<RtcPeerConnectionDiagnosticsResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const results: RtcPeerConnectionDiagnosticsResult[] = [];
+  for (let run = 0; run < input.worker.input.runs; run += 1) {
+    const result = await input.run();
+    results.push(result);
+    if (validateResult(input.worker.input, result).length > 0) break;
+  }
+  return createRtcPeerConnectionDiagnosticsSamples({ worker: input.worker, results });
+}
 
 async function main(): Promise<void> {
-    const args = parseArgs();
-    const writeLine = console.log.bind(console);
-    console.log = () => {
-    };
-    console.warn = () => {
-    };
-
-    installFakePeerConnection();
-
-    const originalSetTimeout = globalThis.setTimeout;
-    const originalClearTimeout = globalThis.clearTimeout;
-
-    (globalThis as unknown as {
-        setTimeout: typeof setTimeout;
-        clearTimeout: typeof clearTimeout;
-    }).setTimeout = ((callback: () => void | Promise<void>) => {
-        const id = nextTimerId++;
-        timers.push({ id, callback });
-        return id;
-    }) as typeof setTimeout;
-    (globalThis as unknown as {
-        clearTimeout: typeof clearTimeout;
-    }).clearTimeout = ((id: number) => {
-        timers = timers.filter((timer) => timer.id !== id);
-    }) as typeof clearTimeout;
-
-    try {
-        const results: BenchResult[] = [];
-
-        for (let run = 1; run <= args.runs; run++) {
-            FakeRTCPeerConnection.instances = [];
-            timers = [];
-            const start = performance.now();
-            const diagnostics = createZeroDiagnostics();
-            let signalingMessagesSent = 0;
-
-            for (let index = 0; index < args.peers; index++) {
-                const politePeer = createPeer(`polite-${index}`, true, () => {
-                    signalingMessagesSent++;
-                });
-                politePeer.connect();
-
-                for (let candidateIndex = 0; candidateIndex < args.iceCandidatesPerPeer; candidateIndex++) {
-                    await politePeer.handleSignal(QRtcSignalingType.IceCandidate, {
-                        description: null,
-                        candidate: {
-                            candidate: `candidate-${index}-${candidateIndex}`,
-                            sdpMid: '0',
-                            sdpMLineIndex: 0,
-                        },
-                    });
-                }
-
-                await politePeer.handleSignal(QRtcSignalingType.Offer, {
-                    description: {
-                        type: 'offer',
-                        sdp: `remote-offer-${index}`,
-                    } as RTCSessionDescription,
-                    candidate: null,
-                });
-
-                addDiagnostics(diagnostics, politePeer.readDiagnostics());
-
-                const impolitePeer = createPeer(`impolite-${index}`, false, () => {
-                    signalingMessagesSent++;
-                });
-                impolitePeer.connect();
-                const pc = FakeRTCPeerConnection.instances.at(-1);
-                if (!pc) {
-                    throw new Error('Expected fake RTCPeerConnection instance');
-                }
-                impolitePeer.status.makingOffer = true;
-                pc.signalingState = 'have-local-offer';
-
-                for (let collisionIndex = 0; collisionIndex < args.offerCollisionsPerPeer; collisionIndex++) {
-                    await impolitePeer.handleSignal(QRtcSignalingType.Offer, {
-                        description: {
-                            type: 'offer',
-                            sdp: `colliding-offer-${index}-${collisionIndex}`,
-                        } as RTCSessionDescription,
-                        candidate: null,
-                    });
-                }
-
-                pc.connectionState = 'failed';
-                await impolitePeer.handleReconnect();
-                await impolitePeer.handleReconnect();
-                await drainTimers();
-                await (impolitePeer as unknown as { signalingChain: Promise<void> }).signalingChain;
-                impolitePeer.status.reconnectAttempts = 5;
-                await impolitePeer.handleReconnect();
-
-                addDiagnostics(diagnostics, impolitePeer.readDiagnostics());
-            }
-
-            results.push({
-                run,
-                durationMs: performance.now() - start,
-                peerCount: args.peers * 2,
-                iceCandidatesPerPeer: args.iceCandidatesPerPeer,
-                offerCollisionsPerPeer: args.offerCollisionsPerPeer,
-                signalingMessagesSent,
-                diagnostics,
-            });
-        }
-
-        await Deno.writeTextFile(
-            args.out,
-            JSON.stringify({
-                createdAt: new Date().toISOString(),
-                input: args,
-                results,
-            }, null, 2),
-        );
-
-        writeLine(`Wrote ${args.out}`);
-    } finally {
-        (globalThis as unknown as {
-            setTimeout: typeof setTimeout;
-            clearTimeout: typeof clearTimeout;
-        }).setTimeout = originalSetTimeout;
-        (globalThis as unknown as {
-            clearTimeout: typeof clearTimeout;
-        }).clearTimeout = originalClearTimeout;
+  const parsed = parseRtcPeerConnectionDiagnosticsArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  const fakeRuntime = createRtcPeerConnectionDiagnosticsDependencies();
+  try {
+    if (parsed.value.mode === 'accepted') {
+      const samples = await runRtcPeerConnectionDiagnosticsAcceptedSamples({
+        worker: parsed.value,
+        run: () => runRtcPeerConnectionDiagnostics(parsed.value.input, fakeRuntime.dependencies),
+      });
+      writeLine(JSON.stringify(samples));
+      return;
     }
-}
-
-function parseArgs(): Args {
-    return {
-        peers: Number(readArg('--peers') ?? '500'),
-        iceCandidatesPerPeer: Number(readArg('--ice-candidates') ?? '5'),
-        offerCollisionsPerPeer: Number(readArg('--offer-collisions') ?? '3'),
-        runs: Number(readArg('--runs') ?? '3'),
-        out: readArg('--out') ??
-            'tmp/perf/results/rtc-peer-connection-diagnostics-burst.json',
-    };
-}
-
-function readArg(name: string): string | undefined {
-    return Deno.args.find((arg) => arg.startsWith(`${name}=`))
-        ?.slice(name.length + 1);
-}
-
-function createPeer(
-    id: string,
-    isPolite: boolean,
-    onSend: () => void,
-): QRtcPeerConnection {
-    return new QRtcPeerConnection(
+    const results: BenchResult[] = [];
+    for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+      const result = await runRtcPeerConnectionDiagnostics(
+        parsed.value.input,
+        fakeRuntime.dependencies,
+      );
+      results.push({
+        ...result,
+        run,
+        iceCandidatesPerPeer: parsed.value.input.iceCandidatesPerPeer,
+        offerCollisionsPerPeer: parsed.value.input.offerCollisionsPerPeer,
+      });
+    }
+    await Deno.writeTextFile(
+      parsed.value.out,
+      JSON.stringify(
         {
-            send: async () => {
-                onSend();
-            },
+          createdAt: new Date().toISOString(),
+          input: { ...parsed.value.input, out: parsed.value.out },
+          results,
         },
-        {
-            sessionId: `self-${id}`,
-            token: 'token',
-            peerSessionId: `peer-${id}`,
-            iceCandidates: {
-                iceServers: [],
-                expiresAtEpochMs: Date.now() + 60_000,
-            },
-            isPolite,
-        },
+        null,
+        2,
+      ),
+      { createNew: true },
     );
+    writeLine(`Wrote ${parsed.value.out}`);
+  } finally {
+    fakeRuntime.restore();
+  }
 }
 
-async function drainTimers(): Promise<void> {
-    while (timers.length > 0) {
-        const pending = timers;
-        timers = [];
-
-        for (const timer of pending) {
-            await timer.callback();
-        }
-    }
-}
-
-function createZeroDiagnostics(): NumericDiagnostics {
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const out = options.out ?? 'tmp/perf/results/rtc-peer-connection-diagnostics-burst.json';
+  const outComponents = out.split('/');
+  const validOut =
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    outComponents.every((component) => component !== '' && component !== '.' && component !== '..');
+  const peers = parseRtcBaselineBoundedInteger(options.peers ?? '500', 'peers', 1, 500);
+  const ice = parseRtcBaselineBoundedInteger(
+    options['ice-candidates'] ?? '5',
+    'ice-candidates',
+    0,
+    5,
+  );
+  const collisions = parseRtcBaselineBoundedInteger(
+    options['offer-collisions'] ?? '3',
+    'offer-collisions',
+    0,
+    3,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '3', 'runs', 1, 5);
+  if (!peers.ok || !ice.ok || !collisions.ok || !runs.ok || !validOut) {
     return {
-        connectCallCount: 0,
-        connectIgnoredCount: 0,
-        resetCount: 0,
-        closedPeerConnectionCount: 0,
-        negotiationNeededCount: 0,
-        negotiationSkippedCount: 0,
-        offerCreatedCount: 0,
-        inboundOfferCount: 0,
-        inboundAnswerCount: 0,
-        inboundIceCandidateCount: 0,
-        staleAnswerIgnoredCount: 0,
-        offerCollisionCount: 0,
-        ignoredOfferCollisionCount: 0,
-        politeOfferRollbackCount: 0,
-        outboundOfferCount: 0,
-        outboundAnswerCount: 0,
-        outboundIceCandidateCount: 0,
-        queuedIceCandidateCount: 0,
-        addedIceCandidateCount: 0,
-        flushedIceCandidateCount: 0,
-        ignoredIceCandidateForIgnoredOfferCount: 0,
-        reconnectAttemptCount: 0,
-        reconnectTimerAlreadyActiveCount: 0,
-        reconnectExhaustedCount: 0,
-        iceRestartCount: 0,
-        iceRestartSkippedConnectedCount: 0,
-        outboundSignalingErrorCount: 0,
-        inboundSignalingErrorCount: 0,
-        pendingIceCandidateQueueLength: 0,
-        reconnectAttemptsInFlight: 0,
+      ok: false as const,
+      issues: [
+        ...(!peers.ok ? peers.issues : []),
+        ...(!ice.ok ? ice.issues : []),
+        ...(!collisions.ok ? collisions.issues : []),
+        ...(!runs.ok ? runs.issues : []),
+        ...(!validOut
+          ? [rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.')]
+          : []),
+      ],
     };
+  }
+  return {
+    ok: true as const,
+    value: {
+      mode: 'diagnostic' as const,
+      input: {
+        peers: peers.value,
+        iceCandidatesPerPeer: ice.value,
+        offerCollisionsPerPeer: collisions.value,
+        runs: runs.value,
+      },
+      out,
+    },
+  };
 }
 
-function addDiagnostics(
-    aggregate: NumericDiagnostics,
-    diagnostics: QRtcPeerConnectionDiagnostics,
-): void {
-    for (const [key, value] of Object.entries(diagnostics)) {
-        if (typeof value === 'number') {
-            aggregate[key as keyof NumericDiagnostics] += value;
-        }
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = outer.ok ? [] : [...outer.issues];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B01',
+    'case-id': 'peer-connection-diagnostics-burst',
+    'input-key': 'pairs-500',
+    'rtc-ice-candidates-per-peer': '5',
+    'rtc-inner-runs': '5',
+    'rtc-offer-collisions-per-peer': '3',
+    'rtc-peers': '500',
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
     }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(
+    'peer-connection-diagnostics-burst-pairs-500',
+    phase === 'warmup' ? phase : 'retained',
+    ordinal,
+  );
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { peers: 500, iceCandidatesPerPeer: 5, offerCollisionsPerPeer: 3, runs: 5 },
+          baselineId: options['baseline-id']!,
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
 }
 
-function installFakePeerConnection(): void {
-    (globalThis as unknown as { RTCPeerConnection: typeof FakeRTCPeerConnection })
-        .RTCPeerConnection = FakeRTCPeerConnection;
+function createExpectedSampleIds(prefix: string, phase: string, outerOrdinal: number): string[] {
+  const attemptPrefix = `rtc-b01-${prefix}-${phase}-${String(outerOrdinal).padStart(3, '0')}`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${attemptPrefix}-${String(index + 1).padStart(3, '0')}`,
+  );
 }
 
-class FakeRTCPeerConnection {
-    static instances: FakeRTCPeerConnection[] = [];
-
-    connectionState: RTCPeerConnectionState = 'new';
-    signalingState: RTCSignalingState = 'stable';
-    iceConnectionState: RTCIceConnectionState = 'new';
-    iceGatheringState: RTCIceGatheringState = 'new';
-    localDescription: RTCSessionDescription | null = null;
-    remoteDescription: RTCSessionDescription | null = null;
-
-    onnegotiationneeded: (() => Promise<void>) | null = null;
-    onicecandidate:
-        | ((event: { candidate: RTCIceCandidateInit | null }) => Promise<void>)
-        | null = null;
-    ondatachannel: ((event: RTCDataChannelEvent) => Promise<void>) | null = null;
-    ontrack: ((event: RTCTrackEvent) => Promise<void>) | null = null;
-    oniceconnectionstatechange: (() => void) | null = null;
-    onsignalingstatechange: (() => void) | null = null;
-    onconnectionstatechange: (() => void) | null = null;
-
-    constructor(_configuration: RTCConfiguration) {
-        FakeRTCPeerConnection.instances.push(this);
-    }
-
-    addEventListener(_type: string, _listener: (event?: Event) => void): void {
-    }
-
-    removeEventListener(_type: string, _listener: (event?: Event) => void): void {
-    }
-
-    getTransceivers(): Array<{ stop: () => void }> {
-        return [];
-    }
-
-    close(): void {
-        this.connectionState = 'closed';
-    }
-
-    restartIce(): void {
-    }
-
-    createDataChannel(_label: string): RTCDataChannel {
-        return {} as RTCDataChannel;
-    }
-
-    addIceCandidate(_candidate?: RTCIceCandidateInit): Promise<void> {
-        return Promise.resolve();
-    }
-
-    async setRemoteDescription(description: RTCSessionDescription): Promise<void> {
-        this.remoteDescription = description;
-        this.signalingState = description.type === 'offer'
-            ? 'have-remote-offer'
-            : 'stable';
-    }
-
-    async setLocalDescription(
-        description?: RTCSessionDescriptionInit,
-    ): Promise<void> {
-        if (description) {
-            this.localDescription = description as RTCSessionDescription;
-        } else if (this.remoteDescription?.type === 'offer') {
-            this.localDescription = {
-                type: 'answer',
-                sdp: 'answer-sdp',
-            } as RTCSessionDescription;
-        } else {
-            this.localDescription = {
-                type: 'offer',
-                sdp: 'offer-sdp',
-            } as RTCSessionDescription;
-        }
-
-        this.signalingState = this.localDescription.type === 'offer'
-            ? 'have-local-offer'
-            : 'stable';
-    }
+function createIdentity(
+  worker: AcceptedArguments,
+  sampleId: string,
+  innerOrdinal: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId,
+    workloadId: 'RTC-B01' as const,
+    caseId: 'peer-connection-diagnostics-burst',
+    inputKey: 'pairs-500',
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal,
+  };
 }
 
-await main();
+function createSample(
+  sampleInput: CreateRtcPeerConnectionDiagnosticsSampleInput,
+): RtcBaselineSampleDto {
+  const { identity, outcome, rawEvidence, issues } = sampleInput;
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome,
+    evidenceClass: 'synthetic-path',
+    metrics: rawEvidence
+      ? [{ metric: 'durationMs', unit: 'ms', value: rawEvidence.durationMs }]
+      : [],
+    rawEvidence: rawEvidence === null ? null : createRawEvidence(rawEvidence),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(input: DiagnosticsInput, result: RtcPeerConnectionDiagnosticsResult) {
+  const counters = result.diagnostics;
+  const issues = [];
+  if (result.peerCount !== input.peers * 2) {
+    issues.push(rtcBaselineIssue('$.rawEvidence.peerCount', 'counter-mismatch', 'Unexpected.'));
+  }
+  if (result.signalingMessagesSent !== input.peers) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.signalingMessagesSent', 'counter-mismatch', 'Unexpected.'),
+    );
+  }
+  const expected = {
+    queuedIceCandidateCount: input.peers * input.iceCandidatesPerPeer,
+    flushedIceCandidateCount: input.peers * input.iceCandidatesPerPeer,
+    offerCollisionCount: input.peers * input.offerCollisionsPerPeer,
+    ignoredOfferCollisionCount: input.peers * input.offerCollisionsPerPeer,
+    reconnectAttemptCount: input.peers,
+    reconnectTimerAlreadyActiveCount: input.peers,
+    reconnectExhaustedCount: input.peers,
+    iceRestartCount: input.peers,
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (counters[name] !== value) {
+      issues.push(
+        rtcBaselineIssue(
+          `$.rawEvidence.diagnostics.${name}`,
+          'counter-mismatch',
+          `Expected ${value}.`,
+        ),
+      );
+    }
+  }
+  for (const [name, value] of Object.entries(result.cleanup)) {
+    if (value !== 0) {
+      issues.push(
+        rtcBaselineIssue(`$.rawEvidence.cleanup.${name}`, 'cleanup-nonzero', 'Expected 0.'),
+      );
+    }
+  }
+  return issues;
+}
+
+function createRawEvidence(result: RtcPeerConnectionDiagnosticsResult): RtcBaselineJson {
+  return {
+    durationMs: result.durationMs,
+    peerCount: result.peerCount,
+    signalingMessagesSent: result.signalingMessagesSent,
+    diagnostics: { ...result.diagnostics },
+    cleanup: { ...result.cleanup },
+  };
+}
+
+if (import.meta.main) await main();

--- a/scripts/perf/rtc-peer-listener-cleanup-bench.ts
+++ b/scripts/perf/rtc-peer-listener-cleanup-bench.ts
@@ -1,177 +1,394 @@
 import { QRtcPeerConnection } from '@shared/webrtc/QRtcPeerConnection.ts';
 
+import {
+  rtcBaselineIssue,
+  type RtcBaselineJson,
+  type RtcBaselineSampleIdentityDto,
+  type RtcBaselineSampleDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
+
 type Listener = (event?: Event) => void;
+interface ListenerInput {
+  readonly peers: number;
+  readonly runs: number;
+}
+interface DiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: ListenerInput;
+  readonly out: string;
+}
+interface AcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: ListenerInput;
+  readonly baselineId: string;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+export interface RtcPeerListenerCleanupResult {
+  readonly durationMs: number;
+  readonly peerCount: number;
+  readonly retainedIceGatheringListeners: number;
+  readonly maxListenersPerPeer: number;
+  readonly unclearedHandlerSlots: number;
+}
+interface BenchResult extends RtcPeerListenerCleanupResult {
+  readonly run: number;
+}
+interface CreateRtcPeerListenerCleanupSampleInput {
+  readonly identity: RtcBaselineSampleIdentityDto;
+  readonly outcome: 'passed' | 'failed' | 'not-run';
+  readonly rawEvidence: RtcPeerListenerCleanupResult | null;
+  readonly issues: RtcBaselineSampleDto['issues'];
+}
 
-type BenchResult = Readonly<{
-    run: number;
-    durationMs: number;
-    peerCount: number;
-    retainedIceGatheringListeners: number;
-    maxListenersPerPeer: number;
-    unclearedHandlerSlots: number;
-}>;
+const acceptedNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-inner-runs',
+  'rtc-peers',
+];
 
-const OUT = readArg('--out') ??
-    'tmp/perf/results/rtc-peer-listener-cleanup.json';
-const PEERS = Number(readArg('--peers') ?? '10000');
-const RUNS = Number(readArg('--runs') ?? '5');
-const writeLine = console.log.bind(console);
+export function parseRtcPeerListenerCleanupArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['peers', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
 
-console.log = () => {
-};
+export function createRtcPeerListenerCleanupSamples(input: {
+  worker: AcceptedArguments;
+  results: readonly RtcPeerListenerCleanupResult[];
+}): RtcBaselineSampleDto[] {
+  let priorFailureId: string | undefined;
+  return input.worker.sampleIds.map((sampleId, index) => {
+    const identity = createIdentity(input.worker, sampleId, index + 1);
+    const result = input.results[index];
+    if (priorFailureId !== undefined || result === undefined) {
+      return createSample({
+        identity,
+        outcome: 'not-run',
+        rawEvidence: null,
+        issues: [
+          rtcBaselineIssue(
+            '$.rawEvidence',
+            'causal-not-run',
+            priorFailureId ?? 'Missing inner run.',
+          ),
+        ],
+      });
+    }
+    const issues = validateResult(input.worker.input, result);
+    if (issues.length > 0) priorFailureId = sampleId;
+    return createSample({
+      identity,
+      outcome: issues.length === 0 ? 'passed' : 'failed',
+      rawEvidence: result,
+      issues,
+    });
+  });
+}
+
+export async function runRtcPeerListenerCleanupAcceptedSamples(input: {
+  worker: AcceptedArguments;
+  run: () => Promise<RtcPeerListenerCleanupResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const results: RtcPeerListenerCleanupResult[] = [];
+  for (let run = 0; run < input.worker.input.runs; run += 1) {
+    const result = await input.run();
+    results.push(result);
+    if (validateResult(input.worker.input, result).length > 0) break;
+  }
+  return createRtcPeerListenerCleanupSamples({ worker: input.worker, results });
+}
+
+async function main(): Promise<void> {
+  const parsed = parseRtcPeerListenerCleanupArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  const originalPeerConnection = globalThis.RTCPeerConnection;
+  Reflect.set(globalThis, 'RTCPeerConnection', FakeRTCPeerConnection);
+  try {
+    if (parsed.value.mode === 'accepted') {
+      const samples = await runRtcPeerListenerCleanupAcceptedSamples({
+        worker: parsed.value,
+        run: async () => runListenerCleanup(parsed.value.input.peers),
+      });
+      writeLine(JSON.stringify(samples));
+      return;
+    }
+    const results: BenchResult[] = [];
+    for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+      results.push({ run, ...runListenerCleanup(parsed.value.input.peers) });
+    }
+    await Deno.writeTextFile(
+      parsed.value.out,
+      JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          input: { peerCount: parsed.value.input.peers, runs: parsed.value.input.runs },
+          results,
+        },
+        null,
+        2,
+      ),
+      { createNew: true },
+    );
+    writeLine(`Wrote ${parsed.value.out}`);
+  } finally {
+    Reflect.set(globalThis, 'RTCPeerConnection', originalPeerConnection);
+  }
+}
+
+function runListenerCleanup(peers: number): RtcPeerListenerCleanupResult {
+  FakeRTCPeerConnection.instances = [];
+  const startedAt = performance.now();
+  for (let index = 0; index < peers; index += 1) {
+    const peer = new QRtcPeerConnection(
+      { send: async () => {} },
+      {
+        sessionId: `self-${index}`,
+        token: 'token',
+        peerSessionId: `peer-${index}`,
+        iceCandidates: { iceServers: [], expiresAtEpochMs: Date.now() + 60_000 },
+        isPolite: true,
+      },
+    );
+    peer.connect();
+    peer.reset();
+  }
+  const durationMs = performance.now() - startedAt;
+  const listenerCounts = FakeRTCPeerConnection.instances.map((peer) =>
+    peer.listenerCount('icegatheringstatechange'),
+  );
+  return {
+    durationMs,
+    peerCount: peers,
+    retainedIceGatheringListeners: listenerCounts.reduce((sum, count) => sum + count, 0),
+    maxListenersPerPeer: Math.max(...listenerCounts),
+    unclearedHandlerSlots: FakeRTCPeerConnection.instances.reduce(
+      (sum, peer) => sum + peer.unclearedHandlerSlotCount(),
+      0,
+    ),
+  };
+}
+
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const out = options.out ?? 'tmp/perf/results/rtc-peer-listener-cleanup.json';
+  const outComponents = out.split('/');
+  const validOut =
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    outComponents.every((component) => component !== '' && component !== '.' && component !== '..');
+  const peers = parseRtcBaselineBoundedInteger(options.peers ?? '10000', 'peers', 1, 10000);
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  if (!peers.ok || !runs.ok || !validOut) {
+    return {
+      ok: false as const,
+      issues: [
+        ...(!peers.ok ? peers.issues : []),
+        ...(!runs.ok ? runs.issues : []),
+        ...(!validOut
+          ? [rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.')]
+          : []),
+      ],
+    };
+  }
+  return {
+    ok: true as const,
+    value: {
+      mode: 'diagnostic' as const,
+      input: { peers: peers.value, runs: runs.value },
+      out,
+    },
+  };
+}
+
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = outer.ok ? [] : [...outer.issues];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B01',
+    'case-id': 'peer-listener-cleanup',
+    'input-key': 'peers-10000',
+    'rtc-inner-runs': '5',
+    'rtc-peers': '10000',
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
+    }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(phase === 'warmup' ? phase : 'retained', ordinal);
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { peers: 10000, runs: 5 },
+          baselineId: options['baseline-id']!,
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
+}
+
+function createExpectedSampleIds(phase: string, outerOrdinal: number): string[] {
+  const attemptPrefix =
+    `rtc-b01-peer-listener-cleanup-peers-10000-${phase}-` + String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${attemptPrefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function createIdentity(
+  worker: AcceptedArguments,
+  sampleId: string,
+  innerOrdinal: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId,
+    workloadId: 'RTC-B01' as const,
+    caseId: 'peer-listener-cleanup',
+    inputKey: 'peers-10000',
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal,
+  };
+}
+
+function createSample(sampleInput: CreateRtcPeerListenerCleanupSampleInput): RtcBaselineSampleDto {
+  const { identity, outcome, rawEvidence, issues } = sampleInput;
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome,
+    evidenceClass: 'synthetic-path',
+    metrics: rawEvidence
+      ? [{ metric: 'durationMs', unit: 'ms', value: rawEvidence.durationMs }]
+      : [],
+    rawEvidence: rawEvidence === null ? null : createRawEvidence(rawEvidence),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(input: ListenerInput, result: RtcPeerListenerCleanupResult) {
+  const issues = [];
+  if (result.peerCount !== input.peers) {
+    issues.push(rtcBaselineIssue('$.rawEvidence.peerCount', 'counter-mismatch', 'Unexpected.'));
+  }
+  for (const name of [
+    'retainedIceGatheringListeners',
+    'maxListenersPerPeer',
+    'unclearedHandlerSlots',
+  ] as const) {
+    if (result[name] !== 0) {
+      issues.push(rtcBaselineIssue(`$.rawEvidence.${name}`, 'cleanup-nonzero', 'Expected 0.'));
+    }
+  }
+  return issues;
+}
+
+function createRawEvidence(result: RtcPeerListenerCleanupResult): RtcBaselineJson {
+  return {
+    durationMs: result.durationMs,
+    peerCount: result.peerCount,
+    retainedIceGatheringListeners: result.retainedIceGatheringListeners,
+    maxListenersPerPeer: result.maxListenersPerPeer,
+    unclearedHandlerSlots: result.unclearedHandlerSlots,
+  };
+}
 
 class FakeRTCPeerConnection {
-    static instances: FakeRTCPeerConnection[] = [];
-
-    connectionState: RTCPeerConnectionState = 'new';
-    signalingState: RTCSignalingState = 'stable';
-    iceConnectionState: RTCIceConnectionState = 'new';
-    iceGatheringState: RTCIceGatheringState = 'new';
-    localDescription: RTCSessionDescription | null = null;
-
-    onnegotiationneeded: (() => Promise<void>) | null = null;
-    onicecandidate:
-        | ((event: { candidate: RTCIceCandidateInit | null }) => Promise<void>)
-        | null = null;
-    ondatachannel: ((event: RTCDataChannelEvent) => Promise<void>) | null = null;
-    ontrack: ((event: RTCTrackEvent) => Promise<void>) | null = null;
-    oniceconnectionstatechange: (() => void) | null = null;
-    onsignalingstatechange: (() => void) | null = null;
-    onconnectionstatechange: (() => void) | null = null;
-
-    private readonly listeners = new Map<string, Listener[]>();
-
-    constructor(_configuration: RTCConfiguration) {
-        FakeRTCPeerConnection.instances.push(this);
-    }
-
-    addEventListener(type: string, listener: Listener): void {
-        const listeners = this.listeners.get(type) ?? [];
-        listeners.push(listener);
-        this.listeners.set(type, listeners);
-    }
-
-    removeEventListener(type: string, listener: Listener): void {
-        const listeners = this.listeners.get(type);
-        if (!listeners) {
-            return;
-        }
-
-        const index = listeners.indexOf(listener);
-        if (index >= 0) {
-            listeners.splice(index, 1);
-        }
-        if (listeners.length === 0) {
-            this.listeners.delete(type);
-        }
-    }
-
-    listenerCount(type: string): number {
-        return this.listeners.get(type)?.length ?? 0;
-    }
-
-    unclearedHandlerSlotCount(): number {
-        return [
-            this.onnegotiationneeded,
-            this.onicecandidate,
-            this.ondatachannel,
-            this.ontrack,
-            this.oniceconnectionstatechange,
-            this.onsignalingstatechange,
-            this.onconnectionstatechange,
-        ].filter((handler) => handler !== null).length;
-    }
-
-    getTransceivers(): Array<{ stop: () => void }> {
-        return [];
-    }
-
-    createDataChannel(_label: string): RTCDataChannel {
-        return {} as RTCDataChannel;
-    }
-
-    close(): void {
-        this.connectionState = 'closed';
-    }
-
-    setLocalDescription(): Promise<void> {
-        this.localDescription = {
-            type: 'offer',
-            sdp: 'offer-sdp',
-            toJSON: () => ({ type: 'offer', sdp: 'offer-sdp' }),
-        };
-        return Promise.resolve();
-    }
+  static instances: FakeRTCPeerConnection[] = [];
+  connectionState: RTCPeerConnectionState = 'new';
+  signalingState: RTCSignalingState = 'stable';
+  iceConnectionState: RTCIceConnectionState = 'new';
+  iceGatheringState: RTCIceGatheringState = 'new';
+  localDescription: RTCSessionDescription | null = null;
+  onnegotiationneeded: (() => Promise<void>) | null = null;
+  onicecandidate: ((event: { candidate: RTCIceCandidateInit | null }) => Promise<void>) | null =
+    null;
+  ondatachannel: ((event: RTCDataChannelEvent) => Promise<void>) | null = null;
+  ontrack: ((event: RTCTrackEvent) => Promise<void>) | null = null;
+  oniceconnectionstatechange: (() => void) | null = null;
+  onsignalingstatechange: (() => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  private readonly listeners = new Map<string, Listener[]>();
+  constructor(_configuration: RTCConfiguration) {
+    FakeRTCPeerConnection.instances.push(this);
+  }
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+  removeEventListener(type: string, listener: Listener): void {
+    const listeners = (this.listeners.get(type) ?? []).filter((value) => value !== listener);
+    if (listeners.length === 0) this.listeners.delete(type);
+    else this.listeners.set(type, listeners);
+  }
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.length ?? 0;
+  }
+  unclearedHandlerSlotCount(): number {
+    return [
+      this.onnegotiationneeded,
+      this.onicecandidate,
+      this.ondatachannel,
+      this.ontrack,
+      this.oniceconnectionstatechange,
+      this.onsignalingstatechange,
+      this.onconnectionstatechange,
+    ].filter((handler) => handler !== null).length;
+  }
+  getTransceivers(): Array<{ stop: () => void }> {
+    return [];
+  }
+  createDataChannel(_label: string): RTCDataChannel {
+    return {} as RTCDataChannel;
+  }
+  close(): void {
+    this.connectionState = 'closed';
+  }
+  setLocalDescription(): Promise<void> {
+    this.localDescription = { type: 'offer', sdp: 'offer-sdp' } as RTCSessionDescription;
+    return Promise.resolve();
+  }
 }
 
-(globalThis as unknown as { RTCPeerConnection: typeof FakeRTCPeerConnection })
-    .RTCPeerConnection = FakeRTCPeerConnection;
-
-const results: BenchResult[] = [];
-
-for (let run = 1; run <= RUNS; run++) {
-    FakeRTCPeerConnection.instances = [];
-    const start = performance.now();
-
-    for (let index = 0; index < PEERS; index++) {
-        const peer = new QRtcPeerConnection(
-            {
-                send: async () => {
-                },
-            },
-            {
-                sessionId: `self-${index}`,
-                token: 'token',
-                peerSessionId: `peer-${index}`,
-                iceCandidates: {
-                    iceServers: [],
-                    expiresAtEpochMs: Date.now() + 60_000,
-                },
-                isPolite: true,
-            },
-        );
-        peer.connect();
-        peer.reset();
-    }
-
-    const durationMs = performance.now() - start;
-    const retainedIceGatheringListeners = FakeRTCPeerConnection.instances
-        .reduce(
-            (sum, pc) => sum + pc.listenerCount('icegatheringstatechange'),
-            0,
-        );
-    results.push({
-        run,
-        durationMs,
-        peerCount: PEERS,
-        retainedIceGatheringListeners,
-        maxListenersPerPeer: Math.max(
-            ...FakeRTCPeerConnection.instances.map((pc) =>
-                pc.listenerCount('icegatheringstatechange')
-            ),
-        ),
-        unclearedHandlerSlots: FakeRTCPeerConnection.instances.reduce(
-            (sum, pc) => sum + pc.unclearedHandlerSlotCount(),
-            0,
-        ),
-    });
-}
-
-await Deno.writeTextFile(
-    OUT,
-    JSON.stringify({
-        createdAt: new Date().toISOString(),
-        input: {
-            peerCount: PEERS,
-            runs: RUNS,
-        },
-        results,
-    }, null, 2),
-);
-
-writeLine(`Wrote ${OUT}`);
-
-function readArg(name: string): string | undefined {
-    return Deno.args.find((arg) => arg.startsWith(`${name}=`))
-        ?.slice(name.length + 1);
-}
+if (import.meta.main) await main();


### PR DESCRIPTION
## Summary

- builds on the RTC foundation merged in PR #150
- adds the RTC-B01 signaling, ICE, and listener lifecycle diagnostics runtime with explicit fake-peer dependencies
- preserves the three diagnostic CLIs and adds only the common accepted-capture boundary
- records raw counters and cleanup state, validates frozen identities and bounds, recomputes counters, stops after persisted failure, and keeps diagnostic output separate from accepted evidence

## RTC baseline status

- B01 is green
- B02-B05 remain pending
- every other RTC hold remains active
- no benchmark was run and no performance result is claimed

## Validation

- intended RED: `npx vitest run packages/tests/repo/rtc-performance-baseline-harnesses.test.ts -t "RTC-B01"` failed because the B01 runtime/accepted behavior was absent
- B01 harness tests: 5 passed, 2 skipped by filter
- `qrtc-peer-connection` and `webrtc-connection-service`: 30 passed
- exact 18 RTC foundation files: 255 passed
- configured Deno check over the foundation and four B01 files: passed
- `npm run test:unit`: 7,518 passed, 3 skipped
- `npm run test:ci`: passed, including Deno, Playwright, and full-stack memory phases
- `npm run build`: passed across all workspaces
- Prettier, `git diff --check`, changed-style, and the 400-physical-line gate: passed

## Scope and guardrails

- approved plan blob: `d977a6495cffee240d7484a7f238533afc5feacf`
- foundation merge commit: `f43c1881e684fd2a423b0993c4389d969c264311`
- no workloads, evidence rules, environments, reservations, or holds changed
- no B02-B07, optimization, README, production RTC, raw-artifact publication, or Phase 2 work is included
