### PR TITLE
Make retained legacy guidance visible and testable

### DIFF
--- a/.agents/evaluations/rallar-code-writing/v1/rubric.json
+++ b/.agents/evaluations/rallar-code-writing/v1/rubric.json
@@ -31,6 +31,34 @@
     {
       "id": "stewardship.genuine-decision-escalation",
       "pass": "Escalates only for a genuine exception for a remaining real standards violation, a public compatibility or migration decision, an unresolved correctness or safety conflict, or a failed post-consolidation navigation probe after one autonomous coherent consolidation. Treats pre-work repository state, stale or unrelated governance state, and checker or resource failures as reportable validation or environment evidence rather than another escalation category."
+    },
+    {
+      "id": "legacy.safe-private-removal",
+      "pass": "Deletes the affected private duplicate helper and obsolete private mode after the scenario's complete caller and contract facts establish that no independent requirement or verified consumer needs them, and classifies both legacy items as removed."
+    },
+    {
+      "id": "legacy.behavior-preservation",
+      "pass": "Keeps the requested canonical behavior correct, replaces or removes tests coupled only to predecessor topology, and adds or updates semantic tests that protect the independently required canonical or compatibility behavior."
+    },
+    {
+      "id": "legacy.scope-containment",
+      "pass": "Completes the affected production and test closure while keeping independent untouched legacy and unrelated cleanup outside the change."
+    },
+    {
+      "id": "legacy.preexisting-pressure-rejection",
+      "pass": "Does not retain safely removable affected legacy because it pre-existed, a coupled test protects it, removal was not named, the first diff was narrow, or a deadline is close; also does not use those pressures to silently remove a verified public compatibility requirement."
+    },
+    {
+      "id": "legacy.public-compatibility-safety",
+      "pass": "Does not silently delete the deprecated public entry point while its verified consumer remains active; identifies removal as a public compatibility or migration decision requiring explicit maintainer direction rather than treating deprecation alone as removal authority."
+    },
+    {
+      "id": "legacy.minimized-boundary",
+      "pass": "Removes duplicate business logic from the deprecated public entry point and proposes or keeps only a thin, explicitly named compatibility boundary that delegates directly to the canonical implementation."
+    },
+    {
+      "id": "legacy.retention-governance",
+      "pass": "Requires explicit authorized-maintainer approval and a durable retained-legacy registry entry for the exact path and symbol before completing with the public boundary retained. The registry facts name its purpose, canonical owner, verified consumer dependency, unsafe-removal reason, minimization, compatibility tests, named owner, and review or removal condition."
     }
   ],
   "resultContract": {

--- a/.agents/evaluations/rallar-code-writing/v1/scenarios.json
+++ b/.agents/evaluations/rallar-code-writing/v1/scenarios.json
@@ -22,6 +22,46 @@
         "stewardship.no-debt-only-permission-request",
         "stewardship.genuine-decision-escalation"
       ]
+    },
+    {
+      "id": "safe-private-legacy-removal",
+      "title": "A touched private predecessor has no caller or independent requirement",
+      "critical": true,
+      "primarySkill": "rallar-code-writing",
+      "pressures": [
+        "small-diff-request",
+        "pre-existing-legacy",
+        "coupled-test",
+        "release-deadline"
+      ],
+      "prompt": "IMPORTANT: This is a deterministic, non-mutating decision exercise. Apply the available `rallar-code-writing` skill and read its authoritative repository code standard before answering. You may read applicable agent guidance. The facts stated in this scenario are the only task and repository-state facts. Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state; do not edit files, mutate plans or governance, run validation commands, or call external systems. A narrow implementation request changes the canonical score-normalization behavior in one production module. The touched module also contains a private duplicate scoring helper and an obsolete private mode. Complete caller and contract inspection is already established as a scenario fact: no production caller, export, persisted value, protocol, configuration, migration, or independent requirement uses either predecessor; only a coupled implementation test invokes the obsolete mode. The requested canonical behavior must remain correct. A release lead says to leave the predecessors because they pre-existed, removal was not named in the request, and the deadline is close. State the exact production, test, legacy-disposition, and scope decisions you would make next. Do not answer with general advice; make the decision for this scenario.",
+      "requiredDimensions": [
+        "legacy.safe-private-removal",
+        "legacy.behavior-preservation",
+        "legacy.scope-containment",
+        "legacy.preexisting-pressure-rejection"
+      ]
+    },
+    {
+      "id": "public-compatibility-legacy-restraint",
+      "title": "A deprecated public predecessor still has an active consumer",
+      "critical": true,
+      "primarySkill": "rallar-code-writing",
+      "pressures": [
+        "deprecated-public-api",
+        "verified-active-consumer",
+        "duplicate-business-logic",
+        "release-deadline"
+      ],
+      "prompt": "IMPORTANT: This is a deterministic, non-mutating decision exercise. Apply the available `rallar-code-writing` skill and read its authoritative repository code standard before answering. You may read applicable agent guidance. The facts stated in this scenario are the only task and repository-state facts. Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state; do not edit files, mutate plans or governance, run validation commands, or call external systems. A narrow implementation request changes validation in a canonical public route. The touched module also exposes a deprecated public entry point with a verified active consumer outside the current change, and that consumer cannot migrate in this task. The deprecated entry point contains duplicate business logic instead of delegating to the canonical route. The requested canonical behavior and the active consumer behavior must remain correct. A release lead says to delete the deprecated entry point immediately because it is legacy and the deadline is close. State the exact production, test, compatibility, legacy-disposition, scope, and completion decisions you would make next, including what evidence or approval is needed, if any. Do not answer with general advice; make the decision for this scenario.",
+      "requiredDimensions": [
+        "legacy.public-compatibility-safety",
+        "legacy.minimized-boundary",
+        "legacy.retention-governance",
+        "legacy.behavior-preservation",
+        "legacy.scope-containment",
+        "legacy.preexisting-pressure-rejection"
+      ]
     }
   ]
 }

--- a/.agents/skills/adaptive-plan-execution/SKILL.md
+++ b/.agents/skills/adaptive-plan-execution/SKILL.md
@@ -29,6 +29,14 @@ file, that file enters the closure recursively. Independent untouched code
 remains outside the closure. Checker tolerance is not authority and does not
 define touched-file standards closure.
 
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
+
 When giving a next-action decision before edits, and again in the final
 handoff, state all three closure facts explicitly:
 

