### PR TITLE
fix(bb-test): D0 — rtc.send.expect fails closed on the control path

### DIFF
--- a/apps/rallar-black-box/src/manual-workbench.ts
+++ b/apps/rallar-black-box/src/manual-workbench.ts
@@ -543,10 +543,6 @@ export function manualRtcNackProbeCommands(
             negativeCase: 'not-yet-in-sync',
             expectedOutcome: 'nack',
         },
-        expect: {
-            outcome: 'nack',
-            code: 'not-yet-in-sync',
-        },
     }];
 }
 
@@ -574,10 +570,6 @@ export function manualRtcNegativeRecipeSnippet(
                 negativeCase: 'missing-peer',
                 expectedOutcome: 'delivery-failure',
             },
-            expect: {
-                status: 'failed',
-                code: 'missing-peer',
-            },
         },
         {
             ...asRtcSendCommand(manualSendCommand({
@@ -589,10 +581,6 @@ export function manualRtcNegativeRecipeSnippet(
             metadata: {
                 negativeCase: 'stale-agent',
                 expectedOutcome: 'delivery-failure',
-            },
-            expect: {
-                status: 'failed',
-                code: 'stale-agent',
             },
         },
         {
@@ -612,10 +600,6 @@ export function manualRtcNegativeRecipeSnippet(
                 negativeCase: 'permission-denied',
                 expectedOutcome: 'permission-failure',
             },
-            expect: {
-                status: 'failed',
-                code: 'permission-denied',
-            },
         },
         manualSimpleCommand('close', 7),
         {
@@ -625,10 +609,6 @@ export function manualRtcNegativeRecipeSnippet(
             metadata: {
                 negativeCase: 'closed-transport',
                 expectedOutcome: 'transport-failure',
-            },
-            expect: {
-                status: 'failed',
-                code: 'closed-transport',
             },
         },
         ...manualRtcNackProbeCommands(baseValues, payload, 9),

--- a/packages/shared-test/rallar-bb-test/control-protocol.ts
+++ b/packages/shared-test/rallar-bb-test/control-protocol.ts
@@ -1179,7 +1179,6 @@ export function validateRallarBlackBoxTestCommand(
                     ...base,
                     'connection',
                     'send',
-                    'expect',
                     'applicationId',
                     'workspaceId',
                     'scope',

--- a/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-and-capabilities.md
@@ -87,6 +87,24 @@ identity is not recipe-resolvable because simulated providers and external
 runtime configuration can remain valid. `refreshRoom` is an internal runtime
 bridge operation, not a recipe command or public command-schema field.
 
+## RTC Send Boundary And HTTP Result Evidence
+
+`rtc.send` has no `expect` field on the control path: the command schema and
+`validateRallarBlackBoxTestCommand` reject it, because no agent runtime ever
+evaluates it and a control-dispatched recipe carrying it would validate green
+while asserting nothing. The `RallarBlackBoxTestRtcSendCommand.expect`
+TypeScript field exists only for the in-process black-box-runner adapter,
+which calls `runtime.execute` directly and records runner-side expectations.
+Distributed delivery expectations belong in `wait` and `assert` commands.
+
+`http.request` results record `url`, `status`, `statusText`, `ok`, the full
+response header record, and the decoded body. Every recorded result value,
+failure detail, and the mirrored `rallar.bb.http.response` event passes the
+runtime redaction pipeline, so sensitive header and body names (authorization,
+cookie, token, ticket, and the other default key substrings) appear as
+`<redacted>` in results, events, failures, and artifacts. Header evidence is
+therefore assertable from recorded results without extra capture options.
+
 ## Validation
 
 Use `validateJsonSchema(schema, value)` for lightweight browser-safe validation.

--- a/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
@@ -153,3 +153,46 @@ Prompt/documentation updates:
 
 Verification:
 ```
+
+## Upgrade Notes
+
+```text
+Title: rtc.send.expect fails closed on the control-protocol path
+Date: 2026-08-11
+Owner: rallar-bb-test distributed assertion parity plan, workstream D0
+
+Change type:
+- Breaking schema change (removal of a silently ignored optional field)
+
+Affected schemas:
+- RALLAR_BLACK_BOX_TEST_RECIPE_SCHEMA
+- RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA (rtc.send branch)
+- validateRallarBlackBoxTestCommand rtc.send allowlist
+
+Old shape:
+rtc.send accepted an optional `expect` field. No agent runtime ever read it,
+so a control-dispatched recipe carrying it validated green while asserting
+nothing.
+
+New shape:
+rtc.send rejects `expect` at schema validation and control-protocol
+validateKeys ("rtc.send has unsupported field: expect."). The TypeScript
+field remains for the in-process black-box-runner adapter, which bypasses
+network validation and records runner-side expectations.
+
+Migration:
+Remove `expect` from distributed rtc.send commands; move authoring hints
+into `metadata`. Delivery expectations belong in `wait`/`assert` commands.
+
+Golden corpus updates:
+Added invalid recipe case `rtc-send-expect-rejected`.
+
+Prompt/documentation updates:
+rtc.send capability metadata no longer lists `expect`; capability
+description no longer mentions recorded expectations.
+
+Verification:
+npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-control-protocol.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
+```

--- a/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
+++ b/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
@@ -599,6 +599,31 @@
           }
         ]
       }
+    },
+    {
+      "caseId": "rtc-send-expect-rejected",
+      "expectedErrors": ["$.commands[0].expect: Unexpected property."],
+      "value": {
+        "schemaVersion": 1,
+        "recipeId": "rtc-send-expect-rejected",
+        "commands": [
+          {
+            "kind": "rtc.send",
+            "commandId": "rtc-send-with-expect",
+            "connection": "rtc",
+            "transport": "realtime",
+            "send": {
+              "roomId": "bb-group",
+              "data": {
+                "topic": "room.negative.expect"
+              }
+            },
+            "expect": {
+              "outcome": "ack"
+            }
+          }
+        ]
+      }
     }
   ],
   "invalidDistributedManifests": [

--- a/packages/shared-test/rallar-bb-test/schema.ts
+++ b/packages/shared-test/rallar-bb-test/schema.ts
@@ -584,7 +584,6 @@ const COMMAND_SCHEMAS: Readonly<Record<RallarBlackBoxCommandCapability['kind'], 
     'rtc.send': strictCommandSchema('rtc.send', [], {
         connection: stringSchema,
         send: anySchema,
-        expect: anySchema,
         applicationId: stringSchema,
         workspaceId: stringSchema,
         scope: recordSchema,
@@ -1021,12 +1020,11 @@ export const RALLAR_BLACK_BOX_COMMAND_CAPABILITIES: readonly RallarBlackBoxComma
     {
         kind: 'rtc.send',
         title: 'RTC Send',
-        description: 'Sends JSON through a connected RTC/realtime provider and optionally records expectations.',
+        description: 'Sends JSON through a connected RTC/realtime provider.',
         requiredFields: [],
         optionalFields: [
             'connection',
             'send',
-            'expect',
             'applicationId',
             'workspaceId',
             'scope',

--- a/packages/shared-test/rallar-bb-test/types.ts
+++ b/packages/shared-test/rallar-bb-test/types.ts
@@ -239,7 +239,7 @@ export type RallarBlackBoxTestRtcSendCommand =
     & Readonly<{
     connection?: string;
     send?: unknown;
-    expect?: unknown;
+    expect?: unknown; // black-box-runner-adapter in-process only; control validators reject it
     applicationId?: string;
     workspaceId?: string;
     scope?: Readonly<Record<string, unknown>>;

--- a/packages/tests/rallar-black-box/manual-workbench.test.ts
+++ b/packages/tests/rallar-black-box/manual-workbench.test.ts
@@ -293,11 +293,10 @@ describe('rallar-black-box manual workbench helpers', () => {
                 negativeCase: 'not-yet-in-sync',
                 expectedOutcome: 'nack',
             },
-            expect: {
-                outcome: 'nack',
-                code: 'not-yet-in-sync',
-            },
         });
+        for (const command of recipe.commands) {
+            expect(command.expect, command.commandId).toBeUndefined();
+        }
     });
 
     it('carries browser-rallar auth defaults into manual configure commands', () => {

--- a/packages/tests/shared-test/rallar-bb-test-http-result-redaction.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-http-result-redaction.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { createRallarBlackBoxBrowserTestRuntime } from '../../shared-test/rallar-bb-test/browser-adapter.ts';
+import type { RallarBlackBoxTestResult } from '../../shared-test/rallar-bb-test/types.ts';
+
+type HttpResultValue = Readonly<{
+    status: number;
+    headers: Readonly<Record<string, string>>;
+    body: Readonly<Record<string, unknown>>;
+}>;
+
+function httpResultValue(result: RallarBlackBoxTestResult | undefined): HttpResultValue {
+    expect(result?.ok).toBe(true);
+    return result?.value as HttpResultValue;
+}
+
+describe('http.request result redaction', () => {
+    it('redacts sensitive response headers and body fields in the recorded result and mirrored event', async () => {
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async () => new Response(
+                JSON.stringify({
+                    profile: { username: 'alice' },
+                    accessToken: 'live-access-token',
+                }),
+                {
+                    status: 200,
+                    headers: {
+                        'content-type': 'application/json',
+                        'x-session-cookie': 'session=live-cookie-value',
+                        'x-rallar-ticket': 'live-ticket-value',
+                    },
+                },
+            )) as typeof fetch,
+        });
+
+        const result = await runtime.execute({
+            kind: 'http.request',
+            commandId: 'http-sensitive-response',
+            request: {
+                url: 'https://api.example.test/api/session',
+                method: 'GET',
+            },
+            response: {
+                body: 'json',
+            },
+        });
+
+        const value = httpResultValue(result);
+        expect(value.status).toBe(200);
+        expect(value.headers['x-session-cookie']).toBe('<redacted>');
+        expect(value.headers['x-rallar-ticket']).toBe('<redacted>');
+        expect(value.headers['content-type']).toBe('application/json');
+        expect(value.body.accessToken).toBe('<redacted>');
+        expect(value.body.profile).toEqual({ username: 'alice' });
+
+        const cachedValue = httpResultValue(runtime.state().resultCache['http-sensitive-response']);
+        expect(cachedValue.headers['x-session-cookie']).toBe('<redacted>');
+        expect(cachedValue.body.accessToken).toBe('<redacted>');
+
+        const mirroredEvent = runtime.state().events
+            .find(event => event.topic === 'rallar.bb.http.response');
+        expect(mirroredEvent?.payload).toMatchObject({
+            status: 200,
+            headers: {
+                'x-session-cookie': '<redacted>',
+                'x-rallar-ticket': '<redacted>',
+            },
+            body: {
+                accessToken: '<redacted>',
+            },
+        });
+    });
+
+    it('redacts the http result recorded for a rejected status code', async () => {
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async () => new Response(
+                JSON.stringify({ error: 'denied', refreshToken: 'live-refresh-token' }),
+                {
+                    status: 403,
+                    headers: {
+                        'content-type': 'application/json',
+                        authorization: 'Bearer leaked-server-echo',
+                    },
+                },
+            )) as typeof fetch,
+        });
+
+        const result = await runtime.execute({
+            kind: 'http.request',
+            commandId: 'http-rejected-status',
+            request: {
+                url: 'https://api.example.test/api/denied',
+                method: 'GET',
+            },
+            response: {
+                body: 'json',
+                acceptedStatusCodes: [200],
+            },
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe('RALLAR_BLACK_BOX_HTTP_STATUS_NOT_ACCEPTED');
+        const failedValue = result.value as HttpResultValue;
+        expect(failedValue.headers.authorization).toBe('<redacted>');
+        expect(failedValue.body.refreshToken).toBe('<redacted>');
+        const errorDetails = result.error?.details as HttpResultValue;
+        expect(errorDetails.headers.authorization).toBe('<redacted>');
+        expect(errorDetails.body.refreshToken).toBe('<redacted>');
+    });
+});

--- a/packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-rtc-send-expect-fail-closed.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { createRallarBlackBoxRtcClient } from '../../shared-test/rallar-bb-test/black-box-runner-adapter.ts';
+import { validateRallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/control-protocol.ts';
+import { createRallarBlackBoxTestRuntime } from '../../shared-test/rallar-bb-test/runtime.ts';
+import {
+    RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA,
+    formatJsonSchemaValidationErrors,
+    validateJsonSchema,
+} from '../../shared-test/rallar-bb-test/schema.ts';
+import type { RallarBlackBoxTestRtcSendCommand } from '../../shared-test/rallar-bb-test/types.ts';
+
+const rtcSendWithExpect = {
+    kind: 'rtc.send',
+    commandId: 'rtc-send-with-expect',
+    connection: 'rtc',
+    transport: 'realtime',
+    send: {
+        roomId: 'bb-group',
+        data: {
+            topic: 'room.negative.expect',
+        },
+    },
+    expect: {
+        outcome: 'ack',
+    },
+} as const satisfies RallarBlackBoxTestRtcSendCommand & Readonly<{ commandId: string }>;
+
+function createDeterministicRuntime() {
+    let now = 1_000;
+    let sequence = 1;
+    return createRallarBlackBoxTestRuntime({
+        now: () => now++,
+        idFactory: (prefix) => `${prefix}-${sequence++}`,
+    });
+}
+
+describe('rtc.send expect fail-closed boundary', () => {
+    it('rejects a control-dispatched rtc.send carrying expect', () => {
+        expect(validateRallarBlackBoxTestCommand(rtcSendWithExpect)).toEqual({
+            ok: false,
+            error: 'rtc.send has unsupported field: expect.',
+        });
+    });
+
+    it('still accepts a control-dispatched rtc.send without expect', () => {
+        const { expect: _discarded, ...withoutExpect } = rtcSendWithExpect;
+        expect(validateRallarBlackBoxTestCommand(withoutExpect)).toEqual({ ok: true });
+    });
+
+    it('rejects expect in the rtc.send command schema branch', () => {
+        const result = validateJsonSchema(RALLAR_BLACK_BOX_TEST_COMMAND_SCHEMA, rtcSendWithExpect);
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(formatJsonSchemaValidationErrors(result.errors)).toContain(
+                '$.expect: Unexpected property.',
+            );
+        }
+    });
+
+    it('keeps the in-process black-box-runner adapter executing rtc.send with expectations', async () => {
+        const runtime = createDeterministicRuntime();
+        const client = createRallarBlackBoxRtcClient(runtime, {
+            name: 'adapterRtc',
+            roomId: 'bb-group',
+            applicationId: 'rallar-server',
+        });
+
+        await client.send(
+            { topic: 'room.adapter.parity', text: 'hello' },
+            { response: { outcome: 'ack' } },
+        );
+
+        const sendResult = runtime.state().commandHistory.find(result => result.kind === 'rtc.send');
+        expect(sendResult?.ok).toBe(true);
+
+        const sendDiagnostic = runtime.state().events
+            .find(event => event.topic === 'rallar.bb.fake.rtc.send');
+        expect(sendDiagnostic?.payload).toMatchObject({
+            command: {
+                kind: 'rtc.send',
+                expect: { outcome: 'ack' },
+            },
+        });
+    });
+});

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -7,12 +7,12 @@
 > intended starting instruction; the baked-in decision resolves the one choice
 > that would otherwise block mid-task.
 
-Status: proposed; not started. Implements the decision items of issue
+Status: in progress. Implements the decision items of issue
 [#176](https://github.com/intact-software-systems/ar-eye-hunter/issues/176).
 
 | Workstream | Status | Branch / PR |
 |---|---|---|
-| D0 fail-closed `rtc.send.expect` + http result redaction | not started | — |
+| D0 fail-closed `rtc.send.expect` + http result redaction | in review | `codex/bb-test-d0-fail-closed-rtc-send-expect` |
 | D1 `wait` absence mode | not started | — |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |
@@ -119,6 +119,17 @@ entirely (`runtime.execute` directly, no `validateKeys` on that path), so the
 in-process runner adapter keeps working; only control-server-delivered
 commands fail closed. For redaction: pass `http.request` result `value`
 through the same redaction the mirrored event already gets.
+
+**D0 revalidation (2026-08-11):** the redaction gap does not exist —
+`toResult` (`runtime.ts:2476`) already passes every command result `value`
+and `error` through the redaction pipeline, with the default key substrings
+applying even before any `configure` sets redaction options, at the plan's
+own evidence base `93483f47` and on current `main`. D0 therefore proves the
+behavior with regression tests
+(`rallar-bb-test-http-result-redaction.test.ts`) and documents it instead of
+adding a duplicate redaction pass. The fail-closed `expect` half proceeds as
+written; the manual-workbench negative snippets stop emitting the vacuous
+`expect` blobs so app-generated recipes stay dispatchable.
 
 **Prompt:**
 

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -12,7 +12,7 @@ Status: in progress. Implements the decision items of issue
 
 | Workstream | Status | Branch / PR |
 |---|---|---|
-| D0 fail-closed `rtc.send.expect` + http result redaction | in review | `codex/bb-test-d0-fail-closed-rtc-send-expect` |
+| D0 fail-closed `rtc.send.expect` + http result redaction | in review | [#180](https://github.com/intact-software-systems/ar-eye-hunter/pull/180) |
 | D1 `wait` absence mode | not started | — |
 | D2 assert operator extension | not started | — |
 | D3 `loop` until-success polling | not started | — |


### PR DESCRIPTION
## Summary

Workstream **D0** of [the distributed assertion-parity plan](https://github.com/intact-software-systems/ar-eye-hunter/blob/codex/bb-test-d0-fail-closed-rtc-send-expect/plans/rallar-bb-test-distributed-assertion-parity-plan.md) (stack layer 2; parent #178, plan on the base branch). Implements decision item 2 of #176: the one silent vacuous-assertion path in the distributed dialect fails closed.

- `rtc.send` rejects `expect` at both network validators: dropped from the `validateKeys` allowlist in `control-protocol.ts` (`rtc.send has unsupported field: expect.`) and from the command schema branch + capability metadata in `schema.ts` (`$.expect: Unexpected property.`).
- `RallarBlackBoxTestRtcSendCommand.expect` stays in `types.ts`, commented as in-process-adapter-only: `black-box-runner-adapter.ts` calls `runtime.execute` directly and keeps recording runner-side expectations (regression-tested).
- Manual-workbench RTC negative snippets stop emitting the vacuous `expect` blobs (agent runtimes never read them; after this change they would also make the copied snippets undispatchable). Their `metadata.negativeCase`/`expectedOutcome` already carry the intent.
- Golden corpus gains invalid case `rtc-send-expect-rejected`; first entry in the new **Upgrade Notes** section of `schema-compatibility-guide.md`; `schema-and-capabilities.md` documents the boundary and http result evidence.

## Plan revalidation — the D0 redaction gap does not exist

The plan claimed http.request result values are recorded unredacted. Revalidation (per the plan's own instruction) shows `toResult` (`runtime.ts:2476`) already redacts every result `value`/`error` with the default key substrings, even before any `configure` — verified at the plan's evidence base `93483f47` and current `main`. D0 therefore adds no duplicate redaction pass; it pins the behavior with `rallar-bb-test-http-result-redaction.test.ts` (result value, result cache, failure details, mirrored `rallar.bb.http.response` event) and records the outcome in the plan doc. The D0 "Done when" criterion (sensitive header names show redaction placeholders) is met and proven.

## Validation

- `npx vitest run` rallar-bb-test-schema, -control-protocol, -rtc-send-expect-fail-closed (new), -http-result-redaction (new), -composite-conformance, rallar-companion-coverage, -recipe-fixtures, manual-workbench — pass
- `npm run test:repo-governance` — 391 pass
- control server `deno task check` + `deno task test` — 79 pass (protocol allowlist changed)
- `npm --workspace @ar-eye-hunter/shared-test run typecheck`, `npm --workspace rallar-black-box run typecheck` — pass
- `npm run check:repo-style:changed -- origin/main HEAD` — PASS (no new findings; no net growth of the five over-cap files: control-protocol −1, schema −2, types ±0)

Base: `codex/bb-test-assertion-parity-plan`. Plan Status table updated (D0 → in review). Follow-up issues: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)