### PR TITLE
feat(black-box): W2 — generic http.poll-until step

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -219,7 +219,7 @@ Use HTTP steps for REST API calls and ordinary fetch-compatible network checks.
 
 Common fields:
 
-- `type`: `http` or `http.request`
+- `type`: `http`, `http.request`, or `http.poll-until`
 - `connection`: optional connection name from `connections`
 - `request.method`: HTTP method, defaulting to `GET`
 - `request.path` or `request.url`: endpoint path or absolute URL
@@ -271,6 +271,52 @@ Accepted status arrays are useful for idempotent operations:
         "code": "already-exists"
       }
     ]
+  }
+}
+```
+
+An `http.poll-until` step repeats the same request until its own `expect`
+passes, with exponential backoff between attempts. `request.poll` reuses the
+retry field names and adds one duration bound:
+
+- `poll.maxAttempts`: attempt bound, default `10`
+- `poll.maxDurationMs`: elapsed-time bound, default `15000`
+- `poll.backoffMs`: initial backoff, default `100`
+- `poll.backoffMultiplier`: exponential factor, default `2`
+
+Success is the step's own `expect` passing. Exhausting either bound fails the
+step with the last attempt's result plus `pollAttempts`, `pollExhausted`, and
+`pollElapsedMs` report fields. A connection error counts as a failed attempt
+and polling continues within the bounds. `request.retry` still applies inside
+each individual attempt (transport retry), so keep it minimal on polled steps.
+Use `http.poll-until` for read-your-writes and convergence reads instead of
+hand-unrolled `nonBlockingFailure` poll rounds when the poll is one HTTP
+request; rounds that fan out over `parallel` groups stay explicit.
+
+```json
+{
+  "name": "pollGroupConverged",
+  "type": "http.poll-until",
+  "connection": "api",
+  "request": {
+    "method": "GET",
+    "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}",
+    "headers": {
+      "Authorization": "{ownerAuthHeader}",
+      "x-client-id": "{ownerClientId}"
+    },
+    "poll": {
+      "maxAttempts": 8,
+      "maxDurationMs": 10000,
+      "backoffMs": 100,
+      "backoffMultiplier": 2
+    }
+  },
+  "expect": {
+    "status": 200,
+    "body": {
+      "onlineMemberCount": 13
+    }
   }
 }
 ```

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -33,6 +33,11 @@ import {
 } from './rallar-remote-browser-provider.ts';
 import type { RallarBlackBoxTestCommand } from '../rallar-bb-test/types.ts';
 import { normalizeBlackBoxResponseHeaders } from './http/normalize-black-box-response-headers.ts';
+import { executeHttpInteraction } from './http/execute-http-interaction.ts';
+import {
+    toHttpInteractionStatus,
+    toStatus,
+} from './http/http-response-expectations.ts';
 import {
     directSafeOutputTransformSpec,
     evaluateSafeOutputTransform,
@@ -706,124 +711,6 @@ function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function toRetryPolicy(request: any): any {
-    const retry = request?.resilience?.retry || request?.retry || {};
-
-    return {
-        maxAttempts: Number.parseInt(retry.maxAttempts || 1),
-        backoffMs: Number.parseInt(retry.backoffMs || 0),
-        backoffMultiplier: Number.parseFloat(retry.backoffMultiplier || 1),
-        onStatus: retry.onStatus || [],
-        onException: retry.onException !== false,
-    };
-}
-
-function shouldRetryStatus(response: any, retryPolicy: any): boolean {
-    return retryPolicy.onStatus
-        .map((status: any) => Number.parseInt(status))
-        .includes(response.status);
-}
-
-function toBackoffMs(retryPolicy: any, attemptNumber: number): number {
-    return retryPolicy.backoffMs * Math.pow(retryPolicy.backoffMultiplier, attemptNumber - 1);
-}
-
-async function fetchWithRetry(request: any): Promise<any> {
-    const retryPolicy = toRetryPolicy(request);
-    const maxAttempts = Number.isFinite(retryPolicy.maxAttempts) && retryPolicy.maxAttempts > 0
-        ? retryPolicy.maxAttempts
-        : 1;
-
-    let lastException: any;
-
-    for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
-        try {
-            const response = await fetchDataBasic(request) as any;
-
-            response.blackBoxAttemptNumber = attemptNumber;
-            response.blackBoxMaxAttempts = maxAttempts;
-
-            if (attemptNumber < maxAttempts && shouldRetryStatus(response, retryPolicy)) {
-                const backoffMs = toBackoffMs(retryPolicy, attemptNumber);
-                if (backoffMs > 0) {
-                    await sleep(backoffMs);
-                }
-                continue;
-            }
-
-            return response;
-        } catch (e) {
-            lastException = e instanceof Error
-                ? e
-                : new Error(String(e));
-
-            lastException.blackBoxAttemptNumber = attemptNumber;
-            lastException.blackBoxMaxAttempts = maxAttempts;
-
-            if (!retryPolicy.onException || attemptNumber >= maxAttempts) {
-                throw lastException;
-            }
-
-            const backoffMs = toBackoffMs(retryPolicy, attemptNumber);
-            if (backoffMs > 0) {
-                await sleep(backoffMs);
-            }
-        }
-    }
-
-    throw lastException || new Error('Request failed without response');
-}
-
-function toBody(request: any): BodyInit | undefined {
-    if (request.form) {
-        return new URLSearchParams(request.form);
-    }
-
-    return request.body && request.method !== undefined && request.method !== 'GET'
-        ? JSON.stringify(request.body)
-        : undefined;
-}
-
-async function toJson(res: Response): Promise<any> {
-    return res.json()
-        .catch(() => {
-            return {};
-        });
-}
-
-function toStatus(
-    config: any,
-    result: string,
-    actualJson: any,
-    res: any,
-    interaction: any,
-    results: any = {},
-): any {
-    return {
-        name: config.interactionName,
-        status: FAILURE,
-        result,
-        ...toCorrelationReportFields(interaction),
-        method: interaction.request.method || 'GET',
-        path: interaction.request.path,
-        timeoutMs: interaction.request.timeoutMs,
-        attemptNumber: res.blackBoxAttemptNumber,
-        maxAttempts: res.blackBoxMaxAttempts,
-        scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
-        interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
-        repeatIndex: config.interaction.request.repeatIndex,
-        expected: interaction.response,
-        actual: {
-            body: actualJson,
-            headers: normalizeBlackBoxResponseHeaders(res.headers),
-            statusCode: res.status,
-            statusText: res.statusText,
-        },
-        details: results,
-        ...config,
-    };
-}
-
 function toOutputReportFields(interaction: any): any {
     return {
         output: interaction.request.output,
@@ -834,124 +721,6 @@ function toOutputReportFields(interaction: any): any {
         redact: interaction.request.redact,
         redactAs: interaction.request.redactAs,
     };
-}
-
-function toSuccessStatus(config: any, actualJson: any, response: any, interaction: any): any {
-    return {
-        name: config.interactionName,
-        status: SUCCESS,
-        ...toCorrelationReportFields(interaction),
-        method: interaction.request.method,
-        path: interaction.request.path,
-        timeoutMs: interaction.request.timeoutMs,
-        attemptNumber: response.blackBoxAttemptNumber,
-        maxAttempts: response.blackBoxMaxAttempts,
-        scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
-        interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
-        repeatIndex: config.interaction.request.repeatIndex,
-        expected: interaction.response,
-        actual: {
-            body: actualJson,
-            headers: normalizeBlackBoxResponseHeaders(response.headers),
-            statusCode: response.status,
-            statusText: response.statusText,
-        },
-        ...toOutputReportFields(interaction),
-        input: interaction.request.input,
-    };
-}
-
-function toNumberList(value: unknown): number[] {
-    if (Array.isArray(value)) {
-        return value
-            .map(item => Number.parseInt(String(item), 10))
-            .filter(item => Number.isFinite(item));
-    }
-
-    if (typeof value === 'string' && value.includes(',')) {
-        return toNumberList(value.split(','));
-    }
-
-    if (value !== undefined && value !== null) {
-        const parsed = Number.parseInt(String(value), 10);
-        return Number.isFinite(parsed)
-            ? [parsed]
-            : [];
-    }
-
-    return [];
-}
-
-function expectedHttpStatusCodes(response: any): number[] {
-    return [
-        ...toNumberList(response?.statusCode),
-        ...toNumberList(response?.status),
-        ...toNumberList(response?.statusCodes),
-        ...toNumberList(response?.allowedStatusCodes),
-    ];
-}
-
-function bodyExpectationAlternatives(response: any): any[] {
-    const alternatives = response?.bodyAnyOf ?? response?.anyBodyOf ?? response?.bodyIn;
-
-    return Array.isArray(alternatives)
-        ? alternatives
-        : [];
-}
-
-function compareExpectedBody(expectedBody: any, actualJson: any, interaction: any): any {
-    return compareJson(
-        expectedBody,
-        actualJson,
-        toConfig(
-            interaction.response?.comparison || COMPARISON.COMPATIBLE,
-            interaction.response?.ignoreJsonKeys || [],
-            interaction.response?.ignoreJsonPaths || [],
-        ),
-    );
-}
-
-function toHttpInteractionStatus(config: any, interaction: any, response: any, actualJson: any): any {
-    const expectedStatuses = expectedHttpStatusCodes(interaction.response);
-    const hasExpectedStatus = expectedStatuses.length > 0;
-
-    if (hasExpectedStatus && !expectedStatuses.includes(Number.parseInt(String(response.status), 10))) {
-        return toStatus(config, 'Expected responseCode not the same as actual responseCode', actualJson, response, interaction, {
-            expectedStatusCodes: expectedStatuses,
-        });
-    }
-
-    if (!response.ok && !hasExpectedStatus) {
-        return toStatus(config, 'Server request failed.', actualJson, response, interaction);
-    }
-
-    const bodyAlternatives = bodyExpectationAlternatives(interaction.response);
-    if (bodyAlternatives.length > 0) {
-        if (actualJson === undefined || actualJson === null) {
-            return toStatus(config, 'Server with no body in response. Expects a body.', actualJson, response, interaction);
-        }
-
-        const comparisons = bodyAlternatives.map(expectedBody => compareExpectedBody(expectedBody, actualJson, interaction));
-        const matchedIndex = comparisons.findIndex(result => result.isEqual);
-        if (matchedIndex < 0) {
-            return toStatus(config, 'Expected response not to match any accepted response body', actualJson, response, interaction, {
-                bodyAnyOf: bodyAlternatives,
-                comparisons,
-            });
-        }
-    } else if (interaction?.response?.body !== undefined) {
-        if (actualJson === undefined || actualJson === null) {
-            return toStatus(config, 'Server with no body in response. Expects a body.', actualJson, response, interaction);
-        }
-
-        const results = compareExpectedBody(interaction.response.body, actualJson, interaction);
-
-        if (!results.isEqual) {
-            return toStatus(config, 'Expected response not the same as actual response', actualJson, response, interaction, results);
-        }
-    }
-
-    return toSuccessStatus(config, actualJson, response, interaction);
 }
 
 function toInteractionName(interactionWithConfig: any): string {
@@ -2534,32 +2303,6 @@ function toReport(context: any, options: any, startedAtEpochMs: number, endedAtE
     }, context.redactions);
 }
 
-function fetchDataBasic(request: any): Promise<Response> {
-    const controller = request.timeoutMs
-        ? new AbortController()
-        : undefined;
-
-    const timeout = request.timeoutMs
-        ? setTimeout(() => controller?.abort(), Number.parseInt(request.timeoutMs))
-        : undefined;
-
-    return fetch(
-        request.path,
-        {
-            method: request.method,
-            credentials: request.credentials ? request.credentials : 'omit',
-            mode: request.mode ? request.mode : 'cors',
-            headers: request.headers,
-            body: toBody(request),
-            signal: controller?.signal,
-        },
-    ).finally(() => {
-        if (timeout) {
-            clearTimeout(timeout);
-        }
-    });
-}
-
 function isDryRunExecution(interaction: any, config: any, context: any): boolean {
     return interaction?.request?.dryRun === true
         || interaction?.dryRun === true
@@ -2805,30 +2548,7 @@ function executeInteraction(interactionWithConfig: any, context: any): Promise<a
         return executeRemoteHttpInteraction(interaction, config, context);
     }
 
-    return fetchWithRetry(interaction.request)
-        .then(async response => {
-            const actualJson = await toJson(response);
-            return toHttpInteractionStatus(config, interaction, response, actualJson);
-        })
-        .catch(e => {
-            return {
-                name: config.interactionName,
-                exception: e?.name === 'AbortError'
-                    ? 'Request timed out after ' + interaction.request.timeoutMs + ' ms'
-                    : e?.message,
-                status: FAILURE,
-                ...toCorrelationReportFields(interaction),
-                method: interaction.request.method || 'GET',
-                path: interaction.request.path,
-                timeoutMs: interaction.request.timeoutMs,
-                attemptNumber: e.blackBoxAttemptNumber,
-                maxAttempts: e.blackBoxMaxAttempts,
-                scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
-                interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
-                repeatIndex: config.interaction.request.repeatIndex,
-                ...config,
-            };
-        });
+    return executeHttpInteraction(interaction, config);
 }
 
 function toParallelFailureStatus(config: any, interaction: any, result: string, details: any = {}): any {

--- a/packages/shared-test/black-box-runner/http/execute-http-interaction.ts
+++ b/packages/shared-test/black-box-runner/http/execute-http-interaction.ts
@@ -1,0 +1,242 @@
+// deno-lint-ignore-file no-explicit-any
+import { toHttpInteractionStatus } from './http-response-expectations.ts';
+
+const SUCCESS = 'SUCCESS';
+const FAILURE = 'FAILURE';
+
+function isRecord(value: any): value is Record<string, any> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toCorrelationReportFields(interaction: any): any {
+    const correlation = interaction?.request?.correlation;
+    if (!correlation) {
+        return {};
+    }
+
+    return {
+        runnerRunId: correlation.runnerRunId,
+        runnerStepId: correlation.runnerStepId,
+        correlation,
+    };
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function toRetryPolicy(request: any): any {
+    const retry = request?.resilience?.retry || request?.retry || {};
+
+    return {
+        maxAttempts: Number.parseInt(retry.maxAttempts || 1),
+        backoffMs: Number.parseInt(retry.backoffMs || 0),
+        backoffMultiplier: Number.parseFloat(retry.backoffMultiplier || 1),
+        onStatus: retry.onStatus || [],
+        onException: retry.onException !== false,
+    };
+}
+
+function shouldRetryStatus(response: any, retryPolicy: any): boolean {
+    return retryPolicy.onStatus
+        .map((status: any) => Number.parseInt(status))
+        .includes(response.status);
+}
+
+function toBackoffMs(retryPolicy: any, attemptNumber: number): number {
+    return retryPolicy.backoffMs * Math.pow(retryPolicy.backoffMultiplier, attemptNumber - 1);
+}
+
+async function fetchWithRetry(request: any): Promise<any> {
+    const retryPolicy = toRetryPolicy(request);
+    const maxAttempts = Number.isFinite(retryPolicy.maxAttempts) && retryPolicy.maxAttempts > 0
+        ? retryPolicy.maxAttempts
+        : 1;
+
+    let lastException: any;
+
+    for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
+        try {
+            const response = await fetchDataBasic(request) as any;
+
+            response.blackBoxAttemptNumber = attemptNumber;
+            response.blackBoxMaxAttempts = maxAttempts;
+
+            if (attemptNumber < maxAttempts && shouldRetryStatus(response, retryPolicy)) {
+                const backoffMs = toBackoffMs(retryPolicy, attemptNumber);
+                if (backoffMs > 0) {
+                    await sleep(backoffMs);
+                }
+                continue;
+            }
+
+            return response;
+        } catch (e) {
+            lastException = e instanceof Error
+                ? e
+                : new Error(String(e));
+
+            lastException.blackBoxAttemptNumber = attemptNumber;
+            lastException.blackBoxMaxAttempts = maxAttempts;
+
+            if (!retryPolicy.onException || attemptNumber >= maxAttempts) {
+                throw lastException;
+            }
+
+            const backoffMs = toBackoffMs(retryPolicy, attemptNumber);
+            if (backoffMs > 0) {
+                await sleep(backoffMs);
+            }
+        }
+    }
+
+    throw lastException || new Error('Request failed without response');
+}
+
+function toBody(request: any): BodyInit | undefined {
+    if (request.form) {
+        return new URLSearchParams(request.form);
+    }
+
+    return request.body && request.method !== undefined && request.method !== 'GET'
+        ? JSON.stringify(request.body)
+        : undefined;
+}
+
+async function toJson(res: Response): Promise<any> {
+    return res.json()
+        .catch(() => {
+            return {};
+        });
+}
+
+function fetchDataBasic(request: any): Promise<Response> {
+    const controller = request.timeoutMs
+        ? new AbortController()
+        : undefined;
+
+    const timeout = request.timeoutMs
+        ? setTimeout(() => controller?.abort(), Number.parseInt(request.timeoutMs))
+        : undefined;
+
+    return fetch(
+        request.path,
+        {
+            method: request.method,
+            credentials: request.credentials ? request.credentials : 'omit',
+            mode: request.mode ? request.mode : 'cors',
+            headers: request.headers,
+            body: toBody(request),
+            signal: controller?.signal,
+        },
+    ).finally(() => {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+    });
+}
+
+function toHttpExceptionStatus(config: any, interaction: any, error: any): any {
+    return {
+        name: config.interactionName,
+        exception: error?.name === 'AbortError'
+            ? 'Request timed out after ' + interaction.request.timeoutMs + ' ms'
+            : error?.message,
+        status: FAILURE,
+        ...toCorrelationReportFields(interaction),
+        method: interaction.request.method || 'GET',
+        path: interaction.request.path,
+        timeoutMs: interaction.request.timeoutMs,
+        attemptNumber: error.blackBoxAttemptNumber,
+        maxAttempts: error.blackBoxMaxAttempts,
+        scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
+        interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
+        repeatIndex: config.interaction.request.repeatIndex,
+        ...config,
+    };
+}
+
+function executeSingleHttpAttempt(interaction: any, config: any): Promise<any> {
+    return fetchWithRetry(interaction.request)
+        .then(async response => {
+            const actualJson = await toJson(response);
+            return toHttpInteractionStatus(config, interaction, response, actualJson);
+        })
+        .catch(e => {
+            return toHttpExceptionStatus(config, interaction, e);
+        });
+}
+
+function isPollUntilHttpRequest(request: any): boolean {
+    return String(request?.action || '').toLowerCase() === 'poll-until' ||
+        isRecord(request?.poll);
+}
+
+function toPollUntilPolicy(request: any): any {
+    const poll = isRecord(request?.poll) ? request.poll : {};
+
+    return {
+        maxAttempts: Number.parseInt(String(poll.maxAttempts ?? 10), 10),
+        maxDurationMs: Number.parseInt(String(poll.maxDurationMs ?? 15000), 10),
+        backoffMs: Number.parseInt(String(poll.backoffMs ?? 100), 10),
+        backoffMultiplier: Number.parseFloat(String(poll.backoffMultiplier ?? 2)),
+    };
+}
+
+function withPollReportFields(status: any, poll: any): any {
+    return {
+        ...status,
+        pollAttempts: poll.attempts,
+        pollExhausted: poll.exhausted,
+        pollElapsedMs: poll.elapsedMs,
+    };
+}
+
+// Success is the step's own expect passing; exhaustion of either bound is a
+// failure carrying the last attempt's status.
+async function executePollUntilHttp(interaction: any, config: any): Promise<any> {
+    const policy = toPollUntilPolicy(interaction.request);
+    const startedAtEpochMs = Date.now();
+    let lastStatus: any;
+
+    for (let attemptNumber = 1; attemptNumber <= policy.maxAttempts; attemptNumber++) {
+        lastStatus = await executeSingleHttpAttempt(interaction, config);
+
+        if (lastStatus?.status === SUCCESS) {
+            return withPollReportFields(lastStatus, {
+                attempts: attemptNumber,
+                exhausted: false,
+                elapsedMs: Date.now() - startedAtEpochMs,
+            });
+        }
+
+        const backoffMs = toBackoffMs(
+            { backoffMs: policy.backoffMs, backoffMultiplier: policy.backoffMultiplier },
+            attemptNumber,
+        );
+        const elapsedMs = Date.now() - startedAtEpochMs;
+        if (attemptNumber >= policy.maxAttempts || elapsedMs + backoffMs > policy.maxDurationMs) {
+            return withPollReportFields(lastStatus, {
+                attempts: attemptNumber,
+                exhausted: true,
+                elapsedMs,
+            });
+        }
+
+        await sleep(backoffMs);
+    }
+
+    return withPollReportFields(lastStatus, {
+        attempts: policy.maxAttempts,
+        exhausted: true,
+        elapsedMs: Date.now() - startedAtEpochMs,
+    });
+}
+
+export function executeHttpInteraction(interaction: any, config: any): Promise<any> {
+    if (isPollUntilHttpRequest(interaction.request)) {
+        return executePollUntilHttp(interaction, config);
+    }
+
+    return executeSingleHttpAttempt(interaction, config);
+}

--- a/packages/shared-test/black-box-runner/http/http-response-expectations.ts
+++ b/packages/shared-test/black-box-runner/http/http-response-expectations.ts
@@ -1,0 +1,222 @@
+// deno-lint-ignore-file no-explicit-any
+import { compareJson, COMPARISON, toConfig } from '../../json-compare/CompareJson.ts';
+import { normalizeBlackBoxResponseHeaders } from './normalize-black-box-response-headers.ts';
+
+const SUCCESS = 'SUCCESS';
+const FAILURE = 'FAILURE';
+
+function toOutputReportFields(interaction: any): any {
+    return {
+        output: interaction.request.output,
+        outputPath: interaction.request.outputPath,
+        outputs: interaction.request.outputs,
+        transform: interaction.request.transform,
+        secret: interaction.request.secret,
+        redact: interaction.request.redact,
+        redactAs: interaction.request.redactAs,
+    };
+}
+
+function toCorrelationReportFields(interaction: any): any {
+    const correlation = interaction?.request?.correlation;
+    if (!correlation) {
+        return {};
+    }
+
+    return {
+        runnerRunId: correlation.runnerRunId,
+        runnerStepId: correlation.runnerStepId,
+        correlation,
+    };
+}
+
+export function toStatus(
+    config: any,
+    result: string,
+    actualJson: any,
+    res: any,
+    interaction: any,
+    results: any = {},
+): any {
+    return {
+        name: config.interactionName,
+        status: FAILURE,
+        result,
+        ...toCorrelationReportFields(interaction),
+        method: interaction.request.method || 'GET',
+        path: interaction.request.path,
+        timeoutMs: interaction.request.timeoutMs,
+        attemptNumber: res.blackBoxAttemptNumber,
+        maxAttempts: res.blackBoxMaxAttempts,
+        scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
+        interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
+        repeatIndex: config.interaction.request.repeatIndex,
+        expected: interaction.response,
+        actual: {
+            body: actualJson,
+            headers: normalizeBlackBoxResponseHeaders(res.headers),
+            statusCode: res.status,
+            statusText: res.statusText,
+        },
+        details: results,
+        ...config,
+    };
+}
+
+function toSuccessStatus(config: any, actualJson: any, response: any, interaction: any): any {
+    return {
+        name: config.interactionName,
+        status: SUCCESS,
+        ...toCorrelationReportFields(interaction),
+        method: interaction.request.method,
+        path: interaction.request.path,
+        timeoutMs: interaction.request.timeoutMs,
+        attemptNumber: response.blackBoxAttemptNumber,
+        maxAttempts: response.blackBoxMaxAttempts,
+        scenarioExecutionNumber: config.interaction.request.scenarioExecutionNumber,
+        interactionExecutionNumber: config.interaction.request.interactionExecutionNumber,
+        repeatIndex: config.interaction.request.repeatIndex,
+        expected: interaction.response,
+        actual: {
+            body: actualJson,
+            headers: normalizeBlackBoxResponseHeaders(response.headers),
+            statusCode: response.status,
+            statusText: response.statusText,
+        },
+        ...toOutputReportFields(interaction),
+        input: interaction.request.input,
+    };
+}
+
+function toNumberList(value: unknown): number[] {
+    if (Array.isArray(value)) {
+        return value
+            .map(item => Number.parseInt(String(item), 10))
+            .filter(item => Number.isFinite(item));
+    }
+
+    if (typeof value === 'string' && value.includes(',')) {
+        return toNumberList(value.split(','));
+    }
+
+    if (value !== undefined && value !== null) {
+        const parsed = Number.parseInt(String(value), 10);
+        return Number.isFinite(parsed)
+            ? [parsed]
+            : [];
+    }
+
+    return [];
+}
+
+function expectedHttpStatusCodes(response: any): number[] {
+    return [
+        ...toNumberList(response?.statusCode),
+        ...toNumberList(response?.status),
+        ...toNumberList(response?.statusCodes),
+        ...toNumberList(response?.allowedStatusCodes),
+    ];
+}
+
+function bodyExpectationAlternatives(response: any): any[] {
+    const alternatives = response?.bodyAnyOf ?? response?.anyBodyOf ?? response?.bodyIn;
+
+    return Array.isArray(alternatives)
+        ? alternatives
+        : [];
+}
+
+function compareExpectedBody(expectedBody: any, actualJson: any, interaction: any): any {
+    return compareJson(
+        expectedBody,
+        actualJson,
+        toConfig(
+            interaction.response?.comparison || COMPARISON.COMPATIBLE,
+            interaction.response?.ignoreJsonKeys || [],
+            interaction.response?.ignoreJsonPaths || [],
+        ),
+    );
+}
+
+export function toHttpInteractionStatus(
+    config: any,
+    interaction: any,
+    response: any,
+    actualJson: any,
+): any {
+    const expectedStatuses = expectedHttpStatusCodes(interaction.response);
+    const hasExpectedStatus = expectedStatuses.length > 0;
+
+    const actualStatusCode = Number.parseInt(String(response.status), 10);
+    if (hasExpectedStatus && !expectedStatuses.includes(actualStatusCode)) {
+        return toStatus(
+            config,
+            'Expected responseCode not the same as actual responseCode',
+            actualJson,
+            response,
+            interaction,
+            {
+                expectedStatusCodes: expectedStatuses,
+            },
+        );
+    }
+
+    if (!response.ok && !hasExpectedStatus) {
+        return toStatus(config, 'Server request failed.', actualJson, response, interaction);
+    }
+
+    const bodyAlternatives = bodyExpectationAlternatives(interaction.response);
+    if (bodyAlternatives.length > 0) {
+        if (actualJson === undefined || actualJson === null) {
+            return toStatus(
+                config,
+                'Server with no body in response. Expects a body.',
+                actualJson,
+                response,
+                interaction,
+            );
+        }
+
+        const comparisons = bodyAlternatives.map(expectedBody =>
+            compareExpectedBody(expectedBody, actualJson, interaction));
+        const matchedIndex = comparisons.findIndex(result => result.isEqual);
+        if (matchedIndex < 0) {
+            return toStatus(
+                config,
+                'Expected response not to match any accepted response body',
+                actualJson,
+                response,
+                interaction,
+                {
+                    bodyAnyOf: bodyAlternatives,
+                    comparisons,
+                },
+            );
+        }
+    } else if (interaction?.response?.body !== undefined) {
+        if (actualJson === undefined || actualJson === null) {
+            return toStatus(
+                config,
+                'Server with no body in response. Expects a body.',
+                actualJson,
+                response,
+                interaction,
+            );
+        }
+
+        const results = compareExpectedBody(interaction.response.body, actualJson, interaction);
+
+        if (!results.isEqual) {
+            return toStatus(
+                config,
+                'Expected response not the same as actual response',
+                actualJson,
+                response,
+                interaction,
+                results,
+            );
+        }
+    }
+
+    return toSuccessStatus(config, actualJson, response, interaction);
+}

--- a/packages/tests/shared-test/execute-black-box-poll-until.test.ts
+++ b/packages/tests/shared-test/execute-black-box-poll-until.test.ts
@@ -1,0 +1,227 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import {describe, expect, it} from 'vitest';
+import {executeBlackBox} from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+async function startHttpServer(
+    handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ url: string, close: () => Promise<void> }> {
+    const server = createServer(handler);
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+        });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('Failed to start HTTP test server');
+    }
+
+    return {
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((resolve, reject) => {
+            server.close(error => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+
+                resolve();
+            });
+        }),
+    };
+}
+
+async function tryStartHttpServer(
+    handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ url: string, close: () => Promise<void> } | undefined> {
+    try {
+        return await startHttpServer(handler);
+    } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+            ? String((error as { code?: unknown }).code)
+            : '';
+        if (code === 'EPERM' || code === 'EACCES') {
+            return undefined;
+        }
+        throw error;
+    }
+}
+
+function json(response: ServerResponse, statusCode: number, body: unknown): void {
+    response.writeHead(statusCode, {
+        'Content-Type': 'application/json',
+    });
+    response.end(JSON.stringify(body));
+}
+
+function pollUntilStep(input: {
+    path: string;
+    poll: Record<string, unknown>;
+    expectBody: Record<string, unknown>;
+    nonBlockingFailure?: boolean;
+}): Record<string, unknown> {
+    return {
+        HTTP: {
+            request: {
+                action: 'poll-until',
+                method: 'GET',
+                path: input.path,
+                poll: input.poll,
+                nonBlockingFailure: input.nonBlockingFailure,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1,
+            },
+            response: {
+                status: 200,
+                body: input.expectBody,
+            },
+        },
+        pollUntilConverged: {},
+    };
+}
+
+describe('executeBlackBox http poll-until', () => {
+    it('repeats the request until its expect passes', async () => {
+        let calls = 0;
+        const server = await tryStartHttpServer((_request, response) => {
+            calls++;
+            if (calls < 3) {
+                json(response, 200, { converged: false, revision: calls });
+                return;
+            }
+            json(response, 200, { converged: true, revision: calls });
+        });
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [pollUntilStep({
+                    path: `${server.url}/state`,
+                    poll: { maxAttempts: 10, maxDurationMs: 5000, backoffMs: 10, backoffMultiplier: 1 },
+                    expectBody: { converged: true },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(0);
+            const result = report.resultsByName.pollUntilConverged[0];
+            expect(result.status).toBe('SUCCESS');
+            expect(result.pollAttempts).toBe(3);
+            expect(result.pollExhausted).toBe(false);
+            expect(result.actual.body.converged).toBe(true);
+            expect(calls).toBe(3);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('fails with the last attempt status when max attempts are exhausted', async () => {
+        let calls = 0;
+        const server = await tryStartHttpServer((_request, response) => {
+            calls++;
+            json(response, 200, { converged: false, revision: calls });
+        });
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [pollUntilStep({
+                    path: `${server.url}/state`,
+                    poll: { maxAttempts: 4, maxDurationMs: 5000, backoffMs: 5, backoffMultiplier: 1 },
+                    expectBody: { converged: true },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.pollUntilConverged[0];
+            expect(result.status).toBe('FAILURE');
+            expect(result.result).toBe('Expected response not the same as actual response');
+            expect(result.pollAttempts).toBe(4);
+            expect(result.pollExhausted).toBe(true);
+            expect(calls).toBe(4);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('stops polling when the max duration bound would be exceeded', async () => {
+        let calls = 0;
+        const server = await tryStartHttpServer((_request, response) => {
+            calls++;
+            json(response, 200, { converged: false });
+        });
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [pollUntilStep({
+                    path: `${server.url}/state`,
+                    poll: { maxAttempts: 100, maxDurationMs: 150, backoffMs: 60, backoffMultiplier: 2 },
+                    expectBody: { converged: true },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.pollUntilConverged[0];
+            expect(result.status).toBe('FAILURE');
+            expect(result.pollExhausted).toBe(true);
+            expect(result.pollAttempts).toBeLessThan(100);
+            expect(result.pollElapsedMs).toBeLessThanOrEqual(1000);
+            expect(calls).toBeLessThan(10);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('keeps polling across connection failures and marks the step non-blocking when asked', async () => {
+        const report = await executeBlackBox(
+            [
+                pollUntilStep({
+                    path: 'http://127.0.0.1:1/unreachable',
+                    poll: { maxAttempts: 2, maxDurationMs: 2000, backoffMs: 5, backoffMultiplier: 1 },
+                    expectBody: { converged: true },
+                    nonBlockingFailure: true,
+                }),
+                {
+                    SET: {
+                        request: {
+                            output: 'afterPoll',
+                            value: 'reached',
+                            scenarioExecutionNumber: 1,
+                            interactionExecutionNumber: 2,
+                        },
+                        response: {},
+                    },
+                    continuesAfterNonBlockingPoll: {},
+                },
+            ],
+            0,
+            { failFast: true },
+        );
+
+        const result = report.resultsByName.pollUntilConverged[0];
+        expect(result.status).toBe('FAILURE');
+        expect(result.nonBlockingFailure).toBe(true);
+        expect(result.pollAttempts).toBe(2);
+        expect(result.pollExhausted).toBe(true);
+        expect(typeof result.exception).toBe('string');
+        expect(report.outputs.afterPoll).toBe('reached');
+        expect(report.summary.failure).toBe(0);
+        expect(report.summary.observedFailure).toBe(1);
+    });
+});

--- a/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
+++ b/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
@@ -13,7 +13,7 @@ Status: in execution as a stacked PR series based on
 | Workstream | Status | Branch / PR |
 |---|---|---|
 | W1 `expect.absent` | implemented; in review | `codex/black-box-w1-ws-rtc-absent` |
-| W2 `poll-until` | not started | — |
+| W2 `poll-until` | runner capability implemented; recipe rewrite blocked on decision | `codex/black-box-w2-poll-until` |
 | W3 comparators + `compatible-complete` | not started | — |
 | W4 pure-API recipes | not started | — |
 | W5 `expect.headers` | not started | — |
@@ -139,6 +139,20 @@ and governance gates.
 **Done when:** the rewritten recipe asserts an identical final state to before
 and is materially shorter; a new recipe uses `poll-until` for read-your-writes
 (see W4).
+
+**Execution correction (2026-08-11):** the premise misnamed the target. As of
+#160, `api-v1-state-topology-churn.json` contains **zero** `nonBlockingFailure`
+poll rounds — it already uses revision-floor reads with transport `retry` plus
+one loop-based poll, and its structure is pinned by
+`api-v1-three-server-recipe-semantics.test.ts`. The hand-unrolled rounds live in
+`api-v1-state-medium-scale-churn.json` (5 rounds) and
+`api-v1-state-write-convergence.json` (5 rounds), and every one of them is a
+`parallel` step fanning over 3–15 groups — outside what a single-request
+`poll-until` can express, and both files are protected convergence gates. The
+W2 PR therefore ships the runner capability, unit tests, and documentation; no
+convergence recipe was rewritten. Rewriting those rounds needs either a
+group-scoped poll operator or explicit approval to restructure the gates —
+flagged to the plan owner as an open decision.
 
 ---
 

--- a/plans/repo-style-lineages/black-box-runner-wait-expectations.json
+++ b/plans/repo-style-lineages/black-box-runner-wait-expectations.json
@@ -8,6 +8,8 @@
         "blob": "f5f30bb18b2916879e06dd9a0c3d4f1b8e72124a"
       },
       "targets": [
+        "packages/shared-test/black-box-runner/http/execute-http-interaction.ts",
+        "packages/shared-test/black-box-runner/http/http-response-expectations.ts",
         "packages/shared-test/black-box-runner/ws/ws-interaction-statuses.ts",
         "packages/shared-test/black-box-runner/ws/ws-wait-expectations.ts"
       ]


### PR DESCRIPTION
## W2 — generic `http.poll-until` step

Second workstream of
`plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md`.
Stacked on `codex/black-box-w1-ws-rtc-absent` (W1); do not merge before it.

### What

- New `http.poll-until` step: repeat one HTTP request until the step's own `expect` passes, with
  exponential backoff. `request.poll` reuses the existing retry field names (`maxAttempts`,
  `backoffMs`, `backoffMultiplier`) and adds `maxDurationMs`; both bounds are enforced per the
  plan's baked-in decision. Exhaustion fails the step with the last attempt's status plus
  `pollAttempts` / `pollExhausted` / `pollElapsedMs`. Connection errors count as failed attempts and
  polling continues within the bounds. The dotted type rides the existing `technology.action` step
  convention, so `scenario-black-box.ts` needed no changes.
- The HTTP execution cluster moved out of `execute-black-box.ts` into
  `http/execute-http-interaction.ts` (fetch/retry/poll loop) and
  `http/http-response-expectations.ts` (status + body expectation evaluation), continuing the W1
  decomposition under the same structural-lineage manifest. `execute-black-box.ts` is down to ~2.6k
  lines from its 3.4k baseline.
- Operator documented in `black-box-runner-recipe-guide.md` with a worked example and explicit
  guidance: single-request polls replace hand-unrolled rounds; `parallel`-fanned rounds stay
  explicit.

### ⚠️ Plan correction — no convergence recipe was rewritten (decision needed)

The plan told W2 to rewrite `api-v1-state-topology-churn`'s hand-unrolled `nonBlockingFailure` poll
rounds. That premise is stale: since #160 that recipe has **zero** such rounds — it uses
revision-floor reads with transport `retry`, and its structure is pinned by
`api-v1-three-server-recipe-semantics.test.ts`. The hand-unrolled rounds actually live in
`api-v1-state-medium-scale-churn.json` (5 rounds) and `api-v1-state-write-convergence.json`
(5 rounds) — and every round there is a `parallel` step fanning over 3–15 groups, which a
single-request `poll-until` cannot express. Both files are protected convergence gates
("never weaken the medium-scale gate…"), so rewriting them is exactly the "convergence gate would
have to change" case the plan owner asked to be consulted on. Recorded in the plan doc under W2;
options are a group-scoped poll operator (new capability) or explicit approval to restructure those
gates. W4 will exercise `http.poll-until` in a new recipe as planned.

### Validation

- `npx vitest run packages/tests/shared-test` — all passed (773), including new
  `execute-black-box-poll-until.test.ts` (pass-after-N, attempts exhaustion, duration bound,
  connection-failure polling + non-blocking continuation).
- `deno check` over the runner modules — clean.
- `npm run check:repo-style:changed -- origin/main WORKTREE` — zero findings from this branch
  (PR #161's 9 inherited findings remain).
- `npm run test:api-v1:black-box:memory` — 16/16 recipes PASSED (exit 0) with the extracted HTTP pipeline live under every recipe.
- Governance untouched by this PR's file set (no recipe/matrix changes); `test:repo-governance`
  passed on the W1 base.
