### PR TITLE
feat(bb-test): D4 — assertion capability advertisement + staging preflight gate

### DIFF
--- a/apps/rallar-black-box-control-server/src/routes/swagger-routes.ts
+++ b/apps/rallar-black-box-control-server/src/routes/swagger-routes.ts
@@ -1270,6 +1270,24 @@ const CONTROL_OPENAPI_SPEC: JsonRecord = {
                 },
                 additionalProperties: false,
               },
+              assertions: {
+                type: 'object',
+                required: ['absence', 'untilLoop', 'operators'],
+                description:
+                  'Assertion features this agent build evaluates: absence waits, ' +
+                  'until loops, and the advertised assert operator set. Staging ' +
+                  'preflight blocks manifests whose inline recipes need features ' +
+                  'a targeted agent does not advertise.',
+                properties: {
+                  absence: { type: 'boolean' },
+                  untilLoop: { type: 'boolean' },
+                  operators: {
+                    type: 'array',
+                    items: { type: 'string' },
+                  },
+                },
+                additionalProperties: false,
+              },
             },
             additionalProperties: false,
           },

--- a/packages/shared-test/rallar-bb-test/control-client.ts
+++ b/packages/shared-test/rallar-bb-test/control-client.ts
@@ -11,6 +11,7 @@ import type {
     RallarBlackBoxControlAgentIdentity,
     RallarBlackBoxGeoLocation,
 } from './distributed-run.ts';
