### PR TITLE
docs(bb-test): distributed assertion-parity plan (D0–D5) + W1–W8 plan close-out

### DIFF
--- a/apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json
@@ -1,0 +1,216 @@
+{
+  "schemaVersion": 1,
+  "distributedRunId": "hetzner-rtc-absence-wait-2-agent",
+  "controlRunId": "hetzner-manifest-template-control-run",
+  "displayName": "RTC absence wait 2-agent",
+  "group": {
+    "applicationId": "rallar-server",
+    "workspaceId": "default",
+    "groupId": "hetzner-headless-room"
+  },
+  "recipes": [
+    {
+      "recipeId": "rtc-absence-wait-recipe",
+      "recipe": {
+        "recipeId": "rtc-absence-wait-recipe",
+        "name": "RTC absence wait recipe",
+        "continueOnFailure": false,
+        "metadata": {
+          "profile": "rtc-absence",
+          "group": {
+            "applicationId": "rallar-server",
+            "workspaceId": "default",
+            "groupId": "hetzner-headless-room"
+          }
+        },
+        "commands": [
+          {
+            "kind": "http.request",
+            "commandId": "rtc-absence-ensure-group",
+            "timeoutMs": 5000,
+            "metadata": {
+              "purpose": "Ensure the backend group exists before RTC room join.",
+              "idempotent": true,
+              "group": {
+                "applicationId": "rallar-server",
+                "workspaceId": "default",
+                "groupId": "hetzner-headless-room"
+              }
+            },
+            "request": {
+              "method": "POST",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups",
+              "body": {
+                "requestId": "rtc-absence:ensure-group:rallar-server:default:hetzner-headless-room:{auth.sessionId}",
+                "groupId": "hetzner-headless-room",
+                "displayName": "hetzner-headless-room",
+                "kind": "room",
+                "joinMode": "open"
+              }
+            },
+            "response": {
+              "body": "json",
+              "acceptedStatusCodes": [
+                200,
+                201,
+                409
+              ]
+            }
+          },
+          {
+            "kind": "http.request",
+            "commandId": "rtc-absence-ensure-member",
+            "timeoutMs": 5000,
+            "metadata": {
+              "purpose": "Ensure the logged-in browser client is an active group member before RTC room join.",
+              "idempotent": true,
+              "group": {
+                "applicationId": "rallar-server",
+                "workspaceId": "default",
+                "groupId": "hetzner-headless-room"
+              }
+            },
+            "request": {
+              "method": "PUT",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}",
+              "body": {
+                "requestId": "rtc-absence:ensure-member:rallar-server:default:hetzner-headless-room:{auth.clientId}:{auth.sessionId}",
+                "status": "active"
+              }
+            },
+            "response": {
+              "body": "json",
+              "acceptedStatusCodes": [
+                200,
+                201
+              ]
+            }
+          },
+          {
+            "kind": "rtc.connect",
+            "commandId": "rtc-absence-connect",
+            "connection": "absenceRtc",
+            "actor": "{auth.clientId}",
+            "roomId": "hetzner-headless-room",
+            "applicationId": "rallar-server",
+            "workspaceId": "default",
+            "roomRef": {
+              "applicationId": "rallar-server",
+              "workspaceId": "default",
+              "groupId": "hetzner-headless-room"
+            },
+            "transport": "realtime",
+            "timeoutMs": 15000,
+            "readiness": {
+              "minReadyPeers": 1,
+              "timeoutMs": 10000,
+              "intervalMs": 100
+            }
+          },
+          {
+            "kind": "rtc.send",
+            "commandId": "rtc-absence-send-control",
+            "connection": "absenceRtc",
+            "applicationId": "rallar-server",
+            "workspaceId": "default",
+            "roomRef": {
+              "applicationId": "rallar-server",
+              "workspaceId": "default",
+              "groupId": "hetzner-headless-room"
+            },
+            "transport": "realtime",
+            "send": {
+              "roomId": "hetzner-headless-room",
+              "roomRef": {
+                "applicationId": "rallar-server",
+                "workspaceId": "default",
+                "groupId": "hetzner-headless-room"
+              },
+              "data": {
+                "topic": "black-box.absence.control",
+                "marker": "same-room-positive-control",
+                "actor": "{auth.clientId}"
+              }
+            },
+            "timeoutMs": 3000
+          },
+          {
+            "kind": "wait",
+            "commandId": "rtc-absence-positive-control",
+            "timeoutMs": 10000,
+            "metadata": {
+              "purpose": "Same-room positive control: the control frame must arrive before any absence claim."
+            },
+            "match": {
+              "kind": "message",
+              "connection": "absenceRtc",
+              "topic": "rallar.browser.realtime.message",
+              "payloadPath": "data.topic",
+              "equals": "black-box.absence.control"
+            }
+          },
+          {
+            "kind": "wait",
+            "commandId": "rtc-absence-no-leak-probe",
+            "absent": true,
+            "timeoutMs": 4000,
+            "metadata": {
+              "purpose": "No agent may ever observe a leak-probe frame on this connection."
+            },
+            "match": {
+              "kind": "message",
+              "connection": "absenceRtc",
+              "topic": "rallar.browser.realtime.message",
+              "payloadPath": "data.topic",
+              "equals": "black-box.absence.leak-probe"
+            }
+          },
+          {
+            "kind": "wait",
+            "commandId": "rtc-absence-no-send-failures",
+            "absent": true,
+            "timeoutMs": 2000,
+            "metadata": {
+              "purpose": "No silent rtc send failure may exist anywhere in the run buffer."
+            },
+            "match": {
+              "kind": "diagnostic",
+              "topic": "rallar.bb.rtc.send_failed"
+            }
+          },
+          {
+            "kind": "stats",
+            "commandId": "rtc-absence-stats"
+          }
+        ]
+      },
+      "profile": "rtc",
+      "required": true
+    }
+  ],
+  "targetPolicy": {
+    "mode": "all-online-group-members",
+    "expectedParticipantCount": 2
+  },
+  "ackTimeoutMs": 30000,
+  "barrier": {
+    "enabled": true,
+    "timeoutMs": 15000
+  },
+  "startMode": "manual",
+  "artifactPolicy": {
+    "retainArtifacts": true,
+    "includeDistributedMetadata": true,
+    "includeEventJsonl": true,
+    "includeResultJsonl": true,
+    "includeFailureBundle": true
+  },
+  "metadata": {
+    "createdBy": "rallar-black-box-spa",
+    "rolePattern": "all-agents",
+    "manifestSuite": "hetzner-distributed",
+    "diagnostic": false,
+    "expectedFailure": false
+  },
+  "description": "Same-room positive control delivery followed by absence waits proving no leak-probe frame and no silent rtc send failure."
+}

--- a/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
+++ b/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
@@ -20,6 +20,9 @@ import {
 import {
     createHetznerProviderParityRecipe,
 } from './hetzner/create-hetzner-provider-parity-recipe.ts';
+import {
+    createHetznerRtcAbsenceWaitRecipe,
+} from './hetzner/create-hetzner-rtc-absence-wait-recipe.ts';
 
 export const HETZNER_DISTRIBUTED_MANIFEST_GROUP: RallarBlackBoxDistributedGroupRef = {
     applicationId: 'rallar-server',
@@ -51,6 +54,7 @@ export const HETZNER_DISTRIBUTED_MANIFEST_EXTENDED_ORDER = [
     'apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json',
     'apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json',
     'apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json',
+    'apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json',
 ] as const;
 
 export type HetznerDistributedManifestEntry = Readonly<{
@@ -373,6 +377,16 @@ export function buildHetznerDistributedManifestCatalog(): readonly HetznerDistri
             }),
         }),
         ...buildRtcMessagesMainlineAlternativeEntries(),
