### PR TITLE
perf(rtc): add B02 data-channel baseline instrumentation

### DIFF
--- a/packages/tests/repo/rtc-performance-baseline-harnesses.test.ts
+++ b/packages/tests/repo/rtc-performance-baseline-harnesses.test.ts
@@ -1,400 +1,396 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { expect, it, onTestFinished } from 'vitest';
 
-import { runRtcPeerConnectionDiagnostics } from '../../../scripts/perf/rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts';
-import {
-  createRtcIceCandidateQueueSamples,
-  parseRtcIceCandidateQueueArguments,
-} from '../../../scripts/perf/rtc-ice-candidate-queue-bench.ts';
-import {
-  createRtcPeerConnectionDiagnosticsDependencies,
-  parseRtcPeerConnectionDiagnosticsArguments,
-  runRtcPeerConnectionDiagnosticsAcceptedSamples,
-} from '../../../scripts/perf/rtc-peer-connection-diagnostics-burst.ts';
-import {
-  createRtcPeerListenerCleanupSamples,
-  parseRtcPeerListenerCleanupArguments,
-} from '../../../scripts/perf/rtc-peer-listener-cleanup-bench.ts';
 import { createRtcBaselineEvidenceAcceptance } from '../../../scripts/perf/rtc-baseline/rtc-baseline-evidence-acceptance.ts';
+import type {
+  RtcBaselineAcceptedArtifact,
+  RtcBaselineResult,
+  RtcBaselineSampleDto,
+} from '../../../scripts/perf/rtc-baseline/rtc-baseline-contracts.ts';
+import * as DrainBench from '../../../scripts/perf/rtc-baseline/rtc-data-channel-drain-bench.ts';
+import { runRtcPeerConnectionDiagnostics } from '../../../scripts/perf/rtc-baseline/rtc-peer-connection-diagnostics-runtime.ts';
 import { deriveRtcBaselineCaptureManifest } from '../../../scripts/perf/rtc-baseline/rtc-baseline-workload-manifest.ts';
+import * as CloseBench from '../../../scripts/perf/rtc-data-channel-close-retention-bench.ts';
+import * as ErrorBench from '../../../scripts/perf/rtc-data-channel-error-reference-bench.ts';
+import * as ReplaceBench from '../../../scripts/perf/rtc-data-channel-replace-key-bench.ts';
+import * as IceQueueBench from '../../../scripts/perf/rtc-ice-candidate-queue-bench.ts';
+import * as DiagnosticsBench from '../../../scripts/perf/rtc-peer-connection-diagnostics-burst.ts';
+import * as ListenerBench from '../../../scripts/perf/rtc-peer-listener-cleanup-bench.ts';
 
+const fileNames = (manifest: string): string[] => manifest.trim().split(/\s+/);
+const baselineFeatureFiles = fileNames(`
+contracts decoding artifact-decoding workload-catalog workload-manifest validation
+artifact-validation statistics evidence-layout evidence-store failure-accounting evidence-acceptance
+finalized-evidence finalized-reader envelope runtime-observation deno-adapters deno-runtime
+cli-options cli-grammar cli`);
 const featureFiles = [
-  'rtc-baseline-contracts.ts',
-  'rtc-baseline-decoding.ts',
-  'rtc-baseline-artifact-decoding.ts',
-  'rtc-baseline-workload-catalog.ts',
-  'rtc-baseline-workload-manifest.ts',
-  'rtc-baseline-validation.ts',
-  'rtc-baseline-artifact-validation.ts',
-  'rtc-baseline-statistics.ts',
-  'rtc-baseline-evidence-layout.ts',
-  'rtc-baseline-evidence-store.ts',
-  'rtc-baseline-failure-accounting.ts',
-  'rtc-baseline-evidence-acceptance.ts',
-  'rtc-baseline-finalized-evidence.ts',
-  'rtc-baseline-finalized-reader.ts',
-  'rtc-baseline-envelope.ts',
-  'rtc-baseline-runtime-observation.ts',
-  'rtc-baseline-deno-adapters.ts',
-  'rtc-baseline-deno-runtime.ts',
-  'rtc-baseline-cli-options.ts',
-  'rtc-baseline-cli-grammar.ts',
-  'rtc-baseline-cli.ts',
+  ...baselineFeatureFiles.map((name) => `rtc-baseline-${name}.ts`),
   'rtc-data-channel-drain-bench.ts',
   'rtc-rtt-repository-filter-bench.ts',
   'rtc-peer-connection-diagnostics-runtime.ts',
 ];
-
-const repositoryTests = [
-  'rtc-performance-baseline-contract.test.ts',
-  'rtc-performance-baseline-decoding.test.ts',
-  'rtc-performance-baseline-validation.test.ts',
-  'rtc-performance-baseline-artifact-validation.test.ts',
-  'rtc-performance-baseline-statistics.test.ts',
-  'rtc-performance-baseline-workload-catalog.test.ts',
-  'rtc-performance-baseline-workload-manifest.test.ts',
-  'rtc-performance-baseline-evidence-acceptance.test.ts',
-  'rtc-performance-baseline-evidence-failure.test.ts',
-  'rtc-performance-baseline-evidence-store.test.ts',
-  'rtc-performance-baseline-harnesses.test.ts',
-  'rtc-performance-baseline-envelope.test.ts',
-  'rtc-performance-baseline-finalization.test.ts',
-  'rtc-performance-baseline-finalized-reader.test.ts',
-  'rtc-performance-baseline-deno-adapters.test.ts',
-  'rtc-performance-baseline-deno-runtime.test.ts',
-  'rtc-performance-baseline-cli-grammar.test.ts',
-  'rtc-performance-baseline-cli.test.ts',
-];
-
-const existingTypeScriptHarnesses = [
-  'rtc-peer-connection-diagnostics-burst.ts',
-  'rtc-ice-candidate-queue-bench.ts',
-  'rtc-peer-listener-cleanup-bench.ts',
-  'rtc-data-channel-replace-key-bench.ts',
-  'rtc-data-channel-close-retention-bench.ts',
-  'rtc-data-channel-error-reference-bench.ts',
-  'rtc-topology-star-bench.ts',
-  'rtc-topology-tree-no-rtt-bench.ts',
-  'rtc-topology-mesh-no-rtt-bench.ts',
-  'rtc-room-graph-rtt-bench.ts',
-  'rtc-topology-inactive-churn-bench.ts',
-  'rtc-multicast-serialization-bench.ts',
-  'webrtc-group-cache-fallback-bench.ts',
-  'webrtc-group-manager-state-bench.ts',
-  'webrtc-group-manager-peer-owners-bench.ts',
-  'webrtc-heartbeat-callback-churn-bench.ts',
-];
-
+const repositoryTests = fileNames(`
+contract decoding validation artifact-validation statistics workload-catalog workload-manifest
+evidence-acceptance evidence-failure evidence-store harnesses envelope finalization finalized-reader
+deno-adapters deno-runtime cli-grammar cli
+`).map((name) => `rtc-performance-baseline-${name}.test.ts`);
+const rtcHarnessFiles = fileNames(`
+peer-connection-diagnostics-burst ice-candidate-queue-bench peer-listener-cleanup-bench
+data-channel-replace-key-bench data-channel-close-retention-bench data-channel-error-reference-bench
+topology-star-bench topology-tree-no-rtt-bench topology-mesh-no-rtt-bench room-graph-rtt-bench
+topology-inactive-churn-bench multicast-serialization-bench
+`).map((name) => `rtc-${name}.ts`);
+const webRtcHarnessFiles = fileNames(`
+group-cache-fallback-bench group-manager-state-bench group-manager-peer-owners-bench
+heartbeat-callback-churn-bench
+`).map((name) => `webrtc-${name}.ts`);
+const existingTypeScriptHarnesses = [...rtcHarnessFiles, ...webRtcHarnessFiles];
 const nodeSoak = ['rtc-data-channel-browser-soak.mjs'];
