### PR TITLE
feat(black-box): W5 — first-class expect.headers HTTP operator

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -230,6 +230,12 @@ Common fields:
 - `expect.status`: expected HTTP status
 - `expect.statusCode`: expected HTTP status or accepted status array
 - `expect.statusCodes`: accepted status array
+- `expect.headers`: expected response headers by name (case-insensitive), with
+  exact values or the usual type tokens (`string`, `integer`, `any`, `a|b`);
+  only the runner's allow-listed observability headers are observable
+  (`Cache-Control`, `Rallar-Group-Revision`, `Rallar-Presence-Revision`,
+  `Rallar-State-Revision`, `Rallar-State-Source`), so expecting any other name
+  fails
 - `expect.body`: expected response JSON
 - `expect.bodyAnyOf`: accepted response body shapes
 - `expect.comparison`: comparison mode (`compatible` default, `compatible-structure`,

--- a/packages/shared-test/black-box-runner/http/http-response-expectations.ts
+++ b/packages/shared-test/black-box-runner/http/http-response-expectations.ts
@@ -5,6 +5,34 @@ import { normalizeBlackBoxResponseHeaders } from './normalize-black-box-response
 const SUCCESS = 'SUCCESS';
 const FAILURE = 'FAILURE';
 
+function isRecord(value: any): value is Record<string, any> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toLowercaseHeaderNames(expectedHeaders: Record<string, any>): Record<string, any> {
+    return Object.fromEntries(
+        Object.entries(expectedHeaders)
+            .map(([name, value]) => [String(name).toLowerCase(), value]),
+    );
+}
+
+function compareExpectedHeaders(interaction: any, response: any): any | undefined {
+    const expectedHeaders = interaction.response?.headers;
+    if (!isRecord(expectedHeaders)) {
+        return undefined;
+    }
+
+    return compareJson(
+        toLowercaseHeaderNames(expectedHeaders),
+        normalizeBlackBoxResponseHeaders(response.headers),
+        toConfig(
+            interaction.response?.comparison || COMPARISON.COMPATIBLE,
+            interaction.response?.ignoreJsonKeys || [],
+            interaction.response?.ignoreJsonPaths || [],
+        ),
+    );
+}
+
 function toOutputReportFields(interaction: any): any {
     return {
         output: interaction.request.output,
@@ -163,6 +191,21 @@ export function toHttpInteractionStatus(
 
     if (!response.ok && !hasExpectedStatus) {
         return toStatus(config, 'Server request failed.', actualJson, response, interaction);
+    }
+
+    const headerComparison = compareExpectedHeaders(interaction, response);
+    if (headerComparison !== undefined && !headerComparison.isEqual) {
+        return toStatus(
+            config,
+            'Expected response headers not the same as actual response headers',
+            actualJson,
+            response,
+            interaction,
+            {
+                expectedHeaders: interaction.response.headers,
+                headerComparison,
+            },
+        );
     }
 
     const bodyAlternatives = bodyExpectationAlternatives(interaction.response);

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-read-convergence.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-read-convergence.json
@@ -1,20 +1,65 @@
 {
   "variables": {
-    "apiPrimary": { "env": "RALLAR_API_BASE_URL", "default": "http://127.0.0.1:18080" },
-    "apiSecondary": { "env": "RALLAR_API_BASE_URL_SECONDARY", "default": "http://127.0.0.1:18081" },
-    "apiTertiary": { "env": "RALLAR_API_BASE_URL_TERTIARY", "default": "http://127.0.0.1:18082" },
+    "apiPrimary": {
+      "env": "RALLAR_API_BASE_URL",
+      "default": "http://127.0.0.1:18080"
+    },
+    "apiSecondary": {
+      "env": "RALLAR_API_BASE_URL_SECONDARY",
+      "default": "http://127.0.0.1:18081"
+    },
+    "apiTertiary": {
+      "env": "RALLAR_API_BASE_URL_TERTIARY",
+      "default": "http://127.0.0.1:18082"
+    },
     "applicationId": "state-read-{runId}",
     "workspaceId": "default-{runId}",
     "groupId": "snapshot-room-{runId}",
-    "aliceUsername": { "env": "RALLAR_ALICE_USERNAME", "default": "alice" },
-    "alicePassword": { "env": "RALLAR_ALICE_PASSWORD", "default": "secret", "secret": true },
-    "runId": { "env": "RALLAR_BB_RUN_ID", "default": "local" }
+    "aliceUsername": {
+      "env": "RALLAR_ALICE_USERNAME",
+      "default": "alice"
+    },
+    "alicePassword": {
+      "env": "RALLAR_ALICE_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
+    "runId": {
+      "env": "RALLAR_BB_RUN_ID",
+      "default": "local"
+    }
   },
-  "execution": { "correlation": { "injectHeaders": true, "injectPayloads": false } },
+  "execution": {
+    "correlation": {
+      "injectHeaders": true,
+      "injectPayloads": false
+    }
+  },
   "connections": {
-    "primary": { "type": "http", "baseUrl": "{apiPrimary}", "headers": { "Content-Type": "application/json" }, "timeoutMs": 10000 },
-    "secondary": { "type": "http", "baseUrl": "{apiSecondary}", "headers": { "Content-Type": "application/json" }, "timeoutMs": 10000 },
-    "tertiary": { "type": "http", "baseUrl": "{apiTertiary}", "headers": { "Content-Type": "application/json" }, "timeoutMs": 10000 }
+    "primary": {
+      "type": "http",
+      "baseUrl": "{apiPrimary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 10000
+    },
+    "secondary": {
+      "type": "http",
+      "baseUrl": "{apiSecondary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 10000
+    },
+    "tertiary": {
+      "type": "http",
+      "baseUrl": "{apiTertiary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 10000
+    }
   },
   "steps": [
     {
@@ -24,14 +69,22 @@
       "request": {
         "method": "POST",
         "path": "/api/auth/login",
-        "body": { "username": "{aliceUsername}", "password": "{alicePassword}" },
+        "body": {
+          "username": "{aliceUsername}",
+          "password": "{alicePassword}"
+        },
         "outputs": {
           "aliceClientId": "body.clientId",
           "aliceSessionId": "body.sessionId",
-          "aliceAccessToken": { "path": "body.accessToken", "secret": true }
+          "aliceAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
         }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "deriveAliceAuthHeader",
@@ -39,7 +92,14 @@
       "output": "aliceAuthHeader",
       "secret": true,
       "redactAs": "aliceAuthHeader",
-      "transform": { "concat": ["Bearer ", { "path": "outputs.aliceAccessToken" }] }
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.aliceAccessToken"
+          }
+        ]
+      }
     },
     {
       "name": "createClientState",
@@ -48,7 +108,10 @@
       "request": {
         "method": "PUT",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}/principal",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
         "body": {
           "requestId": "client-create-{runId}",
           "username": "{aliceUsername}",
@@ -57,7 +120,9 @@
           "roles": []
         }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "warmPrimaryClient",
@@ -66,10 +131,17 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
-        "outputs": { "warmClientSource": "headers.rallar-state-source" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "outputs": {
+          "warmClientSource": "headers.rallar-state-source"
+        }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "mutateClientOnSecondary",
@@ -78,7 +150,10 @@
       "request": {
         "method": "PUT",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}/principal",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
         "body": {
           "requestId": "client-update-{runId}",
           "username": "{aliceUsername}",
@@ -88,10 +163,18 @@
         },
         "outputs": {
           "clientFloor": "body.stateRevision",
-          "clientFloorString": { "transform": { "string": { "path": "body.stateRevision" } } }
+          "clientFloorString": {
+            "transform": {
+              "string": {
+                "path": "body.stateRevision"
+              }
+            }
+          }
         }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "readClientFloorOnTertiary",
@@ -100,9 +183,18 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}?minStateRevision={clientFloor}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200,
+        "headers": {
+          "Rallar-State-Revision": "{clientFloorString}",
+          "Rallar-State-Source": "string"
+        }
+      }
     },
     {
       "name": "rejectUnsatisfiedClientFloor",
@@ -111,9 +203,17 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}?minStateRevision=9007199254740991",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
       },
-      "expect": { "status": 409, "body": { "code": "state-revision-floor-not-satisfied" } }
+      "expect": {
+        "status": 409,
+        "body": {
+          "code": "state-revision-floor-not-satisfied"
+        }
+      }
     },
     {
       "name": "createGroup",
@@ -122,7 +222,10 @@
       "request": {
         "method": "POST",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
         "body": {
           "requestId": "group-create-{runId}",
           "groupId": "{groupId}",
@@ -132,7 +235,9 @@
           "createdByPrincipalId": "{aliceClientId}"
         }
       },
-      "expect": { "status": 201 }
+      "expect": {
+        "status": 201
+      }
     },
     {
       "name": "warmPrimaryGroup",
@@ -141,10 +246,17 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
-        "outputs": { "warmGroupSource": "headers.rallar-state-source" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "outputs": {
+          "warmGroupSource": "headers.rallar-state-source"
+        }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "mutatePresenceOnSecondary",
@@ -153,7 +265,10 @@
       "request": {
         "method": "PUT",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/sessions/{aliceSessionId}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" },
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
         "body": {
           "requestId": "presence-connect-{runId}",
           "generationId": "generation-{runId}",
@@ -161,12 +276,26 @@
         },
         "outputs": {
           "groupFloor": "body.causalRevision.groupRevision",
-          "groupFloorString": { "transform": { "string": { "path": "body.causalRevision.groupRevision" } } },
+          "groupFloorString": {
+            "transform": {
+              "string": {
+                "path": "body.causalRevision.groupRevision"
+              }
+            }
+          },
           "presenceFloor": "body.causalRevision.presenceRevision",
-          "presenceFloorString": { "transform": { "string": { "path": "body.causalRevision.presenceRevision" } } }
+          "presenceFloorString": {
+            "transform": {
+              "string": {
+                "path": "body.causalRevision.presenceRevision"
+              }
+            }
+          }
         }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200
+      }
     },
     {
       "name": "readGroupFloorOnTertiary",
@@ -175,9 +304,19 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}?minGroupRevision={groupFloor}&minPresenceRevision={presenceFloor}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
       },
-      "expect": { "status": 200 }
+      "expect": {
+        "status": 200,
+        "headers": {
+          "Rallar-Group-Revision": "{groupFloorString}",
+          "Rallar-Presence-Revision": "{presenceFloorString}",
+          "Rallar-State-Source": "string"
+        }
+      }
     },
     {
       "name": "rejectPartialGroupFloor",
@@ -186,9 +325,17 @@
       "request": {
         "method": "GET",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}?minGroupRevision={groupFloor}",
-        "headers": { "Authorization": "{aliceAuthHeader}", "x-client-id": "{aliceClientId}" }
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
       },
-      "expect": { "status": 400, "body": { "code": "invalid-group-causal-revision" } }
+      "expect": {
+        "status": 400,
+        "body": {
+          "code": "invalid-group-causal-revision"
+        }
+      }
     },
     {
       "name": "assertReadConvergenceEvidence",
@@ -197,26 +344,18 @@
         "warmClientSource": "{warmClientSource}",
         "warmGroupSource": "{warmGroupSource}",
         "clientRevisionBody": "{resultsByName.readClientFloorOnTertiary.0.actual.body.stateRevision}",
-        "clientRevisionHeader": "{resultsByName.readClientFloorOnTertiary.0.actual.headers.rallar-state-revision}",
-        "clientSource": "{resultsByName.readClientFloorOnTertiary.0.actual.headers.rallar-state-source}",
         "groupRevisionBody": "{resultsByName.readGroupFloorOnTertiary.0.actual.body.causalRevision.groupRevision}",
-        "groupRevisionHeader": "{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-group-revision}",
-        "presenceRevisionBody": "{resultsByName.readGroupFloorOnTertiary.0.actual.body.causalRevision.presenceRevision}",
-        "presenceRevisionHeader": "{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-presence-revision}",
-        "groupSource": "{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-state-source}"
+        "presenceRevisionBody": "{resultsByName.readGroupFloorOnTertiary.0.actual.body.causalRevision.presenceRevision}"
       },
