### PR TITLE
chore: refresh RTC benchmark Deno workspace locks

### DIFF
--- a/apps/api-v1/deno.lock
+++ b/apps/api-v1/deno.lock
@@ -829,6 +829,7 @@
           "npm:graphology@0.26.0"
         ]
       },
+      "npm:@ar-eye-hunter/shared-rtc-bench@0.1.0": {},
       "npm:@ar-eye-hunter/shared-server@0.1.0": {},
       "npm:@ar-eye-hunter/shared-test@0.1.0": {},
       "npm:@ar-eye-hunter/shared-web@0.1.0": {

--- a/apps/relic-hunter-server-v1/deno.lock
+++ b/apps/relic-hunter-server-v1/deno.lock
@@ -68,6 +68,7 @@
           "npm:graphology@0.26.0"
         ]
       },
+      "npm:@ar-eye-hunter/shared-rtc-bench@0.1.0": {},
       "npm:@ar-eye-hunter/shared-server@0.1.0": {},
       "npm:@ar-eye-hunter/shared-test@0.1.0": {},
       "npm:@ar-eye-hunter/shared-web@0.1.0": {

--- a/deno.lock
+++ b/deno.lock
@@ -3635,6 +3635,18 @@
           ]
         }
       },
+      "packages/shared-rtc-bench": {
+        "dependencies": [
+          "jsr:@std/path@^1.0.9",
+          "npm:graphology@0.26.0",
+          "npm:postgres@^3.4.9"
+        ],
+        "packageJson": {
+          "dependencies": [
+            "npm:@types/deno@2.7.0"
+          ]
+        }
+      },
       "packages/shared-web": {
         "packageJson": {
           "dependencies": [


### PR DESCRIPTION
## Summary

- complete Task 4A Deno workspace participation after PR #198 added `packages/shared-rtc-bench`
- add the Deno-generated workspace member to the root lock
- add the Deno-generated empty workspace link to the API and Relic server locks

## Why this follow-up is required

The required resulting-main **Run Hetzner Supported Distributed Manifests** run [31640463428](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/31640463428) failed on merge commit `03f690f3ae9d821876d50035ef7463def0985059` during frozen Deno cache preparation, before any distributed recipe ran. Deno reported that the new npm workspace was absent from the committed lock metadata.

Although these generated lockfiles were omitted from Section 10's explicit integration path list, this is the smallest correction required by Task 4A's approved workspace creation, Deno participation, and resulting-main frozen rollout gate. It does not expand into Task 4B, B04, capture, B06, ontology, or production RTC work.

## Exact change

- `deno.lock`: add the `packages/shared-rtc-bench` workspace member and its already-approved imports/dev dependency
- `apps/api-v1/deno.lock`: add the empty `@ar-eye-hunter/shared-rtc-bench` workspace link
- `apps/relic-hunter-server-v1/deno.lock`: add the same empty workspace link

The delta is exactly 3 generated lockfiles and 14 insertions. No version, integrity hash, runtime import, product dependency edge, executable behavior, or benchmark semantic changes.

## Validation

- independent regeneration from exact base `03f690f3ae9d821876d50035ef7463def0985059`: byte-for-byte match for all three lockfiles
- frozen Deno check/cache: shared RTC bench, API, control server, and Relic server passed
- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check`: 29 files / 274 tests passed; TypeScript and all 24 Deno roots passed
- `npm run test:unit`: 776 files passed, 3 skipped; 6,941 tests passed, 5 skipped
- `npm run test:ci`: passed
- `npm run build`: passed
- `npm run check:repo-style:changed -- origin/main`: passed with no findings
- JSON validation and `git diff --check`: passed
- independent review: Critical 0, Important 0, Minor 0

## Evidence lineage

- approved RTC plan blob: `b78e00e982d186264bc5ba6b4b2a943f15a328f3`
- Task 4A implementation PR: #198
- Task 4A merge/main commit: `03f690f3ae9d821876d50035ef7463def0985059`
- this correction commit: `10a161addffc6821cb6240f28e23e0773d7ee19b`
- this correction tree: `d8af997cbcc9ad1476470687228eee1b16595ef6`