+        buildManifestEntry({
+            filePath: HETZNER_DISTRIBUTED_MANIFEST_EXTENDED_ORDER[15],
+            title: 'RTC absence wait 2-agent',
+            description: 'Same-room positive control delivery followed by absence waits proving no leak-probe frame and no silent rtc send failure.',
+            distributedRunId: 'hetzner-rtc-absence-wait-2-agent',
+            recipe: createHetznerRtcAbsenceWaitRecipe(HETZNER_DISTRIBUTED_MANIFEST_GROUP),
+            agentCount: 2,
+            profiles: ['rtc', 'absence', 'isolation', 'extended'],
+            live: true,
+        }),
         buildManifestEntry({
             filePath: 'apps/rallar-black-box/manifests/hetzner/diagnostic/barrier-health-2-agent.json',
             title: 'Barrier health 2-agent',

--- a/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
+++ b/apps/rallar-black-box/src/hetzner-distributed-manifests.ts
@@ -380,7 +380,8 @@ export function buildHetznerDistributedManifestCatalog(): readonly HetznerDistri
         buildManifestEntry({
             filePath: HETZNER_DISTRIBUTED_MANIFEST_EXTENDED_ORDER[15],
             title: 'RTC absence wait 2-agent',
-            description: 'Same-room positive control delivery followed by absence waits proving no leak-probe frame and no silent rtc send failure.',
+            description: 'Same-room positive control delivery followed by absence waits proving ' +
+                'no leak-probe frame and no silent rtc send failure.',
             distributedRunId: 'hetzner-rtc-absence-wait-2-agent',
             recipe: createHetznerRtcAbsenceWaitRecipe(HETZNER_DISTRIBUTED_MANIFEST_GROUP),
             agentCount: 2,

--- a/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
+++ b/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
@@ -1,0 +1,165 @@
+import type {
+    RallarBlackBoxDistributedGroupRef,
+} from '@shared-test/rallar-bb-test/distributed-run.ts';
+import type { RallarBlackBoxTestRecipe } from '@shared-test/rallar-bb-test/types.ts';
+
+const CONTROL_TOPIC = 'black-box.absence.control';
+const LEAK_PROBE_TOPIC = 'black-box.absence.leak-probe';
+
+// The Hetzner isolation contract pins every identity in a manifest to one
+// effective group, so the absence claims stay inside that room: the delivered
+// control topic proves transport health, then the run asserts no leak-probe
+// frame and no silent rtc send failure ever surfaced on the same connection.
+export function createHetznerRtcAbsenceWaitRecipe(
+    group: RallarBlackBoxDistributedGroupRef,
+): RallarBlackBoxTestRecipe {
+    const roomRef = {
+        applicationId: group.applicationId,
+        workspaceId: group.workspaceId,
+        groupId: group.groupId,
+    };
+    const scopedGroup = `${group.applicationId}:${group.workspaceId}:${group.groupId}`;
+
+    return {
+        recipeId: 'rtc-absence-wait-recipe',
+        name: 'RTC absence wait recipe',
+        continueOnFailure: false,
+        metadata: {
+            profile: 'rtc-absence',
+            group: roomRef,
+        },
+        commands: [
+            {
+                kind: 'http.request',
+                commandId: 'rtc-absence-ensure-group',
+                timeoutMs: 5_000,
+                metadata: {
+                    purpose: 'Ensure the backend group exists before RTC room join.',
+                    idempotent: true,
+                    group: roomRef,
+                },
+                request: {
+                    method: 'POST',
+                    path: `/api/state/apps/${group.applicationId}/workspaces/${group.workspaceId}/groups`,
+                    body: {
+                        requestId: `rtc-absence:ensure-group:${scopedGroup}:{auth.sessionId}`,
+                        groupId: group.groupId,
+                        displayName: group.groupId,
+                        kind: 'room',
+                        joinMode: 'open',
+                    },
+                },
+                response: {
+                    body: 'json',
+                    acceptedStatusCodes: [200, 201, 409],
+                },
+            },
+            {
+                kind: 'http.request',
+                commandId: 'rtc-absence-ensure-member',
+                timeoutMs: 5_000,
+                metadata: {
+                    purpose: 'Ensure the logged-in browser client is an active group member before RTC room join.',
+                    idempotent: true,
+                    group: roomRef,
+                },
+                request: {
+                    method: 'PUT',
+                    path: `/api/state/apps/${group.applicationId}/workspaces/${group.workspaceId}/groups/${group.groupId}/members/{auth.clientId}`,
+                    body: {
+                        requestId: `rtc-absence:ensure-member:${scopedGroup}:{auth.clientId}:{auth.sessionId}`,
+                        status: 'active',
+                    },
+                },
+                response: {
+                    body: 'json',
+                    acceptedStatusCodes: [200, 201],
+                },
+            },
+            {
+                kind: 'rtc.connect',
+                commandId: 'rtc-absence-connect',
+                connection: 'absenceRtc',
+                actor: '{auth.clientId}',
+                roomId: group.groupId,
+                applicationId: group.applicationId,
+                workspaceId: group.workspaceId,
+                roomRef,
+                transport: 'realtime',
+                timeoutMs: 15_000,
+                readiness: {
+                    minReadyPeers: 1,
+                    timeoutMs: 10_000,
+                    intervalMs: 100,
+                },
+            },
+            {
+                kind: 'rtc.send',
+                commandId: 'rtc-absence-send-control',
+                connection: 'absenceRtc',
+                applicationId: group.applicationId,
+                workspaceId: group.workspaceId,
+                roomRef,
+                transport: 'realtime',
+                send: {
+                    roomId: group.groupId,
+                    roomRef,
+                    data: {
+                        topic: CONTROL_TOPIC,
+                        marker: 'same-room-positive-control',
+                        actor: '{auth.clientId}',
+                    },
+                },
+                timeoutMs: 3_000,
+            },
+            {
+                kind: 'wait',
+                commandId: 'rtc-absence-positive-control',
+                timeoutMs: 10_000,
+                metadata: {
+                    purpose: 'Same-room positive control: the control frame must arrive before any absence claim.',
+                },
+                match: {
+                    kind: 'message',
+                    connection: 'absenceRtc',
+                    topic: 'rallar.browser.realtime.message',
+                    payloadPath: 'data.topic',
+                    equals: CONTROL_TOPIC,
+                },
+            },
+            {
+                kind: 'wait',
+                commandId: 'rtc-absence-no-leak-probe',
+                absent: true,
+                timeoutMs: 4_000,
+                metadata: {
+                    purpose: 'No agent may ever observe a leak-probe frame on this connection.',
+                },
+                match: {
+                    kind: 'message',
+                    connection: 'absenceRtc',
+                    topic: 'rallar.browser.realtime.message',
+                    payloadPath: 'data.topic',
+                    equals: LEAK_PROBE_TOPIC,
+                },
+            },
+            {
+                kind: 'wait',
+                commandId: 'rtc-absence-no-send-failures',
+                absent: true,
+                timeoutMs: 2_000,
+                metadata: {
+                    purpose: 'No silent rtc send failure may exist anywhere in the run buffer.',
+                },
+                match: {
+                    kind: 'diagnostic',
+                    topic: 'rallar.bb.rtc.send_failed',
+                },
+            },
+            {
+                kind: 'stats',
+                commandId: 'rtc-absence-stats',
+            },
+        ],
+    };
+}

--- a/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
+++ b/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
@@ -19,6 +19,7 @@ export function createHetznerRtcAbsenceWaitRecipe(
         groupId: group.groupId,
     };
     const scopedGroup = `${group.applicationId}:${group.workspaceId}:${group.groupId}`;
+    const statePrefix = `/api/state/apps/${group.applicationId}/workspaces/${group.workspaceId}`;
 
     return {
         recipeId: 'rtc-absence-wait-recipe',
@@ -40,7 +41,7 @@ export function createHetznerRtcAbsenceWaitRecipe(
                 },
                 request: {
                     method: 'POST',
-                    path: `/api/state/apps/${group.applicationId}/workspaces/${group.workspaceId}/groups`,
+                    path: `${statePrefix}/groups`,
                     body: {
                         requestId: `rtc-absence:ensure-group:${scopedGroup}:{auth.sessionId}`,
                         groupId: group.groupId,
@@ -59,15 +60,17 @@ export function createHetznerRtcAbsenceWaitRecipe(
                 commandId: 'rtc-absence-ensure-member',
                 timeoutMs: 5_000,
                 metadata: {
-                    purpose: 'Ensure the logged-in browser client is an active group member before RTC room join.',
+                    purpose: 'Ensure the logged-in browser client is an active group member ' +
+                        'before RTC room join.',
                     idempotent: true,
                     group: roomRef,
                 },
                 request: {
                     method: 'PUT',
-                    path: `/api/state/apps/${group.applicationId}/workspaces/${group.workspaceId}/groups/${group.groupId}/members/{auth.clientId}`,
+                    path: `${statePrefix}/groups/${group.groupId}/members/{auth.clientId}`,
                     body: {
-                        requestId: `rtc-absence:ensure-member:${scopedGroup}:{auth.clientId}:{auth.sessionId}`,
+                        requestId: `rtc-absence:ensure-member:${scopedGroup}` +
+                            ':{auth.clientId}:{auth.sessionId}',
                         status: 'active',
                     },
                 },
@@ -117,7 +120,8 @@ export function createHetznerRtcAbsenceWaitRecipe(
                 commandId: 'rtc-absence-positive-control',
                 timeoutMs: 10_000,
                 metadata: {
-                    purpose: 'Same-room positive control: the control frame must arrive before any absence claim.',
+                    purpose: 'Same-room positive control: the control frame must arrive ' +
+                        'before any absence claim.',
                 },
                 match: {
                     kind: 'message',

--- a/apps/rallar-black-box/src/manual-workbench.ts
+++ b/apps/rallar-black-box/src/manual-workbench.ts
@@ -543,10 +543,6 @@ export function manualRtcNackProbeCommands(
             negativeCase: 'not-yet-in-sync',
             expectedOutcome: 'nack',
         },
-        expect: {
-            outcome: 'nack',
-            code: 'not-yet-in-sync',
-        },
     }];
 }
 
@@ -574,10 +570,6 @@ export function manualRtcNegativeRecipeSnippet(
                 negativeCase: 'missing-peer',
                 expectedOutcome: 'delivery-failure',
             },
-            expect: {
-                status: 'failed',
-                code: 'missing-peer',
-            },
         },
         {
             ...asRtcSendCommand(manualSendCommand({
@@ -589,10 +581,6 @@ export function manualRtcNegativeRecipeSnippet(
             metadata: {
                 negativeCase: 'stale-agent',
                 expectedOutcome: 'delivery-failure',
-            },
-            expect: {
-                status: 'failed',
-                code: 'stale-agent',
             },
         },
         {
@@ -612,10 +600,6 @@ export function manualRtcNegativeRecipeSnippet(
                 negativeCase: 'permission-denied',
                 expectedOutcome: 'permission-failure',
             },
-            expect: {
-                status: 'failed',
-                code: 'permission-denied',
-            },
         },
         manualSimpleCommand('close', 7),
         {
@@ -625,10 +609,6 @@ export function manualRtcNegativeRecipeSnippet(
             metadata: {
                 negativeCase: 'closed-transport',
                 expectedOutcome: 'transport-failure',
-            },
-            expect: {
-                status: 'failed',
-                code: 'closed-transport',
             },
         },
         ...manualRtcNackProbeCommands(baseValues, payload, 9),

--- a/packages/shared-test/rallar-bb-test/composite-conformance.ts
+++ b/packages/shared-test/rallar-bb-test/composite-conformance.ts
@@ -3,7 +3,9 @@ import {
     type RallarBlackBoxCompositeResultSummary,
 } from './composite-results.ts';
 import { redactRallarBlackBoxValue } from './redaction.ts';
-import { createRallarBlackBoxCompositeConformanceRecipe } from './conformance/composite-conformance-recipes.ts';
+import {
+    createRallarBlackBoxCompositeConformanceRecipe,
+} from './conformance/create-rallar-black-box-composite-conformance-recipe.ts';
 import type {
     RallarBlackBoxTestCommand,
     RallarBlackBoxTestEvent,
@@ -181,7 +183,14 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_CASES:
             title: 'Wait Absence Hold',
             intent: 'Prove an absence wait holds the full window and passes when nothing matches.',
             expectedStatus: 'ok',
-            requiredCommandKinds: ['configure', 'rtc.connect', 'rtc.send', 'wait', 'stats', 'close'],
+            requiredCommandKinds: [
+                'configure',
+                'rtc.connect',
+                'rtc.send',
+                'wait',
+                'stats',
+                'close',
+            ],
             requiredCompositeKinds: [],
             requiredEventTopics: ['rallar.conformance.message'],
             liveSafe: true,

--- a/packages/shared-test/rallar-bb-test/composite-conformance.ts
+++ b/packages/shared-test/rallar-bb-test/composite-conformance.ts
@@ -3,6 +3,7 @@ import {
     type RallarBlackBoxCompositeResultSummary,
 } from './composite-results.ts';
 import { redactRallarBlackBoxValue } from './redaction.ts';
+import { createRallarBlackBoxCompositeConformanceRecipe } from './conformance/composite-conformance-recipes.ts';
 import type {
     RallarBlackBoxTestCommand,
     RallarBlackBoxTestEvent,
@@ -19,6 +20,8 @@ export type RallarBlackBoxCompositeConformanceCaseId =
     | 'parallel-ws-rtc-groups'
     | 'wait-assert-evidence'
     | 'cancel-during-loop'
+    | 'wait-absence-hold'
+    | 'wait-absence-violated'
     | 'negative-no-peer';
 
 export type RallarBlackBoxCompositeConformanceProviderId =
@@ -174,6 +177,27 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_CASES:
             liveSafe: true,
         },
         {
+            caseId: 'wait-absence-hold',
+            title: 'Wait Absence Hold',
+            intent: 'Prove an absence wait holds the full window and passes when nothing matches.',
+            expectedStatus: 'ok',
+            requiredCommandKinds: ['configure', 'rtc.connect', 'rtc.send', 'wait', 'stats', 'close'],
+            requiredCompositeKinds: [],
+            requiredEventTopics: ['rallar.conformance.message'],
+            liveSafe: true,
+        },
+        {
+            caseId: 'wait-absence-violated',
+            title: 'Wait Absence Violated Control',
+            intent: 'Prove a deliberately-broken absence wait fails with the offending redacted event.',
+            expectedStatus: 'failed',
+            requiredCommandKinds: ['configure', 'rtc.connect', 'rtc.send', 'wait'],
+            requiredCompositeKinds: [],
+            requiredEventTopics: ['rallar.conformance.message'],
+            expectedFailureCodes: ['RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED'],
+            liveSafe: true,
+        },
+        {
             caseId: 'negative-no-peer',
             title: 'No-peer Negative Case',
             intent: 'Prove delivery failure is reported separately from local composite orchestration.',
@@ -198,6 +222,8 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_PROVIDERS:
                 'parallel-ws-rtc-groups',
                 'wait-assert-evidence',
                 'cancel-during-loop',
+                'wait-absence-hold',
+                'wait-absence-violated',
                 'negative-no-peer',
             ],
             capabilityDifferences: [
@@ -214,6 +240,8 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_PROVIDERS:
                 'parallel-ws-rtc-groups',
                 'wait-assert-evidence',
                 'cancel-during-loop',
+                'wait-absence-hold',
+                'wait-absence-violated',
                 'negative-no-peer',
             ],
             requires: {
@@ -248,6 +276,8 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_PROVIDERS:
                 'parallel-ws-rtc-groups',
                 'wait-assert-evidence',
                 'cancel-during-loop',
+                'wait-absence-hold',
+                'wait-absence-violated',
                 'negative-no-peer',
             ],
             requires: {
@@ -281,11 +311,6 @@ export const RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_PROVIDERS:
         },
     ] as const;
 
-const DEFAULT_TIMEOUT_MS = 5_000;
-const DEFAULT_CONNECTION = 'conformanceRtc';
-const DEFAULT_WS_CONNECTION = 'conformanceWs';
-const DEFAULT_ROOM_ID = 'rallar-conformance-room';
-
 export function rallarBlackBoxCompositeConformanceCaseById(
     caseId: RallarBlackBoxCompositeConformanceCaseId,
 ): RallarBlackBoxCompositeConformanceCase {
@@ -306,24 +331,6 @@ export function rallarBlackBoxCompositeConformanceProviderById(
         throw new Error(`Unknown composite conformance provider: ${providerId}`);
     }
     return found;
-}
-
-export function createRallarBlackBoxCompositeConformanceRecipe(
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-    options: RallarBlackBoxCompositeConformanceRecipeOptions = {},
-): RallarBlackBoxTestRecipe {
-    switch (caseId) {
-        case 'looped-rtc-send':
-            return loopedRtcRecipe(options);
-        case 'parallel-ws-rtc-groups':
-            return parallelWsRtcRecipe(options);
-        case 'wait-assert-evidence':
-            return waitAssertRecipe(options);
-        case 'cancel-during-loop':
-            return cancelDuringLoopRecipe(options);
-        case 'negative-no-peer':
-            return negativeNoPeerRecipe(options);
-    }
 }
 
 export function createRallarBlackBoxCompositeConformanceMatrix(
@@ -441,400 +448,6 @@ export function toRallarBlackBoxCompositeConformanceReport(
         capabilityDifferences: entry.provider.capabilityDifferences,
         diagnostics: diagnostics.map(event => redactDiagnostic(event, input.redaction)),
         redactedFailures: failures.map(failure => redactRallarBlackBoxValue(failure, input.redaction)),
-    };
-}
-
-function loopedRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
-    const connection = options.connection ?? DEFAULT_CONNECTION;
-    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
-    const transport = options.transport ?? 'realtime';
-    return {
-        recipeId: recipeId('looped-rtc-send', options),
-        name: 'Composite conformance: looped RTC send',
-        continueOnFailure: false,
-        metadata: recipeMetadata('looped-rtc-send'),
-        commands: [
-            configureCommand('looped-rtc-send', options),
-            rtcConnectCommand('looped-rtc-send', 'looped-rtc-send-connect', connection, roomId, transport, options),
-            {
-                kind: 'loop',
-                commandId: 'looped-rtc-send-loop',
-                count: 3,
-                intervalMs: 10,
-                thresholds: {
-                    minSendSuccessRatio: 1,
-                    maxStartDriftMs: 1_000,
-                },
-                metadata: commandMetadata('looped-rtc-send', 'looped-rtc-send-loop'),
-                commands: [
-                    {
-                        kind: 'rtc.send',
-                        commandId: 'looped-rtc-send-frame',
-                        connection,
-                        transport,
-                        timeoutMs: timeoutMs(options),
-                        send: {
-                            data: {
-                                topic: 'rallar.conformance.looped-rtc-send',
-                                frame: '{loop.index}',
-                                iteration: '{loop.iteration}',
-                                elapsedMs: '{loop.elapsedMs}',
-                            },
-                            roomId,
-                            ...scopeFields(options),
-                        },
-                        metadata: commandMetadata('looped-rtc-send', 'looped-rtc-send-frame'),
-                    },
-                ],
-            },
-            statsCommand('looped-rtc-send-stats', 'looped-rtc-send'),
-            closeCommand('looped-rtc-send-close', 'looped-rtc-send'),
-        ],
-    };
-}
-
-function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
-    const connection = options.connection ?? DEFAULT_CONNECTION;
-    const wsConnection = options.wsConnection ?? DEFAULT_WS_CONNECTION;
-    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
-    const transport = options.transport ?? 'messages.rtc';
-    return {
-        recipeId: recipeId('parallel-ws-rtc-groups', options),
-        name: 'Composite conformance: parallel WS and RTC groups',
-        continueOnFailure: false,
-        metadata: recipeMetadata('parallel-ws-rtc-groups'),
-        commands: [
-            configureCommand('parallel-ws-rtc-groups', options),
-            {
-                kind: 'ws.open',
-                commandId: 'parallel-ws-open',
-                connection: wsConnection,
-                url: '{config.wsBaseUrl}/api/ws',
-                timeoutMs: timeoutMs(options),
-                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-open'),
-            },
-            rtcConnectCommand('parallel-ws-rtc-groups', 'parallel-rtc-connect', connection, roomId, transport, options),
-            {
-                kind: 'parallel',
-                commandId: 'parallel-ws-rtc',
-                maxConcurrency: 2,
-                groups: [
-                    {
-                        groupId: 'ws',
-                        commands: [
-                            {
-                                kind: 'ws.send',
-                                commandId: 'parallel-ws-send',
-                                connection: wsConnection,
-                                data: {
-                                    topic: 'rallar.conformance.parallel.ws',
-                                    payload: {
-                                        source: 'ws',
-                                    },
-                                },
-                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-send'),
-                            },
-                        ],
-                    },
-                    {
-                        groupId: 'rtc',
-                        commands: [
-                            {
-                                kind: 'rtc.send',
-                                commandId: 'parallel-rtc-send',
-                                connection,
-                                transport,
-                                timeoutMs: timeoutMs(options),
-                                send: {
-                                    payload: {
-                                        topic: 'rallar.conformance.parallel.rtc',
-                                        source: 'rtc',
-                                    },
-                                    roomId,
-                                    ...scopeFields(options),
-                                },
-                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-rtc-send'),
-                            },
-                        ],
-                    },
-                ],
-                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-rtc'),
-            },
-            statsCommand('parallel-ws-rtc-stats', 'parallel-ws-rtc-groups'),
-            {
-                kind: 'ws.close',
-                commandId: 'parallel-ws-close',
-                connection: wsConnection,
-                code: 1000,
-                reason: 'conformance complete',
-                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-close'),
-            },
-            closeCommand('parallel-close', 'parallel-ws-rtc-groups'),
-        ],
-    };
-}
-
-function waitAssertRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
-    const connection = options.connection ?? DEFAULT_CONNECTION;
-    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
-    const transport = options.transport ?? 'realtime';
-    return {
-        recipeId: recipeId('wait-assert-evidence', options),
-        name: 'Composite conformance: wait and assert evidence',
-        continueOnFailure: false,
-        metadata: recipeMetadata('wait-assert-evidence'),
-        commands: [
-            configureCommand('wait-assert-evidence', options),
-            rtcConnectCommand('wait-assert-evidence', 'wait-assert-connect', connection, roomId, transport, options),
-            {
-                kind: 'rtc.send',
-                commandId: 'wait-assert-send',
-                connection,
-                transport,
-                timeoutMs: timeoutMs(options),
-                send: {
-                    data: {
-                        topic: 'rallar.conformance.wait-assert',
-                        marker: 'wait-assert-evidence',
-                    },
-                    roomId,
-                    ...scopeFields(options),
-                },
-                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-send'),
-            },
-            {
-                kind: 'wait',
-                commandId: 'wait-assert-wait-message',
-                timeoutMs: timeoutMs(options),
-                match: {
-                    kind: 'message',
-                    topic: 'rallar.conformance.message',
-                    payloadPath: 'data.topic',
-                    equals: 'rallar.conformance.wait-assert',
-                },
-                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-wait-message'),
-            },
-            {
-                kind: 'assert',
-                commandId: 'wait-assert-check-message',
-                source: 'messages.0.payload.data.marker',
-                operator: 'equals',
-                expected: 'wait-assert-evidence',
-                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-check-message'),
-            },
-            statsCommand('wait-assert-stats', 'wait-assert-evidence'),
-            closeCommand('wait-assert-close', 'wait-assert-evidence'),
-        ],
-    };
-}
-
-function cancelDuringLoopRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
-    return {
-        recipeId: recipeId('cancel-during-loop', options),
-        name: 'Composite conformance: cancellation during loop',
-        continueOnFailure: false,
-        metadata: recipeMetadata('cancel-during-loop'),
-        commands: [
-            configureCommand('cancel-during-loop', options),
-            {
-                kind: 'loop',
-                commandId: 'cancel-during-loop-loop',
-                count: 3,
-                intervalMs: 10,
-                metadata: commandMetadata('cancel-during-loop', 'cancel-during-loop-loop'),
-                commands: [
-                    {
-                        kind: 'health',
-                        commandId: 'cancel-loop-health',
-                        metadata: commandMetadata('cancel-during-loop', 'cancel-loop-health'),
-                    },
-                    {
-                        kind: 'recipe.cancel',
-                        commandId: 'cancel-loop-request',
-                        reason: 'composite conformance cancellation case',
-                        metadata: commandMetadata('cancel-during-loop', 'cancel-loop-request'),
-                    },
-                ],
-            },
-            statsCommand('cancel-during-loop-stats', 'cancel-during-loop'),
-        ],
-    };
-}
-
-function negativeNoPeerRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
-    const connection = options.connection ?? DEFAULT_CONNECTION;
-    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
-    const transport = options.transport ?? 'realtime';
-    return {
-        recipeId: recipeId('negative-no-peer', options),
-        name: 'Composite conformance: no-peer negative case',
-        continueOnFailure: false,
-        metadata: recipeMetadata('negative-no-peer'),
-        commands: [
-            configureCommand('negative-no-peer', options),
-            rtcConnectCommand('negative-no-peer', 'negative-no-peer-connect', connection, roomId, transport, options),
-            {
-                kind: 'rtc.send',
-                commandId: 'negative-no-peer-send',
-                connection,
-                transport,
-                timeoutMs: timeoutMs(options),
-                send: {
-                    data: {
-                        topic: 'rallar.conformance.negative-no-peer',
-                        marker: 'negative-no-peer',
-                    },
-                    roomId,
-                    peerIds: ['missing-peer'],
-                    ...scopeFields(options),
-                },
-                metadata: commandMetadata('negative-no-peer', 'negative-no-peer-send'),
-            },
-            statsCommand('negative-no-peer-stats', 'negative-no-peer'),
-        ],
-    };
-}
-
-function configureCommand(
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-    options: RallarBlackBoxCompositeConformanceRecipeOptions,
-): Extract<RallarBlackBoxTestCommand, { kind: 'configure' }> {
-    return {
-        kind: 'configure',
-        commandId: `${caseId}-configure`,
-        config: {
-            runId: options.runId ?? 'rallar-composite-conformance-run',
-            agentId: options.agentId ?? 'local-conformance-agent',
-            environment: options.environment ?? 'local',
-            apiBaseUrl: options.apiBaseUrl ?? 'http://localhost:8080',
-            actor: options.actor ?? 'alice',
-            sessionId: options.sessionId ?? 'alice-session',
-            roomId: options.roomId ?? DEFAULT_ROOM_ID,
-            transport: options.transport ?? 'realtime',
-            rallar: {
-                apiBaseUrl: options.apiBaseUrl ?? 'http://localhost:8080',
-                wsBaseUrl: wsBaseUrl(options.apiBaseUrl ?? 'http://localhost:8080'),
-                applicationId: options.applicationId ?? 'rallar-server',
-                workspaceId: options.workspaceId ?? 'default',
-                roomId: options.roomId ?? DEFAULT_ROOM_ID,
-            },
-            control: {
-                providerMode: options.providerMode ?? 'simulated',
-                conformance: true,
-            },
-            defaults: {
-                timeoutMs: timeoutMs(options),
-                connection: options.connection ?? DEFAULT_CONNECTION,
-            },
-            redaction: {
-                keys: ['password', 'accessToken', 'token'],
-            },
-        },
-        metadata: commandMetadata(caseId, `${caseId}-configure`),
-    };
-}
-
-function rtcConnectCommand(
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-    commandId: string,
-    connection: string,
-    roomId: string,
-    transport: Extract<RallarBlackBoxTestTransport, 'realtime' | 'messages.rtc'>,
-    options: RallarBlackBoxCompositeConformanceRecipeOptions,
-): Extract<RallarBlackBoxTestCommand, { kind: 'rtc.connect' }> {
-    return {
-        kind: 'rtc.connect',
-        commandId,
-        connection,
-        actor: options.actor ?? 'alice',
-        roomId,
-        transport,
-        timeoutMs: timeoutMs(options),
-        ...scopeFields(options),
-        rallar: {
-            sessionId: options.sessionId ?? 'alice-session',
-            transport,
-        },
-        metadata: commandMetadata(caseId, commandId),
-    };
-}
-
-function statsCommand(
-    commandId: string,
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-): Extract<RallarBlackBoxTestCommand, { kind: 'stats' }> {
-    return {
-        kind: 'stats',
-        commandId,
-        metadata: commandMetadata(caseId, commandId),
-    };
-}
-
-function closeCommand(
-    commandId: string,
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-): Extract<RallarBlackBoxTestCommand, { kind: 'close' }> {
-    return {
-        kind: 'close',
-        commandId,
-        metadata: commandMetadata(caseId, commandId),
-    };
-}
-
-function recipeId(
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-    options: RallarBlackBoxCompositeConformanceRecipeOptions,
-): string {
-    return [options.recipeIdPrefix ?? 'composite-conformance', caseId].join('-');
-}
-
-function timeoutMs(options: RallarBlackBoxCompositeConformanceRecipeOptions): number {
-    return Number.isFinite(options.timeoutMs) && options.timeoutMs !== undefined && options.timeoutMs > 0
-        ? Math.round(options.timeoutMs)
-        : DEFAULT_TIMEOUT_MS;
-}
-
-function scopeFields(options: RallarBlackBoxCompositeConformanceRecipeOptions): Record<string, unknown> {
-    return {
-        applicationId: options.applicationId ?? 'rallar-server',
-        workspaceId: options.workspaceId ?? 'default',
-        roomRef: {
-            applicationId: options.applicationId ?? 'rallar-server',
-            workspaceId: options.workspaceId ?? 'default',
-            groupId: options.roomId ?? DEFAULT_ROOM_ID,
-        },
-    };
-}
-
-function wsBaseUrl(apiBaseUrl: string): string {
-    try {
-        const url = new URL(apiBaseUrl);
-        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-        return url.toString().replace(/\/+$/, '');
-    } catch {
-        return 'ws://localhost:8080';
-    }
-}
-
-function recipeMetadata(caseId: RallarBlackBoxCompositeConformanceCaseId): Record<string, unknown> {
-    return {
-        conformance: {
-            schemaVersion: 1,
-            caseId,
-        },
-    };
-}
-
-function commandMetadata(
-    caseId: RallarBlackBoxCompositeConformanceCaseId,
-    commandId: string,
-): Record<string, unknown> {
-    return {
-        conformance: {
-            schemaVersion: 1,
-            caseId,
-            commandId,
-        },
     };
 }
 

--- a/packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts
@@ -1,0 +1,157 @@
+import type {
+    RallarBlackBoxTestCommand,
+    RallarBlackBoxTestTransport,
+} from '../types.ts';
+
+import type {
+    RallarBlackBoxCompositeConformanceCaseId,
+    RallarBlackBoxCompositeConformanceRecipeOptions,
+} from '../composite-conformance.ts';
+
+export const DEFAULT_TIMEOUT_MS = 5_000;
+export const DEFAULT_CONNECTION = 'conformanceRtc';
+export const DEFAULT_WS_CONNECTION = 'conformanceWs';
+export const DEFAULT_ROOM_ID = 'rallar-conformance-room';
+
+export function configureCommand(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): Extract<RallarBlackBoxTestCommand, { kind: 'configure' }> {
+    return {
+        kind: 'configure',
+        commandId: `${caseId}-configure`,
+        config: {
+            runId: options.runId ?? 'rallar-composite-conformance-run',
+            agentId: options.agentId ?? 'local-conformance-agent',
+            environment: options.environment ?? 'local',
+            apiBaseUrl: options.apiBaseUrl ?? 'http://localhost:8080',
+            actor: options.actor ?? 'alice',
+            sessionId: options.sessionId ?? 'alice-session',
+            roomId: options.roomId ?? DEFAULT_ROOM_ID,
+            transport: options.transport ?? 'realtime',
+            rallar: {
+                apiBaseUrl: options.apiBaseUrl ?? 'http://localhost:8080',
+                wsBaseUrl: wsBaseUrl(options.apiBaseUrl ?? 'http://localhost:8080'),
+                applicationId: options.applicationId ?? 'rallar-server',
+                workspaceId: options.workspaceId ?? 'default',
+                roomId: options.roomId ?? DEFAULT_ROOM_ID,
+            },
+            control: {
+                providerMode: options.providerMode ?? 'simulated',
+                conformance: true,
+            },
+            defaults: {
+                timeoutMs: timeoutMs(options),
+                connection: options.connection ?? DEFAULT_CONNECTION,
+            },
+            redaction: {
+                keys: ['password', 'accessToken', 'token'],
+            },
+        },
+        metadata: commandMetadata(caseId, `${caseId}-configure`),
+    };
+}
+
+export function rtcConnectCommand(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+    commandId: string,
+    connection: string,
+    roomId: string,
+    transport: Extract<RallarBlackBoxTestTransport, 'realtime' | 'messages.rtc'>,
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): Extract<RallarBlackBoxTestCommand, { kind: 'rtc.connect' }> {
+    return {
+        kind: 'rtc.connect',
+        commandId,
+        connection,
+        actor: options.actor ?? 'alice',
+        roomId,
+        transport,
+        timeoutMs: timeoutMs(options),
+        ...scopeFields(options),
+        rallar: {
+            sessionId: options.sessionId ?? 'alice-session',
+            transport,
+        },
+        metadata: commandMetadata(caseId, commandId),
+    };
+}
+
+export function statsCommand(
+    commandId: string,
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+): Extract<RallarBlackBoxTestCommand, { kind: 'stats' }> {
+    return {
+        kind: 'stats',
+        commandId,
+        metadata: commandMetadata(caseId, commandId),
+    };
+}
+
+export function closeCommand(
+    commandId: string,
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+): Extract<RallarBlackBoxTestCommand, { kind: 'close' }> {
+    return {
+        kind: 'close',
+        commandId,
+        metadata: commandMetadata(caseId, commandId),
+    };
+}
+
+export function recipeId(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): string {
+    return [options.recipeIdPrefix ?? 'composite-conformance', caseId].join('-');
+}
+
+export function timeoutMs(options: RallarBlackBoxCompositeConformanceRecipeOptions): number {
+    return Number.isFinite(options.timeoutMs) && options.timeoutMs !== undefined && options.timeoutMs > 0
+        ? Math.round(options.timeoutMs)
+        : DEFAULT_TIMEOUT_MS;
+}
+
+export function scopeFields(options: RallarBlackBoxCompositeConformanceRecipeOptions): Record<string, unknown> {
+    return {
+        applicationId: options.applicationId ?? 'rallar-server',
+        workspaceId: options.workspaceId ?? 'default',
+        roomRef: {
+            applicationId: options.applicationId ?? 'rallar-server',
+            workspaceId: options.workspaceId ?? 'default',
+            groupId: options.roomId ?? DEFAULT_ROOM_ID,
+        },
+    };
+}
+
+function wsBaseUrl(apiBaseUrl: string): string {
+    try {
+        const url = new URL(apiBaseUrl);
+        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+        return url.toString().replace(/\/+$/, '');
+    } catch {
+        return 'ws://localhost:8080';
+    }
+}
+
+export function recipeMetadata(caseId: RallarBlackBoxCompositeConformanceCaseId): Record<string, unknown> {
+    return {
+        conformance: {
+            schemaVersion: 1,
+            caseId,
+        },
+    };
+}
+
+export function commandMetadata(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+    commandId: string,
+): Record<string, unknown> {
+    return {
+        conformance: {
+            schemaVersion: 1,
+            caseId,
+            commandId,
+        },
+    };
+}

--- a/packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts
@@ -107,12 +107,15 @@ export function recipeId(
 }
 
 export function timeoutMs(options: RallarBlackBoxCompositeConformanceRecipeOptions): number {
-    return Number.isFinite(options.timeoutMs) && options.timeoutMs !== undefined && options.timeoutMs > 0
+    return Number.isFinite(options.timeoutMs) && options.timeoutMs !== undefined &&
+            options.timeoutMs > 0
         ? Math.round(options.timeoutMs)
         : DEFAULT_TIMEOUT_MS;
 }
 
-export function scopeFields(options: RallarBlackBoxCompositeConformanceRecipeOptions): Record<string, unknown> {
+export function scopeFields(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): Record<string, unknown> {
     return {
         applicationId: options.applicationId ?? 'rallar-server',
         workspaceId: options.workspaceId ?? 'default',
@@ -134,7 +137,9 @@ function wsBaseUrl(apiBaseUrl: string): string {
     }
 }
 
-export function recipeMetadata(caseId: RallarBlackBoxCompositeConformanceCaseId): Record<string, unknown> {
+export function recipeMetadata(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+): Record<string, unknown> {
     return {
         conformance: {
             schemaVersion: 1,

--- a/packages/shared-test/rallar-bb-test/conformance/composite-conformance-recipes.ts
+++ b/packages/shared-test/rallar-bb-test/conformance/composite-conformance-recipes.ts
@@ -1,0 +1,299 @@
+import type {
+    RallarBlackBoxTestRecipe,
+} from '../types.ts';
+
+import type {
+    RallarBlackBoxCompositeConformanceCaseId,
+    RallarBlackBoxCompositeConformanceRecipeOptions,
+} from '../composite-conformance.ts';
+import {
+    closeCommand,
+    commandMetadata,
+    configureCommand,
+    DEFAULT_CONNECTION,
+    DEFAULT_ROOM_ID,
+    DEFAULT_WS_CONNECTION,
+    recipeId,
+    recipeMetadata,
+    rtcConnectCommand,
+    scopeFields,
+    statsCommand,
+    timeoutMs,
+} from './composite-conformance-command-fixtures.ts';
+import {
+    waitAbsenceHoldRecipe,
+    waitAbsenceViolatedRecipe,
+} from '../wait/wait-absence-conformance-recipes.ts';
+
+export function createRallarBlackBoxCompositeConformanceRecipe(
+    caseId: RallarBlackBoxCompositeConformanceCaseId,
+    options: RallarBlackBoxCompositeConformanceRecipeOptions = {},
+): RallarBlackBoxTestRecipe {
+    switch (caseId) {
+        case 'looped-rtc-send':
+            return loopedRtcRecipe(options);
+        case 'parallel-ws-rtc-groups':
+            return parallelWsRtcRecipe(options);
+        case 'wait-assert-evidence':
+            return waitAssertRecipe(options);
+        case 'cancel-during-loop':
+            return cancelDuringLoopRecipe(options);
+        case 'wait-absence-hold':
+            return waitAbsenceHoldRecipe(options);
+        case 'wait-absence-violated':
+            return waitAbsenceViolatedRecipe(options);
+        case 'negative-no-peer':
+            return negativeNoPeerRecipe(options);
+    }
+}
+
+function loopedRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'realtime';
+    return {
+        recipeId: recipeId('looped-rtc-send', options),
+        name: 'Composite conformance: looped RTC send',
+        continueOnFailure: false,
+        metadata: recipeMetadata('looped-rtc-send'),
+        commands: [
+            configureCommand('looped-rtc-send', options),
+            rtcConnectCommand('looped-rtc-send', 'looped-rtc-send-connect', connection, roomId, transport, options),
+            {
+                kind: 'loop',
+                commandId: 'looped-rtc-send-loop',
+                count: 3,
+                intervalMs: 10,
+                thresholds: {
+                    minSendSuccessRatio: 1,
+                    maxStartDriftMs: 1_000,
+                },
+                metadata: commandMetadata('looped-rtc-send', 'looped-rtc-send-loop'),
+                commands: [
+                    {
+                        kind: 'rtc.send',
+                        commandId: 'looped-rtc-send-frame',
+                        connection,
+                        transport,
+                        timeoutMs: timeoutMs(options),
+                        send: {
+                            data: {
+                                topic: 'rallar.conformance.looped-rtc-send',
+                                frame: '{loop.index}',
+                                iteration: '{loop.iteration}',
+                                elapsedMs: '{loop.elapsedMs}',
+                            },
+                            roomId,
+                            ...scopeFields(options),
+                        },
+                        metadata: commandMetadata('looped-rtc-send', 'looped-rtc-send-frame'),
+                    },
+                ],
+            },
+            statsCommand('looped-rtc-send-stats', 'looped-rtc-send'),
+            closeCommand('looped-rtc-send-close', 'looped-rtc-send'),
+        ],
+    };
+}
+
+function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const wsConnection = options.wsConnection ?? DEFAULT_WS_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'messages.rtc';
+    return {
+        recipeId: recipeId('parallel-ws-rtc-groups', options),
+        name: 'Composite conformance: parallel WS and RTC groups',
+        continueOnFailure: false,
+        metadata: recipeMetadata('parallel-ws-rtc-groups'),
+        commands: [
+            configureCommand('parallel-ws-rtc-groups', options),
+            {
+                kind: 'ws.open',
+                commandId: 'parallel-ws-open',
+                connection: wsConnection,
+                url: '{config.wsBaseUrl}/api/ws',
+                timeoutMs: timeoutMs(options),
+                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-open'),
+            },
+            rtcConnectCommand('parallel-ws-rtc-groups', 'parallel-rtc-connect', connection, roomId, transport, options),
+            {
+                kind: 'parallel',
+                commandId: 'parallel-ws-rtc',
+                maxConcurrency: 2,
+                groups: [
+                    {
+                        groupId: 'ws',
+                        commands: [
+                            {
+                                kind: 'ws.send',
+                                commandId: 'parallel-ws-send',
+                                connection: wsConnection,
+                                data: {
+                                    topic: 'rallar.conformance.parallel.ws',
+                                    payload: {
+                                        source: 'ws',
+                                    },
+                                },
+                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-send'),
+                            },
+                        ],
+                    },
+                    {
+                        groupId: 'rtc',
+                        commands: [
+                            {
+                                kind: 'rtc.send',
+                                commandId: 'parallel-rtc-send',
+                                connection,
+                                transport,
+                                timeoutMs: timeoutMs(options),
+                                send: {
+                                    payload: {
+                                        topic: 'rallar.conformance.parallel.rtc',
+                                        source: 'rtc',
+                                    },
+                                    roomId,
+                                    ...scopeFields(options),
+                                },
+                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-rtc-send'),
+                            },
+                        ],
+                    },
+                ],
+                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-rtc'),
+            },
+            statsCommand('parallel-ws-rtc-stats', 'parallel-ws-rtc-groups'),
+            {
+                kind: 'ws.close',
+                commandId: 'parallel-ws-close',
+                connection: wsConnection,
+                code: 1000,
+                reason: 'conformance complete',
+                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-close'),
+            },
+            closeCommand('parallel-close', 'parallel-ws-rtc-groups'),
+        ],
+    };
+}
+
+function waitAssertRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'realtime';
+    return {
+        recipeId: recipeId('wait-assert-evidence', options),
+        name: 'Composite conformance: wait and assert evidence',
+        continueOnFailure: false,
+        metadata: recipeMetadata('wait-assert-evidence'),
+        commands: [
+            configureCommand('wait-assert-evidence', options),
+            rtcConnectCommand('wait-assert-evidence', 'wait-assert-connect', connection, roomId, transport, options),
+            {
+                kind: 'rtc.send',
+                commandId: 'wait-assert-send',
+                connection,
+                transport,
+                timeoutMs: timeoutMs(options),
+                send: {
+                    data: {
+                        topic: 'rallar.conformance.wait-assert',
+                        marker: 'wait-assert-evidence',
+                    },
+                    roomId,
+                    ...scopeFields(options),
+                },
+                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-send'),
+            },
+            {
+                kind: 'wait',
+                commandId: 'wait-assert-wait-message',
+                timeoutMs: timeoutMs(options),
+                match: {
+                    kind: 'message',
+                    topic: 'rallar.conformance.message',
+                    payloadPath: 'data.topic',
+                    equals: 'rallar.conformance.wait-assert',
+                },
+                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-wait-message'),
+            },
+            {
+                kind: 'assert',
+                commandId: 'wait-assert-check-message',
+                source: 'messages.0.payload.data.marker',
+                operator: 'equals',
+                expected: 'wait-assert-evidence',
+                metadata: commandMetadata('wait-assert-evidence', 'wait-assert-check-message'),
+            },
+            statsCommand('wait-assert-stats', 'wait-assert-evidence'),
+            closeCommand('wait-assert-close', 'wait-assert-evidence'),
+        ],
+    };
+}
+
+function cancelDuringLoopRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    return {
+        recipeId: recipeId('cancel-during-loop', options),
+        name: 'Composite conformance: cancellation during loop',
+        continueOnFailure: false,
+        metadata: recipeMetadata('cancel-during-loop'),
+        commands: [
+            configureCommand('cancel-during-loop', options),
+            {
+                kind: 'loop',
+                commandId: 'cancel-during-loop-loop',
+                count: 3,
+                intervalMs: 10,
+                metadata: commandMetadata('cancel-during-loop', 'cancel-during-loop-loop'),
+                commands: [
+                    {
+                        kind: 'health',
+                        commandId: 'cancel-loop-health',
+                        metadata: commandMetadata('cancel-during-loop', 'cancel-loop-health'),
+                    },
+                    {
+                        kind: 'recipe.cancel',
+                        commandId: 'cancel-loop-request',
+                        reason: 'composite conformance cancellation case',
+                        metadata: commandMetadata('cancel-during-loop', 'cancel-loop-request'),
+                    },
+                ],
+            },
+            statsCommand('cancel-during-loop-stats', 'cancel-during-loop'),
+        ],
+    };
+}
+
+function negativeNoPeerRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'realtime';
+    return {
+        recipeId: recipeId('negative-no-peer', options),
+        name: 'Composite conformance: no-peer negative case',
+        continueOnFailure: false,
+        metadata: recipeMetadata('negative-no-peer'),
+        commands: [
+            configureCommand('negative-no-peer', options),
+            rtcConnectCommand('negative-no-peer', 'negative-no-peer-connect', connection, roomId, transport, options),
+            {
+                kind: 'rtc.send',
+                commandId: 'negative-no-peer-send',
+                connection,
+                transport,
+                timeoutMs: timeoutMs(options),
+                send: {
+                    data: {
+                        topic: 'rallar.conformance.negative-no-peer',
+                        marker: 'negative-no-peer',
+                    },
+                    roomId,
+                    peerIds: ['missing-peer'],
+                    ...scopeFields(options),
+                },
+                metadata: commandMetadata('negative-no-peer', 'negative-no-peer-send'),
+            },
+            statsCommand('negative-no-peer-stats', 'negative-no-peer'),
+        ],
+    };
+}

--- a/packages/shared-test/rallar-bb-test/conformance/create-rallar-black-box-composite-conformance-recipe.ts
+++ b/packages/shared-test/rallar-bb-test/conformance/create-rallar-black-box-composite-conformance-recipe.ts
@@ -47,7 +47,9 @@ export function createRallarBlackBoxCompositeConformanceRecipe(
     }
 }
 
-function loopedRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+function loopedRtcRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
     const transport = options.transport ?? 'realtime';
@@ -58,7 +60,14 @@ function loopedRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOption
         metadata: recipeMetadata('looped-rtc-send'),
         commands: [
             configureCommand('looped-rtc-send', options),
-            rtcConnectCommand('looped-rtc-send', 'looped-rtc-send-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'looped-rtc-send',
+                'looped-rtc-send-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'loop',
                 commandId: 'looped-rtc-send-loop',
@@ -96,7 +105,9 @@ function loopedRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOption
     };
 }
 
-function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+function parallelWsRtcRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const wsConnection = options.wsConnection ?? DEFAULT_WS_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
@@ -116,7 +127,14 @@ function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOp
                 timeoutMs: timeoutMs(options),
                 metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-open'),
             },
-            rtcConnectCommand('parallel-ws-rtc-groups', 'parallel-rtc-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'parallel-ws-rtc-groups',
+                'parallel-rtc-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'parallel',
                 commandId: 'parallel-ws-rtc',
@@ -135,7 +153,10 @@ function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOp
                                         source: 'ws',
                                     },
                                 },
-                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-ws-send'),
+                                metadata: commandMetadata(
+                                    'parallel-ws-rtc-groups',
+                                    'parallel-ws-send',
+                                ),
                             },
                         ],
                     },
@@ -156,7 +177,10 @@ function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOp
                                     roomId,
                                     ...scopeFields(options),
                                 },
