### PR TITLE
feat(repo-style): tolerance band for file.length in the changed-findings gate

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -67,7 +67,8 @@ inventing another abstraction.
   repository-wide cleanup.
 - The manual review gate is active now. The full-repository checker remains warning-only while legacy debt remains.
   No global strict checker mode is available. Feature-branch CI blocks only new or worsened findings against the merge
-  base.
+  base. For file length, worsened means crossing a size tier (400/500/800) or same-tier growth of more than
+  max(10% of the merge-base length, 25 physical lines); every other rule treats any magnitude growth as worsened.
 - Tests, mocks, stories, fixtures, and generated artifacts are excluded from the default production-code checker, but
   not from the human-readable standard.
 - A deliberate exception requires explicit human approval and a short rationale in the task handoff. Existing violations

--- a/docs/repo-human-style-guide.md
+++ b/docs/repo-human-style-guide.md
@@ -386,7 +386,10 @@ understood. The merge-base feature-branch gate below is active.
 
 The full-repository scan remains warning-only so legacy debt does not block
 unrelated work. Feature branches run a separate comparison against their merge
-base and fail only for new or worsened findings:
+base and fail only for new or worsened findings. For file length, worsened
+means crossing a size tier (400/500/800) or same-tier growth of more than
+max(10% of the merge-base length, 25 physical lines); every other rule treats
+any magnitude growth as worsened:
 
 ```bash
 npm run check:repo-style:changed -- origin/main

--- a/packages/tests/repo/repo-style-changed-check.test.ts
+++ b/packages/tests/repo/repo-style-changed-check.test.ts
@@ -124,6 +124,58 @@ describe('changed repository style checker', () => {
     expect(result.stdout).toContain('Line 1 exceeds 100 chars');
   });
 
+  it('tolerates small same-tier growth of an over-limit file', () => {
+    const fixture = createGitFixture({
+      'apps/example/legacy-large.ts': linesSource(600),
+    });
+    commitAll(fixture, 'base');
+    writeFixture(fixture, 'apps/example/legacy-large.ts', linesSource(618));
+
+    const result = runChangedChecker(fixture);
+
+    expect(result.status, result.stdout).toBe(0);
+    expect(result.stdout).toContain('PASS: no new repository style findings');
+  });
+
+  it('fails when same-tier growth exceeds the tolerance band', () => {
+    const fixture = createGitFixture({
+      'apps/example/legacy-large.ts': linesSource(600),
+    });
+    commitAll(fixture, 'base');
+    writeFixture(fixture, 'apps/example/legacy-large.ts', linesSource(700));
+
+    const result = runChangedChecker(fixture);
+
+    expect(result.status, result.stdout).toBe(1);
+    expect(result.stdout).toContain('file.length');
+  });
+
+  it('fails when tolerated-size growth crosses a file-size tier', () => {
+    const fixture = createGitFixture({
+      'apps/example/legacy-large.ts': linesSource(495),
+    });
+    commitAll(fixture, 'base');
+    writeFixture(fixture, 'apps/example/legacy-large.ts', linesSource(507));
+
+    const result = runChangedChecker(fixture);
+
+    expect(result.status, result.stdout).toBe(1);
+    expect(result.stdout).toContain('file.length');
+  });
+
+  it('fails when a compliant file grows past the 400-line limit within the band', () => {
+    const fixture = createGitFixture({
+      'apps/example/growing-file.ts': linesSource(395),
+    });
+    commitAll(fixture, 'base');
+    writeFixture(fixture, 'apps/example/growing-file.ts', linesSource(410));
+
+    const result = runChangedChecker(fixture);
+
+    expect(result.status, result.stdout).toBe(1);
+    expect(result.stdout).toContain('file.length');
+  });
+
   it('fails when an existing finding becomes measurably worse', () => {
     const fixture = createGitFixture({
       'apps/example/feature.ts': overlongSource('x'.repeat(1)),
@@ -344,6 +396,10 @@ function runGit(fixtureRoot: string, args: readonly string[]): void {
 
 function overlongSource(label: string): string {
   return `const value = '${label}${'x'.repeat(110)}';\n`;
+}
+
+function linesSource(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, index) => `const value${index} = true;`).join('\n');
 }
 
 function forwardCaptureSource(): string {

--- a/packages/tests/repo/repo-style-check.test.ts
+++ b/packages/tests/repo/repo-style-check.test.ts
@@ -369,6 +369,7 @@ describe('repo style checker', () => {
       'scripts/repo-style-check/construction-rules.mjs',
       'scripts/repo-style-check/construction-scope-model.mjs',
       'scripts/repo-style-check/factory-route-rules.mjs',
+      'scripts/repo-style-check/finding-magnitude.mjs',
       'scripts/repo-style-check/function-analysis.mjs',
       'scripts/repo-style-check/layout-rules.mjs',
       'scripts/repo-style-check/repository-scan.mjs',

--- a/scripts/check-changed-repo-style.mjs
+++ b/scripts/check-changed-repo-style.mjs
@@ -7,6 +7,12 @@ import {
   isProductionCodeFile,
   scanProductionSources,
 } from './repo-style-check/repository-scan.mjs';
+import {
+  boundaryUnknownMagnitude,
+  compareFindingMagnitudeDescending,
+  findingMagnitude,
+  matchesBaseMagnitude,
+} from './repo-style-check/finding-magnitude.mjs';
 import { isReviewedDisposition } from './repo-style-check/reviewed-dispositions.mjs';
 import {
   readStructuralLineageMap,
@@ -215,8 +221,8 @@ function subtractExistingFindings(input) {
     const baseMagnitudes = baseMagnitudesByKey.get(key) ?? [];
     for (const finding of findings.toSorted(compareFindingMagnitudeDescending)) {
       const targetMagnitude = findingMagnitude(finding);
-      const matchIndex = baseMagnitudes.findIndex(
-        (baseMagnitude) => baseMagnitude >= targetMagnitude,
+      const matchIndex = baseMagnitudes.findIndex((baseMagnitude) =>
+        matchesBaseMagnitude(finding.ruleId, baseMagnitude, targetMagnitude),
       );
       if (matchIndex < 0) {
         newFindingSet.add(finding);
@@ -245,20 +251,6 @@ function groupStructuralBoundaryCapacity(input) {
     }
   }
   return capacityByPath;
-}
-
-function boundaryUnknownMagnitude(finding) {
-  if (Number.isInteger(finding.affectedCount) && finding.affectedCount > 0) {
-    return finding.affectedCount;
-  }
-  const summaryPrefix = '... and ';
-  const summarySuffix =
-    ' additional unknown occurrences. Reduce unknown propagation at domain boundaries.';
-  if (!finding.message.startsWith(summaryPrefix) || !finding.message.endsWith(summarySuffix)) {
-    return 1;
-  }
-  const magnitude = finding.message.slice(summaryPrefix.length, -summarySuffix.length);
-  return /^\d+$/u.test(magnitude) ? Number(magnitude) : 1;
 }
 
 function findingKey(repoRoot, finding, logicalSourceByTargetPath) {
@@ -302,28 +294,6 @@ function findingVariant(finding) {
     return prefixMatch === null ? finding.message : `prefix:${prefixMatch[1]}`;
   }
   return finding.message.startsWith('... and ') ? 'summary' : 'detail';
-}
-
-function findingMagnitude(finding) {
-  const patternsByRule = {
-    'file.length': /File length (\d+)/u,
-    'line.width': /(?:actual |\.\.\. and )(\d+)/u,
-    'route.handler-length': /has (\d+) lines/u,
-    'route.handler-complexity': /complexity (\d+)/u,
-    'factory.spacing': /has a (\d+)-line block/u,
-    'function.input-contract': /has (\d+) parameters/u,
-    'layout.directory-density': /directory has (\d+) direct production TypeScript files/u,
-    'layout.feature-prefix-cluster': /appears in (\d+) direct files/u,
-  };
-  const match = patternsByRule[finding.ruleId]?.exec(finding.message);
-  if (match !== undefined && match !== null) {
-    return Number(match[1]);
-  }
-  return finding.affectedCount ?? 0;
-}
-
-function compareFindingMagnitudeDescending(left, right) {
-  return findingMagnitude(right) - findingMagnitude(left);
 }
 
 function toRenameMap(changes) {

--- a/scripts/repo-style-check/finding-magnitude.mjs
+++ b/scripts/repo-style-check/finding-magnitude.mjs
@@ -1,0 +1,65 @@
+const magnitudePatternsByRule = {
+  'file.length': /File length (\d+)/u,
+  'line.width': /(?:actual |\.\.\. and )(\d+)/u,
+  'route.handler-length': /has (\d+) lines/u,
+  'route.handler-complexity': /complexity (\d+)/u,
+  'factory.spacing': /has a (\d+)-line block/u,
+  'function.input-contract': /has (\d+) parameters/u,
+  'layout.directory-density': /directory has (\d+) direct production TypeScript files/u,
+  'layout.feature-prefix-cluster': /appears in (\d+) direct files/u,
+};
+
+const fileLengthTierUpperBounds = [400, 500, 800];
+const fileLengthGrowthToleranceFraction = 0.1;
+const fileLengthGrowthToleranceMinimumLines = 25;
+
+export function findingMagnitude(finding) {
+  const match = magnitudePatternsByRule[finding.ruleId]?.exec(finding.message);
+  if (match !== undefined && match !== null) {
+    return Number(match[1]);
+  }
+  return finding.affectedCount ?? 0;
+}
+
+export function compareFindingMagnitudeDescending(left, right) {
+  return findingMagnitude(right) - findingMagnitude(left);
+}
+
+// file.length worsening means crossing a size tier (400/500/800) or same-tier
+// growth beyond max(10% of base, 25 lines); every other rule treats any
+// magnitude growth as worsened.
+export function matchesBaseMagnitude(ruleId, baseMagnitude, targetMagnitude) {
+  if (baseMagnitude >= targetMagnitude) {
+    return true;
+  }
+  if (ruleId !== 'file.length') {
+    return false;
+  }
+  if (toFileLengthTier(targetMagnitude) !== toFileLengthTier(baseMagnitude)) {
+    return false;
+  }
+  const toleratedGrowth = Math.max(
+    fileLengthGrowthToleranceFraction * baseMagnitude,
+    fileLengthGrowthToleranceMinimumLines,
+  );
+  return targetMagnitude - baseMagnitude <= toleratedGrowth;
+}
+
+export function boundaryUnknownMagnitude(finding) {
+  if (Number.isInteger(finding.affectedCount) && finding.affectedCount > 0) {
+    return finding.affectedCount;
+  }
+  const summaryPrefix = '... and ';
+  const summarySuffix =
+    ' additional unknown occurrences. Reduce unknown propagation at domain boundaries.';
+  if (!finding.message.startsWith(summaryPrefix) || !finding.message.endsWith(summarySuffix)) {
+    return 1;
+  }
+  const magnitude = finding.message.slice(summaryPrefix.length, -summarySuffix.length);
+  return /^\d+$/u.test(magnitude) ? Number(magnitude) : 1;
+}
+
+function toFileLengthTier(magnitude) {
+  const tierIndex = fileLengthTierUpperBounds.findIndex((upperBound) => magnitude <= upperBound);
+  return tierIndex < 0 ? fileLengthTierUpperBounds.length : tierIndex;
+}


### PR DESCRIPTION
## What

Gives the changed-findings style gate a tolerance band for `file.length`: a finding only counts as **worsened** when the file **crosses a size tier (400/500/800)** or grows within its tier by **more than max(10% of the merge-base length, 25 physical lines)**. Every other rule keeps strict any-growth-is-worsened semantics — `boundary.unknown` capacity pools, `line.width` instance/summary matching, lineage pooling, and greedy magnitude matching are unchanged.

Mechanically: the magnitude-matching predicate moves into a new `scripts/repo-style-check/finding-magnitude.mjs` module (together with the existing magnitude parsing it belongs to — the main script was at 392 of its own 400-line limit), and the standard's wording in `repo-code-style.md` + `docs/repo-human-style-guide.md` now defines file-length worsening explicitly.

## Why

The comparator failed any branch that grew an already-over-400 file by even two lines. A repo-wide mechanical migration (the `erasableSyntaxOnly` conversion on PR #164: +982 physical lines, +366 statements, cognitive-complexity delta 0 across 147 files) produced 45 such findings — 44 of them on legacy files whose growth was pure syntax boilerplate. The gate's job is to catch drift a reviewer should see, not to veto comprehension-neutral migrations.

## Verification

- 4 new fixture tests pin the tolerance semantics: tolerated same-tier growth; same-tier growth beyond the band fails; small growth that crosses a tier fails; a compliant file crossing 400 fails even inside the band.
- `packages/tests/repo` checker suites: 75/75; full `npm run test:repo-governance`: 391/391.
- Own gate: `check:repo-style:changed -- origin/main HEAD` → PASS.
- **Acceptance run against the real migration branch** (`worktree-erasable-syntax-only`): findings drop **49 → 7**, and the 7 survivors are exactly the intended convictions — `config-route.ts` (499→502, crosses the 500 tier), `AppCrdtInboxService.ts` (394→405, crosses 400), `Resilience.ts` (620→696, +12% beyond band), plus the 4 strict `boundary.unknown` counts.

## Reviewer notes

Tier crossings stay strict on purpose — tiers are review-escalation points, so grazing 500 by two lines still flags (that file gets trimmed on #164 instead). Constants (`400/500/800`, `10%`, `25`) live at the top of `finding-magnitude.mjs`; the cognitive-load metric replacement (phase 2/3) will supersede this rule family later, calibration data in the #164 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
