### PR TITLE
feat(pr-review): record not-legacy candidates in aggregate for large reports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -116,6 +116,18 @@ legacy item uses `classification: legacy` and exactly one disposition:
 `classification: not-legacy` with a concrete rationale; it is not a legacy
 exception or an implicit disposition.
 
+When per-item `not-legacy` rows would push the pull request body over the
+GitHub body size cap, a stage ledger may record its not-legacy candidates in
+aggregate instead: a `notLegacyAggregate` object beside `items` holding the
+aggregated candidate count, the whole-report SHA-256 (the `REPORT-SHA256`
+line from `npm run review:legacy`, reproducible byte-exactly with
+`--report-out`), the location where the full report is preserved (a workflow
+artifact or a committed evidence file), and one concrete rationale. Every
+legacy-classified item keeps its own ledger row; the aggregate never carries
+a disposition or approval. `Legacy candidate count` equals the per-item rows
+plus the aggregate count, and the stage check recomputes the report and
+rejects an aggregate whose digest or count does not match.
+
 The final review's `Legacy ledger and dispositions` field is the one bound,
 human-readable retained ledger. `Legacy exception ID` is the projection's `id`.
 Each retained item also presents the exact path and symbol, purpose, consumer

--- a/docs/pr-human-review-record.md
+++ b/docs/pr-human-review-record.md
@@ -168,6 +168,33 @@ command validates their shape, but not semantic quality or whether the cited
 GitHub review is a trusted human approval; those remain the PR record validator
 and human's responsibility.
 
+### Aggregated not-legacy candidates for large reports
+
+A large candidate report can exceed GitHub's pull-request body size cap when
+every not-legacy candidate receives its own ledger row, because the ledger
+appears both in the visible section and in the metadata fence. For that case a
+stage ledger may replace its per-item `not-legacy` rows with one
+`notLegacyAggregate` object beside `items`:
+
+- `count`: the number of aggregated not-legacy candidates;
+- `reportSha256`: the whole-report SHA-256 printed as `REPORT-SHA256` by
+  `npm run review:legacy` (write the byte-exact report with
+  `--report-out path/to/report.json`);
+- `evidence`: where the full canonical report is preserved — a workflow
+  artifact or a committed evidence file;
+- `rationale`: one concrete rationale for the aggregate classification.
+
+Per-item rows stay mandatory for every `legacy`-classified item, and the
+aggregate never carries a disposition or approval fields. The stage's
+`Legacy candidate count` equals the per-item rows plus the aggregate count.
+The trusted stage check recomputes the stage's candidate report from Git data
+and rejects an aggregate whose `count` or `reportSha256` does not match the
+recomputed report, so the aggregate binds exactly the reported candidate set.
+Aggregation is optional: a report whose per-item rows fit the body cap keeps
+the fully itemized form, and previously published itemized records remain
+valid. Aggregated candidates remain human-classified evidence — the digest
+preserves auditability; it does not approve the classification.
+
 Every legacy item in the active plan's affected production surface has exactly
 one disposition:
 

--- a/packages/tests/repo/legacy-review-stage-driver.test.ts
+++ b/packages/tests/repo/legacy-review-stage-driver.test.ts
@@ -75,6 +75,36 @@ describe('PR legacy review stage driver', () => {
     expect(result.stdout).toContain('validated 2 exact-SHA legacy candidate review stage(s)');
   });
 
+  it('validates an aggregated not-legacy stage ledger against the recomputed report', () => {
+    const fixture = createStageFixture();
+    const items = reportedItems(fixture, 'resolved');
+    const record = {
+      scope: 'code-changing',
+      initialReview: {
+        mergeBaseSha: fixture.base,
+        headSha: fixture.head,
+        legacy: {
+          candidateCount: items.length,
+          items: [],
+          notLegacyAggregate: {
+            count: items.length,
+            reportSha256: stageReportDigest(fixture),
+            evidence: 'Workflow artifact legacy-report-initial for this fixture run.',
+            rationale: 'Deliberate alternate-route alias with no predecessor implementation.',
+          },
+        },
+      },
+      milestoneReview: { classification: 'none', entries: [] },
+      finalReview: null,
+      retainedLegacy: [],
+    };
+
+    const result = runStageDriver(fixture, record, true);
+
+    expect(result.status, result.stdout).toBe(0);
+    expect(result.stdout).toContain('validated 1 exact-SHA legacy candidate review stage(s)');
+  });
+
   it('rejects a stage ledger that is not the exact scanner candidate set', () => {
     const fixture = createStageFixture();
     const incompleteItems = reportedItems(fixture, 'resolved').slice(1);
@@ -164,6 +194,17 @@ function reportedItems(fixture: ReturnType<typeof createStageFixture>, dispositi
         disposition,
       };
     });
+}
+
+function stageReportDigest(fixture: ReturnType<typeof createStageFixture>): string {
+  const result = spawnSync(process.execPath, [legacyReviewPath, fixture.base, fixture.head], {
+    cwd: fixture.root,
+    encoding: 'utf8',
+  });
+  expect(result.status, result.stdout).toBe(0);
+  const digestLine = result.stdout.split('\n').find((line) => line.startsWith('REPORT-SHA256: '));
+  expect(digestLine, result.stdout).toBeDefined();
+  return (digestLine ?? '').slice('REPORT-SHA256: '.length);
 }
 
 function stageReview(

--- a/packages/tests/repo/legacy-review.test.ts
+++ b/packages/tests/repo/legacy-review.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -330,6 +331,117 @@ describe('changed production legacy review', () => {
     );
   });
 
