### PR TITLE
feat(black-box): W3 — ASSERT value comparators + compatible-complete mode

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -232,7 +232,11 @@ Common fields:
 - `expect.statusCodes`: accepted status array
 - `expect.body`: expected response JSON
 - `expect.bodyAnyOf`: accepted response body shapes
-- `expect.comparison`: comparison mode
+- `expect.comparison`: comparison mode (`compatible` default, `compatible-structure`,
+  `compatible-complete`, `exact-structure`, `exact`); `compatible-complete` keeps
+  extra object keys tolerated but rejects unexpected array elements, closing the
+  vacuous-assertion gap where `compatible` matches an empty expected array
+  against anything
 - `output`: optional output name for the step result
 - `outputPath`: optional path inside the result to store under `output`
 - `outputs`: optional map of output names to result paths
@@ -455,12 +459,43 @@ Common fields:
 - `request.actual` or `actual`: actual value
 - `expect.expected`, `expect.expect`, or `expect.body`: expected value
 - `expect.anyOf`: accepted expected values
-- `expect.comparison`: comparison mode
+- `expect.comparators`: value comparators over paths inside the resolved actual
+- `expect.comparison`: comparison mode (`compatible` default, `compatible-structure`,
+  `compatible-complete`, `exact-structure`, `exact`); `compatible-complete` keeps
+  extra object keys tolerated but rejects unexpected array elements, closing the
+  vacuous-assertion gap where `compatible` matches an empty expected array
+  against anything
 - `expect.ignoreJsonKeys`: keys to ignore
 - `expect.ignoreJsonPaths`: paths to ignore
 
 ASSERT steps are useful after a previous step stored a result in `outputs` or
 when a recipe needs to compare two observed payloads.
+
+`expect.comparators` is a list of `{path, ...comparator}` entries evaluated
+against the resolved actual; every failing entry is reported, never just the
+first. Numeric comparators are `gt`, `gte`, `lt`, `lte`, and
+`between: [low, high]` (inclusive); `length` requires an array or string of the
+exact length; string comparators are `contains` and `matches` (a regular
+expression source). Comparator bounds resolve placeholders, so a captured floor
+like `{floorRevision}` works. An ASSERT step may use comparators alone —
+without `expect.body` — or combine them with a body comparison; a path that
+does not resolve is a failure, which is what makes a comparator-based check
+non-vacuous.
+
+```json
+{
+  "name": "assertConvergedStats",
+  "type": "assert",
+  "actual": "{groupStats}",
+  "expect": {
+    "comparators": [
+      { "path": "stats.memberCount", "gte": 1, "lte": 100 },
+      { "path": "activeSessions", "length": 1 },
+      { "path": "receipt.causalRevision.groupRevision", "gte": "{floorRevision}" }
+    ]
+  }
+}
+```
 
 ### SET
 

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -34,6 +34,7 @@ import {
 import type { RallarBlackBoxTestCommand } from '../rallar-bb-test/types.ts';
 import { normalizeBlackBoxResponseHeaders } from './http/normalize-black-box-response-headers.ts';
 import { executeHttpInteraction } from './http/execute-http-interaction.ts';
+import { validateAssertValueComparators } from './expectations/assert-value-comparators.ts';
 import {
     toHttpInteractionStatus,
     toStatus,
@@ -1071,17 +1072,8 @@ function monotonicComparisonFailures(actual: any, paths: unknown): any[] {
     });
 }
 