-                                metadata: commandMetadata('parallel-ws-rtc-groups', 'parallel-rtc-send'),
+                                metadata: commandMetadata(
+                                    'parallel-ws-rtc-groups',
+                                    'parallel-rtc-send',
+                                ),
                             },
                         ],
                     },
@@ -177,7 +201,9 @@ function parallelWsRtcRecipe(options: RallarBlackBoxCompositeConformanceRecipeOp
     };
 }
 
-function waitAssertRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+function waitAssertRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
     const transport = options.transport ?? 'realtime';
@@ -188,7 +214,14 @@ function waitAssertRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptio
         metadata: recipeMetadata('wait-assert-evidence'),
         commands: [
             configureCommand('wait-assert-evidence', options),
-            rtcConnectCommand('wait-assert-evidence', 'wait-assert-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'wait-assert-evidence',
+                'wait-assert-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'rtc.send',
                 commandId: 'wait-assert-send',
@@ -231,7 +264,9 @@ function waitAssertRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptio
     };
 }
 
-function cancelDuringLoopRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+function cancelDuringLoopRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     return {
         recipeId: recipeId('cancel-during-loop', options),
         name: 'Composite conformance: cancellation during loop',
@@ -264,7 +299,9 @@ function cancelDuringLoopRecipe(options: RallarBlackBoxCompositeConformanceRecip
     };
 }
 
-function negativeNoPeerRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+function negativeNoPeerRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
     const transport = options.transport ?? 'realtime';