-      "expect": { "body": {
-        "warmClientSource": "durable",
-        "warmGroupSource": "durable",
-        "clientRevisionBody": "{clientFloor}",
-        "clientRevisionHeader": "{clientFloorString}",
-        "clientSource": "string",
-        "groupRevisionBody": "{groupFloor}",
-        "groupRevisionHeader": "{groupFloorString}",
-        "presenceRevisionBody": "{presenceFloor}",
-        "presenceRevisionHeader": "{presenceFloorString}",
-        "groupSource": "string"
-      } }
+      "expect": {
+        "body": {
+          "warmClientSource": "durable",
+          "warmGroupSource": "durable",
+          "clientRevisionBody": "{clientFloor}",
+          "groupRevisionBody": "{groupFloor}",
+          "presenceRevisionBody": "{presenceFloor}"
+        }
+      }
     }
   ]
 }

--- a/packages/tests/shared-test/api-v1-state-read-convergence-recipe.test.ts
+++ b/packages/tests/shared-test/api-v1-state-read-convergence-recipe.test.ts
@@ -15,6 +15,7 @@ interface StateReadRecipeStep {
   readonly actual?: Record<string, unknown>;
   readonly expect?: {
     readonly status?: number;
+    readonly headers?: Record<string, unknown>;
     readonly body?: Record<string, unknown>;
   };
 }