-function executeAssertInteraction(interaction: any, config: any, context: any): Promise<any> {
-    const expectedAlternatives = Array.isArray(interaction.response.anyOf)
-        ? interaction.response.anyOf
-        : [];
-    const expected = interaction.response.body !== undefined
-        ? interaction.response.body
-        : interaction.response.expect !== undefined
-            ? interaction.response.expect
-            : interaction.response.expected;
-
-    const actual = interaction.response.actual !== undefined
+function toResolvedAssertActual(interaction: any, context: any): any {
+    return interaction.response.actual !== undefined
         ? isRecord(interaction.response.actual) && interaction.response.actual.transform !== undefined
             ? evaluateScenarioTransform({
                 transform: interaction.response.actual.transform,
@@ -1094,13 +1086,56 @@ function executeAssertInteraction(interaction: any, config: any, context: any): 
                 interaction.response.missingActualValue,
             )
         : interaction.request.actual;
+}
 
-    if (expected === undefined && expectedAlternatives.length <= 0) {
+function toAssertAnyOfStatus(interaction: any, config: any, actual: any): any {
+    const expectedAlternatives = interaction.response.anyOf;
+    const comparisons = expectedAlternatives.map((expectedValue: any) => compareJson(
+        expectedValue,
+        actual,
+        toConfig(
+            interaction.response?.comparison || COMPARISON.COMPATIBLE,
+            interaction.response?.ignoreJsonKeys || [],
+            interaction.response?.ignoreJsonPaths || [],
+        ),
+    ));
+    const matchedIndex = comparisons.findIndex((result: any) => result.isEqual);
+
+    if (matchedIndex < 0) {
+        return toAssertFailureStatus(config, interaction, actual, 'Assert comparison failed', {
+            anyOf: expectedAlternatives,
+            comparisons,
+        });
+    }
+
+    return toAssertSuccessStatus(config, interaction, actual, {
+        anyOfMatchedIndex: matchedIndex,
+        comparison: comparisons[matchedIndex],
+    });
+}
+
+function executeAssertInteraction(interaction: any, config: any, context: any): Promise<any> {
+    const expectedAlternatives = Array.isArray(interaction.response.anyOf)
+        ? interaction.response.anyOf
+        : [];
+    const comparators = Array.isArray(interaction.response.comparators)
+        ? interaction.response.comparators
+        : [];
+    const expected = interaction.response.body !== undefined
+        ? interaction.response.body
+        : interaction.response.expect !== undefined
+            ? interaction.response.expect
+            : interaction.response.expected;
+
+    const actual = toResolvedAssertActual(interaction, context);
+
+    if (expected === undefined && expectedAlternatives.length <= 0 && comparators.length <= 0) {
         return Promise.resolve(toAssertFailureStatus(
             config,
             interaction,
             actual,
-            'Assert step is missing expected value. Use expect.body, expect.expect, or expect.expected.',
+            'Assert step is missing expected value. ' +
+                'Use expect.body, expect.expect, expect.expected, or expect.comparators.',
         ));
     }
 
@@ -1130,34 +1165,27 @@ function executeAssertInteraction(interaction: any, config: any, context: any): 
         ));
     }
 
-    if (expectedAlternatives.length > 0) {
-        const comparisons = expectedAlternatives.map((expectedValue: any) => compareJson(
-            expectedValue,
+    const comparatorIssues = validateAssertValueComparators(actual, comparators);
+    if (comparatorIssues.length > 0) {
+        return Promise.resolve(toAssertFailureStatus(
+            config,
+            interaction,
             actual,
-            toConfig(
-                interaction.response?.comparison || COMPARISON.COMPATIBLE,
-                interaction.response?.ignoreJsonKeys || [],
-                interaction.response?.ignoreJsonPaths || [],
-            ),
+            'Assert comparator failed',
+            {
+                comparators,
+                failures: comparatorIssues,
+            },
         ));
-        const matchedIndex = comparisons.findIndex((result: any) => result.isEqual);
+    }
 
-        if (matchedIndex < 0) {
-            return Promise.resolve(toAssertFailureStatus(
-                config,
-                interaction,
-                actual,
-                'Assert comparison failed',
-                {
-                    anyOf: expectedAlternatives,
-                    comparisons,
-                },
-            ));
-        }
+    if (expectedAlternatives.length > 0) {
+        return Promise.resolve(toAssertAnyOfStatus(interaction, config, actual));
+    }
 
+    if (expected === undefined) {
         return Promise.resolve(toAssertSuccessStatus(config, interaction, actual, {
-            anyOfMatchedIndex: matchedIndex,
-            comparison: comparisons[matchedIndex],
+            comparators,
         }));
     }
 

--- a/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
+++ b/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
@@ -1,0 +1,224 @@
+// deno-lint-ignore-file no-explicit-any
+export interface AssertComparatorIssue {
+    readonly path: any;
+    readonly comparator: string;
+    readonly expected: any;
+    readonly actual: any;
+    readonly message: string;
+}
+
+function toPathSegments(path: string): string[] {
+    return path
+        .replaceAll(/\[(\d+)]/g, '.$1')
+        .split('.')
+        .map(segment => segment.trim())
+        .filter(segment => segment.length > 0);
+}
+
+function resolveComparatorValue(path: string, root: any): { found: boolean, value?: any } {
+    let value = root;
+
+    for (const segment of toPathSegments(path)) {
+        if (value === undefined || value === null) {
+            return { found: false };
+        }
+
+        value = value[segment];
+    }
+
+    return value === undefined ? { found: false } : { found: true, value };
+}
+
+function toIssue(input: {
+    path: any;
+    comparator: string;
+    expected: any;
+    actual: any;
+    message: string;
+}): AssertComparatorIssue {
+    return {
+        path: input.path,
+        comparator: input.comparator,
+        expected: input.expected,
+        actual: input.actual,
+        message: input.message,
+    };
+}
+
+function numericIssues(entry: any, value: any): AssertComparatorIssue[] {
+    const issues: AssertComparatorIssue[] = [];
+    const actualNumber = Number(value);
+    const numericComparators: Array<[string, (actual: number, bound: number) => boolean]> = [
+        ['gt', (actual, bound) => actual > bound],
+        ['gte', (actual, bound) => actual >= bound],
+        ['lt', (actual, bound) => actual < bound],
+        ['lte', (actual, bound) => actual <= bound],
+    ];
+
+    for (const [comparator, satisfies] of numericComparators) {
+        if (entry[comparator] === undefined) {
+            continue;
+        }
+
+        const bound = Number(entry[comparator]);
+        if (!Number.isFinite(actualNumber) || !Number.isFinite(bound)) {
+            issues.push(toIssue({
+                path: entry.path,
+                comparator,
+                expected: entry[comparator],
+                actual: value,
+                message: 'Comparator requires finite numeric values.',
+            }));
+            continue;
+        }
+
+        if (!satisfies(actualNumber, bound)) {
+            issues.push(toIssue({
+                path: entry.path,
+                comparator,
+                expected: entry[comparator],
+                actual: value,
+                message: `Expected value ${comparator} ${bound}.`,
+            }));
+        }
+    }
+
+    return issues;
+}
+
+function betweenIssues(entry: any, value: any): AssertComparatorIssue[] {
+    if (entry.between === undefined) {
+        return [];
+    }
+
+    const bounds = Array.isArray(entry.between) ? entry.between.map(Number) : [];
+    const actualNumber = Number(value);
+    if (bounds.length !== 2 || bounds.some((bound: number) => !Number.isFinite(bound))) {
+        return [toIssue({
+            path: entry.path,
+            comparator: 'between',
+            expected: entry.between,
+            actual: value,
+            message: 'Comparator between requires a [low, high] numeric pair.',
+        })];
+    }
+
+    if (!Number.isFinite(actualNumber) || actualNumber < bounds[0] || actualNumber > bounds[1]) {
+        return [toIssue({
+            path: entry.path,
+            comparator: 'between',
+            expected: entry.between,
+            actual: value,
+            message: `Expected value between ${bounds[0]} and ${bounds[1]} inclusive.`,
+        })];
+    }
+
+    return [];
+}
+
+function lengthIssues(entry: any, value: any): AssertComparatorIssue[] {
+    if (entry.length === undefined) {
+        return [];
+    }
+
+    const expectedLength = Number(entry.length);
+    const actualLength = Array.isArray(value) || typeof value === 'string'
+        ? value.length
+        : undefined;
+    if (actualLength === undefined || actualLength !== expectedLength) {
+        return [toIssue({
+            path: entry.path,
+            comparator: 'length',
+            expected: entry.length,
+            actual: value,
+            message: `Expected an array or string of length ${expectedLength}.`,
+        })];
+    }
+
+    return [];
+}
+
+function stringIssues(entry: any, value: any): AssertComparatorIssue[] {
+    const issues: AssertComparatorIssue[] = [];
+
+    if (entry.contains !== undefined) {
+        if (typeof value !== 'string' || !value.includes(String(entry.contains))) {
+            issues.push(toIssue({
+                path: entry.path,
+                comparator: 'contains',
+                expected: entry.contains,
+                actual: value,
+                message: `Expected a string containing ${String(entry.contains)}.`,
+            }));
+        }
+    }
+
+    if (entry.matches !== undefined) {
+        if (typeof value !== 'string' || !new RegExp(String(entry.matches)).test(value)) {
+            issues.push(toIssue({
+                path: entry.path,
+                comparator: 'matches',
+                expected: entry.matches,
+                actual: value,
+                message: `Expected a string matching /${String(entry.matches)}/.`,
+            }));
+        }
+    }
+
+    return issues;
+}
+
+const COMPARATOR_KEYS = ['gt', 'gte', 'lt', 'lte', 'between', 'length', 'contains', 'matches'];
+
+function entryIssues(entry: any, actual: any): AssertComparatorIssue[] {
+    if (typeof entry?.path !== 'string' || entry.path.length <= 0) {
+        return [toIssue({
+            path: entry?.path,
+            comparator: 'path',
+            expected: undefined,
+            actual: undefined,
+            message: 'Comparator entries need a non-empty string path.',
+        })];
+    }
+
+    if (!COMPARATOR_KEYS.some(key => entry[key] !== undefined)) {
+        return [toIssue({
+            path: entry.path,
+            comparator: 'none',
+            expected: undefined,
+            actual: undefined,
+            message: `Comparator entries need at least one of: ${COMPARATOR_KEYS.join(', ')}.`,
+        })];
+    }
+
+    const resolved = resolveComparatorValue(entry.path, actual);
+    if (!resolved.found) {
+        return [toIssue({
+            path: entry.path,
+            comparator: 'path',
+            expected: undefined,
+            actual: undefined,
+            message: 'Comparator path did not resolve to a value.',
+        })];
+    }
+
+    return [
+        ...numericIssues(entry, resolved.value),
+        ...betweenIssues(entry, resolved.value),
+        ...lengthIssues(entry, resolved.value),
+        ...stringIssues(entry, resolved.value),
+    ];
+}
+
+// Pure validate-all pass over expect.comparators: every entry is evaluated and
+// every failing comparator is reported, never just the first.
+export function validateAssertValueComparators(
+    actual: any,
+    comparators: any,
+): readonly AssertComparatorIssue[] {
+    if (!Array.isArray(comparators)) {
+        return [];
+    }
+
+    return comparators.flatMap(entry => entryIssues(entry, actual));
+}

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-write-convergence.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-write-convergence.json
@@ -347,6 +347,7 @@
       },
       "expect": {
         "status": 200,
+        "comparison": "compatible-complete",
         "body": {
           "memberCount": 1,
           "members": [
@@ -515,6 +516,7 @@
               },
               "expect": {
                 "status": 200,
+                "comparison": "compatible-complete",
                 "body": {
                   "activeSessions": [
                     {
@@ -693,6 +695,7 @@
       },
       "expect": {
         "status": 200,
+        "comparison": "compatible-complete",
         "body": {
           "activeSessions": [
             {

--- a/packages/shared-test/json-compare/CompareJson.ts
+++ b/packages/shared-test/json-compare/CompareJson.ts
@@ -12,6 +12,7 @@ export type JsonArray = JsonValue[];
 export interface CompareConfig {
     compareValues: boolean;
     compareExact: boolean;
+    compareArraysComplete: boolean;
     ignoreJsonKeys: string[];
     ignoreJsonPaths: string[];
 }
@@ -265,6 +266,17 @@ function isCompatibleArrays(
         }
     }
 
+    if (config.compareArraysComplete && !config.compareExact) {
+        const actualNotFound = actualToCompare.filter(a => a !== undefined);
+        if (actualNotFound.length > 0) {
+            return toNotCompatible(expected, actual, 'Json array has unexpected elements', {
+                expectedFound: expectedFound.filter(a => a !== undefined),
+                expectedNotFound: expectedNotFound.filter(a => a !== undefined),
+                actualNotFound,
+            });
+        }
+    }
+
     if (config.compareValues) {
         return expectedFound.length === expected.length
             ? toCompatible()
@@ -296,43 +308,59 @@ export function compareJson(expected: JsonValue, actual: JsonValue, config: Comp
 export const COMPARISON = {
     COMPATIBLE_STRUCTURE: 'compatible-structure',
     COMPATIBLE: 'compatible',
+    COMPATIBLE_COMPLETE: 'compatible-complete',
     EXACT_STRUCTURE: 'exact-structure',
     EXACT: 'exact',
 } as const;
 
 export type Comparison = typeof COMPARISON[keyof typeof COMPARISON];
 
+const COMPARE_FLAGS_BY_COMPARISON: Record<
+    Comparison,
+    Pick<CompareConfig, 'compareValues' | 'compareExact' | 'compareArraysComplete'>
+> = {
+    [COMPARISON.COMPATIBLE_STRUCTURE]: {
+        compareValues: false,
+        compareExact: false,
+        compareArraysComplete: false,
+    },
+    [COMPARISON.COMPATIBLE]: {
+        compareValues: true,
+        compareExact: false,
+        compareArraysComplete: false,
+    },
+    [COMPARISON.COMPATIBLE_COMPLETE]: {
+        compareValues: true,
+        compareExact: false,
+        compareArraysComplete: true,
+    },
+    [COMPARISON.EXACT_STRUCTURE]: {
+        compareValues: false,
+        compareExact: true,
+        compareArraysComplete: false,
+    },
+    [COMPARISON.EXACT]: {
+        compareValues: true,
+        compareExact: true,
+        compareArraysComplete: false,
+    },
+};
+
 export function toConfig(
     comparison: Comparison | string,
     ignoreJsonKeys: string[] = [],
     ignoreJsonPaths: string[] = [],
 ): CompareConfig {
-    switch (comparison.toLowerCase()) {
-        case COMPARISON.COMPATIBLE_STRUCTURE:
-            return toConfigDto(false, false, ignoreJsonKeys, ignoreJsonPaths);
-        case COMPARISON.COMPATIBLE:
-            return toConfigDto(true, false, ignoreJsonKeys, ignoreJsonPaths);
-        case COMPARISON.EXACT_STRUCTURE:
-            return toConfigDto(false, true, ignoreJsonKeys, ignoreJsonPaths);
-        case COMPARISON.EXACT:
-            return toConfigDto(true, true, ignoreJsonKeys, ignoreJsonPaths);
-        default:
-            throw {
-                error: 'Comparison unsupported: ' + comparison.toLowerCase(),
-                comparisons: COMPARISON,
-            };
+    const compareFlags = COMPARE_FLAGS_BY_COMPARISON[comparison.toLowerCase() as Comparison];
+    if (compareFlags === undefined) {
+        throw {
+            error: 'Comparison unsupported: ' + comparison.toLowerCase(),
+            comparisons: COMPARISON,
+        };
     }
-}
 
-function toConfigDto(
-    compareValues: boolean,
-    compareExact: boolean,
-    ignoreJsonKeys: string[],
-    ignoreJsonPaths: string[],
-): CompareConfig {
     return {
-        compareValues,
-        compareExact,
+        ...compareFlags,
         ignoreJsonKeys,
         ignoreJsonPaths,
     };

--- a/packages/shared-test/json-compare/json-compare.ts
+++ b/packages/shared-test/json-compare/json-compare.ts
@@ -14,11 +14,21 @@ export interface CompareJsonOptions {
 export interface CompareJsonFacade {
     compatibleStructure(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): ComparisonResult;
     compatible(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): ComparisonResult;
+    compatibleComplete(
+        expected: JsonValue,
+        actual: JsonValue,
+        options?: CompareJsonOptions,
+    ): ComparisonResult;
     exactStructure(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): ComparisonResult;
     exact(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): ComparisonResult;
     compare(expected: JsonValue, actual: JsonValue, comparison: Comparison | string, options?: CompareJsonOptions): ComparisonResult;
     assertCompatibleStructure(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): void;
     assertCompatible(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): void;
+    assertCompatibleComplete(
+        expected: JsonValue,
+        actual: JsonValue,
+        options?: CompareJsonOptions,
+    ): void;
     assertExactStructure(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): void;
     assertExact(expected: JsonValue, actual: JsonValue, options?: CompareJsonOptions): void;
 }
@@ -46,6 +56,15 @@ export const CompareJson: CompareJsonFacade = {
         return compareJson(expected, actual, toFacadeConfig(COMPARISON.COMPATIBLE, options));
     },
 
+    compatibleComplete(
+        expected: JsonValue,
+        actual: JsonValue,
+        options: CompareJsonOptions = {},
+    ): ComparisonResult {
+        const config = toFacadeConfig(COMPARISON.COMPATIBLE_COMPLETE, options);
+        return compareJson(expected, actual, config);
+    },
+
     exactStructure(expected: JsonValue, actual: JsonValue, options: CompareJsonOptions = {}): ComparisonResult {
         return compareJson(expected, actual, toFacadeConfig(COMPARISON.EXACT_STRUCTURE, options));
     },
@@ -69,6 +88,14 @@ export const CompareJson: CompareJsonFacade = {
 
     assertCompatible(expected: JsonValue, actual: JsonValue, options: CompareJsonOptions = {}): void {
         assertComparisonResult(this.compatible(expected, actual, options));
+    },
+
+    assertCompatibleComplete(
+        expected: JsonValue,
+        actual: JsonValue,
+        options: CompareJsonOptions = {},
+    ): void {
+        assertComparisonResult(this.compatibleComplete(expected, actual, options));
     },
 
     assertExactStructure(expected: JsonValue, actual: JsonValue, options: CompareJsonOptions = {}): void {

--- a/packages/tests/shared-test/CompareJson.test.ts
+++ b/packages/tests/shared-test/CompareJson.test.ts
@@ -291,3 +291,104 @@ describe('CompareJson facade', () => {
         expect(result.isEqual).toBe(false);
     });
 });
+
+describe('CompareJson compatible-complete', () => {
+    it('accepts arrays whose elements are exactly the expected ones', () => {
+        const expected = {
+            members: [
+                {principalId: 'client-1', status: 'active'},
+            ],
+        };
+
+        const actual = {
+            members: [
+                {principalId: 'client-1', status: 'active', joinedAtEpochMs: 1},
+            ],
+            traceId: 'extra-object-fields-stay-allowed',
+        };
+
+        const result = CompareJson.compatibleComplete(expected, actual);
+
+        expect(result.isEqual).toBe(true);
+    });
+
+    it('rejects an unexpected extra array element that plain compatible accepts', () => {
+        const expected = {
+            members: [
+                {principalId: 'client-1', status: 'active'},
+            ],
+        };
+
+        const actual = {
+            members: [
+                {principalId: 'client-1', status: 'active'},
+                {principalId: 'intruder', status: 'active'},
+            ],
+        };
+
+        expect(CompareJson.compatible(expected, actual).isEqual).toBe(true);
+
+        const result = CompareJson.compatibleComplete(expected, actual);
+        expect(result.isEqual).toBe(false);
+        if (!result.isEqual) {
+            expect(result.message).toBe('Json array has unexpected elements');
+            expect(result.actualNotFound).toEqual([
+                {principalId: 'intruder', status: 'active'},
+            ]);
+        }
+    });
+
+    it('still reports missing expected elements', () => {
+        const expected = {
+            activeSessions: [
+                {sessionId: 'session-1'},
+                {sessionId: 'session-2'},
+            ],
+        };
+
+        const actual = {
+            activeSessions: [
+                {sessionId: 'session-1'},
+            ],
+        };
+
+        const result = CompareJson.compatibleComplete(expected, actual);
+
+        expect(result.isEqual).toBe(false);
+    });
+
+    it('keeps object extra-key tolerance unlike exact', () => {
+        const expected = {
+            group: {groupId: 'g-1'},
+            members: [
+                {principalId: 'client-1'},
+            ],
+        };
+
+        const actual = {
+            group: {groupId: 'g-1', displayName: 'Group One'},
+            members: [
+                {principalId: 'client-1', status: 'active'},
+            ],
+        };
+
+        expect(CompareJson.compatibleComplete(expected, actual).isEqual).toBe(true);
+        expect(CompareJson.exact(expected, actual).isEqual).toBe(false);
+    });
+
+    it('supports wildcard tokens inside complete arrays', () => {
+        const expected = {
+            members: [
+                {principalId: 'string', status: 'active|invited'},
+            ],
+        };
+
+        const actual = {
+            members: [
+                {principalId: 'client-77', status: 'invited'},
+            ],
+        };
+
+        expect(CompareJson.compatibleComplete(expected, actual).isEqual).toBe(true);
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
+++ b/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
@@ -1,0 +1,163 @@
+import {describe, expect, it} from 'vitest';
+import {executeBlackBox} from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+function assertStep(input: {
+    actual: unknown;
+    expectFields: Record<string, unknown>;
+    name?: string;
+}): Record<string, unknown> {
+    return {
+        ASSERT: {
+            request: {
+                actual: input.actual,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1,
+            },
+            response: input.expectFields,
+        },
+        [input.name ?? 'assertWithComparators']: {},
+    };
+}
+
+describe('executeBlackBox ASSERT expect.comparators', () => {
+    it('passes when every comparator on the resolved actual holds', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: {
+                    stats: { memberCount: 5, onlineMemberCount: 3 },
+                    activeSessions: [{ sessionId: 'session-1' }],
+                    sessionId: 'session-abc-123',
+                },
+                expectFields: {
+                    comparators: [
+                        { path: 'stats.memberCount', gt: 1, lte: 5 },
+                        { path: 'stats.onlineMemberCount', between: [1, 5] },
+                        { path: 'activeSessions', length: 1 },
+                        { path: 'sessionId', contains: 'session-' },
+                        { path: 'sessionId', matches: '^session-[a-z]+-[0-9]+$' },
+                    ],
+                },
+            })],
+            0,
+            { failFast: true },
+        );
+
+        expect(report.summary.failure).toBe(0);
+        const result = report.resultsByName.assertWithComparators[0];
+        expect(result.status).toBe('SUCCESS');
+    });
+
+    it('collects every failing comparator instead of stopping at the first', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: {
+                    stats: { memberCount: 0 },
+                    activeSessions: [{ sessionId: 'a' }, { sessionId: 'b' }],
+                },
+                expectFields: {
+                    comparators: [
+                        { path: 'stats.memberCount', gte: 1 },
+                        { path: 'activeSessions', length: 1 },
+                        { path: 'stats.missing', gt: 0 },
+                    ],
+                },
+            })],
+            0,
+            { failFast: true },
+        );
+
+        expect(report.summary.failure).toBe(1);
+        const result = report.resultsByName.assertWithComparators[0];
+        expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('Assert comparator failed');
+        expect(result.details.failures).toHaveLength(3);
+        const comparatorNames = result.details.failures.map(
+            (failure: { comparator: string }) => failure.comparator,
+        );
+        expect(comparatorNames).toEqual(['gte', 'length', 'path']);
+    });
+
+    it('combines comparators with a body comparison and placeholder bounds', async () => {
+        const report = await executeBlackBox(
+            [
+                {
+                    SET: {
+                        request: {
+                            output: 'floorRevision',
+                            value: 3,
+                            scenarioExecutionNumber: 1,
+                            interactionExecutionNumber: 1,
+                        },
+                        response: {},
+                    },
+                    setFloorRevision: {},
+                },
+                {
+                    ASSERT: {
+                        request: {
+                            actual: { revision: 7, kind: 'group-state' },
+                            scenarioExecutionNumber: 1,
+                            interactionExecutionNumber: 2,
+                        },
+                        response: {
+                            body: { kind: 'group-state' },
+                            comparators: [
+                                { path: 'revision', gte: '{floorRevision}' },
+                            ],
+                        },
+                    },
+                    assertBodyAndComparators: {},
+                },
+            ],
+            0,
+            { failFast: true },
+        );
+
+        expect(report.summary.failure).toBe(0);
+        expect(report.resultsByName.assertBodyAndComparators[0].status).toBe('SUCCESS');
+    });
+
+    it('fails an entry without any known comparator key', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { value: 1 },
+                expectFields: {
+                    comparators: [{ path: 'value' }],
+                },
+            })],
+            0,
+            { failFast: true },
+        );
+
+        expect(report.summary.failure).toBe(1);
+        const failure = report.resultsByName.assertWithComparators[0].details.failures[0];
+        expect(failure.comparator).toBe('none');
+    });
+
+    it('supports compatible-complete comparison from ASSERT expects', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: {
+                    members: [
+                        { principalId: 'client-1', status: 'active' },
+                        { principalId: 'intruder', status: 'active' },
+                    ],
+                },
+                expectFields: {
+                    comparison: 'compatible-complete',
+                    body: {
+                        members: [
+                            { principalId: 'client-1', status: 'active' },
+                        ],
+                    },
+                },
+            })],
+            0,
+            { failFast: true },
+        );
+
+        expect(report.summary.failure).toBe(1);
+        const result = report.resultsByName.assertWithComparators[0];
+        expect(result.details.message).toBe('Json array has unexpected elements');
+    });
+});