+  it('emits a reproducible whole-report digest and canonical report file', () => {
+    const fixture = createGitFixture({
+      'packages/example/src/compatibility-route.ts': [
+        "export { createCanonicalRoute as createLegacyRoute } from './canonical-route.ts';",
+        "export const fallbackMode = 'legacy';",
+      ].join('\n'),
+    });
+
+    const result = runLegacyReview(fixture, ['--report-out', 'report.json']);
+
+    expect(result.status, result.stdout).toBe(0);
+    const digest = reportDigest(result.stdout);
+    const reportText = readFileSync(path.join(fixture.root, 'report.json'), 'utf8');
+    expect(createHash('sha256').update(reportText).digest('hex')).toBe(digest);
+    const report = JSON.parse(reportText) as {
+      version: number;
+      mergeBase: string;
+      head: string;
+      candidateCount: number;
+      candidates: readonly { id: string }[];
+    };
+    expect(report.version).toBe(1);
+    expect(report.mergeBase).toBe(fixture.base);
+    expect(report.head).toBe(fixture.head);
+    expect(report.candidateCount).toBeGreaterThan(1);
+    expect(report.candidates.map((candidate) => candidate.id)).toEqual(candidateIds(result.stdout));
+  });
+
+  it('accepts an aggregated not-legacy ledger bound to the recomputed report digest', () => {
+    const fixture = createGitFixture({
+      'packages/example/src/compatibility-route.ts': [
+        "export { createCanonicalRoute as createLegacyRoute } from './canonical-route.ts';",
+        "export const fallbackMode = 'legacy';",
+      ].join('\n'),
+    });
+    const digest = reportDigest(runLegacyReview(fixture).stdout);
+    const items = reportedItems(fixture, 'resolved');
+    writeFileSync(
+      path.join(fixture.root, 'review.json'),
+      JSON.stringify({
+        finalReview: {
+          legacy: {
+            candidateCount: items.length,
+            items: [items[0]],
+            notLegacyAggregate: {
+              count: items.length - 1,
+              reportSha256: digest,
+              evidence: 'Committed evidence file docs/evidence/legacy-report.json in this change.',
+              rationale: 'Heuristic vocabulary matches with no predecessor implementation.',
+            },
+          },
+        },
+      }),
+    );
+
+    const complete = runLegacyReview(fixture, ['--review-record', 'review.json']);
+
+    expect(complete.status, complete.stdout).toBe(0);
+    expect(complete.stdout).toContain(
+      'PASS: supplied final review ledger disposes every reported candidate',
+    );
+  });
+
+  it('rejects an aggregated ledger whose digest or count does not match the report', () => {
+    const fixture = createGitFixture({
+      'packages/example/src/compatibility-route.ts': [
+        "export { createCanonicalRoute as createLegacyRoute } from './canonical-route.ts';",
+        "export const fallbackMode = 'legacy';",
+      ].join('\n'),
+    });
+    const digest = reportDigest(runLegacyReview(fixture).stdout);
+    const items = reportedItems(fixture, 'resolved');
+    const aggregatedReview = (aggregate: Readonly<Record<string, unknown>>) => ({
+      finalReview: {
+        legacy: {
+          candidateCount: items.length,
+          items: [items[0]],
+          notLegacyAggregate: aggregate,
+        },
+      },
+    });
+    const validAggregate = {
+      count: items.length - 1,
+      reportSha256: digest,
+      evidence: 'Committed evidence file docs/evidence/legacy-report.json in this change.',
+      rationale: 'Heuristic vocabulary matches with no predecessor implementation.',
+    };
+
+    writeFileSync(
+      path.join(fixture.root, 'review.json'),
+      JSON.stringify(aggregatedReview({ ...validAggregate, reportSha256: 'd'.repeat(64) })),
+    );
+    const staleDigest = runLegacyReview(fixture, ['--review-record', 'review.json']);
+
+    expect(staleDigest.status).toBe(1);
+    expect(staleDigest.stdout).toContain(
+      'FAIL: final review aggregate report digest does not match the recomputed report',
+    );
+
+    writeFileSync(
+      path.join(fixture.root, 'review.json'),
+      JSON.stringify(aggregatedReview({ ...validAggregate, count: items.length })),
+    );
+    const wrongCount = runLegacyReview(fixture, ['--review-record', 'review.json']);
+
+    expect(wrongCount.status).toBe(1);
+    expect(wrongCount.stdout).toContain(
+      'FAIL: final review ledger candidate count must equal items',
+    );
+  });
+
   it('discovers renamed and deleted predecessor paths, non-ASCII paths, and operational support code', () => {
     const fixture = createGitFixture({
       'packages/example/src/old-route.ts': 'export const runRoute = () => 200;\n',
@@ -470,6 +582,12 @@ function candidateLines(output: string): string[] {
 
 function candidateIds(output: string): string[] {
   return candidateLines(output).map((line) => line.split(' ')[1]);
+}
+
+function reportDigest(output: string): string {
+  const digestLine = output.split('\n').find((line) => line.startsWith('REPORT-SHA256: '));
+  expect(digestLine, output).toBeDefined();
+  return (digestLine ?? '').slice('REPORT-SHA256: '.length);
 }
 
 function writeFixture(root: string, file: string, content: string): void {

--- a/packages/tests/repo/pr-human-review-record-contract.test.ts
+++ b/packages/tests/repo/pr-human-review-record-contract.test.ts
@@ -117,6 +117,29 @@ describe('PR human review record contract', () => {
     ]);
   });
 
+  it('documents the aggregated not-legacy ledger option for oversized candidate reports', () => {
+    const template = readRepo(templatePath);
+    const contract = readRepo(reviewRecordPath);
+
+    for (const source of [template, contract]) {
+      expectAllNormalized(source, [
+        'notLegacyAggregate',
+        'REPORT-SHA256',
+        'workflow artifact or a committed evidence file',
+      ]);
+    }
+    expectAllNormalized(template, [
+      'Every legacy-classified item keeps its own ledger row',
+      'the aggregate never carries a disposition or approval',
+      'equals the per-item rows plus the aggregate count',
+    ]);
+    expectAllNormalized(contract, [
+      'Per-item rows stay mandatory for every `legacy`-classified item',
+      'rejects an aggregate whose `count` or `reportSha256` does not match',
+      'previously published itemized records remain valid',
+    ]);
+  });
+
   it('allows a documented exemption only for plan, documentation, or agent-guidance-only pull requests', () => {
     const template = readRepo(templatePath);
     const contract = readRepo(reviewRecordPath);

--- a/packages/tests/repo/pr-human-review-validation.test.ts
+++ b/packages/tests/repo/pr-human-review-validation.test.ts
@@ -227,6 +227,111 @@ describe('PR human review record validator', () => {
     expect(ledgerResult.stdout).toContain('legacyLedger');
   });
 
+  it('keeps a 216-candidate aggregated record valid and under the GitHub body cap', () => {
+    const legacyItems = [
+      {
+        id: 'production-legacy-candidate-aaaa000000000001',
+        path: 'apps/example/compat-route.ts',
+        symbol: 'compatRoute',
+        classification: 'legacy',
+        disposition: 'resolved',
+      },
+      {
+        id: 'production-legacy-candidate-aaaa000000000002',
+        path: 'apps/example/compat-mode.ts',
+        symbol: 'compatMode',
+        classification: 'legacy',
+        disposition: 'removed',
+      },
+    ];
+    const aggregatedLegacy = {
+      candidateCount: 216,
+      items: legacyItems,
+      notLegacyAggregate: {
+        count: 214,
+        reportSha256: 'c'.repeat(64),
+        evidence: 'Workflow artifact legacy-report-final on the validating workflow run.',
+        rationale: 'Mechanical migration-sweep candidates with no predecessor implementation.',
+      },
+    };
+    const body = recordBody({
+      initialReview: review({ legacy: aggregatedLegacy }),
+      finalReview: review({ stage: 'final', legacy: aggregatedLegacy }),
+    });
+    const fixture = createFixture({
+      draft: false,
+      body,
+      changedPaths: ['scripts/new-check.mjs'],
+    });
+
+    const result = runValidator(fixture);
+
+    expect(result.status, result.stdout).toBe(0);
+    expect(body.length).toBeLessThan(60_000);
+  });
+
+  it.each([
+    {
+      name: 'count arithmetic that does not cover the candidate count',
+      patch: { count: 2 },
+      candidateCount: 4,
+      expected: 'legacy candidate count must equal ledger items plus the aggregate',
+    },
+    {
+      name: 'a malformed whole-report digest',
+      patch: { reportSha256: 'deadbeef' },
+      candidateCount: 3,
+      expected: 'not-legacy aggregate report SHA-256 must be exact',
+    },
+    {
+      name: 'a placeholder aggregate rationale',
+      patch: { rationale: 'TBD' },
+      candidateCount: 3,
+      expected: 'not-legacy aggregate requires a concrete rationale',
+    },
+    {
+      name: 'a smuggled aggregate disposition',
+      patch: { disposition: 'resolved' },
+      candidateCount: 3,
+      expected: 'not-legacy aggregate has unsupported fields: disposition',
+    },
+  ])('rejects an aggregated ledger with $name', ({ patch, candidateCount, expected }) => {
+    const fixture = createFixture({
+      body: recordBody({
+        initialReview: review({
+          legacy: {
+            candidateCount,
+            items: [],
+            notLegacyAggregate: { ...validNotLegacyAggregate(), ...patch },
+          },
+        }),
+      }),
+      changedPaths: ['scripts/new-check.mjs'],
+    });
+
+    const result = runValidator(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(expected);
+  });
+
+  it('binds the visible aggregated ledger to the metadata aggregate', () => {
+    const body = recordBody({
+      initialReview: review({
+        legacy: { candidateCount: 3, items: [], notLegacyAggregate: validNotLegacyAggregate() },
+      }),
+    });
+    const fixture = createFixture({
+      body: body.replace('"count":3', '"count":4'),
+      changedPaths: ['scripts/new-check.mjs'],
+    });
+
+    const result = runValidator(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('initial visible review contradicts metadata: legacyLedger');
+  });
+
   it('accepts reviewed milestone entries and binds every review field to visible evidence', () => {
     const milestone = milestoneReview();
     const fixture = createFixture({
@@ -997,6 +1102,7 @@ interface Review {
     readonly candidateCount: number;
     readonly items: readonly Record<string, string>[];
     readonly candidatesInspected: string;
+    readonly notLegacyAggregate?: Readonly<Record<string, unknown>>;
   };
 }
 
@@ -1088,6 +1194,15 @@ function trustedReview(
         .sort()
         .join(',')}`,
     ].join('\n'),
+  };
+}
+
+function validNotLegacyAggregate(): Readonly<Record<string, unknown>> {
+  return {
+    count: 3,
+    reportSha256: 'c'.repeat(64),
+    evidence: 'Workflow artifact legacy-report-initial on the validating workflow run.',
+    rationale: 'Vocabulary-only candidates from a mechanical migration sweep.',
   };
 }
 
@@ -1239,9 +1354,7 @@ function visibleReview(
     `- Behavior and judgment not proven by automation: ${review.narrative.automationGaps}`,
     `- Legacy candidate count: ${review.legacy.candidateCount}`,
     `- Legacy ledger and dispositions: ${JSON.stringify(
-      stage === 'final'
-        ? enrichedLedgerForTest(review.legacy.items, retainedLegacy)
-        : [...review.legacy.items].sort((left, right) => left.id.localeCompare(right.id)),
+      visibleLedgerForTest(review, stage, retainedLegacy),
     )}`,
     ...(stage === 'final'
       ? [
@@ -1252,6 +1365,30 @@ function visibleReview(
     `- Important findings unresolved: ${review.unresolvedFindings.important}`,
     `- Verdict: ${review.verdict}`,
   ];
+}
+
+function visibleLedgerForTest(
+  review: Review,
+  stage: 'initial' | 'milestone' | 'final',
+  retainedLegacy: readonly ReturnType<typeof retainedApproval>[],
+): unknown {
+  const items =
+    stage === 'final'
+      ? enrichedLedgerForTest(review.legacy.items, retainedLegacy)
+      : [...review.legacy.items].sort((left, right) => left.id.localeCompare(right.id));
+  const aggregate = review.legacy.notLegacyAggregate;
+  if (!aggregate) {
+    return items;
+  }
+  return {
+    items,
+    notLegacyAggregate: {
+      count: aggregate.count,
+      reportSha256: aggregate.reportSha256,
+      evidence: aggregate.evidence,
+      rationale: aggregate.rationale,
+    },
+  };
 }
 
 function enrichedLedgerForTest(

--- a/scripts/legacy-review/candidate-report.mjs
+++ b/scripts/legacy-review/candidate-report.mjs
@@ -21,6 +21,32 @@ export function deduplicateAndSort(candidates) {
   );
 }
 
+export function toCanonicalReport(input) {
+  return {
+    version: 1,
+    mergeBase: input.mergeBase,
+    head: input.head,
+    candidateCount: input.candidates.length,
+    candidates: input.candidates.map((item) => ({
+      id: item.id,
+      kind: item.kind,
+      path: item.path,
+      line: item.line,
+      symbol: item.symbol,
+      reason: item.reason,
+      detail: item.detail,
+    })),
+  };
+}
+
+export function toCanonicalReportText(report) {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function computeReportSha256(reportText) {
+  return createHash('sha256').update(reportText).digest('hex');
+}
+
 export function printReport(result) {
   console.log(`Legacy candidate review: ${result.mergeBase} -> ${result.head}`);
   console.log(
@@ -33,6 +59,7 @@ export function printReport(result) {
   );
   if (result.exempt)
     return console.log('PASS: explicit PR-review exemption skips legacy candidate scanning');
+  console.log(`REPORT-SHA256: ${result.reportSha256}`);
   if (result.candidates.length === 0)
     return console.log('PASS: no changed production legacy candidates');
   console.log(

--- a/scripts/legacy-review/validate-supplied-evidence.mjs
+++ b/scripts/legacy-review/validate-supplied-evidence.mjs
@@ -1,7 +1,16 @@
 import { readFileSync } from 'node:fs';
 
 import { readRegistrySection } from '../pr-human-review/trusted-retained-legacy.mjs';
-import { validateLegacyItemShape } from '../pr-human-review/validate-legacy-item.mjs';
+import {
+  resolveNotLegacyAggregateCount,
+  validateLegacyItemShape,
+  validateNotLegacyAggregateShape,
+} from '../pr-human-review/validate-legacy-item.mjs';
+import {
+  computeReportSha256,
+  toCanonicalReport,
+  toCanonicalReportText,
+} from './candidate-report.mjs';
 
 export function validateSuppliedEvidence(input, candidates) {
   if (!input.reviewRecord) {
@@ -21,11 +30,17 @@ export function validateSuppliedEvidence(input, candidates) {
   if (reviews.length === 0) {
     return stage === 'milestone' ? [] : [`${stage} review legacy ledger is required`];
   }
+  const reportSha256 = computeReportSha256(
+    toCanonicalReportText(
+      toCanonicalReport({ mergeBase: input.mergeBase, head: input.head, candidates }),
+    ),
+  );
   const errors = [];
   for (const [index, review] of reviews.entries()) {
     validateLedger({
       legacy: review?.legacy,
       candidates,
+      reportSha256,
       errors,
       label: stage === 'milestone' ? `milestone review ${index + 1}` : `${stage} review`,
       registryPath: input.registry,
@@ -51,6 +66,7 @@ function reviewsForStage(record, stage) {
 function validateLedger({
   legacy,
   candidates,
+  reportSha256,
   errors,
   label,
   registryPath,
@@ -61,10 +77,18 @@ function validateLedger({
     errors.push(`${label} legacy ledger is required and must include candidateCount and items`);
     return;
   }
-  if (legacy.candidateCount !== legacy.items.length) {
+  const aggregate = legacy.notLegacyAggregate ?? undefined;
+  if (aggregate !== undefined) {
+    validateNotLegacyAggregateShape({ aggregate, label, errors });
+    if (aggregate?.reportSha256 !== reportSha256) {
+      errors.push(`${label} aggregate report digest does not match the recomputed report`);
+    }
+  }
+  const coveredCount = legacy.items.length + resolveNotLegacyAggregateCount(aggregate);
+  if (legacy.candidateCount !== coveredCount) {
     errors.push(`${label} ledger candidate count must equal items`);
   }
-  if (legacy.items.length !== candidates.length) {
+  if (coveredCount !== candidates.length) {
     errors.push(`${label} ledger candidate count must equal report count (${candidates.length})`);
   }
   const itemsById = collectLedgerItems({
@@ -76,7 +100,13 @@ function validateLedger({
   });
   const candidateIds = new Set(candidates.map((candidate) => candidate.id));
   for (const candidate of candidates) {
-    validateCandidateDisposition({ candidate, itemsById, errors, label });
+    validateCandidateDisposition({
+      candidate,
+      itemsById,
+      errors,
+      label,
+      aggregateCoversMissing: aggregate !== undefined,
+    });
   }
   for (const identifier of itemsById.keys()) {
     if (!candidateIds.has(identifier)) {
@@ -131,10 +161,18 @@ function collectLedgerItems({ items, errors, label, retainedLegacy, requireRetai
   return itemsById;
 }
 
-function validateCandidateDisposition({ candidate, itemsById, errors, label }) {
+function validateCandidateDisposition({
+  candidate,
+  itemsById,
+  errors,
+  label,
+  aggregateCoversMissing,
+}) {
   const item = itemsById.get(candidate.id);
   if (!item) {
-    errors.push(`${label} ledger is missing disposition: ${candidate.id}`);
+    if (!aggregateCoversMissing) {
+      errors.push(`${label} ledger is missing disposition: ${candidate.id}`);
+    }
     return;
   }
   if (item.path !== candidate.path || item.symbol !== candidate.symbol) {

--- a/scripts/pr-human-review/validate-legacy-item.mjs
+++ b/scripts/pr-human-review/validate-legacy-item.mjs
@@ -29,6 +29,41 @@ const retainedApprovalOnlyFields = retainedApprovalFields.filter(
   (field) => !['id', 'path', 'symbol'].includes(field),
 );
 
+export const notLegacyAggregateFields = ['count', 'reportSha256', 'evidence', 'rationale'];
+
+export function resolveNotLegacyAggregateCount(aggregate) {
+  return isPlainRecord(aggregate) && Number.isInteger(aggregate.count) && aggregate.count > 0
+    ? aggregate.count
+    : 0;
+}
+
+export function validateNotLegacyAggregateShape({ aggregate, label, errors }) {
+  if (!isPlainRecord(aggregate)) {
+    errors.push(`${label} not-legacy aggregate must be a plain object`);
+    return;
+  }
+  const unsupportedFields = Object.keys(aggregate).filter(
+    (field) => !notLegacyAggregateFields.includes(field),
+  );
+  if (unsupportedFields.length > 0) {
+    errors.push(
+      `${label} not-legacy aggregate has unsupported fields: ${unsupportedFields.join(', ')}`,
+    );
+  }
+  if (!Number.isInteger(aggregate.count) || aggregate.count <= 0) {
+    errors.push(`${label} not-legacy aggregate count must be a positive integer`);
+  }
+  if (!exactHash.test(aggregate.reportSha256 ?? '')) {
+    errors.push(`${label} not-legacy aggregate report SHA-256 must be exact`);
+  }
+  if (!isEvidenceText(aggregate.evidence)) {
+    errors.push(`${label} not-legacy aggregate evidence location is required`);
+  }
+  if (!isConcreteRationale(aggregate.rationale)) {
+    errors.push(`${label} not-legacy aggregate requires a concrete rationale`);
+  }
+}
+
 export function validateLegacyItemShape(input) {
   const { item, label, errors } = input;
   const retainedApproval = input.retainedApproval;

--- a/scripts/pr-human-review/validate-review-evidence.mjs
+++ b/scripts/pr-human-review/validate-review-evidence.mjs
@@ -1,5 +1,10 @@
 import { retainedLedgerProjection } from './trusted-retained-legacy.mjs';
-import { validateLegacyItemShape } from './validate-legacy-item.mjs';
+import {
+  notLegacyAggregateFields,
+  resolveNotLegacyAggregateCount,
+  validateLegacyItemShape,
+  validateNotLegacyAggregateShape,
+} from './validate-legacy-item.mjs';
 
 const exactSha = /^[0-9a-f]{40}$/u;
 
@@ -218,7 +223,7 @@ function visibleFields(review, stage, retainedLegacy) {
     ['Legacy candidate count', String(review.legacy?.candidateCount), 'legacyCandidateCount'],
     [
       'Legacy ledger and dispositions',
-      JSON.stringify(visibleLegacyLedger(review.legacy.items, stage, retainedLegacy)),
+      JSON.stringify(visibleLegacyLedger(review.legacy, stage, retainedLegacy)),
       'legacyLedger',
     ],
     ...(stage === 'final'
@@ -262,7 +267,21 @@ function visibleReviewLabels(stage) {
   };
 }
 
-function visibleLegacyLedger(items, stage, retainedLegacy) {
+function visibleLegacyLedger(legacy, stage, retainedLegacy) {
+  const items = visibleLedgerItems(legacy.items, stage, retainedLegacy);
+  const aggregate = legacy.notLegacyAggregate;
+  if (!isPlainRecord(aggregate)) {
+    return items;
+  }
+  return {
+    items,
+    notLegacyAggregate: Object.fromEntries(
+      notLegacyAggregateFields.map((field) => [field, aggregate[field]]),
+    ),
+  };
+}
+
+function visibleLedgerItems(items, stage, retainedLegacy) {
   if (stage !== 'final') {
     return [...items].sort((left, right) => left.id.localeCompare(right.id));
   }
@@ -286,8 +305,17 @@ function validateLegacyLedger({ legacy, stage, retainedLegacy, errors }) {
     errors.push(`${stage} review legacy ledger is required`);
     return;
   }
-  if (!Number.isInteger(legacy.candidateCount) || legacy.candidateCount !== legacy.items.length) {
-    errors.push(`${stage} review legacy candidate count must equal ledger items`);
+  const aggregate = legacy.notLegacyAggregate ?? undefined;
+  if (aggregate !== undefined) {
+    validateNotLegacyAggregateShape({ aggregate, label: `${stage} review`, errors });
+  }
+  const expectedItemCount = legacy.items.length + resolveNotLegacyAggregateCount(aggregate);
+  if (!Number.isInteger(legacy.candidateCount) || legacy.candidateCount !== expectedItemCount) {
+    errors.push(
+      aggregate === undefined
+        ? `${stage} review legacy candidate count must equal ledger items`
+        : `${stage} review legacy candidate count must equal ledger items plus the aggregate`,
+    );
   }
   const identifiers = new Set();
   for (const item of legacy.items) {

--- a/scripts/review-legacy.mjs
+++ b/scripts/review-legacy.mjs
@@ -1,19 +1,27 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 import {
   readReviewRecord,
   validateSuppliedEvidence,
 } from './legacy-review/validate-supplied-evidence.mjs';
-import { printReport } from './legacy-review/candidate-report.mjs';
+import {
+  computeReportSha256,
+  printReport,
+  toCanonicalReport,
+  toCanonicalReportText,
+} from './legacy-review/candidate-report.mjs';
 import { scanChangedProduction } from './legacy-review/scan-changed-production.mjs';
 
 const input = readInput(process.argv.slice(2));
 const result = input.isExempt
   ? { ...input, changedFiles: [], candidates: [], exempt: true }
-  : scanChangedProduction(input);
+  : toDigestedScan(scanChangedProduction(input));
 
+if (!input.isExempt && input.reportOut !== undefined) {
+  writeFileSync(input.reportOut, toCanonicalReportText(toCanonicalReport(result)));
+}
 printReport(result);
 const validationErrors = validateSuppliedEvidence(input, result.candidates);
 if (validationErrors.length > 0) {
@@ -25,12 +33,17 @@ if (validationErrors.length > 0) {
   console.log('PASS: supplied final review ledger disposes every reported candidate');
 }
 
+function toDigestedScan(scan) {
+  const reportText = toCanonicalReportText(toCanonicalReport(scan));
+  return { ...scan, reportSha256: computeReportSha256(reportText) };
+}
+
 function readInput(args) {
   const [baseReference, headReference, ...optionArgs] = args;
   if (!baseReference || !headReference) {
     failUsage(
       'usage: npm run review:legacy -- <base> <head> ' +
-        '[--review-record file] [--registry file] [--stage stage]',
+        '[--review-record file] [--registry file] [--stage stage] [--report-out file]',
     );
   }
   const options = readOptions(optionArgs);
@@ -47,6 +60,7 @@ function readInput(args) {
     reviewRecord: options['review-record'],
     registry: options.registry,
     stage: options.stage,
+    reportOut: options['report-out'],
     isExempt,
   };
 }
@@ -69,7 +83,8 @@ function readOptions(args) {
       failUsage('options must use --name value pairs');
     }
     const name = option.slice(2);
-    if (!['review-record', 'registry', 'stage'].includes(name) || options[name] !== undefined) {
+    const supportedOptions = ['review-record', 'registry', 'stage', 'report-out'];
+    if (!supportedOptions.includes(name) || options[name] !== undefined) {
       failUsage(`unsupported or repeated option: ${option}`);
     }
     options[name] = value;


### PR DESCRIPTION
# Pull request

## Summary

Queue item 1 of the erasableSyntaxOnly follow-ups: fix the PR Human Review Record contract for
large PRs. A ~200-file PR produced 216 `review:legacy` candidates (~108k chars of ledger
duplicated across the visible section and the metadata fence) against GitHub's 65,536-char body
cap, so #164 could not publish a valid record and was admin-merged red.

- A stage ledger may now record its not-legacy candidates in aggregate: `notLegacyAggregate`
  with the aggregated count, the whole-report SHA-256, the preserved-report location (workflow
  artifact or committed evidence file), and one concrete rationale.
- `npm run review:legacy` prints `REPORT-SHA256` and writes the byte-exact canonical report
  with `--report-out`.
- `check:pr-human-review` validates aggregate shape, count arithmetic
  (`candidateCount = items + aggregate.count`), and the visible-ledger byte binding; the CI
  stage driver recomputes the stage report from Git data and rejects a digest or count mismatch.
- Per-item rows stay mandatory for legacy-classified items; existing itemized records stay valid.
- A synthetic 216-candidate record validates and renders under 60k chars
  (`pr-human-review-validation.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Human Review Record v1

Use this record for every pull request. It preserves the evidence that an
independent reviewer examined the exact candidate tree; it is not an automated
approval form.

Production code is the primary design artifact; tests are secondary evidence.
Automation validates evidence and freshness; it does not approve semantic
quality or retained legacy.

### PR classification

- Review scope: code-changing
- Explicit exemption, if any: none
  `agent-guidance-only`
- Exemption evidence: not applicable — code-changing pull request

Plan-, documentation-, and agent-guidance-only pull requests may use the
explicit exemption only when no production, test, script, workflow, package
metadata, or runtime files changed. An exemption does not permit a mixed PR to
skip review.

No production, test, script, workflow, package metadata, or runtime files
changed is required for an exemption.

### Change intent and scope

- Requirements and independently stated behavior: erasableSyntaxOnly follow-up queue item 1 — amend the PR Human Review Record contract so large candidate reports fit the GitHub body cap: not-legacy candidates may be recorded in aggregate (count plus whole-report SHA-256 with the full report preserved as an artifact or committed evidence file) while per-item rows stay mandatory for legacy-classified items and existing itemized records stay valid.
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 4aa81aa9c277758088098d0878c534de42837377
- Default-branch revalidation outcome: branched from origin/main 33fa104d; no default-branch movement affected this surface at preparation time.
- Active-plan legacy baseline and changed affected surface: no active plan owns this surface; the changed surface is review-governance tooling, its pinning tests, the PR template, and the record contract doc. review:legacy reports zero candidates for the range.

### Initial independent review

An Initial independent review is required before a code-changing draft pull
request is created. Record `not yet required` only for an explicit exemption.

- Record status: complete
- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 4aa81aa9c277758088098d0878c534de42837377
- Production owner-to-result trace: npm run review:legacy resolves the range in scripts/review-legacy.mjs, scans candidates in scripts/legacy-review/scan-changed-production.mjs, computes the canonical report and its SHA-256 in scripts/legacy-review/candidate-report.mjs (toCanonicalReport, toCanonicalReportText, computeReportSha256), prints REPORT-SHA256 via printReport, and writes the byte-exact report with --report-out. scripts/legacy-review/validate-supplied-evidence.mjs recomputes the digest from the stage candidates and validates ledger coverage (items plus notLegacyAggregate.count equals the report count, digest equality, per-item path/symbol agreement). scripts/pr-human-review/validate-review-evidence.mjs binds candidateCount = items + aggregate count and renders the visible ledger JSON including the aggregate; scripts/pr-human-review/validate-legacy-item.mjs owns the aggregate shape (count, reportSha256, evidence, rationale; unsupported fields rejected). The stage driver forwards the ledger unchanged and re-runs review-legacy per stage, so CI recomputes and binds the digest from Git data.
- Cognitive-indirection findings: The aggregate shape and effective-count resolution live only in the schema authority validate-legacy-item.mjs and both validators import them, so there is one owner and no duplicated policy. visibleLegacyLedger was split into visibleLedgerItems plus an aggregate wrapper keyed by the exported field list, keeping one projection owner. No new layers, callbacks, or renamed dataflow were added.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Backward compatibility: records without notLegacyAggregate validate byte-identically to the previous contract (all 81 focused suite tests and 343 repo-governance tests pass unchanged plus the new cases). The aggregate is rejected on count arithmetic, malformed digest, placeholder rationale, smuggled disposition/approval fields, and visible-versus-metadata contradiction.
- Tests rewritten or removed: No tests were removed. The visible-ledger test helper was extended (visibleLedgerForTest) to mirror the production projection, and new cases cover the 216-candidate aggregated record under the body cap, aggregate rejection paths, digest emission with --report-out, aggregated supplied-evidence acceptance and rejection, and an aggregated stage-driver run.
- Production was not compromised for tests: Validator behavior for existing itemized records is unchanged; no test-only wiring or alternate construction paths were added to the scripts.
- Behavior and judgment not proven by automation: The validator cannot judge whether aggregated candidates are truly not legacy; the whole-report digest preserves auditability of the exact candidate set but does not approve the human classification. Reviewer independence also remains a human claim.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

### Milestone review

Add one entry for every milestone where a new ownership, control-flow, or
legacy family appears. Use `not applicable` only when no such family appeared.

- Milestone classification: none

When the classification is `reviewed`, add the exact heading
`#### Milestone review entry` immediately before the fields below. Copy the
complete heading-and-fields block for each additional reviewed milestone. When
the classification is `none`, leave the metadata `entries` array empty and do
not add that heading.

- Reviewer and independence (separate agent or human):
- Exact merge base SHA:
- Exact candidate head SHA:
- New ownership, control-flow, or legacy family:
- Production owner-to-result trace:
- Cognitive-indirection findings:
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings):
- Tests rewritten or removed:
- Production was not compromised for tests:
- Behavior and judgment not proven by automation:
- Legacy candidate count:
- Legacy ledger and dispositions:
- Critical findings unresolved: `0`
- Important findings unresolved: `0`
- Verdict: `pass` | `changes-requested` | `not-applicable`

### Complete code and legacy review

Complete code and legacy review is required before the pull request is ready
for merge. It must match the current candidate head SHA and follow every
changed production path from entry owner to result.

- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 4aa81aa9c277758088098d0878c534de42837377
- Changed production owner-to-result trace, including decisions, effects, failures, callbacks, compatibility branches, and tests: npm run review:legacy resolves the range in scripts/review-legacy.mjs, scans candidates in scripts/legacy-review/scan-changed-production.mjs, computes the canonical report and its SHA-256 in scripts/legacy-review/candidate-report.mjs (toCanonicalReport, toCanonicalReportText, computeReportSha256), prints REPORT-SHA256 via printReport, and writes the byte-exact report with --report-out. scripts/legacy-review/validate-supplied-evidence.mjs recomputes the digest from the stage candidates and validates ledger coverage (items plus notLegacyAggregate.count equals the report count, digest equality, per-item path/symbol agreement). scripts/pr-human-review/validate-review-evidence.mjs binds candidateCount = items + aggregate count and renders the visible ledger JSON including the aggregate; scripts/pr-human-review/validate-legacy-item.mjs owns the aggregate shape (count, reportSha256, evidence, rationale; unsupported fields rejected). The stage driver forwards the ledger unchanged and re-runs review-legacy per stage, so CI recomputes and binds the digest from Git data.
- Cognitive-indirection findings and resolution: The aggregate shape and effective-count resolution live only in the schema authority validate-legacy-item.mjs and both validators import them, so there is one owner and no duplicated policy. visibleLegacyLedger was split into visibleLedgerItems plus an aggregate wrapper keyed by the exported field list, keeping one projection owner. No new layers, callbacks, or renamed dataflow were added.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Backward compatibility: records without notLegacyAggregate validate byte-identically to the previous contract (all 81 focused suite tests and 343 repo-governance tests pass unchanged plus the new cases). The aggregate is rejected on count arithmetic, malformed digest, placeholder rationale, smuggled disposition/approval fields, and visible-versus-metadata contradiction.
- Tests rewritten or removed, with independent behavior retained: No tests were removed. The visible-ledger test helper was extended (visibleLedgerForTest) to mirror the production projection, and new cases cover the 216-candidate aggregated record under the body cap, aggregate rejection paths, digest emission with --report-out, aggregated supplied-evidence acceptance and rejection, and an aggregated stage-driver run.
- Production was not compromised for tests: Validator behavior for existing itemized records is unchanged; no test-only wiring or alternate construction paths were added to the scripts.
- Behavior and judgment not proven by automation: The validator cannot judge whether aggregated candidates are truly not legacy; the whole-report digest preserves auditability of the exact candidate set but does not approve the human classification. Reviewer independence also remains a human claim.
- Legacy candidates inspected (baseline, automated report, changed files, and production call paths): npm run review:legacy -- 33fa104d 4aa81aa9 reports zero candidates (REPORT-SHA256 1bdbbb021133dac9823aa0b26293a0e28d6c3138d710a5626bd008c4603d8015); the changed paths are governance tooling under scripts/pr-human-review and scripts/legacy-review, repo tests, the PR template, and the record contract doc — none on the production scan surface — and no production call path changed.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

Completed work requires zero unresolved Critical or Important findings.

### Human approval for retained legacy

List every `retained-pending-human-approval` item. Every confirmed affected
legacy item uses `classification: legacy` and exactly one disposition:
`removed`, `minimized-boundary`, `resolved`, or
`retained-pending-human-approval`. A heuristic candidate that is not legacy uses
`classification: not-legacy` with a concrete rationale; it is not a legacy
exception or an implicit disposition.

When per-item `not-legacy` rows would push the pull request body over the
GitHub body size cap, a stage ledger may record its not-legacy candidates in
aggregate instead: a `notLegacyAggregate` object beside `items` holding the
aggregated candidate count, the whole-report SHA-256 (the `REPORT-SHA256`
line from `npm run review:legacy`, reproducible byte-exactly with
`--report-out`), the location where the full report is preserved (a workflow
artifact or a committed evidence file), and one concrete rationale. Every
legacy-classified item keeps its own ledger row; the aggregate never carries
a disposition or approval. `Legacy candidate count` equals the per-item rows
plus the aggregate count, and the stage check recomputes the report and
rejects an aggregate whose digest or count does not match.

The final review's `Legacy ledger and dispositions` field is the one bound,
human-readable retained ledger. `Legacy exception ID` is the projection's `id`.
Each retained item also presents the exact path and symbol, purpose, consumer
or operational dependency, unsafe-removal
reason, minimization, canonical owner, compatibility tests, named owner,
review/removal condition, and approved production SHA. The validator hashes
that exact canonical projection. Record trusted GitHub approval provenance in
the `retainedLegacy` metadata and durable registry; do not duplicate the
approval details in another unbound visible block.

Silence, an issue, an earlier plan approval, agent judgment, or automation is
not approval. A production change invalidates the final review and any
retained-legacy approval. Record the approved item in
[`docs/production-legacy-exceptions.md`](../docs/production-legacy-exceptions.md)
before completion.

### Validation and publication

- Passed commands and exact current-head workflow evidence: npx vitest run over the four touched repo suites (81 tests), npm run test:repo-governance (21 files, 343 tests), npm run check:repo-style:changed -- origin/main (PASS, no new findings), npm run review:legacy -- 33fa104d 4aa81aa9 (zero candidates, REPORT-SHA256 emitted), npm run check:pr-human-review against this body with both the origin/main validator and this branch validator (PASS), npm run test:unit (6854 passed, 3 skipped; the 6 failures are the known sandbox port/signal restrictions in 3 files, which pass unsandboxed 24/24) — all at head 4aa81aa9. Branch Release Gate passed on this exact head (run 31532067435).
- Failed or skipped commands and reason: test:deno, test:e2e, and test:full-stack were delegated to Branch Release Gate for this governance-tooling change; no Deno-owned or app runtime path changed.
- Follow-up issues: none

### Validator metadata

Replace every value in this JSON fence with the exact evidence recorded above.
The check rejects placeholder text and does not approve semantic quality or
retained legacy.

```pr-human-review-record-v1
{
  "version": 1,
  "scope": "code-changing",
  "exemption": null,
  "initialReview": {
    "status": "complete",
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "4aa81aa9c277758088098d0878c534de42837377",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "npm run review:legacy resolves the range in scripts/review-legacy.mjs, scans candidates in scripts/legacy-review/scan-changed-production.mjs, computes the canonical report and its SHA-256 in scripts/legacy-review/candidate-report.mjs (toCanonicalReport, toCanonicalReportText, computeReportSha256), prints REPORT-SHA256 via printReport, and writes the byte-exact report with --report-out. scripts/legacy-review/validate-supplied-evidence.mjs recomputes the digest from the stage candidates and validates ledger coverage (items plus notLegacyAggregate.count equals the report count, digest equality, per-item path/symbol agreement). scripts/pr-human-review/validate-review-evidence.mjs binds candidateCount = items + aggregate count and renders the visible ledger JSON including the aggregate; scripts/pr-human-review/validate-legacy-item.mjs owns the aggregate shape (count, reportSha256, evidence, rationale; unsupported fields rejected). The stage driver forwards the ledger unchanged and re-runs review-legacy per stage, so CI recomputes and binds the digest from Git data.",
      "cognitiveIndirectionFindings": "The aggregate shape and effective-count resolution live only in the schema authority validate-legacy-item.mjs and both validators import them, so there is one owner and no duplicated policy. visibleLegacyLedger was split into visibleLedgerItems plus an aggregate wrapper keyed by the exported field list, keeping one projection owner. No new layers, callbacks, or renamed dataflow were added.",
      "completeFindings": "No Critical or Important findings remain. Backward compatibility: records without notLegacyAggregate validate byte-identically to the previous contract (all 81 focused suite tests and 343 repo-governance tests pass unchanged plus the new cases). The aggregate is rejected on count arithmetic, malformed digest, placeholder rationale, smuggled disposition/approval fields, and visible-versus-metadata contradiction.",
      "testsRewrittenOrRemoved": "No tests were removed. The visible-ledger test helper was extended (visibleLedgerForTest) to mirror the production projection, and new cases cover the 216-candidate aggregated record under the body cap, aggregate rejection paths, digest emission with --report-out, aggregated supplied-evidence acceptance and rejection, and an aggregated stage-driver run.",
      "productionNotCompromisedForTests": "Validator behavior for existing itemized records is unchanged; no test-only wiring or alternate construction paths were added to the scripts.",
      "automationGaps": "The validator cannot judge whether aggregated candidates are truly not legacy; the whole-report digest preserves auditability of the exact candidate set but does not approve the human classification. Reviewer independence also remains a human claim."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 4aa81aa9 reports zero candidates (REPORT-SHA256 1bdbbb021133dac9823aa0b26293a0e28d6c3138d710a5626bd008c4603d8015); the changed paths are governance tooling under scripts/pr-human-review and scripts/legacy-review, repo tests, the PR template, and the record contract doc — none on the production scan surface — and no production call path changed."
    }
  },
  "milestoneReview": {
    "classification": "none",
    "entries": []
  },
  "finalReview": {
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "4aa81aa9c277758088098d0878c534de42837377",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "npm run review:legacy resolves the range in scripts/review-legacy.mjs, scans candidates in scripts/legacy-review/scan-changed-production.mjs, computes the canonical report and its SHA-256 in scripts/legacy-review/candidate-report.mjs (toCanonicalReport, toCanonicalReportText, computeReportSha256), prints REPORT-SHA256 via printReport, and writes the byte-exact report with --report-out. scripts/legacy-review/validate-supplied-evidence.mjs recomputes the digest from the stage candidates and validates ledger coverage (items plus notLegacyAggregate.count equals the report count, digest equality, per-item path/symbol agreement). scripts/pr-human-review/validate-review-evidence.mjs binds candidateCount = items + aggregate count and renders the visible ledger JSON including the aggregate; scripts/pr-human-review/validate-legacy-item.mjs owns the aggregate shape (count, reportSha256, evidence, rationale; unsupported fields rejected). The stage driver forwards the ledger unchanged and re-runs review-legacy per stage, so CI recomputes and binds the digest from Git data.",
      "cognitiveIndirectionFindings": "The aggregate shape and effective-count resolution live only in the schema authority validate-legacy-item.mjs and both validators import them, so there is one owner and no duplicated policy. visibleLegacyLedger was split into visibleLedgerItems plus an aggregate wrapper keyed by the exported field list, keeping one projection owner. No new layers, callbacks, or renamed dataflow were added.",
      "completeFindings": "No Critical or Important findings remain. Backward compatibility: records without notLegacyAggregate validate byte-identically to the previous contract (all 81 focused suite tests and 343 repo-governance tests pass unchanged plus the new cases). The aggregate is rejected on count arithmetic, malformed digest, placeholder rationale, smuggled disposition/approval fields, and visible-versus-metadata contradiction.",
      "testsRewrittenOrRemoved": "No tests were removed. The visible-ledger test helper was extended (visibleLedgerForTest) to mirror the production projection, and new cases cover the 216-candidate aggregated record under the body cap, aggregate rejection paths, digest emission with --report-out, aggregated supplied-evidence acceptance and rejection, and an aggregated stage-driver run.",
      "productionNotCompromisedForTests": "Validator behavior for existing itemized records is unchanged; no test-only wiring or alternate construction paths were added to the scripts.",
      "automationGaps": "The validator cannot judge whether aggregated candidates are truly not legacy; the whole-report digest preserves auditability of the exact candidate set but does not approve the human classification. Reviewer independence also remains a human claim."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 4aa81aa9 reports zero candidates (REPORT-SHA256 1bdbbb021133dac9823aa0b26293a0e28d6c3138d710a5626bd008c4603d8015); the changed paths are governance tooling under scripts/pr-human-review and scripts/legacy-review, repo tests, the PR template, and the record contract doc — none on the production scan surface — and no production call path changed."
    }
  },
  "retainedLegacy": []
}
```

The visible Initial, Milestone, and Complete review sections above are the
human record. Fill each stable labeled field once with the exact matching
metadata value; do not add copied marker blocks. For retained legacy, metadata
must reference a trusted human GitHub review ID, login, submitted date,
approved production SHA, and whole-ledger SHA-256. A later registry recording
commit is allowed only when it changes no production path.