-
-describe('RTC baseline reservation inventory', () => {
-  it('retains the exact test-owned 24/18/16/1 inventory', () => {
-    expect({ featureFiles, repositoryTests, existingTypeScriptHarnesses, nodeSoak }).toEqual({
-      featureFiles: [
-        'rtc-baseline-contracts.ts',
-        'rtc-baseline-decoding.ts',
-        'rtc-baseline-artifact-decoding.ts',
-        'rtc-baseline-workload-catalog.ts',
-        'rtc-baseline-workload-manifest.ts',
-        'rtc-baseline-validation.ts',
-        'rtc-baseline-artifact-validation.ts',
-        'rtc-baseline-statistics.ts',
-        'rtc-baseline-evidence-layout.ts',
-        'rtc-baseline-evidence-store.ts',
-        'rtc-baseline-failure-accounting.ts',
-        'rtc-baseline-evidence-acceptance.ts',
-        'rtc-baseline-finalized-evidence.ts',
-        'rtc-baseline-finalized-reader.ts',
-        'rtc-baseline-envelope.ts',
-        'rtc-baseline-runtime-observation.ts',
-        'rtc-baseline-deno-adapters.ts',
-        'rtc-baseline-deno-runtime.ts',
-        'rtc-baseline-cli-options.ts',
-        'rtc-baseline-cli-grammar.ts',
-        'rtc-baseline-cli.ts',
-        'rtc-data-channel-drain-bench.ts',
-        'rtc-rtt-repository-filter-bench.ts',
-        'rtc-peer-connection-diagnostics-runtime.ts',
-      ],
-      repositoryTests: [
-        'rtc-performance-baseline-contract.test.ts',
-        'rtc-performance-baseline-decoding.test.ts',
-        'rtc-performance-baseline-validation.test.ts',
-        'rtc-performance-baseline-artifact-validation.test.ts',
-        'rtc-performance-baseline-statistics.test.ts',
-        'rtc-performance-baseline-workload-catalog.test.ts',
-        'rtc-performance-baseline-workload-manifest.test.ts',
-        'rtc-performance-baseline-evidence-acceptance.test.ts',
-        'rtc-performance-baseline-evidence-failure.test.ts',
-        'rtc-performance-baseline-evidence-store.test.ts',
-        'rtc-performance-baseline-harnesses.test.ts',
-        'rtc-performance-baseline-envelope.test.ts',
-        'rtc-performance-baseline-finalization.test.ts',
-        'rtc-performance-baseline-finalized-reader.test.ts',
-        'rtc-performance-baseline-deno-adapters.test.ts',
-        'rtc-performance-baseline-deno-runtime.test.ts',
-        'rtc-performance-baseline-cli-grammar.test.ts',
-        'rtc-performance-baseline-cli.test.ts',
-      ],
-      existingTypeScriptHarnesses: [
-        'rtc-peer-connection-diagnostics-burst.ts',
-        'rtc-ice-candidate-queue-bench.ts',
-        'rtc-peer-listener-cleanup-bench.ts',
-        'rtc-data-channel-replace-key-bench.ts',
-        'rtc-data-channel-close-retention-bench.ts',
-        'rtc-data-channel-error-reference-bench.ts',
-        'rtc-topology-star-bench.ts',
-        'rtc-topology-tree-no-rtt-bench.ts',
-        'rtc-topology-mesh-no-rtt-bench.ts',
-        'rtc-room-graph-rtt-bench.ts',
-        'rtc-topology-inactive-churn-bench.ts',
-        'rtc-multicast-serialization-bench.ts',
-        'webrtc-group-cache-fallback-bench.ts',
-        'webrtc-group-manager-state-bench.ts',
-        'webrtc-group-manager-peer-owners-bench.ts',
-        'webrtc-heartbeat-callback-churn-bench.ts',
-      ],
-      nodeSoak: ['rtc-data-channel-browser-soak.mjs'],
-    });
-  });
-
-  it('excludes the three historical probes from accepted harnesses', () => {
-    expect(existingTypeScriptHarnesses).not.toContain('rtc-room-graph-no-rtt-bench.ts');
-    expect(existingTypeScriptHarnesses).not.toContain('rtc-rtt-group-scan-bench.ts');
-    expect(existingTypeScriptHarnesses).not.toContain('rtc-topology-rtt-traffic-metrics.ts');
-  });
+it('retains the exact RTC baseline test-owned 24/18/16/1 inventory and exclusions', () => {
+  const inventory = [featureFiles, repositoryTests, existingTypeScriptHarnesses, nodeSoak];
+  const inventoryHash = createHash('sha256').update(JSON.stringify(inventory)).digest('hex');
+  expect(inventoryHash).toBe('c1f1b81f32fdb75a83648d6fbd06a109006889d8dd49232ab3a27fcdb847dbe1');
 });
-
 const baselineId = '20260807-0123456789ab-e1-local';
-function retainedSampleIds(caseInput: string): string[] {
-  return [1, 2, 3, 4, 5].map(
-    (inner) => `rtc-b01-${caseInput}-retained-001-${String(inner).padStart(3, '0')}`,
-  );
-}
-const burstSampleIds = retainedSampleIds('peer-connection-diagnostics-burst-pairs-500');
-const queueSampleIds = retainedSampleIds('ice-candidate-queue-candidates-25000');
-const listenerSampleIds = retainedSampleIds('peer-listener-cleanup-peers-10000');
-
-function workerArguments(caseId: string, inputKey: string, sampleIds: readonly string[]) {
-  return [
-    '--capture=worker',
-    `--baseline-id=${baselineId}`,
-    '--workload=RTC-B01',
-    `--case-id=${caseId}`,
-    `--input-key=${inputKey}`,
-    '--intended-phase=retained',
-    '--outer-ordinal=1',
-    `--sample-ids=${sampleIds.join(',')}`,
-  ];
-}
-
-const repeated = <T>(value: T): T[] => [value, value, value, value, value];
-function parseExactWorkers() {
+const denoPrefix = fileNames('run --config=apps/api-v1/deno.json --allow-read --allow-write');
+const repeated = <T>(value: T): T[] => Array.from({ length: 5 }, () => value);
+function workerArguments(caseId: string, inputKey: string, flags: readonly string[]) {
+  const workload = caseId.startsWith('data-channel-') ? 'RTC-B02' : 'RTC-B01';
+  const prefix = `rtc-${workload.slice(4).toLowerCase()}-${caseId}-${inputKey}-retained-001`;
+  const ids = [1, 2, 3, 4, 5].map((inner) => `${prefix}-${String(inner).padStart(3, '0')}`);
   return {
-    burst: parseRtcPeerConnectionDiagnosticsArguments([
-      ...workerArguments('peer-connection-diagnostics-burst', 'pairs-500', burstSampleIds),
-      '--rtc-ice-candidates-per-peer=5',
-      '--rtc-inner-runs=5',
-      '--rtc-offer-collisions-per-peer=3',
-      '--rtc-peers=500',
-    ]),
-    queue: parseRtcIceCandidateQueueArguments([
-      ...workerArguments('ice-candidate-queue', 'candidates-25000', queueSampleIds),
-      '--rtc-candidates=25000',
-      '--rtc-inner-runs=5',
-    ]),
-    listeners: parseRtcPeerListenerCleanupArguments([
-      ...workerArguments('peer-listener-cleanup', 'peers-10000', listenerSampleIds),
-      '--rtc-inner-runs=5',
-      '--rtc-peers=10000',
-    ]),
+    ids,
+    arguments: [
+      '--capture=worker',
+      `--baseline-id=${baselineId}`,
+      `--workload=${workload}`,
+      `--case-id=${caseId}`,
+      `--input-key=${inputKey}`,
+      '--intended-phase=retained',
+      '--outer-ordinal=1',
+      `--sample-ids=${ids.join(',')}`,
+      ...flags,
+    ],
   };
 }
-
-const zeroCleanup = {
-  pendingIceCandidateQueueLength: 0,
-  reconnectAttemptsInFlight: 0,
-  activeReconnectTimerCount: 0,
-  pendingTimerCount: 0,
-};
-const validBurstResult = {
-  durationMs: 1,
-  peerCount: 1000,
-  signalingMessagesSent: 500,
-  diagnostics: {
-    queuedIceCandidateCount: 2500,
-    flushedIceCandidateCount: 2500,
-    offerCollisionCount: 1500,
-    ignoredOfferCollisionCount: 1500,
-    reconnectAttemptCount: 500,
-    reconnectTimerAlreadyActiveCount: 500,
-    reconnectExhaustedCount: 500,
-    iceRestartCount: 500,
-  },
-  cleanup: zeroCleanup,
-};
-
-describe('RTC-B01 accepted signaling, ICE, and listener instrumentation', () => {
-  it('rejects invalid diagnostic bounds and non-frozen accepted inputs', () => {
-    expect(parseRtcPeerConnectionDiagnosticsArguments(['--peers=0'])).toMatchObject({ ok: false });
-    expect(parseRtcIceCandidateQueueArguments(['--candidates=25001'])).toMatchObject({ ok: false });
-    expect(parseRtcPeerListenerCleanupArguments(['--runs=6'])).toMatchObject({ ok: false });
-    const invalidOut = ['--out=/tmp/result.json'];
-    const rejected = { ok: false };
-    expect(parseRtcPeerConnectionDiagnosticsArguments(invalidOut)).toMatchObject(rejected);
-    expect(parseRtcIceCandidateQueueArguments(invalidOut)).toMatchObject(rejected);
-    expect(parseRtcPeerListenerCleanupArguments(invalidOut)).toMatchObject(rejected);
-    expect(
-      parseRtcPeerConnectionDiagnosticsArguments([
-        ...workerArguments('peer-connection-diagnostics-burst', 'pairs-500', burstSampleIds),
-        '--rtc-ice-candidates-per-peer=5',
-        '--rtc-inner-runs=5',
-        '--rtc-offer-collisions-per-peer=3',
-        '--rtc-peers=499',
-      ]),
-    ).toMatchObject({ ok: false });
+function drainArguments(depth: 32 | 1000 | 5000) {
+  return workerArguments('data-channel-drain', `depth-${depth}`, [
+    '--rtc-high-watermark-bytes=1',
+    '--rtc-inner-runs=5',
+    '--rtc-low-watermark-bytes=0',
+    '--rtc-overflow=replace-by-key',
+    '--rtc-payload-bytes=256',
+    `--rtc-queue-depth=${depth}`,
+  ]);
+}
+function replaceArgument(arguments_: readonly string[], name: string, value: string): string[] {
+  const prefix = `--${name}=`;
+  return arguments_.map((argument) =>
+    argument.startsWith(prefix) ? `${prefix}${value}` : argument,
+  );
+}
+function requireAccepted<T extends { readonly mode: string }>(result: RtcBaselineResult<T>) {
+  if (!result.ok || result.value.mode !== 'accepted') throw new Error('Expected exact worker.');
+  return result.value as Extract<T, { readonly mode: 'accepted' }>;
+}
+async function runUntilFailure<T>(
+  expectedIds: readonly string[],
+  invalidResult: T,
+  runAccepted: (run: () => Promise<T>) => Promise<RtcBaselineSampleDto[]>,
+): Promise<RtcBaselineSampleDto[]> {
+  let executions = 0;
+  const samples = await runAccepted(async () => {
+    executions += 1;
+    return invalidResult;
   });
-  it('recomputes signaling counters and exposes zero cleanup state from explicit fakes', async () => {
-    const hadPeerConnection = Object.hasOwn(globalThis, 'RTCPeerConnection');
-    const fakeRuntime = createRtcPeerConnectionDiagnosticsDependencies();
-    try {
-      const result = await runRtcPeerConnectionDiagnostics(
-        { peers: 2, iceCandidatesPerPeer: 2, offerCollisionsPerPeer: 3 },
-        fakeRuntime.dependencies,
-      );
-      expect(result).toMatchObject({
-        peerCount: 4,
-        signalingMessagesSent: 2,
-        diagnostics: {
-          queuedIceCandidateCount: 4,
-          flushedIceCandidateCount: 4,
-          offerCollisionCount: 6,
-          ignoredOfferCollisionCount: 6,
-          reconnectAttemptCount: 2,
-          reconnectTimerAlreadyActiveCount: 2,
-          reconnectExhaustedCount: 2,
-          iceRestartCount: 2,
-        },
-        cleanup: zeroCleanup,
-      });
-    } finally {
-      fakeRuntime.restore();
-    }
-    expect(Object.hasOwn(globalThis, 'RTCPeerConnection')).toBe(hadPeerConnection);
+  expect(executions).toBe(1);
+  expect(samples.map((sample) => [sample.identity.sampleId, sample.outcome])).toEqual([
+    [expectedIds[0], 'failed'],
+    ...expectedIds.slice(1).map((id) => [id, 'not-run']),
+  ]);
+  expect(
+    samples.slice(1).map((sample) => [sample.issues[0]?.code, sample.issues[0]?.message]),
+  ).toEqual(expectedIds.slice(1).map(() => ['causal-not-run', expectedIds[0]]));
+  return samples;
+}
+async function persistFailure(
+  workloadId: 'RTC-B01' | 'RTC-B02',
+  caseId: string,
+  outcomes: RtcBaselineSampleDto[],
+) {
+  const manifest = deriveRtcBaselineCaptureManifest({
+    schema: 'rallar.rtc-baseline.capture-request.v1',
+    baselineId,
+    workloadIds: [workloadId],
+    environmentId: 'E1-local',
+    retainedSampleMultiplier: 1,
+    repeatLink: null,
+    conditionalEnvironmentDecisions: [],
   });
-  it('accepts exact B01 inputs and recomputes producer counters and identities', () => {
-    const { burst, queue, listeners } = parseExactWorkers();
-    if (!burst.ok || !queue.ok || !listeners.ok) throw new Error('Expected exact worker inputs.');
-    const queueSamples = createRtcIceCandidateQueueSamples({
-      worker: queue.value,
-      results: repeated({
-        durationMs: 1,
-        candidateCount: 25000,
-        addedCandidates: 25000,
-        remainingQueuedCandidates: 0,
-      }),
-    });
-    const listenerSamples = createRtcPeerListenerCleanupSamples({
-      worker: listeners.value,
-      results: repeated({
-        durationMs: 1,
-        peerCount: 10000,
-        retainedIceGatheringListeners: 0,
-        maxListenersPerPeer: 0,
-        unclearedHandlerSlots: 0,
-      }),
-    });
+  const attempt = manifest.outerAttempts.find(
+    (value) => value.caseId === caseId && value.intendedPhase === 'retained',
+  );
+  if (attempt === undefined) throw new Error(`Missing retained ${caseId} attempt.`);
+  const writes: RtcBaselineAcceptedArtifact[] = [];
+  const acceptance = createRtcBaselineEvidenceAcceptance({
+    initializeStore: async () => ({ ok: true as const, value: undefined }),
+    readManifest: async () => ({
+      ok: true as const,
+      value: { ...manifest, outerAttempts: [attempt] },
+    }),
+    writeAcceptedArtifact: async (_id, artifact) => {
+      writes.push(artifact);
+      return { ok: true as const, value: undefined };
+    },
+    readStagedJson: async () => ({ ok: false as const, issues: [] }),
+    runFreshWorker: async () => ({ outcomes }),
+    reconcileAcceptedOperation: async () => [],
+  });
+  return { result: await acceptance.captureWorkload({ baselineId, workloadId }), writes };
+}
+
+const burst = workerArguments('peer-connection-diagnostics-burst', 'pairs-500', [
+  '--rtc-ice-candidates-per-peer=5',
+  '--rtc-inner-runs=5',
+  '--rtc-offer-collisions-per-peer=3',
+  '--rtc-peers=500',
+]);
+it('RTC-B01 rejects invalid bounds, paths, and accepted overrides', () => {
+  const invalidDiagnostics = [
+    [DiagnosticsBench.parseRtcPeerConnectionDiagnosticsArguments, ['--peers=0']],
+    [IceQueueBench.parseRtcIceCandidateQueueArguments, ['--candidates=25001']],
+    [ListenerBench.parseRtcPeerListenerCleanupArguments, ['--runs=6']],
+  ] as const;
+  for (const [parse, args] of invalidDiagnostics) {
+    expect(parse(args)).toMatchObject({ ok: false });
+    expect(parse(['--out=/tmp/result.json'])).toMatchObject({ ok: false });
+  }
+  expect(
+    DiagnosticsBench.parseRtcPeerConnectionDiagnosticsArguments(
+      replaceArgument(burst.arguments, 'rtc-peers', '499'),
+    ),
+  ).toMatchObject({ ok: false });
+});
+it('RTC-B01 preserves counters, cleanup, identities, and failure persistence', async () => {
+  const fakeRuntime = DiagnosticsBench.createRtcPeerConnectionDiagnosticsDependencies();
+  onTestFinished(fakeRuntime.restore);
+  const valid = await runRtcPeerConnectionDiagnostics(
+    { peers: 500, iceCandidatesPerPeer: 5, offerCollisionsPerPeer: 3 },
+    fakeRuntime.dependencies,
+  );
+  expect([valid.peerCount, valid.signalingMessagesSent]).toEqual([1000, 500]);
+  const counters = valid.diagnostics;
+  expect([counters.queuedIceCandidateCount, counters.flushedIceCandidateCount]).toEqual([
+    2500, 2500,
+  ]);
+  expect([counters.offerCollisionCount, counters.ignoredOfferCollisionCount]).toEqual([1500, 1500]);
+  expect([counters.reconnectAttemptCount, counters.reconnectTimerAlreadyActiveCount]).toEqual([
+    500, 500,
+  ]);
+  expect([counters.reconnectExhaustedCount, counters.iceRestartCount]).toEqual([500, 500]);
+  expect(Object.values(valid.cleanup).every((value) => value === 0)).toBe(true);
+  const invalid = {
+    ...valid,
+    diagnostics: { ...valid.diagnostics, queuedIceCandidateCount: 2499 },
+  };
+  const worker = requireAccepted(
+    DiagnosticsBench.parseRtcPeerConnectionDiagnosticsArguments(burst.arguments),
+  );
+  const outcomes = await runUntilFailure(burst.ids, invalid, (run) =>
+    DiagnosticsBench.runRtcPeerConnectionDiagnosticsAcceptedSamples({ worker, run }),
+  );
+  const persisted = await persistFailure('RTC-B01', 'peer-connection-diagnostics-burst', outcomes);
+  expect(persisted.result).toMatchObject({ ok: false });
+  expect(persisted.writes[0]).toMatchObject({
+    artifactKind: 'failure',
+    identity: { sampleId: burst.ids[0] },
+    issues: [{ code: 'counter-mismatch' }],
+  });
+});
+it('RTC-B01 accepts the fixed queue and listener matrices', () => {
+  const queue = workerArguments('ice-candidate-queue', 'candidates-25000', [
+    '--rtc-candidates=25000',
+    '--rtc-inner-runs=5',
+  ]);
+  const listeners = workerArguments('peer-listener-cleanup', 'peers-10000', [
+    '--rtc-inner-runs=5',
+    '--rtc-peers=10000',
+  ]);
+  const parsedQueue = IceQueueBench.parseRtcIceCandidateQueueArguments(queue.arguments);
+  const parsedListeners = ListenerBench.parseRtcPeerListenerCleanupArguments(listeners.arguments);
+  if (!parsedQueue.ok || !parsedListeners.ok) throw new Error('Expected exact workers.');
+  const queueSamples = IceQueueBench.createRtcIceCandidateQueueSamples({
+    worker: parsedQueue.value,
+    results: repeated({
+      durationMs: 1,
+      candidateCount: 25000,
+      addedCandidates: 25000,
+      remainingQueuedCandidates: 0,
+    }),
+  });
+  const listenerSamples = ListenerBench.createRtcPeerListenerCleanupSamples({
+    worker: parsedListeners.value,
+    results: repeated({
+      durationMs: 1,
+      peerCount: 10000,
+      retainedIceGatheringListeners: 0,
+      maxListenersPerPeer: 0,
+      unclearedHandlerSlots: 0,
+    }),
+  });
+  expect(
+    [...queueSamples, ...listenerSamples].every(
+      (sample) => sample.outcome === 'passed' && sample.evidenceClass === 'synthetic-path',
+    ),
+  ).toBe(true);
+});
+
+const parseReplace = ReplaceBench.parseRtcDataChannelReplaceKeyArguments;
+const parseDrain = DrainBench.parseRtcDataChannelDrainArguments;
+const parseClose = CloseBench.parseRtcDataChannelCloseRetentionArguments;
+const parseError = ErrorBench.parseRtcDataChannelErrorReferenceArguments;
+const acceptedReplace = workerArguments('data-channel-replace-key', 'depth-32', [
+  '--rtc-inner-runs=5',
+  '--rtc-queue-depth=32',
+  '--rtc-replacements=25000',
+]);
+const acceptedDrain = drainArguments(32);
+const acceptedClose = workerArguments('data-channel-close-retention', 'queue-32', [
+  '--rtc-inner-runs=5',
+  '--rtc-queue-depth=32',
+]);
+const acceptedError = workerArguments('data-channel-error-reference', 'fixed', [
+  '--rtc-inner-runs=5',
+]);
+const replaceWorker = requireAccepted(parseReplace(acceptedReplace.arguments));
+const drainWorker = requireAccepted(parseDrain(acceptedDrain.arguments));
+const closeWorker = requireAccepted(parseClose(acceptedClose.arguments));
+const errorWorker = requireAccepted(parseError(acceptedError.arguments));
+it('RTC-B02 accepts only the exact matrix and preserves diagnostic arguments', () => {
+  for (const depth of [32, 1000, 5000]) {
+    const replace = workerArguments('data-channel-replace-key', `depth-${depth}`, [
+      '--rtc-inner-runs=5',
+      `--rtc-queue-depth=${depth}`,
+      '--rtc-replacements=25000',
+    ]);
     expect(
-      [...queueSamples, ...listenerSamples].every(
-        (sample) => sample.outcome === 'passed' && sample.evidenceClass === 'synthetic-path',
+      [parseReplace(replace.arguments), parseDrain(drainArguments(depth).arguments)].every(
+        (result) => result.ok,
       ),
     ).toBe(true);
-  });
-  it('persists a counter failure before returning the accepted failure', async () => {
-    const { burst: worker } = parseExactWorkers();
-    if (!worker.ok) throw new Error('Expected exact worker input.');
-    const invalid = {
-      ...validBurstResult,
-      diagnostics: {
-        ...validBurstResult.diagnostics,
-        queuedIceCandidateCount: 2499,
+  }
+  const rejected = [
+    [parseReplace, acceptedReplace.arguments, 'rtc-queue-depth', '032'],
+    [parseDrain, acceptedDrain.arguments, 'rtc-payload-bytes', '255'],
+    [parseClose, acceptedClose.arguments, 'rtc-queue-depth', '032'],
+    [parseError, acceptedError.arguments, 'rtc-inner-runs', '4'],
+  ] as const;
+  for (const [parse, arguments_, name, value] of rejected) {
+    expect(parse(['--out=/tmp/result.json'])).toMatchObject({ ok: false });
+    expect(parse(replaceArgument(arguments_, name, value))).toMatchObject({ ok: false });
+  }
+});
+it('RTC-B02 bounds lifecycle evidence and stops every runner after its first failure', async () => {
+  const payloadBytes = [0, 31, 999, 4999].map(
+    (index) =>
+      new TextEncoder().encode(DrainBench.createRtcDataChannelDrainPayload(index)).byteLength,
+  );
+  expect(payloadBytes).toEqual([256, 256, 256, 256]);
+  let intervalRead = 0;
+  const result = await DrainBench.runRtcDataChannelDrain(32, {
+    nativeChannel: new DrainBench.RtcDataChannelDrainFakeNativeChannel(() => undefined),
+    clock: {
+      createdAtEpochMs: (index) => 1_700_000_000_000 + index,
+      monotonicNow: () => (intervalRead++ === 0 ? 100 : 125),
+    },
+    payload: {
+      create: (index) => {
+        if (intervalRead !== 0) throw new Error('Payload construction entered the interval.');
+        return DrainBench.createRtcDataChannelDrainPayload(index);
       },
-    };
-    let executedRuns = 0;
-    const outcomes = await runRtcPeerConnectionDiagnosticsAcceptedSamples({
-      worker: worker.value,
-      run: async () => {
-        executedRuns += 1;
-        return invalid;
-      },
-    });
-    expect(executedRuns).toBe(1);
-    expect(outcomes.map((sample) => sample.identity.sampleId)).toEqual(burstSampleIds);
-    const writes: unknown[] = [];
-    const manifest = deriveRtcBaselineCaptureManifest({
-      schema: 'rallar.rtc-baseline.capture-request.v1',
-      baselineId,
-      workloadIds: ['RTC-B01'],
-      environmentId: 'E1-local',
-      retainedSampleMultiplier: 1,
-      repeatLink: null,
-      conditionalEnvironmentDecisions: [],
-    });
-    const attempt = manifest.outerAttempts.find(
-      (value) =>
-        value.caseId === 'peer-connection-diagnostics-burst' && value.intendedPhase === 'retained',
-    )!;
-    const acceptance = createRtcBaselineEvidenceAcceptance({
-      initializeStore: async () => ({ ok: true as const, value: undefined }),
-      readManifest: async () => ({
-        ok: true as const,
-        value: { ...manifest, outerAttempts: [attempt] },
-      }),
-      writeAcceptedArtifact: async (_acceptedBaselineId, artifact) => {
-        writes.push(artifact);
-        return { ok: true as const, value: undefined };
-      },
-      readStagedJson: async () => ({ ok: false as const, issues: [] }),
-      runFreshWorker: async () => ({ outcomes }),
-      reconcileAcceptedOperation: async () => [],
-    });
-    expect(await acceptance.captureWorkload({ baselineId, workloadId: 'RTC-B01' })).toMatchObject({
-      ok: false,
-    });
-    expect(writes[0]).toMatchObject({
-      artifactKind: 'failure',
-      identity: { sampleId: burstSampleIds[0] },
-      issues: [{ code: 'counter-mismatch' }],
-    });
+      byteLength: (value) => new TextEncoder().encode(value).byteLength,
+    },
   });
-  it('keeps create-new diagnostic JSON separate from accepted evidence', () => {
-    mkdirSync('tmp/perf/results', { recursive: true });
-    const directory = mkdtempSync(join('tmp/perf/results', 'rtc-b01-diagnostic-'));
-    const outputPath = join(directory, 'ice.json');
-    const command = [
-      'run',
-      '--config=apps/api-v1/deno.json',
-      '--allow-read',
-      '--allow-write',
-      'scripts/perf/rtc-ice-candidate-queue-bench.ts',
-      '--candidates=1',
-      '--runs=1',
-      `--out=${outputPath}`,
-    ];
-    try {
-      const first = spawnSync('deno', command, { encoding: 'utf8' });
-      const persisted = JSON.parse(readFileSync(outputPath, 'utf8'));
-      const second = spawnSync('deno', command, { encoding: 'utf8' });
-      expect(first.status).toBe(0);
-      expect(persisted).toMatchObject({ input: { candidateCount: 1, runs: 1 } });
-      expect(persisted).not.toHaveProperty('schema');
-      expect(persisted).not.toHaveProperty('outcome');
-      expect(second.status).not.toBe(0);
-    } finally {
-      rmSync(directory, { recursive: true, force: true });
-    }
-  });
+  expect(result).toMatchObject({ queueDepth: 32, queuedBeforeDrain: 32, queuedAfterDrain: 0 });
+  expect(result.maximumQueuedItemCount).toBe(32);
+  expect(result).toMatchObject({ sentBeforeDrain: 0, sentDuringDrain: 32, payloadBytes: 256 });
+  expect(result.sentBytesDuringDrain).toBe(8192);
+  expect(result.intervalStartedAtMs).toBe(100);
+  expect(result.intervalCompletedAtMs).toBe(125);
+  expect(result.drainDurationMs).toBe(25);
+  expect(intervalRead).toBe(2);
+  const replacement = await ReplaceBench.runRtcDataChannelReplaceKey(32, 25000);
+  expect(replacement).toMatchObject({ queueDepth: 32, replacements: 25000, queuedItemCount: 32 });
+  expect(replacement.sentCount).toBe(0);
+  expect(replacement.counters).toMatchObject({ queued: 32, replaced: 25000 });
+  const close = await CloseBench.runRtcDataChannelCloseRetention(32);
+  expect(close.queuedBeforeClose).toBe(32);
+  expect(close.queuedAfterNativeClose).toBe(0);
+  expect(close.queuedAfterReconnect).toBe(0);
+  expect(close.replacementSentCount).toBe(0);
+  expect(close.staleFlushOnReconnect).toBe(false);
+  const error = await ErrorBench.runRtcDataChannelErrorReference();
+  expect(error.readyStateAfterError).toBeUndefined();
+  expect(error.statusHasDataChannelAfterError).toBe(false);
+  expect(error.attachedHandlerCountAfterError).toBe(0);
+  const failures = await Promise.all([
+    runUntilFailure(acceptedReplace.ids, { ...replacement, queuedItemCount: 31 }, (run) =>
+      ReplaceBench.runRtcDataChannelReplaceKeyAcceptedSamples({ worker: replaceWorker, run }),
+    ),
+    runUntilFailure(
+      acceptedDrain.ids,
+      {
+        ...result,
+        queuedAfterDrain: 1,
+        sentDuringDrain: 31,
+        sentBytesDuringDrain: 7936,
+      },
+      (run) => DrainBench.runRtcDataChannelDrainAcceptedSamples({ worker: drainWorker, run }),
+    ),
+    runUntilFailure(acceptedClose.ids, { ...close, queuedAfterReconnect: 1 }, (run) =>
+      CloseBench.runRtcDataChannelCloseRetentionAcceptedSamples({ worker: closeWorker, run }),
+    ),
+    runUntilFailure(acceptedError.ids, { ...error, attachedHandlerCountAfterError: 1 }, (run) =>
+      ErrorBench.runRtcDataChannelErrorReferenceAcceptedSamples({ worker: errorWorker, run }),
+    ),
+  ]);
+  const outcomes = failures[1];
+  const persisted = await persistFailure('RTC-B02', 'data-channel-drain', outcomes);
+  expect(persisted.result).toMatchObject({ ok: false });
+  const failureArtifact = persisted.writes[0];
+  if (failureArtifact?.artifactKind !== 'failure') throw new Error('Expected failure artifact.');
+  expect(failureArtifact.identity).toMatchObject({ sampleId: acceptedDrain.ids[0] });
+  for (let index = 1; index < acceptedDrain.ids.length; index += 1) {
+    expect(persisted.writes[index]).toMatchObject({
+      artifactKind: 'not-run',
+      failureId: failureArtifact.failureId,
+      causalFailureId: failureArtifact.failureId,
+      identity: { sampleId: acceptedDrain.ids[index] },
+      issues: [{ code: 'causal-not-run' }],
+    });
+  }
+});
+it('RTC-B02 keeps every diagnostic create-new file outside accepted evidence', () => {
+  mkdirSync('tmp/perf/results', { recursive: true });
+  const directory = mkdtempSync(join('tmp/perf/results', 'rtc-diagnostic-'));
+  onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+  const cases = [
+    ['scripts/perf/rtc-ice-candidate-queue-bench.ts', '--candidates=1'],
+    ['scripts/perf/rtc-data-channel-replace-key-bench.ts', '--queue-size=1', '--replacements=1'],
+    ['scripts/perf/rtc-baseline/rtc-data-channel-drain-bench.ts', '--queue-depth=32'],
+    ['scripts/perf/rtc-data-channel-close-retention-bench.ts', '--queue-items=1'],
+    ['scripts/perf/rtc-data-channel-error-reference-bench.ts'],
+  ];
+  for (const [index, arguments_] of cases.entries()) {
+    const outputPath = join(directory, `${index}.json`);
+    const command = [...denoPrefix, ...arguments_, '--runs=1', `--out=${outputPath}`];
+    expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
+    const persisted = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect([persisted.schema, persisted.outcome]).toEqual([undefined, undefined]);
+    expect(spawnSync('deno', command, { encoding: 'utf8' }).status).not.toBe(0);
+  }
 });

--- a/scripts/perf/rtc-baseline/rtc-data-channel-drain-bench.ts
+++ b/scripts/perf/rtc-baseline/rtc-data-channel-drain-bench.ts
@@ -1,0 +1,399 @@
+import { QRtcDataChannel, type RtcDataChannelPayload } from '@shared/webrtc/QRtcDataChannel.ts';
+
+import {
+  rtcBaselineIssue,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+} from './rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline-validation.ts';
+
+export type RtcDataChannelDrainDepth = 32 | 1000 | 5000;
+const frozenDepthByValue: Readonly<Record<string, RtcDataChannelDrainDepth>> = {
+  '32': 32,
+  '1000': 1000,
+  '5000': 5000,
+};
+export interface RtcDataChannelDrainDependencies {
+  readonly nativeChannel: RtcDataChannelDrainFakeNativeChannel;
+  readonly clock: Readonly<{
+    createdAtEpochMs: (index: number) => number;
+    monotonicNow: () => number;
+  }>;
+  readonly payload: Readonly<{
+    create: (index: number) => string;
+    byteLength: (value: string) => number;
+  }>;
+}
+export interface RtcDataChannelDrainResult {
+  readonly queueDepth: number;
+  readonly queuedBeforeDrain: number;
+  readonly queuedAfterDrain: number;
+  readonly maximumQueuedItemCount: number;
+  readonly sentBeforeDrain: number;
+  readonly sentDuringDrain: number;
+  readonly payloadBytes: number;
+  readonly sentBytesDuringDrain: number;
+  readonly intervalStartedAtMs: number;
+  readonly intervalCompletedAtMs: number;
+  readonly drainDurationMs: number;
+  readonly highWatermarkBytes: 1;
+  readonly lowWatermarkBytes: 0;
+  readonly overflow: 'replace-by-key';
+}
+interface RtcDataChannelDrainInput {
+  readonly queueDepth: RtcDataChannelDrainDepth;
+  readonly runs: number;
+}
+interface RtcDataChannelDrainAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: RtcDataChannelDrainInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+const acceptedNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-queue-depth rtc-payload-bytes rtc-high-watermark-bytes rtc-low-watermark-bytes ' +
+  'rtc-overflow rtc-inner-runs'
+).split(' ');
+
+export function createRtcDataChannelDrainPayload(index: number): string {
+  const prefix = `{"entityId":"entity-${index}","padding":"`;
+  const suffix = '"}';
+  return `${prefix}${'x'.repeat(256 - prefix.length - suffix.length)}${suffix}`;
+}
+export async function runRtcDataChannelDrain(
+  queueDepth: RtcDataChannelDrainDepth,
+  dependencies: RtcDataChannelDrainDependencies,
+): Promise<RtcDataChannelDrainResult> {
+  const peerConnection = {
+    onDataChannelDo: () => peerConnection,
+    createDataChannel: () => dependencies.nativeChannel,
+  };
+  const dataChannel = new QRtcDataChannel(peerConnection as never, {
+    peerId: 'rtc-b02-peer',
+    dataChannelName: 'realtime',
+    flowControl: {
+      highWatermarkBytes: 1,
+      lowWatermarkBytes: 0,
+      overflow: 'replace-by-key',
+      maxQueueItems: queueDepth,
+    },
+  });
+  const payloads = createDrainPayloads(queueDepth, dependencies.payload);
+  dataChannel.connect(true);
+  await dependencies.nativeChannel.emitOpen();
+  dependencies.nativeChannel.bufferedAmount = 1;
+  for (let index = 0; index < queueDepth; index += 1) {
+    const offered = dataChannel.sendRaw(payloads[index], {
+      key: `entity-${index}`,
+      now: () => dependencies.clock.createdAtEpochMs(index),
+    });
+    if (offered.status !== 'queued') {
+      throw new Error(`Expected queued fill result, received ${offered.status}.`);
+    }
+  }
+  const beforeDrain = dataChannel.readHealth().queuedItemCount;
+  const sentBeforeDrain = dependencies.nativeChannel.sent.length;
+  dependencies.nativeChannel.bufferedAmount = 0;
+  const startedAtMs = dependencies.clock.monotonicNow();
+  await dependencies.nativeChannel.emitBufferedAmountLow();
+  const completedAtMs = dependencies.clock.monotonicNow();
+  const sentDuringDrain = dependencies.nativeChannel.sent.length - sentBeforeDrain;
+  return {
+    queueDepth,
+    queuedBeforeDrain: beforeDrain,
+    queuedAfterDrain: dataChannel.readHealth().queuedItemCount,
+    maximumQueuedItemCount: beforeDrain,
+    sentBeforeDrain,
+    sentDuringDrain,
+    payloadBytes: 256,
+    sentBytesDuringDrain: sentDuringDrain * 256,
+    intervalStartedAtMs: startedAtMs,
+    intervalCompletedAtMs: completedAtMs,
+    drainDurationMs: completedAtMs - startedAtMs,
+    highWatermarkBytes: 1,
+    lowWatermarkBytes: 0,
+    overflow: 'replace-by-key',
+  };
+}
+export function parseRtcDataChannelDrainArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['queue-depth', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+export async function runRtcDataChannelDrainAcceptedSamples(input: {
+  readonly worker: RtcDataChannelDrainAcceptedArguments;
+  readonly run: () => Promise<RtcDataChannelDrainResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const samples: RtcBaselineSampleDto[] = [];
+  let failureId: string | undefined;
+  for (let index = 0; index < input.worker.sampleIds.length; index += 1) {
+    const sampleId = input.worker.sampleIds[index];
+    const result = failureId === undefined ? await input.run() : null;
+    const issues =
+      result === null
+        ? [rtcBaselineIssue('$.rawEvidence', 'causal-not-run', failureId ?? 'Missing inner run.')]
+        : validateResult(input.worker.input.queueDepth, result);
+    if (result !== null && issues.length > 0) failureId = sampleId;
+    samples.push({
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity: {
+        sampleId,
+        workloadId: 'RTC-B02',
+        caseId: 'data-channel-drain',
+        inputKey: `depth-${input.worker.input.queueDepth}`,
+        intendedPhase: input.worker.intendedPhase,
+        outerOrdinal: input.worker.outerOrdinal,
+        innerOrdinal: index + 1,
+      },
+      outcome: result === null ? 'not-run' : issues.length === 0 ? 'passed' : 'failed',
+      evidenceClass: 'synthetic-path',
+      metrics:
+        result === null
+          ? []
+          : [{ metric: 'drainDurationMs', unit: 'ms', value: result.drainDurationMs }],
+      rawEvidence: result === null ? null : { ...result },
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    });
+  }
+  return samples;
+}
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const depth = parseFrozenDepth(options['queue-depth'] ?? '5000', 'queue-depth');
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const out = options.out ?? 'tmp/perf/results/rtc-data-channel-drain.json';
+  const issues = [...(!depth.ok ? depth.issues : []), ...(!runs.ok ? runs.issues : [])];
+  const confinedOutput =
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    out
+      .split('/')
+      .every((component) => component !== '' && component !== '.' && component !== '..');
+  if (!confinedOutput) {
+    issues.push(
+      rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.'),
+    );
+  }
+  const queueDepth = depth.ok ? depth.value : 32;
+  const runCount = runs.ok ? runs.value : 1;
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: { mode: 'diagnostic' as const, input: { queueDepth, runs: runCount }, out },
+      };
+}
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const depth = parseFrozenDepth(options['rtc-queue-depth'] ?? '', 'rtc-queue-depth');
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = [...(!depth.ok ? depth.issues : []), ...(!outer.ok ? outer.issues : [])];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = depth.ok
+    ? {
+        capture: 'worker',
+        workload: 'RTC-B02',
+        'case-id': 'data-channel-drain',
+        'input-key': `depth-${depth.value}`,
+        'rtc-payload-bytes': '256',
+        'rtc-high-watermark-bytes': '1',
+        'rtc-low-watermark-bytes': '0',
+        'rtc-overflow': 'replace-by-key',
+        'rtc-inner-runs': '5',
+      }
+    : {};
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
+    }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const queueDepth = depth.ok ? depth.value : 32;
+  const expectedIds = createExpectedSampleIds(
+    queueDepth,
+    phase === 'warmup' ? phase : 'retained',
+    ordinal,
+  );
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { queueDepth, runs: 5 },
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
+}
+function parseFrozenDepth(
+  value: string,
+  name: string,
+): RtcBaselineResult<RtcDataChannelDrainDepth> {
+  const depth = frozenDepthByValue[value];
+  if (depth !== undefined) return { ok: true as const, value: depth };
+  return {
+    ok: false as const,
+    issues: [
+      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', 'Expected 32, 1000, or 5000.'),
+    ],
+  };
+}
+function createExpectedSampleIds(
+  depth: number,
+  phase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix =
+    `rtc-b02-data-channel-drain-depth-${depth}-${phase}-` + String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+function createDrainPayloads(
+  queueDepth: RtcDataChannelDrainDepth,
+  payloadDependency: RtcDataChannelDrainDependencies['payload'],
+): string[] {
+  return Array.from({ length: queueDepth }, (_value, index) => {
+    const payload = payloadDependency.create(index);
+    if (payloadDependency.byteLength(payload) !== 256) {
+      throw new Error(`Payload ${index} must contain exactly 256 UTF-8 bytes.`);
+    }
+    return payload;
+  });
+}
+function validateResult(depth: RtcDataChannelDrainDepth, result: RtcDataChannelDrainResult) {
+  const issues = [];
+  if (
+    result.queueDepth !== depth ||
+    result.queuedBeforeDrain !== depth ||
+    result.queuedAfterDrain !== 0 ||
+    result.maximumQueuedItemCount !== depth
+  ) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.queueDepth', 'queue-bound-mismatch', 'Unexpected.'),
+    );
+  }
+  if (result.sentBeforeDrain !== 0 || result.sentDuringDrain !== depth) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.sentDuringDrain', 'send-count-mismatch', 'Unexpected.'),
+    );
+  }
+  if (result.payloadBytes !== 256 || result.sentBytesDuringDrain !== depth * 256) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.sentBytesDuringDrain', 'byte-count-mismatch', 'Unexpected.'),
+    );
+  }
+  if (
+    result.drainDurationMs !== result.intervalCompletedAtMs - result.intervalStartedAtMs ||
+    result.drainDurationMs < 0
+  ) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.drainDurationMs', 'interval-mismatch', 'Unexpected.'),
+    );
+  }
+  if (
+    result.highWatermarkBytes !== 1 ||
+    result.lowWatermarkBytes !== 0 ||
+    result.overflow !== 'replace-by-key'
+  ) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.flowControl', 'flow-control-mismatch', 'Unexpected.'),
+    );
+  }
+  return issues;
+}
+
+function createDefaultDependencies(): RtcDataChannelDrainDependencies {
+  const encoder = new TextEncoder();
+  return {
+    nativeChannel: new RtcDataChannelDrainFakeNativeChannel(),
+    clock: {
+      createdAtEpochMs: (index) => 1_700_000_000_000 + index,
+      monotonicNow: () => performance.now(),
+    },
+    payload: {
+      create: createRtcDataChannelDrainPayload,
+      byteLength: (value) => encoder.encode(value).byteLength,
+    },
+  };
+}
+async function main(): Promise<void> {
+  const parsed = parseRtcDataChannelDrainArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  if (parsed.value.mode === 'accepted') {
+    const samples = await runRtcDataChannelDrainAcceptedSamples({
+      worker: parsed.value,
+      run: () => runRtcDataChannelDrain(parsed.value.input.queueDepth, createDefaultDependencies()),
+    });
+    writeLine(JSON.stringify(samples));
+    return;
+  }
+  const results = [];
+  for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+    results.push({
+      run,
+      ...(await runRtcDataChannelDrain(parsed.value.input.queueDepth, createDefaultDependencies())),
+    });
+  }
+  const output = { input: parsed.value.input, results };
+  await Deno.writeTextFile(parsed.value.out, `${JSON.stringify(output, null, 2)}\n`, {
+    createNew: true,
+  });
+  writeLine(`Wrote ${parsed.value.out}`);
+}
+
+export class RtcDataChannelDrainFakeNativeChannel {
+  readonly sent: RtcDataChannelPayload[] = [];
+  readyState: RTCDataChannelState = 'connecting';
+  bufferedAmount = 1;
+  onopen: (() => void | Promise<void>) | null = null;
+  onbufferedamountlow: (() => void | Promise<void>) | null = null;
+  private readonly onSend: (data: RtcDataChannelPayload) => void;
+  constructor(onSend: (data: RtcDataChannelPayload) => void = () => {}) {
+    this.onSend = onSend;
+  }
+  send(data: RtcDataChannelPayload): void {
+    this.sent.push(data);
+    this.onSend(data);
+  }
+  close(): void {
+    this.readyState = 'closed';
+  }
+  async emitOpen(): Promise<void> {
+    this.readyState = 'open';
+    await this.onopen?.();
+  }
+  async emitBufferedAmountLow(): Promise<void> {
+    await this.onbufferedamountlow?.();
+  }
+}
+if (import.meta.main) await main();