@@ -275,7 +312,14 @@ function negativeNoPeerRecipe(options: RallarBlackBoxCompositeConformanceRecipeO
         metadata: recipeMetadata('negative-no-peer'),
         commands: [
             configureCommand('negative-no-peer', options),
-            rtcConnectCommand('negative-no-peer', 'negative-no-peer-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'negative-no-peer',
+                'negative-no-peer-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'rtc.send',
                 commandId: 'negative-no-peer-send',

--- a/packages/shared-test/rallar-bb-test/control-protocol.ts
+++ b/packages/shared-test/rallar-bb-test/control-protocol.ts
@@ -503,6 +503,9 @@ function validateWaitCommand(command: Record<string, unknown>): ControlCommandVa
     if (!isRecord(command.match)) {
         return fail('wait.match is required.');
     }
+    if (command.absent !== undefined && command.absent !== true) {
+        return fail('wait.absent must be true when present.');
+    }
 
     let result = validateKeys(command.match, [
         'kind',
@@ -1147,7 +1150,7 @@ export function validateRallarBlackBoxTestCommand(
             );
             return !result.ok ? result : validateParallelCommand(command, depth);
         case 'wait':
-            result = validateKeys(command, [...base, 'match'], 'wait');
+            result = validateKeys(command, [...base, 'match', 'absent'], 'wait');
             return !result.ok ? result : validateWaitCommand(command);
         case 'assert':
             result = validateKeys(command, [...base, 'source', 'operator', 'expected'], 'assert');

--- a/packages/shared-test/rallar-bb-test/control-protocol.ts
+++ b/packages/shared-test/rallar-bb-test/control-protocol.ts
@@ -1179,7 +1179,6 @@ export function validateRallarBlackBoxTestCommand(
                     ...base,
                     'connection',
                     'send',
-                    'expect',
                     'applicationId',
                     'workspaceId',
                     'scope',

--- a/packages/shared-test/rallar-bb-test/docs/ai-recipe-prompt-guide.md
+++ b/packages/shared-test/rallar-bb-test/docs/ai-recipe-prompt-guide.md
@@ -173,6 +173,37 @@ Constraints:
   and distributed metadata.
 ```
 
+## Prompt: Distributed Absence Wait
+
+Use this when the test must prove a message was never delivered — the
+distributed twin of the runner's `expect.absent`.
+
+```text
+Generate one Rallar black-box browser-agent recipe as JSON.
+
+Use:
+- RALLAR_BLACK_BOX_TEST_RECIPE_SCHEMA
+
+Goal:
+- Prove cross-scope isolation: traffic sent to one topic must never appear on
+  another topic this agent observes.
+
+Constraints:
+- Output JSON only with schemaVersion 1.
+- First deliver a same-scope positive control: rtc.send on the observed topic
+  followed by a normal wait that matches it, so transport health is proven
+  before any absence claim.
+- Then add a wait command with absent: true whose match targets the
+  other-scope topic that must stay silent. Give it an explicit timeoutMs —
+  the agent holds that full window before scanning, and the absence claim is
+  only as strong as this window.
+- Do not set absent to anything other than true; the schema rejects it.
+- A matching event buffered before the absence wait started also violates it,
+  exactly like positive waits match past events.
+- On violation the run fails with RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED and
+  the offending redacted event; do not add a separate assert for it.
+```
+
 ## Prompt: Looped RTC Realtime
 
 Use this when you want a compact distributed recipe that sends game-style

--- a/packages/shared-test/rallar-bb-test/docs/composite-conformance-matrix.md
+++ b/packages/shared-test/rallar-bb-test/docs/composite-conformance-matrix.md
@@ -22,7 +22,7 @@ transport permutation:
   orchestration.
 
 Case recipes are built in
-`conformance/composite-conformance-recipes.ts` (absence cases in
+`conformance/create-rallar-black-box-composite-conformance-recipe.ts` (absence cases in
 `wait/wait-absence-conformance-recipes.ts`) from the shared command fixtures
 in `conformance/composite-conformance-command-fixtures.ts`.
 

--- a/packages/shared-test/rallar-bb-test/docs/composite-conformance-matrix.md
+++ b/packages/shared-test/rallar-bb-test/docs/composite-conformance-matrix.md
@@ -11,8 +11,20 @@ transport permutation:
 - `parallel-ws-rtc-groups`: bounded parallel WS and RTC send branches.
 - `wait-assert-evidence`: send evidence consumed by `wait` and `assert`.
 - `cancel-during-loop`: cancellation propagation from inside a loop.
+- `wait-absence-hold`: a same-topic positive control delivery followed by an
+  `absent: true` wait on a different topic that holds the full window and
+  passes.
+- `wait-absence-violated`: the deliberately-broken control — the absence wait
+  targets the topic that was just delivered and must fail with
+  `RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED` carrying the offending redacted
+  event.
 - `negative-no-peer`: no-peer send failure separated from local composite
   orchestration.
+
+Case recipes are built in
+`conformance/composite-conformance-recipes.ts` (absence cases in
+`wait/wait-absence-conformance-recipes.ts`) from the shared command fixtures
+in `conformance/composite-conformance-command-fixtures.ts`.
 
 Provider rows are:
 

--- a/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
@@ -87,6 +87,24 @@ identity is not recipe-resolvable because simulated providers and external
 runtime configuration can remain valid. `refreshRoom` is an internal runtime
 bridge operation, not a recipe command or public command-schema field.
 
+## RTC Send Boundary And HTTP Result Evidence
+
+`rtc.send` has no `expect` field on the control path: the command schema and
+`validateRallarBlackBoxTestCommand` reject it, because no agent runtime ever
+evaluates it and a control-dispatched recipe carrying it would validate green
+while asserting nothing. The `RallarBlackBoxTestRtcSendCommand.expect`
+TypeScript field exists only for the in-process black-box-runner adapter,
+which calls `runtime.execute` directly and records runner-side expectations.
+Distributed delivery expectations belong in `wait` and `assert` commands.
+
+`http.request` results record `url`, `status`, `statusText`, `ok`, the full
+response header record, and the decoded body. Every recorded result value,
+failure detail, and the mirrored `rallar.bb.http.response` event passes the
+runtime redaction pipeline, so sensitive header and body names (authorization,
+cookie, token, ticket, and the other default key substrings) appear as
+`<redacted>` in results, events, failures, and artifacts. Header evidence is
+therefore assertable from recorded results without extra capture options.
+
 ## Validation
 
 Use `validateJsonSchema(schema, value)` for lightweight browser-safe validation.

--- a/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
@@ -105,6 +105,22 @@ cookie, token, ticket, and the other default key substrings) appear as
 `<redacted>` in results, events, failures, and artifacts. Header evidence is
 therefore assertable from recorded results without extra capture options.
 
+## Wait Absence
+
+`wait` with `absent: true` asserts non-delivery: the agent holds the full wait
+window (`timeoutMs`/`deadlineEpochMs`, default 5000 ms — an absence claim is
+only as strong as the time spent listening), then scans the whole event
+buffer once. Any matching event — buffered before the wait started or arriving
+during the window — fails the command with
+`RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED` and the offending redacted event in
+the result value and error details; an empty scan succeeds with
+`matched: false, absent: true`. Past events match by design, exactly like
+positive waits. `absent` accepts only `true`; schema and control validation
+reject other values. Semantics mirror the black-box-runner's `expect.absent`
+waits. Pair every absence wait with a same-scope positive control delivery so
+a broken transport cannot masquerade as proven absence. Evaluation lives in
+`wait/wait-for-event.ts`; match semantics live in `wait/wait-event-match.ts`.
+
 ## Validation
 
 Use `validateJsonSchema(schema, value)` for lightweight browser-safe validation.

--- a/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
@@ -196,3 +196,50 @@ npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
 npx vitest run packages/tests/shared-test/rallar-bb-test-control-protocol.test.ts
 npx vitest run packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
 ```
+
+```text
+Title: wait gains an optional absent: true absence mode
+Date: 2026-08-11
+Owner: rallar-bb-test distributed assertion parity plan, workstream D1
+
+Change type:
+- Compatible optional addition (with a fail-closed rollout edge)
+
+Affected schemas:
+- RALLAR_BLACK_BOX_TEST_RECIPE_SCHEMA
+- RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA (wait branch)
+- validateRallarBlackBoxTestCommand wait allowlist
+
+Old shape:
+wait matched only positively: it succeeded when an event matched and timed
+out otherwise. Non-delivery could not be asserted.
+
+New shape:
+wait accepts optional absent: true. The agent holds the full wait window,
+then scans the whole event buffer once; any match (buffered or new) fails
+with RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED carrying the offending redacted
+event, an empty scan succeeds with matched: false, absent: true. Only the
+literal true is accepted. Semantics mirror the runner's expect.absent.
+
+Migration:
+No change for existing recipes. Recipes using absent: true dispatched to
+agents built before this change fail closed at validateKeys with
+"wait has unsupported field: absent." — intended behavior. World-fleet
+manifests must not adopt absence waits until the D4 capability gate exists.
+
+Golden corpus updates:
+golden-composite-wait-assert-v1 gained an absent wait command
+(golden-wait-absent-v1).
+
+Prompt/documentation updates:
+New "Prompt: Distributed Absence Wait" section; wait capability metadata
+lists absent; schema-and-capabilities.md documents the hold-then-scan
+semantics; composite-conformance matrix gained wait-absence-hold and
+wait-absence-violated cases.
+
+Verification:
+npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-control-protocol.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-wait-absence.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-composite-conformance.test.ts
+```

--- a/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
@@ -153,3 +153,46 @@ Prompt/documentation updates:
 
 Verification:
 ```
+
+## Upgrade Notes
+
+```text
+Title: rtc.send.expect fails closed on the control-protocol path
+Date: 2026-08-11
+Owner: rallar-bb-test distributed assertion parity plan, workstream D0
+
+Change type:
+- Breaking schema change (removal of a silently ignored optional field)
+
+Affected schemas:
+- RALLAR_BLACK_BOX_TEST_RECIPE_SCHEMA
+- RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA (rtc.send branch)
+- validateRallarBlackBoxTestCommand rtc.send allowlist
+
+Old shape:
+rtc.send accepted an optional `expect` field. No agent runtime ever read it,
+so a control-dispatched recipe carrying it validated green while asserting
+nothing.
+
+New shape:
+rtc.send rejects `expect` at schema validation and control-protocol
+validateKeys ("rtc.send has unsupported field: expect."). The TypeScript
+field remains for the in-process black-box-runner adapter, which bypasses
+network validation and records runner-side expectations.
+
+Migration:
+Remove `expect` from distributed rtc.send commands; move authoring hints
+into `metadata`. Delivery expectations belong in `wait`/`assert` commands.
+
+Golden corpus updates:
+Added invalid recipe case `rtc-send-expect-rejected`.
+
+Prompt/documentation updates:
+rtc.send capability metadata no longer lists `expect`; capability
+description no longer mentions recorded expectations.
+
+Verification:
+npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-control-protocol.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
+```

--- a/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
+++ b/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
@@ -599,6 +599,31 @@
           }
         ]
       }
+    },
+    {
+      "caseId": "rtc-send-expect-rejected",
+      "expectedErrors": ["$.commands[0].expect: Unexpected property."],
+      "value": {
+        "schemaVersion": 1,
+        "recipeId": "rtc-send-expect-rejected",
+        "commands": [
+          {
+            "kind": "rtc.send",
+            "commandId": "rtc-send-with-expect",
+            "connection": "rtc",
+            "transport": "realtime",
+            "send": {
+              "roomId": "bb-group",
+              "data": {
+                "topic": "room.negative.expect"
+              }
+            },
+            "expect": {
+              "outcome": "ack"
+            }
+          }
+        ]
+      }
     }
   ],
   "invalidDistributedManifests": [

--- a/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
+++ b/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
@@ -135,7 +135,9 @@
           "commandId": "ws-open-v1",
           "connection": "goldenWs",
           "url": "{config.wsBaseUrl}/api/ws",
-          "protocols": ["rallar-json"]
+          "protocols": [
+            "rallar-json"
+          ]
         },
         {
           "kind": "ws.send",
@@ -206,7 +208,9 @@
             "operations": [
               {
                 "kind": "register.set",
-                "path": ["title"],
+                "path": [
+                  "title"
+                ],
                 "value": "Golden",
                 "policy": "lww"
               }
@@ -265,7 +269,9 @@
           "operations": [
             {
               "kind": "register.set",
-              "path": ["title"],
+              "path": [
+                "title"
+              ],
               "value": "Untitled",
               "policy": "lww"
             }
@@ -280,7 +286,9 @@
           "operations": [
             {
               "kind": "register.set",
-              "path": ["title"],
+              "path": [
+                "title"
+              ],
               "value": "Golden",
               "policy": "lww"
             }
@@ -428,6 +436,18 @@
           }
         },
         {
+          "kind": "wait",
+          "commandId": "golden-wait-absent-v1",
+          "absent": true,
+          "timeoutMs": 1500,
+          "match": {
+            "kind": "message",
+            "topic": "room.golden.other-room",
+            "payloadPath": "data.messageId",
+            "contains": "golden"
+          }
+        },
+        {
           "kind": "assert",
           "commandId": "golden-assert-v1",
           "source": "events.length",
@@ -520,7 +540,9 @@
       "targetPolicy": {
         "mode": "role-map",
         "roles": {
-          "sender": ["agent-alice"]
+          "sender": [
+            "agent-alice"
+          ]
         },
         "expectedParticipantCount": 1
       },
@@ -540,7 +562,9 @@
   "invalidRecipes": [
     {
       "caseId": "unsupported-recipe-schema-version",
-      "expectedErrors": ["$.schemaVersion: Expected 1."],
+      "expectedErrors": [
+        "$.schemaVersion: Expected 1."
+      ],
       "value": {
         "schemaVersion": 2,
         "recipeId": "invalid-v2-recipe",
@@ -553,7 +577,9 @@
     },
     {
       "caseId": "missing-recipe-id",
-      "expectedErrors": ["Missing required property recipeId"],
+      "expectedErrors": [
+        "Missing required property recipeId"
+      ],
       "value": {
         "schemaVersion": 1,
         "commands": [
@@ -565,7 +591,9 @@
     },
     {
       "caseId": "nested-child-missing-required-field",
-      "expectedErrors": ["Missing required property request"],
+      "expectedErrors": [
+        "Missing required property request"
+      ],
       "value": {
         "schemaVersion": 1,
         "recipeId": "invalid-nested-child",
@@ -585,7 +613,9 @@
     },
     {
       "caseId": "invalid-wait-event-kind",
-      "expectedErrors": ["Expected one of"],
+      "expectedErrors": [
+        "Expected one of"
+      ],
       "value": {
         "schemaVersion": 1,
         "recipeId": "invalid-wait",
@@ -602,7 +632,9 @@
     },
     {
       "caseId": "rtc-send-expect-rejected",
-      "expectedErrors": ["$.commands[0].expect: Unexpected property."],
+      "expectedErrors": [
+        "$.commands[0].expect: Unexpected property."
+      ],
       "value": {
         "schemaVersion": 1,
         "recipeId": "rtc-send-expect-rejected",
@@ -629,7 +661,9 @@
   "invalidDistributedManifests": [
     {
       "caseId": "unsupported-manifest-schema-version",
-      "expectedErrors": ["$.schemaVersion: Expected 1."],
+      "expectedErrors": [
+        "$.schemaVersion: Expected 1."
+      ],
       "value": {
         "schemaVersion": 2,
         "distributedRunId": "invalid-manifest-v2",
@@ -650,7 +684,9 @@
     },
     {
       "caseId": "invalid-inline-recipe",
-      "expectedErrors": ["Missing required property request"],
+      "expectedErrors": [
+        "Missing required property request"
+      ],
       "value": {
         "schemaVersion": 1,
         "distributedRunId": "invalid-inline-recipe",
@@ -675,7 +711,9 @@
         ],
         "targetPolicy": {
           "mode": "selected-agents",
-          "agentIds": ["agent-a"],
+          "agentIds": [
+            "agent-a"
+          ],
           "expectedParticipantCount": 1
         }
       }

--- a/packages/shared-test/rallar-bb-test/mod.ts
+++ b/packages/shared-test/rallar-bb-test/mod.ts
@@ -36,5 +36,5 @@ export * from './black-box-runner-adapter.ts';
 export * from './provider-parity.ts';
 export * from './companion-coverage.ts';
 export * from './composite-conformance.ts';
-export * from './conformance/composite-conformance-recipes.ts';
+export * from './conformance/create-rallar-black-box-composite-conformance-recipe.ts';
 export * from './wait/wait-for-event.ts';

--- a/packages/shared-test/rallar-bb-test/mod.ts
+++ b/packages/shared-test/rallar-bb-test/mod.ts
@@ -36,3 +36,5 @@ export * from './black-box-runner-adapter.ts';
 export * from './provider-parity.ts';
 export * from './companion-coverage.ts';
 export * from './composite-conformance.ts';
+export * from './conformance/composite-conformance-recipes.ts';
+export * from './wait/wait-for-event.ts';

--- a/packages/shared-test/rallar-bb-test/runtime.ts
+++ b/packages/shared-test/rallar-bb-test/runtime.ts
@@ -7,6 +7,13 @@ import {
     rallarBlackBoxParallelChildSourceRecipePath,
 } from './composite-results.ts';
 import {
+    containsValue,
+    lookupPayloadPath,
+    type PayloadPathLookup,
+    sameJsonValue,
+} from './wait/wait-event-match.ts';
+import { waitForEvent } from './wait/wait-for-event.ts';
+import {
     RALLAR_BLACK_BOX_TEST_COMPOSITE_LIMITS,
     type RallarBlackBoxTestAssertCommand,
     type RallarBlackBoxTestAssertOperator,
@@ -43,8 +50,6 @@ import {
     type RallarBlackBoxTestStatsSnapshot,
     type RallarBlackBoxTestTransport,
     type RallarBlackBoxTestWaitCommand,
-    type RallarBlackBoxTestWaitMatch,
-    type RallarBlackBoxTestWaitResultValue,
 } from './types.ts';
 
 export type CreateRallarBlackBoxTestRuntimeOptions = Readonly<{
@@ -98,7 +103,6 @@ type LoopResultMetrics = Readonly<{
 
 const LOOP_PLACEHOLDER_PATTERN = /\{loop\.(index|iteration|elapsedMs|commandIndex)\}/g;
 const LOOP_EXACT_PLACEHOLDER_PATTERN = /^\{loop\.(index|iteration|elapsedMs|commandIndex)\}$/;
-const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
 const RECENT_ASSERT_SOURCE_LIMIT = 20;
 const ASSERT_OPERATORS = ['equals', 'notEquals', 'contains', 'exists', 'gte', 'lte'] as const;
 const ABORT_ERROR_CODE = 'RALLAR_BLACK_BOX_ABORTED';
@@ -116,11 +120,6 @@ const RALLAR_CONFIG_INHERITED_KEYS = [
     'leaveRoomOnClose',
     'timeoutMs',
 ] as const;
-
-type PayloadPathLookup = Readonly<{
-    exists: boolean;
-    value?: unknown;
-}>;
 
 function initialState(): RallarBlackBoxTestState {
     return {
@@ -358,85 +357,6 @@ function replaceLoopPlaceholders(value: unknown, context: LoopContext): unknown 
     }
 
     return value;
-}
-
-function normalisePayloadPath(path: string): string {
-    if (path.startsWith('$.payload.')) {
-        return path.slice('$.payload.'.length);
-    }
-    if (path.startsWith('payload.')) {
-        return path.slice('payload.'.length);
-    }
-    if (path.startsWith('$.')) {
-        return path.slice('$.'.length);
-    }
-    return path;
-}
-
-function lookupPayloadPath(payload: unknown, path: string | undefined): PayloadPathLookup {
-    if (!path || path.trim().length === 0) {
-        return {
-            exists: payload !== undefined,
-            value: payload,
-        };
-    }
-
-    let current = payload;
-    const segments = normalisePayloadPath(path)
-        .split('.')
-        .filter(segment => segment.length > 0);
-    for (const segment of segments) {
-        if ((Array.isArray(current) || typeof current === 'string') && segment === 'length') {
-            current = current.length;
-            continue;
-        }
-
-        if (Array.isArray(current)) {
-            const index = Number(segment);
-            if (!Number.isInteger(index) || index < 0 || index >= current.length) {
-                return { exists: false };
-            }
-            current = current[index];
-            continue;
-        }
-
-        if (!current || typeof current !== 'object') {
-            return { exists: false };
-        }
-
-        const record = current as Record<string, unknown>;
-        if (!Object.prototype.hasOwnProperty.call(record, segment)) {
-            return { exists: false };
-        }
-        current = record[segment];
-    }
-
-    return {
-        exists: true,
-        value: current,
-    };
-}
-
-function sameJsonValue(left: unknown, right: unknown): boolean {
-    try {
-        return JSON.stringify(left) === JSON.stringify(right);
-    } catch (_error) {
-        return Object.is(left, right);
-    }
-}
-
-function containsValue(value: unknown, expected: string): boolean {
-    if (typeof value === 'string') {
-        return value.includes(expected);
-    }
-    try {
-        const serialized = JSON.stringify(value);
-        return typeof serialized === 'string'
-            ? serialized.includes(expected)
-            : String(value).includes(expected);
-    } catch (_error) {
-        return String(value).includes(expected);
-    }
 }
 
 function containsAssertValue(value: unknown, expected: unknown): boolean {
@@ -1992,251 +1912,16 @@ class InMemoryRallarBlackBoxTestRuntime implements RallarBlackBoxTestRuntime {
     }
 
     private async waitForEvent(command: WaitCommandWithId): Promise<CommandOutcome> {
-        if (!command.match || Object.keys(command.match).length === 0) {
-            return this.waitInvalid(command, 'Wait requires at least one match field.');
-        }
-
-        if (this.cancelRequested) {
-            return this.waitCancelled(command);
-        }
-
-        const immediate = this.findWaitEvent(command.match);
-        if (immediate) {
-            return this.waitMatched(command, immediate);
-        }
-
-        const deadlineEpochMs = this.waitDeadlineEpochMs(command);
-        if (this.now() >= deadlineEpochMs) {
-            return this.waitTimedOut(command, deadlineEpochMs);
-        }
-
-        return await new Promise<CommandOutcome>((resolve) => {
-            let settled = false;
-            let timeout: ReturnType<typeof setTimeout> | undefined;
-            let unsubscribe: (() => void) | undefined;
-            let cleanupAfterSubscribe = false;
-            const signal = this.cancellationController.signal;
-
-            const cleanup = () => {
-                if (timeout) {
-                    clearTimeout(timeout);
-                    timeout = undefined;
-                }
-                signal.removeEventListener('abort', onAbort);
-                if (unsubscribe) {
-                    unsubscribe();
-                    unsubscribe = undefined;
-                } else {
-                    cleanupAfterSubscribe = true;
-                }
-            };
-
-            const settle = (outcome: CommandOutcome) => {
-                if (settled) {
-                    return;
-                }
-                settled = true;
-                cleanup();
-                resolve(outcome);
-            };
-
-            const evaluate = () => {
-                if (this.cancelRequested) {
-                    settle(this.waitCancelled(command));
-                    return;
-                }
-
-                const matched = this.findWaitEvent(command.match);
-                if (matched) {
-                    settle(this.waitMatched(command, matched));
-                    return;
-                }
-
-                if (this.now() >= deadlineEpochMs) {
-                    settle(this.waitTimedOut(command, deadlineEpochMs));
-                }
-            };
-
-            const timeoutDelayMs = Math.max(0, deadlineEpochMs - this.now());
-            const onAbort = () => {
-                settle(this.waitCancelled(command));
-            };
-            if (signal.aborted) {
-                settle(this.waitCancelled(command));
-                return;
-            }
-            timeout = setTimeout(() => {
-                settle(this.waitTimedOut(command, deadlineEpochMs));
-            }, timeoutDelayMs);
-            signal.addEventListener('abort', onAbort, {
-                once: true,
-            });
-            unsubscribe = this.subscribe(evaluate);
-            if (cleanupAfterSubscribe && unsubscribe) {
-                unsubscribe();
-                unsubscribe = undefined;
-            }
+        return await waitForEvent({
+            command,
+            now: this.now,
+            sleep: this.sleep,
+            cancellationSignal: this.cancellationController.signal,
+            cancelRequested: () => this.cancelRequested,
+            currentStatus: () => this.currentState.status,
+            currentEvents: () => this.currentState.events,
+            subscribe: listener => this.subscribe(() => listener()),
         });
-    }
-
-    private findWaitEvent(match: RallarBlackBoxTestWaitMatch): RallarBlackBoxTestEvent | undefined {
-        const events = this.currentState.events;
-        for (let index = events.length - 1; index >= 0; index--) {
-            const event = events[index];
-            if (this.waitEventMatches(event, match)) {
-                return event;
-            }
-        }
-        return undefined;
-    }
-
-    private waitEventMatches(
-        event: RallarBlackBoxTestEvent,
-        match: RallarBlackBoxTestWaitMatch,
-    ): boolean {
-        if (match.kind !== undefined && event.kind !== match.kind) {
-            return false;
-        }
-        if (match.topic !== undefined && event.topic !== match.topic) {
-            return false;
-        }
-        if (match.commandId !== undefined && event.commandId !== match.commandId) {
-            return false;
-        }
-        if (match.connection !== undefined && event.connection !== match.connection) {
-            return false;
-        }
-        if (match.transport !== undefined && event.transport !== match.transport) {
-            return false;
-        }
-        if (match.severity !== undefined && event.severity !== match.severity) {
-            return false;
-        }
-
-        if (
-            match.payloadPath !== undefined ||
-            match.equals !== undefined ||
-            match.contains !== undefined ||
-            match.exists !== undefined
-        ) {
-            const lookup = lookupPayloadPath(event.payload, match.payloadPath);
-            if (match.exists !== undefined && lookup.exists !== match.exists) {
-                return false;
-            }
-            if (match.exists !== false && !lookup.exists) {
-                return false;
-            }
-            if (match.equals !== undefined && !sameJsonValue(lookup.value, match.equals)) {
-                return false;
-            }
-            if (match.contains !== undefined && !containsValue(lookup.value, match.contains)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private waitDeadlineEpochMs(command: WaitCommandWithId): number {
-        const timeoutMs = command.timeoutMs === undefined
-            ? command.deadlineEpochMs === undefined
-                ? DEFAULT_WAIT_TIMEOUT_MS
-                : undefined
-            : Math.max(0, command.timeoutMs);
-        const timeoutDeadline = timeoutMs === undefined
-            ? undefined
-            : this.now() + timeoutMs;
-
-        if (command.deadlineEpochMs === undefined) {
-            return timeoutDeadline ?? (this.now() + DEFAULT_WAIT_TIMEOUT_MS);
-        }
-
-        return timeoutDeadline === undefined
-            ? command.deadlineEpochMs
-            : Math.min(timeoutDeadline, command.deadlineEpochMs);
-    }
-
-    private toWaitResultValue(
-        command: WaitCommandWithId,
-        partial: Readonly<{
-            matched: boolean;
-            timedOut?: boolean;
-            cancelled?: boolean;
-            event?: RallarBlackBoxTestEvent;
-        }>,
-    ): RallarBlackBoxTestWaitResultValue {
-        return {
-            commandId: command.commandId,
-            match: command.match,
-            ...partial,
-        };
-    }
-
-    private waitMatched(
-        command: WaitCommandWithId,
-        event: RallarBlackBoxTestEvent,
-    ): CommandOutcome {
-        return {
-            status: 'ok',
-            value: this.toWaitResultValue(command, {
-                matched: true,
-                event,
-            }),
-            nextStatus: this.currentState.status,
-        };
-    }
-
-    private waitTimedOut(
-        command: WaitCommandWithId,
-        deadlineEpochMs: number,
-    ): CommandOutcome {
-        return {
-            status: 'failed',
-            value: this.toWaitResultValue(command, {
-                matched: false,
-                timedOut: true,
-            }),
-            error: {
-                code: 'RALLAR_BLACK_BOX_WAIT_TIMEOUT',
-                message: 'Wait command timed out before matching a runtime event.',
-                details: {
-                    timeoutMs: command.timeoutMs,
-                    deadlineEpochMs,
-                    match: command.match,
-                },
-            },
-            nextStatus: 'failed',
-        };
-    }
-
-    private waitCancelled(command: WaitCommandWithId): CommandOutcome {
-        return {
-            status: 'cancelled',
-            value: this.toWaitResultValue(command, {
-                matched: false,
-                cancelled: true,
-            }),
-            nextStatus: 'cancelled',
-        };
-    }
-
-    private waitInvalid(
-        command: WaitCommandWithId,
-        message: string,
-        details?: unknown,
-    ): CommandOutcome {
-        return {
-            status: 'failed',
-            value: this.toWaitResultValue(command, {
-                matched: false,
-            }),
-            error: {
-                code: 'RALLAR_BLACK_BOX_WAIT_INVALID',
-                message,
-                details,
-            },
-            nextStatus: 'failed',
-        };
     }
 
     private assertRuntimeEvidence(command: AssertCommandWithId): CommandOutcome {

--- a/packages/shared-test/rallar-bb-test/schema.ts
+++ b/packages/shared-test/rallar-bb-test/schema.ts
@@ -584,7 +584,6 @@ const COMMAND_SCHEMAS: Readonly<Record<RallarBlackBoxCommandCapability['kind'], 
     'rtc.send': strictCommandSchema('rtc.send', [], {
         connection: stringSchema,
         send: anySchema,
-        expect: anySchema,
         applicationId: stringSchema,
         workspaceId: stringSchema,
         scope: recordSchema,
@@ -1021,12 +1020,11 @@ export const RALLAR_BLACK_BOX_COMMAND_CAPABILITIES: readonly RallarBlackBoxComma
     {
         kind: 'rtc.send',
         title: 'RTC Send',
-        description: 'Sends JSON through a connected RTC/realtime provider and optionally records expectations.',
+        description: 'Sends JSON through a connected RTC/realtime provider.',
         requiredFields: [],
         optionalFields: [
             'connection',
             'send',
-            'expect',
             'applicationId',
             'workspaceId',
             'scope',

--- a/packages/shared-test/rallar-bb-test/schema.ts
+++ b/packages/shared-test/rallar-bb-test/schema.ts
@@ -562,6 +562,7 @@ const COMMAND_SCHEMAS: Readonly<Record<RallarBlackBoxCommandCapability['kind'], 
     }),
     wait: strictCommandSchema('wait', ['match'], {
         match: waitMatchSchema,
+        absent: { const: true },
     }),
     assert: strictCommandSchema('assert', ['source', 'operator'], {
         source: stringSchema,
@@ -936,9 +937,16 @@ export const RALLAR_BLACK_BOX_COMMAND_CAPABILITIES: readonly RallarBlackBoxComma
     {
         kind: 'wait',
         title: 'Wait For Runtime Evidence',
-        description: 'Waits for an existing or future browser-agent runtime event, diagnostic, message, result, stats, or report that matches simple fields.',
+        description: 'Waits for a matching runtime event; with absent: true it instead holds the full window and fails when any buffered or new event matches.',
         requiredFields: ['match'],
-        optionalFields: ['commandId', 'label', 'timeoutMs', 'deadlineEpochMs', 'metadata'],
+        optionalFields: [
+            'absent',
+            'commandId',
+            'label',
+            'timeoutMs',
+            'deadlineEpochMs',
+            'metadata',
+        ],
         supportedProviderModes: ['simulated', 'browser-rallar', 'rallar-browser', 'rallar-remote-browser', 'rallar-memory', 'mixed'],
         runtimeSurfaces: ['spa-local', 'control-agent'],
         liveServiceRequirements: ['the matching evidence must be emitted by earlier or concurrent commands, browser adapters, or provider event bridges'],

--- a/packages/shared-test/rallar-bb-test/types.ts
+++ b/packages/shared-test/rallar-bb-test/types.ts
@@ -194,6 +194,7 @@ export type RallarBlackBoxTestWaitCommand =
     & RallarBlackBoxTestCommandBase<'wait'>
     & Readonly<{
     match: RallarBlackBoxTestWaitMatch;
+    absent?: true;
 }>;
 
 export type RallarBlackBoxTestAssertOperator =
@@ -746,6 +747,7 @@ export type RallarBlackBoxTestParallelResultValue = Readonly<{
 export type RallarBlackBoxTestWaitResultValue = Readonly<{
     commandId: string;
     matched: boolean;
+    absent?: true;
     timedOut?: boolean;
     cancelled?: boolean;
     match: RallarBlackBoxTestWaitMatch;

--- a/packages/shared-test/rallar-bb-test/types.ts
+++ b/packages/shared-test/rallar-bb-test/types.ts
@@ -239,7 +239,7 @@ export type RallarBlackBoxTestRtcSendCommand =
     & Readonly<{
     connection?: string;
     send?: unknown;
-    expect?: unknown;
+    expect?: unknown; // black-box-runner-adapter in-process only; control validators reject it
     applicationId?: string;
     workspaceId?: string;
     scope?: Readonly<Record<string, unknown>>;

--- a/packages/shared-test/rallar-bb-test/wait/wait-absence-conformance-recipes.ts
+++ b/packages/shared-test/rallar-bb-test/wait/wait-absence-conformance-recipes.ts
@@ -19,7 +19,9 @@ import {
     timeoutMs,
 } from '../conformance/composite-conformance-command-fixtures.ts';
 
-export function waitAbsenceHoldRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+export function waitAbsenceHoldRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
     const transport = options.transport ?? 'realtime';
@@ -30,7 +32,14 @@ export function waitAbsenceHoldRecipe(options: RallarBlackBoxCompositeConformanc
         metadata: recipeMetadata('wait-absence-hold'),
         commands: [
             configureCommand('wait-absence-hold', options),
-            rtcConnectCommand('wait-absence-hold', 'wait-absence-hold-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'wait-absence-hold',
+                'wait-absence-hold-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'rtc.send',
                 commandId: 'wait-absence-hold-send',
@@ -57,7 +66,10 @@ export function waitAbsenceHoldRecipe(options: RallarBlackBoxCompositeConformanc
                     payloadPath: 'data.topic',
                     equals: 'rallar.conformance.wait-absence-hold',
                 },
-                metadata: commandMetadata('wait-absence-hold', 'wait-absence-hold-positive-control'),
+                metadata: commandMetadata(
+                    'wait-absence-hold',
+                    'wait-absence-hold-positive-control',
+                ),
             },
             {
                 kind: 'wait',
@@ -78,7 +90,9 @@ export function waitAbsenceHoldRecipe(options: RallarBlackBoxCompositeConformanc
     };
 }
 
-export function waitAbsenceViolatedRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+export function waitAbsenceViolatedRecipe(
+    options: RallarBlackBoxCompositeConformanceRecipeOptions,
+): RallarBlackBoxTestRecipe {
     const connection = options.connection ?? DEFAULT_CONNECTION;
     const roomId = options.roomId ?? DEFAULT_ROOM_ID;
     const transport = options.transport ?? 'realtime';
@@ -89,7 +103,14 @@ export function waitAbsenceViolatedRecipe(options: RallarBlackBoxCompositeConfor
         metadata: recipeMetadata('wait-absence-violated'),
         commands: [
             configureCommand('wait-absence-violated', options),
-            rtcConnectCommand('wait-absence-violated', 'wait-absence-violated-connect', connection, roomId, transport, options),
+            rtcConnectCommand(
+                'wait-absence-violated',
+                'wait-absence-violated-connect',
+                connection,
+                roomId,
+                transport,
+                options,
+            ),
             {
                 kind: 'rtc.send',
                 commandId: 'wait-absence-violated-send',
@@ -116,7 +137,10 @@ export function waitAbsenceViolatedRecipe(options: RallarBlackBoxCompositeConfor
                     payloadPath: 'data.topic',
                     equals: 'rallar.conformance.wait-absence-violated',
                 },
-                metadata: commandMetadata('wait-absence-violated', 'wait-absence-violated-positive-control'),
+                metadata: commandMetadata(
+                    'wait-absence-violated',
+                    'wait-absence-violated-positive-control',
+                ),
             },
             {
                 kind: 'wait',

--- a/packages/shared-test/rallar-bb-test/wait/wait-absence-conformance-recipes.ts
+++ b/packages/shared-test/rallar-bb-test/wait/wait-absence-conformance-recipes.ts
@@ -1,0 +1,136 @@
+import type {
+    RallarBlackBoxTestRecipe,
+} from '../types.ts';
+
+import type {
+    RallarBlackBoxCompositeConformanceRecipeOptions,
+} from '../composite-conformance.ts';
+import {
+    closeCommand,
+    commandMetadata,
+    configureCommand,
+    DEFAULT_CONNECTION,
+    DEFAULT_ROOM_ID,
+    recipeId,
+    recipeMetadata,
+    rtcConnectCommand,
+    scopeFields,
+    statsCommand,
+    timeoutMs,
+} from '../conformance/composite-conformance-command-fixtures.ts';
+
+export function waitAbsenceHoldRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'realtime';
+    return {
+        recipeId: recipeId('wait-absence-hold', options),
+        name: 'Composite conformance: wait absence holds',
+        continueOnFailure: false,
+        metadata: recipeMetadata('wait-absence-hold'),
+        commands: [
+            configureCommand('wait-absence-hold', options),
+            rtcConnectCommand('wait-absence-hold', 'wait-absence-hold-connect', connection, roomId, transport, options),
+            {
+                kind: 'rtc.send',
+                commandId: 'wait-absence-hold-send',
+                connection,
+                transport,
+                timeoutMs: timeoutMs(options),
+                send: {
+                    data: {
+                        topic: 'rallar.conformance.wait-absence-hold',
+                        marker: 'wait-absence-hold',
+                    },
+                    roomId,
+                    ...scopeFields(options),
+                },
+                metadata: commandMetadata('wait-absence-hold', 'wait-absence-hold-send'),
+            },
+            {
+                kind: 'wait',
+                commandId: 'wait-absence-hold-positive-control',
+                timeoutMs: timeoutMs(options),
+                match: {
+                    kind: 'message',
+                    topic: 'rallar.conformance.message',
+                    payloadPath: 'data.topic',
+                    equals: 'rallar.conformance.wait-absence-hold',
+                },
+                metadata: commandMetadata('wait-absence-hold', 'wait-absence-hold-positive-control'),
+            },
+            {
+                kind: 'wait',
+                commandId: 'wait-absence-hold-absent',
+                absent: true,
+                timeoutMs: 1_500,
+                match: {
+                    kind: 'message',
+                    topic: 'rallar.conformance.message',
+                    payloadPath: 'data.topic',
+                    equals: 'rallar.conformance.wait-absence-other-room',
+                },
+                metadata: commandMetadata('wait-absence-hold', 'wait-absence-hold-absent'),
+            },
+            statsCommand('wait-absence-hold-stats', 'wait-absence-hold'),
+            closeCommand('wait-absence-hold-close', 'wait-absence-hold'),
+        ],
+    };
+}
+
+export function waitAbsenceViolatedRecipe(options: RallarBlackBoxCompositeConformanceRecipeOptions): RallarBlackBoxTestRecipe {
+    const connection = options.connection ?? DEFAULT_CONNECTION;
+    const roomId = options.roomId ?? DEFAULT_ROOM_ID;
+    const transport = options.transport ?? 'realtime';
+    return {
+        recipeId: recipeId('wait-absence-violated', options),
+        name: 'Composite conformance: wait absence violated control',
+        continueOnFailure: false,
+        metadata: recipeMetadata('wait-absence-violated'),
+        commands: [
+            configureCommand('wait-absence-violated', options),
+            rtcConnectCommand('wait-absence-violated', 'wait-absence-violated-connect', connection, roomId, transport, options),
+            {
+                kind: 'rtc.send',
+                commandId: 'wait-absence-violated-send',
+                connection,
+                transport,
+                timeoutMs: timeoutMs(options),
+                send: {
+                    data: {
+                        topic: 'rallar.conformance.wait-absence-violated',
+                        marker: 'wait-absence-violated',
+                    },
+                    roomId,
+                    ...scopeFields(options),
+                },
+                metadata: commandMetadata('wait-absence-violated', 'wait-absence-violated-send'),
+            },
+            {
+                kind: 'wait',
+                commandId: 'wait-absence-violated-positive-control',
+                timeoutMs: timeoutMs(options),
+                match: {
+                    kind: 'message',
+                    topic: 'rallar.conformance.message',
+                    payloadPath: 'data.topic',
+                    equals: 'rallar.conformance.wait-absence-violated',
+                },
+                metadata: commandMetadata('wait-absence-violated', 'wait-absence-violated-positive-control'),
+            },
+            {
+                kind: 'wait',
+                commandId: 'wait-absence-violated-absent',
+                absent: true,
+                timeoutMs: 1_500,
+                match: {
+                    kind: 'message',
+                    topic: 'rallar.conformance.message',
+                    payloadPath: 'data.topic',
+                    equals: 'rallar.conformance.wait-absence-violated',
+                },
+                metadata: commandMetadata('wait-absence-violated', 'wait-absence-violated-absent'),
+            },
+        ],
+    };
+}

--- a/packages/shared-test/rallar-bb-test/wait/wait-event-match.ts
+++ b/packages/shared-test/rallar-bb-test/wait/wait-event-match.ts
@@ -1,0 +1,148 @@
+import type {
+    RallarBlackBoxTestEvent,
+    RallarBlackBoxTestWaitMatch,
+} from '../types.ts';
+
+export type PayloadPathLookup = Readonly<{
+    exists: boolean;
+    value?: unknown;
+}>;
+
+function normalisePayloadPath(path: string): string {
+    if (path.startsWith('$.payload.')) {
+        return path.slice('$.payload.'.length);
+    }
+    if (path.startsWith('payload.')) {
+        return path.slice('payload.'.length);
+    }
+    if (path.startsWith('$.')) {
+        return path.slice('$.'.length);
+    }
+    return path;
+}
+
+export function lookupPayloadPath(payload: unknown, path: string | undefined): PayloadPathLookup {
+    if (!path || path.trim().length === 0) {
+        return {
+            exists: payload !== undefined,
+            value: payload,
+        };
+    }
+
+    let current = payload;
+    const segments = normalisePayloadPath(path)
+        .split('.')
+        .filter(segment => segment.length > 0);
+    for (const segment of segments) {
+        if ((Array.isArray(current) || typeof current === 'string') && segment === 'length') {
+            current = current.length;
+            continue;
+        }
+
+        if (Array.isArray(current)) {
+            const index = Number(segment);
+            if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+                return { exists: false };
+            }
+            current = current[index];
+            continue;
+        }
+
+        if (!current || typeof current !== 'object') {
+            return { exists: false };
+        }
+
+        const record = current as Record<string, unknown>;
+        if (!Object.prototype.hasOwnProperty.call(record, segment)) {
+            return { exists: false };
+        }
+        current = record[segment];
+    }
+
+    return {
+        exists: true,
+        value: current,
+    };
+}
+
+export function sameJsonValue(left: unknown, right: unknown): boolean {
+    try {
+        return JSON.stringify(left) === JSON.stringify(right);
+    } catch (_error) {
+        return Object.is(left, right);
+    }
+}
+
+export function containsValue(value: unknown, expected: string): boolean {
+    if (typeof value === 'string') {
+        return value.includes(expected);
+    }
+    try {
+        const serialized = JSON.stringify(value);
+        return typeof serialized === 'string'
+            ? serialized.includes(expected)
+            : String(value).includes(expected);
+    } catch (_error) {
+        return String(value).includes(expected);
+    }
+}
+
+export function waitEventMatches(
+    event: RallarBlackBoxTestEvent,
+    match: RallarBlackBoxTestWaitMatch,
+): boolean {
+    if (match.kind !== undefined && event.kind !== match.kind) {
+        return false;
+    }
+    if (match.topic !== undefined && event.topic !== match.topic) {
+        return false;
+    }
+    if (match.commandId !== undefined && event.commandId !== match.commandId) {
+        return false;
+    }
+    if (match.connection !== undefined && event.connection !== match.connection) {
+        return false;
+    }
+    if (match.transport !== undefined && event.transport !== match.transport) {
+        return false;
+    }
+    if (match.severity !== undefined && event.severity !== match.severity) {
+        return false;
+    }
+
+    if (
+        match.payloadPath !== undefined ||
+        match.equals !== undefined ||
+        match.contains !== undefined ||
+        match.exists !== undefined
+    ) {
+        const lookup = lookupPayloadPath(event.payload, match.payloadPath);
+        if (match.exists !== undefined && lookup.exists !== match.exists) {
+            return false;
+        }
+        if (match.exists !== false && !lookup.exists) {
+            return false;
+        }
+        if (match.equals !== undefined && !sameJsonValue(lookup.value, match.equals)) {
+            return false;
+        }
+        if (match.contains !== undefined && !containsValue(lookup.value, match.contains)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function findWaitEvent(
+    events: readonly RallarBlackBoxTestEvent[],
+    match: RallarBlackBoxTestWaitMatch,
+): RallarBlackBoxTestEvent | undefined {
+    for (let index = events.length - 1; index >= 0; index--) {
+        const event = events[index];
+        if (waitEventMatches(event, match)) {
+            return event;
+        }
+    }
+    return undefined;
+}

--- a/packages/shared-test/rallar-bb-test/wait/wait-for-event.ts
+++ b/packages/shared-test/rallar-bb-test/wait/wait-for-event.ts
@@ -1,0 +1,286 @@
+import type {
+    RallarBlackBoxTestCommandOutcome,
+    RallarBlackBoxTestEvent,
+    RallarBlackBoxTestRuntimeStatus,
+    RallarBlackBoxTestWaitCommand,
+    RallarBlackBoxTestWaitResultValue,
+} from '../types.ts';
+
+import { findWaitEvent } from './wait-event-match.ts';
+
+export const RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED = 'RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED';
+
+const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
+
+type WaitCommandWithId = RallarBlackBoxTestWaitCommand & Readonly<{ commandId: string }>;
+
+export interface WaitForEventInput {
+    readonly command: WaitCommandWithId;
+    readonly now: () => number;
+    readonly sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+    readonly cancellationSignal: AbortSignal;
+    readonly cancelRequested: () => boolean;
+    readonly currentStatus: () => RallarBlackBoxTestRuntimeStatus;
+    readonly currentEvents: () => readonly RallarBlackBoxTestEvent[];
+    readonly subscribe: (listener: () => void) => () => void;
+}
+
+export async function waitForEvent(input: WaitForEventInput): Promise<RallarBlackBoxTestCommandOutcome> {
+    const command = input.command;
+    if (!command.match || Object.keys(command.match).length === 0) {
+        return waitInvalid(command, 'Wait requires at least one match field.');
+    }
+    if (command.absent !== undefined && command.absent !== true) {
+        return waitInvalid(command, 'Wait absent must be true when present.', {
+            absent: command.absent,
+        });
+    }
+
+    if (input.cancelRequested()) {
+        return waitCancelled(command);
+    }
+
+    if (command.absent === true) {
+        return await holdForEventAbsence(input);
+    }
+
+    const immediate = findWaitEvent(input.currentEvents(), command.match);
+    if (immediate) {
+        return waitMatched(command, immediate, input.currentStatus());
+    }
+
+    const deadlineEpochMs = waitDeadlineEpochMs(command, input.now);
+    if (input.now() >= deadlineEpochMs) {
+        return waitTimedOut(command, deadlineEpochMs);
+    }
+
+    return await new Promise<RallarBlackBoxTestCommandOutcome>((resolve) => {
+        let settled = false;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        let unsubscribe: (() => void) | undefined;
+        let cleanupAfterSubscribe = false;
+        const signal = input.cancellationSignal;
+
+        const cleanup = () => {
+            if (timeout) {
+                clearTimeout(timeout);
+                timeout = undefined;
+            }
+            signal.removeEventListener('abort', onAbort);
+            if (unsubscribe) {
+                unsubscribe();
+                unsubscribe = undefined;
+            } else {
+                cleanupAfterSubscribe = true;
+            }
+        };
+
+        const settle = (outcome: RallarBlackBoxTestCommandOutcome) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cleanup();
+            resolve(outcome);
+        };
+
+        const evaluate = () => {
+            if (input.cancelRequested()) {
+                settle(waitCancelled(command));
+                return;
+            }
+
+            const matched = findWaitEvent(input.currentEvents(), command.match);
+            if (matched) {
+                settle(waitMatched(command, matched, input.currentStatus()));
+                return;
+            }
+
+            if (input.now() >= deadlineEpochMs) {
+                settle(waitTimedOut(command, deadlineEpochMs));
+            }
+        };
+
+        const timeoutDelayMs = Math.max(0, deadlineEpochMs - input.now());
+        const onAbort = () => {
+            settle(waitCancelled(command));
+        };
+        if (signal.aborted) {
+            settle(waitCancelled(command));
+            return;
+        }
+        timeout = setTimeout(() => {
+            settle(waitTimedOut(command, deadlineEpochMs));
+        }, timeoutDelayMs);
+        signal.addEventListener('abort', onAbort, {
+            once: true,
+        });
+        unsubscribe = input.subscribe(evaluate);
+        if (cleanupAfterSubscribe && unsubscribe) {
+            unsubscribe();
+            unsubscribe = undefined;
+        }
+    });
+}
+
+// Parity with the runner's absence waits: the full window is always held —
+// an absence claim is only as strong as the time the agent kept listening —
+// then the whole buffer is scanned once, so earlier events violate by design.
+async function holdForEventAbsence(input: WaitForEventInput): Promise<RallarBlackBoxTestCommandOutcome> {
+    const command = input.command;
+    const deadlineEpochMs = waitDeadlineEpochMs(command, input.now);
+
+    try {
+        await input.sleep(Math.max(0, deadlineEpochMs - input.now()), input.cancellationSignal);
+    } catch (_error) {
+        return waitCancelled(command);
+    }
+    if (input.cancelRequested()) {
+        return waitCancelled(command);
+    }
+
+    const offending = findWaitEvent(input.currentEvents(), command.match);
+    if (offending) {
+        return waitAbsenceViolated(command, offending, deadlineEpochMs);
+    }
+
+    return {
+        status: 'ok',
+        value: toWaitResultValue(command, {
+            matched: false,
+            absent: true,
+        }),
+        nextStatus: input.currentStatus(),
+    };
+}
+
+function waitDeadlineEpochMs(command: WaitCommandWithId, now: () => number): number {
+    const timeoutMs = command.timeoutMs === undefined
+        ? command.deadlineEpochMs === undefined
+            ? DEFAULT_WAIT_TIMEOUT_MS
+            : undefined
+        : Math.max(0, command.timeoutMs);
+    const timeoutDeadline = timeoutMs === undefined
+        ? undefined
+        : now() + timeoutMs;
+
+    if (command.deadlineEpochMs === undefined) {
+        return timeoutDeadline ?? (now() + DEFAULT_WAIT_TIMEOUT_MS);
+    }
+
+    return timeoutDeadline === undefined
+        ? command.deadlineEpochMs
+        : Math.min(timeoutDeadline, command.deadlineEpochMs);
+}
+
+function toWaitResultValue(
+    command: WaitCommandWithId,
+    partial: Readonly<{
+        matched: boolean;
+        absent?: true;
+        timedOut?: boolean;
+        cancelled?: boolean;
+        event?: RallarBlackBoxTestEvent;
+    }>,
+): RallarBlackBoxTestWaitResultValue {
+    return {
+        commandId: command.commandId,
+        match: command.match,
+        ...partial,
+    };
+}
+
+function waitMatched(
+    command: WaitCommandWithId,
+    event: RallarBlackBoxTestEvent,
+    nextStatus: RallarBlackBoxTestRuntimeStatus,
+): RallarBlackBoxTestCommandOutcome {
+    return {
+        status: 'ok',
+        value: toWaitResultValue(command, {
+            matched: true,
+            event,
+        }),
+        nextStatus,
+    };
+}
+
+function waitAbsenceViolated(
+    command: WaitCommandWithId,
+    event: RallarBlackBoxTestEvent,
+    deadlineEpochMs: number,
+): RallarBlackBoxTestCommandOutcome {
+    return {
+        status: 'failed',
+        value: toWaitResultValue(command, {
+            matched: true,
+            absent: true,
+            event,
+        }),
+        error: {
+            code: RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED,
+            message: 'Wait absence was violated: a runtime event matched before the window closed.',
+            details: {
+                timeoutMs: command.timeoutMs,
+                deadlineEpochMs,
+                match: command.match,
+                event,
+            },
+        },
+        nextStatus: 'failed',
+    };
+}
+
+function waitTimedOut(
+    command: WaitCommandWithId,
+    deadlineEpochMs: number,
+): RallarBlackBoxTestCommandOutcome {
+    return {
+        status: 'failed',
+        value: toWaitResultValue(command, {
+            matched: false,
+            timedOut: true,
+        }),
+        error: {
+            code: 'RALLAR_BLACK_BOX_WAIT_TIMEOUT',
+            message: 'Wait command timed out before matching a runtime event.',
+            details: {
+                timeoutMs: command.timeoutMs,
+                deadlineEpochMs,
+                match: command.match,
+            },
+        },
+        nextStatus: 'failed',
+    };
+}
+
+function waitCancelled(command: WaitCommandWithId): RallarBlackBoxTestCommandOutcome {
+    return {
+        status: 'cancelled',
+        value: toWaitResultValue(command, {
+            matched: false,
+            ...(command.absent === true ? { absent: true } : {}),
+            cancelled: true,
+        }),
+        nextStatus: 'cancelled',
+    };
+}
+
+function waitInvalid(
+    command: WaitCommandWithId,
+    message: string,
+    details?: unknown,
+): RallarBlackBoxTestCommandOutcome {
+    return {
+        status: 'failed',
+        value: toWaitResultValue(command, {
+            matched: false,
+        }),
+        error: {
+            code: 'RALLAR_BLACK_BOX_WAIT_INVALID',
+            message,
+            details,
+        },
+        nextStatus: 'failed',
+    };
+}

--- a/packages/shared-test/rallar-bb-test/wait/wait-for-event.ts
+++ b/packages/shared-test/rallar-bb-test/wait/wait-for-event.ts
@@ -25,7 +25,9 @@ export interface WaitForEventInput {
     readonly subscribe: (listener: () => void) => () => void;
 }
 
-export async function waitForEvent(input: WaitForEventInput): Promise<RallarBlackBoxTestCommandOutcome> {
+export async function waitForEvent(
+    input: WaitForEventInput,
+): Promise<RallarBlackBoxTestCommandOutcome> {
     const command = input.command;
     if (!command.match || Object.keys(command.match).length === 0) {
         return waitInvalid(command, 'Wait requires at least one match field.');
@@ -126,7 +128,9 @@ export async function waitForEvent(input: WaitForEventInput): Promise<RallarBlac
 // Parity with the runner's absence waits: the full window is always held —
 // an absence claim is only as strong as the time the agent kept listening —
 // then the whole buffer is scanned once, so earlier events violate by design.
-async function holdForEventAbsence(input: WaitForEventInput): Promise<RallarBlackBoxTestCommandOutcome> {
+async function holdForEventAbsence(
+    input: WaitForEventInput,
+): Promise<RallarBlackBoxTestCommandOutcome> {
     const command = input.command;
     const deadlineEpochMs = waitDeadlineEpochMs(command, input.now);
 

--- a/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
+++ b/packages/tests/rallar-black-box/hetzner-distributed-manifests.test.ts
@@ -127,6 +127,7 @@ describe('Hetzner distributed manifest catalog', () => {
             'apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json',
             'apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json',
             'apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json',
+            'apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json',
         ]);
         expect(diagnosticPaths).toEqual([
             'apps/rallar-black-box/manifests/hetzner/diagnostic/barrier-health-2-agent.json',
@@ -277,6 +278,7 @@ describe('Hetzner distributed manifest catalog', () => {
             ['apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json', { peers: 1, timeoutMs: 45_000 }],
             ['apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json', { peers: 1, timeoutMs: 45_000 }],
             ['apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json', { peers: 1, timeoutMs: 45_000 }],
+            ['apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json', { peers: 1, timeoutMs: 10_000 }],
         ]);
 
         for (const entry of buildHetznerDistributedManifestCatalog().filter(candidate => !candidate.diagnostic)) {

--- a/packages/tests/rallar-black-box/manual-workbench.test.ts
+++ b/packages/tests/rallar-black-box/manual-workbench.test.ts
@@ -293,11 +293,10 @@ describe('rallar-black-box manual workbench helpers', () => {
                 negativeCase: 'not-yet-in-sync',
                 expectedOutcome: 'nack',
             },
-            expect: {
-                outcome: 'nack',
-                code: 'not-yet-in-sync',
-            },
         });
+        for (const command of recipe.commands) {
+            expect(command.expect, command.commandId).toBeUndefined();
+        }
     });
 
     it('carries browser-rallar auth defaults into manual configure commands', () => {

--- a/packages/tests/shared-test/rallar-bb-test-composite-conformance.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-composite-conformance.test.ts
@@ -201,6 +201,8 @@ describe('rallar-bb-test composite conformance matrix', () => {
             'parallel-ws-rtc-groups',
             'wait-assert-evidence',
             'cancel-during-loop',
+            'wait-absence-hold',
+            'wait-absence-violated',
             'negative-no-peer',
         ]);
         expect(RALLAR_BLACK_BOX_COMPOSITE_CONFORMANCE_PROVIDERS.map(entry => entry.providerId)).toEqual([
@@ -215,7 +217,7 @@ describe('rallar-bb-test composite conformance matrix', () => {
             },
         });
 
-        expect(matrix).toHaveLength(15);
+        expect(matrix).toHaveLength(21);
         expect(new Set(matrix.map(entry => entry.entryId)).size).toBe(matrix.length);
         matrix.forEach(entry => {
             expect(entry.supported).toBe(true);

--- a/packages/tests/shared-test/rallar-bb-test-http-result-redaction.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-http-result-redaction.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { createRallarBlackBoxBrowserTestRuntime } from '../../shared-test/rallar-bb-test/browser-adapter.ts';
+import type { RallarBlackBoxTestResult } from '../../shared-test/rallar-bb-test/types.ts';
+
+type HttpResultValue = Readonly<{
+    status: number;
+    headers: Readonly<Record<string, string>>;
+    body: Readonly<Record<string, unknown>>;
+}>;
+
+function httpResultValue(result: RallarBlackBoxTestResult | undefined): HttpResultValue {
+    expect(result?.ok).toBe(true);
+    return result?.value as HttpResultValue;
+}
+
+describe('http.request result redaction', () => {
+    it('redacts sensitive response headers and body fields in the recorded result and mirrored event', async () => {
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async () => new Response(
+                JSON.stringify({
+                    profile: { username: 'alice' },
+                    accessToken: 'live-access-token',
+                }),
+                {
+                    status: 200,
+                    headers: {
+                        'content-type': 'application/json',
+                        'x-session-cookie': 'session=live-cookie-value',
+                        'x-rallar-ticket': 'live-ticket-value',
+                    },
+                },
+            )) as typeof fetch,
+        });
+
+        const result = await runtime.execute({
+            kind: 'http.request',
+            commandId: 'http-sensitive-response',
+            request: {
+                url: 'https://api.example.test/api/session',
+                method: 'GET',
+            },
+            response: {
+                body: 'json',
+            },
+        });
+
+        const value = httpResultValue(result);
+        expect(value.status).toBe(200);
+        expect(value.headers['x-session-cookie']).toBe('<redacted>');
+        expect(value.headers['x-rallar-ticket']).toBe('<redacted>');
+        expect(value.headers['content-type']).toBe('application/json');
+        expect(value.body.accessToken).toBe('<redacted>');
+        expect(value.body.profile).toEqual({ username: 'alice' });
+
+        const cachedValue = httpResultValue(runtime.state().resultCache['http-sensitive-response']);
+        expect(cachedValue.headers['x-session-cookie']).toBe('<redacted>');
+        expect(cachedValue.body.accessToken).toBe('<redacted>');
+
+        const mirroredEvent = runtime.state().events
+            .find(event => event.topic === 'rallar.bb.http.response');
+        expect(mirroredEvent?.payload).toMatchObject({
+            status: 200,
+            headers: {
+                'x-session-cookie': '<redacted>',
+                'x-rallar-ticket': '<redacted>',
+            },
+            body: {
+                accessToken: '<redacted>',
+            },
+        });
+    });
+
+    it('redacts the http result recorded for a rejected status code', async () => {
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async () => new Response(
+                JSON.stringify({ error: 'denied', refreshToken: 'live-refresh-token' }),
+                {
+                    status: 403,
+                    headers: {
+                        'content-type': 'application/json',
+                        authorization: 'Bearer leaked-server-echo',
+                    },
+                },
+            )) as typeof fetch,
+        });
+
+        const result = await runtime.execute({
+            kind: 'http.request',
+            commandId: 'http-rejected-status',
+            request: {
+                url: 'https://api.example.test/api/denied',
+                method: 'GET',
+            },
+            response: {
+                body: 'json',
+                acceptedStatusCodes: [200],
+            },
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe('RALLAR_BLACK_BOX_HTTP_STATUS_NOT_ACCEPTED');
+        const failedValue = result.value as HttpResultValue;
+        expect(failedValue.headers.authorization).toBe('<redacted>');
+        expect(failedValue.body.refreshToken).toBe('<redacted>');
+        const errorDetails = result.error?.details as HttpResultValue;
+        expect(errorDetails.headers.authorization).toBe('<redacted>');
+        expect(errorDetails.body.refreshToken).toBe('<redacted>');
+    });
+});

--- a/packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { createRallarBlackBoxRtcClient } from '../../shared-test/rallar-bb-test/black-box-runner-adapter.ts';
+import { validateRallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/control-protocol.ts';
+import { createRallarBlackBoxTestRuntime } from '../../shared-test/rallar-bb-test/runtime.ts';
+import {
+    RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA,
+    formatJsonSchemaValidationErrors,
+    validateJsonSchema,
+} from '../../shared-test/rallar-bb-test/schema.ts';
+import type { RallarBlackBoxTestRtcSendCommand } from '../../shared-test/rallar-bb-test/types.ts';
+
+const rtcSendWithExpect = {
+    kind: 'rtc.send',
+    commandId: 'rtc-send-with-expect',
+    connection: 'rtc',
+    transport: 'realtime',
+    send: {
+        roomId: 'bb-group',
+        data: {
+            topic: 'room.negative.expect',
+        },
+    },
+    expect: {
+        outcome: 'ack',
+    },
+} as const satisfies RallarBlackBoxTestRtcSendCommand & Readonly<{ commandId: string }>;
+
+function createDeterministicRuntime() {
+    let now = 1_000;
+    let sequence = 1;
+    return createRallarBlackBoxTestRuntime({
+        now: () => now++,
+        idFactory: (prefix) => `${prefix}-${sequence++}`,
+    });
+}
+
+describe('rtc.send expect fail-closed boundary', () => {
+    it('rejects a control-dispatched rtc.send carrying expect', () => {
+        expect(validateRallarBlackBoxTestCommand(rtcSendWithExpect)).toEqual({
+            ok: false,
+            error: 'rtc.send has unsupported field: expect.',
+        });
+    });
+
+    it('still accepts a control-dispatched rtc.send without expect', () => {
+        const { expect: _discarded, ...withoutExpect } = rtcSendWithExpect;
+        expect(validateRallarBlackBoxTestCommand(withoutExpect)).toEqual({ ok: true });
+    });
+
+    it('rejects expect in the rtc.send command schema branch', () => {
+        const result = validateJsonSchema(RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA, rtcSendWithExpect);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(formatJsonSchemaValidationErrors(result.errors)).toContain(
+                '$.expect: Unexpected property.',
+            );
+        }
+    });
+
+    it('keeps the in-process black-box-runner adapter executing rtc.send with expectations', async () => {
+        const runtime = createDeterministicRuntime();
+        const client = createRallarBlackBoxRtcClient(runtime, {
+            name: 'adapterRtc',
+            roomId: 'bb-group',
+            applicationId: 'rallar-server',
+        });
+
+        await client.send(
+            { topic: 'room.adapter.parity', text: 'hello' },
+            { response: { outcome: 'ack' } },
+        );
+
+        const sendResult = runtime.state().commandHistory.find(result => result.kind === 'rtc.send');
+        expect(sendResult?.ok).toBe(true);
+
+        const sendDiagnostic = runtime.state().events
+            .find(event => event.topic === 'rallar.bb.fake.rtc.send');
+        expect(sendDiagnostic?.payload).toMatchObject({
+            command: {
+                kind: 'rtc.send',
+                expect: { outcome: 'ack' },
+            },
+        });
+    });
+});

--- a/packages/tests/shared-test/rallar-bb-test-wait-absence.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-wait-absence.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import { createRallarBlackBoxTestRuntime } from '../../shared-test/rallar-bb-test/runtime.ts';
+import { validateRallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/control-protocol.ts';
+import {
+    RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA,
+    formatJsonSchemaValidationErrors,
+    validateJsonSchema,
+} from '../../shared-test/rallar-bb-test/schema.ts';
+import type {
+    RallarBlackBoxTestWaitResultValue,
+} from '../../shared-test/rallar-bb-test/types.ts';
+
+function sleepMs(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('rallar-bb-test wait absence', () => {
+    it('holds the full window and succeeds when nothing matches', async () => {
+        let now = 1_000;
+        const sleptDurations: number[] = [];
+        const runtime = createRallarBlackBoxTestRuntime({
+            now: () => now,
+            sleep: async ms => {
+                sleptDurations.push(ms);
+                now += ms;
+            },
+        });
+
+        runtime.recordEvent({
+            kind: 'message',
+            topic: 'room.other-topic',
+            payload: { data: { topic: 'room.allowed' } },
+        });
+
+        const result = await runtime.execute({
+            kind: 'wait',
+            commandId: 'absence-holds',
+            absent: true,
+            timeoutMs: 2_000,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        });
+
+        const value = result.value as RallarBlackBoxTestWaitResultValue;
+        expect(result.ok).toBe(true);
+        expect(value.matched).toBe(false);
+        expect(value.absent).toBe(true);
+        expect(value.event).toBeUndefined();
+        expect(sleptDurations).toEqual([2_000]);
+        expect(now).toBe(3_000);
+    });
+
+    it('fails with the offending event when a matching event was already buffered', async () => {
+        let now = 1_000;
+        const runtime = createRallarBlackBoxTestRuntime({
+            now: () => now,
+            sleep: async ms => {
+                now += ms;
+            },
+        });
+
+        runtime.recordEvent({
+            kind: 'message',
+            topic: 'room.forbidden-topic',
+            payload: { data: { marker: 'leaked-before-wait' } },
+        });
+
+        const result = await runtime.execute({
+            kind: 'wait',
+            commandId: 'absence-violated-buffered',
+            absent: true,
+            timeoutMs: 1_000,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        });
+
+        const value = result.value as RallarBlackBoxTestWaitResultValue;
+        expect(result.status).toBe('failed');
+        expect(result.error?.code).toBe('RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED');
+        expect(value.matched).toBe(true);
+        expect(value.absent).toBe(true);
+        expect(value.event?.topic).toBe('room.forbidden-topic');
+    });
+
+    it('fails when the matching event arrives during the held window', async () => {
+        let now = 1_000;
+        let releaseHold: (() => void) | undefined;
+        const runtime = createRallarBlackBoxTestRuntime({
+            now: () => now,
+            sleep: ms =>
+                new Promise<void>(resolve => {
+                    releaseHold = () => {
+                        now += ms;
+                        resolve();
+                    };
+                }),
+        });
+
+        const pending = runtime.execute({
+            kind: 'wait',
+            commandId: 'absence-violated-during-window',
+            absent: true,
+            timeoutMs: 1_000,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+                payloadPath: 'data.secretName',
+                exists: true,
+            },
+        });
+
+        await sleepMs(5);
+        runtime.recordEvent({
+            kind: 'message',
+            topic: 'room.forbidden-topic',
+            payload: {
+                data: {
+                    secretName: 'leaked-during-window',
+                    accessToken: 'live-leak-token',
+                },
+            },
+        });
+        expect(releaseHold).toBeDefined();
+        releaseHold?.();
+
+        const result = await pending;
+        const value = result.value as RallarBlackBoxTestWaitResultValue;
+        expect(result.status).toBe('failed');
+        expect(result.error?.code).toBe('RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED');
+        expect(value.matched).toBe(true);
+        expect((value.event?.payload as { data: { accessToken: string } }).data.accessToken)
+            .toBe('<redacted>');
+        const details = result.error?.details as { event: { payload: { data: { accessToken: string } } } };
+        expect(details.event.payload.data.accessToken).toBe('<redacted>');
+    });
+
+    it('cancels an absence hold when recipe cancellation is requested', async () => {
+        const runtime = createRallarBlackBoxTestRuntime();
+        const pending = runtime.execute({
+            kind: 'wait',
+            commandId: 'absence-cancelled',
+            absent: true,
+            timeoutMs: 500,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        });
+
+        await sleepMs(10);
+        await runtime.execute({
+            kind: 'recipe.cancel',
+            commandId: 'cancel-absence-hold',
+            reason: 'operator requested stop',
+        });
+
+        const result = await pending;
+        const value = result.value as RallarBlackBoxTestWaitResultValue;
+        expect(result.status).toBe('cancelled');
+        expect(value.cancelled).toBe(true);
+        expect(value.absent).toBe(true);
+        expect(value.matched).toBe(false);
+    });
+
+    it('rejects absent values other than true at the runtime boundary', async () => {
+        const runtime = createRallarBlackBoxTestRuntime();
+        const result = await runtime.execute({
+            kind: 'wait',
+            commandId: 'absence-invalid-flag',
+            absent: false,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        } as never);
+
+        expect(result.status).toBe('failed');
+        expect(result.error?.code).toBe('RALLAR_BLACK_BOX_WAIT_INVALID');
+    });
+
+    it('validates absent at the control protocol and schema boundaries', () => {
+        expect(validateRallarBlackBoxTestCommand({
+            kind: 'wait',
+            commandId: 'absence-protocol-valid',
+            absent: true,
+            timeoutMs: 1_000,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        })).toEqual({ ok: true });
+
+        expect(validateRallarBlackBoxTestCommand({
+            kind: 'wait',
+            commandId: 'absence-protocol-invalid',
+            absent: false,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        } as never)).toEqual({
+            ok: false,
+            error: 'wait.absent must be true when present.',
+        });
+
+        expect(validateJsonSchema(RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA, {
+            kind: 'wait',
+            commandId: 'absence-schema-valid',
+            absent: true,
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        }).ok).toBe(true);
+
+        const invalid = validateJsonSchema(RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA, {
+            kind: 'wait',
+            commandId: 'absence-schema-invalid',
+            absent: 'yes',
+            match: {
+                kind: 'message',
+                topic: 'room.forbidden-topic',
+            },
+        });
+        expect(invalid.ok).toBe(false);
+        if (!invalid.ok) {
+            expect(formatJsonSchemaValidationErrors(invalid.errors)).toContain('$.absent: Expected true.');
+        }
+    });
+});

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -1,0 +1,349 @@
+# Rallar BB-Test Distributed Assertion Parity Plan
+
+> **For Codex/Claude:** Execute each workstream as its own PR with
+> `publishing-plan-progress`, `rallar-code-writing`, and `rallar-testing`;
+> read `rallar-hetzner-ops` before touching manifests, rollout scripts, or
+> workflow dispatch. The paste-able prompt under each workstream is the
+> intended starting instruction; the baked-in decision resolves the one choice
+> that would otherwise block mid-task.
+
+Status: proposed; not started. Implements the decision items of issue
+[#176](https://github.com/intact-software-systems/ar-eye-hunter/issues/176).
+
+| Workstream | Status | Branch / PR |
+|---|---|---|
+| D0 fail-closed `rtc.send.expect` + http result redaction | not started | — |
+| D1 `wait` absence mode | not started | — |
+| D2 assert operator extension | not started | — |
+| D3 `loop` until-success polling | not started | — |
+| D4 capability advertisement + preflight gating | not started | — |
+| D5 parity and conformance deepening | not started | — |
+
+Plan evidence base: authored 2026-08-11 after the W1–W8 assertion-coverage
+stack landed on `main` at `93483f47` (Branch Release Gate green on
+`6f763ddf`, Hetzner Supported Distributed Manifests green on `93483f47`).
+The distributed availability analysis behind #176 established that the
+runner and the distributed `rallar-bb-test` family are separate execution
+stacks: distributed recipes are `RallarBlackBoxTestRecipe.commands[]`
+evaluated agent-side by `RallarBlackBoxTestRuntime`, with no path through
+`executeBlackBox` and no `compareJson` import anywhere in `rallar-bb-test`.
+Revalidate the file/line references below before starting each workstream.
+
+## Why this exists
+
+The runner's recipe corpus can now assert absence, poll until an expectation
+holds, apply value comparators and complete-array comparison, check headers,
+and bound step latency. The distributed dialect cannot express any of that:
+
+- `wait` matches only `kind/topic/commandId/connection/transport/severity` +
+  payload-path `equals|contains|exists` (`types.ts:181-191`); there is no
+  absence concept. The composite-conformance "negative" case is a no-peer
+  *send failure*, not a non-delivery assertion.
+- `assert` has six operators (`equals|notEquals|contains|exists|gte|lte`,
+  `runtime.ts:2342-2366`) and its comparison primitive is
+  `JSON.stringify` equality (`sameJsonValue`, `runtime.ts:420`). `gte/lte`
+  are numbers-only; `notEquals` passes when the path is missing.
+- `loop` cannot poll: it aborts on the first child failure
+  (`RALLAR_BLACK_BOX_LOOP_CHILD_FAILED`, `runtime.ts:1154-1166`) or, with
+  `continueOnFailure: true`, runs every iteration and still succeeds. There
+  is no success-exit, no backoff (`intervalMs` is flat).
+- `rtc.send` allowlists an `expect` field (`control-protocol.ts:1180-1182`,
+  `types.ts:242`) that no agent code ever reads — a recipe carrying it
+  validates green and asserts nothing. This is the same vacuous-assertion
+  class the W1–W8 stack was written to kill, and it fails **silently**,
+  unlike every other gap (the strict `validateKeys` allowlists otherwise
+  fail closed on unknown fields).
+- `http.request` results already carry a full unfiltered header record
+  (`browser-adapter.ts:2356-2363`, `toHeadersRecord` at `:524-530`) — header
+  assertions need documentation, not new capture. But the result `value` is
+  recorded unredacted; only the mirrored `rallar.bb.http.response` event
+  passes the redaction pipeline (`runtime.ts:2715`).
+
+## Design constraints (bind every workstream)
+
+- **Compatibility model.** `schemaVersion` stays `1`. Every addition is an
+  optional field or a widened operator enum — "adding optional fields to an
+  existing command is compatible" (`schema-and-capabilities.md`). New-operator
+  recipes dispatched to old agents fail closed at `validateKeys` with a clear
+  unsupported-field error; that is the intended behavior, not a defect. No
+  `protocolVersion` bump: the strict equality check at
+  `control-protocol.ts:1336/1404` has no negotiation, and the per-agent
+  capability block (`RallarBlackBoxControlAgentCapabilities.crdt`,
+  `distributed-run.ts:111-125`) is the established precedent for feature
+  advertisement — D4 follows it.
+- **Aligned-surfaces rule.** Every contract change updates, in the same PR:
+  `types.ts` shape, `RALLAR_BLACK_BOX_COMMAND_CAPABILITIES` metadata, the
+  command schema branch, at least one validating example, the golden
+  compatibility corpus (`fixtures/schema/v1/golden-compatibility-corpus.json`),
+  the AI prompt guide + `schema-and-capabilities.md`, and an upgrade note per
+  the template in `schema-compatibility-guide.md`. The lockstep tests in
+  `packages/tests/shared-test/rallar-bb-test-schema.test.ts` (`:166`, `:298`,
+  `:347`) enforce most of this mechanically.
+- **Style-gate budgets.** `runtime.ts` (2761), `schema.ts` (2100),
+  `control-protocol.ts` (1540), `control-client.ts` (938), and `types.ts`
+  (907) are all over the 800-line cap and **none is registered** in
+  `docs/repo-code-style-exceptions.md`. The changed-findings gate forbids net
+  growth of over-cap files, so new evaluator logic lands in new feature
+  modules (`wait-absence.ts`, `assert-value-operators.ts`,
+  `loop-until.ts` beside `runtime.ts`) with minimal dispatch wiring offset by
+  equivalent extractions under a structural-lineage manifest — the exact
+  pattern the W1–W8 stack used on the runner megafiles. Budget this cost into
+  every estimate; it dominated the runner work.
+- **Redaction.** Every new evidence payload (offending absence event,
+  comparator actuals, poll attempt results) passes the runtime redaction
+  pipeline before it reaches results, events, failures, or artifacts.
+- **Fleet reality.** Hetzner agents rebuild from the repo checkout on every
+  rollout (`08-rollout-controller.sh` → `build_rallar_black_box_spa` →
+  headless workers restart), so the Hetzner fleet moves atomically with the
+  repo. World-fleet agents do not — they are already-running remote agents —
+  which is why D4's capability gating is required before checked-in
+  world-fleet manifests may use the new operators.
+- **Semantics parity.** Where an operator exists in both dialects, its
+  semantics match the runner's: absence waits hold the full window and scan
+  the whole buffer; polling success is the child expectation passing;
+  exhaustion of either bound is a failure carrying the last attempt.
+
+---
+
+## D0 — Fail-closed `rtc.send.expect` + http result redaction (P0, small)
+
+**Serves:** removes the one silent vacuous-assertion path in the distributed
+dialect, and closes the unredacted http result gap found during analysis.
+
+**Baked-in decision:** reject `expect` at the network validators only —
+remove it from the `rtc.send` allowlist in `control-protocol.ts` and from the
+command schema branch, keep the `types.ts:242` field with a comment marking
+it in-process-only. `black-box-runner-adapter.ts` bypasses validation
+entirely (`runtime.execute` directly, no `validateKeys` on that path), so the
+in-process runner adapter keeps working; only control-server-delivered
+commands fail closed. For redaction: pass `http.request` result `value`
+through the same redaction the mirrored event already gets.
+
+**Prompt:**
+
+```
+In packages/shared-test/rallar-bb-test, make rtc.send.expect fail closed on
+the control-protocol path: drop 'expect' from the rtc.send validateKeys
+allowlist and the rtc.send schema branch, keep the types.ts field documented
+as in-process-adapter-only, and add regression tests proving a
+control-dispatched rtc.send with expect is rejected while
+black-box-runner-adapter still executes. Separately, redact http.request
+result values (headers and body) with the runtime redaction pipeline before
+they are recorded, matching the mirrored event. Update the golden corpus
+invalid examples and write the upgrade note. Run the rallar-bb-test schema,
+control-protocol, and conformance vitest suites plus test:repo-governance.
+```
+
+**Done when:** a control-dispatched `rtc.send` carrying `expect` is rejected
+with a named validation error; the adapter parity test still passes; http
+result headers show redaction placeholders for sensitive names; upgrade note
+recorded.
+
+---
+
+## D1 — `wait` absence mode (P0)
+
+**Serves:** fleet-scale negative delivery contracts — "no agent in room A
+ever receives room-B frames", the distributed twin of the runner's
+`expect.absent` and the highest-value gap.
+
+**Baked-in decision:** an optional `absent: true` field on the existing
+`wait` command (no new kind). Semantics mirror the runner: wait the full
+window (`timeoutMs`/`deadlineEpochMs`, same 5s default), then scan the whole
+event buffer — past events match by design, exactly like positive waits
+(`findWaitEvent` walks all of `currentState.events`) — and fail with the
+offending event (redacted) if anything matched, succeed otherwise. Failure
+code `RALLAR_BLACK_BOX_WAIT_ABSENCE_VIOLATED`. Evaluation lives in a new
+`wait-absence.ts` module; `runtime.ts` gains only dispatch lines.
+
+**Prompt:**
+
+```
+Add an optional absent: true mode to the rallar-bb-test wait command: hold
+the full wait window, then fail with the offending (redacted) event if any
+buffered or newly arrived event matches the wait match, succeed otherwise.
+Implement in a new wait-absence.ts module with dispatch wiring in runtime.ts
+kept net-neutral via extraction under a structural-lineage manifest. Update
+types, capability metadata, schema branch, validating example, golden corpus,
+prompt guide, and schema-and-capabilities docs; add a composite-conformance
+absence case with a deliberately-broken control, plus one checked-in Hetzner
+manifest exercising cross-room non-delivery with a same-room positive control
+first. Run the schema/conformance/companion suites, test:repo-governance, and
+dispatch the manifest through the Hetzner workflow once reviewed.
+```
+
+**Done when:** the conformance absence case passes on deterministic local and
+browser providers, its broken control fails with the offending event, and the
+new manifest passes a real Hetzner dispatch.
+
+---
+
+## D2 — Assert operator extension (P1)
+
+**Serves:** kills the `JSON.stringify`-equality ceiling: numeric bounds,
+string matching, length, and structural containment for distributed
+evidence, matching the runner's W3 comparators.
+
+**Baked-in decision:** widen the `assert` operator enum with `gt`, `lt`,
+`between` (expected `[low, high]` inclusive), `length` (arrays/strings),
+`matches` (regular-expression source), and two structural operators
+`matchesShape` / `matchesShapeComplete` implemented by importing
+`packages/shared-test/json-compare` (`compatible` and `compatible-complete`
+modes — first `json-compare` use inside `rallar-bb-test`, browser-safe).
+Existing operator quirks are documented, not changed (`notEquals` passing on
+a missing path stays; `gte/lte` stay numbers-only). Evaluation moves to a new
+`assert-value-operators.ts`; every failing detail passes redaction.
+
+**Prompt:**
+
+```
+Extend the rallar-bb-test assert command with gt, lt, between, length,
+matches, matchesShape, and matchesShapeComplete operators, the last two
+backed by json-compare's compatible and compatible-complete modes. Implement
+in a new assert-value-operators.ts module with net-neutral runtime.ts
+dispatch. Update types, capability metadata, schema enum, validating
+examples, golden corpus (valid and invalid), prompt guide, and docs; extend
+the composite-conformance wait-assert-evidence case to exercise the new
+operators including one matchesShapeComplete rejection of an unexpected
+array element. Run the schema/conformance suites and test:repo-governance.
+```
+
+**Done when:** all new operators evaluate correctly on `lastResult`,
+`resultCache.<commandId>`, and recent-evidence roots; an unexpected array
+element fails `matchesShapeComplete`; old six-operator recipes are untouched.
+
+---
+
+## D3 — `loop` until-success polling (P1)
+
+**Serves:** the distributed read-your-writes / convergence-poll shape — the
+twin of the runner's `http.poll-until` — without hand-unrolled repetition.
+
+**Baked-in decision:** optional `until: 'first-success'` mode plus optional
+`backoffMultiplier` on the existing `loop` command. In until mode the loop
+runs its children each iteration, exits successfully the first iteration in
+which **every** child succeeds, sleeps `intervalMs × backoffMultiplier^n`
+between attempts, and fails with
+`RALLAR_BLACK_BOX_LOOP_UNTIL_EXHAUSTED` (carrying the last iteration's
+failure, redacted) when `count`/`durationMs`/deadline bounds exhaust.
+`continueOnFailure` is rejected in until mode (contradictory). Existing
+loops are untouched; pacing/threshold observability keeps working.
+
+**Prompt:**
+
+```
+Add until: 'first-success' polling to the rallar-bb-test loop command with
+exponential backoff via an optional backoffMultiplier: exit on the first
+iteration whose children all succeed, fail with the last iteration's result
+when count/duration bounds exhaust, and reject continueOnFailure in until
+mode. Implement the mode in a new loop-until.ts module with net-neutral
+runtime.ts wiring. Update types, capability metadata, schema, examples,
+golden corpus, prompt guide, and docs; add a conformance case polling an
+http.request+assert pair to convergence with a broken control that exhausts.
+Run the schema/conformance suites and test:repo-governance.
+```
+
+**Done when:** a `[http.request, assert]` loop in until mode converges early
+on success, exhausts to a failure carrying the last attempt, and the
+composite result tree/pacing observability remains valid for until-mode
+loops.
+
+---
+
+## D4 — Capability advertisement + preflight gating (P2)
+
+**Serves:** safe rollout to fleets that do not move atomically with the repo
+(world-fleet no-spawn agents): a manifest that needs the new operators must
+not be staged onto agents that cannot evaluate them.
+
+**Baked-in decision:** follow the `crdt` capability precedent — agents
+advertise an `assertions` block (`absence`, `untilLoop`, `operators: [...]`)
+in `RallarBlackBoxControlAgentCapabilities`; the distributed-run staging
+preflight scans inline recipes for the new fields/operators and fails
+staging (not the run) with a named reason when a targeted agent does not
+advertise them. Hetzner flows are unaffected in practice (rollout rebuilds
+agents from the checkout before dispatch); world-fleet manifests may adopt
+the operators only behind this gate.
+
+**Prompt:**
+
+```
+Add an assertions capability block to the rallar-bb-test agent capability
+advertisement (absence, untilLoop, operators list), populate it from the
+runtime feature set, and teach distributed-run staging preflight to reject
+manifests whose inline recipes use absence waits, until loops, or extended
+assert operators when a targeted agent does not advertise them, with a named
+staging failure reason. Update distributed-run contract docs, the golden
+corpus manifest examples, and the control-server OpenAPI examples. Run the
+schema, control-protocol, distributed-run, and control-server deno suites
+plus test:repo-governance.
+```
+
+**Done when:** an old-capability agent causes staging failure with the named
+reason for a new-operator manifest, and a capability-complete fleet stages
+and runs it; documented in `distributed-run-contract.md`.
+
+---
+
+## D5 — Parity and conformance deepening (P2)
+
+**Serves:** proof that the two dialects agree — today provider-parity
+compares only step presence and status (`compareRallarBlackBoxProviderParityReports`
+matches by key), not assertion outcomes.
+
+**Baked-in decision:** extend `provider-parity.ts` with outcome rows for the
+ported operators — shared fixtures evaluated by both the runner
+(`expect.absent`, comparators, `compatible-complete`, `http.poll-until`) and
+the bb-test runtime (`wait absent`, extended `assert`, `loop until`), with
+pass/fail verdicts compared, not just statuses. Extend the artifact analyzer
+(`distributed-artifact-analysis.ts`) and failure-triage vocabulary with the
+new failure codes so Hetzner `analysis.json`/`fix-proposal.md` name them.
+
+**Prompt:**
+
+```
+Extend the rallar-bb-test provider-parity suite with assertion-outcome
+comparisons between the black-box-runner operators and their distributed
+twins on shared fixtures (absence, extended operators, complete-array,
+polling), and teach distributed-artifact-analysis plus the failure-triage
+vocabulary the new failure codes so Hetzner analysis artifacts name them.
+Update composite-conformance provider rows and the conformance matrix doc.
+Run the parity, conformance, and artifact-analysis suites plus
+test:repo-governance.
+```
+
+**Done when:** a semantics divergence between the dialects fails the parity
+suite, and a synthetic failing distributed run yields an `analysis.json`
+naming the new failure code with a usable fix proposal.
+
+---
+
+## Sequencing and guardrails
+
+| # | Depends on | Notes |
+|---|---|---|
+| D0 | — | ship first; pure hardening |
+| D1 | — | independent of D0 |
+| D2 | — | independent; introduces the json-compare dependency |
+| D3 | — | independent |
+| D4 | D1–D3 shapes | capability names must match shipped fields |
+| D5 | D1–D3 | parity needs both sides implemented |
+
+- One capability per PR; every PR carries its schema branch, capability
+  metadata, validating example, corpus update, docs, and upgrade note — the
+  lockstep tests make omissions fail.
+- Never grow the five over-cap files net; land logic in new modules with
+  lineage manifests, or register a deliberate exception with rationale.
+- The strict validators stay fail-closed; no permissive fallbacks, no
+  `additionalProperties: true` anywhere in the command schemas.
+- No secrets in manifests, prompts, or workflow inputs; new evidence passes
+  redaction before artifacts.
+- Validation floor per PR: `rallar-bb-test-schema`, `composite-conformance`,
+  `control-protocol`, and `companion-coverage` vitest suites; control-server
+  `deno task test` when the protocol changes; `test:repo-governance`;
+  `hetzner-distributed-manifests` vitest when manifests change; and one real
+  **Run Hetzner Distributed Recipe** dispatch for D1's manifest before the
+  plan is complete.
+- Rollout order for adopting operators in checked-in manifests: Hetzner
+  manifests only after `08-rollout-controller.sh` + worker restart paths are
+  proven on the new build; world-fleet manifests only after D4's gate exists.

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -13,7 +13,7 @@ Status: in progress. Implements the decision items of issue
 | Workstream | Status | Branch / PR |
 |---|---|---|
 | D0 fail-closed `rtc.send.expect` + http result redaction | in review | [#180](https://github.com/intact-software-systems/ar-eye-hunter/pull/180) |
-| D1 `wait` absence mode | in review | `codex/bb-test-d1-wait-absence-mode` |
+| D1 `wait` absence mode | in review | [#181](https://github.com/intact-software-systems/ar-eye-hunter/pull/181) |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |
 | D4 capability advertisement + preflight gating | not started | — |

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -18,6 +18,7 @@ Status: proposed; not started. Implements the decision items of issue
 | D3 `loop` until-success polling | not started | — |
 | D4 capability advertisement + preflight gating | not started | — |
 | D5 parity and conformance deepening | not started | — |
+| D6 coordinator-evaluated group assertions | not started | — |
 
 Plan evidence base: authored 2026-08-11 after the W1–W8 assertion-coverage
 stack landed on `main` at `93483f47` (Branch Release Gate green on
@@ -318,6 +319,66 @@ naming the new failure code with a usable fix proposal.
 
 ---
 
+## D6 — Coordinator-evaluated group assertions (P1)
+
+**Serves:** the assertion altitude neither dialect has: invariants over the
+collected evidence of every agent in the shared group. Per-agent asserts can
+never state "we all agree" or "no agent saw it"; today those facts are
+checked by humans reading artifacts.
+
+**Baked-in decision:** a manifest-level `groupAssertions` block beside
+`targetPolicy`/`barrier`, evaluated by the control server's distributed-run
+rollup after barrier/required-recipe completion — **coordinator-side only**,
+so agents are unchanged and D4's capability gate does not apply. Each
+assertion names an `assertionId`; a `scope` (`role`, `minParticipants`); a
+`source` address (`recipeId`, `commandId`, dot `path` into that command's
+result value — the same coordinates `resultCache` and composite result paths
+already use); and an `aggregate`. v1 aggregates, strict by default:
+
+- `allEqual` / `allEqualWithin` (numeric tolerance) — agreement/convergence;
+- `noneMatched` — group absence (fleet-scale isolation; failures name the
+  violating agents and their redacted matching evidence);
+- `countMatching` with `equals`/`gte`/`lte` — exactly-one-winner, exactly-K,
+  fan-out completeness;
+- `forall` — every agent's numeric satisfies a bound (sugar over
+  `countMatching == participants`);
+- optional `minRatio` quorum on any aggregate for world-fleet runs — an
+  explicit, visible weakening, never a default.
+
+A participating agent that contributes no value at the source address is a
+violation by default; `minParticipants` interacts with
+`targetPolicy.expectedParticipantCount` and must be stated per assertion.
+Failure evidence is a redacted per-agent value table plus violating agent
+IDs, recorded in `failures.json` and named for the analyzer. Spread/fairness
+and cross-agent ordering aggregates are explicitly deferred; perf-flavored
+group checks stay in analyzer thresholds, not run-failing asserts.
+
+**Prompt:**
+
+```
+Add a manifest-level groupAssertions block to the rallar-bb-test distributed
+run contract, evaluated coordinator-side in the distributed-run rollup after
+barrier/required-recipe completion: allEqual/allEqualWithin, noneMatched,
+countMatching (equals/gte/lte), forall, with scope (role, minParticipants),
+result-address sources (recipeId, commandId, path), optional minRatio quorum,
+and missing-evidence-is-violation semantics. Implement evaluation in a new
+distributed-run module (net-neutral wiring in existing over-cap files),
+update the manifest schema + golden corpus + distributed-run-contract doc +
+control-server OpenAPI examples, emit redacted per-agent value tables with
+named failure codes into failures.json and the artifact analyzer, and add a
+conformance case per aggregate with a deliberately-broken control, plus one
+checked-in Hetzner manifest asserting allEqual convergence and noneMatched
+isolation across the fleet. Run the schema, distributed-run, control-server
+deno, conformance, and artifact-analysis suites plus test:repo-governance;
+dispatch the manifest through the Hetzner workflow once reviewed.
+```
+
+**Done when:** a synthetic run with one disagreeing agent fails `allEqual`
+naming that agent; one leaked frame anywhere fails `noneMatched` with the
+offending evidence; a missing agent fails by default; quorum mode passes the
+same runs only when explicitly configured; and the Hetzner manifest passes a
+real dispatch.
+
 ## Sequencing and guardrails
 
 | # | Depends on | Notes |
@@ -328,6 +389,7 @@ naming the new failure code with a usable fix proposal.
 | D3 | — | independent |
 | D4 | D1–D3 shapes | capability names must match shipped fields |
 | D5 | D1–D3 | parity needs both sides implemented |
+| D6 | D1–D3 evidence shapes | coordinator-side only; old agents work unchanged, so D4's gate does not apply |
 
 - One capability per PR; every PR carries its schema branch, capability
   metadata, validating example, corpus update, docs, and upgrade note — the

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -7,12 +7,12 @@
 > intended starting instruction; the baked-in decision resolves the one choice
 > that would otherwise block mid-task.
 
-Status: proposed; not started. Implements the decision items of issue
+Status: in progress. Implements the decision items of issue
 [#176](https://github.com/intact-software-systems/ar-eye-hunter/issues/176).
 
 | Workstream | Status | Branch / PR |
 |---|---|---|
-| D0 fail-closed `rtc.send.expect` + http result redaction | not started | — |
+| D0 fail-closed `rtc.send.expect` + http result redaction | in review | `codex/bb-test-d0-fail-closed-rtc-send-expect` |
 | D1 `wait` absence mode | not started | — |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |
@@ -119,6 +119,17 @@ entirely (`runtime.execute` directly, no `validateKeys` on that path), so the
 in-process runner adapter keeps working; only control-server-delivered
 commands fail closed. For redaction: pass `http.request` result `value`
 through the same redaction the mirrored event already gets.
+
+**D0 revalidation (2026-08-11):** the redaction gap does not exist —
+`toResult` (`runtime.ts:2476`) already passes every command result `value`
+and `error` through the redaction pipeline, with the default key substrings
+applying even before any `configure` sets redaction options, at the plan's
+own evidence base `93483f47` and on current `main`. D0 therefore proves the
+behavior with regression tests
+(`rallar-bb-test-http-result-redaction.test.ts`) and documents it instead of
+adding a duplicate redaction pass. The fail-closed `expect` half proceeds as
+written; the manual-workbench negative snippets stop emitting the vacuous
+`expect` blobs so app-generated recipes stay dispatchable.
 
 **Prompt:**
 

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -328,56 +328,103 @@ checked by humans reading artifacts.
 
 **Baked-in decision:** a manifest-level `groupAssertions` block beside
 `targetPolicy`/`barrier`, evaluated by the control server's distributed-run
-rollup after barrier/required-recipe completion — **coordinator-side only**,
-so agents are unchanged and D4's capability gate does not apply. Each
-assertion names an `assertionId`; a `scope` (`role`, `minParticipants`); a
-`source` address (`recipeId`, `commandId`, dot `path` into that command's
-result value — the same coordinates `resultCache` and composite result paths
-already use); and an `aggregate`. v1 aggregates, strict by default:
+rollup after required recipes and barriers complete — **coordinator-side
+only**, so agents are unchanged and D4's capability gate does not apply.
+Every assertion reads **one result value from every targeted agent** through
+a typed address `{ recipeId, commandId, path }` (the coordinates
+`resultCache` and composite result paths already use) and applies value
+predicates drawn from the assert operator vocabulary (including D2's
+extended operators — which is why D2 must ship its evaluation as pure,
+runtime-agnostic functions the control server can import, so agent-side and
+coordinator-side predicates cannot drift).
 
-- `allEqual` / `allEqualWithin` (numeric tolerance) — agreement/convergence;
-- `noneMatched` — group absence (fleet-scale isolation; failures name the
-  violating agents and their redacted matching evidence);
-- `countMatching` with `equals`/`gte`/`lte` — exactly-one-winner, exactly-K,
-  fan-out completeness;
-- `forall` — every agent's numeric satisfies a bound (sugar over
-  `countMatching == participants`);
-- optional `minRatio` quorum on any aggregate for world-fleet runs — an
-  explicit, visible weakening, never a default.
+v1 aggregate vocabulary — fixed, strict, deterministic:
 
-A participating agent that contributes no value at the source address is a
-violation by default; `minParticipants` interacts with
-`targetPolicy.expectedParticipantCount` and must be stated per assertion.
-Failure evidence is a redacted per-agent value table plus violating agent
-IDs, recorded in `failures.json` and named for the analyzer. Spread/fairness
-and cross-agent ordering aggregates are explicitly deferred; perf-flavored
-group checks stay in analyzer thresholds, not run-failing asserts.
+- `allMatch` — every participating agent's value satisfies a predicate
+  ("every receiver observed exactly 100 messages", "every agent reports the
+  expected topology revision", "every result matches the required shape").
+- `noneMatch` — no participating agent's value satisfies a predicate ("no
+  room-A agent received a room-B frame", "no agent reported an authorization
+  failure"). Kept as a named aggregate even though it equals
+  `countMatching == 0`: the intent and the diagnostics are clearer.
+- `countMatching` with `equals`/`gte`/`lte` — "exactly one agent became
+  leader", "at least 45 of 50 received it", "no more than two retried".
+  Quorum-style checks are expressed here, against the frozen participant
+  denominator — there is **no** generic `minRatio` modifier (its meaning is
+  ambiguous for `allEqual`); a separately defined `consensusRatio` aggregate
+  may come later if a real need appears.
+- `allEqual` — every participating agent contributed the same JSON value,
+  using **proper deep equality: object-key-order insensitive, array-order
+  sensitive**. Explicitly not `JSON.stringify` equality (the runtime's
+  `sameJsonValue` is disqualified), and not `json-compare`'s `exact` mode
+  either (its array matching is order-insensitive); D6 ships a small pure
+  `deepEqualJson` with exactly these semantics.
+- `allEqualWithin` — numeric agreement within an absolute tolerance
+  ("replicated counters differ by at most one").
+- `sum` (v1.1) — the sum of numeric values satisfies a comparison ("total
+  successful deliveries equal the expected fan-out", "aggregate loss is
+  zero"). Pull into v1 only if delivery accounting lands in the same cycle.
+
+Authoring rule recorded in the prompt guide: when the expected value is
+known, use `allMatch equals X` — `allEqual` alone passes when every agent
+agrees on the same *wrong* value; `allEqual` is for values the test cannot
+predict, and the two compose ("all equal AND the first one matches X").
+
+**Participation rules — mandatory on every group assertion:**
+
+- The expected participant set is **frozen during target resolution** and
+  recorded in the run snapshot; the assertion evaluates against that set.
+- Missing, duplicate, or unresolved evidence at the address **fails by
+  default** — absence of evidence is never a pass.
+- `scope.role` narrows participants to a manifest role; `minParticipants`
+  exists only as an explicit, visible relaxation of the frozen set.
+- Failure artifacts record a redacted per-agent value table and identify
+  both missing and violating agents by agent ID.
+
+**Deferred explicitly** (hard to explain and diagnose; revisit only with a
+concrete consumer): arbitrary expression languages, cross-agent temporal
+ordering, joins across multiple evidence sources, fairness/distribution
+analysis, percentiles and other performance calculations, and set-union /
+cross-agent message-ID reconciliation.
+
+**Open product decision (plan owner):** are group assertions exclusively
+run-failing *correctness* gates, or may fleet performance/SLO checks also
+fail a run? Recommendation: correctness-only in v1 — performance stays in
+artifact-analysis thresholds (`performance-thresholds.md`), matching the
+repo's "no latency SLOs in gates" doctrine — with a deliberate, per-contract
+promotion path later if a specific performance bound becomes an explicit
+product contract. Record the resolution here before implementing D6.
 
 **Prompt:**
 
 ```
 Add a manifest-level groupAssertions block to the rallar-bb-test distributed
 run contract, evaluated coordinator-side in the distributed-run rollup after
-barrier/required-recipe completion: allEqual/allEqualWithin, noneMatched,
-countMatching (equals/gte/lte), forall, with scope (role, minParticipants),
-result-address sources (recipeId, commandId, path), optional minRatio quorum,
-and missing-evidence-is-violation semantics. Implement evaluation in a new
+required recipes and barriers complete: allMatch, noneMatch, countMatching
+(equals/gte/lte), allEqual (deep equality: key-order insensitive,
+array-order sensitive — a new pure deepEqualJson, not sameJsonValue and not
+json-compare exact), and allEqualWithin, with typed sources
+{recipeId, commandId, path}, predicates reused as pure functions from D2's
+operator module, role scoping, a participant set frozen at target
+resolution, and missing/duplicate/unresolved evidence failing by default
+(minParticipants only as explicit relaxation). Implement evaluation in a new
 distributed-run module (net-neutral wiring in existing over-cap files),
 update the manifest schema + golden corpus + distributed-run-contract doc +
-control-server OpenAPI examples, emit redacted per-agent value tables with
-named failure codes into failures.json and the artifact analyzer, and add a
-conformance case per aggregate with a deliberately-broken control, plus one
-checked-in Hetzner manifest asserting allEqual convergence and noneMatched
-isolation across the fleet. Run the schema, distributed-run, control-server
-deno, conformance, and artifact-analysis suites plus test:repo-governance;
-dispatch the manifest through the Hetzner workflow once reviewed.
+control-server OpenAPI examples, emit redacted per-agent value tables naming
+missing and violating agents with named failure codes into failures.json and
+the artifact analyzer, and add a conformance case per aggregate with a
+deliberately-broken control, plus one checked-in Hetzner manifest asserting
+allEqual convergence and noneMatch isolation across the fleet. Run the
+schema, distributed-run, control-server deno, conformance, and
+artifact-analysis suites plus test:repo-governance; dispatch the manifest
+through the Hetzner workflow once reviewed.
 ```
 
 **Done when:** a synthetic run with one disagreeing agent fails `allEqual`
-naming that agent; one leaked frame anywhere fails `noneMatched` with the
-offending evidence; a missing agent fails by default; quorum mode passes the
-same runs only when explicitly configured; and the Hetzner manifest passes a
-real dispatch.
+naming that agent; one leaked frame anywhere fails `noneMatch` with the
+offending evidence; a missing agent fails by default; `countMatching`
+expresses the quorum cases against the frozen denominator; and the Hetzner
+manifest passes a real dispatch.
 
 ## Sequencing and guardrails
 
@@ -389,7 +436,7 @@ real dispatch.
 | D3 | — | independent |
 | D4 | D1–D3 shapes | capability names must match shipped fields |
 | D5 | D1–D3 | parity needs both sides implemented |
-| D6 | D1–D3 evidence shapes | coordinator-side only; old agents work unchanged, so D4's gate does not apply |
+| D6 | D2's pure operator module + D1–D3 evidence shapes | coordinator-side only; old agents work unchanged, so D4's gate does not apply; one open product decision recorded in its section |
 
 - One capability per PR; every PR carries its schema branch, capability
   metadata, validating example, corpus update, docs, and upgrade note — the

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -12,7 +12,7 @@ Status: in progress. Implements the decision items of issue
 
 | Workstream | Status | Branch / PR |
 |---|---|---|
-| D0 fail-closed `rtc.send.expect` + http result redaction | in review | `codex/bb-test-d0-fail-closed-rtc-send-expect` |
+| D0 fail-closed `rtc.send.expect` + http result redaction | in review | [#180](https://github.com/intact-software-systems/ar-eye-hunter/pull/180) |
 | D1 `wait` absence mode | not started | — |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -13,7 +13,7 @@ Status: in progress. Implements the decision items of issue
 | Workstream | Status | Branch / PR |
 |---|---|---|
 | D0 fail-closed `rtc.send.expect` + http result redaction | in review | [#180](https://github.com/intact-software-systems/ar-eye-hunter/pull/180) |
-| D1 `wait` absence mode | not started | — |
+| D1 `wait` absence mode | in review | `codex/bb-test-d1-wait-absence-mode` |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |
 | D4 capability advertisement + preflight gating | not started | — |
@@ -187,6 +187,21 @@ dispatch the manifest through the Hetzner workflow once reviewed.
 **Done when:** the conformance absence case passes on deterministic local and
 browser providers, its broken control fails with the offending event, and the
 new manifest passes a real Hetzner dispatch.
+
+**D1 revalidation (2026-08-11):** the checked-in Hetzner manifest cannot
+express literal cross-room non-delivery — the Hetzner isolation contract
+(`scripts/github-actions/hetzner-run-manifest-scope.mjs`) pins every
+`applicationId`/`workspaceId`/`groupId`/`roomId`, state path, and
+ensure-group/member request identity in a manifest to one effective group,
+and the materializer fails closed on any second room. The shipped extended
+manifest `16-rtc-absence-wait-2-agent` therefore proves the strongest
+in-contract absence claims: a same-room positive control delivery first,
+then absence of leak-probe frames on the same connection and absence of
+silent `rallar.bb.rtc.send_failed` diagnostics. A true cross-room manifest
+needs an isolation-contract decision (declared secondary rooms) — deferred
+to a product call, not taken unilaterally. Cross-topic/cross-scope absence
+remains fully expressible in recipes outside the Hetzner materializer (the
+conformance cases cover it).
 
 ---
 

--- a/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
+++ b/plans/rallar-black-box-assertion-coverage-and-canonicalization-plan.md
@@ -7,8 +7,14 @@
 > choice that would otherwise block mid-task. Keep the draft PR and this record
 > current after every checkpoint.
 
-Status: in execution as a stacked PR series based on
-`fix/api-v1-blackbox-authz-presence-findings` (PR #161, unmerged base).
+Status: complete. Landed on `main` at `93483f47` (squash of the W1–W8
+stack via PR #173; per-workstream review history in PRs #165–#168 and
+#170–#173). Completion evidence: Branch Release Gate green on the final
+feature-branch commit `6f763ddf`; Run Hetzner Supported Distributed
+Manifests green on the resulting `main` commit `93483f47`. Open follow-ups:
+#174 (poll-round rewrite decision), #175 (remote-browser RTC absent), #176
+(distributed parity — now planned in
+[rallar-bb-test-distributed-assertion-parity-plan.md](./rallar-bb-test-distributed-assertion-parity-plan.md)).
 
 | Workstream | Status | Branch / PR |
 |---|---|---|

--- a/plans/repo-style-lineages/rallar-bb-test-distributed-assertion-parity.json
+++ b/plans/repo-style-lineages/rallar-bb-test-distributed-assertion-parity.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "lineages": [
+    {
+      "mergeBase": "93483f4760b68db3c3274f05b32025d3e567b755",
+      "source": {
+        "path": "packages/shared-test/rallar-bb-test/runtime.ts",
+        "blob": "01e6d1877dd91100d78edfd61d4eb6bb5a485a88"
+      },
+      "targets": [
+        "packages/shared-test/rallar-bb-test/wait/wait-event-match.ts",
+        "packages/shared-test/rallar-bb-test/wait/wait-for-event.ts"
+      ]
+    },
+    {
+      "mergeBase": "93483f4760b68db3c3274f05b32025d3e567b755",
+      "source": {
+        "path": "packages/shared-test/rallar-bb-test/composite-conformance.ts",
+        "blob": "0777ad7b71910da81763bf6a92a327852be29a26"
+      },
+      "targets": [
+        "packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts",
+        "packages/shared-test/rallar-bb-test/conformance/composite-conformance-recipes.ts"
+      ]
+    }
+  ]
+}

--- a/plans/repo-style-lineages/rallar-bb-test-distributed-assertion-parity.json
+++ b/plans/repo-style-lineages/rallar-bb-test-distributed-assertion-parity.json
@@ -20,7 +20,7 @@
       },
       "targets": [
         "packages/shared-test/rallar-bb-test/conformance/composite-conformance-command-fixtures.ts",
-        "packages/shared-test/rallar-bb-test/conformance/composite-conformance-recipes.ts"
+        "packages/shared-test/rallar-bb-test/conformance/create-rallar-black-box-composite-conformance-recipe.ts"
       ]
     }
   ]


### PR DESCRIPTION
## Distributed rallar-bb-test assertion-parity plan (plan-only)

One new plan document — `plans/rallar-bb-test-distributed-assertion-parity-plan.md` — implementing
the decision items of #176, plus the close-out of the landed W1–W8 plan record (`93483f47`, gate
evidence `6f763ddf` / `93483f47`).

### What the plan proposes (one PR per workstream)

- **D0 (P0, small)**: make `rtc.send.expect` fail closed on the control-protocol path — the one
  *silent* vacuous-assertion hole (the field validates but no agent code reads it); the in-process
  runner adapter bypasses `validateKeys` and keeps working. Plus: redact `http.request` result
  values (headers/body) to match their already-redacted mirrored events.
- **D1 (P0)**: `wait` absence mode (`absent: true`) with runner-matching full-window, whole-buffer
  semantics; conformance case with a broken control; one Hetzner cross-room non-delivery manifest.
- **D2 (P1)**: assert operators `gt/lt/between/length/matches` + `matchesShape` /
  `matchesShapeComplete` backed by `json-compare` — the first structural comparison in the dialect
  (today's primitive is `JSON.stringify` equality).
- **D3 (P1)**: `loop until: 'first-success'` polling with exponential backoff — today's loop aborts
  on first child failure and cannot poll; this is `http.poll-until`'s distributed twin.
- **D4 (P2)**: agent capability advertisement (`assertions` block, following the `crdt` precedent)
  + staging preflight gating — required before world-fleet no-spawn manifests may adopt operators,
  since only the Hetzner fleet moves atomically with the repo.
- **D5 (P2)**: assertion-outcome provider parity between the dialects (today's parity compares
  presence/status only) + artifact-analyzer awareness of the new failure codes.

### Grounding

Read for this plan: `rallar-hetzner-ops` skill (+ workflow/artifact references),
`schema-and-capabilities.md`, `schema-compatibility-guide.md`, `distributed-run-contract.md`,
`composite-conformance-matrix.md`, and a runtime probe (loop/wait/assert semantics with file:line
evidence, header capture, adapter validation bypass, strict `protocolVersion` equality, atomic
Hetzner rollout, and the five over-cap files with no registered exceptions — hence the new-module +
lineage-manifest landing-zone rule baked into every workstream).

Compatibility model: `schemaVersion` stays 1; every addition is an optional field or widened enum;
new-operator recipes on old agents fail closed loudly at `validateKeys` (intended); golden corpus +
upgrade note per change, enforced by the lockstep schema tests.

### Validation

Plan-only branch (all changed paths under `plans/`), excluded by
`branch-release-gate.yml` — no build gates apply per the plan-completion policy.
