### PR TITLE
refactor(shared-server): drop redundant AppInboxService override re-declarations

### DIFF
--- a/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
@@ -68,12 +68,8 @@ const AUTH_TYPES = [
 export class AppAuthInboxService extends AppInboxService {
   private readonly authInboxHandler: AuthInboxHandler;
 
-  public override readonly inbox: InboxQueueReader;
-  public override readonly resourceInbox: ResourceInboxRepository;
-  public override readonly resourceInboxResults: ResourceInboxResultsRepository;
   public readonly authMutationService: AuthMutationService;
   public readonly credentialIssuer: AuthCredentialIssuer;
-  public override readonly serviceId: string;
 
   constructor(
     inbox: InboxQueueReader,
@@ -98,12 +94,8 @@ export class AppAuthInboxService extends AppInboxService {
       options,
       wakeQueue,
     );
-    this.inbox = inbox;
-    this.resourceInbox = resourceInbox;
-    this.resourceInboxResults = resourceInboxResults;
     this.authMutationService = authMutationService;
     this.credentialIssuer = credentialIssuer;
-    this.serviceId = serviceId;
     this.authInboxHandler = new AuthInboxHandler({
       mutationService: authMutationService,
       credentialIssuer,

--- a/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
@@ -52,11 +52,7 @@ import { ClientStateInboxHandler } from './client-state-inbox-handler.ts';
 export class AppClientInboxService extends AppInboxService {
   private readonly handler: ClientStateInboxHandler;
 
-  public override readonly inbox: InboxQueueReader;
-  public override readonly resourceInbox: ResourceInboxRepository;
-  public override readonly resourceInboxResults: ResourceInboxResultsRepository;
   public readonly clientStateService: ClientStateService;
-  public override readonly serviceId: string;
 
   constructor(
     inbox: InboxQueueReader,
@@ -80,11 +76,7 @@ export class AppClientInboxService extends AppInboxService {
       options,
       wakeQueue,
     );
-    this.inbox = inbox;
-    this.resourceInbox = resourceInbox;
-    this.resourceInboxResults = resourceInboxResults;
     this.clientStateService = clientStateService;
-    this.serviceId = serviceId;
     this.handler = new ClientStateInboxHandler({
       mutationService: clientStateService,
       sessionGenerationLifecycle: clientStateService.sessionGenerationLifecycle,

--- a/packages/shared-server/rallar-system/services/AppAdminInboxService.ts
+++ b/packages/shared-server/rallar-system/services/AppAdminInboxService.ts
@@ -81,11 +81,7 @@ type AdminPruneComputed = Readonly<{
 export class AppAdminInboxService extends AppInboxService {
   private readonly aggregateWaitPolicy: TryWithPolicy;
 
-  public override readonly inbox: InboxQueueReader;
-  public override readonly resourceInbox: ResourceInboxRepository;
-  public override readonly resourceInboxResults: ResourceInboxResultsRepository;
   private readonly pruner: AdminOperationsPruner;
-  public override readonly serviceId: string;
   private readonly pageSize: number;
   private readonly readAuthority: AdminPruneAuthorityReader;
   private readonly wakeQueue?: () => void;
@@ -115,11 +111,7 @@ export class AppAdminInboxService extends AppInboxService {
       options,
       wakeQueue,
     );
-    this.inbox = inbox;
-    this.resourceInbox = resourceInbox;
-    this.resourceInboxResults = resourceInboxResults;
     this.pruner = pruner;
-    this.serviceId = serviceId;
     this.pageSize = pageSize;
     this.readAuthority = readAuthority;
     this.wakeQueue = wakeQueue;

--- a/packages/shared-server/rallar-system/services/AppGroupInboxService.ts
+++ b/packages/shared-server/rallar-system/services/AppGroupInboxService.ts
@@ -120,11 +120,7 @@ class AppGroupInboxService extends AppInboxService {
   private topologyManagementService?: GroupTopologyManagementService;
   private rtcRttDependencies?: RtcRttAppInboxDependencies;
 
-  public override readonly inbox: InboxQueueReader;
-  public override readonly resourceInbox: ResourceInboxRepository;
-  public override readonly resourceInboxResults: ResourceInboxResultsRepository;
   public readonly groupStateService: GroupStateService;
-  public override readonly serviceId: string;
   private readonly wakeQueue?: () => void;
 
   constructor(
@@ -150,11 +146,7 @@ class AppGroupInboxService extends AppInboxService {
       options,
       wakeQueue,
     );
-    this.inbox = inbox;
-    this.resourceInbox = resourceInbox;
-    this.resourceInboxResults = resourceInboxResults;
     this.groupStateService = groupStateService;
-    this.serviceId = serviceId;
     this.wakeQueue = wakeQueue;
     this.groupStateInboxHandler = new GroupStateInboxHandler({
       mutationService: this.groupStateService,


### PR DESCRIPTION
# Pull request

## Summary

Queue item 4b of the erasableSyntaxOnly follow-ups: delete the redundant
`public override readonly` re-declarations left by the #164 parameter-property conversion.

- `AppAuthInboxService`, `AppGroupInboxService`, `AppClientInboxService`, and
  `AppAdminInboxService` re-declared base-identical fields (`inbox`, `resourceInbox`,
  `resourceInboxResults`, `serviceId`) and re-assigned them after `super()` — state the
  base constructor already owns. Pure deletion (−32 lines); subclass-own fields stay.
- The `AppCrdtInboxService` cleanup on #164 is the model; the remaining
  `override readonly name` matches are Error-class name overrides with real semantics and
  are untouched.
- shared-server typecheck clean; `packages/tests/shared-server` 1,838 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Human Review Record v1

Use this record for every pull request. It preserves the evidence that an
independent reviewer examined the exact candidate tree; it is not an automated
approval form.

Production code is the primary design artifact; tests are secondary evidence.
Automation validates evidence and freshness; it does not approve semantic
quality or retained legacy.

### PR classification

- Review scope: code-changing
- Explicit exemption, if any: none
  `agent-guidance-only`
- Exemption evidence: not applicable — code-changing pull request

Plan-, documentation-, and agent-guidance-only pull requests may use the
explicit exemption only when no production, test, script, workflow, package
metadata, or runtime files changed. An exemption does not permit a mixed PR to
skip review.

No production, test, script, workflow, package metadata, or runtime files
changed is required for an exemption.

### Change intent and scope

- Requirements and independently stated behavior: erasableSyntaxOnly follow-up queue item 4b — delete base-identical public override readonly field re-declarations plus their post-super() re-assignments in the AppInboxService subclasses, keeping subclass-own fields; the AppCrdtInboxService cleanup from #164 is the model. No behavior change.
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 1f08df1e84311389c6ed5ef9d606082cadddc23b
- Default-branch revalidation outcome: branched from origin/main 33fa104d; no default-branch movement affected this surface at preparation time.
- Active-plan legacy baseline and changed affected surface: no active plan owns this surface; the change is a pure deletion (32 lines) in four shared-server inbox services. review:legacy reports zero candidates.

### Initial independent review

An Initial independent review is required before a code-changing draft pull
request is created. Record `not yet required` only for an explicit exemption.

- Record status: complete
- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 1f08df1e84311389c6ed5ef9d606082cadddc23b
- Production owner-to-result trace: AppInboxService declares and assigns public readonly inbox, resourceInbox, resourceInboxResults, and serviceId in its constructor. AppAuthInboxService, AppGroupInboxService, AppClientInboxService, and AppAdminInboxService passed the same values to super() and then re-declared and re-assigned them, duplicating state the base owns. After the deletion every read of those fields resolves to the single base declaration; subclass-own fields (authMutationService, credentialIssuer, groupStateService, clientStateService, pruner, pageSize, readAuthority, wakeQueue) keep their explicit declarations and assignments.
- Cognitive-indirection findings: The deletion removes a duplicated-ownership hop: field state now has exactly one declaring owner per service, matching the AppCrdtInboxService shape from #164.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Pure deletion; the shared-server typecheck is clean and all 1,838 shared-server tests pass unchanged.
- Tests rewritten or removed: No tests changed; packages/tests/shared-server passes unchanged (1,838 tests).
- Production was not compromised for tests: No test-only wiring; production-only deletion.
- Behavior and judgment not proven by automation: That the four services were the complete sibling set was established by repository-wide search for override readonly re-declarations; the two remaining matches are Error.name overrides with different semantics and stay.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

### Milestone review

Add one entry for every milestone where a new ownership, control-flow, or
legacy family appears. Use `not applicable` only when no such family appeared.

- Milestone classification: none

When the classification is `reviewed`, add the exact heading
`#### Milestone review entry` immediately before the fields below. Copy the
complete heading-and-fields block for each additional reviewed milestone. When
the classification is `none`, leave the metadata `entries` array empty and do
not add that heading.

- Reviewer and independence (separate agent or human):
- Exact merge base SHA:
- Exact candidate head SHA:
- New ownership, control-flow, or legacy family:
- Production owner-to-result trace:
- Cognitive-indirection findings:
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings):
- Tests rewritten or removed:
- Production was not compromised for tests:
- Behavior and judgment not proven by automation:
- Legacy candidate count:
- Legacy ledger and dispositions:
- Critical findings unresolved: `0`
- Important findings unresolved: `0`
- Verdict: `pass` | `changes-requested` | `not-applicable`

### Complete code and legacy review

Complete code and legacy review is required before the pull request is ready
for merge. It must match the current candidate head SHA and follow every
changed production path from entry owner to result.

- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 1f08df1e84311389c6ed5ef9d606082cadddc23b
- Changed production owner-to-result trace, including decisions, effects, failures, callbacks, compatibility branches, and tests: AppInboxService declares and assigns public readonly inbox, resourceInbox, resourceInboxResults, and serviceId in its constructor. AppAuthInboxService, AppGroupInboxService, AppClientInboxService, and AppAdminInboxService passed the same values to super() and then re-declared and re-assigned them, duplicating state the base owns. After the deletion every read of those fields resolves to the single base declaration; subclass-own fields (authMutationService, credentialIssuer, groupStateService, clientStateService, pruner, pageSize, readAuthority, wakeQueue) keep their explicit declarations and assignments.
- Cognitive-indirection findings and resolution: The deletion removes a duplicated-ownership hop: field state now has exactly one declaring owner per service, matching the AppCrdtInboxService shape from #164.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Pure deletion; the shared-server typecheck is clean and all 1,838 shared-server tests pass unchanged.
- Tests rewritten or removed, with independent behavior retained: No tests changed; packages/tests/shared-server passes unchanged (1,838 tests).
- Production was not compromised for tests: No test-only wiring; production-only deletion.
- Behavior and judgment not proven by automation: That the four services were the complete sibling set was established by repository-wide search for override readonly re-declarations; the two remaining matches are Error.name overrides with different semantics and stay.
- Legacy candidates inspected (baseline, automated report, changed files, and production call paths): npm run review:legacy -- 33fa104d 1f08df1e reports zero candidates; the changed paths are the four subclass service files, all on reviewed production call paths covered by the shared-server suite.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

Completed work requires zero unresolved Critical or Important findings.

### Human approval for retained legacy

List every `retained-pending-human-approval` item. Every confirmed affected
legacy item uses `classification: legacy` and exactly one disposition:
`removed`, `minimized-boundary`, `resolved`, or
`retained-pending-human-approval`. A heuristic candidate that is not legacy uses
`classification: not-legacy` with a concrete rationale; it is not a legacy
exception or an implicit disposition.

The final review's `Legacy ledger and dispositions` field is the one bound,
human-readable retained ledger. `Legacy exception ID` is the projection's `id`.
Each retained item also presents the exact path and symbol, purpose, consumer
or operational dependency, unsafe-removal
reason, minimization, canonical owner, compatibility tests, named owner,
review/removal condition, and approved production SHA. The validator hashes
that exact canonical projection. Record trusted GitHub approval provenance in
the `retainedLegacy` metadata and durable registry; do not duplicate the
approval details in another unbound visible block.

Silence, an issue, an earlier plan approval, agent judgment, or automation is
not approval. A production change invalidates the final review and any
retained-legacy approval. Record the approved item in
[`docs/production-legacy-exceptions.md`](../docs/production-legacy-exceptions.md)
before completion.

### Validation and publication

- Passed commands and exact current-head workflow evidence: npx tsc -p packages/shared-server/tsconfig.json --noEmit (clean), npx vitest run packages/tests/shared-server (1,838 passed, 3 skipped), prettier check on the four files, npm run check:repo-style:changed -- origin/main (PASS), npm run review:legacy (zero candidates), npm run check:pr-human-review against this body (PASS) — at head 1f08df1e. Branch Release Gate runs on this exact head.
- Failed or skipped commands and reason: broader test:ci delegated to Branch Release Gate; the change is a type-level deletion inside shared-server with its focused suite green.
- Follow-up issues: none

### Validator metadata

Replace every value in this JSON fence with the exact evidence recorded above.
The check rejects placeholder text and does not approve semantic quality or
retained legacy.

```pr-human-review-record-v1
{
  "version": 1,
  "scope": "code-changing",
  "exemption": null,
  "initialReview": {
    "status": "complete",
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "1f08df1e84311389c6ed5ef9d606082cadddc23b",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "AppInboxService declares and assigns public readonly inbox, resourceInbox, resourceInboxResults, and serviceId in its constructor. AppAuthInboxService, AppGroupInboxService, AppClientInboxService, and AppAdminInboxService passed the same values to super() and then re-declared and re-assigned them, duplicating state the base owns. After the deletion every read of those fields resolves to the single base declaration; subclass-own fields (authMutationService, credentialIssuer, groupStateService, clientStateService, pruner, pageSize, readAuthority, wakeQueue) keep their explicit declarations and assignments.",
      "cognitiveIndirectionFindings": "The deletion removes a duplicated-ownership hop: field state now has exactly one declaring owner per service, matching the AppCrdtInboxService shape from #164.",
      "completeFindings": "No Critical or Important findings remain. Pure deletion; the shared-server typecheck is clean and all 1,838 shared-server tests pass unchanged.",
      "testsRewrittenOrRemoved": "No tests changed; packages/tests/shared-server passes unchanged (1,838 tests).",
      "productionNotCompromisedForTests": "No test-only wiring; production-only deletion.",
      "automationGaps": "That the four services were the complete sibling set was established by repository-wide search for override readonly re-declarations; the two remaining matches are Error.name overrides with different semantics and stay."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 1f08df1e reports zero candidates; the changed paths are the four subclass service files, all on reviewed production call paths covered by the shared-server suite."
    }
  },
  "milestoneReview": {
    "classification": "none",
    "entries": []
  },
  "finalReview": {
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "1f08df1e84311389c6ed5ef9d606082cadddc23b",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "AppInboxService declares and assigns public readonly inbox, resourceInbox, resourceInboxResults, and serviceId in its constructor. AppAuthInboxService, AppGroupInboxService, AppClientInboxService, and AppAdminInboxService passed the same values to super() and then re-declared and re-assigned them, duplicating state the base owns. After the deletion every read of those fields resolves to the single base declaration; subclass-own fields (authMutationService, credentialIssuer, groupStateService, clientStateService, pruner, pageSize, readAuthority, wakeQueue) keep their explicit declarations and assignments.",
      "cognitiveIndirectionFindings": "The deletion removes a duplicated-ownership hop: field state now has exactly one declaring owner per service, matching the AppCrdtInboxService shape from #164.",
      "completeFindings": "No Critical or Important findings remain. Pure deletion; the shared-server typecheck is clean and all 1,838 shared-server tests pass unchanged.",
      "testsRewrittenOrRemoved": "No tests changed; packages/tests/shared-server passes unchanged (1,838 tests).",
      "productionNotCompromisedForTests": "No test-only wiring; production-only deletion.",
      "automationGaps": "That the four services were the complete sibling set was established by repository-wide search for override readonly re-declarations; the two remaining matches are Error.name overrides with different semantics and stay."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 1f08df1e reports zero candidates; the changed paths are the four subclass service files, all on reviewed production call paths covered by the shared-server suite."
    }
  },
  "retainedLegacy": []
}
```

The visible Initial, Milestone, and Complete review sections above are the
human record. Fill each stable labeled field once with the exact matching
metadata value; do not add copied marker blocks. For retained legacy, metadata
must reference a trusted human GitHub review ID, login, submitted date,
approved production SHA, and whole-ledger SHA-256. A later registry recording
commit is allowed only when it changes no production path.