@@ -40,33 +41,39 @@ describe('API-v1 state-read convergence recipe', () => {
     const groupRead = recipe.steps.find((step) => step.name === 'readGroupFloorOnTertiary');
     const assertion = recipe.steps.find((step) => step.name === 'assertReadConvergenceEvidence');
 
-    expect(clientRead).toMatchObject({ connection: 'tertiary', expect: { status: 200 } });
-    expect(groupRead).toMatchObject({ connection: 'tertiary', expect: { status: 200 } });
+    expect(clientRead).toMatchObject({
+      connection: 'tertiary',
+      expect: {
+        status: 200,
+        headers: {
+          'Rallar-State-Revision': '{clientFloorString}',
+          'Rallar-State-Source': 'string',
+        },
+      },
+    });
+    expect(groupRead).toMatchObject({
+      connection: 'tertiary',
+      expect: {
+        status: 200,
+        headers: {
+          'Rallar-Group-Revision': '{groupFloorString}',
+          'Rallar-Presence-Revision': '{presenceFloorString}',
+          'Rallar-State-Source': 'string',
+        },
+      },
+    });
     expect(assertion?.actual).toMatchObject({
       clientRevisionBody: '{resultsByName.readClientFloorOnTertiary.0.actual.body.stateRevision}',
-      clientRevisionHeader:
-        '{resultsByName.readClientFloorOnTertiary.0.actual.headers.rallar-state-revision}',
-      clientSource:
-        '{resultsByName.readClientFloorOnTertiary.0.actual.headers.rallar-state-source}',
       groupRevisionBody:
         '{resultsByName.readGroupFloorOnTertiary.0.actual.body.causalRevision.groupRevision}',
-      groupRevisionHeader:
-        '{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-group-revision}',
       presenceRevisionBody:
         '{resultsByName.readGroupFloorOnTertiary.0.actual.body.causalRevision.presenceRevision}',
-      presenceRevisionHeader:
-        '{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-presence-revision}',
-      groupSource: '{resultsByName.readGroupFloorOnTertiary.0.actual.headers.rallar-state-source}',
     });
     expect(assertion?.expect?.body).toMatchObject({
       clientRevisionBody: '{clientFloor}',
-      clientRevisionHeader: '{clientFloorString}',
-      clientSource: 'string',
       groupRevisionBody: '{groupFloor}',
-      groupRevisionHeader: '{groupFloorString}',
       presenceRevisionBody: '{presenceFloor}',
-      presenceRevisionHeader: '{presenceFloorString}',
-      groupSource: 'string',
     });
+    expect(JSON.stringify(assertion)).not.toContain('.actual.headers.');
   });
 });

