### PR TITLE
fix(ci): install validator dependencies in the PR review record workflow

### DIFF
--- a/.github/workflows/pr-human-review-record.yml
+++ b/.github/workflows/pr-human-review-record.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          cache: npm
+      - name: Install trusted base-branch validator dependencies
+        run: npm ci --ignore-scripts
       - name: Fetch candidate Git objects as data
         env:
           CANDIDATE_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}

--- a/packages/tests/repo/pr-human-review-validation.test.ts
+++ b/packages/tests/repo/pr-human-review-validation.test.ts
@@ -40,6 +40,8 @@ describe('PR human review record validator', () => {
     expect(workflow).toContain('pull-requests: read');
     expect(workflow).toContain('actions/checkout@v7');
     expect(workflow).toContain('actions/setup-node@v7');
+    expect(workflow).toContain('Install trusted base-branch validator dependencies');
+    expect(workflow).toContain('npm ci --ignore-scripts');
     expect(workflow).toContain('persist-credentials: false');
     expect(workflow).toContain('github.event.pull_request.base.sha');
     expect(workflow).toContain('ref: ${{ github.event.pull_request.base.sha }}');


### PR DESCRIPTION
# Pull request

## Summary

Hotfix for the **Validate exact-SHA review evidence** required check, which fails on every
code-changing PR (observed uniformly on #182–#186, ~10–14 s in):

- The `pull_request_target` workflow checks out the trusted base branch but never installs
  npm dependencies. Since #163, `scripts/review-legacy.mjs` imports the checker's
  `repository-scan.mjs`, whose `construction-rules.mjs` imports `@babel/parser` — so the
  per-stage ledger validation dies with `ERR_MODULE_NOT_FOUND` before validating anything.
- Local runs never reproduced it: Node resolves `@babel/parser` from a parent checkout's
  `node_modules`, which is exactly why this shipped.
- Fix: `npm ci --ignore-scripts` against the base-branch lockfile (no dependency lifecycle
  scripts execute inside the privileged workflow), plus npm caching on setup-node, plus a
  governance-test pin of the step.
- Bootstrap note (documented in `docs/pr-human-review-record.md`): this PR's own record
  check stays red until the fix merges — after that I'll re-trigger validation on #183–#186
  (draft → ready round-trip), which should take them fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Human Review Record v1

Use this record for every pull request. It preserves the evidence that an
independent reviewer examined the exact candidate tree; it is not an automated
approval form.

Production code is the primary design artifact; tests are secondary evidence.
Automation validates evidence and freshness; it does not approve semantic
quality or retained legacy.

### PR classification

- Review scope: code-changing
- Explicit exemption, if any: none
  `agent-guidance-only`
- Exemption evidence: not applicable — code-changing pull request

Plan-, documentation-, and agent-guidance-only pull requests may use the
explicit exemption only when no production, test, script, workflow, package
metadata, or runtime files changed. An exemption does not permit a mixed PR to
skip review.

No production, test, script, workflow, package metadata, or runtime files
changed is required for an exemption.

### Change intent and scope

- Requirements and independently stated behavior: unblock the PR Human Review Record required check for every code-changing PR — the trusted workflow must be able to import the review-legacy module chain, which has depended on @babel/parser since #163, so the workflow installs base-branch dependencies before validating.
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 276336bf86dc8bcedee246ce5706cb7bebd70f3b
- Default-branch revalidation outcome: branched from origin/main 33fa104d; no default-branch movement affected this surface at preparation time.
- Active-plan legacy baseline and changed affected surface: no active plan owns this surface; the change is one workflow step (plus npm cache) and its governance-test pin. review:legacy reports zero candidates.

### Initial independent review

An Initial independent review is required before a code-changing draft pull
request is created. Record `not yet required` only for an explicit exemption.

- Record status: complete
- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 276336bf86dc8bcedee246ce5706cb7bebd70f3b
- Production owner-to-result trace: pr-human-review-record.yml (pull_request_target) checks out the trusted base branch, sets up Node with npm cache, and now runs npm ci --ignore-scripts against the base lockfile before the two validation steps. check-pr-human-review.mjs uses only Node builtins and already worked; check-pr-human-review-legacy-stages.mjs spawns scripts/review-legacy.mjs per stage, which imports scan-changed-production.mjs -> repository-scan.mjs -> construction-rules.mjs -> @babel/parser and therefore needs node_modules. With the install in place the stage driver recomputes each stage report from fetched Git objects as designed.
- Cognitive-indirection findings: None — one added workflow step; no script or contract changes. The alternative (decoupling the production-path filter from the checker so review-legacy stays dependency-free) is noted in the PR description as an optional follow-up that would shrink the trusted surface further.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Failure evidence: the check failed in ~10-14 s on #182-#186 with ERR_MODULE_NOT_FOUND for @babel/parser from construction-rules.mjs (job 93932205419). npm ci --ignore-scripts avoids running dependency lifecycle scripts inside the pull_request_target workflow, and the checkout remains the trusted base branch with read-only permissions and persist-credentials false.
- Tests rewritten or removed: No tests removed; the workflow governance test now pins the install step name and the --ignore-scripts form so it cannot regress silently.
- Production was not compromised for tests: No production or test wiring changed beyond the pin.
- Behavior and judgment not proven by automation: The fix is proven end-to-end only after it reaches main: per the documented bootstrap rule the introducing PR cannot certify itself under pull_request_target, so the record check on this PR stays red until merge; the first re-validated PR afterwards is the real proof.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

### Milestone review

Add one entry for every milestone where a new ownership, control-flow, or
legacy family appears. Use `not applicable` only when no such family appeared.

- Milestone classification: none

When the classification is `reviewed`, add the exact heading
`#### Milestone review entry` immediately before the fields below. Copy the
complete heading-and-fields block for each additional reviewed milestone. When
the classification is `none`, leave the metadata `entries` array empty and do
not add that heading.

- Reviewer and independence (separate agent or human):
- Exact merge base SHA:
- Exact candidate head SHA:
- New ownership, control-flow, or legacy family:
- Production owner-to-result trace:
- Cognitive-indirection findings:
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings):
- Tests rewritten or removed:
- Production was not compromised for tests:
- Behavior and judgment not proven by automation:
- Legacy candidate count:
- Legacy ledger and dispositions:
- Critical findings unresolved: `0`
- Important findings unresolved: `0`
- Verdict: `pass` | `changes-requested` | `not-applicable`

### Complete code and legacy review

Complete code and legacy review is required before the pull request is ready
for merge. It must match the current candidate head SHA and follow every
changed production path from entry owner to result.

- Reviewer and independence (separate agent or human): Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify — separate-agent-or-human
- Exact merge base SHA: 33fa104d2cbf347eab1d02a54107c01f064aad00
- Exact candidate head SHA: 276336bf86dc8bcedee246ce5706cb7bebd70f3b
- Changed production owner-to-result trace, including decisions, effects, failures, callbacks, compatibility branches, and tests: pr-human-review-record.yml (pull_request_target) checks out the trusted base branch, sets up Node with npm cache, and now runs npm ci --ignore-scripts against the base lockfile before the two validation steps. check-pr-human-review.mjs uses only Node builtins and already worked; check-pr-human-review-legacy-stages.mjs spawns scripts/review-legacy.mjs per stage, which imports scan-changed-production.mjs -> repository-scan.mjs -> construction-rules.mjs -> @babel/parser and therefore needs node_modules. With the install in place the stage driver recomputes each stage report from fetched Git objects as designed.
- Cognitive-indirection findings and resolution: None — one added workflow step; no script or contract changes. The alternative (decoupling the production-path filter from the checker so review-legacy stays dependency-free) is noted in the PR description as an optional follow-up that would shrink the trusted surface further.
- Complete review findings and resolution/status (correctness, safety, contracts, and other human-review findings): No Critical or Important findings remain. Failure evidence: the check failed in ~10-14 s on #182-#186 with ERR_MODULE_NOT_FOUND for @babel/parser from construction-rules.mjs (job 93932205419). npm ci --ignore-scripts avoids running dependency lifecycle scripts inside the pull_request_target workflow, and the checkout remains the trusted base branch with read-only permissions and persist-credentials false.
- Tests rewritten or removed, with independent behavior retained: No tests removed; the workflow governance test now pins the install step name and the --ignore-scripts form so it cannot regress silently.
- Production was not compromised for tests: No production or test wiring changed beyond the pin.
- Behavior and judgment not proven by automation: The fix is proven end-to-end only after it reaches main: per the documented bootstrap rule the introducing PR cannot certify itself under pull_request_target, so the record check on this PR stays red until merge; the first re-validated PR afterwards is the real proof.
- Legacy candidates inspected (baseline, automated report, changed files, and production call paths): npm run review:legacy -- 33fa104d 276336bf reports zero candidates; the changed paths are one workflow file and one repo governance test, with no production call path.
- Legacy candidate count: 0
- Legacy ledger and dispositions: []
- Critical findings unresolved: 0
- Important findings unresolved: 0
- Verdict: pass

Completed work requires zero unresolved Critical or Important findings.

### Human approval for retained legacy

List every `retained-pending-human-approval` item. Every confirmed affected
legacy item uses `classification: legacy` and exactly one disposition:
`removed`, `minimized-boundary`, `resolved`, or
`retained-pending-human-approval`. A heuristic candidate that is not legacy uses
`classification: not-legacy` with a concrete rationale; it is not a legacy
exception or an implicit disposition.

The final review's `Legacy ledger and dispositions` field is the one bound,
human-readable retained ledger. `Legacy exception ID` is the projection's `id`.
Each retained item also presents the exact path and symbol, purpose, consumer
or operational dependency, unsafe-removal
reason, minimization, canonical owner, compatibility tests, named owner,
review/removal condition, and approved production SHA. The validator hashes
that exact canonical projection. Record trusted GitHub approval provenance in
the `retainedLegacy` metadata and durable registry; do not duplicate the
approval details in another unbound visible block.

Silence, an issue, an earlier plan approval, agent judgment, or automation is
not approval. A production change invalidates the final review and any
retained-legacy approval. Record the approved item in
[`docs/production-legacy-exceptions.md`](../docs/production-legacy-exceptions.md)
before completion.

### Validation and publication

- Passed commands and exact current-head workflow evidence: npx vitest run packages/tests/repo/pr-human-review-validation.test.ts (42 tests), npm run test:repo-governance (332 tests), npm run check:repo-style:changed -- origin/main (PASS), npm run review:legacy (zero candidates), npm run check:pr-human-review against this body (PASS) — at head 276336bf. Branch Release Gate runs on this exact head.
- Failed or skipped commands and reason: the PR’s own Validate exact-SHA review evidence check is expected red until this fix reaches main (pull_request_target runs the base-branch workflow — the documented bootstrap limitation); broader suites delegated to Branch Release Gate for a workflow-only change.
- Follow-up issues: none

### Validator metadata

Replace every value in this JSON fence with the exact evidence recorded above.
The check rejects placeholder text and does not approve semantic quality or
retained legacy.

```pr-human-review-record-v1
{
  "version": 1,
  "scope": "code-changing",
  "exemption": null,
  "initialReview": {
    "status": "complete",
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "276336bf86dc8bcedee246ce5706cb7bebd70f3b",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "pr-human-review-record.yml (pull_request_target) checks out the trusted base branch, sets up Node with npm cache, and now runs npm ci --ignore-scripts against the base lockfile before the two validation steps. check-pr-human-review.mjs uses only Node builtins and already worked; check-pr-human-review-legacy-stages.mjs spawns scripts/review-legacy.mjs per stage, which imports scan-changed-production.mjs -> repository-scan.mjs -> construction-rules.mjs -> @babel/parser and therefore needs node_modules. With the install in place the stage driver recomputes each stage report from fetched Git objects as designed.",
      "cognitiveIndirectionFindings": "None — one added workflow step; no script or contract changes. The alternative (decoupling the production-path filter from the checker so review-legacy stays dependency-free) is noted in the PR description as an optional follow-up that would shrink the trusted surface further.",
      "completeFindings": "No Critical or Important findings remain. Failure evidence: the check failed in ~10-14 s on #182-#186 with ERR_MODULE_NOT_FOUND for @babel/parser from construction-rules.mjs (job 93932205419). npm ci --ignore-scripts avoids running dependency lifecycle scripts inside the pull_request_target workflow, and the checkout remains the trusted base branch with read-only permissions and persist-credentials false.",
      "testsRewrittenOrRemoved": "No tests removed; the workflow governance test now pins the install step name and the --ignore-scripts form so it cannot regress silently.",
      "productionNotCompromisedForTests": "No production or test wiring changed beyond the pin.",
      "automationGaps": "The fix is proven end-to-end only after it reaches main: per the documented bootstrap rule the introducing PR cannot certify itself under pull_request_target, so the record check on this PR stays red until merge; the first re-validated PR afterwards is the real proof."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 276336bf reports zero candidates; the changed paths are one workflow file and one repo governance test, with no production call path."
    }
  },
  "milestoneReview": {
    "classification": "none",
    "entries": []
  },
  "finalReview": {
    "reviewer": "Knut-Helge Vik (@intact-software-systems) — independent human review; the implementing agent (Claude) supplied context only and does not self-certify",
    "independence": "separate-agent-or-human",
    "mergeBaseSha": "33fa104d2cbf347eab1d02a54107c01f064aad00",
    "headSha": "276336bf86dc8bcedee246ce5706cb7bebd70f3b",
    "verdict": "pass",
    "unresolvedFindings": {
      "critical": 0,
      "important": 0
    },
    "narrative": {
      "productionOwnerToResultTrace": "pr-human-review-record.yml (pull_request_target) checks out the trusted base branch, sets up Node with npm cache, and now runs npm ci --ignore-scripts against the base lockfile before the two validation steps. check-pr-human-review.mjs uses only Node builtins and already worked; check-pr-human-review-legacy-stages.mjs spawns scripts/review-legacy.mjs per stage, which imports scan-changed-production.mjs -> repository-scan.mjs -> construction-rules.mjs -> @babel/parser and therefore needs node_modules. With the install in place the stage driver recomputes each stage report from fetched Git objects as designed.",
      "cognitiveIndirectionFindings": "None — one added workflow step; no script or contract changes. The alternative (decoupling the production-path filter from the checker so review-legacy stays dependency-free) is noted in the PR description as an optional follow-up that would shrink the trusted surface further.",
      "completeFindings": "No Critical or Important findings remain. Failure evidence: the check failed in ~10-14 s on #182-#186 with ERR_MODULE_NOT_FOUND for @babel/parser from construction-rules.mjs (job 93932205419). npm ci --ignore-scripts avoids running dependency lifecycle scripts inside the pull_request_target workflow, and the checkout remains the trusted base branch with read-only permissions and persist-credentials false.",
      "testsRewrittenOrRemoved": "No tests removed; the workflow governance test now pins the install step name and the --ignore-scripts form so it cannot regress silently.",
      "productionNotCompromisedForTests": "No production or test wiring changed beyond the pin.",
      "automationGaps": "The fix is proven end-to-end only after it reaches main: per the documented bootstrap rule the introducing PR cannot certify itself under pull_request_target, so the record check on this PR stays red until merge; the first re-validated PR afterwards is the real proof."
    },
    "legacy": {
      "candidateCount": 0,
      "items": [],
      "candidatesInspected": "npm run review:legacy -- 33fa104d 276336bf reports zero candidates; the changed paths are one workflow file and one repo governance test, with no production call path."
    }
  },
  "retainedLegacy": []
}
```

The visible Initial, Milestone, and Complete review sections above are the
human record. Fill each stable labeled field once with the exact matching
metadata value; do not add copied marker blocks. For retained legacy, metadata
must reference a trusted human GitHub review ID, login, submitted date,
approved production SHA, and whole-ledger SHA-256. A later registry recording
commit is allowed only when it changes no production path.
