### PR TITLE
feat(black-box): W6 — expect.maxDurationMs per-step latency bound

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -238,6 +238,10 @@ Common fields:
   fails
 - `expect.body`: expected response JSON
 - `expect.bodyAnyOf`: accepted response body shapes
+- `expect.maxDurationMs`: fail the step when its measured `durationMs` exceeds
+  the bound; a bound never masks the step's own failure, and it also applies to
+  WS steps. Use it for smoke bounds only — do not put latency SLOs into
+  convergence gates
 - `expect.comparison`: comparison mode (`compatible` default, `compatible-structure`,
   `compatible-complete`, `exact-structure`, `exact`); `compatible-complete` keeps
   extra object keys tolerated but rejects unexpected array elements, closing the

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -2771,9 +2771,34 @@ function executeBlackBoxRecursive(
         })
         .then(data => {
             const endedAtEpochMs = Date.now();
-            return executeNext({ ...data, startedAtEpochMs, endedAtEpochMs,
-                durationMs: endedAtEpochMs - startedAtEpochMs });
+            return executeNext(withMaxDurationBound({ ...data, startedAtEpochMs, endedAtEpochMs,
+                durationMs: endedAtEpochMs - startedAtEpochMs }, interactionWithConfig));
         });
+}
+
+// A bound never masks the step's own failure: only a step that succeeded and
+// overran expect.maxDurationMs is flipped, keeping its original actual data.
+function withMaxDurationBound(interactionData: any, interactionWithConfig: any): any {
+    const response = toExecutableInteraction(interactionWithConfig)?.response;
+    const maxDurationMs = Number.parseInt(String(response?.maxDurationMs ?? ''), 10);
+
+    if (!Number.isFinite(maxDurationMs) || maxDurationMs <= 0) {
+        return interactionData;
+    }
+
+    if (interactionData.status !== SUCCESS || interactionData.durationMs <= maxDurationMs) {
+        return {
+            ...interactionData,
+            maxDurationMs,
+        };
+    }
+
+    return {
+        ...interactionData,
+        status: FAILURE,
+        result: 'Step duration exceeded expect.maxDurationMs',
+        maxDurationMs,
+    };
 }
 
 function closeAllWsConnections(context: any): void {

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-ice-config.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-ice-config.json
@@ -106,6 +106,7 @@
       },
       "expect": {
         "status": 200,
+        "maxDurationMs": 10000,
         "body": {
           "iceServers": [],
           "expiresAtEpochMs": "integer"

--- a/packages/tests/shared-test/execute-black-box-max-duration.test.ts
+++ b/packages/tests/shared-test/execute-black-box-max-duration.test.ts
@@ -1,0 +1,224 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import {describe, expect, it} from 'vitest';
+import {executeBlackBox} from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+async function tryStartHttpServer(
+    handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ url: string, close: () => Promise<void> } | undefined> {
+    const server = createServer(handler);
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', () => {
+                server.off('error', reject);
+                resolve();
+            });
+        });
+    } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+            ? String((error as { code?: unknown }).code)
+            : '';
+        if (code === 'EPERM' || code === 'EACCES') {
+            return undefined;
+        }
+        throw error;
+    }
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('Failed to start HTTP test server');
+    }
+
+    return {
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((resolve, reject) => {
+            server.close(error => error ? reject(error) : resolve());
+        }),
+    };
+}
+
+function slowOkHandler(delayMs: number) {
+    return (_request: IncomingMessage, response: ServerResponse): void => {
+        setTimeout(() => {
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({ ok: true }));
+        }, delayMs);
+    };
+}
+
+function httpStep(path: string, expectFields: Record<string, unknown>): Record<string, unknown> {
+    return {
+        HTTP: {
+            request: {
+                method: 'GET',
+                path,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1,
+            },
+            response: expectFields,
+        },
+        boundedRead: {},
+    };
+}
+
+describe('executeBlackBox expect.maxDurationMs', () => {
+    it('keeps a fast successful step successful and reports the bound', async () => {
+        const server = await tryStartHttpServer(slowOkHandler(0));
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/fast`, {
+                    status: 200,
+                    maxDurationMs: 10000,
+                    body: { ok: true },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(0);
+            const result = report.resultsByName.boundedRead[0];
+            expect(result.status).toBe('SUCCESS');
+            expect(result.maxDurationMs).toBe(10000);
+            expect(result.durationMs).toBeLessThanOrEqual(10000);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('fails a successful step whose duration exceeds the bound', async () => {
+        const server = await tryStartHttpServer(slowOkHandler(150));
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/slow`, {
+                    status: 200,
+                    maxDurationMs: 50,
+                    body: { ok: true },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.boundedRead[0];
+            expect(result.status).toBe('FAILURE');
+            expect(result.result).toBe('Step duration exceeded expect.maxDurationMs');
+            expect(result.maxDurationMs).toBe(50);
+            expect(result.durationMs).toBeGreaterThan(50);
+            expect(result.actual.body.ok).toBe(true);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('never masks the step failure when the expectation itself fails', async () => {
+        const server = await tryStartHttpServer(slowOkHandler(150));
+        if (!server) {
+            return;
+        }
+
+        try {
+            const report = await executeBlackBox(
+                [httpStep(`${server.url}/slow`, {
+                    status: 200,
+                    maxDurationMs: 50,
+                    body: { ok: false },
+                })],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.boundedRead[0];
+            expect(result.result).toBe('Expected response not the same as actual response');
+            expect(result.maxDurationMs).toBe(50);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('bounds a WS wait that always holds its full absence window', async () => {
+        const originalWebSocket = globalThis.WebSocket;
+
+        class InstantOpenWebSocket {
+            static CONNECTING = 0;
+            static OPEN = 1;
+            static CLOSING = 2;
+            static CLOSED = 3;
+
+            readyState = InstantOpenWebSocket.CONNECTING;
+            onopen: ((event: unknown) => void) | undefined;
+            onmessage: ((event: { data: unknown }) => void) | undefined;
+            onclose: ((event: unknown) => void) | undefined;
+            onerror: ((event: unknown) => void) | undefined;
+
+            constructor(public readonly url: string) {
+                setTimeout(() => {
+                    this.readyState = InstantOpenWebSocket.OPEN;
+                    this.onopen?.({ url: this.url });
+                }, 0);
+            }
+
+            send(): void {}
+
+            close(): void {
+                this.readyState = InstantOpenWebSocket.CLOSED;
+            }
+        }
+
+        (globalThis as any).WebSocket = InstantOpenWebSocket;
+        try {
+            const report = await executeBlackBox(
+                [
+                    {
+                        WS: {
+                            request: {
+                                action: 'open',
+                                connection: 'quietWs',
+                                path: 'ws://example.invalid/quiet',
+                                scenarioExecutionNumber: 1,
+                                interactionExecutionNumber: 1,
+                            },
+                            response: {},
+                        },
+                        openQuietWs: {},
+                    },
+                    {
+                        WS: {
+                            request: {
+                                action: 'wait',
+                                connection: 'quietWs',
+                                scenarioExecutionNumber: 1,
+                                interactionExecutionNumber: 2,
+                            },
+                            response: {
+                                connection: 'quietWs',
+                                withinMs: 200,
+                                maxDurationMs: 50,
+                                absent: { kind: 'never-sent' },
+                            },
+                        },
+                        boundedQuietWait: {},
+                    },
+                ],
+                0,
+                { failFast: true },
+            );
+
+            expect(report.summary.failure).toBe(1);
+            const result = report.resultsByName.boundedQuietWait[0];
+            expect(result.status).toBe('FAILURE');
+            expect(result.result).toBe('Step duration exceeded expect.maxDurationMs');
+        } finally {
+            (globalThis as any).WebSocket = originalWebSocket;
+        }
+    });
+});

--- a/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
+++ b/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
@@ -17,7 +17,7 @@ Status: in execution as a stacked PR series based on
 | W3 comparators + `compatible-complete` | implemented; in review | `codex/black-box-w3-comparators` |
 | W4 pure-API recipes | implemented; in review | `codex/black-box-w4-pure-api-recipes` |
 | W5 `expect.headers` | implemented; in review | `codex/black-box-w5-expect-headers` |
-| W6 `expect.maxDurationMs` | not started | — |
+| W6 `expect.maxDurationMs` | implemented; in review | `codex/black-box-w6-max-duration` |
 | W7 observability-routed evidence plan | not started (plan-only) | — |
 | W8 recipe tiering | not started | — |
 


### PR DESCRIPTION
## W6 — `expect.maxDurationMs` per-step latency bound

Sixth workstream of `plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md`.
Stacked on `codex/black-box-w5-expect-headers` (W5); do not merge before it.

### What

- `expect.maxDurationMs` on HTTP/WS steps (applied uniformly where the recursive executor stamps
  `durationMs`, so every step type gets it): a **successful** step whose measured duration exceeds
  the bound flips to FAILURE (`Step duration exceeded expect.maxDurationMs`) with its original
  actual data preserved; a step that already failed keeps its own failure — the bound never masks
  it. The bound is attached to the result either way for report visibility.
- Exercising recipe: `api-v1-ice-config`'s authenticated read carries a deliberately generous 10s
  smoke bound. Per the plan's constraint, **no convergence gate gained a latency SLO**, and the
  guide documents the smoke-bound-only intent.

### Validation

- New `execute-black-box-max-duration.test.ts` — 4 tests (fast pass with bound reported, overrun
  flip, no-masking, WS absence-window overrun) — all pass.
- `deno check` clean; `npm run test:api-v1:black-box:memory` — 19/19 PASSED.
- `npm run check:repo-style:changed -- origin/main WORKTREE` — zero findings from this branch
  (PR #161's 9 inherited findings remain).