--- a/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
+++ b/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
@@ -14,7 +14,7 @@ Status: in execution as a stacked PR series based on
 |---|---|---|
 | W1 `expect.absent` | implemented; in review | `codex/black-box-w1-ws-rtc-absent` |
 | W2 `poll-until` | runner capability implemented; recipe rewrite blocked on decision | `codex/black-box-w2-poll-until` |
-| W3 comparators + `compatible-complete` | not started | — |
+| W3 comparators + `compatible-complete` | implemented; in review | `codex/black-box-w3-comparators` |
 | W4 pure-API recipes | not started | — |
 | W5 `expect.headers` | not started | — |
 | W6 `expect.maxDurationMs` | not started | — |
@@ -182,6 +182,17 @@ expectations to use `compatible-complete`. Run governance + memory black-box.
 
 **Done when:** an array with an unexpected extra element fails
 `compatible-complete`; the tightened recipes still pass on correct data.
+
+**Execution correction (2026-08-11):** of the five app-inbox evidence recipes,
+only `api-v1-state-write-convergence` has blocking single-element
+member/session expectations (`activateOwnerMembership`,
+`reconnectReusedSession`, `readPostExpiryGeneration` — all three tightened to
+`compatible-complete`). `api-v1-admin-operations`, `api-v1-auth-session`, and
+`api-v1-crdt-app-inbox` assert evidence fields, not member/session arrays —
+nothing to tighten. `api-v1-state-medium-scale-churn`'s 50 single-element
+`activeSessions` expects all live inside the non-blocking poll rounds of the
+protected medium-scale gate and were left untouched (same open decision as
+W2's poll-round rewrite).
 
 ---
 


### PR DESCRIPTION
## W3 — ASSERT value comparators + `compatible-complete`

Third workstream of `plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md`.
Stacked on `codex/black-box-w2-poll-until` (W2); do not merge before it.

### What

- **`expect.comparators`** on ASSERT steps: `{path, gt|gte|lt|lte|between|length|contains|matches}`
  entries evaluated against the resolved actual. All failing entries are reported (validate-all,
  never first-only); bounds resolve placeholders (`{floorRevision}`); comparator-only asserts are
  allowed; an unresolvable path is a failure — that is what makes these non-vacuous. Pure evaluation
  in `expectations/assert-value-comparators.ts`; `executeAssertInteraction` restructured (anyOf
  branch extracted) so it lands below its baseline size.
- **`compatible-complete`** CompareJson mode: all expected present AND no unexpected array elements,
  while object extra keys stay tolerated (unlike `exact`). Existing recipes untouched by default —
  the mode is opt-in per expect, per the plan's baked-in decision. The comparison-flag table also
  retires the 4-positional `toConfigDto`. Facade gains `compatibleComplete` /
  `assertCompatibleComplete`.
- Tightened the three blocking single-element member/session expectations in
  `api-v1-state-write-convergence` (`activateOwnerMembership`, `reconnectReusedSession`,
  `readPostExpiryGeneration`) to `compatible-complete` — a ghost member or a lingering expired
  session now fails instead of matching. This strengthens, and does not weaken, the gate.

### Plan correction (recorded in the plan doc)

Of "the five app-inbox evidence recipes", only `state-write-convergence` has blocking
single-element member/session expects. `admin-operations` / `auth-session` / `crdt-app-inbox`
assert evidence fields, not member arrays — nothing to tighten. `state-medium-scale-churn`'s 50
single-element `activeSessions` expects all sit inside the protected medium-scale gate's
non-blocking poll rounds and were left untouched (same open decision as W2's poll-round rewrite).

### Validation

- `npx vitest run packages/tests/shared-test` — 783 passed, including new
  `execute-black-box-assert-comparators.test.ts` (5) and 5 new `CompareJson` compatible-complete
  cases; recipe pinning tests (`api-v1-state-write-convergence-recipe`, `state-write-recipe-evidence`,
  `rallar-bb-test-schema`) — 25 passed.
- `deno check` runner modules — clean.
- Offline recipe validation of the tightened recipe — no issues.
- `npm run test:api-v1:black-box:memory` — 16/16 PASSED (the tightened recipe itself is
  cluster-only; its expects run in the Branch Release Gate Postgres jobs).
- `npm run check:repo-style:changed -- origin/main WORKTREE` — zero findings from this branch
  (PR #161's 9 inherited findings remain).