+import { toControlAgentCapabilities } from './distributed/control-agent-capabilities.ts';
 import { redactRallarBlackBoxValue } from './redaction.ts';
 import {
     type ControlClientEnvelope,
@@ -168,30 +169,6 @@ function firstString(...values: readonly unknown[]): string | undefined {
     return undefined;
 }
 
-const CONTROL_AGENT_CRDT_TRANSPORTS = [
-    'local-only',
-    'ws',
-    'rtc',
-    'ws-then-rtc',
-    'rtc-with-ws-fallback',
-] as const;
-
-function hasCrdtRuntimeHints(config: RallarBlackBoxTestState['currentConfig']): boolean {
-    const rallar = asRecord(config?.rallar);
-    return Boolean(
-        rallar.crdt === true ||
-            typeof rallar.crdtTransport === 'string' ||
-            rallar.crdtRuntime === true,
-    );
-}
-
-function isCrdtCapableProvider(providerMode: string | undefined): boolean {
-    return providerMode === 'browser-rallar' ||
-        providerMode === 'rallar-browser' ||
-        providerMode === 'rallar-remote-browser' ||
-        providerMode === 'mixed';
-}
-
 function toControlAgentIdentity(
     state: RallarBlackBoxTestState,
     agentId: string,
@@ -214,7 +191,6 @@ function toControlAgentIdentity(
     const sessionId = firstString(rallar.sessionId, config.sessionId);
     const providerMode = firstString(control.providerMode, defaults.providerMode, rallar.providerMode);
     const apiBaseUrl = firstString(config.apiBaseUrl, rallar.apiBaseUrl, defaults.apiBaseUrl);
-    const crdtSupported = isCrdtCapableProvider(providerMode) || hasCrdtRuntimeHints(config);
     const identity: RallarBlackBoxControlAgentIdentity = {
         principalId,
         clientId: firstString(rallar.clientId, principalId),
@@ -242,14 +218,11 @@ function toControlAgentIdentity(
         os: firstString(fleet.os, browser.os),
         tags: stringArray(fleet.tags),
         location: geoLocation(fleet.location),
-        capabilities: {
-            crdt: {
-                supported: crdtSupported,
-                transports: crdtSupported ? CONTROL_AGENT_CRDT_TRANSPORTS : [],
-                runtimeSurface: providerMode,
-                apiBaseUrlConfigured: Boolean(apiBaseUrl),
-            },
-        },
+        capabilities: toControlAgentCapabilities({
+            config,
+            providerMode,
+            apiBaseUrl,
+        }),
         updatedAtEpochMs: Date.now(),
     };
 

--- a/packages/shared-test/rallar-bb-test/control-protocol.ts
+++ b/packages/shared-test/rallar-bb-test/control-protocol.ts
@@ -11,6 +11,9 @@ import type {
     RallarBlackBoxGeoLocation,
 } from './distributed-run.ts';
 import {
+    parseControlAgentCapabilities,
+} from './distributed/control-agent-capabilities.ts';
+import {
     type RallarValidationIssue,
     type RallarValidationResult,
     formatRallarValidation,
@@ -1005,41 +1008,6 @@ function optionalString(value: unknown): string | undefined {
     return typeof value === 'string' && value.trim().length > 0
         ? value
         : undefined;
-}
-
-const CRDT_TRANSPORTS = [
-    'local-only',
-    'ws',
-    'rtc',
-    'ws-then-rtc',
-    'rtc-with-ws-fallback',
-] as const;
-
-function parseControlAgentCapabilities(value: unknown): RallarBlackBoxControlAgentIdentity['capabilities'] {
-    if (!isRecord(value)) {
-        return undefined;
-    }
-    const crdt = isRecord(value.crdt) ? value.crdt : undefined;
-    if (!crdt || typeof crdt.supported !== 'boolean') {
-        return undefined;
-    }
-
-    const transports = Array.isArray(crdt.transports)
-        ? crdt.transports.filter((transport): transport is typeof CRDT_TRANSPORTS[number] =>
-            typeof transport === 'string' &&
-            CRDT_TRANSPORTS.includes(transport as typeof CRDT_TRANSPORTS[number])
-        )
-        : undefined;
-    return {
-        crdt: {
-            supported: crdt.supported,
-            transports,
-            runtimeSurface: optionalString(crdt.runtimeSurface),
-            apiBaseUrlConfigured: typeof crdt.apiBaseUrlConfigured === 'boolean'
-                ? crdt.apiBaseUrlConfigured
-                : undefined,
-        },
-    };
 }
 
 function parseControlAgentIdentity(value: unknown): RallarBlackBoxControlAgentIdentity | undefined {

--- a/packages/shared-test/rallar-bb-test/distributed-run-monitor.ts
+++ b/packages/shared-test/rallar-bb-test/distributed-run-monitor.ts
@@ -8,6 +8,11 @@ import type {
     RallarBlackBoxDistributedTargetResolution,
     RallarBlackBoxDistributedTargetPolicy,
 } from './distributed-run.ts';
+import {
+    collectDistributedAssertionFeatures,
+    validateAgentAssertionCapability,
+    type DistributedAssertionFeatures,
+} from './distributed/control-agent-capabilities.ts';
 import { RALLAR_BLACK_BOX_COMMAND_CAPABILITIES } from './schema.ts';
 import {
     flattenRallarBlackBoxCompositeResults,
@@ -176,6 +181,7 @@ export type DistributedRecipeTargetStatus =
     | 'different-group'
     | 'missing-identity'
     | 'missing-crdt-runtime'
+    | 'missing-assertion-capability'
     | 'missing-crdt-transport';
 
 export type DistributedRecipeTargetRow = Readonly<{
@@ -781,15 +787,19 @@ export function distributedRecipeTargetRows(input: Readonly<{
     const requiredCrdtTransports = uniqueValues(
         (input.requiredRecipes ?? []).flatMap(distributedRecipeCrdtTransports),
     );
+    const requiredAssertionFeatures = collectDistributedAssertionFeatures(
+        input.requiredRecipes ?? [],
+    );
     const rows = agents.map(agent =>
-        distributedRecipeTargetRow(
+        distributedRecipeTargetRow({
             agent,
-            input.group,
+            group: input.group,
             nowEpochMs,
             staleAfterMs,
             requiresCrdtRuntime,
             requiredCrdtTransports,
-        )
+            requiredAssertionFeatures,
+        })
     );
     const duplicateIdentityCounts = new Map<string, number>();
 
@@ -2517,14 +2527,21 @@ export function deriveDistributedRunWarningRegressionReport(input: Readonly<{
     };
 }
 
+interface DistributedRecipeTargetRowInput {
+    readonly agent: ControlAgentSnapshot;
+    readonly group: RallarBlackBoxDistributedGroupRef;
+    readonly nowEpochMs: number;
+    readonly staleAfterMs: number;
+    readonly requiresCrdtRuntime: boolean;
+    readonly requiredCrdtTransports: readonly RallarBlackBoxTestCrdtTransport[];
+    readonly requiredAssertionFeatures: DistributedAssertionFeatures;
+}
+
 function distributedRecipeTargetRow(
-    agent: ControlAgentSnapshot,
-    group: RallarBlackBoxDistributedGroupRef,
-    nowEpochMs: number,
-    staleAfterMs: number,
-    requiresCrdtRuntime: boolean,
-    requiredCrdtTransports: readonly RallarBlackBoxTestCrdtTransport[],
+    input: DistributedRecipeTargetRowInput,
 ): DistributedRecipeTargetRow {
+    const { agent, group, nowEpochMs, staleAfterMs, requiresCrdtRuntime, requiredCrdtTransports } =
+        input;
     const identity = agent.identity;
     const crdt = identity?.capabilities?.crdt;
     const crdtTransports = crdt?.transports ?? [];
@@ -2601,6 +2618,19 @@ function distributedRecipeTargetRow(
             status: 'missing-crdt-transport',
             targetable: false,
             reason: `Agent CRDT runtime does not report ${missingCrdtTransport} transport support.`,
+        };
+    }
+
+    const unmetAssertionReason = validateAgentAssertionCapability(
+        input.requiredAssertionFeatures,
+        identity?.capabilities,
+    );
+    if (unmetAssertionReason) {
+        return {
+            ...base,
+            status: 'missing-assertion-capability',
+            targetable: false,
+            reason: unmetAssertionReason,
         };
     }
 

--- a/packages/shared-test/rallar-bb-test/distributed-run.ts
+++ b/packages/shared-test/rallar-bb-test/distributed-run.ts
@@ -1,7 +1,13 @@
 import type {
+    RallarBlackBoxTestAssertOperator,
     RallarBlackBoxTestCrdtTransport,
     RallarBlackBoxTestRecipe,
 } from './types.ts';
+import {
+    collectDistributedAssertionFeatures,
+    validateAgentAssertionCapability,
+    type DistributedAssertionFeatures,
+} from './distributed/control-agent-capabilities.ts';
 
 export const RALLAR_BLACK_BOX_DISTRIBUTED_RUN_STATES = [
     'draft',
@@ -114,6 +120,13 @@ export type RallarBlackBoxControlAgentIdentity = Readonly<{
 
 export type RallarBlackBoxControlAgentCapabilities = Readonly<{
     crdt?: RallarBlackBoxControlAgentCrdtCapability;
+    assertions?: RallarBlackBoxControlAgentAssertionsCapability;
+}>;
+
+export type RallarBlackBoxControlAgentAssertionsCapability = Readonly<{
+    absence: boolean;
+    untilLoop: boolean;
+    operators: readonly RallarBlackBoxTestAssertOperator[];
 }>;
 
 export type RallarBlackBoxControlAgentCrdtCapability = Readonly<{
@@ -250,6 +263,7 @@ export type RallarBlackBoxDistributedTargetBlockerStatus =
     | 'offline-agent'
     | 'stale-agent'
     | 'different-group'
+    | 'missing-assertion-capability'
     | 'agent-without-identity';
 
 export type RallarBlackBoxDistributedTargetBlocker = Readonly<{
@@ -276,6 +290,7 @@ export type RallarBlackBoxDistributedTargetResolution = Readonly<{
         staleAgents: number;
         offlineAgents: number;
         wrongGroupAgents: number;
+        assertionCapabilityBlockedAgents?: number;
         agentsWithoutIdentity: number;
         roleCounts: Readonly<Record<string, number>>;
         regions: Readonly<Record<string, number>>;
@@ -641,9 +656,20 @@ export function resolveDistributedRunTargets(input: Readonly<{
     const blockers: RallarBlackBoxDistributedTargetBlocker[] = [];
     const targetableAgentIds: string[] = [];
     const targetableById = new Set<string>();
+    const assertionFeatures = collectDistributedAssertionFeatures(
+        input.manifest.recipes
+            .map(selection => selection.recipe)
+            .filter((recipe): recipe is RallarBlackBoxTestRecipe => recipe !== undefined),
+    );
 
     for (const agent of input.agents) {
-        const blocker = distributedTargetBlocker(agent, input.manifest.group, nowEpochMs, staleAfterMs);
+        const blocker = distributedTargetBlocker({
+            agent,
+            group: input.manifest.group,
+            nowEpochMs,
+            staleAfterMs,
+            assertionFeatures,
+        });
         if (blocker) {
             blockers.push(blocker);
             continue;
@@ -686,6 +712,8 @@ export function resolveDistributedRunTargets(input: Readonly<{
             staleAgents: blockers.filter(blocker => blocker.status === 'stale-agent').length,
             offlineAgents: blockers.filter(blocker => blocker.status === 'offline-agent').length,
             wrongGroupAgents: blockers.filter(blocker => blocker.status === 'different-group').length,
+            assertionCapabilityBlockedAgents: blockers
+                .filter(blocker => blocker.status === 'missing-assertion-capability').length,
             agentsWithoutIdentity: blockers.filter(blocker => blocker.status === 'agent-without-identity').length,
             roleCounts,
             regions: countBy(selectedAgents.map(agent => agent.identity?.region).filter(isString)),
@@ -694,12 +722,18 @@ export function resolveDistributedRunTargets(input: Readonly<{
     };
 }
 
+interface DistributedTargetBlockerInput {
+    readonly agent: RallarBlackBoxControlAgentCandidate;
+    readonly group: RallarBlackBoxDistributedGroupRef;
+    readonly nowEpochMs: number;
+    readonly staleAfterMs: number;
+    readonly assertionFeatures: DistributedAssertionFeatures;
+}
+
 function distributedTargetBlocker(
-    agent: RallarBlackBoxControlAgentCandidate,
-    group: RallarBlackBoxDistributedGroupRef,
-    nowEpochMs: number,
-    staleAfterMs: number,
+    input: DistributedTargetBlockerInput,
 ): RallarBlackBoxDistributedTargetBlocker | undefined {
+    const agent = input.agent;
     if (!agent.identity) {
         return {
             agentId: agent.agentId,
@@ -707,7 +741,7 @@ function distributedTargetBlocker(
             reason: 'Control agent has not reported Rallar identity metadata.',
         };
     }
-    if (!identityMatchesGroup(agent.identity, group)) {
+    if (!identityMatchesGroup(agent.identity, input.group)) {
         return {
             agentId: agent.agentId,
             status: 'different-group',
@@ -723,11 +757,23 @@ function distributedTargetBlocker(
             identity: agent.identity,
         };
     }
-    if (agentIsStale(agent, nowEpochMs, staleAfterMs)) {
+    if (agentIsStale(agent, input.nowEpochMs, input.staleAfterMs)) {
         return {
             agentId: agent.agentId,
             status: 'stale-agent',
             reason: 'Control agent heartbeat is stale.',
+            identity: agent.identity,
+        };
+    }
+    const unmetAssertionReason = validateAgentAssertionCapability(
+        input.assertionFeatures,
+        agent.identity.capabilities,
+    );
+    if (unmetAssertionReason) {
+        return {
+            agentId: agent.agentId,
+            status: 'missing-assertion-capability',
+            reason: unmetAssertionReason,
             identity: agent.identity,
         };
     }

--- a/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
+++ b/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
@@ -206,6 +206,6 @@ function optionalString(value: any): string | undefined {
     return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
 }
 
-function isRecord(value: any): value is Record<string, unknown> {
+function isRecord(value: any): value is Record<string, any> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
+++ b/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import { RALLAR_BLACK_BOX_ASSERT_OPERATORS } from '../assert/assert-value-operators.ts';
 import type {
     RallarBlackBoxControlAgentCapabilities,
@@ -28,8 +29,8 @@ const BASELINE_ASSERT_OPERATORS: readonly RallarBlackBoxTestAssertOperator[] = [
     'lte',
 ];
 
-export const RALLAR_BLACK_BOX_EXTENDED_ASSERT_OPERATORS: readonly RallarBlackBoxTestAssertOperator[] =
-    RALLAR_BLACK_BOX_ASSERT_OPERATORS
+export const RALLAR_BLACK_BOX_EXTENDED_ASSERT_OPERATORS:
+    readonly RallarBlackBoxTestAssertOperator[] = RALLAR_BLACK_BOX_ASSERT_OPERATORS
         .filter(operator => !BASELINE_ASSERT_OPERATORS.includes(operator));
 
 export interface DistributedAssertionFeatures {
@@ -68,7 +69,7 @@ export function toControlAgentCapabilities(
 }
 
 export function parseControlAgentCapabilities(
-    value: unknown,
+    value: any,
 ): RallarBlackBoxControlAgentCapabilities | undefined {
     if (!isRecord(value)) {
         return undefined;
@@ -163,7 +164,7 @@ export function validateAgentAssertionCapability(
 }
 
 function parseAssertionsCapability(
-    value: unknown,
+    value: any,
 ): RallarBlackBoxControlAgentAssertionsCapability | undefined {
     if (!isRecord(value)) {
         return undefined;
@@ -201,10 +202,10 @@ function hasCrdtRuntimeHints(config: RallarBlackBoxTestConfig | undefined): bool
     );
 }
 
-function optionalString(value: unknown): string | undefined {
+function optionalString(value: any): string | undefined {
     return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(value: any): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
+++ b/packages/shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts
@@ -1,0 +1,210 @@
+import { RALLAR_BLACK_BOX_ASSERT_OPERATORS } from '../assert/assert-value-operators.ts';
+import type {
+    RallarBlackBoxControlAgentCapabilities,
+    RallarBlackBoxControlAgentAssertionsCapability,
+} from '../distributed-run.ts';
+import type {
+    RallarBlackBoxTestAssertOperator,
+    RallarBlackBoxTestCommand,
+    RallarBlackBoxTestConfig,
+    RallarBlackBoxTestCrdtTransport,
+    RallarBlackBoxTestRecipe,
+} from '../types.ts';
+
+const CONTROL_AGENT_CRDT_TRANSPORTS = [
+    'local-only',
+    'ws',
+    'rtc',
+    'ws-then-rtc',
+    'rtc-with-ws-fallback',
+] as const;
+
+const BASELINE_ASSERT_OPERATORS: readonly RallarBlackBoxTestAssertOperator[] = [
+    'equals',
+    'notEquals',
+    'contains',
+    'exists',
+    'gte',
+    'lte',
+];
+
+export const RALLAR_BLACK_BOX_EXTENDED_ASSERT_OPERATORS: readonly RallarBlackBoxTestAssertOperator[] =
+    RALLAR_BLACK_BOX_ASSERT_OPERATORS
+        .filter(operator => !BASELINE_ASSERT_OPERATORS.includes(operator));
+
+export interface DistributedAssertionFeatures {
+    readonly absence: boolean;
+    readonly untilLoop: boolean;
+    readonly operators: readonly RallarBlackBoxTestAssertOperator[];
+}
+
+export interface ToControlAgentCapabilitiesInput {
+    readonly config: RallarBlackBoxTestConfig | undefined;
+    readonly providerMode: string | undefined;
+    readonly apiBaseUrl: string | undefined;
+}
+
+// The advertisement is a build-time truth: an agent built from this checkout
+// evaluates absence waits, until loops, and the full operator set, so the
+// capability block mirrors the runtime feature set rather than configuration.
+export function toControlAgentCapabilities(
+    input: ToControlAgentCapabilitiesInput,
+): RallarBlackBoxControlAgentCapabilities {
+    const crdtSupported = isCrdtCapableProvider(input.providerMode) ||
+        hasCrdtRuntimeHints(input.config);
+    return {
+        crdt: {
+            supported: crdtSupported,
+            transports: crdtSupported ? CONTROL_AGENT_CRDT_TRANSPORTS : [],
+            runtimeSurface: input.providerMode,
+            apiBaseUrlConfigured: Boolean(input.apiBaseUrl),
+        },
+        assertions: {
+            absence: true,
+            untilLoop: true,
+            operators: RALLAR_BLACK_BOX_ASSERT_OPERATORS,
+        },
+    };
+}
+
+export function parseControlAgentCapabilities(
+    value: unknown,
+): RallarBlackBoxControlAgentCapabilities | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+    const crdt = isRecord(value.crdt) ? value.crdt : undefined;
+    if (!crdt || typeof crdt.supported !== 'boolean') {
+        return undefined;
+    }
+
+    const transports = Array.isArray(crdt.transports)
+        ? crdt.transports.filter((transport): transport is RallarBlackBoxTestCrdtTransport =>
+            typeof transport === 'string' &&
+            CONTROL_AGENT_CRDT_TRANSPORTS
+                .includes(transport as typeof CONTROL_AGENT_CRDT_TRANSPORTS[number])
+        )
+        : undefined;
+    const assertions = parseAssertionsCapability(value.assertions);
+    return {
+        crdt: {
+            supported: crdt.supported,
+            transports,
+            runtimeSurface: optionalString(crdt.runtimeSurface),
+            apiBaseUrlConfigured: typeof crdt.apiBaseUrlConfigured === 'boolean'
+                ? crdt.apiBaseUrlConfigured
+                : undefined,
+        },
+        ...(assertions ? { assertions } : {}),
+    };
+}
+
+export function collectDistributedAssertionFeatures(
+    recipes: readonly RallarBlackBoxTestRecipe[],
+): DistributedAssertionFeatures {
+    let absence = false;
+    let untilLoop = false;
+    const operators = new Set<RallarBlackBoxTestAssertOperator>();
+
+    const visit = (command: RallarBlackBoxTestCommand): void => {
+        if (command.kind === 'wait' && command.absent === true) {
+            absence = true;
+        }
+        if (command.kind === 'loop') {
+            if (command.until !== undefined) {
+                untilLoop = true;
+            }
+            command.commands.forEach(visit);
+        }
+        if (command.kind === 'parallel') {
+            command.groups.forEach(group => group.commands.forEach(visit));
+        }
+        if (
+            command.kind === 'assert' &&
+            RALLAR_BLACK_BOX_EXTENDED_ASSERT_OPERATORS.includes(command.operator)
+        ) {
+            operators.add(command.operator);
+        }
+        if ((command.kind === 'recipe.load' || command.kind === 'recipe.run') && command.recipe) {
+            command.recipe.commands.forEach(visit);
+        }
+    };
+    recipes.forEach(recipe => recipe.commands.forEach(visit));
+
+    return {
+        absence,
+        untilLoop,
+        operators: [...operators].sort(),
+    };
+}
+
+export function validateAgentAssertionCapability(
+    features: DistributedAssertionFeatures,
+    capabilities: RallarBlackBoxControlAgentCapabilities | undefined,
+): string | undefined {
+    const missing: string[] = [];
+    const assertions = capabilities?.assertions;
+    if (features.absence && assertions?.absence !== true) {
+        missing.push('absence waits');
+    }
+    if (features.untilLoop && assertions?.untilLoop !== true) {
+        missing.push('until loops');
+    }
+    const advertisedOperators = assertions?.operators ?? [];
+    const missingOperators = features.operators
+        .filter(operator => !advertisedOperators.includes(operator));
+    if (missingOperators.length > 0) {
+        missing.push(`assert operators: ${missingOperators.join(', ')}`);
+    }
+    if (missing.length === 0) {
+        return undefined;
+    }
+    return `Agent does not advertise required assertion capabilities: ${missing.join('; ')}.`;
+}
+
+function parseAssertionsCapability(
+    value: unknown,
+): RallarBlackBoxControlAgentAssertionsCapability | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+    if (typeof value.absence !== 'boolean' || typeof value.untilLoop !== 'boolean') {
+        return undefined;
+    }
+    const operators = Array.isArray(value.operators)
+        ? value.operators.filter((operator): operator is RallarBlackBoxTestAssertOperator =>
+            typeof operator === 'string' &&
+            RALLAR_BLACK_BOX_ASSERT_OPERATORS
+                .includes(operator as RallarBlackBoxTestAssertOperator)
+        )
+        : [];
+    return {
+        absence: value.absence,
+        untilLoop: value.untilLoop,
+        operators,
+    };
+}
+
+function isCrdtCapableProvider(providerMode: string | undefined): boolean {
+    return providerMode === 'browser-rallar' ||
+        providerMode === 'rallar-browser' ||
+        providerMode === 'rallar-remote-browser' ||
+        providerMode === 'mixed';
+}
+
+function hasCrdtRuntimeHints(config: RallarBlackBoxTestConfig | undefined): boolean {
+    const rallar = isRecord(config?.rallar) ? config.rallar : {};
+    return Boolean(
+        rallar.crdt === true ||
+            typeof rallar.crdtTransport === 'string' ||
+            rallar.crdtRuntime === true,
+    );
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/shared-test/rallar-bb-test/docs/distributed-run-contract.md
+++ b/packages/shared-test/rallar-bb-test/docs/distributed-run-contract.md
@@ -174,9 +174,32 @@ server and operator SPA. It returns `targetResolution` with:
 - resolved `targetAgentIds`
 - derived `roleAssignments`
 - expected/actual participant counts
-- stale/offline/wrong-group/missing-identity blocker totals
+- stale/offline/wrong-group/missing-identity/assertion-capability blocker
+  totals
 - blocking agent IDs and reasons
 - role, region, and provider counts
+
+### Assertion Capability Gate
+
+Agents advertise an `assertions` block in
+`RallarBlackBoxControlAgentCapabilities` beside the established `crdt` block:
+`absence` (wait `absent: true`), `untilLoop` (loop `until: 'first-success'`),
+and `operators` (the assert operator set the build evaluates). The block is
+populated from the runtime feature set by
+`toControlAgentCapabilities(...)` in
+`distributed/control-agent-capabilities.ts` and survives the
+register-envelope parse.
+
+Staging preflight scans every inline manifest recipe (including nested
+`loop`/`parallel`/`recipe.load`/`recipe.run` children) with
+`collectDistributedAssertionFeatures(...)`. A targeted agent that does not
+advertise a required feature becomes a `missing-assertion-capability`
+blocker with a named reason listing exactly what is missing, so staging
+fails before dispatch instead of the run failing agent-side at
+`validateKeys`. Hetzner fleets rebuild from the checkout on rollout and
+always advertise the current feature set; world-fleet agents are the
+population this gate protects — checked-in world-fleet manifests may adopt
+absence waits, until loops, and extended operators only behind this gate.
 
 For `roleAssignmentPolicy.mode === "ordered-targets"`, target IDs are sorted by
 `agentId` before roles are derived. For principal multicast, the first resolved

--- a/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
+++ b/packages/shared-test/rallar-bb-test/docs/schema-compatibility-guide.md
@@ -336,3 +336,47 @@ npx vitest run packages/tests/shared-test/rallar-bb-test-loop-until.test.ts
 npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
 npx vitest run packages/tests/shared-test/rallar-bb-test-composite-conformance.test.ts
 ```
+
+```text
+Title: agents advertise assertion capabilities; staging gates on them
+Date: 2026-08-11
+Owner: rallar-bb-test distributed assertion parity plan, workstream D4
+
+Change type:
+- Compatible optional addition (identity metadata + staging preflight)
+
+Affected schemas:
+- RallarBlackBoxControlAgentCapabilities (new optional assertions block)
+- Distributed target resolution (new missing-assertion-capability blocker)
+- Control-server OpenAPI ControlAgentIdentity capabilities schema
+
+Old shape:
+Agent capability advertisement covered only the crdt block. Manifests using
+D1-D3 features dispatched to old agents failed agent-side at validateKeys.
+
+New shape:
+Agents advertise assertions { absence, untilLoop, operators } populated from
+the build's runtime feature set. resolveDistributedRunTargets and the
+operator target rows scan inline recipes for absence waits, until loops, and
+extended assert operators; a targeted agent that does not advertise a
+required feature becomes a missing-assertion-capability blocker with a
+named reason, failing staging instead of the run.
+
+Migration:
+No manifest changes required. World-fleet manifests may adopt the D1-D3
+features once their fleets advertise the block; Hetzner rollouts advertise
+it automatically after rebuild.
+
+Golden corpus updates:
+The golden distributed manifest's inline recipe gained an absence wait and
+an until loop so manifest examples exercise the gated features.
+
+Prompt/documentation updates:
+distributed-run-contract.md documents the assertions block and the staging
+gate; control-server OpenAPI describes the assertions capability schema.
+
+Verification:
+npx vitest run packages/tests/shared-test/rallar-bb-test-assertion-capability-gate.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-distributed-run.test.ts
+npx vitest run packages/tests/shared-test/rallar-bb-test-schema.test.ts
+```

--- a/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
+++ b/packages/shared-test/rallar-bb-test/fixtures/schema/v1/golden-compatibility-corpus.json
@@ -588,6 +588,34 @@
                   }
                 },
                 "timeoutMs": 60000
+              },
+              {
+                "kind": "wait",
+                "commandId": "ai-wait-absent-v1",
+                "absent": true,
+                "timeoutMs": 1500,
+                "match": {
+                  "kind": "message",
+                  "topic": "room.golden.other-room",
+                  "payloadPath": "data.topic",
+                  "equals": "room.golden.leak-probe"
+                }
+              },
+              {
+                "kind": "loop",
+                "commandId": "ai-loop-until-v1",
+                "until": "first-success",
+                "count": 5,
+                "intervalMs": 100,
+                "commands": [
+                  {
+                    "kind": "assert",
+                    "commandId": "ai-loop-until-assert-v1",
+                    "source": "state.commandHistory.length",
+                    "operator": "gt",
+                    "expected": 0
+                  }
+                ]
               }
             ],
             "metadata": {

--- a/packages/shared-test/rallar-bb-test/mod.ts
+++ b/packages/shared-test/rallar-bb-test/mod.ts
@@ -40,3 +40,4 @@ export * from './conformance/create-rallar-black-box-composite-conformance-recip
 export * from './wait/wait-for-event.ts';
 export * from './assert/assert-value-operators.ts';
 export * from './loop/loop-until.ts';
+export * from './distributed/control-agent-capabilities.ts';

--- a/packages/tests/shared-test/rallar-bb-test-assertion-capability-gate.test.ts
+++ b/packages/tests/shared-test/rallar-bb-test-assertion-capability-gate.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+    collectDistributedAssertionFeatures,
+    parseControlAgentCapabilities,
+    toControlAgentCapabilities,
+    validateAgentAssertionCapability,
+} from '../../shared-test/rallar-bb-test/distributed/control-agent-capabilities.ts';
+import {
+    resolveDistributedRunTargets,
+    type RallarBlackBoxControlAgentCandidate,
+    type RallarBlackBoxControlAgentCapabilities,
+    type RallarBlackBoxDistributedRunManifest,
+} from '../../shared-test/rallar-bb-test/distributed-run.ts';
+import type { RallarBlackBoxTestRecipe } from '../../shared-test/rallar-bb-test/types.ts';
+
+const NEW_FEATURE_RECIPE: RallarBlackBoxTestRecipe = {
+    schemaVersion: 1,
+    recipeId: 'gate-new-features',
+    commands: [
+        {
+            kind: 'wait',
+            commandId: 'gate-absence',
+            absent: true,
+            timeoutMs: 1_000,
+            match: { kind: 'message', topic: 'room.gate.forbidden' },
+        },
+        {
+            kind: 'loop',
+            commandId: 'gate-until',
+            until: 'first-success',
+            count: 3,
+            commands: [
+                {
+                    kind: 'assert',
+                    commandId: 'gate-extended-assert',
+                    source: 'state.commandHistory.length',
+                    operator: 'gt',
+                    expected: 0,
+                },
+            ],
+        },
+    ],
+};
+
+const BASELINE_RECIPE: RallarBlackBoxTestRecipe = {
+    schemaVersion: 1,
+    recipeId: 'gate-baseline',
+    commands: [
+        { kind: 'health', commandId: 'gate-health' },
+        {
+            kind: 'assert',
+            commandId: 'gate-baseline-assert',
+            source: 'state.commandHistory.length',
+            operator: 'gte',
+            expected: 0,
+        },
+    ],
+};
+
+function manifestWith(recipe: RallarBlackBoxTestRecipe): RallarBlackBoxDistributedRunManifest {
+    return {
+        distributedRunId: `gate-${recipe.recipeId}`,
+        group: {
+            applicationId: 'rallar-server',
+            workspaceId: 'default',
+            groupId: 'gate-room',
+        },
+        recipes: [
+            {
+                recipeId: recipe.recipeId,
+                required: true,
+                recipe,
+            },
+        ],
+        targetPolicy: {
+            mode: 'all-online-group-members',
+            expectedParticipantCount: 1,
+        },
+        startMode: 'manual',
+    };
+}
+
+function agentWith(
+    capabilities: RallarBlackBoxControlAgentCapabilities,
+): RallarBlackBoxControlAgentCandidate {
+    return {
+        agentId: 'gate-agent',
+        connected: true,
+        lastHeartbeatAtEpochMs: 1_000,
+        identity: {
+            principalId: 'gate-principal',
+            sessionId: 'gate-session',
+            applicationId: 'rallar-server',
+            workspaceId: 'default',
+            groupId: 'gate-room',
+            capabilities,
+            updatedAtEpochMs: 1_000,
+        },
+    };
+}
+
+describe('rallar-bb-test assertion capability gate', () => {
+    it('collects absence, until, and extended operator usage from inline recipes', () => {
+        const features = collectDistributedAssertionFeatures([NEW_FEATURE_RECIPE]);
+        expect(features).toEqual({
+            absence: true,
+            untilLoop: true,
+            operators: ['gt'],
+        });
+
+        expect(collectDistributedAssertionFeatures([BASELINE_RECIPE])).toEqual({
+            absence: false,
+            untilLoop: false,
+            operators: [],
+        });
+    });
+
+    it('blocks staging targets for old-capability agents with a named reason', () => {
+        const resolution = resolveDistributedRunTargets({
+            manifest: manifestWith(NEW_FEATURE_RECIPE),
+            agents: [agentWith({ crdt: { supported: true } })],
+            nowEpochMs: 1_500,
+        });
+
+        expect(resolution.targetAgentIds).toEqual([]);
+        expect(resolution.blockers).toHaveLength(1);
+        expect(resolution.blockers[0]).toMatchObject({
+            agentId: 'gate-agent',
+            status: 'missing-assertion-capability',
+        });
+        expect(resolution.blockers[0].reason).toContain('absence waits');
+        expect(resolution.blockers[0].reason).toContain('until loops');
+        expect(resolution.blockers[0].reason).toContain('assert operators: gt');
+        expect(resolution.summary.assertionCapabilityBlockedAgents).toBe(1);
+        expect(resolution.summary.missingExpectedParticipants).toBe(1);
+    });
+
+    it('stages a capability-complete fleet and leaves baseline manifests ungated', () => {
+        const complete = agentWith(toControlAgentCapabilities({
+            config: undefined,
+            providerMode: 'browser-rallar',
+            apiBaseUrl: 'http://localhost:8080',
+        }));
+
+        const gated = resolveDistributedRunTargets({
+            manifest: manifestWith(NEW_FEATURE_RECIPE),
+            agents: [complete],
+            nowEpochMs: 1_500,
+        });
+        expect(gated.targetAgentIds).toEqual(['gate-agent']);
+        expect(gated.blockers).toEqual([]);
+
+        const baseline = resolveDistributedRunTargets({
+            manifest: manifestWith(BASELINE_RECIPE),
+            agents: [agentWith({ crdt: { supported: true } })],
+            nowEpochMs: 1_500,
+        });
+        expect(baseline.targetAgentIds).toEqual(['gate-agent']);
+        expect(baseline.blockers).toEqual([]);
+    });
+
+    it('advertises the runtime feature set and survives the register-envelope parse', () => {
+        const advertised = toControlAgentCapabilities({
+            config: undefined,
+            providerMode: 'browser-rallar',
+            apiBaseUrl: 'http://localhost:8080',
+        });
+        expect(advertised.assertions).toMatchObject({
+            absence: true,
+            untilLoop: true,
+        });
+        expect(advertised.assertions?.operators).toContain('matchesShapeComplete');
+
+        const parsed = parseControlAgentCapabilities(
+            JSON.parse(JSON.stringify(advertised)),
+        );
+        expect(parsed?.assertions).toEqual(advertised.assertions);
+        expect(parsed?.crdt?.supported).toBe(true);
+
+        const legacyParsed = parseControlAgentCapabilities({
+            crdt: { supported: true },
+        });
+        expect(legacyParsed?.assertions).toBeUndefined();
+        expect(validateAgentAssertionCapability(
+            collectDistributedAssertionFeatures([NEW_FEATURE_RECIPE]),
+            legacyParsed,
+        )).toContain('does not advertise required assertion capabilities');
+    });
+});

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -16,7 +16,7 @@ Status: in progress. Implements the decision items of issue
 | D1 `wait` absence mode | in review | [#181](https://github.com/intact-software-systems/ar-eye-hunter/pull/181) |
 | D2 assert operator extension | in review | [#182](https://github.com/intact-software-systems/ar-eye-hunter/pull/182) |
 | D3 `loop` until-success polling | in review | [#187](https://github.com/intact-software-systems/ar-eye-hunter/pull/187) |
-| D4 capability advertisement + preflight gating | not started | — |
+| D4 capability advertisement + preflight gating | in review | `codex/bb-test-d4-capability-gating` |
 | D5 parity and conformance deepening | not started | — |
 | D6 coordinator-evaluated group assertions | not started | — |
 

--- a/plans/rallar-bb-test-distributed-assertion-parity-plan.md
+++ b/plans/rallar-bb-test-distributed-assertion-parity-plan.md
@@ -16,7 +16,7 @@ Status: in progress. Implements the decision items of issue
 | D1 `wait` absence mode | in review | [#181](https://github.com/intact-software-systems/ar-eye-hunter/pull/181) |
 | D2 assert operator extension | in review | [#182](https://github.com/intact-software-systems/ar-eye-hunter/pull/182) |
 | D3 `loop` until-success polling | in review | [#187](https://github.com/intact-software-systems/ar-eye-hunter/pull/187) |
-| D4 capability advertisement + preflight gating | in review | `codex/bb-test-d4-capability-gating` |
+| D4 capability advertisement + preflight gating | in review | [#190](https://github.com/intact-software-systems/ar-eye-hunter/pull/190) |
 | D5 parity and conformance deepening | not started | — |
 | D6 coordinator-evaluated group assertions | not started | — |
 


### PR DESCRIPTION
## Summary

Workstream **D4** of the distributed assertion-parity plan (stack layer 6; parent #187, plan PR #178). Safe rollout for fleets that do not move atomically with the repo: a manifest needing D1–D3 features must not be staged onto agents that cannot evaluate them.

- **Advertisement (crdt precedent):** agents advertise `assertions { absence, untilLoop, operators }` in `RallarBlackBoxControlAgentCapabilities`, populated from the build's runtime feature set by `toControlAgentCapabilities(...)`. The register-envelope parser now preserves the block (it previously stripped anything but `crdt` server-side — that alone would have silently defeated any capability gate).
- **Staging gate:** `resolveDistributedRunTargets` (the control server's staging resolver) and the operator target rows scan inline manifest recipes — including nested `loop`/`parallel`/`recipe.load`/`recipe.run` children — with `collectDistributedAssertionFeatures(...)`. A targeted agent missing a required feature becomes a **`missing-assertion-capability`** blocker whose reason names exactly what is missing (e.g. "absence waits; until loops; assert operators: gt"), failing **staging** (missing expected participants) rather than the run. A summary counter (`assertionCapabilityBlockedAgents`) rolls the blockers up.
- **Structure:** all capability logic (build, parse, scan, validate) lives in `distributed/control-agent-capabilities.ts`; `control-client.ts` (−25) and `control-protocol.ts` (−31) delegate to it — both over-cap files net-negative this PR. The two gate-adjacent positional-heavy functions became named-input contracts.
- **Aligned surfaces:** control-server OpenAPI `ControlAgentIdentity.capabilities` documents the assertions schema; the golden corpus manifest's inline recipe now exercises an absence wait + until loop; `distributed-run-contract.md` documents the gate; upgrade note recorded.

Hetzner fleets rebuild from the checkout on rollout, so they always advertise the current set; world-fleet no-spawn agents are the population this gate protects — world-fleet manifests may adopt the D1–D3 features only behind it.

## Validation

- `rallar-bb-test-assertion-capability-gate` (new, 4 tests: feature collection incl. nested composites, old-agent staging block with named reason + summary counter, capability-complete fleet stages + baseline manifests ungated, advertise→parse round-trip + legacy parse) — pass
- Full `packages/tests/shared-test/` + `packages/tests/rallar-black-box/` — **2421 pass** (unsandboxed)
- `npm run test:repo-governance` — 391 pass
- control-server `deno task check` + `deno task test` — 79 pass (identity parse + OpenAPI changed)
- shared-test + rallar-black-box typecheck — pass
- `npm run check:repo-style:changed -- origin/main HEAD` — PASS (control-client −25, control-protocol −31 net)

Base: `codex/bb-test-d3-loop-until-polling`. Plan Status table updated. Follow-up issues: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)