### PR TITLE
build(control-server): restore erasableSyntaxOnly in deno.json

### DIFF
--- a/.agents/skills/rallar-code-writing/references/typescript-type-organization.md
+++ b/.agents/skills/rallar-code-writing/references/typescript-type-organization.md
@@ -172,11 +172,10 @@ merged class type-checks cleanly under `--strict` and under
 `--erasableSyntaxOnly`, and a namespace containing runtime values fails
 `--erasableSyntaxOnly` with TS1294. Deno 2.9.5 (`deno check`) accepts the
 type-only pattern. Every repository tsconfig and deno.json enables
-`erasableSyntaxOnly` — except `apps/rallar-black-box-control-server/deno.json`,
-whose file-sourced Deno Deploy build config rejects the option; restore it there
-once the Deploy builder accepts it. The flag keeps shared `packages/**`
-TypeScript portable across both runtimes and is an enforced compiler setting,
-not merely a design target.
+`erasableSyntaxOnly`, including `apps/rallar-black-box-control-server/deno.json`
+now that its file-sourced Deno Deploy build accepts the option. The flag keeps
+shared `packages/**` TypeScript portable across both runtimes and is an
+enforced compiler setting, not merely a design target.
 
 Do not introduce new TypeScript enums. For a type-only finite set, prefer a
 string-literal union:

--- a/apps/rallar-black-box-control-server/deno.json
+++ b/apps/rallar-black-box-control-server/deno.json
@@ -25,6 +25,7 @@
   },
   "compilerOptions": {
     "strict": true,
+    "erasableSyntaxOnly": true,
     "lib": [
       "deno.ns",
       "dom",


### PR DESCRIPTION
# Pull request

## Summary

Queue item 4a of the erasableSyntaxOnly follow-ups: restore
`"erasableSyntaxOnly": true` in `apps/rallar-black-box-control-server/deno.json`.

- The option was removed on 2026-08-11 because the file-sourced Deno Deploy build config for
  `rallar-bb-server` rejected it; the restore condition was recorded in
  `typescript-type-organization.md` (updated here to drop the exception).
- Local `deno task check` passes with the option restored.
- Acceptance signal: the **deploy/rallar-bb-server** check on this branch. If Deploy still
  rejects the option, the recorded fallback is to revert just the deno.json change and
  restore the doc exception note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Human Review Record v1

Use this record for every pull request. It preserves the evidence that an
independent reviewer examined the exact candidate tree; it is not an automated
approval form.

Production code is the primary design artifact; tests are secondary evidence.
Automation validates evidence and freshness; it does not approve semantic
quality or retained legacy.

### PR classification

- Review scope: code-changing
- Explicit exemption, if any: none
  `agent-guidance-only`
- Exemption evidence: not applicable — code-changing pull request

Plan-, documentation-, and agent-guidance-only pull requests may use the
explicit exemption only when no production, test, script, workflow, package
metadata, or runtime files changed. An exemption does not permit a mixed PR to
skip review.

No production, test, script, workflow, package metadata, or runtime files
changed is required for an exemption.

### Change intent and scope

- Requirements and independently stated behavior: erasableSyntaxOnly follow-up queue item 4a — restore "erasableSyntaxOnly": true in apps/rallar-black-box-control-server/deno.json and verify the deploy/rallar-bb-server check on this branch; if the Deploy builder still rejects the option, revert only that file and restore the doc exception note.
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 3f215786b8c6ade6f0e84434ae99fdc65508db15
- Default-branch revalidation outcome: branched from origin/main 33fa104d; no default-branch movement affected this surface at preparation time.
- Active-plan legacy baseline and changed affected surface: no active plan owns this surface; the change is one deno.json compiler option plus the matching sentence in typescript-type-organization.md. review:legacy reports zero candidates.

### Initial independent review

An Initial independent review is required before a code-changing draft pull
request is created. Record `not yet required` only for an explicit exemption.

- Record status: complete
- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 3f215786b8c6ade6f0e84434ae99fdc65508db15
- Production owner-to-result trace: apps/rallar-black-box-control-server/deno.json compilerOptions gains "erasableSyntaxOnly": true; deno check (the deno task check entry) and the Deno Deploy file-sourced build for app rallar-bb-server both consume this config. No runtime source changes; the option only rejects non-erasable TypeScript syntax at check/build time, and the tree already contains none (enforced repo-wide by #164).
- Cognitive-indirection findings: None — a one-line compiler-option restore plus the doc sentence that recorded the restore condition. No new indirection.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Local deno task check passes with the option restored. The remaining risk is external: the Deno Deploy builder rejected the option on 2026-08-11; the deploy/rallar-bb-server check on this branch is the verification, and the recorded fallback is to revert this file alone.
- Tests rewritten or removed: No tests changed; deno task check covers the config against every server test entry point.
- Production was not compromised for tests: No production or test wiring changed.
- Behavior and judgment not proven by automation: Whether the Deno Deploy builder now accepts the option is proven only by the deploy/rallar-bb-server check on this exact branch, not by local validation.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

### Milestone review

Add one entry for every milestone where a new ownership, control-flow, or
legacy family appears. Use `not applicable` only when no such family appeared.

- Milestone classification: none

When the classification is `reviewed`, add the exact heading
`#### Milestone review entry` immediately before the fields below. Copy the
complete heading-and-fields block for each additional reviewed milestone. When
the classification is `none`, leave the metadata `entries` array empty and do
not add that heading.

- Reviewer and independence (separate agent or human):
- Exact merge base SHA:
- Exact candidate head SHA:
- New ownership, control-flow, or legacy family:
- Production owner-to-result trace:
- Cognitive-indirection findings:
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings):
- Tests rewritten or removed:
- Production was not compromised for tests:
- Behavior and judgment not proven by automation:
- Legacy candidate count:
- Legacy ledger and dispositions:
- Critical findings unresolved: `0`
- Important findings unresolved: `0`
- Verdict: `pass` | `changes-requested` | `not-applicable`

### Complete code and legacy review

Complete code and legacy review is required before the pull request is ready
for merge. It must match the current candidate head SHA and follow every
changed production path from entry owner to result.

- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 3f215786b8c6ade6f0e84434ae99fdc65508db15
- Changed production owner-to-result trace, including decisions, effects, failures, callbacks, compatibility branches, and tests: apps/rallar-black-box-control-server/deno.json compilerOptions gains "erasableSyntaxOnly": true; deno check (the deno task check entry) and the Deno Deploy file-sourced build for app rallar-bb-server both consume this config. No runtime source changes; the option only rejects non-erasable TypeScript syntax at check/build time, and the tree already contains none (enforced repo-wide by #164).
- Cognitive-indirection findings and resolution: None — a one-line compiler-option restore plus the doc sentence that recorded the restore condition. No new indirection.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Local deno task check passes with the option restored. The remaining risk is external: the Deno Deploy builder rejected the option on 2026-08-11; the deploy/rallar-bb-server check on this branch is the verification, and the recorded fallback is to revert this file alone.
- Tests rewritten or removed, with independent behavior retained: No tests changed; deno task check covers the config against every server test entry point.
- Production was not compromised for tests: No production or test wiring changed.
- Behavior and judgment not proven by automation: Whether the Deno Deploy builder now accepts the option is proven only by the deploy/rallar-bb-server check on this exact branch, not by local validation.
- Legacy candidates inspected (baseline, automated report, changed files, and production call paths): npm run review:legacy -- 33fa104d 3f215786 reports zero candidates; the changed paths are one deno.json and one agent-guidance doc, with no production call path.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

Completed work requires zero unresolved Critical or Important findings.

### Human approval for retained legacy

List every `retained-pending-human-approval` item. Every confirmed affected
legacy item uses `classification: legacy` and exactly one disposition:
`removed`, `minimized-boundary`, `resolved`, or
`retained-pending-human-approval`. A heuristic candidate that is not legacy uses
`classification: not-legacy` with a concrete rationale; it is not a legacy
exception or an implicit disposition.

The final review's `Legacy ledger and dispositions` field is the one bound,
human-readable retained ledger. `Legacy exception ID` is the projection's `id`.
Each retained item also presents the exact path and symbol, purpose, consumer
or operational dependency, unsafe-removal
reason, minimization, canonical owner, compatibility tests, named owner,
review/removal condition, and approved production SHA. The validator hashes
that exact canonical projection. Record trusted GitHub approval provenance in
the `retainedLegacy` metadata and durable registry; do not duplicate the
approval details in another unbound visible block.

Silence, an issue, an earlier plan approval, agent judgment, or automation is
not approval. A production change invalidates the final review and any
retained-legacy approval. Record the approved item in
[`docs/production-legacy-exceptions.md`](../docs/production-legacy-exceptions.md)
before completion.

### Validation and publication

- Passed commands and exact current-head workflow evidence: deno task check in apps/rallar-black-box-control-server (all entry points), npm run review:legacy (zero candidates), npm run check:pr-human-review against this body (PASS) — at head 3f215786. Branch Release Gate and the deploy/rallar-bb-server check run on this head.
- Failed or skipped commands and reason: npm-side suites delegated to Branch Release Gate; no npm-runtime path changed. Deploy acceptance is pending the deploy/rallar-bb-server branch check.
- Follow-up issues: none

### Validator metadata

Replace every value in this JSON fence with the exact evidence recorded above.
The check rejects placeholder text and does not approve semantic quality or
retained legacy.

```pr-human-review-record-v1
{
  "version": 1,
  "scope": "code-changing",
  "exemption": null,
  "initialReview": {
    "status": "complete",
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "3f215786b8c6ade6f0e84434ae99fdc65508db15",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "apps/rallar-black-box-control-server/deno.json compilerOptions gains \"erasableSyntaxOnly\": true; deno check (the deno task check entry) and the Deno Deploy file-sourced build for app rallar-bb-server both consume this config. No runtime source changes; the option only rejects non-erasable TypeScript syntax at check/build time, and the tree already contains none (enforced repo-wide by #164).",
      "cognitiveIndirectionFindings": "None — a one-line compiler-option restore plus the doc sentence that recorded the restore condition. No new indirection.",
      "completeFindings": "No Critical or Important findings remain. Local deno task check passes with the option restored. The remaining risk is external: the Deno Deploy builder rejected the option on 2026-08-11; the deploy/rallar-bb-server check on this branch is the verification, and the recorded fallback is to revert this file alone.",
      "testsRewrittenOrRemoved": "No tests changed; deno task check covers the config against every server test entry point.",
      "productionNotCompromisedForTests": "No production or test wiring changed.",
      "automationGaps": "Whether the Deno Deploy builder now accepts the option is proven only by the deploy/rallar-bb-server check on this exact branch, not by local validation."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 3f215786 reports zero candidates; the changed paths are one deno.json and one agent-guidance doc, with no production call path."
    }
  },
  "milestoneReview": {
    "classification": "none",
    "entries": []
  },
  "finalReview": {
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "3f215786b8c6ade6f0e84434ae99fdc65508db15",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "apps/rallar-black-box-control-server/deno.json compilerOptions gains \"erasableSyntaxOnly\": true; deno check (the deno task check entry) and the Deno Deploy file-sourced build for app rallar-bb-server both consume this config. No runtime source changes; the option only rejects non-erasable TypeScript syntax at check/build time, and the tree already contains none (enforced repo-wide by #164).",
      "cognitiveIndirectionFindings": "None — a one-line compiler-option restore plus the doc sentence that recorded the restore condition. No new indirection.",
      "completeFindings": "No Critical or Important findings remain. Local deno task check passes with the option restored. The remaining risk is external: the Deno Deploy builder rejected the option on 2026-08-11; the deploy/rallar-bb-server check on this branch is the verification, and the recorded fallback is to revert this file alone.",
      "testsRewrittenOrRemoved": "No tests changed; deno task check covers the config against every server test entry point.",
      "productionNotCompromisedForTests": "No production or test wiring changed.",
      "automationGaps": "Whether the Deno Deploy builder now accepts the option is proven only by the deploy/rallar-bb-server check on this exact branch, not by local validation."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 3f215786 reports zero candidates; the changed paths are one deno.json and one agent-guidance doc, with no production call path."
    }
  },
  "retainedLegacy": []
}
```

The visible Initial, Milestone, and Complete review sections above are the
human record. Fill each stable labeled field once with the exact matching
metadata value; do not add copied marker blocks. For retained legacy, metadata
must reference a trusted human GitHub review ID, login, submitted date,
approved production SHA, and whole-ledger SHA-256. A later registry recording
commit is allowed only when it changes no production path.