--- a/packages/tests/shared-test/execute-black-box-header-expectations.test.ts
+++ b/packages/tests/shared-test/execute-black-box-header-expectations.test.ts
@@ -1,0 +1,154 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import {describe, expect, it} from 'vitest';
+import {executeBlackBox} from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+async function tryStartHttpServer(
+    handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ url: string, close: () => Promise<void> } | undefined> {
+    const server = createServer(handler);
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', () => {
+                server.off('error', reject);
+                resolve();
+            });
+        });
+    } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+            ? String((error as { code?: unknown }).code)
+            : '';
+        if (code === 'EPERM' || code === 'EACCES') {
+            return undefined;
+        }
+        throw error;
+    }
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('Failed to start HTTP test server');
+    }
+
+    return {
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((resolve, reject) => {
+            server.close(error => error ? reject(error) : resolve());
+        }),
+    };
+}
+
+function revisionHeaderHandler(_request: IncomingMessage, response: ServerResponse): void {
+    response.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Rallar-State-Revision': '7',
+        'Rallar-State-Source': 'durable',
+    });
+    response.end(JSON.stringify({ stateRevision: 7 }));
+}
+
+function httpStep(path: string, expectFields: Record<string, unknown>): Record<string, unknown> {
+    return {
+        HTTP: {
+            request: {
+                method: 'GET',
+                path,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1,
+            },
+            response: expectFields,
+        },
+        readWithHeaderExpectations: {},
+    };
+}
+
+describe('executeBlackBox HTTP expect.headers', () => {
+    it('matches exact values and type tokens with case-insensitive names', async () => {
+        const server = await tryStartHttpServer(revisionHeaderHandler);
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/state`, {
+                    status: 200,
+                    headers: {
+                        'Rallar-State-Revision': '7',
+                        'RALLAR-STATE-SOURCE': 'string',
+                        'cache-control': 'no-store',
+                    },
+                    body: { stateRevision: 7 },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(0);
+            expect(report.resultsByName.readWithHeaderExpectations[0].status).toBe('SUCCESS');
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('fails on a header value mismatch with the header comparison details', async () => {
+        const server = await tryStartHttpServer(revisionHeaderHandler);
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/state`, {
+                    status: 200,
+                    headers: {
+                        'Rallar-State-Revision': '8',
+                    },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.readWithHeaderExpectations[0];
+            expect(result.result).toBe(
+                'Expected response headers not the same as actual response headers',
+            );
+            expect(result.details.headerComparison.isEqual).toBe(false);
+            expect(result.actual.headers['rallar-state-revision']).toBe('7');
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('fails when an expected observability header is missing from the response', async () => {
+        const server = await tryStartHttpServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({ ok: true }));
+        });
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/state`, {
+                    status: 200,
+                    headers: {
+                        'Rallar-State-Source': 'string',
+                    },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            expect(report.resultsByName.readWithHeaderExpectations[0].result).toBe(
+                'Expected response headers not the same as actual response headers',
+            );
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
+++ b/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
@@ -16,7 +16,7 @@ Status: in execution as a stacked PR series based on
 | W2 `poll-until` | runner capability implemented; recipe rewrite blocked on decision | `codex/black-box-w2-poll-until` |
 | W3 comparators + `compatible-complete` | implemented; in review | `codex/black-box-w3-comparators` |
 | W4 pure-API recipes | implemented; in review | `codex/black-box-w4-pure-api-recipes` |
-| W5 `expect.headers` | not started | — |
+| W5 `expect.headers` | implemented; in review | `codex/black-box-w5-expect-headers` |
 | W6 `expect.maxDurationMs` | not started | — |
 | W7 observability-routed evidence plan | not started (plan-only) | — |
 | W8 recipe tiering | not started | — |


### PR DESCRIPTION
## W5 — first-class `expect.headers` HTTP operator

Fifth workstream of `plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md`.
Stacked on `codex/black-box-w4-pure-api-recipes` (W4); do not merge before it.

### What

- HTTP steps assert named response headers directly: **case-insensitive names**, exact values or
  the usual type tokens (`string`, `integer`, `any`, `a|b`), evaluated between the status check and
  the body check with the step's comparison config — following the `expect.body` dispatch, in
  `http/http-response-expectations.ts`. Only the runner's allow-listed observability headers are
  observable (`Cache-Control`, `Rallar-Group-Revision`, `Rallar-Presence-Revision`,
  `Rallar-State-Revision`, `Rallar-State-Source`); expecting any other name fails loudly, never
  vacuously. Documented in the recipe guide.
- `api-v1-state-read-convergence`'s capture-then-ASSERT header contortion removed **without
  changing what is asserted**: the two tertiary floor reads now assert their revision/source
  headers first-class (`Rallar-State-Revision: {clientFloorString}` etc.), and the final ASSERT
  keeps the body-floor and warm-source comparisons. Its pinning test now pins the first-class shape
  and rejects any return of the `.actual.headers.` reach.

### Validation

- New `execute-black-box-header-expectations.test.ts` — 3 tests (exact + token + case-insensitivity,
  value mismatch with comparison details, missing-header failure); updated
  `api-v1-state-read-convergence-recipe.test.ts` — both pass.
- `deno check` clean; offline `--validate --strict` on the simplified recipe — no issues.
- `npm run test:api-v1:black-box:memory` — 19/19 PASSED (the simplified recipe itself is
  cluster-only and runs in the Branch Release Gate Postgres jobs).
- `npm run check:repo-style:changed -- origin/main WORKTREE` — zero findings from this branch
  (PR #161's 9 inherited findings remain).