--- a/scripts/perf/rtc-data-channel-close-retention-bench.ts
+++ b/scripts/perf/rtc-data-channel-close-retention-bench.ts
@@ -1,165 +1,387 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
-import { performance } from 'node:perf_hooks';
-import { QRtcDataChannel } from '../../../packages/shared/webrtc/QRtcDataChannel.ts';
+import { QRtcDataChannel, type RtcDataChannelPayload } from '@shared/webrtc/QRtcDataChannel.ts';
 
-type Args = Readonly<{
-    queueItems: number;
-    runs: number;
-    out: string;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineJson,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
 
-type RunResult = Readonly<{
-    run: number;
-    queueItems: number;
-    durationMs: number;
-    queuedBeforeClose: number;
-    queuedAfterNativeClose: number;
-    queuedAfterReconnect: number;
-    replacementSentCount: number;
-    staleFlushOnReconnect: boolean;
-}>;
-
-class FakeRTCDataChannel {
-    readonly sent: Array<string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>> = [];
-    readyState: RTCDataChannelState = 'connecting';
-    bufferedAmount = 0;
-    bufferedAmountLowThreshold = 0;
-    binaryType: BinaryType = 'blob';
-    onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
-    onopen: (() => void | Promise<void>) | null = null;
-    onclose: (() => void | Promise<void>) | null = null;
-    onerror: (() => void | Promise<void>) | null = null;
-    onbufferedamountlow: (() => void | Promise<void>) | null = null;
-
-    constructor(public readonly label: string) {
-    }
-
-    send(data: string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>): void {
-        this.sent.push(data);
-    }
-
-    close(): void {
-        this.readyState = 'closed';
-    }
-
-    async emitOpen(): Promise<void> {
-        this.readyState = 'open';
-        await this.onopen?.();
-    }
-
-    async emitClose(): Promise<void> {
-        this.readyState = 'closed';
-        await this.onclose?.();
-    }
-
-    async emitBufferedAmountLow(): Promise<void> {
-        await this.onbufferedamountlow?.();
-    }
+interface RtcDataChannelCloseRetentionInput {
+  readonly queueDepth: number;
+  readonly runs: number;
 }
 
-function createPeerConnectionHarness() {
-    const createdChannels: FakeRTCDataChannel[] = [];
-    const peerConnection = {
-        isReadyToConnect: () => true,
-        onDataChannelDo: function () {
-            return peerConnection;
-        },
-        createDataChannel: (label: string) => {
-            const channel = new FakeRTCDataChannel(label);
-            createdChannels.push(channel);
-            return channel;
-        },
-    };
-
-    return {
-        peerConnection,
-        createdChannels,
-    };
+interface RtcDataChannelCloseRetentionAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: RtcDataChannelCloseRetentionInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
 }
 
-function parseArgs(): Args {
-    const args = process.argv.slice(2);
-    const readValue = (name: string, fallback: string) => {
-        const prefix = `--${name}=`;
-        return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback;
-    };
-
-    return {
-        queueItems: Number(readValue('queue-items', '32')),
-        runs: Number(readValue('runs', '3')),
-        out: readValue(
-            'out',
-            'tmp/perf/results/rtc-data-channel-close-retention.json',
-        ),
-    };
+export interface RtcDataChannelCloseRetentionResult {
+  readonly durationMs: number;
+  readonly queueDepth: number;
+  readonly queuedBeforeClose: number;
+  readonly queuedAfterNativeClose: number;
+  readonly queuedAfterReconnect: number;
+  readonly replacementSentCount: number;
+  readonly staleFlushOnReconnect: boolean;
 }
 
-async function runOnce(run: number, queueItems: number): Promise<RunResult> {
-    const start = performance.now();
-    const peerConnection = createPeerConnectionHarness();
-    const dataChannel = new QRtcDataChannel(
-        peerConnection.peerConnection as never,
-        {
-            peerId: 'perf-peer',
-            dataChannelName: 'realtime',
-            flowControl: {
-                highWatermarkBytes: 1,
-                lowWatermarkBytes: 0,
-                overflow: 'queue',
-                maxQueueItems: queueItems,
-            },
-        },
+const acceptedNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-queue-depth',
+  'rtc-inner-runs',
+];
+
+export function parseRtcDataChannelCloseRetentionArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['queue-items', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+
+export async function runRtcDataChannelCloseRetention(
+  queueDepth: number,
+): Promise<RtcDataChannelCloseRetentionResult> {
+  const startedAt = performance.now();
+  const nativeChannels: FakeRtcDataChannel[] = [];
+  const peerConnection = {
+    isReadyToConnect: () => true,
+    onDataChannelDo: () => peerConnection,
+    createDataChannel: (label: string) => {
+      const channel = new FakeRtcDataChannel(label);
+      nativeChannels.push(channel);
+      return channel;
+    },
+  };
+  const dataChannel = new QRtcDataChannel(peerConnection as never, {
+    peerId: 'perf-peer',
+    dataChannelName: 'realtime',
+    flowControl: {
+      highWatermarkBytes: 1,
+      lowWatermarkBytes: 0,
+      overflow: 'queue',
+      maxQueueItems: queueDepth,
+    },
+  });
+
+  dataChannel.connect(true);
+  const firstChannel = nativeChannels[0];
+  firstChannel.bufferedAmount = 1;
+  await firstChannel.emitOpen();
+  for (let index = 0; index < queueDepth; index += 1) {
+    dataChannel.sendJson({ seq: index });
+  }
+  const queuedBeforeClose = dataChannel.readHealth().queuedItemCount;
+  await firstChannel.emitClose();
+  const queuedAfterNativeClose = dataChannel.readHealth().queuedItemCount;
+
+  dataChannel.connect(true);
+  const replacementChannel = nativeChannels[1];
+  await replacementChannel.emitOpen();
+  replacementChannel.bufferedAmount = 0;
+  await replacementChannel.emitBufferedAmountLow();
+  const queuedAfterReconnect = dataChannel.readHealth().queuedItemCount;
+  const replacementSentCount = replacementChannel.sent.length;
+  return {
+    durationMs: performance.now() - startedAt,
+    queueDepth,
+    queuedBeforeClose,
+    queuedAfterNativeClose,
+    queuedAfterReconnect,
+    replacementSentCount,
+    staleFlushOnReconnect: replacementSentCount > 0,
+  };
+}
+
+export async function runRtcDataChannelCloseRetentionAcceptedSamples(input: {
+  readonly worker: RtcDataChannelCloseRetentionAcceptedArguments;
+  readonly run: () => Promise<RtcDataChannelCloseRetentionResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const samples: RtcBaselineSampleDto[] = [];
+  let failureId: string | undefined;
+  for (let index = 0; index < input.worker.sampleIds.length; index += 1) {
+    const identity = createIdentity(input.worker, index);
+    if (failureId !== undefined) {
+      samples.push(
+        createSample(identity, null, [
+          rtcBaselineIssue('$.rawEvidence', 'causal-not-run', failureId),
+        ]),
+      );
+      continue;
+    }
+    const result = await input.run();
+    const issues = validateResult(input.worker.input.queueDepth, result);
+    if (issues.length > 0) failureId = identity.sampleId;
+    samples.push(createSample(identity, result, issues));
+  }
+  return samples;
+}
+
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const queueDepth = parseRtcBaselineBoundedInteger(
+    options['queue-items'] ?? '32',
+    'queue-items',
+    1,
+    5000,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '3', 'runs', 1, 5);
+  const out = options.out ?? 'tmp/perf/results/rtc-data-channel-close-retention.json';
+  const issues = [...(!queueDepth.ok ? queueDepth.issues : []), ...(!runs.ok ? runs.issues : [])];
+  if (!isDiagnosticOutput(out)) {
+    issues.push(
+      rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.'),
     );
+  }
+  const queueDepthValue = queueDepth.ok ? queueDepth.value : 1;
+  const runCount = runs.ok ? runs.value : 1;
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'diagnostic' as const,
+          input: { queueDepth: queueDepthValue, runs: runCount },
+          out,
+        },
+      };
+}
 
-    dataChannel.connect(true);
-    const firstChannel = peerConnection.createdChannels[0];
-    firstChannel.bufferedAmount = 1;
-    await firstChannel.emitOpen();
-
-    for (let i = 0; i < queueItems; i += 1) {
-        dataChannel.sendJson({ seq: i });
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const queueDepth = parseRtcBaselineBoundedInteger(
+    options['rtc-queue-depth'] ?? '',
+    'rtc-queue-depth',
+    32,
+    32,
+  );
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = [...(!queueDepth.ok ? queueDepth.issues : []), ...(!outer.ok ? outer.issues : [])];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B02',
+    'case-id': 'data-channel-close-retention',
+    'input-key': 'queue-32',
+    'rtc-queue-depth': '32',
+    'rtc-inner-runs': '5',
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
     }
-
-    const queuedBeforeClose = dataChannel.readHealth().queuedItemCount;
-    await firstChannel.emitClose();
-    const queuedAfterNativeClose = dataChannel.readHealth().queuedItemCount;
-
-    dataChannel.connect(true);
-    const replacementChannel = peerConnection.createdChannels[1];
-    await replacementChannel.emitOpen();
-    replacementChannel.bufferedAmount = 0;
-    await replacementChannel.emitBufferedAmountLow();
-
-    const queuedAfterReconnect = dataChannel.readHealth().queuedItemCount;
-    const replacementSentCount = replacementChannel.sent.length;
-
-    return {
-        run,
-        queueItems,
-        durationMs: performance.now() - start,
-        queuedBeforeClose,
-        queuedAfterNativeClose,
-        queuedAfterReconnect,
-        replacementSentCount,
-        staleFlushOnReconnect: replacementSentCount > 0,
-    };
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(phase === 'warmup' ? phase : 'retained', ordinal);
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { queueDepth: 32, runs: 5 },
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
 }
 
-const args = parseArgs();
-const results: RunResult[] = [];
-
-for (let run = 1; run <= args.runs; run += 1) {
-    results.push(await runOnce(run, args.queueItems));
+function createExpectedSampleIds(phase: 'warmup' | 'retained', outerOrdinal: number): string[] {
+  const prefix =
+    `rtc-b02-data-channel-close-retention-queue-32-${phase}-` +
+    String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
 }
 
-const output = {
-    command: process.argv.join(' '),
-    queueItems: args.queueItems,
-    runs: args.runs,
-    results,
-};
+function createIdentity(
+  worker: RtcDataChannelCloseRetentionAcceptedArguments,
+  index: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId: worker.sampleIds[index],
+    workloadId: 'RTC-B02',
+    caseId: 'data-channel-close-retention',
+    inputKey: 'queue-32',
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal: index + 1,
+  };
+}
 
-mkdirSync(dirname(args.out), { recursive: true });
-writeFileSync(args.out, `${JSON.stringify(output, null, 2)}\n`);
-console.log(JSON.stringify(output, null, 2));
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: RtcDataChannelCloseRetentionResult | null,
+  issues: RtcBaselineSampleDto['issues'],
+): RtcBaselineSampleDto {
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: result === null ? 'not-run' : issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics:
+      result === null ? [] : [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: result === null ? null : toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(queueDepth: number, result: RtcDataChannelCloseRetentionResult) {
+  const issues = [];
+  if (result.queueDepth !== queueDepth || result.queuedBeforeClose !== queueDepth) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.queuedBeforeClose', 'queue-bound-mismatch', 'Unexpected.'),
+    );
+  }
+  if (result.queuedAfterNativeClose !== 0 || result.queuedAfterReconnect !== 0) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.queuedAfterReconnect', 'cleanup-nonzero', 'Expected 0.'),
+    );
+  }
+  if (result.replacementSentCount !== 0 || result.staleFlushOnReconnect) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rawEvidence.replacementSentCount',
+        'stale-reconnect-send',
+        'Expected no stale send.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function toRawEvidence(result: RtcDataChannelCloseRetentionResult): RtcBaselineJson {
+  return {
+    durationMs: result.durationMs,
+    queueDepth: result.queueDepth,
+    queuedBeforeClose: result.queuedBeforeClose,
+    queuedAfterNativeClose: result.queuedAfterNativeClose,
+    queuedAfterReconnect: result.queuedAfterReconnect,
+    replacementSentCount: result.replacementSentCount,
+    staleFlushOnReconnect: result.staleFlushOnReconnect,
+  };
+}
+
+function isDiagnosticOutput(out: string): boolean {
+  return (
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    out.split('/').every((component) => component !== '' && component !== '.' && component !== '..')
+  );
+}
+
+async function main(): Promise<void> {
+  const parsed = parseRtcDataChannelCloseRetentionArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  if (parsed.value.mode === 'accepted') {
+    const samples = await runRtcDataChannelCloseRetentionAcceptedSamples({
+      worker: parsed.value,
+      run: () => runRtcDataChannelCloseRetention(parsed.value.input.queueDepth),
+    });
+    writeLine(JSON.stringify(samples));
+    return;
+  }
+  const results = [];
+  for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+    results.push({
+      run,
+      ...(await runRtcDataChannelCloseRetention(parsed.value.input.queueDepth)),
+    });
+  }
+  await Deno.writeTextFile(
+    parsed.value.out,
+    `${JSON.stringify(
+      {
+        command: Deno.args,
+        queueItems: parsed.value.input.queueDepth,
+        runs: parsed.value.input.runs,
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+    { createNew: true },
+  );
+  writeLine(
+    JSON.stringify(
+      { queueItems: parsed.value.input.queueDepth, runs: parsed.value.input.runs, results },
+      null,
+      2,
+    ),
+  );
+}
+
+class FakeRtcDataChannel {
+  readonly label: string;
+  readonly sent: RtcDataChannelPayload[] = [];
+  readyState: RTCDataChannelState = 'connecting';
+  bufferedAmount = 0;
+  bufferedAmountLowThreshold = 0;
+  binaryType: BinaryType = 'blob';
+  onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
+  onopen: (() => void | Promise<void>) | null = null;
+  onclose: (() => void | Promise<void>) | null = null;
+  onerror: (() => void | Promise<void>) | null = null;
+  onbufferedamountlow: (() => void | Promise<void>) | null = null;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+  send(data: RtcDataChannelPayload): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 'closed';
+  }
+  async emitOpen(): Promise<void> {
+    this.readyState = 'open';
+    await this.onopen?.();
+  }
+  async emitClose(): Promise<void> {
+    this.readyState = 'closed';
+    await this.onclose?.();
+  }
+  async emitBufferedAmountLow(): Promise<void> {
+    await this.onbufferedamountlow?.();
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/perf/rtc-data-channel-error-reference-bench.ts
+++ b/scripts/perf/rtc-data-channel-error-reference-bench.ts
@@ -1,139 +1,309 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
-import { performance } from 'node:perf_hooks';
-import { QRtcDataChannel } from '../../../packages/shared/webrtc/QRtcDataChannel.ts';
+import { QRtcDataChannel } from '@shared/webrtc/QRtcDataChannel.ts';
 
-type Args = Readonly<{
-    runs: number;
-    out: string;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineJson,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
 
-type RunResult = Readonly<{
-    run: number;
-    durationMs: number;
-    readyStateAfterError: RTCDataChannelState | undefined;
-    statusHasDataChannelAfterError: boolean;
-    attachedHandlerCountAfterError: number;
-}>;
-
-class FakeRTCDataChannel {
-    readonly sent: Array<string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>> = [];
-    readyState: RTCDataChannelState = 'connecting';
-    bufferedAmount = 0;
-    bufferedAmountLowThreshold = 0;
-    binaryType: BinaryType = 'blob';
-    onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
-    onopen: (() => void | Promise<void>) | null = null;
-    onclose: (() => void | Promise<void>) | null = null;
-    onerror: (() => void | Promise<void>) | null = null;
-    onbufferedamountlow: (() => void | Promise<void>) | null = null;
-
-    constructor(public readonly label: string) {
-    }
-
-    send(data: string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>): void {
-        this.sent.push(data);
-    }
-
-    close(): void {
-        this.readyState = 'closed';
-    }
-
-    async emitOpen(): Promise<void> {
-        this.readyState = 'open';
-        await this.onopen?.();
-    }
-
-    async emitError(): Promise<void> {
-        this.readyState = 'closed';
-        await this.onerror?.();
-    }
-
-    attachedHandlerCount(): number {
-        return [
-            this.onmessage,
-            this.onopen,
-            this.onclose,
-            this.onerror,
-            this.onbufferedamountlow,
-        ].filter((handler) => handler !== null).length;
-    }
+interface RtcDataChannelErrorReferenceAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly runs: number;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
 }
 
-function createPeerConnectionHarness() {
-    const createdChannels: FakeRTCDataChannel[] = [];
+export interface RtcDataChannelErrorReferenceResult {
+  readonly durationMs: number;
+  readonly readyStateAfterError: RTCDataChannelState | undefined;
+  readonly statusHasDataChannelAfterError: boolean;
+  readonly attachedHandlerCountAfterError: number;
+}
+
+const acceptedNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-inner-runs',
+];
+
+export function parseRtcDataChannelErrorReferenceArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+
+export const runRtcDataChannelErrorReference =
+  async (): Promise<RtcDataChannelErrorReferenceResult> => {
+    const startedAt = performance.now();
+    const nativeChannel = new FakeRtcDataChannel('realtime');
     const peerConnection = {
-        isReadyToConnect: () => true,
-        onDataChannelDo: function () {
-            return peerConnection;
-        },
-        createDataChannel: (label: string) => {
-            const channel = new FakeRTCDataChannel(label);
-            createdChannels.push(channel);
-            return channel;
-        },
+      isReadyToConnect: () => true,
+      onDataChannelDo: () => peerConnection,
+      createDataChannel: () => nativeChannel,
     };
-
-    return {
-        peerConnection,
-        createdChannels,
-    };
-}
-
-function parseArgs(): Args {
-    const args = process.argv.slice(2);
-    const readValue = (name: string, fallback: string) => {
-        const prefix = `--${name}=`;
-        return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback;
-    };
-
-    return {
-        runs: Number(readValue('runs', '3')),
-        out: readValue(
-            'out',
-            'tmp/perf/results/rtc-data-channel-error-reference.json',
-        ),
-    };
-}
-
-async function runOnce(run: number): Promise<RunResult> {
-    const start = performance.now();
-    const peerConnection = createPeerConnectionHarness();
-    const dataChannel = new QRtcDataChannel(
-        peerConnection.peerConnection as never,
-        {
-            peerId: 'perf-peer',
-            dataChannelName: 'realtime',
-        },
-    );
-
+    const dataChannel = new QRtcDataChannel(peerConnection as never, {
+      peerId: 'perf-peer',
+      dataChannelName: 'realtime',
+    });
     dataChannel.connect(true);
-    const nativeChannel = peerConnection.createdChannels[0];
     await nativeChannel.emitOpen();
     await nativeChannel.emitError();
-
     return {
-        run,
-        durationMs: performance.now() - start,
-        readyStateAfterError: dataChannel.readHealth().readyState,
-        statusHasDataChannelAfterError: dataChannel.status.dc !== undefined,
-        attachedHandlerCountAfterError: nativeChannel.attachedHandlerCount(),
+      durationMs: performance.now() - startedAt,
+      readyStateAfterError: dataChannel.readHealth().readyState,
+      statusHasDataChannelAfterError: dataChannel.status.dc !== undefined,
+      attachedHandlerCountAfterError: nativeChannel.attachedHandlerCount(),
     };
+  };
+
+export async function runRtcDataChannelErrorReferenceAcceptedSamples(input: {
+  readonly worker: RtcDataChannelErrorReferenceAcceptedArguments;
+  readonly run: () => Promise<RtcDataChannelErrorReferenceResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const samples: RtcBaselineSampleDto[] = [];
+  let failureId: string | undefined;
+  for (let index = 0; index < input.worker.sampleIds.length; index += 1) {
+    const identity = createIdentity(input.worker, index);
+    if (failureId !== undefined) {
+      samples.push(
+        createSample(identity, null, [
+          rtcBaselineIssue('$.rawEvidence', 'causal-not-run', failureId),
+        ]),
+      );
+      continue;
+    }
+    const result = await input.run();
+    const issues = validateResult(result);
+    if (issues.length > 0) failureId = identity.sampleId;
+    samples.push(createSample(identity, result, issues));
+  }
+  return samples;
 }
 
-const args = parseArgs();
-const results: RunResult[] = [];
-
-for (let run = 1; run <= args.runs; run += 1) {
-    results.push(await runOnce(run));
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '3', 'runs', 1, 5);
+  const out = options.out ?? 'tmp/perf/results/rtc-data-channel-error-reference.json';
+  const issues = [...(!runs.ok ? runs.issues : [])];
+  if (!isDiagnosticOutput(out)) {
+    issues.push(
+      rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.'),
+    );
+  }
+  const runCount = runs.ok ? runs.value : 1;
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: { mode: 'diagnostic' as const, runs: runCount, out },
+      };
 }
 
-const output = {
-    command: process.argv.join(' '),
-    runs: args.runs,
-    results,
-};
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = [...(!outer.ok ? outer.issues : [])];
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B02',
+    'case-id': 'data-channel-error-reference',
+    'input-key': 'fixed',
+    'rtc-inner-runs': '5',
+  };
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
+    }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(phase === 'warmup' ? phase : 'retained', ordinal);
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          runs: 5,
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
+}
 
-mkdirSync(dirname(args.out), { recursive: true });
-writeFileSync(args.out, `${JSON.stringify(output, null, 2)}\n`);
-console.log(JSON.stringify(output, null, 2));
+function createExpectedSampleIds(phase: 'warmup' | 'retained', outerOrdinal: number): string[] {
+  const prefix =
+    `rtc-b02-data-channel-error-reference-fixed-${phase}-` + String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function createIdentity(
+  worker: RtcDataChannelErrorReferenceAcceptedArguments,
+  index: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId: worker.sampleIds[index],
+    workloadId: 'RTC-B02',
+    caseId: 'data-channel-error-reference',
+    inputKey: 'fixed',
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal: index + 1,
+  };
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: RtcDataChannelErrorReferenceResult | null,
+  issues: RtcBaselineSampleDto['issues'],
+): RtcBaselineSampleDto {
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: result === null ? 'not-run' : issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics:
+      result === null ? [] : [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: result === null ? null : toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(result: RtcDataChannelErrorReferenceResult) {
+  const issues = [];
+  if (result.readyStateAfterError !== undefined || result.statusHasDataChannelAfterError) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rawEvidence.statusHasDataChannelAfterError',
+        'native-reference-retained',
+        'Expected no native channel reference.',
+      ),
+    );
+  }
+  if (result.attachedHandlerCountAfterError !== 0) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rawEvidence.attachedHandlerCountAfterError',
+        'handler-retained',
+        'Expected 0.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function toRawEvidence(result: RtcDataChannelErrorReferenceResult): RtcBaselineJson {
+  return {
+    durationMs: result.durationMs,
+    readyStateAfterError: result.readyStateAfterError ?? null,
+    statusHasDataChannelAfterError: result.statusHasDataChannelAfterError,
+    attachedHandlerCountAfterError: result.attachedHandlerCountAfterError,
+  };
+}
+
+function isDiagnosticOutput(out: string): boolean {
+  return (
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    out.split('/').every((component) => component !== '' && component !== '.' && component !== '..')
+  );
+}
+
+async function main(): Promise<void> {
+  const parsed = parseRtcDataChannelErrorReferenceArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  if (parsed.value.mode === 'accepted') {
+    const samples = await runRtcDataChannelErrorReferenceAcceptedSamples({
+      worker: parsed.value,
+      run: runRtcDataChannelErrorReference,
+    });
+    writeLine(JSON.stringify(samples));
+    return;
+  }
+  const results = [];
+  for (let run = 1; run <= parsed.value.runs; run += 1) {
+    results.push({ run, ...(await runRtcDataChannelErrorReference()) });
+  }
+  const output = { command: Deno.args, runs: parsed.value.runs, results };
+  await Deno.writeTextFile(parsed.value.out, `${JSON.stringify(output, null, 2)}\n`, {
+    createNew: true,
+  });
+  writeLine(JSON.stringify(output, null, 2));
+}
+
+class FakeRtcDataChannel {
+  readonly label: string;
+  readyState: RTCDataChannelState = 'connecting';
+  bufferedAmount = 0;
+  bufferedAmountLowThreshold = 0;
+  binaryType: BinaryType = 'blob';
+  onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
+  onopen: (() => void | Promise<void>) | null = null;
+  onclose: (() => void | Promise<void>) | null = null;
+  onerror: (() => void | Promise<void>) | null = null;
+  onbufferedamountlow: (() => void | Promise<void>) | null = null;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+  send(): void {}
+  close(): void {
+    this.readyState = 'closed';
+  }
+  async emitOpen(): Promise<void> {
+    this.readyState = 'open';
+    await this.onopen?.();
+  }
+  async emitError(): Promise<void> {
+    this.readyState = 'closed';
+    await this.onerror?.();
+  }
+  attachedHandlerCount(): number {
+    return [
+      this.onmessage,
+      this.onopen,
+      this.onclose,
+      this.onerror,
+      this.onbufferedamountlow,
+    ].filter((handler) => handler !== null).length;
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/perf/rtc-data-channel-replace-key-bench.ts
+++ b/scripts/perf/rtc-data-channel-replace-key-bench.ts
@@ -1,174 +1,399 @@
-import { QRtcDataChannel } from '@shared/webrtc/QRtcDataChannel.ts';
+import { QRtcDataChannel, type RtcDataChannelPayload } from '@shared/webrtc/QRtcDataChannel.ts';
 
-type BenchResult = Readonly<{
-    run: number;
-    fillDurationMs: number;
-    replacementDurationMs: number;
-    totalDurationMs: number;
-    queueSize: number;
-    replacements: number;
-    queuedItemCount: number;
-    sentCount: number;
-    counters: Record<string, number>;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from './rtc-baseline/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from './rtc-baseline/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from './rtc-baseline/rtc-baseline-validation.ts';
 
-const OUT = readArg('--out') ??
-    'tmp/perf/results/rtc-data-channel-replace-key.json';
-const QUEUE_SIZE = Number(readArg('--queue-size') ?? '5000');
-const REPLACEMENTS = Number(readArg('--replacements') ?? '25000');
-const RUNS = Number(readArg('--runs') ?? '5');
-
-const writeLine = console.log.bind(console);
-console.log = () => {
-};
-console.warn = () => {
-};
-
-class FakeRTCDataChannel {
-    readonly sent: Array<string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>> = [];
-    readyState: RTCDataChannelState = 'connecting';
-    bufferedAmount = 1;
-    bufferedAmountLowThreshold = 0;
-    binaryType: BinaryType = 'blob';
-    onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
-    onopen: (() => void | Promise<void>) | null = null;
-    onclose: (() => void | Promise<void>) | null = null;
-    onerror: (() => void | Promise<void>) | null = null;
-    onbufferedamountlow: (() => void | Promise<void>) | null = null;
-
-    constructor(public readonly label: string) {
-    }
-
-    send(data: string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>): void {
-        this.sent.push(data);
-    }
-
-    close(): void {
-        this.readyState = 'closed';
-    }
-
-    async emitOpen(): Promise<void> {
-        this.readyState = 'open';
-        await this.onopen?.();
-    }
+interface RtcDataChannelReplaceKeyInput {
+  readonly queueDepth: number;
+  readonly replacements: number;
+  readonly runs: number;
 }
 
-function createPeerConnectionHarness() {
-    const createdChannels: FakeRTCDataChannel[] = [];
-    const peerConnection = {
-        onDataChannelDo: () => peerConnection,
-        createDataChannel: (label: string, _init?: RTCDataChannelInit) => {
-            const channel = new FakeRTCDataChannel(label);
-            createdChannels.push(channel);
-            return channel;
-        },
-    };
-
-    return {
-        peerConnection,
-        createdChannels,
-    };
+interface RtcDataChannelReplaceKeyAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: RtcDataChannelReplaceKeyInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
 }
 
-async function createOpenBackPressuredChannel(): Promise<{
-    dataChannel: QRtcDataChannel;
-    rtcChannel: FakeRTCDataChannel;
-}> {
-    const harness = createPeerConnectionHarness();
-    const dataChannel = new QRtcDataChannel(
-        harness.peerConnection as never,
-        {
-            peerId: 'peer-1',
-            dataChannelName: 'realtime',
-            flowControl: {
-                highWatermarkBytes: 1,
-                lowWatermarkBytes: 0,
-                overflow: 'replace-by-key',
-                maxQueueItems: QUEUE_SIZE,
-            },
-        },
-    );
-
-    dataChannel.connect(true);
-    const rtcChannel = harness.createdChannels[0];
-    await rtcChannel.emitOpen();
-    rtcChannel.bufferedAmount = 1;
-
-    return { dataChannel, rtcChannel };
+export interface RtcDataChannelReplaceKeyResult {
+  readonly fillDurationMs: number;
+  readonly replacementDurationMs: number;
+  readonly totalDurationMs: number;
+  readonly queueDepth: number;
+  readonly replacements: number;
+  readonly queuedItemCount: number;
+  readonly sentCount: number;
+  readonly counters: Readonly<Record<string, number>>;
 }
 
-function payload(sequence: number): Record<string, number> {
-    return {
-        sequence,
-        x: sequence % 1024,
-        y: sequence % 2048,
-    };
+const frozenDepths = new Set<number>([32, 1000, 5000]);
+const acceptedNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-queue-depth rtc-replacements rtc-inner-runs'
+).split(' ');
+
+export function parseRtcDataChannelReplaceKeyArguments(arguments_: readonly string[]) {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['queue-size', 'replacements', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
 }
 
-const results: BenchResult[] = [];
+export async function runRtcDataChannelReplaceKey(
+  queueDepth: number,
+  replacements: number,
+): Promise<RtcDataChannelReplaceKeyResult> {
+  const nativeChannel = new FakeRtcDataChannel('realtime');
+  const peerConnection = {
+    onDataChannelDo: () => peerConnection,
+    createDataChannel: () => nativeChannel,
+  };
+  const dataChannel = new QRtcDataChannel(peerConnection as never, {
+    peerId: 'peer-1',
+    dataChannelName: 'realtime',
+    flowControl: {
+      highWatermarkBytes: 1,
+      lowWatermarkBytes: 0,
+      overflow: 'replace-by-key',
+      maxQueueItems: queueDepth,
+    },
+  });
+  dataChannel.connect(true);
+  await nativeChannel.emitOpen();
+  nativeChannel.bufferedAmount = 1;
 
-for (let run = 1; run <= RUNS; run++) {
-    const { dataChannel, rtcChannel } = await createOpenBackPressuredChannel();
-    const totalStart = performance.now();
-    const fillStart = performance.now();
-
-    for (let index = 0; index < QUEUE_SIZE; index++) {
-        const result = dataChannel.sendJson(payload(index), {
-            key: `entity-${index}`,
-            now: () => 1_700_000_000_000,
-        });
-        if (result.status !== 'queued') {
-            throw new Error(`Expected queued during fill, received ${result.status}`);
-        }
-    }
-
-    const fillDurationMs = performance.now() - fillStart;
-    const replacementStart = performance.now();
-
-    for (let index = 0; index < REPLACEMENTS; index++) {
-        const keyIndex = index % QUEUE_SIZE;
-        const result = dataChannel.sendJson(payload(index + QUEUE_SIZE), {
-            key: `entity-${keyIndex}`,
-            now: () => 1_700_000_000_000 + index + 1,
-        });
-        if (result.status !== 'replaced') {
-            throw new Error(
-                `Expected replaced during replacements, received ${result.status}`,
-            );
-        }
-    }
-
-    const replacementDurationMs = performance.now() - replacementStart;
-    const health = dataChannel.readHealth();
-    results.push({
-        run,
-        fillDurationMs,
-        replacementDurationMs,
-        totalDurationMs: performance.now() - totalStart,
-        queueSize: QUEUE_SIZE,
-        replacements: REPLACEMENTS,
-        queuedItemCount: health.queuedItemCount,
-        sentCount: rtcChannel.sent.length,
-        counters: health.counters as unknown as Record<string, number>,
+  const totalStart = performance.now();
+  const fillStart = performance.now();
+  for (let index = 0; index < queueDepth; index += 1) {
+    const result = dataChannel.sendJson(createPayload(index), {
+      key: `entity-${index}`,
+      now: () => 1_700_000_000_000,
     });
+    if (result.status !== 'queued') {
+      throw new Error(`Expected queued during fill, received ${result.status}.`);
+    }
+  }
+  const fillDurationMs = performance.now() - fillStart;
+  const replacementStart = performance.now();
+  for (let index = 0; index < replacements; index += 1) {
+    const result = dataChannel.sendJson(createPayload(index + queueDepth), {
+      key: `entity-${index % queueDepth}`,
+      now: () => 1_700_000_000_001 + index,
+    });
+    if (result.status !== 'replaced') {
+      throw new Error(`Expected replaced during replacements, received ${result.status}.`);
+    }
+  }
+  const replacementDurationMs = performance.now() - replacementStart;
+  const health = dataChannel.readHealth();
+  return {
+    fillDurationMs,
+    replacementDurationMs,
+    totalDurationMs: performance.now() - totalStart,
+    queueDepth,
+    replacements,
+    queuedItemCount: health.queuedItemCount,
+    sentCount: nativeChannel.sent.length,
+    counters: health.counters,
+  };
 }
 
-await Deno.writeTextFile(
-    OUT,
-    JSON.stringify({
-        createdAt: new Date().toISOString(),
-        input: {
-            queueSize: QUEUE_SIZE,
-            replacements: REPLACEMENTS,
-            runs: RUNS,
+export async function runRtcDataChannelReplaceKeyAcceptedSamples(input: {
+  readonly worker: RtcDataChannelReplaceKeyAcceptedArguments;
+  readonly run: () => Promise<RtcDataChannelReplaceKeyResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  const samples: RtcBaselineSampleDto[] = [];
+  let failureId: string | undefined;
+  for (let index = 0; index < input.worker.sampleIds.length; index += 1) {
+    const identity = createIdentity(input.worker, index);
+    if (failureId !== undefined) {
+      samples.push(
+        createSample(identity, null, [
+          rtcBaselineIssue('$.rawEvidence', 'causal-not-run', failureId),
+        ]),
+      );
+      continue;
+    }
+    const result = await input.run();
+    const issues = validateResult(input.worker.input, result);
+    if (issues.length > 0) failureId = identity.sampleId;
+    samples.push(createSample(identity, result, issues));
+  }
+  return samples;
+}
+
+function parseDiagnosticArguments(options: Readonly<Record<string, string>>) {
+  const queueDepth = parseRtcBaselineBoundedInteger(
+    options['queue-size'] ?? '5000',
+    'queue-size',
+    1,
+    5000,
+  );
+  const replacements = parseRtcBaselineBoundedInteger(
+    options.replacements ?? '25000',
+    'replacements',
+    1,
+    25000,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const out = options.out ?? 'tmp/perf/results/rtc-data-channel-replace-key.json';
+  const issues = [
+    ...(!queueDepth.ok ? queueDepth.issues : []),
+    ...(!replacements.ok ? replacements.issues : []),
+    ...(!runs.ok ? runs.issues : []),
+  ];
+  if (!isDiagnosticOutput(out)) {
+    issues.push(
+      rtcBaselineIssue('$.out', 'invalid-diagnostic-output', 'Expected tmp/perf/results/.'),
+    );
+  }
+  const queueDepthValue = queueDepth.ok ? queueDepth.value : 1;
+  const replacementCount = replacements.ok ? replacements.value : 1;
+  const runCount = runs.ok ? runs.value : 1;
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'diagnostic' as const,
+          input: { queueDepth: queueDepthValue, replacements: replacementCount, runs: runCount },
+          out,
         },
-        results,
-    }, null, 2),
-);
-
-writeLine(`Wrote ${OUT}`);
-
-function readArg(name: string): string | undefined {
-    return Deno.args.find((arg) => arg.startsWith(`${name}=`))
-        ?.slice(name.length + 1);
+      };
 }
+
+function parseAcceptedArguments(options: Readonly<Record<string, string>>) {
+  const queueDepth = parseRtcBaselineBoundedInteger(
+    options['rtc-queue-depth'] ?? '',
+    'rtc-queue-depth',
+    32,
+    5000,
+  );
+  const outer = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = [...(!queueDepth.ok ? queueDepth.issues : []), ...(!outer.ok ? outer.issues : [])];
+  if (queueDepth.ok && !frozenDepths.has(queueDepth.value)) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rtc-queue-depth',
+        'unexpected-worker-input',
+        'Expected 32, 1000, or 5000.',
+      ),
+    );
+  }
+  issues.push(...validateRtcBaselineId(options['baseline-id'] ?? ''));
+  const expected = queueDepth.ok
+    ? {
+        capture: 'worker',
+        workload: 'RTC-B02',
+        'case-id': 'data-channel-replace-key',
+        'input-key': `depth-${queueDepth.value}`,
+        'rtc-queue-depth': String(queueDepth.value),
+        'rtc-replacements': '25000',
+        'rtc-inner-runs': '5',
+      }
+    : {};
+  for (const [name, value] of Object.entries(expected)) {
+    if (options[name] !== value) {
+      issues.push(rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`));
+    }
+  }
+  const phase = options['intended-phase'];
+  if (phase !== 'warmup' && phase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outer.ok ? outer.value : 0;
+  const depth = queueDepth.ok ? queueDepth.value : 32;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedIds = createExpectedSampleIds(
+    depth,
+    phase === 'warmup' ? phase : 'retained',
+    ordinal,
+  );
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : {
+        ok: true as const,
+        value: {
+          mode: 'accepted' as const,
+          input: { queueDepth: depth, replacements: 25000, runs: 5 },
+          intendedPhase: phase as 'warmup' | 'retained',
+          outerOrdinal: ordinal,
+          sampleIds,
+        },
+      };
+}
+
+function createExpectedSampleIds(
+  depth: number,
+  phase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix =
+    `rtc-b02-data-channel-replace-key-depth-${depth}-${phase}-` +
+    String(outerOrdinal).padStart(3, '0');
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function createIdentity(
+  worker: RtcDataChannelReplaceKeyAcceptedArguments,
+  index: number,
+): RtcBaselineSampleIdentityDto {
+  return {
+    sampleId: worker.sampleIds[index],
+    workloadId: 'RTC-B02',
+    caseId: 'data-channel-replace-key',
+    inputKey: `depth-${worker.input.queueDepth}`,
+    intendedPhase: worker.intendedPhase,
+    outerOrdinal: worker.outerOrdinal,
+    innerOrdinal: index + 1,
+  };
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: RtcDataChannelReplaceKeyResult | null,
+  issues: RtcBaselineSampleDto['issues'],
+): RtcBaselineSampleDto {
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: result === null ? 'not-run' : issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics:
+      result === null
+        ? []
+        : [{ metric: 'replacementDurationMs', unit: 'ms', value: result.replacementDurationMs }],
+    rawEvidence: result === null ? null : { ...result, counters: { ...result.counters } },
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function validateResult(
+  input: RtcDataChannelReplaceKeyInput,
+  result: RtcDataChannelReplaceKeyResult,
+) {
+  const issues = [];
+  if (result.queueDepth !== input.queueDepth || result.queuedItemCount !== input.queueDepth) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.queueDepth', 'queue-bound-mismatch', 'Unexpected.'),
+    );
+  }
+  if (
+    result.replacements !== input.replacements ||
+    result.counters.replaced !== input.replacements
+  ) {
+    issues.push(rtcBaselineIssue('$.rawEvidence.replacements', 'counter-mismatch', 'Unexpected.'));
+  }
+  if (result.counters.queued !== input.queueDepth || result.sentCount !== 0) {
+    issues.push(rtcBaselineIssue('$.rawEvidence.sentCount', 'send-count-mismatch', 'Unexpected.'));
+  }
+  return issues;
+}
+
+function createPayload(sequence: number): Record<string, number> {
+  return { sequence, x: sequence % 1024, y: sequence % 2048 };
+}
+
+function isDiagnosticOutput(out: string): boolean {
+  return (
+    out.startsWith('tmp/perf/results/') &&
+    !out.includes('\\') &&
+    out.split('/').every((component) => component !== '' && component !== '.' && component !== '..')
+  );
+}
+
+async function main(): Promise<void> {
+  const parsed = parseRtcDataChannelReplaceKeyArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  const writeLine = console.log.bind(console);
+  console.log = () => {};
+  console.warn = () => {};
+  if (parsed.value.mode === 'accepted') {
+    const samples = await runRtcDataChannelReplaceKeyAcceptedSamples({
+      worker: parsed.value,
+      run: () =>
+        runRtcDataChannelReplaceKey(parsed.value.input.queueDepth, parsed.value.input.replacements),
+    });
+    writeLine(JSON.stringify(samples));
+    return;
+  }
+  const results = [];
+  for (let run = 1; run <= parsed.value.input.runs; run += 1) {
+    results.push({
+      run,
+      ...(await runRtcDataChannelReplaceKey(
+        parsed.value.input.queueDepth,
+        parsed.value.input.replacements,
+      )),
+    });
+  }
+  await Deno.writeTextFile(
+    parsed.value.out,
+    `${JSON.stringify(
+      {
+        input: parsed.value.input,
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+    { createNew: true },
+  );
+  writeLine(`Wrote ${parsed.value.out}`);
+}
+
+class FakeRtcDataChannel {
+  readonly label: string;
+  readonly sent: RtcDataChannelPayload[] = [];
+  readyState: RTCDataChannelState = 'connecting';
+  bufferedAmount = 1;
+  bufferedAmountLowThreshold = 0;
+  binaryType: BinaryType = 'blob';
+  onmessage: ((event: MessageEvent) => void | Promise<void>) | null = null;
+  onopen: (() => void | Promise<void>) | null = null;
+  onclose: (() => void | Promise<void>) | null = null;
+  onerror: (() => void | Promise<void>) | null = null;
+  onbufferedamountlow: (() => void | Promise<void>) | null = null;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+  send(data: RtcDataChannelPayload): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.readyState = 'closed';
+  }
+  async emitOpen(): Promise<void> {
+    this.readyState = 'open';
+    await this.onopen?.();
+  }
+}
+
+if (import.meta.main) await main();


### PR DESCRIPTION
## Dependencies

- Foundation merged in PR #150.
- B01 merged in PR #162.

## Scope and status

- B02 is now green.
- B03-B05 remain pending.
- Every other RTC hold remains active.
- No benchmark was run and no performance result is claimed.

## Implementation

- Adds the direct data-channel drain harness with explicit fake native channel, clock, and exact 256-byte payload dependencies.
- Freezes the accepted B02 replace-key, drain, close-retention, and error-reference matrix.
- Preserves diagnostic CLI arguments, create-new result persistence beneath tmp/perf/results, and separation from accepted evidence.
- Covers queue pressure, deterministic identities, lifecycle cleanup, failure persistence, and truthful stopping after the first failed inner run.

## Validation

- RTC-B02 harness tests and the full RTC performance baseline harness test passed.
- qrtc-data-channel and rtc-data-channel-send-queue tests passed.
- Configured Deno check over the foundation and four B02 files passed.
- The exact 18 RTC foundation test files passed: 18 files, 255 tests.
- npm run test:unit passed: 780 files passed, 2 skipped; 7518 tests passed, 3 skipped.
- npm run test:ci passed, including Deno, browser, recipe-console, and full-stack memory phases.
- npm run build passed across all workspaces.
- Formatting, diff checks, changed-style, full warning-only style, physical-line limits, and independent review passed.