--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -44,6 +44,14 @@ do not turn propagation into repository-wide cleanup. Checker tolerance is not
 authority to retain touched-file noncompliance and does not define touched-file
 standards closure.
 
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
+
 When giving a next-action decision before edits, and again in the final
 handoff, state all three closure facts explicitly:
 

--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -93,6 +93,14 @@ shims, and workarounds; parallel old/new implementations; rollback paths that
 retain a predecessor; and historical vocabulary or types retained only for
 compatibility.
 
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
+
 At completion, each affected item is `removed`, `minimized-boundary`, `resolved`, or `retained`.
 `minimized-boundary` means a thin, explicitly named compatibility boundary that
 delegates to the canonical implementation and contains no duplicate business

--- a/.agents/skills/rallar-code-writing/references/typescript-type-organization.md
+++ b/.agents/skills/rallar-code-writing/references/typescript-type-organization.md
@@ -264,11 +264,15 @@ function createAccount(input: CreateAccounts.Input): void {}
 ```
 
 For exported aliases that may be part of a public package surface, removal can be
-a breaking change. The repo rule that existing public exports and app import
-paths are preserved unless the task explicitly asks for a breaking change applies
-here: do not silently preserve a bad alias forever, and do not silently delete it
-either — distinguish private cleanup from public API migration, and report the
-compatibility implication in the handoff so a human can decide.
+a breaking change.
+
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
 
 ## Review heuristics
 

--- a/.agents/skills/rallar-platform/SKILL.md
+++ b/.agents/skills/rallar-platform/SKILL.md
@@ -36,7 +36,15 @@ rg --files packages/shared packages/shared-web packages/shared-server packages/s
 
 ## Public Surface Rules
 
-- Preserve existing exports unless the task explicitly removes a deprecated API.
+- Do not silently delete public exports or automatically preserve deprecated
+  exports forever.
+- During touched-file standards closure, actively remove affected legacy code when no
+  independent requirement or verified consumer requires it. Do not retain affected legacy solely
+  because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+  independent untouched legacy outside closure. If removal would change a public API, persisted
+  format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+  migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+  and a registry entry for continued retention.
 - Prefer adding narrow helpers beside the domain they belong to, then export through the local package barrel.
 - Treat broad `mod.ts` barrels as compatibility surfaces; avoid moving symbols in ways that break imports.
 - When editing shared contracts, inspect both browser and server consumers before changing a type.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ closure recursively. Independent untouched code remains outside the closure.
 Do not treat warning-only full-repository checks or new/worsened changed checks
 as authority to retain touched-file noncompliance.
 
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
+
 Escalate only for a genuine exception for a remaining real standards violation,
 a public compatibility or migration decision, an unresolved correctness or
 safety conflict, or a failed post-consolidation navigation probe. Do not
@@ -128,8 +136,8 @@ standard.
 - Keep Rallar black-box control protocol, distributed-run artifact contracts,
   reusable recipe fixtures, and artifact analysis in `packages/shared-test`;
   `apps/rallar-black-box` should consume those contracts for UI/operator flows.
-- Preserve existing public exports and app import paths unless a task explicitly
-  asks for a breaking change.
+- Do not silently delete public exports or automatically preserve deprecated
+  exports forever; apply the compatibility and migration rule above.
 - Prefer `GroupRef`/`roomRef` when application/workspace scope matters.
 - For room-scoped app/game traffic, prefer `rallar.realtime.room<T>(...)` and
   `rallar.messages.room<T>(...)` before hand-wiring RTC readiness and sends.

--- a/docs/repo-human-style-guide.md
+++ b/docs/repo-human-style-guide.md
@@ -289,6 +289,14 @@ canonical implementation, and contains no duplicate business logic. Unrelated un
 outside the completion gate unless the change depends on, expands, materially touches, or routes
 changed production flow through it.
 
+During touched-file standards closure, actively remove affected legacy code when no
+independent requirement or verified consumer requires it. Do not retain affected legacy solely
+because it pre-existed, a coupled test protects it, or removal was not named in the request. Keep
+independent untouched legacy outside closure. If removal would change a public API, persisted
+format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or
+migration decision; minimize it to a thin named boundary and require explicit maintainer approval
+and a registry entry for continued retention.
+
 Never allow an issue, reviewer silence, prior approval, agent judgment, or an automated result to
 approve retained legacy. For every retained item, verify an authorized maintainer approved and the
 durable registry records its exact path and symbol, purpose and consumer dependency,

--- a/packages/tests/repo/governance-gate/governance-gate-command.test.ts
+++ b/packages/tests/repo/governance-gate/governance-gate-command.test.ts
@@ -31,6 +31,7 @@ describe('governance gate command', () => {
     expect(result.stdout.trim().split('\n')).toEqual([
       'PASS: governance gate repo-structure',
       'PASS: governance gate repo-style',
+      'retained-legacy fixture success',
       'PASS: governance gate retained-legacy',
       'PASS: governance gate (3 phases)',
     ]);
@@ -39,6 +40,26 @@ describe('governance gate command', () => {
       'repo-style',
       'retained-legacy',
     ]);
+  });
+
+  it('bounds successful advisory output and points to the complete retained-legacy report', () => {
+    const fixtureRoot = createFixture({
+      ...requiredPhaseCommands,
+      'check:retained-legacy': ['retained-legacy-large', 0],
+    });
+
+    const result = runCommand(fixtureRoot);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('retained-legacy-large fixture success');
+    expect(result.stdout).toContain(
+      'TRUNCATED: successful advisory output exceeded 32,000 characters; ' +
+        'run npm run check:retained-legacy for the complete report.',
+    );
+    expect(result.stdout).not.toContain('end-of-large-advisory');
+    const advisoryStart = result.stdout.indexOf('retained-legacy-large fixture success');
+    const advisoryEnd = result.stdout.indexOf('\nPASS: governance gate retained-legacy');
+    expect(result.stdout.slice(advisoryStart, advisoryEnd)).toHaveLength(32_000);
   });
 
   it('fails before execution when a canonical package command is missing', () => {
@@ -108,7 +129,11 @@ function createFixture(commands: Readonly<Record<string, readonly [string, numbe
       "import { appendFileSync } from 'node:fs';",
       'const [phase, status] = process.argv.slice(2);',
       "appendFileSync('executed-phases.txt', `${phase}\\n`);",
-      "console.log(status === '0' ? `${phase} fixture success` : `${phase} fixture failure`);",
+      "if (phase === 'retained-legacy-large') {",
+      "  console.log(`${phase} fixture success ${'x'.repeat(33_000)} end-of-large-advisory`);",
+      '} else {',
+      "  console.log(status === '0' ? `${phase} fixture success` : `${phase} fixture failure`);",
+      '}',
       'process.exitCode = Number(status);',
     ].join('\n'),
   );

--- a/packages/tests/repo/legacy-review.test.ts
+++ b/packages/tests/repo/legacy-review.test.ts
@@ -2,8 +2,9 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { printReport } from '../../../scripts/legacy-review/candidate-report.mjs';
 import { readRetainedLegacyRegistry } from '../../../scripts/legacy-review/retained-legacy-registry.mjs';
 import { validateRetainedLegacy } from '../../../scripts/legacy-review/validate-retained-legacy.mjs';
 
@@ -94,7 +95,82 @@ describe('changed production legacy review command', () => {
     expect(result.stdout).toContain('compatibility vocabulary');
     expect(result.stdout).toContain('compatibility export alias');
     expect(result.stdout).toContain('feature flag or mode retaining a predecessor');
+    expect(result.stdout).not.toContain('::warning');
     expect(result.stdout).not.toMatch(/production-legacy-candidate-|REPORT-SHA256|final ledger/iu);
+  });
+
+  it('emits non-blocking GitHub warnings for heuristic candidates in Actions', () => {
+    const fixture = createGitFixture({
+      'packages/example/src/compatibility-route.ts':
+        "export { createCanonicalRoute as createLegacyRoute } from './canonical-route.ts';\n",
+    });
+
+    const result = runLegacyReview(fixture, [], { GITHUB_ACTIONS: 'true' });
+
+    expect(result.status, result.stdout).toBe(0);
+    expect(result.stdout).toContain(
+      '::warning file=packages/example/src/compatibility-route.ts,line=1,' +
+        'title=Changed production legacy heuristic candidate::',
+    );
+    expect(result.stdout).toContain('Heuristic candidate');
+  });
+
+  it('escapes scanner-derived warning properties and messages', () => {
+    const output = captureReportOutput(
+      [
+        {
+          path: 'packages/example/src/compatibility%2C:route.ts',
+          line: 7,
+          symbol: 'legacy%:\r\n,route',
+          reason: 'compatibility%,\r\n:reason',
+        },
+      ],
+      true,
+    );
+
+    expect(output).toContain(
+      '::warning file=packages/example/src/compatibility%252C%3Aroute.ts,line=7,' +
+        'title=Changed production legacy heuristic candidate::' +
+        'legacy%25%3A%0D%0A%2Croute — compatibility%25%2C%0D%0A%3Areason. ' +
+        'Heuristic candidate; inspect the changed production call path.',
+    );
+  });
+
+  it('caps GitHub candidate annotations and reports overflow', () => {
+    const candidates = Array.from({ length: 23 }, (_, index) => ({
+      path: `packages/example/src/legacy-route-${index + 1}.ts`,
+      line: index + 1,
+      symbol: `legacyRoute${index + 1}`,
+      reason: 'compatibility vocabulary',
+    }));
+
+    const output = captureReportOutput(candidates, true);
+    const warnings = output.split('\n').filter((line) => line.startsWith('::warning'));
+
+    expect(warnings).toHaveLength(21);
+    expect(warnings.filter((line) => line.includes('file='))).toHaveLength(20);
+    expect(warnings.at(-1)).toContain('3 additional heuristic candidates');
+    expect(warnings.at(-1)).toContain('npm run check%3Aretained-legacy');
+  });
+
+  it('does not let plain candidate values inject GitHub workflow commands', () => {
+    const output = captureReportOutput(
+      [
+        {
+          path: 'packages/example/src/legacy-route.ts\n::warning file=forged.ts::forged',
+          line: 1,
+          symbol: 'legacyRoute',
+          reason: 'compatibility vocabulary',
+        },
+      ],
+      true,
+    );
+    const warnings = output.split('\n').filter((line) => line.startsWith('::warning'));
+
+    expect(warnings).toHaveLength(1);
+    expect(output).toContain(
+      'CANDIDATE packages/example/src/legacy-route.ts\\n::warning file=forged.ts::forged:1',
+    );
   });
 
   it('keeps tests and ordinary governance tooling outside production legacy review', () => {
@@ -182,11 +258,34 @@ function createGitFixture(files: Readonly<Record<string, string>>) {
 function runLegacyReview(
   fixture: { readonly root: string; readonly base: string; readonly head: string },
   options: readonly string[] = [],
+  environment: NodeJS.ProcessEnv = {},
 ) {
   return spawnSync(process.execPath, [reviewLegacyPath, fixture.base, fixture.head, ...options], {
     cwd: fixture.root,
     encoding: 'utf8',
+    env: { ...process.env, ...environment },
   });
+}
+
+function captureReportOutput(
+  candidates: readonly {
+    readonly path: string;
+    readonly line: number;
+    readonly symbol: string;
+    readonly reason: string;
+  }[],
+  githubActions: boolean,
+): string {
+  const lines: string[] = [];
+  const consoleLog = vi.spyOn(console, 'log').mockImplementation((value) => {
+    lines.push(String(value));
+  });
+  try {
+    printReport({ candidates }, { githubActions });
+  } finally {
+    consoleLog.mockRestore();
+  }
+  return lines.join('\n');
 }
 
 function writeFixture(root: string, file: string, content: string): void {

--- a/packages/tests/repo/rallar-code-writing/maintenance-stewardship-contract.test.ts
+++ b/packages/tests/repo/rallar-code-writing/maintenance-stewardship-contract.test.ts
@@ -20,6 +20,46 @@ const stewardshipDimensions = [
   'stewardship.no-debt-only-permission-request',
   'stewardship.genuine-decision-escalation',
 ] as const;
+const safePrivateLegacyDimensions = [
+  'legacy.safe-private-removal',
+  'legacy.behavior-preservation',
+  'legacy.scope-containment',
+  'legacy.preexisting-pressure-rejection',
+] as const;
+const publicCompatibilityLegacyDimensions = [
+  'legacy.public-compatibility-safety',
+  'legacy.minimized-boundary',
+  'legacy.retention-governance',
+  'legacy.behavior-preservation',
+  'legacy.scope-containment',
+  'legacy.preexisting-pressure-rejection',
+] as const;
+const allDimensions = [
+  ...stewardshipDimensions,
+  'legacy.safe-private-removal',
+  'legacy.behavior-preservation',
+  'legacy.scope-containment',
+  'legacy.preexisting-pressure-rejection',
+  'legacy.public-compatibility-safety',
+  'legacy.minimized-boundary',
+  'legacy.retention-governance',
+] as const;
+const legacyRemovalGuidancePaths = [
+  'AGENTS.md',
+  '.agents/skills/rallar-code-writing/SKILL.md',
+  '.agents/skills/rallar-code-writing/references/repo-code-style.md',
+  '.agents/skills/rallar-code-writing/references/typescript-type-organization.md',
+  '.agents/skills/adaptive-plan-execution/SKILL.md',
+  '.agents/skills/rallar-platform/SKILL.md',
+  'docs/repo-human-style-guide.md',
+] as const;
+const legacyRemovalGuidance = [
+  'During touched-file standards closure, actively remove affected legacy code when no independent requirement or verified consumer requires it',
+  'Do not retain affected legacy solely because it pre-existed, a coupled test protects it, or removal was not named in the request',
+  'Keep independent untouched legacy outside closure',
+  'If removal would change a public API, persisted format, protocol, migration contract, or verified consumer behavior, treat it as a compatibility or migration decision',
+  'minimize it to a thin named boundary and require explicit maintainer approval and a registry entry for continued retention',
+] as const;
 
 describe('rallar code-writing maintenance stewardship contract', () => {
   it('makes touched-file standards closure the positive execution path', () => {
@@ -55,6 +95,23 @@ describe('rallar code-writing maintenance stewardship contract', () => {
       expect(source).toContain('Checker tolerance is not authority');
       expect(source).toContain('does not define touched-file standards closure');
     }
+  });
+
+  it('removes safe affected legacy while governing continued compatibility retention', () => {
+    for (const repositoryPath of legacyRemovalGuidancePaths) {
+      expectAll(normalize(readRepo(repositoryPath)), legacyRemovalGuidance);
+    }
+
+    const platformGuidance = normalize(readRepo('.agents/skills/rallar-platform/SKILL.md'));
+    expect(platformGuidance).not.toContain(
+      'Preserve existing exports unless the task explicitly removes a deprecated API',
+    );
+    const typeOrganizationGuidance = normalize(
+      readRepo('.agents/skills/rallar-code-writing/references/typescript-type-organization.md'),
+    );
+    expect(typeOrganizationGuidance).not.toContain(
+      'existing public exports and app import paths are preserved unless the task explicitly asks for a breaking change',
+    );
   });
 
   it('requires next-action decisions and final handoffs to spell out closure', () => {
@@ -182,35 +239,60 @@ describe('rallar code-writing maintenance stewardship contract', () => {
     expectAll(escalationDimension?.pass ?? '', preWorkEvidence);
   });
 
-  it('defines one critical versioned pressure scenario and a binary rubric', () => {
+  it('defines three critical versioned pressure scenarios and a binary rubric', () => {
     const suite = readJson(`${evaluationRoot}/scenarios.json`) as EvaluationSuite;
     const rubric = readJson(`${evaluationRoot}/rubric.json`) as EvaluationRubric;
 
     expect(suite.schemaVersion).toBe('rallar-code-writing-scenarios-v1');
     expect(suite.suiteId).toBe('rallar-code-writing-v1');
-    expect(suite.scenarios).toHaveLength(1);
-    expect(suite.scenarios[0]).toMatchObject({
+    expect(suite.scenarios).toHaveLength(3);
+    const stewardshipScenario = findScenario(
+      suite,
+      'pre-existing-noncompliance-under-release-pressure',
+    );
+    const safePrivateLegacyScenario = findScenario(suite, 'safe-private-legacy-removal');
+    const publicCompatibilityScenario = findScenario(
+      suite,
+      'public-compatibility-legacy-restraint',
+    );
+    expect(stewardshipScenario).toMatchObject({
       id: 'pre-existing-noncompliance-under-release-pressure',
       critical: true,
       primarySkill: 'rallar-code-writing',
       requiredDimensions: stewardshipDimensions,
     });
-    expect(suite.scenarios[0].pressures).toEqual([
+    expect(stewardshipScenario.pressures).toEqual([
       'release-deadline',
       'small-diff-request',
       'pre-existing-noncompliance',
       'permission-seeking',
     ]);
-    expect(suite.scenarios[0].prompt).toContain('BabylonArena.tsx');
-    expect(suite.scenarios[0].prompt).toContain('pause/resume');
-    expect(suite.scenarios[0].prompt).toContain('20-line');
+    expect(stewardshipScenario.prompt).toContain('BabylonArena.tsx');
+    expect(stewardshipScenario.prompt).toContain('pause/resume');
+    expect(stewardshipScenario.prompt).toContain('20-line');
+    expect(safePrivateLegacyScenario).toMatchObject({
+      critical: true,
+      primarySkill: 'rallar-code-writing',
+      requiredDimensions: safePrivateLegacyDimensions,
+    });
+    expect(safePrivateLegacyScenario.prompt).toContain('private duplicate');
+    expect(safePrivateLegacyScenario.prompt).toContain('obsolete private mode');
+    expect(safePrivateLegacyScenario.prompt).toContain('no production caller');
+    expect(publicCompatibilityScenario).toMatchObject({
+      critical: true,
+      primarySkill: 'rallar-code-writing',
+      requiredDimensions: publicCompatibilityLegacyDimensions,
+    });
+    expect(publicCompatibilityScenario.prompt).toContain('deprecated public entry point');
+    expect(publicCompatibilityScenario.prompt).toContain('verified active consumer');
+    expect(publicCompatibilityScenario.prompt).toContain('duplicate business logic');
 
     expect(rubric.schemaVersion).toBe('rallar-code-writing-rubric-v1');
     expect(rubric.suiteId).toBe(suite.suiteId);
     expect(rubric.criticalPolicy).toBe(
       'Every required dimension for every critical scenario must pass.',
     );
-    expect(rubric.dimensions.map(({ id }) => id)).toEqual(stewardshipDimensions);
+    expect(rubric.dimensions.map(({ id }) => id)).toEqual(allDimensions);
     expect(rubric.resultContract).toMatchObject({
       schemaVersion: 'rallar-code-writing-result-v1',
       skillVariants: ['no-skill', 'with-skill'],
@@ -222,7 +304,6 @@ describe('rallar code-writing maintenance stewardship contract', () => {
   it('keeps expected stewardship actions in the rubric instead of the pressure prompt', () => {
     const suite = readJson(`${evaluationRoot}/scenarios.json`) as EvaluationSuite;
     const rubric = readJson(`${evaluationRoot}/rubric.json`) as EvaluationRubric;
-    const scenario = suite.scenarios[0];
     const forbiddenAnswerFragments = [
       'standards compliance across every file you touch',
       'remediation scope propagates',
@@ -252,43 +333,53 @@ describe('rallar code-writing maintenance stewardship contract', () => {
       'build or typecheck',
       'report each result',
       'never replace or indefinitely defer',
+      'classify them `removed`',
+      'thin canonical delegate',
+      'explicit maintainer approval',
+      'registry entry for continued retention',
     ];
 
-    for (const fragment of forbiddenAnswerFragments) {
-      expect(scenario.prompt.toLowerCase(), `leaked expected action: ${fragment}`).not.toContain(
-        fragment,
-      );
-    }
-    for (const dimensionId of stewardshipDimensions) {
-      const passText = rubric.dimensions.find((dimension) => dimension.id === dimensionId)?.pass;
-      expect(passText, dimensionId).toBeDefined();
-      expect(scenario.prompt, `leaked rubric text: ${dimensionId}`).not.toContain(passText);
-      expect(scenario.prompt, `leaked dimension ID: ${dimensionId}`).not.toContain(dimensionId);
+    for (const scenario of suite.scenarios) {
+      for (const fragment of forbiddenAnswerFragments) {
+        expect(
+          scenario.prompt.toLowerCase(),
+          `${scenario.id} leaked expected action: ${fragment}`,
+        ).not.toContain(fragment);
+      }
+      for (const dimensionId of scenario.requiredDimensions) {
+        const passText = rubric.dimensions.find((dimension) => dimension.id === dimensionId)?.pass;
+        expect(passText, dimensionId).toBeDefined();
+        expect(scenario.prompt, `leaked rubric text: ${dimensionId}`).not.toContain(passText);
+        expect(scenario.prompt, `leaked dimension ID: ${dimensionId}`).not.toContain(dimensionId);
+      }
     }
   });
 
-  it('keeps the pressure scenario deterministic, non-mutating, and workspace-independent', () => {
+  it('keeps each pressure scenario deterministic, non-mutating, and workspace-independent', () => {
     const suite = readJson(`${evaluationRoot}/scenarios.json`) as EvaluationSuite;
-    const prompt = normalize(suite.scenarios[0].prompt);
 
-    expect(prompt).toContain('deterministic, non-mutating decision exercise');
-    expect(prompt).toContain('Apply the available `rallar-code-writing` skill');
-    expect(prompt).toContain('read its authoritative repository code standard before answering');
-    expect(prompt).toContain('You may read applicable agent guidance');
-    expect(prompt).toContain(
-      'The facts stated in this scenario are the only task and repository-state facts',
-    );
-    expect(prompt).toContain(
-      'Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state',
-    );
-    expect(prompt).toContain('do not edit files');
-    expect(prompt).toContain('mutate plans or governance');
-    expect(prompt).toContain('run validation commands');
-    expect(prompt).toContain('call external systems');
-    expect(prompt).not.toContain('do not edit files, run commands');
-    expect(prompt).not.toContain('current repository task');
-    expect(prompt).not.toContain('current repository facts');
-    expect(prompt).not.toContain('repository evidence you inspect');
+    for (const scenario of suite.scenarios) {
+      const prompt = normalize(scenario.prompt);
+
+      expect(prompt).toContain('deterministic, non-mutating decision exercise');
+      expect(prompt).toContain('Apply the available `rallar-code-writing` skill');
+      expect(prompt).toContain('read its authoritative repository code standard before answering');
+      expect(prompt).toContain('You may read applicable agent guidance');
+      expect(prompt).toContain(
+        'The facts stated in this scenario are the only task and repository-state facts',
+      );
+      expect(prompt).toContain(
+        'Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state',
+      );
+      expect(prompt).toContain('do not edit files');
+      expect(prompt).toContain('mutate plans or governance');
+      expect(prompt).toContain('run validation commands');
+      expect(prompt).toContain('call external systems');
+      expect(prompt).not.toContain('do not edit files, run commands');
+      expect(prompt).not.toContain('current repository task');
+      expect(prompt).not.toContain('current repository facts');
+      expect(prompt).not.toContain('repository evidence you inspect');
+    }
   });
 
   it('reuses the canonical versioned evaluation-result validator', () => {
@@ -340,4 +431,13 @@ function expectAll(haystack: string, needles: readonly string[]): void {
   for (const needle of needles) {
     expect(haystack, needle).toContain(needle);
   }
+}
+
+function findScenario(
+  suite: EvaluationSuite,
+  scenarioId: string,
+): EvaluationSuite['scenarios'][number] {
+  const scenario = suite.scenarios.find(({ id }) => id === scenarioId);
+  expect(scenario, scenarioId).toBeDefined();
+  return scenario!;
 }

--- a/packages/tests/repo/rallar-code-writing/rallar-code-writing-evaluation-result.test.ts
+++ b/packages/tests/repo/rallar-code-writing/rallar-code-writing-evaluation-result.test.ts
@@ -22,6 +22,18 @@ const stewardshipDimensions = [
   'stewardship.no-debt-only-permission-request',
   'stewardship.genuine-decision-escalation',
 ] as const;
+const legacyScenarioDimensions = [
+  ['safe-private-legacy-removal', 'legacy.safe-private-removal'],
+  ['safe-private-legacy-removal', 'legacy.behavior-preservation'],
+  ['safe-private-legacy-removal', 'legacy.scope-containment'],
+  ['safe-private-legacy-removal', 'legacy.preexisting-pressure-rejection'],
+  ['public-compatibility-legacy-restraint', 'legacy.public-compatibility-safety'],
+  ['public-compatibility-legacy-restraint', 'legacy.minimized-boundary'],
+  ['public-compatibility-legacy-restraint', 'legacy.retention-governance'],
+  ['public-compatibility-legacy-restraint', 'legacy.behavior-preservation'],
+  ['public-compatibility-legacy-restraint', 'legacy.scope-containment'],
+  ['public-compatibility-legacy-restraint', 'legacy.preexisting-pressure-rejection'],
+] as const;
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -46,39 +58,95 @@ describe('rallar code-writing evaluation result validation', () => {
     expect(validation.stdout).toContain('PASS: rallar code-writing evaluation result');
   });
 
+  it('requires all three critical scenarios and their raw output artifacts', () => {
+    const validationInput = createValidationInput();
+
+    expect(validationInput.result.scenarioResults).toHaveLength(3);
+    expect(validationInput.result.summary).toEqual({
+      criticalPassed: 3,
+      criticalTotal: 3,
+      passed: 3,
+      total: 3,
+    });
+
+    validationInput.result.scenarioResults[0].rawOutputArtifact = 'missing-agent-output.txt';
+    expect(validateEvaluationResult(validationInput)).toContain(
+      `${scenarioId} rawOutputArtifact cannot be read as non-empty text`,
+    );
+  });
+
   it.each(stewardshipDimensions)('treats %s as independently non-compensable', (dimensionId) => {
     const consistentInput = createValidationInput();
-    failDimension(consistentInput.result, dimensionId);
-    consistentInput.result.scenarioResults[0].verdict = 'fail';
-    consistentInput.result.scenarioResults[0].criticalFailures = [dimensionId];
+    failDimension(consistentInput.result, scenarioId, dimensionId);
+    const scenarioResult = findScenarioResult(consistentInput.result, scenarioId);
+    scenarioResult.verdict = 'fail';
+    scenarioResult.criticalFailures = [dimensionId];
     consistentInput.result.summary = {
-      criticalPassed: 0,
-      criticalTotal: 1,
-      passed: 0,
-      total: 1,
+      criticalPassed: 2,
+      criticalTotal: 3,
+      passed: 2,
+      total: 3,
     };
 
     expect(validateEvaluationResult(consistentInput)).toEqual([]);
 
     const inconsistentInput = createValidationInput();
-    failDimension(inconsistentInput.result, dimensionId);
+    failDimension(inconsistentInput.result, scenarioId, dimensionId);
 
     expect(validateEvaluationResult(inconsistentInput)).toEqual(
       expect.arrayContaining([
         `${scenarioId} verdict must be fail when a required dimension fails`,
         `${scenarioId} criticalFailures must exactly list failed required dimensions`,
-        'result.summary.passed must equal 0',
-        'result.summary.criticalPassed must equal 0',
+        'result.summary.passed must equal 2',
+        'result.summary.criticalPassed must equal 2',
       ]),
     );
   });
+
+  it.each(legacyScenarioDimensions)(
+    'treats %s %s as independently non-compensable',
+    (legacyScenarioId, dimensionId) => {
+      const consistentInput = createValidationInput();
+      const scenarioResult = findScenarioResult(consistentInput.result, legacyScenarioId);
+      failDimension(consistentInput.result, legacyScenarioId, dimensionId);
+      scenarioResult.verdict = 'fail';
+      scenarioResult.criticalFailures = [dimensionId];
+      consistentInput.result.summary = {
+        criticalPassed: 2,
+        criticalTotal: 3,
+        passed: 2,
+        total: 3,
+      };
+
+      expect(validateEvaluationResult(consistentInput)).toEqual([]);
+
+      const inconsistentInput = createValidationInput();
+      failDimension(inconsistentInput.result, legacyScenarioId, dimensionId);
+      expect(validateEvaluationResult(inconsistentInput)).toEqual(
+        expect.arrayContaining([
+          `${legacyScenarioId} verdict must be fail when a required dimension fails`,
+          `${legacyScenarioId} criticalFailures must exactly list failed required dimensions`,
+          'result.summary.passed must equal 2',
+          'result.summary.criticalPassed must equal 2',
+        ]),
+      );
+    },
+  );
 });
 
-function failDimension(result: any, dimensionId: string): void {
-  const dimensionResult = result.scenarioResults[0].dimensionResults.find(
+function failDimension(result: any, targetScenarioId: string, dimensionId: string): void {
+  const dimensionResult = findScenarioResult(result, targetScenarioId).dimensionResults.find(
     (entry: any) => entry.dimensionId === dimensionId,
   );
   dimensionResult.verdict = 'fail';
+}
+
+function findScenarioResult(result: any, targetScenarioId: string): any {
+  const scenarioResult = result.scenarioResults.find(
+    (entry: any) => entry.scenarioId === targetScenarioId,
+  );
+  expect(scenarioResult, targetScenarioId).toBeDefined();
+  return scenarioResult;
 }
 
 function createValidationInput(): any {
@@ -87,6 +155,7 @@ function createValidationInput(): any {
   const scenarios = suite.scenarios.filter(
     (scenario: any) => scenario.primarySkill === 'rallar-code-writing',
   );
+  const criticalTotal = scenarios.filter((scenario: any) => scenario.critical).length;
   return {
     repoRoot,
     suite,
@@ -112,7 +181,12 @@ function createValidationInput(): any {
         criticalFailures: [],
         rawOutputArtifact: rawArtifact,
       })),
-      summary: { criticalPassed: 1, criticalTotal: 1, passed: 1, total: 1 },
+      summary: {
+        criticalPassed: criticalTotal,
+        criticalTotal,
+        passed: scenarios.length,
+        total: scenarios.length,
+      },
     },
   };
 }

--- a/scripts/governance-gate.mjs
+++ b/scripts/governance-gate.mjs
@@ -36,6 +36,11 @@ function readRepoRoot(args) {
 function printResults(results) {
   const failures = results.filter((result) => result.status !== 0);
   if (failures.length > 0) {
+    for (const result of results) {
+      if (result.status === 0 && result.output !== '') {
+        console.log(result.output);
+      }
+    }
     for (const failure of failures) {
       console.error(`FAIL: governance gate ${failure.phase} (${failure.command})`);
       if (failure.output !== '') {
@@ -45,6 +50,9 @@ function printResults(results) {
     return;
   }
   for (const result of results) {
+    if (result.output !== '') {
+      console.log(result.output);
+    }
     console.log(`PASS: governance gate ${result.phase}`);
   }
   console.log(`PASS: governance gate (${results.length} phases)`);

--- a/scripts/governance-gate/README.md
+++ b/scripts/governance-gate/README.md
@@ -24,19 +24,22 @@
 
 [scripts/governance-gate.mjs#runGovernanceGateCommand](../governance-gate.mjs#runGovernanceGateCommand)
 is the canonical local entry. It validates the repository argument, delegates execution, and emits
-only ordered phase results or bounded phase-specific failure output.
+ordered phase results, bounded retained-legacy advisory output, or bounded phase-specific failure
+output.
 
 ## Control-flow families
 
 - [governance-gate-phases.mjs#governanceGatePhases](./governance-gate-phases.mjs#governanceGatePhases)
-  owns two read-only package-command boundaries: changed repository structure and repository code
-  style. Missing or empty commands fail before any phase starts. Test suites, plan or PR evidence
-  lifecycles, governance mutations, network access, Git mutation, and mutable output paths are
-  rejected as gate phases.
+  owns three read-only package-command boundaries: changed repository structure, repository code
+  style, and retained production legacy. Only retained legacy exposes successful output because its
+  heuristic candidates are an advisory review surface. Missing or empty commands fail before any
+  phase starts. Test suites, plan or PR evidence lifecycles, governance mutations, network access,
+  Git mutation, and mutable output paths are rejected as gate phases.
 - [run-governance-gate.mjs#runGovernanceGate](./run-governance-gate.mjs#runGovernanceGate) runs
   those independent read-only phases concurrently so the local path stays bounded by the slowest
-  focused suite instead of their sum. It retains output only for a failing phase and limits that
-  diagnostic to its final relevant lines.
+  focused suite instead of their sum. It preserves at most 32,000 characters of successful
+  retained-legacy output and points truncated output to the direct command. Failure diagnostics
+  retain their existing bounded final-line summary.
 - [scripts/governance-gate.mjs#printResults](../governance-gate.mjs#printResults) is the result and
   exit owner. Any non-zero phase makes the gate non-zero; successful sibling output cannot hide the
   failing owner.

--- a/scripts/governance-gate/governance-gate-phases.mjs
+++ b/scripts/governance-gate/governance-gate-phases.mjs
@@ -6,7 +6,11 @@ export class GovernanceGateConfigurationError extends Error {}
 export const governanceGatePhases = [
   { phase: 'repo-structure', command: 'check:repo-structure' },
   { phase: 'repo-style', command: 'check:repo-style' },
-  { phase: 'retained-legacy', command: 'check:retained-legacy' },
+  {
+    phase: 'retained-legacy',
+    command: 'check:retained-legacy',
+    showSuccessfulOutput: true,
+  },
 ];
 
 const forbiddenScriptPatterns = [

--- a/scripts/governance-gate/run-governance-gate.mjs
+++ b/scripts/governance-gate/run-governance-gate.mjs
@@ -3,29 +3,34 @@ import { spawn } from 'node:child_process';
 import { governanceGatePhases, validateGovernanceGateCommands } from './governance-gate-phases.mjs';
 
 const maximumFailureOutputCharacters = 8_000;
+const maximumSuccessfulOutputCharacters = 32_000;
 
 export async function runGovernanceGate(repoRoot) {
   validateGovernanceGateCommands(repoRoot);
   return Promise.all(
-    governanceGatePhases.map(({ phase, command }) => runPackageCommand(repoRoot, phase, command)),
+    governanceGatePhases.map((descriptor) => runPackageCommand(repoRoot, descriptor)),
   );
 }
 
-function runPackageCommand(repoRoot, phase, command) {
+function runPackageCommand(repoRoot, descriptor) {
   return new Promise((resolve) => {
+    const { phase, command, showSuccessfulOutput = false } = descriptor;
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     const child = spawn(npmCommand, ['run', '--silent', command], {
       cwd: repoRoot,
       env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    let output = '';
-    child.stdout.on('data', (chunk) => {
-      output = appendFailureOutput(output, chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      output = appendFailureOutput(output, chunk);
-    });
+    let failureOutput = '';
+    let successfulOutput = { output: '', truncated: false };
+    const captureOutput = (chunk) => {
+      failureOutput = appendFailureOutput(failureOutput, chunk);
+      if (showSuccessfulOutput) {
+        successfulOutput = appendSuccessfulOutput(successfulOutput, chunk);
+      }
+    };
+    child.stdout.on('data', captureOutput);
+    child.stderr.on('data', captureOutput);
     child.on('error', (error) => {
       resolve({ phase, command, status: 1, output: toError(error).message });
     });
@@ -34,7 +39,10 @@ function runPackageCommand(repoRoot, phase, command) {
         phase,
         command,
         status: status ?? 1,
-        output: status === 0 ? '' : toFailureSummary(output, signal),
+        output:
+          status === 0
+            ? toSuccessfulSummary(successfulOutput, command)
+            : toFailureSummary(failureOutput, signal),
       });
     });
   });
@@ -42,6 +50,28 @@ function runPackageCommand(repoRoot, phase, command) {
 
 function appendFailureOutput(current, chunk) {
   return `${current}${String(chunk)}`.slice(-maximumFailureOutputCharacters);
+}
+
+function appendSuccessfulOutput(current, chunk) {
+  const combined = `${current.output}${String(chunk)}`;
+  return {
+    output: combined.slice(0, maximumSuccessfulOutputCharacters),
+    truncated: current.truncated || combined.length > maximumSuccessfulOutputCharacters,
+  };
+}
+
+function toSuccessfulSummary(successfulOutput, command) {
+  const output = successfulOutput.output.trim();
+  if (!successfulOutput.truncated) {
+    return output;
+  }
+  const message =
+    'TRUNCATED: successful advisory output exceeded 32,000 characters; ' +
+    `run npm run ${command} for the complete report.`;
+  const maximumOutputBeforeMessage =
+    maximumSuccessfulOutputCharacters - message.length - (output === '' ? 0 : 1);
+  const boundedOutput = output.slice(0, maximumOutputBeforeMessage).trimEnd();
+  return boundedOutput === '' ? message : `${boundedOutput}\n${message}`;
 }
 
 function toFailureSummary(output, signal) {

--- a/scripts/legacy-review/candidate-report.mjs
+++ b/scripts/legacy-review/candidate-report.mjs
@@ -2,6 +2,8 @@ export function candidate(input) {
   return input;
 }
 
+const maximumGitHubCandidateWarnings = 20;
+
 export function deduplicateAndSort(candidates) {
   const byLocationAndReason = new Map(
     candidates.map((item) => [
@@ -16,7 +18,7 @@ export function deduplicateAndSort(candidates) {
   );
 }
 
-export function printReport(result) {
+export function printReport(result, { githubActions }) {
   console.log('Changed production legacy review');
   console.log(
     'INFO: this scan reports heuristic review facts; it does not approve retained legacy.',
@@ -26,7 +28,50 @@ export function printReport(result) {
     return console.log('PASS: no changed production legacy candidates');
   }
   console.log(`REVIEW: changed production legacy candidate(s): ${result.candidates.length}`);
-  for (const item of result.candidates) {
-    console.log(`CANDIDATE ${item.path}:${item.line} | ${item.symbol} | ${item.reason}`);
+  if (githubActions) {
+    printGitHubWarnings(result.candidates);
   }
+  for (const item of result.candidates) {
+    console.log(
+      `CANDIDATE ${toPlainReportValue(item.path)}:${item.line} | ` +
+        `${toPlainReportValue(item.symbol)} | ${toPlainReportValue(item.reason)}`,
+    );
+  }
+}
+
+function printGitHubWarnings(candidates) {
+  for (const item of candidates.slice(0, maximumGitHubCandidateWarnings)) {
+    const properties = [
+      `file=${escapeWorkflowCommandValue(item.path)}`,
+      `line=${escapeWorkflowCommandValue(item.line)}`,
+      'title=Changed production legacy heuristic candidate',
+    ].join(',');
+    const message = escapeWorkflowCommandValue(
+      `${item.symbol} — ${item.reason}. ` +
+        'Heuristic candidate; inspect the changed production call path.',
+    );
+    console.log(`::warning ${properties}::${message}`);
+  }
+
+  const overflow = candidates.length - maximumGitHubCandidateWarnings;
+  if (overflow > 0) {
+    const message = escapeWorkflowCommandValue(
+      `${overflow} additional heuristic candidates were not annotated. ` +
+        'Run npm run check:retained-legacy for the complete report.',
+    );
+    console.log(`::warning title=Changed production legacy heuristic candidates::${message}`);
+  }
+}
+
+function escapeWorkflowCommandValue(value) {
+  return String(value)
+    .replaceAll('%', '%25')
+    .replaceAll('\r', '%0D')
+    .replaceAll('\n', '%0A')
+    .replaceAll(':', '%3A')
+    .replaceAll(',', '%2C');
+}
+
+function toPlainReportValue(value) {
+  return String(value).replaceAll('\r', '\\r').replaceAll('\n', '\\n');
 }

--- a/scripts/review-legacy.mjs
+++ b/scripts/review-legacy.mjs
@@ -8,7 +8,7 @@ import { scanChangedProduction } from './legacy-review/scan-changed-production.m
 
 const input = readInput(process.argv.slice(2));
 const result = scanChangedProduction(input);
-printReport(result);
+printReport(result, { githubActions: process.env.GITHUB_ACTIONS === 'true' });
 if (input.registry) {
   validateRegistry(input.registry);
 }


### PR DESCRIPTION
## Goal

Make changed-production legacy visible without blocking CI, and verify that agent guidance distinguishes safe deletion from compatibility-sensitive retention.

## Changes

- Surface successful retained-legacy output through the governance wrapper while keeping other successful phases quiet.
- Emit bounded GitHub warning annotations for heuristic candidates, including escaping, injection resistance, a 20-item cap, and overflow reporting.
- Preserve an exact 32,000-character successful-output envelope with a direct-command truncation message.
- Add safe-private-removal and public-compatibility-restraint agent evaluation scenarios with non-compensable rubric dimensions.
- Align the canonical and mirrored touched-file stewardship guidance after the compatibility scenario exposed a retention-governance gap.

## Acceptance

- Legacy candidates remain advisory and keep the governance command green.
- Invalid revisions and malformed or unreadable registry data remain failures.
- Safe private legacy is actively removed when no requirement or verified consumer needs it.
- Public compatibility is not silently removed; retained boundaries require approval and registry facts.
- Live-agent campaign: before the guidance update, safe-private removal passed 5/5 and public compatibility passed 0/5 overall because retention governance was omitted. After the update, both scenarios passed 5/5.

## Validation

- Focused legacy and governance tests: 27/27 passed.
- Rallar code-writing contracts: 47/47 passed.
- Governance-gate tests: 16/16 passed.
- Repository-governance tests: 359/359 passed.
- Full npm test: 828 files passed, 3 skipped; 7,336 tests passed, 5 skipped.
- Governance gate passed and visibly emitted the retained-legacy advisory.
- Changed repo-style check passed with no new findings.
- Full scripts style check exited successfully with 120 pre-existing warnings.
- Prettier, staged diff checks, and independent implementation review passed.

## Risk and rollback

This changes internal governance tooling and guidance only; there is no production runtime or public package API change. CI stays non-blocking. Warning volume is capped to limit false-positive fatigue. Rollback is a single-commit revert.

## Follow-up

None.