### PR TITLE
Add accepted RTC multicast and group coordination workers

### DIFF
--- a/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-worker-protocol.ts
+++ b/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-worker-protocol.ts
@@ -1,0 +1,265 @@
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../command/rtc-baseline-cli-options.ts';
+import {
+  rtcBaselineIssue,
+  type RtcBaselineIssueDto,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineWorkloadId,
+} from '../contracts/rtc-baseline-contracts.ts';
+import { validateRtcBaselineId } from '../contracts/rtc-baseline-validation.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from './rtc-baseline-failure-accounting.ts';
+
+export interface RtcBaselineAcceptedWorker<CapabilityInput> {
+  readonly mode: 'accepted';
+  readonly input: CapabilityInput;
+  readonly workloadId: RtcBaselineWorkloadId;
+  readonly caseId: string;
+  readonly inputKey: string;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+interface ParseRtcBaselineAcceptedWorkerInput<CapabilityInput> {
+  readonly arguments_: readonly string[];
+  readonly identity: {
+    readonly workloadId: RtcBaselineWorkloadId;
+    readonly caseId: string;
+  };
+  readonly toInputKey: (capability: CapabilityInput) => string;
+  readonly capabilityOptionNames: readonly string[];
+  readonly parseCapability: (
+    options: Readonly<Record<string, string>>,
+  ) => RtcBaselineResult<CapabilityInput>;
+}
+
+interface RtcBaselineWorkerMetric {
+  readonly metric: string;
+  readonly unit: string;
+  readonly value: number;
+}
+
+interface RunRtcBaselineAcceptedWorkerInput<CapabilityInput, Result> {
+  readonly worker: RtcBaselineAcceptedWorker<CapabilityInput>;
+  readonly run: () => Result | Promise<Result>;
+  readonly validate: (result: Result) => readonly RtcBaselineIssueDto[];
+  readonly metrics: (result: Result) => readonly RtcBaselineWorkerMetric[];
+  readonly rawEvidence: (result: Result) => RtcBaselineJson;
+}
+
+interface RunRtcBaselineAcceptedWorkerCliInput<
+  CapabilityInput,
+  Diagnostic extends { readonly mode: 'diagnostic' },
+> {
+  readonly parsed: RtcBaselineAcceptedWorker<CapabilityInput> | Diagnostic;
+  readonly runAccepted: (
+    worker: RtcBaselineAcceptedWorker<CapabilityInput>,
+  ) => Promise<readonly RtcBaselineSampleDto[]>;
+  readonly writeOutput: (output: string) => void;
+}
+
+const commonOptionNames = [
+  'capture',
+  'baseline-id',
+  'workload',
+  'case-id',
+  'input-key',
+  'intended-phase',
+  'outer-ordinal',
+  'sample-ids',
+  'rtc-inner-runs',
+];
+
+export function parseRtcBaselineAcceptedWorker<CapabilityInput>(
+  input: ParseRtcBaselineAcceptedWorkerInput<CapabilityInput>,
+): RtcBaselineResult<RtcBaselineAcceptedWorker<CapabilityInput>> {
+  const parsed = parseRtcBaselineOneTokenOptions(
+    input.arguments_,
+    [...commonOptionNames, ...input.capabilityOptionNames],
+  );
+  if (!parsed.ok) {
+    return parsed;
+  }
+  const capability = input.parseCapability(parsed.value);
+  if (!capability.ok) {
+    return capability;
+  }
+  const identity = { ...input.identity, inputKey: input.toInputKey(capability.value) };
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    parsed.value['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const intendedPhase = parsed.value['intended-phase'];
+  const sampleIds = (parsed.value['sample-ids'] ?? '').split(',');
+  const issues = [
+    ...(!outerOrdinal.ok ? outerOrdinal.issues : []),
+    ...validateRtcBaselineId(parsed.value['baseline-id'] ?? ''),
+    ...validateAcceptedIdentity({
+      options: parsed.value,
+      identity,
+      intendedPhase,
+      outerOrdinal,
+      sampleIds,
+    }),
+  ];
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+  return {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: capability.value,
+      ...identity,
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: outerOrdinal.ok ? outerOrdinal.value : 1,
+      sampleIds,
+    },
+  };
+}
+
+export function runRtcBaselineAcceptedWorker<CapabilityInput, Result>(
+  input: RunRtcBaselineAcceptedWorkerInput<CapabilityInput, Result>,
+): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: input.worker,
+    run: input.run,
+    validate: input.validate,
+    createSample: ({ identity, result, issues }) => {
+      if (result === null) {
+        return createNotRunSample(identity, issues);
+      }
+      return {
+        schema: 'rallar.rtc-baseline.sample.v1',
+        identity,
+        outcome: issues.length === 0 ? 'passed' : 'failed',
+        evidenceClass: 'synthetic-path',
+        metrics: input.metrics(result).filter((metric) =>
+          Number.isFinite(metric.value) && metric.value >= 0
+        ),
+        rawEvidence: normalizeRtcBaselineWorkerJson(input.rawEvidence(result)),
+        rawReferences: [],
+        issues,
+        runtimeObservation: null,
+      };
+    },
+  });
+}
+
+export async function runRtcBaselineAcceptedWorkerCli<
+  CapabilityInput,
+  Diagnostic extends { readonly mode: 'diagnostic' },
+>(input: RunRtcBaselineAcceptedWorkerCliInput<CapabilityInput, Diagnostic>): Promise<
+  | { readonly handled: true }
+  | { readonly handled: false; readonly diagnostic: Diagnostic }
+> {
+  if (input.parsed.mode !== 'accepted') {
+    return { handled: false, diagnostic: input.parsed };
+  }
+  const samples = await input.runAccepted(input.parsed);
+  input.writeOutput(JSON.stringify(samples));
+  return { handled: true };
+}
+
+interface ValidateAcceptedIdentityInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly identity: {
+    readonly workloadId: RtcBaselineWorkloadId;
+    readonly caseId: string;
+    readonly inputKey: string;
+  };
+  readonly intendedPhase: string | undefined;
+  readonly outerOrdinal: RtcBaselineResult<number>;
+  readonly sampleIds: readonly string[];
+}
+
+function validateAcceptedIdentity(input: ValidateAcceptedIdentityInput): RtcBaselineIssueDto[] {
+  const expected = {
+    capture: 'worker',
+    workload: input.identity.workloadId,
+    'case-id': input.identity.caseId,
+    'input-key': input.identity.inputKey,
+    'rtc-inner-runs': '5',
+  };
+  const issues = Object.entries(expected)
+    .filter(([name, value]) => input.options[name] !== value)
+    .map(([name, value]) =>
+      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+    );
+  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
+  const ordinal = input.outerOrdinal.ok ? input.outerOrdinal.value : 1;
+  return [
+    ...issues,
+    ...issueUnless(
+      input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
+      '$.outer-ordinal',
+      'Expected canonical integer syntax.',
+    ),
+    ...issueUnless(
+      ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
+      '$.intended-phase',
+      'Invalid phase.',
+    ),
+    ...issueUnless(
+      JSON.stringify(input.sampleIds) ===
+        JSON.stringify(createExpectedSampleIds(input.identity, phase, ordinal)),
+      '$.sample-ids',
+      'Invalid sample IDs.',
+    ),
+  ];
+}
+
+function createExpectedSampleIds(
+  identity: ValidateAcceptedIdentityInput['identity'],
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix = `${identity.workloadId.toLowerCase()}-${identity.caseId}-${identity.inputKey}-` +
+    `${intendedPhase}-${String(outerOrdinal).padStart(3, '0')}`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function issueUnless(valid: boolean, path: string, message: string): RtcBaselineIssueDto[] {
+  return valid ? [] : [rtcBaselineIssue(path, 'unexpected-worker-input', message)];
+}
+
+function createNotRunSample(
+  identity: RtcBaselineSampleDto['identity'],
+  issues: readonly RtcBaselineIssueDto[],
+): RtcBaselineSampleDto {
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: 'not-run',
+    evidenceClass: 'synthetic-path',
+    metrics: [],
+    rawEvidence: null,
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function normalizeRtcBaselineWorkerJson(value: RtcBaselineJson): RtcBaselineJson {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeRtcBaselineWorkerJson);
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, normalizeRtcBaselineWorkerJson(entry)]),
+  );
+}

--- a/packages/shared-rtc-bench/tests/architecture/rtc-benchmark-executable-inventory.test.ts
+++ b/packages/shared-rtc-bench/tests/architecture/rtc-benchmark-executable-inventory.test.ts
@@ -34,6 +34,7 @@ const executablePaths = [
 const sourcePaths = [
   'baseline/acceptance/rtc-baseline-evidence-acceptance.ts',
   'baseline/acceptance/rtc-baseline-failure-accounting.ts',
+  'baseline/acceptance/rtc-baseline-worker-protocol.ts',
   'baseline/catalog/rtc-baseline-workload-catalog.ts',
   'baseline/catalog/rtc-baseline-workload-manifest.ts',
   'baseline/command/rtc-baseline-cli-grammar.ts',
@@ -91,6 +92,7 @@ const owningTests = [
   'tests/architecture/rtc-benchmark-package-boundaries.test.ts',
   'tests/baseline/acceptance/rtc-performance-baseline-evidence-acceptance.test.ts',
   'tests/baseline/acceptance/rtc-performance-baseline-evidence-failure.test.ts',
+  'tests/baseline/acceptance/rtc-baseline-worker-protocol.test.ts',
   'tests/baseline/catalog/rtc-performance-baseline-workload-catalog.test.ts',
   'tests/baseline/catalog/rtc-performance-baseline-workload-manifest.test.ts',
   'tests/baseline/command/rtc-performance-baseline-cli-grammar.test.ts',
@@ -122,7 +124,9 @@ const owningTests = [
 function filesBelow(root: string): string[] {
   return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
     const entryPath = path.join(root, entry.name);
-    if (entry.isDirectory()) return filesBelow(entryPath);
+    if (entry.isDirectory()) {
+      return filesBelow(entryPath);
+    }
     return entry.isFile() ? [entryPath] : [];
   });
 }

--- a/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-baseline-worker-protocol.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-baseline-worker-protocol.test.ts
@@ -1,0 +1,170 @@
+import { expect, it } from 'vitest';
+
+import { parseRtcBaselineBoundedInteger } from '../../../baseline/command/rtc-baseline-cli-options.ts';
+import {
+  rtcBaselineIssue,
+  type RtcBaselineResult,
+} from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
+
+interface ProtocolTestInput {
+  readonly size: number;
+}
+
+interface ProtocolTestResult {
+  readonly durationMs: number;
+  readonly count: number;
+  readonly succeeded: boolean;
+}
+
+interface DiagnosticTestArguments {
+  readonly mode: 'diagnostic';
+  readonly out: string;
+}
+
+const sampleIds = Array.from(
+  { length: 5 },
+  (_value, index) =>
+    `rtc-b04-protocol-test-fixed-retained-002-${String(index + 1).padStart(3, '0')}`,
+);
+const workerArguments = [
+  '--capture=worker',
+  '--baseline-id=20260807-0123456789ab-e1-local',
+  '--workload=RTC-B04',
+  '--case-id=protocol-test',
+  '--input-key=fixed',
+  '--intended-phase=retained',
+  '--outer-ordinal=2',
+  `--sample-ids=${sampleIds.join(',')}`,
+  '--rtc-inner-runs=5',
+  '--rtc-size=10',
+];
+
+function parseProtocolTestWorker(arguments_: readonly string[]) {
+  return parseRtcBaselineAcceptedWorker({
+    arguments_,
+    identity: { workloadId: 'RTC-B04', caseId: 'protocol-test' },
+    toInputKey: () => 'fixed',
+    capabilityOptionNames: ['rtc-size'],
+    parseCapability: (options): RtcBaselineResult<ProtocolTestInput> => {
+      const size = parseRtcBaselineBoundedInteger(options['rtc-size'] ?? '', 'rtc-size', 1, 10);
+      if (!size.ok) {
+        return size;
+      }
+      return options['rtc-size'] === '10' ? { ok: true, value: { size: size.value } } : {
+        ok: false,
+        issues: [
+          rtcBaselineIssue('$.rtc-size', 'unexpected-worker-input', 'Expected 10.'),
+        ],
+      };
+    },
+  });
+}
+
+function readProtocolTestWorker(): RtcBaselineAcceptedWorker<ProtocolTestInput> {
+  const parsed = parseProtocolTestWorker(workerArguments);
+  if (!parsed.ok) {
+    throw new Error('Expected protocol test worker.');
+  }
+  return parsed.value;
+}
+
+it('parses exact accepted identity and rejects malformed common worker tokens', () => {
+  expect(readProtocolTestWorker()).toEqual({
+    mode: 'accepted',
+    input: { size: 10 },
+    workloadId: 'RTC-B04',
+    caseId: 'protocol-test',
+    inputKey: 'fixed',
+    intendedPhase: 'retained',
+    outerOrdinal: 2,
+    sampleIds,
+  });
+  const mutations: readonly [string, string][] = [
+    ['--capture=worker', '--capture=wrong'],
+    ['--workload=RTC-B04', '--workload=RTC-B03'],
+    ['--case-id=protocol-test', '--case-id=wrong'],
+    ['--input-key=fixed', '--input-key=wrong'],
+    ['--intended-phase=retained', '--intended-phase=wrong'],
+    ['--outer-ordinal=2', '--outer-ordinal=02'],
+    [`--sample-ids=${sampleIds.join(',')}`, '--sample-ids=wrong'],
+    ['--rtc-inner-runs=5', '--rtc-inner-runs=05'],
+    ['--rtc-size=10', '--unexpected=10'],
+  ];
+  for (const [expected, replacement] of mutations) {
+    expect(
+      parseProtocolTestWorker(
+        workerArguments.map((argument) => argument === expected ? replacement : argument),
+      ).ok,
+    ).toBe(false);
+  }
+  for (let index = 0; index < workerArguments.length; index += 1) {
+    expect(
+      parseProtocolTestWorker(workerArguments.filter((_argument, offset) => offset !== index)).ok,
+    )
+      .toBe(false);
+  }
+});
+
+it('owns exact sample envelopes, JSON-safe numbers, and causal failure accounting', async () => {
+  const worker = readProtocolTestWorker();
+  let executions = 0;
+  const samples = await runRtcBaselineAcceptedWorker({
+    worker,
+    run: () => {
+      executions += 1;
+      return { durationMs: Number.POSITIVE_INFINITY, count: Number.NaN, succeeded: false };
+    },
+    validate: () => [rtcBaselineIssue('$.rawEvidence.succeeded', 'failed', 'Expected success.')],
+    metrics: (result) => [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: (result) => result,
+  });
+  expect(executions).toBe(1);
+  expect(samples.map((sample) => [sample.identity.sampleId, sample.outcome])).toEqual([
+    [sampleIds[0], 'failed'],
+    ...sampleIds.slice(1).map((sampleId) => [sampleId, 'not-run']),
+  ]);
+  expect(samples[0]).toMatchObject({
+    schema: 'rallar.rtc-baseline.sample.v1',
+    evidenceClass: 'synthetic-path',
+    metrics: [],
+    rawEvidence: { durationMs: null, count: null, succeeded: false },
+    rawReferences: [],
+    runtimeObservation: null,
+  });
+  expect(samples.slice(1).map((sample) => sample.issues[0])).toEqual(
+    sampleIds.slice(1).map(() => ({
+      path: '$.rawEvidence',
+      code: 'causal-not-run',
+      message: sampleIds[0],
+    })),
+  );
+});
+
+it('dispatches only accepted CLI workers and serializes their samples', async () => {
+  const outputs: string[] = [];
+  const accepted = await runRtcBaselineAcceptedWorkerCli({
+    parsed: readProtocolTestWorker(),
+    runAccepted: () => Promise.resolve([]),
+    writeOutput: (output) => outputs.push(output),
+  });
+  expect(accepted).toEqual({ handled: true });
+  expect(outputs).toEqual(['[]']);
+
+  const diagnostic: DiagnosticTestArguments = { mode: 'diagnostic', out: 'result.json' };
+  const notAccepted = await runRtcBaselineAcceptedWorkerCli({
+    parsed: diagnostic,
+    runAccepted: () =>
+      Promise.reject(
+        new Error('Diagnostic input must not run accepted samples.'),
+      ),
+    writeOutput: (output) => outputs.push(output),
+  });
+  expect(notAccepted).toEqual({ handled: false, diagnostic });
+  expect(outputs).toEqual(['[]']);
+});

--- a/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
@@ -1,22 +1,448 @@
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
-const entries = [
-  'webrtc-group-cache-fallback-bench.ts',
-  'webrtc-group-manager-state-bench.ts',
-  'webrtc-group-manager-peer-owners-bench.ts',
-  'webrtc-heartbeat-callback-churn-bench.ts',
-] as const;
+import { describe, expect, it, onTestFinished } from 'vitest';
 
-it('keeps each group-coordination benchmark checked without running B04', () => {
-  const result = spawnSync(
-    'deno',
-    [
-      'check',
-      '--config',
-      'packages/shared-rtc-bench/deno.json',
-      ...entries.map((entry) => `packages/shared-rtc-bench/workloads/group-coordination/${entry}`),
-    ],
-    { encoding: 'utf8' },
+import type {
+  RtcBaselineResult,
+  RtcBaselineSampleDto,
+} from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import * as CacheFallback from '../../../workloads/group-coordination/webrtc-group-cache-fallback-bench.ts';
+import * as ManagerState from '../../../workloads/group-coordination/webrtc-group-manager-state-bench.ts';
+import * as PeerOwners from '../../../workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts';
+import * as Heartbeat from '../../../workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts';
+
+const baselineId = '20260807-0123456789ab-e1-local';
+
+interface WorkerFixture {
+  readonly caseId: string;
+  readonly sampleIds: readonly string[];
+  readonly arguments: readonly string[];
+}
+
+function createWorkerFixture(
+  caseId: string,
+  capabilityArguments: readonly string[],
+): WorkerFixture {
+  const prefix = `rtc-b04-${caseId}-fixed-retained-001`;
+  const sampleIds = Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
   );
-  expect(result.status, result.stderr).toBe(0);
+  return {
+    caseId,
+    sampleIds,
+    arguments: [
+      '--capture=worker',
+      `--baseline-id=${baselineId}`,
+      '--workload=RTC-B04',
+      `--case-id=${caseId}`,
+      '--input-key=fixed',
+      '--intended-phase=retained',
+      '--outer-ordinal=1',
+      `--sample-ids=${sampleIds.join(',')}`,
+      '--rtc-inner-runs=5',
+      ...capabilityArguments,
+    ],
+  };
+}
+
+function readAcceptedWorker<Accepted>(
+  parsed: RtcBaselineResult<{ readonly mode: string }>,
+): Accepted {
+  if (!parsed.ok || parsed.value.mode !== 'accepted') {
+    throw new Error('Expected exact RTC-B04 accepted worker arguments.');
+  }
+  return parsed.value as Accepted;
+}
+
+function expectPassedSamples(
+  samples: readonly RtcBaselineSampleDto[],
+  fixture: WorkerFixture,
+  metricNames: readonly string[],
+): void {
+  expect(samples.map((sample) => sample.identity)).toEqual(
+    fixture.sampleIds.map((sampleId, index) => ({
+      sampleId,
+      workloadId: 'RTC-B04',
+      caseId: fixture.caseId,
+      inputKey: 'fixed',
+      intendedPhase: 'retained',
+      outerOrdinal: 1,
+      innerOrdinal: index + 1,
+    })),
+  );
+  expect(samples.map((sample) => sample.outcome)).toEqual(Array(5).fill('passed'));
+  expect(samples[0]).toMatchObject({
+    schema: 'rallar.rtc-baseline.sample.v1',
+    evidenceClass: 'synthetic-path',
+    rawReferences: [],
+    runtimeObservation: null,
+  });
+  expect(samples[0]?.metrics.map((metric) => metric.metric)).toEqual(metricNames);
+}
+
+function expectRejectedWorkerMutations(
+  parse: (arguments_: readonly string[]) => RtcBaselineResult<{ readonly mode: string }>,
+  fixture: WorkerFixture,
+  alternateNumericMutations: readonly [string, string][],
+): void {
+  const mutations: readonly [string, string][] = [
+    ['--workload=RTC-B04', '--workload=RTC-B03'],
+    [`--case-id=${fixture.caseId}`, '--case-id=wrong'],
+    ['--input-key=fixed', '--input-key=wrong'],
+    ['--intended-phase=retained', '--intended-phase=wrong'],
+    ['--outer-ordinal=1', '--outer-ordinal=01'],
+    [`--sample-ids=${fixture.sampleIds.join(',')}`, '--sample-ids=wrong'],
+    ['--rtc-inner-runs=5', '--rtc-inner-runs=05'],
+    ...alternateNumericMutations,
+    ['--rtc-inner-runs=5', '--unexpected=1'],
+  ];
+  for (const [expected, replacement] of mutations) {
+    expect(
+      parse(fixture.arguments.map((argument) => argument === expected ? replacement : argument)).ok,
+    ).toBe(false);
+  }
+  for (let index = 0; index < fixture.arguments.length; index += 1) {
+    expect(parse(fixture.arguments.filter((_argument, offset) => offset !== index)).ok).toBe(false);
+  }
+}
+
+async function expectFirstFailureStopsAcceptedWorker(
+  fixture: WorkerFixture,
+  runAccepted: () => Promise<readonly RtcBaselineSampleDto[]>,
+  executionCount: () => number,
+): Promise<void> {
+  const samples = await runAccepted();
+  expect(executionCount()).toBe(1);
+  expect(samples.map((sample) => [sample.identity.sampleId, sample.outcome])).toEqual([
+    [fixture.sampleIds[0], 'failed'],
+    ...fixture.sampleIds.slice(1).map((sampleId) => [sampleId, 'not-run']),
+  ]);
+  expect(samples.slice(1).map((sample) => sample.issues[0])).toEqual(
+    fixture.sampleIds.slice(1).map(() => ({
+      path: '$.rawEvidence',
+      code: 'causal-not-run',
+      message: fixture.sampleIds[0],
+    })),
+  );
+}
+
+async function expectInvalidDurationsRejected(
+  runAccepted: (durationMs: number) => Promise<readonly RtcBaselineSampleDto[]>,
+): Promise<void> {
+  for (const durationMs of [-1, Number.POSITIVE_INFINITY]) {
+    const samples = await runAccepted(durationMs);
+    expect(samples.map((sample) => sample.outcome)).toEqual([
+      'failed',
+      'not-run',
+      'not-run',
+      'not-run',
+      'not-run',
+    ]);
+    expect(samples[0]?.metrics).toEqual([]);
+    expect((samples[0]?.rawEvidence as { durationMs: unknown }).durationMs).toBe(
+      Number.isFinite(durationMs) ? durationMs : null,
+    );
+    expect(() => JSON.parse(JSON.stringify(samples))).not.toThrow();
+  }
+}
+
+const cacheFallback = {
+  fixture: createWorkerFixture('group-cache-fallback', [
+    '--rtc-snapshots=20000',
+    '--rtc-matching-versions=5000',
+    '--rtc-lookups=500',
+  ]),
+  result: {
+    durationMs: 1,
+    snapshotCount: 20000,
+    matchingVersions: 5000,
+    lookups: 500,
+    readCalls: 500,
+    peekCalls: 500,
+    readAllValuesCalls: 500,
+    latestVersion: 5000,
+    targetPeerCount: 1,
+  } satisfies CacheFallback.WebRtcGroupCacheFallbackResult,
+};
+
+describe('RTC-B04 group cache fallback worker', () => {
+  const { fixture, result } = cacheFallback;
+
+  it('emits exact samples from deterministic accepted results', async () => {
+    const worker = readAcceptedWorker<CacheFallback.WebRtcGroupCacheFallbackAcceptedArguments>(
+      CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
+    );
+    const samples = await CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
+      worker,
+      run: () => result,
+    });
+    expectPassedSamples(samples, fixture, ['durationMs']);
+    expect(samples[0]?.rawEvidence).toEqual(result);
+  });
+
+  it('rejects malformed workers and stops after invalid counter evidence', async () => {
+    expectRejectedWorkerMutations(
+      CacheFallback.parseWebRtcGroupCacheFallbackArguments,
+      fixture,
+      [
+        ['--rtc-snapshots=20000', '--rtc-snapshots=020000'],
+        ['--rtc-matching-versions=5000', '--rtc-matching-versions=05000'],
+        ['--rtc-lookups=500', '--rtc-lookups=0500'],
+      ],
+    );
+    let executions = 0;
+    await expectFirstFailureStopsAcceptedWorker(
+      fixture,
+      () =>
+        CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
+          worker: readAcceptedWorker(
+            CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
+          ),
+          run: () => {
+            executions += 1;
+            return { ...result, readCalls: 499 };
+          },
+        }),
+      () => executions,
+    );
+    await expectInvalidDurationsRejected((durationMs) =>
+      CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
+        worker: readAcceptedWorker(
+          CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
+        ),
+        run: () => ({ ...result, durationMs }),
+      })
+    );
+  });
+});
+
+const managerState = {
+  fixture: createWorkerFixture('group-manager-state', [
+    '--rtc-clients=5000',
+    '--rtc-desired=1000',
+    '--rtc-lookups=20',
+  ]),
+  result: {
+    durationMs: 2,
+    clientCount: 5000,
+    desiredPeerCount: 1000,
+    lookups: 20,
+    keysCalls: 20,
+    readCalls: 100000,
+    onlineDesiredPeerCount: 1000,
+    onlinePeerCount: 1000,
+  } satisfies ManagerState.WebRtcGroupManagerStateResult,
+};
+
+describe('RTC-B04 group manager state worker', () => {
+  const { fixture, result } = managerState;
+
+  it('emits exact samples from deterministic accepted results', async () => {
+    const worker = readAcceptedWorker<ManagerState.WebRtcGroupManagerStateAcceptedArguments>(
+      ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
+    );
+    const samples = await ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
+      worker,
+      run: () => result,
+    });
+    expectPassedSamples(samples, fixture, ['durationMs']);
+    expect(samples[0]?.rawEvidence).toEqual(result);
+  });
+
+  it('rejects malformed workers and stops after invalid state evidence', async () => {
+    expectRejectedWorkerMutations(
+      ManagerState.parseWebRtcGroupManagerStateArguments,
+      fixture,
+      [
+        ['--rtc-clients=5000', '--rtc-clients=05000'],
+        ['--rtc-desired=1000', '--rtc-desired=01000'],
+        ['--rtc-lookups=20', '--rtc-lookups=020'],
+      ],
+    );
+    let executions = 0;
+    await expectFirstFailureStopsAcceptedWorker(
+      fixture,
+      () =>
+        ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
+          worker: readAcceptedWorker(
+            ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
+          ),
+          run: () => {
+            executions += 1;
+            return { ...result, onlinePeerCount: 999 };
+          },
+        }),
+      () => executions,
+    );
+    await expectInvalidDurationsRejected((durationMs) =>
+      ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
+        worker: readAcceptedWorker(
+          ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
+        ),
+        run: () => ({ ...result, durationMs }),
+      })
+    );
+  });
+});
+
+const peerOwners = {
+  fixture: createWorkerFixture('group-manager-peer-owners', [
+    '--rtc-groups=1000',
+    '--rtc-peers-per-group=10',
+    '--rtc-lookups=1000',
+  ]),
+  result: {
+    durationMs: 3,
+    groupCount: 1000,
+    peersPerGroup: 10,
+    lookups: 1000,
+    ownedLookups: 1000,
+    totalOwnerGroups: 10000,
+    desiredPeerCount: 1000,
+  } satisfies PeerOwners.WebRtcGroupManagerPeerOwnersResult,
+};
+
+describe('RTC-B04 group peer ownership worker', () => {
+  const { fixture, result } = peerOwners;
+
+  it('emits exact samples from deterministic accepted results', async () => {
+    const worker = readAcceptedWorker<PeerOwners.WebRtcGroupManagerPeerOwnersAcceptedArguments>(
+      PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
+    );
+    const samples = await PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+      worker,
+      run: () => result,
+    });
+    expectPassedSamples(samples, fixture, ['durationMs']);
+    expect(samples[0]?.rawEvidence).toEqual(result);
+  });
+
+  it('rejects malformed workers and stops after invalid ownership evidence', async () => {
+    expectRejectedWorkerMutations(
+      PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments,
+      fixture,
+      [
+        ['--rtc-groups=1000', '--rtc-groups=01000'],
+        ['--rtc-peers-per-group=10', '--rtc-peers-per-group=010'],
+        ['--rtc-lookups=1000', '--rtc-lookups=01000'],
+      ],
+    );
+    let executions = 0;
+    await expectFirstFailureStopsAcceptedWorker(
+      fixture,
+      () =>
+        PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+          worker: readAcceptedWorker(
+            PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
+          ),
+          run: () => {
+            executions += 1;
+            return { ...result, ownedLookups: 999 };
+          },
+        }),
+      () => executions,
+    );
+    await expectInvalidDurationsRejected((durationMs) =>
+      PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+        worker: readAcceptedWorker(
+          PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
+        ),
+        run: () => ({ ...result, durationMs }),
+      })
+    );
+  });
+});
+
+describe('RTC-B04 heartbeat callback churn worker', () => {
+  const fixture = createWorkerFixture('heartbeat-callback-churn', ['--rtc-channels=10000']);
+  const result: Heartbeat.WebRtcHeartbeatCallbackChurnResult = {
+    durationMs: 4,
+    channelCount: 10000,
+    retainedCallbacks: 0,
+    maxCallbacksPerChannel: 0,
+  };
+
+  it('emits exact samples from deterministic accepted results', async () => {
+    const worker = readAcceptedWorker<Heartbeat.WebRtcHeartbeatCallbackChurnAcceptedArguments>(
+      Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
+    );
+    const samples = await Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+      worker,
+      run: () => result,
+    });
+    expectPassedSamples(samples, fixture, ['durationMs']);
+    expect(samples[0]?.rawEvidence).toEqual(result);
+  });
+
+  it('rejects malformed workers and stops after retained callback evidence', async () => {
+    expectRejectedWorkerMutations(
+      Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments,
+      fixture,
+      [['--rtc-channels=10000', '--rtc-channels=010000']],
+    );
+    let executions = 0;
+    await expectFirstFailureStopsAcceptedWorker(
+      fixture,
+      () =>
+        Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+          worker: readAcceptedWorker(
+            Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
+          ),
+          run: () => {
+            executions += 1;
+            return { ...result, retainedCallbacks: 1 };
+          },
+        }),
+      () => executions,
+    );
+    await expectInvalidDurationsRejected((durationMs) =>
+      Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+        worker: readAcceptedWorker(
+          Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
+        ),
+        run: () => ({ ...result, durationMs }),
+      })
+    );
+  });
+});
+
+it('keeps one-item direct diagnostics import-safe, nested, and overwrite-capable', () => {
+  mkdirSync('tmp', { recursive: true });
+  const directory = mkdtempSync(join('tmp', 'rtc-b04-group-diagnostic-'));
+  onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+  const diagnostics = [
+    [
+      'webrtc-group-cache-fallback-bench.ts',
+      '--snapshots=1',
+      '--matching-versions=1',
+      '--lookups=1',
+    ],
+    ['webrtc-group-manager-state-bench.ts', '--clients=1', '--desired=1', '--lookups=1'],
+    [
+      'webrtc-group-manager-peer-owners-bench.ts',
+      '--groups=1',
+      '--peers-per-group=1',
+      '--lookups=1',
+    ],
+    ['webrtc-heartbeat-callback-churn-bench.ts', '--channels=1'],
+  ];
+  for (const [index, [entry, ...capabilityArguments]] of diagnostics.entries()) {
+    const output = join(directory, String(index), 'result.json');
+    const command = [
+      'run',
+      '--config=packages/shared-rtc-bench/deno.json',
+      '--allow-read',
+      '--allow-write',
+      `packages/shared-rtc-bench/workloads/group-coordination/${entry}`,
+      ...capabilityArguments,
+      '--runs=1',
+      `--out=${output}`,
+    ];
+    expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
+    expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
+    expect(JSON.parse(readFileSync(output, 'utf8')).results).toHaveLength(1);
+  }
 });

--- a/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
@@ -8,6 +8,9 @@ import type {
   RtcBaselineResult,
   RtcBaselineSampleDto,
 } from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import type {
+  RtcBaselineAcceptedWorker,
+} from '../../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 import * as CacheFallback from '../../../workloads/group-coordination/webrtc-group-cache-fallback-bench.ts';
 import * as ManagerState from '../../../workloads/group-coordination/webrtc-group-manager-state-bench.ts';
 import * as PeerOwners from '../../../workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts';
@@ -129,22 +132,28 @@ async function expectFirstFailureStopsAcceptedWorker(
   );
 }
 
-async function expectInvalidDurationsRejected(
-  runAccepted: (durationMs: number) => Promise<readonly RtcBaselineSampleDto[]>,
+function createNonFiniteMutations<Result extends object>(
+  result: Result,
+  keys: readonly (keyof Result)[],
+) {
+  return keys.map((key) => ({ key, result: { ...result, [key]: Number.POSITIVE_INFINITY } }));
+}
+
+async function expectNonFiniteNumbersRejected<Result extends object>(
+  fixture: WorkerFixture,
+  mutations: readonly { readonly key: keyof Result; readonly result: Result }[],
+  runAccepted: (result: Result) => Promise<readonly RtcBaselineSampleDto[]>,
 ): Promise<void> {
-  for (const durationMs of [-1, Number.POSITIVE_INFINITY]) {
-    const samples = await runAccepted(durationMs);
-    expect(samples.map((sample) => sample.outcome)).toEqual([
-      'failed',
-      'not-run',
-      'not-run',
-      'not-run',
-      'not-run',
+  for (const mutation of mutations) {
+    const samples = await runAccepted(mutation.result);
+    expect(samples.map((sample) => [sample.identity.sampleId, sample.outcome])).toEqual([
+      [fixture.sampleIds[0], 'failed'],
+      ...fixture.sampleIds.slice(1).map((sampleId) => [sampleId, 'not-run']),
     ]);
-    expect(samples[0]?.metrics).toEqual([]);
-    expect((samples[0]?.rawEvidence as { durationMs: unknown }).durationMs).toBe(
-      Number.isFinite(durationMs) ? durationMs : null,
+    expect(samples.slice(1).map((sample) => sample.issues[0]?.message)).toEqual(
+      Array(4).fill(fixture.sampleIds[0]),
     );
+    expect((samples[0]?.rawEvidence as Record<string, unknown>)[String(mutation.key)]).toBe(null);
     expect(() => JSON.parse(JSON.stringify(samples))).not.toThrow();
   }
 }
@@ -160,9 +169,9 @@ const cacheFallback = {
     snapshotCount: 20000,
     matchingVersions: 5000,
     lookups: 500,
-    readCalls: 500,
-    peekCalls: 500,
-    readAllValuesCalls: 500,
+    readCalls: 1000,
+    peekCalls: 0,
+    readAllValuesCalls: 1000,
     latestVersion: 5000,
     targetPeerCount: 1,
   } satisfies CacheFallback.WebRtcGroupCacheFallbackResult,
@@ -172,7 +181,11 @@ describe('RTC-B04 group cache fallback worker', () => {
   const { fixture, result } = cacheFallback;
 
   it('emits exact samples from deterministic accepted results', async () => {
-    const worker = readAcceptedWorker<CacheFallback.WebRtcGroupCacheFallbackAcceptedArguments>(
+    const worker = readAcceptedWorker<
+      RtcBaselineAcceptedWorker<
+        CacheFallback.WebRtcGroupCacheFallbackInput
+      >
+    >(
       CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
     );
     const samples = await CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
@@ -208,13 +221,16 @@ describe('RTC-B04 group cache fallback worker', () => {
         }),
       () => executions,
     );
-    await expectInvalidDurationsRejected((durationMs) =>
-      CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
-        worker: readAcceptedWorker(
-          CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
-        ),
-        run: () => ({ ...result, durationMs }),
-      })
+    await expectNonFiniteNumbersRejected(
+      fixture,
+      createNonFiniteMutations(result, Object.keys(result) as (keyof typeof result)[]),
+      (invalidResult) =>
+        CacheFallback.runWebRtcGroupCacheFallbackAcceptedSamples({
+          worker: readAcceptedWorker(
+            CacheFallback.parseWebRtcGroupCacheFallbackArguments(fixture.arguments),
+          ),
+          run: () => invalidResult,
+        }),
     );
   });
 });
@@ -233,7 +249,7 @@ const managerState = {
     keysCalls: 20,
     readCalls: 100000,
     onlineDesiredPeerCount: 1000,
-    onlinePeerCount: 1000,
+    onlinePeerCount: 5000,
   } satisfies ManagerState.WebRtcGroupManagerStateResult,
 };
 
@@ -241,7 +257,11 @@ describe('RTC-B04 group manager state worker', () => {
   const { fixture, result } = managerState;
 
   it('emits exact samples from deterministic accepted results', async () => {
-    const worker = readAcceptedWorker<ManagerState.WebRtcGroupManagerStateAcceptedArguments>(
+    const worker = readAcceptedWorker<
+      RtcBaselineAcceptedWorker<
+        ManagerState.WebRtcGroupManagerStateInput
+      >
+    >(
       ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
     );
     const samples = await ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
@@ -277,13 +297,16 @@ describe('RTC-B04 group manager state worker', () => {
         }),
       () => executions,
     );
-    await expectInvalidDurationsRejected((durationMs) =>
-      ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
-        worker: readAcceptedWorker(
-          ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
-        ),
-        run: () => ({ ...result, durationMs }),
-      })
+    await expectNonFiniteNumbersRejected(
+      fixture,
+      createNonFiniteMutations(result, Object.keys(result) as (keyof typeof result)[]),
+      (invalidResult) =>
+        ManagerState.runWebRtcGroupManagerStateAcceptedSamples({
+          worker: readAcceptedWorker(
+            ManagerState.parseWebRtcGroupManagerStateArguments(fixture.arguments),
+          ),
+          run: () => invalidResult,
+        }),
     );
   });
 });
@@ -309,7 +332,11 @@ describe('RTC-B04 group peer ownership worker', () => {
   const { fixture, result } = peerOwners;
 
   it('emits exact samples from deterministic accepted results', async () => {
-    const worker = readAcceptedWorker<PeerOwners.WebRtcGroupManagerPeerOwnersAcceptedArguments>(
+    const worker = readAcceptedWorker<
+      RtcBaselineAcceptedWorker<
+        PeerOwners.WebRtcGroupManagerPeerOwnersInput
+      >
+    >(
       PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
     );
     const samples = await PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
@@ -345,13 +372,16 @@ describe('RTC-B04 group peer ownership worker', () => {
         }),
       () => executions,
     );
-    await expectInvalidDurationsRejected((durationMs) =>
-      PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
-        worker: readAcceptedWorker(
-          PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
-        ),
-        run: () => ({ ...result, durationMs }),
-      })
+    await expectNonFiniteNumbersRejected(
+      fixture,
+      createNonFiniteMutations(result, Object.keys(result) as (keyof typeof result)[]),
+      (invalidResult) =>
+        PeerOwners.runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+          worker: readAcceptedWorker(
+            PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments(fixture.arguments),
+          ),
+          run: () => invalidResult,
+        }),
     );
   });
 });
@@ -366,7 +396,11 @@ describe('RTC-B04 heartbeat callback churn worker', () => {
   };
 
   it('emits exact samples from deterministic accepted results', async () => {
-    const worker = readAcceptedWorker<Heartbeat.WebRtcHeartbeatCallbackChurnAcceptedArguments>(
+    const worker = readAcceptedWorker<
+      RtcBaselineAcceptedWorker<
+        Heartbeat.WebRtcHeartbeatCallbackChurnInput
+      >
+    >(
       Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
     );
     const samples = await Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
@@ -398,13 +432,16 @@ describe('RTC-B04 heartbeat callback churn worker', () => {
         }),
       () => executions,
     );
-    await expectInvalidDurationsRejected((durationMs) =>
-      Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
-        worker: readAcceptedWorker(
-          Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
-        ),
-        run: () => ({ ...result, durationMs }),
-      })
+    await expectNonFiniteNumbersRejected(
+      fixture,
+      createNonFiniteMutations(result, Object.keys(result) as (keyof typeof result)[]),
+      (invalidResult) =>
+        Heartbeat.runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+          worker: readAcceptedWorker(
+            Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments(fixture.arguments),
+          ),
+          run: () => invalidResult,
+        }),
     );
   });
 });

--- a/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/group-coordination/webrtc-group-coordination-benches.test.ts
@@ -108,6 +108,9 @@ function expectRejectedWorkerMutations(
     ).toBe(false);
   }
   for (let index = 0; index < fixture.arguments.length; index += 1) {
+    if (fixture.arguments[index]?.startsWith('--capture=')) {
+      continue;
+    }
     expect(parse(fixture.arguments.filter((_argument, offset) => offset !== index)).ok).toBe(false);
   }
 }
@@ -156,6 +159,16 @@ async function expectNonFiniteNumbersRejected<Result extends object>(
     expect((samples[0]?.rawEvidence as Record<string, unknown>)[String(mutation.key)]).toBe(null);
     expect(() => JSON.parse(JSON.stringify(samples))).not.toThrow();
   }
+}
+
+function expectDiagnosticArguments(
+  parsed: RtcBaselineResult<{ readonly mode: string }>,
+  expected: object,
+): void {
+  if (!parsed.ok || parsed.value.mode !== 'diagnostic') {
+    throw new Error('Expected legacy direct diagnostic arguments.');
+  }
+  expect(parsed.value).toMatchObject(expected);
 }
 
 const cacheFallback = {
@@ -482,4 +495,46 @@ it('keeps one-item direct diagnostics import-safe, nested, and overwrite-capable
     expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
     expect(JSON.parse(readFileSync(output, 'utf8')).results).toHaveLength(1);
   }
+});
+
+it('preserves first-match permissive Number grammar for every group diagnostic', () => {
+  const common = ['--unknown=ignored', '--runs=6.5', '--runs=1'];
+  expectDiagnosticArguments(
+    CacheFallback.parseWebRtcGroupCacheFallbackArguments([
+      '--snapshots=1.5',
+      '--snapshots=2',
+      '--matching-versions=NaN',
+      '--lookups=3',
+      ...common,
+    ]),
+    { input: { snapshots: 1.5, matchingVersions: Number.NaN, lookups: 3 }, runs: 6.5 },
+  );
+  expectDiagnosticArguments(
+    ManagerState.parseWebRtcGroupManagerStateArguments([
+      '--clients=1.5',
+      '--clients=2',
+      '--desired=NaN',
+      '--lookups=3',
+      ...common,
+    ]),
+    { input: { clients: 1.5, desired: Number.NaN, lookups: 3 }, runs: 6.5 },
+  );
+  expectDiagnosticArguments(
+    PeerOwners.parseWebRtcGroupManagerPeerOwnersArguments([
+      '--groups=1.5',
+      '--groups=2',
+      '--peers-per-group=NaN',
+      '--lookups=3',
+      ...common,
+    ]),
+    { input: { groups: 1.5, peersPerGroup: Number.NaN, lookups: 3 }, runs: 6.5 },
+  );
+  expectDiagnosticArguments(
+    Heartbeat.parseWebRtcHeartbeatCallbackChurnArguments([
+      '--channels=1.5',
+      '--channels=2',
+      ...common,
+    ]),
+    { input: { channels: 1.5 }, runs: 6.5 },
+  );
 });

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -1,15 +1,164 @@
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
-it('keeps the multicast benchmark as a checked, non-executed B04 entry', () => {
-  const result = spawnSync(
-    'deno',
-    [
-      'check',
-      '--config',
-      'packages/shared-rtc-bench/deno.json',
-      'packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts',
-    ],
-    { encoding: 'utf8' },
+import { expect, it, onTestFinished } from 'vitest';
+
+import type { RtcBaselineSampleDto } from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import * as Multicast from '../../../workloads/multicast/rtc-multicast-serialization-bench.ts';
+
+const baselineId = '20260807-0123456789ab-e1-local';
+
+function words(value: string): string[] {
+  return value.trim().split(/\s+/);
+}
+
+function worker(peers: 10 | 100 | 1000, payloadBytes: 4096 | 65536) {
+  const inputKey = `peers-${peers}-payload-${payloadBytes}`;
+  const prefix = `rtc-b04-multicast-serialization-${inputKey}-retained-001`;
+  const ids = Array.from(
+    { length: 5 },
+    (_, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
   );
-  expect(result.status, result.stderr).toBe(0);
+  return {
+    ids,
+    arguments: words(`--capture=worker --baseline-id=${baselineId} --workload=RTC-B04
+--case-id=multicast-serialization --input-key=${inputKey} --intended-phase=retained
+--outer-ordinal=1 --sample-ids=${ids.join(',')} --rtc-inner-runs=5 --rtc-peers=${peers}
+--rtc-payload-bytes=${payloadBytes}`),
+  };
+}
+
+function validAcceptedResult(
+  peers: 10 | 100 | 1000,
+  payloadBytes: 4096 | 65536,
+): Multicast.RtcMulticastSerializationResult {
+  return {
+    peerCount: peers,
+    payloadBytes,
+    planDurationMs: 1,
+    serializeDurationMs: 2,
+    originalSerializeDurationMs: 0.5,
+    transportMessages: peers,
+    uniqueSerializedMessages: peers,
+    totalSerializedBytes: peers * payloadBytes,
+    originalSerializedBytes: payloadBytes,
+    allTransportMessagesIdentical: false,
+  };
+}
+
+it('RTC-B04 parses every multicast matrix worker and emits exact accepted samples', async () => {
+  const smokeResult = Multicast.runRtcMulticastSerialization({ peers: 10, payloadBytes: 4096 });
+  expect([
+    smokeResult.peerCount,
+    smokeResult.payloadBytes,
+    smokeResult.transportMessages,
+    smokeResult.uniqueSerializedMessages,
+    smokeResult.allTransportMessagesIdentical,
+  ]).toEqual([10, 4096, 10, 10, false]);
+  expect(smokeResult.totalSerializedBytes).toBeGreaterThanOrEqual(
+    smokeResult.originalSerializedBytes * smokeResult.transportMessages,
+  );
+  expect(smokeResult.planDurationMs).toBeGreaterThanOrEqual(0);
+  expect(smokeResult.serializeDurationMs).toBeGreaterThanOrEqual(0);
+  expect(smokeResult.originalSerializeDurationMs).toBeGreaterThanOrEqual(0);
+
+  for (const peers of [10, 100, 1000] as const) {
+    for (const payloadBytes of [4096, 65536] as const) {
+      const input = worker(peers, payloadBytes);
+      const parsed = Multicast.parseRtcMulticastSerializationArguments(input.arguments);
+      if (!parsed.ok || parsed.value.mode !== 'accepted') {
+        throw new Error('Expected exact B04 worker input.');
+      }
+      const samples = await Multicast.runRtcMulticastSerializationAcceptedSamples({
+        worker: parsed.value,
+        run: () => validAcceptedResult(peers, payloadBytes),
+      });
+      expect(samples.map((sample: RtcBaselineSampleDto) => sample.identity)).toEqual(
+        input.ids.map((sampleId, index) => ({
+          sampleId,
+          workloadId: 'RTC-B04',
+          caseId: 'multicast-serialization',
+          inputKey: `peers-${peers}-payload-${payloadBytes}`,
+          intendedPhase: 'retained',
+          outerOrdinal: 1,
+          innerOrdinal: index + 1,
+        })),
+      );
+      expect(samples.map((sample: RtcBaselineSampleDto) => sample.outcome)).toEqual(
+        Array(5).fill('passed'),
+      );
+      expect(samples[0]).toMatchObject({
+        schema: 'rallar.rtc-baseline.sample.v1',
+        evidenceClass: 'synthetic-path',
+        rawReferences: [],
+        runtimeObservation: null,
+      });
+      expect(samples[0]?.metrics).toHaveLength(3);
+    }
+  }
+});
+
+it('RTC-B04 rejects malformed multicast workers, persists causal failure remainder, and preserves overwrite diagnostics', async () => {
+  const input = worker(10, 4096);
+  expect(Multicast.parseRtcMulticastSerializationArguments(['--out=/tmp/result.json']).ok).toBe(
+    true,
+  );
+  for (
+    const [expected, replacement] of [
+      ['--rtc-peers=10', '--rtc-peers=010'],
+      ['--rtc-payload-bytes=4096', '--rtc-payload-bytes=04096'],
+      ['--outer-ordinal=1', '--outer-ordinal=01'],
+      ['--rtc-inner-runs=5', '--rtc-inner-runs=05'],
+    ]
+  ) {
+    expect(
+      Multicast.parseRtcMulticastSerializationArguments(
+        input.arguments.map((argument) => (argument === expected ? replacement : argument)),
+      ).ok,
+    ).toBe(false);
+  }
+  let executions = 0;
+  const acceptedWorker = Multicast.parseRtcMulticastSerializationArguments(input.arguments);
+  if (!acceptedWorker.ok || acceptedWorker.value.mode !== 'accepted') {
+    throw new Error('Expected exact B04 worker input.');
+  }
+  const samples = await Multicast.runRtcMulticastSerializationAcceptedSamples({
+    worker: acceptedWorker.value,
+    run: () => {
+      executions += 1;
+      return {
+        ...validAcceptedResult(10, 4096),
+        transportMessages: 9,
+      };
+    },
+  });
+  expect(executions).toBe(1);
+  expect(samples.map((sample: RtcBaselineSampleDto) => [sample.identity.sampleId, sample.outcome]))
+    .toEqual([
+      [input.ids[0], 'failed'],
+      ...input.ids.slice(1).map((sampleId) => [sampleId, 'not-run']),
+    ]);
+  expect(samples.slice(1).map((sample: RtcBaselineSampleDto) => sample.issues[0]?.code)).toEqual(
+    Array(4).fill('causal-not-run'),
+  );
+
+  mkdirSync('tmp/perf/results', { recursive: true });
+  const directory = mkdtempSync(join('tmp/perf/results', 'rtc-b04-multicast-diagnostic-'));
+  onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+  const output = join(directory, 'result.json');
+  const command = [
+    'run',
+    '--config=packages/shared-rtc-bench/deno.json',
+    '--allow-read',
+    '--allow-write',
+    'packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts',
+    '--peer-counts=10',
+    '--payload-bytes=4096',
+    '--runs=1',
+    `--out=${output}`,
+  ];
+  expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
+  expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
+  expect(JSON.parse(readFileSync(output, 'utf8')).results).toHaveLength(1);
 });

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -105,7 +105,7 @@ it('RTC-B04 parses every multicast matrix worker and emits exact accepted sample
   }
 });
 
-it('RTC-B04 rejects malformed multicast workers, persists causal failure remainder, and preserves overwrite diagnostics', async () => {
+it('RTC-B04 rejects malformed multicast workers', () => {
   const input = worker(10, 4096);
   expect(Multicast.parseRtcMulticastSerializationArguments(['--out=/tmp/result.json']).ok).toBe(
     true,
@@ -142,6 +142,10 @@ it('RTC-B04 rejects malformed multicast workers, persists causal failure remaind
       ).ok,
     ).toBe(false);
   }
+});
+
+it('RTC-B04 records causal failure remainders', async () => {
+  const input = worker(10, 4096);
   let executions = 0;
   const acceptedWorker = Multicast.parseRtcMulticastSerializationArguments(input.arguments);
   if (!acceptedWorker.ok || acceptedWorker.value.mode !== 'accepted') {
@@ -166,7 +170,12 @@ it('RTC-B04 rejects malformed multicast workers, persists causal failure remaind
   expect(samples.slice(1).map((sample: RtcBaselineSampleDto) => sample.issues[0]?.code)).toEqual(
     Array(4).fill('causal-not-run'),
   );
+  expect(samples.slice(1).map((sample) => sample.issues[0]?.message)).toEqual(
+    Array(4).fill(input.ids[0]),
+  );
+});
 
+it('RTC-B04 diagnostics create nested outputs and overwrite them', () => {
   mkdirSync('tmp', { recursive: true });
   const directory = mkdtempSync(join('tmp', 'rtc-b04-multicast-diagnostic-'));
   onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
@@ -205,7 +214,23 @@ it('RTC-B04 fails every invalid result shape with JSON-safe evidence', async () 
     });
     expect(samples[0]?.outcome).toBe('failed');
     expect(samples.slice(1).map((sample) => sample.outcome)).toEqual(Array(4).fill('not-run'));
-    expect(JSON.stringify(samples)).not.toContain('Infinity');
+    expect(samples.slice(1).map((sample) => sample.issues[0]?.code)).toEqual(
+      Array(4).fill('causal-not-run'),
+    );
+    expect(samples.slice(1).map((sample) => sample.issues[0]?.message)).toEqual(
+      Array(4).fill(samples[0]?.identity.sampleId),
+    );
     expect(samples[0]?.rawEvidence).not.toBeNull();
+    if ('serializeDurationMs' in invalidResult) {
+      const restored = JSON.parse(JSON.stringify(samples[0]));
+      expect(
+        restored.metrics.every((metric: { value: unknown }) => typeof metric.value === 'number'),
+      ).toBe(true);
+      expect(restored.metrics.map((metric: { metric: string }) => metric.metric)).not.toContain(
+        'serializeDurationMs',
+      );
+      expect((restored.rawEvidence as { serializeDurationMs: unknown }).serializeDurationMs)
+        .toBeNull();
+    }
   }
 });

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -186,3 +186,26 @@ it('RTC-B04 rejects malformed multicast workers, persists causal failure remaind
   expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
   expect(JSON.parse(readFileSync(output, 'utf8')).results).toHaveLength(1);
 });
+
+it('RTC-B04 fails every invalid result shape with JSON-safe evidence', async () => {
+  const parsed = Multicast.parseRtcMulticastSerializationArguments(worker(10, 4096).arguments);
+  if (!parsed.ok || parsed.value.mode !== 'accepted') throw new Error('Expected accepted worker.');
+  const invalidResults = [
+    { peerCount: 100 },
+    { uniqueSerializedMessages: 1 },
+    { allTransportMessagesIdentical: true },
+    { originalSerializedBytes: Infinity, totalSerializedBytes: Infinity },
+    { planDurationMs: -1 },
+    { serializeDurationMs: Infinity },
+  ];
+  for (const invalidResult of invalidResults) {
+    const samples = await Multicast.runRtcMulticastSerializationAcceptedSamples({
+      worker: parsed.value,
+      run: () => ({ ...validAcceptedResult(10, 4096), ...invalidResult }),
+    });
+    expect(samples[0]?.outcome).toBe('failed');
+    expect(samples.slice(1).map((sample) => sample.outcome)).toEqual(Array(4).fill('not-run'));
+    expect(JSON.stringify(samples)).not.toContain('Infinity');
+    expect(samples[0]?.rawEvidence).not.toBeNull();
+  }
+});

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { expect, it, onTestFinished } from 'vitest';
 
@@ -137,6 +137,24 @@ it('RTC-B04 parses every multicast matrix worker and emits exact accepted sample
   }
 });
 
+it('supplies accepted multicast inner ordinals one through five', async () => {
+  const input = worker(10, 4096);
+  const parsed = Multicast.parseRtcMulticastSerializationArguments(input.arguments);
+  if (!parsed.ok || parsed.value.mode !== 'accepted') {
+    throw new Error('Expected exact B04 worker input.');
+  }
+  const innerOrdinals: number[] = [];
+  const samples = await Multicast.runRtcMulticastSerializationAcceptedSamples({
+    worker: parsed.value,
+    run: (innerOrdinal: number) => {
+      innerOrdinals.push(innerOrdinal);
+      return validAcceptedResult(10, 4096);
+    },
+  });
+  expect(innerOrdinals).toEqual([1, 2, 3, 4, 5]);
+  expect(samples.map((sample) => sample.outcome)).toEqual(Array(5).fill('passed'));
+});
+
 it('RTC-B04 rejects malformed multicast workers', () => {
   const input = worker(10, 4096);
   expect(Multicast.parseRtcMulticastSerializationArguments(['--out=/tmp/result.json']).ok).toBe(
@@ -176,6 +194,32 @@ it('RTC-B04 rejects malformed multicast workers', () => {
   }
 });
 
+it('preserves first-match permissive Number grammar for multicast diagnostics', () => {
+  const parsed = Multicast.parseRtcMulticastSerializationArguments([
+    '--peer-counts=10,bad,2.5,-1,Infinity,0',
+    '--peer-counts=100',
+    '--payload-bytes=4096,NaN,8192',
+    '--runs=7.5',
+    '--runs=1',
+    '--unknown=ignored',
+  ]);
+  if (!parsed.ok || parsed.value.mode !== 'diagnostic') {
+    throw new Error('Expected legacy multicast diagnostic arguments.');
+  }
+  expect(parsed.value).toMatchObject({
+    peerCounts: [10, 2.5],
+    payloadBytes: [4096, 8192],
+    runs: 7.5,
+  });
+});
+
+it('includes the run ordinal in multicast production message serialization', () => {
+  const first = Multicast.runRtcMulticastSerialization({ peers: 10, payloadBytes: 4096 }, 1);
+  const tenth = Multicast.runRtcMulticastSerialization({ peers: 10, payloadBytes: 4096 }, 10);
+  expect(tenth.originalSerializedBytes).toBe(first.originalSerializedBytes + 1);
+  expect(tenth.totalSerializedBytes).toBe(first.totalSerializedBytes + tenth.transportMessages);
+});
+
 it('RTC-B04 records causal failure remainders', async () => {
   const input = worker(10, 4096);
   let executions = 0;
@@ -207,25 +251,27 @@ it('RTC-B04 records causal failure remainders', async () => {
   );
 });
 
-it('RTC-B04 diagnostics create nested outputs and overwrite them', () => {
+it('runs the documented direct Node diagnostic with exact command and overwrite behavior', () => {
   mkdirSync('tmp', { recursive: true });
   const directory = mkdtempSync(join('tmp', 'rtc-b04-multicast-diagnostic-'));
   onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
   const output = join(directory, 'nested', 'result.json');
-  const command = [
-    'run',
-    '--config=packages/shared-rtc-bench/deno.json',
-    '--allow-read',
-    '--allow-write',
-    'packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts',
+  const entry =
+    'packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts';
+  const arguments_ = [
     '--peer-counts=10',
     '--payload-bytes=4096',
     '--runs=1',
     `--out=${output}`,
   ];
-  expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
-  expect(spawnSync('deno', command, { encoding: 'utf8' }).status).toBe(0);
-  expect(JSON.parse(readFileSync(output, 'utf8')).results).toHaveLength(1);
+  const command = ['--import=tsx', entry, ...arguments_];
+  const first = spawnSync(process.execPath, command, { encoding: 'utf8' });
+  expect(first.status, first.stderr).toBe(0);
+  const second = spawnSync(process.execPath, command, { encoding: 'utf8' });
+  expect(second.status, second.stderr).toBe(0);
+  const result = JSON.parse(readFileSync(output, 'utf8'));
+  expect(result.command).toBe([process.execPath, resolve(entry), ...arguments_].join(' '));
+  expect(result.results).toHaveLength(1);
 });
 
 it('RTC-B04 fails every invalid result shape with JSON-safe evidence', async () => {

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -47,6 +47,38 @@ function validAcceptedResult(
   };
 }
 
+interface InvalidAcceptedResult {
+  readonly result: Multicast.RtcMulticastSerializationResult;
+  readonly normalizedField?: keyof Multicast.RtcMulticastSerializationResult;
+}
+
+function invalidAcceptedResults(): readonly InvalidAcceptedResult[] {
+  const result = validAcceptedResult(10, 4096);
+  const numericFields: readonly (keyof Multicast.RtcMulticastSerializationResult)[] = [
+    'peerCount',
+    'payloadBytes',
+    'planDurationMs',
+    'serializeDurationMs',
+    'originalSerializeDurationMs',
+    'transportMessages',
+    'uniqueSerializedMessages',
+    'totalSerializedBytes',
+    'originalSerializedBytes',
+  ];
+  return [
+    ...numericFields.map((field) => ({
+      result: { ...result, [field]: Number.POSITIVE_INFINITY },
+      normalizedField: field,
+    })),
+    { result: { ...result, planDurationMs: -1 } },
+    { result: { ...result, transportMessages: 9 } },
+    { result: { ...result, uniqueSerializedMessages: 1 } },
+    { result: { ...result, originalSerializedBytes: 0 } },
+    { result: { ...result, totalSerializedBytes: result.originalSerializedBytes - 1 } },
+    { result: { ...result, allTransportMessagesIdentical: true } },
+  ];
+}
+
 it('RTC-B04 parses every multicast matrix worker and emits exact accepted samples', async () => {
   const smokeResult = Multicast.runRtcMulticastSerialization({ peers: 10, payloadBytes: 4096 });
   expect([
@@ -198,19 +230,13 @@ it('RTC-B04 diagnostics create nested outputs and overwrite them', () => {
 
 it('RTC-B04 fails every invalid result shape with JSON-safe evidence', async () => {
   const parsed = Multicast.parseRtcMulticastSerializationArguments(worker(10, 4096).arguments);
-  if (!parsed.ok || parsed.value.mode !== 'accepted') throw new Error('Expected accepted worker.');
-  const invalidResults = [
-    { peerCount: 100 },
-    { uniqueSerializedMessages: 1 },
-    { allTransportMessagesIdentical: true },
-    { originalSerializedBytes: Infinity, totalSerializedBytes: Infinity },
-    { planDurationMs: -1 },
-    { serializeDurationMs: Infinity },
-  ];
-  for (const invalidResult of invalidResults) {
+  if (!parsed.ok || parsed.value.mode !== 'accepted') {
+    throw new Error('Expected accepted worker.');
+  }
+  for (const invalid of invalidAcceptedResults()) {
     const samples = await Multicast.runRtcMulticastSerializationAcceptedSamples({
       worker: parsed.value,
-      run: () => ({ ...validAcceptedResult(10, 4096), ...invalidResult }),
+      run: () => invalid.result,
     });
     expect(samples[0]?.outcome).toBe('failed');
     expect(samples.slice(1).map((sample) => sample.outcome)).toEqual(Array(4).fill('not-run'));
@@ -221,16 +247,13 @@ it('RTC-B04 fails every invalid result shape with JSON-safe evidence', async () 
       Array(4).fill(samples[0]?.identity.sampleId),
     );
     expect(samples[0]?.rawEvidence).not.toBeNull();
-    if ('serializeDurationMs' in invalidResult) {
-      const restored = JSON.parse(JSON.stringify(samples[0]));
-      expect(
-        restored.metrics.every((metric: { value: unknown }) => typeof metric.value === 'number'),
-      ).toBe(true);
-      expect(restored.metrics.map((metric: { metric: string }) => metric.metric)).not.toContain(
-        'serializeDurationMs',
-      );
-      expect((restored.rawEvidence as { serializeDurationMs: unknown }).serializeDurationMs)
-        .toBeNull();
+    const restored = JSON.parse(JSON.stringify(samples[0]));
+    expect(
+      restored.metrics.every((metric: { value: unknown }) => typeof metric.value === 'number'),
+    ).toBe(true);
+    if (invalid.normalizedField !== undefined) {
+      expect(restored.rawEvidence[invalid.normalizedField]).toBeNull();
     }
+    expect(() => JSON.stringify(restored.rawEvidence)).not.toThrow();
   }
 });

--- a/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/multicast/rtc-multicast-serialization-bench.test.ts
@@ -95,6 +95,12 @@ it('RTC-B04 parses every multicast matrix worker and emits exact accepted sample
         runtimeObservation: null,
       });
       expect(samples[0]?.metrics).toHaveLength(3);
+      expect(samples[0]?.metrics).toEqual([
+        { metric: 'planDurationMs', unit: 'ms', value: 1 },
+        { metric: 'originalSerializeDurationMs', unit: 'ms', value: 0.5 },
+        { metric: 'serializeDurationMs', unit: 'ms', value: 2 },
+      ]);
+      expect(samples[0]?.rawEvidence).toEqual(validAcceptedResult(peers, payloadBytes));
     }
   }
 });
@@ -115,6 +121,24 @@ it('RTC-B04 rejects malformed multicast workers, persists causal failure remaind
     expect(
       Multicast.parseRtcMulticastSerializationArguments(
         input.arguments.map((argument) => (argument === expected ? replacement : argument)),
+      ).ok,
+    ).toBe(false);
+  }
+  for (
+    const replacement of [
+      ['--workload=RTC-B04', '--workload=RTC-B03'],
+      ['--case-id=multicast-serialization', '--case-id=wrong'],
+      ['--input-key=peers-10-payload-4096', '--input-key=wrong'],
+      ['--intended-phase=retained', '--intended-phase=wrong'],
+      [`--sample-ids=${input.ids.join(',')}`, '--sample-ids=wrong'],
+      ['--rtc-inner-runs=5', '--unexpected=1'],
+    ]
+  ) {
+    expect(
+      Multicast.parseRtcMulticastSerializationArguments(
+        input.arguments.map((
+          argument,
+        ) => (argument === replacement[0] ? replacement[1] : argument)),
       ).ok,
     ).toBe(false);
   }
@@ -143,10 +167,10 @@ it('RTC-B04 rejects malformed multicast workers, persists causal failure remaind
     Array(4).fill('causal-not-run'),
   );
 
-  mkdirSync('tmp/perf/results', { recursive: true });
-  const directory = mkdtempSync(join('tmp/perf/results', 'rtc-b04-multicast-diagnostic-'));
+  mkdirSync('tmp', { recursive: true });
+  const directory = mkdtempSync(join('tmp', 'rtc-b04-multicast-diagnostic-'));
   onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
-  const output = join(directory, 'result.json');
+  const output = join(directory, 'nested', 'result.json');
   const command = [
     'run',
     '--config=packages/shared-rtc-bench/deno.json',

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
@@ -10,16 +10,17 @@ import {
   type RtcBaselineJson,
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
-  type RtcBaselineSampleIdentityDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   parseRtcBaselineBoundedInteger,
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
-import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
 import {
-  runRtcBaselineAcceptedWorkerSamples,
-} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 export interface WebRtcGroupCacheFallbackInput {
   readonly snapshots: number;
@@ -34,14 +35,6 @@ interface WebRtcGroupCacheFallbackDiagnosticArguments {
   readonly out: string;
 }
 
-export interface WebRtcGroupCacheFallbackAcceptedArguments {
-  readonly mode: 'accepted';
-  readonly input: WebRtcGroupCacheFallbackInput;
-  readonly intendedPhase: 'warmup' | 'retained';
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
-}
-
 export interface WebRtcGroupCacheFallbackResult {
   readonly durationMs: number;
   readonly snapshotCount: number;
@@ -52,14 +45,6 @@ export interface WebRtcGroupCacheFallbackResult {
   readonly readAllValuesCalls: number;
   readonly latestVersion: number | undefined;
   readonly targetPeerCount: number;
-}
-
-interface ValidateAcceptedArgumentsInput {
-  readonly options: Readonly<Record<string, string>>;
-  readonly input: WebRtcGroupCacheFallbackInput;
-  readonly outerOrdinal: RtcBaselineResult<number>;
-  readonly intendedPhase: string | undefined;
-  readonly sampleIds: readonly string[];
 }
 
 interface CreateGroupSnapshotInput {
@@ -76,10 +61,6 @@ interface ValidationRule {
   readonly message: string;
 }
 
-const acceptedOptionNames = (
-  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
-  'rtc-inner-runs rtc-snapshots rtc-matching-versions rtc-lookups'
-).split(' ');
 const acceptedInput: WebRtcGroupCacheFallbackInput = {
   snapshots: 20000,
   matchingVersions: 5000,
@@ -157,15 +138,27 @@ const targetScope = {
 export function parseWebRtcGroupCacheFallbackArguments(
   arguments_: readonly string[],
 ): RtcBaselineResult<
-  WebRtcGroupCacheFallbackDiagnosticArguments | WebRtcGroupCacheFallbackAcceptedArguments
+  | WebRtcGroupCacheFallbackDiagnosticArguments
+  | RtcBaselineAcceptedWorker<WebRtcGroupCacheFallbackInput>
 > {
   const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  if (accepted) {
+    return parseRtcBaselineAcceptedWorker({
+      arguments_,
+      identity: { workloadId: 'RTC-B04', caseId: 'group-cache-fallback' },
+      toInputKey: () => 'fixed',
+      capabilityOptionNames: ['rtc-snapshots', 'rtc-matching-versions', 'rtc-lookups'],
+      parseCapability: parseAcceptedCapability,
+    });
+  }
   const parsed = parseRtcBaselineOneTokenOptions(
     arguments_,
-    accepted ? acceptedOptionNames : ['snapshots', 'matching-versions', 'lookups', 'runs', 'out'],
+    ['snapshots', 'matching-versions', 'lookups', 'runs', 'out'],
   );
-  if (!parsed.ok) return parsed;
-  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  return parseDiagnosticArguments(parsed.value);
 }
 
 export function runWebRtcGroupCacheFallback(
@@ -209,19 +202,15 @@ export function runWebRtcGroupCacheFallback(
 }
 
 export function runWebRtcGroupCacheFallbackAcceptedSamples(input: {
-  readonly worker: WebRtcGroupCacheFallbackAcceptedArguments;
+  readonly worker: RtcBaselineAcceptedWorker<WebRtcGroupCacheFallbackInput>;
   readonly run: () => WebRtcGroupCacheFallbackResult | Promise<WebRtcGroupCacheFallbackResult>;
 }): Promise<RtcBaselineSampleDto[]> {
-  return runRtcBaselineAcceptedWorkerSamples({
-    worker: {
-      ...input.worker,
-      workloadId: 'RTC-B04',
-      caseId: 'group-cache-fallback',
-      inputKey: 'fixed',
-    },
+  return runRtcBaselineAcceptedWorker({
+    worker: input.worker,
     run: input.run,
     validate: (result) => validateResult(input.worker.input, result),
-    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+    metrics: (result) => [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: toRawEvidence,
   });
 }
 
@@ -415,9 +404,9 @@ function parseDiagnosticArguments(
   };
 }
 
-function parseAcceptedArguments(
+function parseAcceptedCapability(
   options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupCacheFallbackAcceptedArguments> {
+): RtcBaselineResult<WebRtcGroupCacheFallbackInput> {
   const snapshots = parseRtcBaselineBoundedInteger(
     options['rtc-snapshots'] ?? '',
     'rtc-snapshots',
@@ -436,105 +425,20 @@ function parseAcceptedArguments(
     1,
     Number.MAX_SAFE_INTEGER,
   );
-  const outerOrdinal = parseRtcBaselineBoundedInteger(
-    options['outer-ordinal'] ?? '',
-    'outer-ordinal',
-    1,
-    999,
-  );
-  const intendedPhase = options['intended-phase'];
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
-  const issues = [
-    ...collectParsingIssues([snapshots, matchingVersions, lookups, outerOrdinal]),
-    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
-  ];
-  const parsedInput = {
-    snapshots: readParsedNumber(snapshots, acceptedInput.snapshots),
-    matchingVersions: readParsedNumber(matchingVersions, acceptedInput.matchingVersions),
-    lookups: readParsedNumber(lookups, acceptedInput.lookups),
-  };
-  issues.push(
-    ...validateAcceptedArguments({
-      options,
-      input: parsedInput,
-      outerOrdinal,
-      intendedPhase,
-      sampleIds,
-    }),
-  );
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'accepted',
-      input: parsedInput,
-      intendedPhase: intendedPhase as 'warmup' | 'retained',
-      outerOrdinal: readParsedNumber(outerOrdinal, 1),
-      sampleIds,
-    },
-  };
-}
-
-function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
   const expected = {
-    capture: 'worker',
-    workload: 'RTC-B04',
-    'case-id': 'group-cache-fallback',
-    'input-key': 'fixed',
-    'rtc-inner-runs': '5',
     'rtc-snapshots': String(acceptedInput.snapshots),
     'rtc-matching-versions': String(acceptedInput.matchingVersions),
     'rtc-lookups': String(acceptedInput.lookups),
   };
-  const issues = Object.entries(expected)
-    .filter(([name, value]) => input.options[name] !== value)
-    .map(([name, value]) =>
-      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
-    );
-  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
-  const ordinal = readParsedNumber(input.outerOrdinal, 1);
-  return [
-    ...issues,
-    ...validateRules([
-      {
-        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
-        path: '$.input',
-        code: 'unexpected-worker-input',
-        message: 'Expected fixed input.',
-      },
-      {
-        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
-        path: '$.outer-ordinal',
-        code: 'unexpected-worker-input',
-        message: 'Expected canonical integer syntax.',
-      },
-      {
-        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
-        path: '$.intended-phase',
-        code: 'unexpected-worker-input',
-        message: 'Invalid phase.',
-      },
-      {
-        valid: JSON.stringify(input.sampleIds) ===
-          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
-        path: '$.sample-ids',
-        code: 'unexpected-worker-input',
-        message: 'Invalid sample IDs.',
-      },
-    ]),
+  const issues = [
+    ...collectParsingIssues([snapshots, matchingVersions, lookups]),
+    ...Object.entries(expected)
+      .filter(([name, value]) => options[name] !== value)
+      .map(([name, value]) =>
+        rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+      ),
   ];
-}
-
-function createExpectedSampleIds(
-  intendedPhase: 'warmup' | 'retained',
-  outerOrdinal: number,
-): string[] {
-  const prefix = `rtc-b04-group-cache-fallback-fixed-${intendedPhase}-${
-    String(outerOrdinal).padStart(3, '0')
-  }`;
-  return Array.from(
-    { length: 5 },
-    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
-  );
+  return issues.length > 0 ? { ok: false, issues } : { ok: true, value: acceptedInput };
 }
 
 function validateResult(
@@ -552,7 +456,7 @@ function validateResult(
     },
     {
       valid: counters.every(Number.isSafeInteger) &&
-        counters.every((count) => count === input.lookups),
+        JSON.stringify(counters) === JSON.stringify([input.lookups * 2, 0, input.lookups * 2]),
       path: '$.rawEvidence.calls',
       code: 'call-count-mismatch',
       message: 'Unexpected calls.',
@@ -589,42 +493,9 @@ function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] 
   );
 }
 
-function createSample(
-  identity: RtcBaselineSampleIdentityDto,
-  result: WebRtcGroupCacheFallbackResult | null,
-  issues: readonly RtcBaselineIssueDto[],
-): RtcBaselineSampleDto {
-  if (result === null) {
-    return {
-      schema: 'rallar.rtc-baseline.sample.v1',
-      identity,
-      outcome: 'not-run',
-      evidenceClass: 'synthetic-path',
-      metrics: [],
-      rawEvidence: null,
-      rawReferences: [],
-      issues,
-      runtimeObservation: null,
-    };
-  }
-  return {
-    schema: 'rallar.rtc-baseline.sample.v1',
-    identity,
-    outcome: issues.length === 0 ? 'passed' : 'failed',
-    evidenceClass: 'synthetic-path',
-    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
-      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
-      : [],
-    rawEvidence: toRawEvidence(result),
-    rawReferences: [],
-    issues,
-    runtimeObservation: null,
-  };
-}
-
 function toRawEvidence(result: WebRtcGroupCacheFallbackResult): RtcBaselineJson {
   return {
-    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    durationMs: result.durationMs,
     snapshotCount: result.snapshotCount,
     matchingVersions: result.matchingVersions,
     lookups: result.lookups,
@@ -638,20 +509,22 @@ function toRawEvidence(result: WebRtcGroupCacheFallbackResult): RtcBaselineJson 
 
 async function main(): Promise<void> {
   const parsed = parseWebRtcGroupCacheFallbackArguments(Deno.args);
-  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
-  if (parsed.value.mode === 'accepted') {
-    const worker = parsed.value;
-    console.log(
-      JSON.stringify(
-        await runWebRtcGroupCacheFallbackAcceptedSamples({
-          worker,
-          run: () => runWebRtcGroupCacheFallback(worker.input),
-        }),
-      ),
-    );
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.issues));
+  }
+  const dispatched = await runRtcBaselineAcceptedWorkerCli({
+    parsed: parsed.value,
+    runAccepted: (worker) =>
+      runWebRtcGroupCacheFallbackAcceptedSamples({
+        worker,
+        run: () => runWebRtcGroupCacheFallback(worker.input),
+      }),
+    writeOutput: (output) => console.log(output),
+  });
+  if (dispatched.handled) {
     return;
   }
-  const diagnostic = parsed.value;
+  const diagnostic = dispatched.diagnostic;
   const results = [];
   for (let run = 1; run <= diagnostic.runs; run += 1) {
     results.push({ run, ...runWebRtcGroupCacheFallback(diagnostic.input) });
@@ -671,4 +544,6 @@ async function main(): Promise<void> {
   console.log(`Wrote ${diagnostic.out}`);
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
@@ -11,10 +11,7 @@ import {
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
-import {
-  parseRtcBaselineBoundedInteger,
-  parseRtcBaselineOneTokenOptions,
-} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { parseRtcBaselineBoundedInteger } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import {
   parseRtcBaselineAcceptedWorker,
   type RtcBaselineAcceptedWorker,
@@ -151,14 +148,7 @@ export function parseWebRtcGroupCacheFallbackArguments(
       parseCapability: parseAcceptedCapability,
     });
   }
-  const parsed = parseRtcBaselineOneTokenOptions(
-    arguments_,
-    ['snapshots', 'matching-versions', 'lookups', 'runs', 'out'],
-  );
-  if (!parsed.ok) {
-    return parsed;
-  }
-  return parseDiagnosticArguments(parsed.value);
+  return { ok: true, value: parseDiagnosticArguments(arguments_) };
 }
 
 export function runWebRtcGroupCacheFallback(
@@ -367,40 +357,23 @@ function createGroupSnapshotSessions(
 }
 
 function parseDiagnosticArguments(
-  options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupCacheFallbackDiagnosticArguments> {
-  const snapshots = parseRtcBaselineBoundedInteger(
-    options.snapshots ?? '20000',
-    'snapshots',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const matchingVersions = parseRtcBaselineBoundedInteger(
-    options['matching-versions'] ?? '5000',
-    'matching-versions',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const lookups = parseRtcBaselineBoundedInteger(
-    options.lookups ?? '500',
-    'lookups',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
-  const issues = collectParsingIssues([snapshots, matchingVersions, lookups, runs]);
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'diagnostic',
-      input: {
-        snapshots: readParsedNumber(snapshots, 1),
-        matchingVersions: readParsedNumber(matchingVersions, 1),
-        lookups: readParsedNumber(lookups, 1),
-      },
-      runs: readParsedNumber(runs, 1),
-      out: options.out ?? 'tmp/perf/results/webrtc-group-cache-fallback.json',
+  arguments_: readonly string[],
+): WebRtcGroupCacheFallbackDiagnosticArguments {
+  return {
+    mode: 'diagnostic',
+    input: {
+      snapshots: Number(readDiagnosticArgument(arguments_, '--snapshots', '20000')),
+      matchingVersions: Number(
+        readDiagnosticArgument(arguments_, '--matching-versions', '5000'),
+      ),
+      lookups: Number(readDiagnosticArgument(arguments_, '--lookups', '500')),
     },
+    runs: Number(readDiagnosticArgument(arguments_, '--runs', '5')),
+    out: readDiagnosticArgument(
+      arguments_,
+      '--out',
+      'tmp/perf/results/webrtc-group-cache-fallback.json',
+    ),
   };
 }
 
@@ -483,8 +456,13 @@ function collectParsingIssues(
   return results.flatMap((result) => result.ok ? [] : result.issues);
 }
 
-function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
-  return result.ok ? result.value : fallback;
+function readDiagnosticArgument(
+  arguments_: readonly string[],
+  name: string,
+  fallback: string,
+): string {
+  return arguments_.find((argument) => argument.startsWith(`${name}=`))?.slice(name.length + 1) ??
+    fallback;
 }
 
 function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
@@ -1,25 +1,90 @@
+import { dirname } from 'node:path';
+
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { ReadableKeyedValues } from '@shared/cache/RepositoryInterfaces.ts';
 import { WebRtcGroupService } from '@shared/services/WebRtcGroupService.ts';
 
-type BenchResult = Readonly<{
-  run: number;
-  durationMs: number;
-  snapshotCount: number;
-  matchingVersions: number;
-  lookups: number;
-  readCalls: number;
-  peekCalls: number;
-  readAllValuesCalls: number;
-  latestVersion: number | undefined;
-  targetPeerCount: number;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineIssueDto,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
+import {
+  runRtcBaselineAcceptedWorkerSamples,
+} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
-const OUT = readArg('--out') ?? 'tmp/perf/results/webrtc-group-cache-fallback.json';
-const SNAPSHOTS = Number(readArg('--snapshots') ?? '20000');
-const MATCHING_VERSIONS = Number(readArg('--matching-versions') ?? '5000');
-const LOOKUPS = Number(readArg('--lookups') ?? '500');
-const RUNS = Number(readArg('--runs') ?? '5');
+export interface WebRtcGroupCacheFallbackInput {
+  readonly snapshots: number;
+  readonly matchingVersions: number;
+  readonly lookups: number;
+}
+
+interface WebRtcGroupCacheFallbackDiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: WebRtcGroupCacheFallbackInput;
+  readonly runs: number;
+  readonly out: string;
+}
+
+export interface WebRtcGroupCacheFallbackAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: WebRtcGroupCacheFallbackInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+export interface WebRtcGroupCacheFallbackResult {
+  readonly durationMs: number;
+  readonly snapshotCount: number;
+  readonly matchingVersions: number;
+  readonly lookups: number;
+  readonly readCalls: number;
+  readonly peekCalls: number;
+  readonly readAllValuesCalls: number;
+  readonly latestVersion: number | undefined;
+  readonly targetPeerCount: number;
+}
+
+interface ValidateAcceptedArgumentsInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly input: WebRtcGroupCacheFallbackInput;
+  readonly outerOrdinal: RtcBaselineResult<number>;
+  readonly intendedPhase: string | undefined;
+  readonly sampleIds: readonly string[];
+}
+
+interface CreateGroupSnapshotInput {
+  readonly groupId: string;
+  readonly version: number;
+  readonly memberSessionIds: readonly string[];
+  readonly scope: Readonly<{ applicationId: string; workspaceId: string }>;
+}
+
+interface ValidationRule {
+  readonly valid: boolean;
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+const acceptedOptionNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-inner-runs rtc-snapshots rtc-matching-versions rtc-lookups'
+).split(' ');
+const acceptedInput: WebRtcGroupCacheFallbackInput = {
+  snapshots: 20000,
+  matchingVersions: 5000,
+  lookups: 500,
+};
 
 class FallbackOnlyGroupCache implements ReadableKeyedValues<string, GroupSnapshot> {
   private readonly snapshots: readonly GroupSnapshot[];
@@ -88,10 +153,25 @@ const targetScope = {
   applicationId: 'app-1',
   workspaceId: 'workspace-1',
 };
-const snapshots = createSnapshots(SNAPSHOTS, MATCHING_VERSIONS);
-const results: BenchResult[] = [];
 
-for (let run = 1; run <= RUNS; run++) {
+export function parseWebRtcGroupCacheFallbackArguments(
+  arguments_: readonly string[],
+): RtcBaselineResult<
+  WebRtcGroupCacheFallbackDiagnosticArguments | WebRtcGroupCacheFallbackAcceptedArguments
+> {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedOptionNames : ['snapshots', 'matching-versions', 'lookups', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+
+export function runWebRtcGroupCacheFallback(
+  input: WebRtcGroupCacheFallbackInput,
+): WebRtcGroupCacheFallbackResult {
+  const snapshots = createSnapshots(input.snapshots, input.matchingVersions);
   const cache = new FallbackOnlyGroupCache(snapshots);
   const service = new WebRtcGroupService(
     {
@@ -109,45 +189,41 @@ for (let run = 1; run <= RUNS; run++) {
   let targetPeerCount = 0;
   const start = performance.now();
 
-  for (let index = 0; index < LOOKUPS; index++) {
+  for (let index = 0; index < input.lookups; index += 1) {
     const snapshot = service.readGroup();
     latestVersion = snapshot?.group.rosterVersion;
     targetPeerCount = service.targetPeerIds().length;
   }
 
-  results.push({
-    run,
+  return {
     durationMs: performance.now() - start,
-    snapshotCount: SNAPSHOTS,
-    matchingVersions: MATCHING_VERSIONS,
-    lookups: LOOKUPS,
+    snapshotCount: input.snapshots,
+    matchingVersions: input.matchingVersions,
+    lookups: input.lookups,
     readCalls: cache.readCalls,
     peekCalls: cache.peekCalls,
     readAllValuesCalls: cache.readAllValuesCalls,
     latestVersion,
     targetPeerCount,
-  });
+  };
 }
 
-await Deno.writeTextFile(
-  OUT,
-  JSON.stringify(
-    {
-      createdAt: new Date().toISOString(),
-      input: {
-        snapshotCount: SNAPSHOTS,
-        matchingVersions: MATCHING_VERSIONS,
-        lookups: LOOKUPS,
-        runs: RUNS,
-      },
-      results,
+export function runWebRtcGroupCacheFallbackAcceptedSamples(input: {
+  readonly worker: WebRtcGroupCacheFallbackAcceptedArguments;
+  readonly run: () => WebRtcGroupCacheFallbackResult | Promise<WebRtcGroupCacheFallbackResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: {
+      ...input.worker,
+      workloadId: 'RTC-B04',
+      caseId: 'group-cache-fallback',
+      inputKey: 'fixed',
     },
-    null,
-    2,
-  ),
-);
-
-console.log(`Wrote ${OUT}`);
+    run: input.run,
+    validate: (result) => validateResult(input.worker.input, result),
+    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+  });
+}
 
 function createSnapshots(
   snapshotCount: number,
@@ -156,15 +232,25 @@ function createSnapshots(
   const snapshots: GroupSnapshot[] = [];
   for (let version = 1; version <= matchingVersions; version++) {
     snapshots.push(
-      createGroupSnapshot(targetGroupId, version, ['self', `target-peer-${version}`], targetScope),
+      createGroupSnapshot({
+        groupId: targetGroupId,
+        version,
+        memberSessionIds: ['self', `target-peer-${version}`],
+        scope: targetScope,
+      }),
     );
   }
 
   for (let index = matchingVersions; index < snapshotCount; index++) {
     snapshots.push(
-      createGroupSnapshot(`other-room-${index}`, index + 1, ['self', `other-peer-${index}`], {
-        applicationId: 'app-1',
-        workspaceId: `workspace-${index % 20}`,
+      createGroupSnapshot({
+        groupId: `other-room-${index}`,
+        version: index + 1,
+        memberSessionIds: ['self', `other-peer-${index}`],
+        scope: {
+          applicationId: 'app-1',
+          workspaceId: `workspace-${index % 20}`,
+        },
       }),
     );
   }
@@ -183,108 +269,406 @@ function shuffleDeterministically<T>(values: readonly T[]): readonly T[] {
   return shuffled;
 }
 
-function createGroupSnapshot(
-  groupId: string,
-  version: number,
-  memberSessionIds: readonly string[],
-  scope: Readonly<{
-    applicationId: string;
-    workspaceId: string;
-  }>,
-): GroupSnapshot {
-  const ownerPrincipalId = memberSessionIds[0] ?? 'creator';
+function createGroupSnapshot(input: CreateGroupSnapshotInput): GroupSnapshot {
+  const { memberSessionIds, version } = input;
   return {
     stateRevision: version,
     causalRevision: {
       groupRevision: version,
       presenceRevision: version,
     },
-    group: {
-      applicationId: scope.applicationId,
-      workspaceId: scope.workspaceId,
-      groupId,
-      slug: groupId,
-      displayName: groupId,
-      description: null,
-      kind: 'room',
-      status: 'active',
-      archived: null,
-      deleted: null,
-      joinMode: 'open',
-      maxMembers: null,
-      maxSessionsPerMember: null,
-      metadata: {},
-      activeMemberCount: memberSessionIds.length,
-      ownerPrincipalId,
-      snapshotVersion: version,
-      metadataVersion: 0,
-      rosterVersion: version,
-      presenceVersion: 0,
-      created: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: version,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      expiresAtEpochMs: null,
-      emptySinceEpochMs: null,
-      purgeAfterEpochMs: null,
-    },
-    members: memberSessionIds.map((sessionId) => ({
-      applicationId: scope.applicationId,
-      workspaceId: scope.workspaceId,
-      groupId,
-      principalId: sessionId,
-      role: 'member',
-      status: 'active',
-      joined: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: version,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      invitedByPrincipalId: null,
-      invitationExpiresAtEpochMs: null,
-      left: null,
-      removed: null,
-      banned: null,
-    })),
-    activeSessions: memberSessionIds.map((sessionId) => ({
-      applicationId: scope.applicationId,
-      workspaceId: scope.workspaceId,
-      groupId,
-      sessionId,
-      principalId: sessionId,
-      generationId: `generation-${sessionId}`,
-      generationVersion: version,
-      status: 'active',
-      connectedAtEpochMs: 1,
-      lastHeartbeatAtEpochMs: version,
-      expiresAtEpochMs: version + 60_000,
-      disconnectedAtEpochMs: null,
-      disconnectReason: null,
-    })),
+    group: createGroupSnapshotGroup(input),
+    members: createGroupSnapshotMembers(input),
+    activeSessions: createGroupSnapshotSessions(input),
     memberCount: memberSessionIds.length,
     onlineMemberCount: memberSessionIds.length,
   };
 }
 
-function readArg(name: string): string | undefined {
-  return Deno.args.find((arg) => arg.startsWith(`${name}=`))?.slice(name.length + 1);
+function createGroupSnapshotGroup(input: CreateGroupSnapshotInput): GroupSnapshot['group'] {
+  return {
+    applicationId: input.scope.applicationId,
+    workspaceId: input.scope.workspaceId,
+    groupId: input.groupId,
+    slug: input.groupId,
+    displayName: input.groupId,
+    description: null,
+    kind: 'room',
+    status: 'active',
+    archived: null,
+    deleted: null,
+    joinMode: 'open',
+    maxMembers: null,
+    maxSessionsPerMember: null,
+    metadata: {},
+    activeMemberCount: input.memberSessionIds.length,
+    ownerPrincipalId: input.memberSessionIds[0] ?? 'creator',
+    snapshotVersion: input.version,
+    metadataVersion: 0,
+    rosterVersion: input.version,
+    presenceVersion: 0,
+    created: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: input.version,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    expiresAtEpochMs: null,
+    emptySinceEpochMs: null,
+    purgeAfterEpochMs: null,
+  };
 }
+
+function createGroupSnapshotMembers(input: CreateGroupSnapshotInput): GroupSnapshot['members'] {
+  return input.memberSessionIds.map((sessionId) => ({
+    applicationId: input.scope.applicationId,
+    workspaceId: input.scope.workspaceId,
+    groupId: input.groupId,
+    principalId: sessionId,
+    role: 'member',
+    status: 'active',
+    joined: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: input.version,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+    left: null,
+    removed: null,
+    banned: null,
+  }));
+}
+
+function createGroupSnapshotSessions(
+  input: CreateGroupSnapshotInput,
+): GroupSnapshot['activeSessions'] {
+  return input.memberSessionIds.map((sessionId) => ({
+    applicationId: input.scope.applicationId,
+    workspaceId: input.scope.workspaceId,
+    groupId: input.groupId,
+    sessionId,
+    principalId: sessionId,
+    generationId: `generation-${sessionId}`,
+    generationVersion: input.version,
+    status: 'active',
+    connectedAtEpochMs: 1,
+    lastHeartbeatAtEpochMs: input.version,
+    expiresAtEpochMs: input.version + 60_000,
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+  }));
+}
+
+function parseDiagnosticArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupCacheFallbackDiagnosticArguments> {
+  const snapshots = parseRtcBaselineBoundedInteger(
+    options.snapshots ?? '20000',
+    'snapshots',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const matchingVersions = parseRtcBaselineBoundedInteger(
+    options['matching-versions'] ?? '5000',
+    'matching-versions',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options.lookups ?? '500',
+    'lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const issues = collectParsingIssues([snapshots, matchingVersions, lookups, runs]);
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'diagnostic',
+      input: {
+        snapshots: readParsedNumber(snapshots, 1),
+        matchingVersions: readParsedNumber(matchingVersions, 1),
+        lookups: readParsedNumber(lookups, 1),
+      },
+      runs: readParsedNumber(runs, 1),
+      out: options.out ?? 'tmp/perf/results/webrtc-group-cache-fallback.json',
+    },
+  };
+}
+
+function parseAcceptedArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupCacheFallbackAcceptedArguments> {
+  const snapshots = parseRtcBaselineBoundedInteger(
+    options['rtc-snapshots'] ?? '',
+    'rtc-snapshots',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const matchingVersions = parseRtcBaselineBoundedInteger(
+    options['rtc-matching-versions'] ?? '',
+    'rtc-matching-versions',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options['rtc-lookups'] ?? '',
+    'rtc-lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const intendedPhase = options['intended-phase'];
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const issues = [
+    ...collectParsingIssues([snapshots, matchingVersions, lookups, outerOrdinal]),
+    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
+  ];
+  const parsedInput = {
+    snapshots: readParsedNumber(snapshots, acceptedInput.snapshots),
+    matchingVersions: readParsedNumber(matchingVersions, acceptedInput.matchingVersions),
+    lookups: readParsedNumber(lookups, acceptedInput.lookups),
+  };
+  issues.push(
+    ...validateAcceptedArguments({
+      options,
+      input: parsedInput,
+      outerOrdinal,
+      intendedPhase,
+      sampleIds,
+    }),
+  );
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: parsedInput,
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: readParsedNumber(outerOrdinal, 1),
+      sampleIds,
+    },
+  };
+}
+
+function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B04',
+    'case-id': 'group-cache-fallback',
+    'input-key': 'fixed',
+    'rtc-inner-runs': '5',
+    'rtc-snapshots': String(acceptedInput.snapshots),
+    'rtc-matching-versions': String(acceptedInput.matchingVersions),
+    'rtc-lookups': String(acceptedInput.lookups),
+  };
+  const issues = Object.entries(expected)
+    .filter(([name, value]) => input.options[name] !== value)
+    .map(([name, value]) =>
+      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+    );
+  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
+  const ordinal = readParsedNumber(input.outerOrdinal, 1);
+  return [
+    ...issues,
+    ...validateRules([
+      {
+        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
+        path: '$.input',
+        code: 'unexpected-worker-input',
+        message: 'Expected fixed input.',
+      },
+      {
+        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
+        path: '$.outer-ordinal',
+        code: 'unexpected-worker-input',
+        message: 'Expected canonical integer syntax.',
+      },
+      {
+        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
+        path: '$.intended-phase',
+        code: 'unexpected-worker-input',
+        message: 'Invalid phase.',
+      },
+      {
+        valid: JSON.stringify(input.sampleIds) ===
+          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
+        path: '$.sample-ids',
+        code: 'unexpected-worker-input',
+        message: 'Invalid sample IDs.',
+      },
+    ]),
+  ];
+}
+
+function createExpectedSampleIds(
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix = `rtc-b04-group-cache-fallback-fixed-${intendedPhase}-${
+    String(outerOrdinal).padStart(3, '0')
+  }`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function validateResult(
+  input: WebRtcGroupCacheFallbackInput,
+  result: WebRtcGroupCacheFallbackResult,
+): RtcBaselineIssueDto[] {
+  const counters = [result.readCalls, result.peekCalls, result.readAllValuesCalls];
+  return validateRules([
+    {
+      valid: JSON.stringify([result.snapshotCount, result.matchingVersions, result.lookups]) ===
+        JSON.stringify([input.snapshots, input.matchingVersions, input.lookups]),
+      path: '$.rawEvidence.input',
+      code: 'input-mismatch',
+      message: 'Unexpected input.',
+    },
+    {
+      valid: counters.every(Number.isSafeInteger) &&
+        counters.every((count) => count === input.lookups),
+      path: '$.rawEvidence.calls',
+      code: 'call-count-mismatch',
+      message: 'Unexpected calls.',
+    },
+    {
+      valid: JSON.stringify([result.latestVersion, result.targetPeerCount]) ===
+        JSON.stringify([input.matchingVersions, 1]),
+      path: '$.rawEvidence.result',
+      code: 'fallback-result-mismatch',
+      message: 'Unexpected fallback result.',
+    },
+    {
+      valid: Number.isFinite(result.durationMs) && result.durationMs >= 0,
+      path: '$.rawEvidence.durationMs',
+      code: 'invalid-timing',
+      message: 'Expected nonnegative.',
+    },
+  ]);
+}
+
+function collectParsingIssues(
+  results: readonly RtcBaselineResult<number>[],
+): RtcBaselineIssueDto[] {
+  return results.flatMap((result) => result.ok ? [] : result.issues);
+}
+
+function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
+  return result.ok ? result.value : fallback;
+}
+
+function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {
+  return rules.filter((rule) => !rule.valid).map((rule) =>
+    rtcBaselineIssue(rule.path, rule.code, rule.message)
+  );
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: WebRtcGroupCacheFallbackResult | null,
+  issues: readonly RtcBaselineIssueDto[],
+): RtcBaselineSampleDto {
+  if (result === null) {
+    return {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity,
+      outcome: 'not-run',
+      evidenceClass: 'synthetic-path',
+      metrics: [],
+      rawEvidence: null,
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    };
+  }
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
+      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
+      : [],
+    rawEvidence: toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function toRawEvidence(result: WebRtcGroupCacheFallbackResult): RtcBaselineJson {
+  return {
+    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    snapshotCount: result.snapshotCount,
+    matchingVersions: result.matchingVersions,
+    lookups: result.lookups,
+    readCalls: result.readCalls,
+    peekCalls: result.peekCalls,
+    readAllValuesCalls: result.readAllValuesCalls,
+    latestVersion: result.latestVersion ?? null,
+    targetPeerCount: result.targetPeerCount,
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseWebRtcGroupCacheFallbackArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  if (parsed.value.mode === 'accepted') {
+    const worker = parsed.value;
+    console.log(
+      JSON.stringify(
+        await runWebRtcGroupCacheFallbackAcceptedSamples({
+          worker,
+          run: () => runWebRtcGroupCacheFallback(worker.input),
+        }),
+      ),
+    );
+    return;
+  }
+  const diagnostic = parsed.value;
+  const results = [];
+  for (let run = 1; run <= diagnostic.runs; run += 1) {
+    results.push({ run, ...runWebRtcGroupCacheFallback(diagnostic.input) });
+  }
+  const output = {
+    createdAt: new Date().toISOString(),
+    input: {
+      snapshotCount: diagnostic.input.snapshots,
+      matchingVersions: diagnostic.input.matchingVersions,
+      lookups: diagnostic.input.lookups,
+      runs: diagnostic.runs,
+    },
+    results,
+  };
+  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
+  await Deno.writeTextFile(diagnostic.out, JSON.stringify(output, null, 2));
+  console.log(`Wrote ${diagnostic.out}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
@@ -13,10 +13,7 @@ import {
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
-import {
-  parseRtcBaselineBoundedInteger,
-  parseRtcBaselineOneTokenOptions,
-} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { parseRtcBaselineBoundedInteger } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import {
   parseRtcBaselineAcceptedWorker,
   type RtcBaselineAcceptedWorker,
@@ -76,14 +73,7 @@ export function parseWebRtcGroupManagerPeerOwnersArguments(
       parseCapability: parseAcceptedCapability,
     });
   }
-  const parsed = parseRtcBaselineOneTokenOptions(
-    arguments_,
-    ['groups', 'peers-per-group', 'lookups', 'runs', 'out'],
-  );
-  if (!parsed.ok) {
-    return parsed;
-  }
-  return parseDiagnosticArguments(parsed.value);
+  return { ok: true, value: parseDiagnosticArguments(arguments_) };
 }
 
 export async function runWebRtcGroupManagerPeerOwners(
@@ -292,40 +282,21 @@ function createGroupSnapshotSessions(
 }
 
 function parseDiagnosticArguments(
-  options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupManagerPeerOwnersDiagnosticArguments> {
-  const groups = parseRtcBaselineBoundedInteger(
-    options.groups ?? '1000',
-    'groups',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const peersPerGroup = parseRtcBaselineBoundedInteger(
-    options['peers-per-group'] ?? '10',
-    'peers-per-group',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const lookups = parseRtcBaselineBoundedInteger(
-    options.lookups ?? '1000',
-    'lookups',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
-  const issues = collectParsingIssues([groups, peersPerGroup, lookups, runs]);
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'diagnostic',
-      input: {
-        groups: readParsedNumber(groups, 1),
-        peersPerGroup: readParsedNumber(peersPerGroup, 1),
-        lookups: readParsedNumber(lookups, 1),
-      },
-      runs: readParsedNumber(runs, 1),
-      out: options.out ?? 'tmp/perf/results/webrtc-group-manager-peer-owners.json',
+  arguments_: readonly string[],
+): WebRtcGroupManagerPeerOwnersDiagnosticArguments {
+  return {
+    mode: 'diagnostic',
+    input: {
+      groups: Number(readDiagnosticArgument(arguments_, '--groups', '1000')),
+      peersPerGroup: Number(readDiagnosticArgument(arguments_, '--peers-per-group', '10')),
+      lookups: Number(readDiagnosticArgument(arguments_, '--lookups', '1000')),
     },
+    runs: Number(readDiagnosticArgument(arguments_, '--runs', '5')),
+    out: readDiagnosticArgument(
+      arguments_,
+      '--out',
+      'tmp/perf/results/webrtc-group-manager-peer-owners.json',
+    ),
   };
 }
 
@@ -407,8 +378,13 @@ function collectParsingIssues(
   return results.flatMap((result) => result.ok ? [] : result.issues);
 }
 
-function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
-  return result.ok ? result.value : fallback;
+function readDiagnosticArgument(
+  arguments_: readonly string[],
+  name: string,
+  fallback: string,
+): string {
+  return arguments_.find((argument) => argument.startsWith(`${name}=`))?.slice(name.length + 1) ??
+    fallback;
 }
 
 function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
@@ -1,39 +1,110 @@
+import { dirname } from 'node:path';
+
 import type { ClientInfo } from '@shared/api/api-config.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { WebRtcGroupManager } from '@shared/services/WebRtcGroupManager.ts';
 
-type BenchResult = Readonly<{
-  run: number;
-  durationMs: number;
-  groupCount: number;
-  peersPerGroup: number;
-  lookups: number;
-  ownedLookups: number;
-  totalOwnerGroups: number;
-  desiredPeerCount: number;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineIssueDto,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
+import {
+  runRtcBaselineAcceptedWorkerSamples,
+} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
-const OUT = readArg('--out') ?? 'tmp/perf/results/webrtc-group-manager-peer-owners.json';
-const GROUPS = Number(readArg('--groups') ?? '1000');
-const PEERS_PER_GROUP = Number(readArg('--peers-per-group') ?? '10');
-const LOOKUPS = Number(readArg('--lookups') ?? '1000');
-const RUNS = Number(readArg('--runs') ?? '5');
+export interface WebRtcGroupManagerPeerOwnersInput {
+  readonly groups: number;
+  readonly peersPerGroup: number;
+  readonly lookups: number;
+}
 
-const results: BenchResult[] = [];
+interface WebRtcGroupManagerPeerOwnersDiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: WebRtcGroupManagerPeerOwnersInput;
+  readonly runs: number;
+  readonly out: string;
+}
 
-for (let run = 1; run <= RUNS; run++) {
+export interface WebRtcGroupManagerPeerOwnersAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: WebRtcGroupManagerPeerOwnersInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+export interface WebRtcGroupManagerPeerOwnersResult {
+  readonly durationMs: number;
+  readonly groupCount: number;
+  readonly peersPerGroup: number;
+  readonly lookups: number;
+  readonly ownedLookups: number;
+  readonly totalOwnerGroups: number;
+  readonly desiredPeerCount: number;
+}
+
+interface ValidateAcceptedArgumentsInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly input: WebRtcGroupManagerPeerOwnersInput;
+  readonly outerOrdinal: RtcBaselineResult<number>;
+  readonly intendedPhase: string | undefined;
+  readonly sampleIds: readonly string[];
+}
+
+interface ValidationRule {
+  readonly valid: boolean;
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+const acceptedOptionNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-inner-runs rtc-groups rtc-peers-per-group rtc-lookups'
+).split(' ');
+const acceptedInput: WebRtcGroupManagerPeerOwnersInput = {
+  groups: 1000,
+  peersPerGroup: 10,
+  lookups: 1000,
+};
+
+export function parseWebRtcGroupManagerPeerOwnersArguments(
+  arguments_: readonly string[],
+): RtcBaselineResult<
+  | WebRtcGroupManagerPeerOwnersDiagnosticArguments
+  | WebRtcGroupManagerPeerOwnersAcceptedArguments
+> {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedOptionNames : ['groups', 'peers-per-group', 'lookups', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
+
+export async function runWebRtcGroupManagerPeerOwners(
+  input: WebRtcGroupManagerPeerOwnersInput,
+): Promise<WebRtcGroupManagerPeerOwnersResult> {
   const groupCache = new LatestRepository<string, GroupSnapshot>();
   const clientCache = new LatestRepository<string, ClientInfo>();
   const rtcQBox = createRtcQBoxHarness('self');
   const manager = new WebRtcGroupManager(rtcQBox.service as never, groupCache, clientCache);
-  const uniquePeerIds = new Set<string>();
 
-  for (let groupIndex = 0; groupIndex < GROUPS; groupIndex++) {
-    const peerIds = Array.from({ length: PEERS_PER_GROUP }, (_unused, peerIndex) => {
-      const peerId = `peer-${(groupIndex + peerIndex) % GROUPS}`;
-      uniquePeerIds.add(peerId);
+  for (let groupIndex = 0; groupIndex < input.groups; groupIndex += 1) {
+    const peerIds = Array.from({ length: input.peersPerGroup }, (_unused, peerIndex) => {
+      const peerId = `peer-${(groupIndex + peerIndex) % input.groups}`;
       return peerId;
     });
     const group = createGroupSnapshot(`group-${groupIndex}`, 1, ['self', ...peerIds]);
@@ -42,8 +113,8 @@ for (let run = 1; run <= RUNS; run++) {
   }
 
   const lookupPeerIds = Array.from(
-    { length: LOOKUPS },
-    (_unused, index) => `peer-${index % GROUPS}`,
+    { length: input.lookups },
+    (_unused, index) => `peer-${index % input.groups}`,
   );
   let ownedLookups = 0;
   let totalOwnerGroups = 0;
@@ -57,37 +128,35 @@ for (let run = 1; run <= RUNS; run++) {
     }
   }
 
-  results.push({
-    run,
+  return {
     durationMs: performance.now() - start,
-    groupCount: GROUPS,
-    peersPerGroup: PEERS_PER_GROUP,
-    lookups: LOOKUPS,
+    groupCount: input.groups,
+    peersPerGroup: input.peersPerGroup,
+    lookups: input.lookups,
     ownedLookups,
     totalOwnerGroups,
     desiredPeerCount: manager.state().desiredPeerIds.length,
-  });
+  };
 }
 
-await Deno.writeTextFile(
-  OUT,
-  JSON.stringify(
-    {
-      createdAt: new Date().toISOString(),
-      input: {
-        groupCount: GROUPS,
-        peersPerGroup: PEERS_PER_GROUP,
-        lookups: LOOKUPS,
-        runs: RUNS,
-      },
-      results,
+export function runWebRtcGroupManagerPeerOwnersAcceptedSamples(input: {
+  readonly worker: WebRtcGroupManagerPeerOwnersAcceptedArguments;
+  readonly run: () =>
+    | WebRtcGroupManagerPeerOwnersResult
+    | Promise<WebRtcGroupManagerPeerOwnersResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: {
+      ...input.worker,
+      workloadId: 'RTC-B04',
+      caseId: 'group-manager-peer-owners',
+      inputKey: 'fixed',
     },
-    null,
-    2,
-  ),
-);
-
-console.log(`Wrote ${OUT}`);
+    run: input.run,
+    validate: (result) => validateResult(input.worker.input, result),
+    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+  });
+}
 
 function createRtcQBoxHarness(sessionId: string) {
   const knownPeerIds = new Set<string>();
@@ -118,102 +187,409 @@ function createGroupSnapshot(
   membershipVersion: number,
   memberSessionIds: readonly string[],
 ): GroupSnapshot {
-  const applicationId = 'app-1';
-  const workspaceId = 'workspace-1';
-  const ownerPrincipalId = memberSessionIds[0] ?? 'creator';
-
   return {
     stateRevision: membershipVersion,
     causalRevision: {
       groupRevision: membershipVersion,
       presenceRevision: membershipVersion,
     },
-    group: {
-      applicationId,
-      workspaceId,
-      groupId,
-      slug: groupId,
-      displayName: groupId,
-      description: null,
-      kind: 'room',
-      status: 'active',
-      archived: null,
-      deleted: null,
-      joinMode: 'open',
-      maxMembers: null,
-      maxSessionsPerMember: null,
-      metadata: {},
-      activeMemberCount: memberSessionIds.length,
-      ownerPrincipalId,
-      snapshotVersion: membershipVersion,
-      metadataVersion: 0,
-      rosterVersion: membershipVersion,
-      presenceVersion: 0,
-      created: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: membershipVersion,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      expiresAtEpochMs: null,
-      emptySinceEpochMs: null,
-      purgeAfterEpochMs: null,
-    },
-    members: memberSessionIds.map((sessionId) => ({
-      applicationId,
-      workspaceId,
-      groupId,
-      principalId: sessionId,
-      role: 'member',
-      status: 'active',
-      joined: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: membershipVersion,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      invitedByPrincipalId: null,
-      invitationExpiresAtEpochMs: null,
-      left: null,
-      removed: null,
-      banned: null,
-    })),
-    activeSessions: memberSessionIds.map((sessionId) => ({
-      applicationId,
-      workspaceId,
-      groupId,
-      sessionId,
-      principalId: sessionId,
-      generationId: `generation-${sessionId}`,
-      generationVersion: membershipVersion,
-      status: 'active',
-      connectedAtEpochMs: 1,
-      lastHeartbeatAtEpochMs: membershipVersion,
-      expiresAtEpochMs: membershipVersion + 60_000,
-      disconnectedAtEpochMs: null,
-      disconnectReason: null,
-    })),
+    group: createGroupSnapshotGroup(groupId, membershipVersion, memberSessionIds),
+    members: createGroupSnapshotMembers(groupId, membershipVersion, memberSessionIds),
+    activeSessions: createGroupSnapshotSessions(groupId, membershipVersion, memberSessionIds),
     memberCount: memberSessionIds.length,
     onlineMemberCount: memberSessionIds.length,
   };
 }
 
-function readArg(name: string): string | undefined {
-  return Deno.args.find((arg) => arg.startsWith(`${name}=`))?.slice(name.length + 1);
+function createGroupSnapshotGroup(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['group'] {
+  return {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    slug: groupId,
+    displayName: groupId,
+    description: null,
+    kind: 'room',
+    status: 'active',
+    archived: null,
+    deleted: null,
+    joinMode: 'open',
+    maxMembers: null,
+    maxSessionsPerMember: null,
+    metadata: {},
+    activeMemberCount: memberSessionIds.length,
+    ownerPrincipalId: memberSessionIds[0] ?? 'creator',
+    snapshotVersion: membershipVersion,
+    metadataVersion: 0,
+    rosterVersion: membershipVersion,
+    presenceVersion: 0,
+    created: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: membershipVersion,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    expiresAtEpochMs: null,
+    emptySinceEpochMs: null,
+    purgeAfterEpochMs: null,
+  };
 }
+
+function createGroupSnapshotMembers(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['members'] {
+  return memberSessionIds.map((sessionId) => ({
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    principalId: sessionId,
+    role: 'member',
+    status: 'active',
+    joined: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: membershipVersion,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+    left: null,
+    removed: null,
+    banned: null,
+  }));
+}
+
+function createGroupSnapshotSessions(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['activeSessions'] {
+  return memberSessionIds.map((sessionId) => ({
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    sessionId,
+    principalId: sessionId,
+    generationId: `generation-${sessionId}`,
+    generationVersion: membershipVersion,
+    status: 'active',
+    connectedAtEpochMs: 1,
+    lastHeartbeatAtEpochMs: membershipVersion,
+    expiresAtEpochMs: membershipVersion + 60_000,
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+  }));
+}
+
+function parseDiagnosticArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupManagerPeerOwnersDiagnosticArguments> {
+  const groups = parseRtcBaselineBoundedInteger(
+    options.groups ?? '1000',
+    'groups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const peersPerGroup = parseRtcBaselineBoundedInteger(
+    options['peers-per-group'] ?? '10',
+    'peers-per-group',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options.lookups ?? '1000',
+    'lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const issues = collectParsingIssues([groups, peersPerGroup, lookups, runs]);
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'diagnostic',
+      input: {
+        groups: readParsedNumber(groups, 1),
+        peersPerGroup: readParsedNumber(peersPerGroup, 1),
+        lookups: readParsedNumber(lookups, 1),
+      },
+      runs: readParsedNumber(runs, 1),
+      out: options.out ?? 'tmp/perf/results/webrtc-group-manager-peer-owners.json',
+    },
+  };
+}
+
+function parseAcceptedArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupManagerPeerOwnersAcceptedArguments> {
+  const groups = parseRtcBaselineBoundedInteger(
+    options['rtc-groups'] ?? '',
+    'rtc-groups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const peersPerGroup = parseRtcBaselineBoundedInteger(
+    options['rtc-peers-per-group'] ?? '',
+    'rtc-peers-per-group',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options['rtc-lookups'] ?? '',
+    'rtc-lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const intendedPhase = options['intended-phase'];
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const parsedInput = {
+    groups: readParsedNumber(groups, acceptedInput.groups),
+    peersPerGroup: readParsedNumber(peersPerGroup, acceptedInput.peersPerGroup),
+    lookups: readParsedNumber(lookups, acceptedInput.lookups),
+  };
+  const issues = [
+    ...collectParsingIssues([groups, peersPerGroup, lookups, outerOrdinal]),
+    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
+    ...validateAcceptedArguments({
+      options,
+      input: parsedInput,
+      outerOrdinal,
+      intendedPhase,
+      sampleIds,
+    }),
+  ];
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: parsedInput,
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: readParsedNumber(outerOrdinal, 1),
+      sampleIds,
+    },
+  };
+}
+
+function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B04',
+    'case-id': 'group-manager-peer-owners',
+    'input-key': 'fixed',
+    'rtc-inner-runs': '5',
+    'rtc-groups': String(acceptedInput.groups),
+    'rtc-peers-per-group': String(acceptedInput.peersPerGroup),
+    'rtc-lookups': String(acceptedInput.lookups),
+  };
+  const issues = Object.entries(expected)
+    .filter(([name, value]) => input.options[name] !== value)
+    .map(([name, value]) =>
+      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+    );
+  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
+  const ordinal = readParsedNumber(input.outerOrdinal, 1);
+  return [
+    ...issues,
+    ...validateRules([
+      {
+        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
+        path: '$.input',
+        code: 'unexpected-worker-input',
+        message: 'Expected fixed input.',
+      },
+      {
+        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
+        path: '$.outer-ordinal',
+        code: 'unexpected-worker-input',
+        message: 'Expected canonical integer syntax.',
+      },
+      {
+        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
+        path: '$.intended-phase',
+        code: 'unexpected-worker-input',
+        message: 'Invalid phase.',
+      },
+      {
+        valid: JSON.stringify(input.sampleIds) ===
+          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
+        path: '$.sample-ids',
+        code: 'unexpected-worker-input',
+        message: 'Invalid sample IDs.',
+      },
+    ]),
+  ];
+}
+
+function createExpectedSampleIds(
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix = `rtc-b04-group-manager-peer-owners-fixed-${intendedPhase}-${
+    String(outerOrdinal).padStart(3, '0')
+  }`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function validateResult(
+  input: WebRtcGroupManagerPeerOwnersInput,
+  result: WebRtcGroupManagerPeerOwnersResult,
+): RtcBaselineIssueDto[] {
+  const counts = [result.ownedLookups, result.totalOwnerGroups, result.desiredPeerCount];
+  return validateRules([
+    {
+      valid: JSON.stringify([result.groupCount, result.peersPerGroup, result.lookups]) ===
+        JSON.stringify([input.groups, input.peersPerGroup, input.lookups]),
+      path: '$.rawEvidence.input',
+      code: 'input-mismatch',
+      message: 'Unexpected input.',
+    },
+    {
+      valid: counts.every(Number.isSafeInteger) && counts.every((count) => count >= 0),
+      path: '$.rawEvidence.counts',
+      code: 'invalid-count',
+      message: 'Expected bounded counts.',
+    },
+    {
+      valid: JSON.stringify(counts) ===
+        JSON.stringify([input.lookups, input.lookups * input.peersPerGroup, input.groups]),
+      path: '$.rawEvidence.owners',
+      code: 'ownership-result-mismatch',
+      message: 'Unexpected ownership result.',
+    },
+    {
+      valid: Number.isFinite(result.durationMs) && result.durationMs >= 0,
+      path: '$.rawEvidence.durationMs',
+      code: 'invalid-timing',
+      message: 'Expected nonnegative.',
+    },
+  ]);
+}
+
+function collectParsingIssues(
+  results: readonly RtcBaselineResult<number>[],
+): RtcBaselineIssueDto[] {
+  return results.flatMap((result) => result.ok ? [] : result.issues);
+}
+
+function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
+  return result.ok ? result.value : fallback;
+}
+
+function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {
+  return rules.filter((rule) => !rule.valid).map((rule) =>
+    rtcBaselineIssue(rule.path, rule.code, rule.message)
+  );
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: WebRtcGroupManagerPeerOwnersResult | null,
+  issues: readonly RtcBaselineIssueDto[],
+): RtcBaselineSampleDto {
+  if (result === null) {
+    return {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity,
+      outcome: 'not-run',
+      evidenceClass: 'synthetic-path',
+      metrics: [],
+      rawEvidence: null,
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    };
+  }
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
+      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
+      : [],
+    rawEvidence: toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function toRawEvidence(result: WebRtcGroupManagerPeerOwnersResult): RtcBaselineJson {
+  return {
+    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    groupCount: result.groupCount,
+    peersPerGroup: result.peersPerGroup,
+    lookups: result.lookups,
+    ownedLookups: result.ownedLookups,
+    totalOwnerGroups: result.totalOwnerGroups,
+    desiredPeerCount: result.desiredPeerCount,
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseWebRtcGroupManagerPeerOwnersArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  if (parsed.value.mode === 'accepted') {
+    const worker = parsed.value;
+    console.log(
+      JSON.stringify(
+        await runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+          worker,
+          run: () => runWebRtcGroupManagerPeerOwners(worker.input),
+        }),
+      ),
+    );
+    return;
+  }
+  const diagnostic = parsed.value;
+  const results = [];
+  for (let run = 1; run <= diagnostic.runs; run += 1) {
+    results.push({ run, ...await runWebRtcGroupManagerPeerOwners(diagnostic.input) });
+  }
+  const output = {
+    createdAt: new Date().toISOString(),
+    input: {
+      groupCount: diagnostic.input.groups,
+      peersPerGroup: diagnostic.input.peersPerGroup,
+      lookups: diagnostic.input.lookups,
+      runs: diagnostic.runs,
+    },
+    results,
+  };
+  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
+  await Deno.writeTextFile(diagnostic.out, JSON.stringify(output, null, 2));
+  console.log(`Wrote ${diagnostic.out}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
@@ -12,16 +12,17 @@ import {
   type RtcBaselineJson,
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
-  type RtcBaselineSampleIdentityDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   parseRtcBaselineBoundedInteger,
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
-import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
 import {
-  runRtcBaselineAcceptedWorkerSamples,
-} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 export interface WebRtcGroupManagerPeerOwnersInput {
   readonly groups: number;
@@ -36,14 +37,6 @@ interface WebRtcGroupManagerPeerOwnersDiagnosticArguments {
   readonly out: string;
 }
 
-export interface WebRtcGroupManagerPeerOwnersAcceptedArguments {
-  readonly mode: 'accepted';
-  readonly input: WebRtcGroupManagerPeerOwnersInput;
-  readonly intendedPhase: 'warmup' | 'retained';
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
-}
-
 export interface WebRtcGroupManagerPeerOwnersResult {
   readonly durationMs: number;
   readonly groupCount: number;
@@ -54,14 +47,6 @@ export interface WebRtcGroupManagerPeerOwnersResult {
   readonly desiredPeerCount: number;
 }
 
-interface ValidateAcceptedArgumentsInput {
-  readonly options: Readonly<Record<string, string>>;
-  readonly input: WebRtcGroupManagerPeerOwnersInput;
-  readonly outerOrdinal: RtcBaselineResult<number>;
-  readonly intendedPhase: string | undefined;
-  readonly sampleIds: readonly string[];
-}
-
 interface ValidationRule {
   readonly valid: boolean;
   readonly path: string;
@@ -69,10 +54,6 @@ interface ValidationRule {
   readonly message: string;
 }
 
-const acceptedOptionNames = (
-  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
-  'rtc-inner-runs rtc-groups rtc-peers-per-group rtc-lookups'
-).split(' ');
 const acceptedInput: WebRtcGroupManagerPeerOwnersInput = {
   groups: 1000,
   peersPerGroup: 10,
@@ -83,15 +64,26 @@ export function parseWebRtcGroupManagerPeerOwnersArguments(
   arguments_: readonly string[],
 ): RtcBaselineResult<
   | WebRtcGroupManagerPeerOwnersDiagnosticArguments
-  | WebRtcGroupManagerPeerOwnersAcceptedArguments
+  | RtcBaselineAcceptedWorker<WebRtcGroupManagerPeerOwnersInput>
 > {
   const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  if (accepted) {
+    return parseRtcBaselineAcceptedWorker({
+      arguments_,
+      identity: { workloadId: 'RTC-B04', caseId: 'group-manager-peer-owners' },
+      toInputKey: () => 'fixed',
+      capabilityOptionNames: ['rtc-groups', 'rtc-peers-per-group', 'rtc-lookups'],
+      parseCapability: parseAcceptedCapability,
+    });
+  }
   const parsed = parseRtcBaselineOneTokenOptions(
     arguments_,
-    accepted ? acceptedOptionNames : ['groups', 'peers-per-group', 'lookups', 'runs', 'out'],
+    ['groups', 'peers-per-group', 'lookups', 'runs', 'out'],
   );
-  if (!parsed.ok) return parsed;
-  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  return parseDiagnosticArguments(parsed.value);
 }
 
 export async function runWebRtcGroupManagerPeerOwners(
@@ -140,21 +132,17 @@ export async function runWebRtcGroupManagerPeerOwners(
 }
 
 export function runWebRtcGroupManagerPeerOwnersAcceptedSamples(input: {
-  readonly worker: WebRtcGroupManagerPeerOwnersAcceptedArguments;
+  readonly worker: RtcBaselineAcceptedWorker<WebRtcGroupManagerPeerOwnersInput>;
   readonly run: () =>
     | WebRtcGroupManagerPeerOwnersResult
     | Promise<WebRtcGroupManagerPeerOwnersResult>;
 }): Promise<RtcBaselineSampleDto[]> {
-  return runRtcBaselineAcceptedWorkerSamples({
-    worker: {
-      ...input.worker,
-      workloadId: 'RTC-B04',
-      caseId: 'group-manager-peer-owners',
-      inputKey: 'fixed',
-    },
+  return runRtcBaselineAcceptedWorker({
+    worker: input.worker,
     run: input.run,
     validate: (result) => validateResult(input.worker.input, result),
-    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+    metrics: (result) => [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: toRawEvidence,
   });
 }
 
@@ -341,9 +329,9 @@ function parseDiagnosticArguments(
   };
 }
 
-function parseAcceptedArguments(
+function parseAcceptedCapability(
   options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupManagerPeerOwnersAcceptedArguments> {
+): RtcBaselineResult<WebRtcGroupManagerPeerOwnersInput> {
   const groups = parseRtcBaselineBoundedInteger(
     options['rtc-groups'] ?? '',
     'rtc-groups',
@@ -362,103 +350,20 @@ function parseAcceptedArguments(
     1,
     Number.MAX_SAFE_INTEGER,
   );
-  const outerOrdinal = parseRtcBaselineBoundedInteger(
-    options['outer-ordinal'] ?? '',
-    'outer-ordinal',
-    1,
-    999,
-  );
-  const intendedPhase = options['intended-phase'];
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
-  const parsedInput = {
-    groups: readParsedNumber(groups, acceptedInput.groups),
-    peersPerGroup: readParsedNumber(peersPerGroup, acceptedInput.peersPerGroup),
-    lookups: readParsedNumber(lookups, acceptedInput.lookups),
-  };
-  const issues = [
-    ...collectParsingIssues([groups, peersPerGroup, lookups, outerOrdinal]),
-    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
-    ...validateAcceptedArguments({
-      options,
-      input: parsedInput,
-      outerOrdinal,
-      intendedPhase,
-      sampleIds,
-    }),
-  ];
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'accepted',
-      input: parsedInput,
-      intendedPhase: intendedPhase as 'warmup' | 'retained',
-      outerOrdinal: readParsedNumber(outerOrdinal, 1),
-      sampleIds,
-    },
-  };
-}
-
-function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
   const expected = {
-    capture: 'worker',
-    workload: 'RTC-B04',
-    'case-id': 'group-manager-peer-owners',
-    'input-key': 'fixed',
-    'rtc-inner-runs': '5',
     'rtc-groups': String(acceptedInput.groups),
     'rtc-peers-per-group': String(acceptedInput.peersPerGroup),
     'rtc-lookups': String(acceptedInput.lookups),
   };
-  const issues = Object.entries(expected)
-    .filter(([name, value]) => input.options[name] !== value)
-    .map(([name, value]) =>
-      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
-    );
-  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
-  const ordinal = readParsedNumber(input.outerOrdinal, 1);
-  return [
-    ...issues,
-    ...validateRules([
-      {
-        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
-        path: '$.input',
-        code: 'unexpected-worker-input',
-        message: 'Expected fixed input.',
-      },
-      {
-        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
-        path: '$.outer-ordinal',
-        code: 'unexpected-worker-input',
-        message: 'Expected canonical integer syntax.',
-      },
-      {
-        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
-        path: '$.intended-phase',
-        code: 'unexpected-worker-input',
-        message: 'Invalid phase.',
-      },
-      {
-        valid: JSON.stringify(input.sampleIds) ===
-          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
-        path: '$.sample-ids',
-        code: 'unexpected-worker-input',
-        message: 'Invalid sample IDs.',
-      },
-    ]),
+  const issues = [
+    ...collectParsingIssues([groups, peersPerGroup, lookups]),
+    ...Object.entries(expected)
+      .filter(([name, value]) => options[name] !== value)
+      .map(([name, value]) =>
+        rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+      ),
   ];
-}
-
-function createExpectedSampleIds(
-  intendedPhase: 'warmup' | 'retained',
-  outerOrdinal: number,
-): string[] {
-  const prefix = `rtc-b04-group-manager-peer-owners-fixed-${intendedPhase}-${
-    String(outerOrdinal).padStart(3, '0')
-  }`;
-  return Array.from(
-    { length: 5 },
-    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
-  );
+  return issues.length > 0 ? { ok: false, issues } : { ok: true, value: acceptedInput };
 }
 
 function validateResult(
@@ -512,42 +417,9 @@ function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] 
   );
 }
 
-function createSample(
-  identity: RtcBaselineSampleIdentityDto,
-  result: WebRtcGroupManagerPeerOwnersResult | null,
-  issues: readonly RtcBaselineIssueDto[],
-): RtcBaselineSampleDto {
-  if (result === null) {
-    return {
-      schema: 'rallar.rtc-baseline.sample.v1',
-      identity,
-      outcome: 'not-run',
-      evidenceClass: 'synthetic-path',
-      metrics: [],
-      rawEvidence: null,
-      rawReferences: [],
-      issues,
-      runtimeObservation: null,
-    };
-  }
-  return {
-    schema: 'rallar.rtc-baseline.sample.v1',
-    identity,
-    outcome: issues.length === 0 ? 'passed' : 'failed',
-    evidenceClass: 'synthetic-path',
-    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
-      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
-      : [],
-    rawEvidence: toRawEvidence(result),
-    rawReferences: [],
-    issues,
-    runtimeObservation: null,
-  };
-}
-
 function toRawEvidence(result: WebRtcGroupManagerPeerOwnersResult): RtcBaselineJson {
   return {
-    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    durationMs: result.durationMs,
     groupCount: result.groupCount,
     peersPerGroup: result.peersPerGroup,
     lookups: result.lookups,
@@ -559,20 +431,22 @@ function toRawEvidence(result: WebRtcGroupManagerPeerOwnersResult): RtcBaselineJ
 
 async function main(): Promise<void> {
   const parsed = parseWebRtcGroupManagerPeerOwnersArguments(Deno.args);
-  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
-  if (parsed.value.mode === 'accepted') {
-    const worker = parsed.value;
-    console.log(
-      JSON.stringify(
-        await runWebRtcGroupManagerPeerOwnersAcceptedSamples({
-          worker,
-          run: () => runWebRtcGroupManagerPeerOwners(worker.input),
-        }),
-      ),
-    );
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.issues));
+  }
+  const dispatched = await runRtcBaselineAcceptedWorkerCli({
+    parsed: parsed.value,
+    runAccepted: (worker) =>
+      runWebRtcGroupManagerPeerOwnersAcceptedSamples({
+        worker,
+        run: () => runWebRtcGroupManagerPeerOwners(worker.input),
+      }),
+    writeOutput: (output) => console.log(output),
+  });
+  if (dispatched.handled) {
     return;
   }
-  const diagnostic = parsed.value;
+  const diagnostic = dispatched.diagnostic;
   const results = [];
   for (let run = 1; run <= diagnostic.runs; run += 1) {
     results.push({ run, ...await runWebRtcGroupManagerPeerOwners(diagnostic.input) });
@@ -592,4 +466,6 @@ async function main(): Promise<void> {
   console.log(`Wrote ${diagnostic.out}`);
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
@@ -14,10 +14,7 @@ import {
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
-import {
-  parseRtcBaselineBoundedInteger,
-  parseRtcBaselineOneTokenOptions,
-} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { parseRtcBaselineBoundedInteger } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import {
   parseRtcBaselineAcceptedWorker,
   type RtcBaselineAcceptedWorker,
@@ -143,14 +140,7 @@ export function parseWebRtcGroupManagerStateArguments(
       parseCapability: parseAcceptedCapability,
     });
   }
-  const parsed = parseRtcBaselineOneTokenOptions(
-    arguments_,
-    ['clients', 'desired', 'lookups', 'runs', 'out'],
-  );
-  if (!parsed.ok) {
-    return parsed;
-  }
-  return parseDiagnosticArguments(parsed.value);
+  return { ok: true, value: parseDiagnosticArguments(arguments_) };
 }
 
 export async function runWebRtcGroupManagerState(
@@ -361,40 +351,21 @@ function createGroupSnapshotSessions(
 }
 
 function parseDiagnosticArguments(
-  options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupManagerStateDiagnosticArguments> {
-  const clients = parseRtcBaselineBoundedInteger(
-    options.clients ?? '5000',
-    'clients',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const desired = parseRtcBaselineBoundedInteger(
-    options.desired ?? '1000',
-    'desired',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const lookups = parseRtcBaselineBoundedInteger(
-    options.lookups ?? '20',
-    'lookups',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
-  const issues = collectParsingIssues([clients, desired, lookups, runs]);
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'diagnostic',
-      input: {
-        clients: readParsedNumber(clients, 1),
-        desired: readParsedNumber(desired, 1),
-        lookups: readParsedNumber(lookups, 1),
-      },
-      runs: readParsedNumber(runs, 1),
-      out: options.out ?? 'tmp/perf/results/webrtc-group-manager-state.json',
+  arguments_: readonly string[],
+): WebRtcGroupManagerStateDiagnosticArguments {
+  return {
+    mode: 'diagnostic',
+    input: {
+      clients: Number(readDiagnosticArgument(arguments_, '--clients', '5000')),
+      desired: Number(readDiagnosticArgument(arguments_, '--desired', '1000')),
+      lookups: Number(readDiagnosticArgument(arguments_, '--lookups', '20')),
     },
+    runs: Number(readDiagnosticArgument(arguments_, '--runs', '5')),
+    out: readDiagnosticArgument(
+      arguments_,
+      '--out',
+      'tmp/perf/results/webrtc-group-manager-state.json',
+    ),
   };
 }
 
@@ -477,8 +448,13 @@ function collectParsingIssues(
   return results.flatMap((result) => result.ok ? [] : result.issues);
 }
 
-function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
-  return result.ok ? result.value : fallback;
+function readDiagnosticArgument(
+  arguments_: readonly string[],
+  name: string,
+  fallback: string,
+): string {
+  return arguments_.find((argument) => argument.startsWith(`${name}=`))?.slice(name.length + 1) ??
+    fallback;
 }
 
 function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path';
+
 import type { ClientInfo } from '@shared/api/api-config.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
@@ -5,23 +7,75 @@ import type { ReadableKeyedValues } from '@shared/cache/RepositoryInterfaces.ts'
 import { Either } from '@shared/resilience/Either.ts';
 import { WebRtcGroupManager } from '@shared/services/WebRtcGroupManager.ts';
 
-type BenchResult = Readonly<{
-  run: number;
-  durationMs: number;
-  clientCount: number;
-  desiredPeerCount: number;
-  lookups: number;
-  keysCalls: number;
-  readCalls: number;
-  onlineDesiredPeerCount: number;
-  onlinePeerCount: number;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineIssueDto,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
+import {
+  runRtcBaselineAcceptedWorkerSamples,
+} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
-const OUT = readArg('--out') ?? 'tmp/perf/results/webrtc-group-manager-state.json';
-const CLIENTS = Number(readArg('--clients') ?? '5000');
-const DESIRED = Number(readArg('--desired') ?? '1000');
-const LOOKUPS = Number(readArg('--lookups') ?? '20');
-const RUNS = Number(readArg('--runs') ?? '5');
+export interface WebRtcGroupManagerStateInput {
+  readonly clients: number;
+  readonly desired: number;
+  readonly lookups: number;
+}
+
+interface WebRtcGroupManagerStateDiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: WebRtcGroupManagerStateInput;
+  readonly runs: number;
+  readonly out: string;
+}
+
+export interface WebRtcGroupManagerStateAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: WebRtcGroupManagerStateInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+export interface WebRtcGroupManagerStateResult {
+  readonly durationMs: number;
+  readonly clientCount: number;
+  readonly desiredPeerCount: number;
+  readonly lookups: number;
+  readonly keysCalls: number;
+  readonly readCalls: number;
+  readonly onlineDesiredPeerCount: number;
+  readonly onlinePeerCount: number;
+}
+
+interface ValidateAcceptedArgumentsInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly input: WebRtcGroupManagerStateInput;
+  readonly outerOrdinal: RtcBaselineResult<number>;
+  readonly intendedPhase: string | undefined;
+  readonly sampleIds: readonly string[];
+}
+
+interface ValidationRule {
+  readonly valid: boolean;
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+const acceptedOptionNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-inner-runs rtc-clients rtc-desired rtc-lookups'
+).split(' ');
+const acceptedInput: WebRtcGroupManagerStateInput = { clients: 5000, desired: 1000, lookups: 20 };
 
 class CountingClientCache implements ReadableKeyedValues<string, ClientInfo> {
   keysCalls = 0;
@@ -92,15 +146,29 @@ class CountingClientCache implements ReadableKeyedValues<string, ClientInfo> {
   }
 }
 
-const results: BenchResult[] = [];
+export function parseWebRtcGroupManagerStateArguments(
+  arguments_: readonly string[],
+): RtcBaselineResult<
+  WebRtcGroupManagerStateDiagnosticArguments | WebRtcGroupManagerStateAcceptedArguments
+> {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedOptionNames : ['clients', 'desired', 'lookups', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
 
-for (let run = 1; run <= RUNS; run++) {
+export async function runWebRtcGroupManagerState(
+  input: WebRtcGroupManagerStateInput,
+): Promise<WebRtcGroupManagerStateResult> {
   const groupCache = new LatestRepository<string, GroupSnapshot>();
   const clientCache = new CountingClientCache();
   const rtcQBox = createRtcQBoxHarness('self');
   const manager = new WebRtcGroupManager(rtcQBox.service as never, groupCache, clientCache);
 
-  for (let index = 0; index < CLIENTS; index++) {
+  for (let index = 0; index < input.clients; index += 1) {
     const peerId = `peer-${index}`;
     clientCache.set(peerId, {
       clientId: peerId,
@@ -112,7 +180,7 @@ for (let run = 1; run <= RUNS; run++) {
   await manager.acceptGroupUpdate(
     createGroupSnapshot('room-1', 1, [
       'self',
-      ...Array.from({ length: DESIRED }, (_, index) => `peer-${index}`),
+      ...Array.from({ length: input.desired }, (_, index) => `peer-${index}`),
     ]),
   );
 
@@ -121,44 +189,40 @@ for (let run = 1; run <= RUNS; run++) {
   let onlinePeerCount = 0;
   const start = performance.now();
 
-  for (let lookup = 0; lookup < LOOKUPS; lookup++) {
+  for (let lookup = 0; lookup < input.lookups; lookup += 1) {
     const state = manager.state();
     onlineDesiredPeerCount = state.onlineDesiredPeerIds.length;
     onlinePeerCount = state.onlinePeerIds.length;
   }
 
-  results.push({
-    run,
+  return {
     durationMs: performance.now() - start,
-    clientCount: CLIENTS,
-    desiredPeerCount: DESIRED,
-    lookups: LOOKUPS,
+    clientCount: input.clients,
+    desiredPeerCount: input.desired,
+    lookups: input.lookups,
     keysCalls: clientCache.keysCalls,
     readCalls: clientCache.readCalls,
     onlineDesiredPeerCount,
     onlinePeerCount,
-  });
+  };
 }
 
-await Deno.writeTextFile(
-  OUT,
-  JSON.stringify(
-    {
-      createdAt: new Date().toISOString(),
-      input: {
-        clientCount: CLIENTS,
-        desiredPeerCount: DESIRED,
-        lookups: LOOKUPS,
-        runs: RUNS,
-      },
-      results,
+export function runWebRtcGroupManagerStateAcceptedSamples(input: {
+  readonly worker: WebRtcGroupManagerStateAcceptedArguments;
+  readonly run: () => WebRtcGroupManagerStateResult | Promise<WebRtcGroupManagerStateResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: {
+      ...input.worker,
+      workloadId: 'RTC-B04',
+      caseId: 'group-manager-state',
+      inputKey: 'fixed',
     },
-    null,
-    2,
-  ),
-);
-
-console.log(`Wrote ${OUT}`);
+    run: input.run,
+    validate: (result) => validateResult(input.worker.input, result),
+    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+  });
+}
 
 function createRtcQBoxHarness(sessionId: string) {
   const knownPeerIds = new Set<string>();
@@ -191,102 +255,411 @@ function createGroupSnapshot(
   membershipVersion: number,
   memberSessionIds: readonly string[],
 ): GroupSnapshot {
-  const applicationId = 'app-1';
-  const workspaceId = 'workspace-1';
-  const ownerPrincipalId = memberSessionIds[0] ?? 'creator';
-
   return {
     stateRevision: membershipVersion,
     causalRevision: {
       groupRevision: membershipVersion,
       presenceRevision: membershipVersion,
     },
-    group: {
-      applicationId,
-      workspaceId,
-      groupId,
-      slug: groupId,
-      displayName: groupId,
-      description: null,
-      kind: 'room',
-      status: 'active',
-      archived: null,
-      deleted: null,
-      joinMode: 'open',
-      maxMembers: null,
-      maxSessionsPerMember: null,
-      metadata: {},
-      activeMemberCount: memberSessionIds.length,
-      ownerPrincipalId,
-      snapshotVersion: membershipVersion,
-      metadataVersion: 0,
-      rosterVersion: membershipVersion,
-      presenceVersion: 0,
-      created: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: membershipVersion,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      expiresAtEpochMs: null,
-      emptySinceEpochMs: null,
-      purgeAfterEpochMs: null,
-    },
-    members: memberSessionIds.map((sessionId) => ({
-      applicationId,
-      workspaceId,
-      groupId,
-      principalId: sessionId,
-      role: 'member',
-      status: 'active',
-      joined: {
-        atEpochMs: 1,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      updated: {
-        atEpochMs: membershipVersion,
-        actor: { kind: 'principal', principalId: 'creator' },
-        reason: null,
-        traceId: null,
-        requestId: null,
-      },
-      invitedByPrincipalId: null,
-      invitationExpiresAtEpochMs: null,
-      left: null,
-      removed: null,
-      banned: null,
-    })),
-    activeSessions: memberSessionIds.map((sessionId) => ({
-      applicationId,
-      workspaceId,
-      groupId,
-      sessionId,
-      principalId: sessionId,
-      generationId: `generation-${sessionId}`,
-      generationVersion: membershipVersion,
-      status: 'active',
-      connectedAtEpochMs: 1,
-      lastHeartbeatAtEpochMs: membershipVersion,
-      expiresAtEpochMs: membershipVersion + 60_000,
-      disconnectedAtEpochMs: null,
-      disconnectReason: null,
-    })),
+    group: createGroupSnapshotGroup(groupId, membershipVersion, memberSessionIds),
+    members: createGroupSnapshotMembers(groupId, membershipVersion, memberSessionIds),
+    activeSessions: createGroupSnapshotSessions(groupId, membershipVersion, memberSessionIds),
     memberCount: memberSessionIds.length,
     onlineMemberCount: memberSessionIds.length,
   };
 }
 
-function readArg(name: string): string | undefined {
-  return Deno.args.find((arg) => arg.startsWith(`${name}=`))?.slice(name.length + 1);
+function createGroupSnapshotGroup(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['group'] {
+  return {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    slug: groupId,
+    displayName: groupId,
+    description: null,
+    kind: 'room',
+    status: 'active',
+    archived: null,
+    deleted: null,
+    joinMode: 'open',
+    maxMembers: null,
+    maxSessionsPerMember: null,
+    metadata: {},
+    activeMemberCount: memberSessionIds.length,
+    ownerPrincipalId: memberSessionIds[0] ?? 'creator',
+    snapshotVersion: membershipVersion,
+    metadataVersion: 0,
+    rosterVersion: membershipVersion,
+    presenceVersion: 0,
+    created: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: membershipVersion,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    expiresAtEpochMs: null,
+    emptySinceEpochMs: null,
+    purgeAfterEpochMs: null,
+  };
 }
+
+function createGroupSnapshotMembers(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['members'] {
+  return memberSessionIds.map((sessionId) => ({
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    principalId: sessionId,
+    role: 'member',
+    status: 'active',
+    joined: {
+      atEpochMs: 1,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    updated: {
+      atEpochMs: membershipVersion,
+      actor: { kind: 'principal', principalId: 'creator' },
+      reason: null,
+      traceId: null,
+      requestId: null,
+    },
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+    left: null,
+    removed: null,
+    banned: null,
+  }));
+}
+
+function createGroupSnapshotSessions(
+  groupId: string,
+  membershipVersion: number,
+  memberSessionIds: readonly string[],
+): GroupSnapshot['activeSessions'] {
+  return memberSessionIds.map((sessionId) => ({
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId,
+    sessionId,
+    principalId: sessionId,
+    generationId: `generation-${sessionId}`,
+    generationVersion: membershipVersion,
+    status: 'active',
+    connectedAtEpochMs: 1,
+    lastHeartbeatAtEpochMs: membershipVersion,
+    expiresAtEpochMs: membershipVersion + 60_000,
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+  }));
+}
+
+function parseDiagnosticArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupManagerStateDiagnosticArguments> {
+  const clients = parseRtcBaselineBoundedInteger(
+    options.clients ?? '5000',
+    'clients',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const desired = parseRtcBaselineBoundedInteger(
+    options.desired ?? '1000',
+    'desired',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options.lookups ?? '20',
+    'lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const issues = collectParsingIssues([clients, desired, lookups, runs]);
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'diagnostic',
+      input: {
+        clients: readParsedNumber(clients, 1),
+        desired: readParsedNumber(desired, 1),
+        lookups: readParsedNumber(lookups, 1),
+      },
+      runs: readParsedNumber(runs, 1),
+      out: options.out ?? 'tmp/perf/results/webrtc-group-manager-state.json',
+    },
+  };
+}
+
+function parseAcceptedArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcGroupManagerStateAcceptedArguments> {
+  const clients = parseRtcBaselineBoundedInteger(
+    options['rtc-clients'] ?? '',
+    'rtc-clients',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const desired = parseRtcBaselineBoundedInteger(
+    options['rtc-desired'] ?? '',
+    'rtc-desired',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const lookups = parseRtcBaselineBoundedInteger(
+    options['rtc-lookups'] ?? '',
+    'rtc-lookups',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const intendedPhase = options['intended-phase'];
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const parsedInput = {
+    clients: readParsedNumber(clients, acceptedInput.clients),
+    desired: readParsedNumber(desired, acceptedInput.desired),
+    lookups: readParsedNumber(lookups, acceptedInput.lookups),
+  };
+  const issues = [
+    ...collectParsingIssues([clients, desired, lookups, outerOrdinal]),
+    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
+    ...validateAcceptedArguments({
+      options,
+      input: parsedInput,
+      outerOrdinal,
+      intendedPhase,
+      sampleIds,
+    }),
+  ];
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: parsedInput,
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: readParsedNumber(outerOrdinal, 1),
+      sampleIds,
+    },
+  };
+}
+
+function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B04',
+    'case-id': 'group-manager-state',
+    'input-key': 'fixed',
+    'rtc-inner-runs': '5',
+    'rtc-clients': String(acceptedInput.clients),
+    'rtc-desired': String(acceptedInput.desired),
+    'rtc-lookups': String(acceptedInput.lookups),
+  };
+  const issues = Object.entries(expected)
+    .filter(([name, value]) => input.options[name] !== value)
+    .map(([name, value]) =>
+      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+    );
+  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
+  const ordinal = readParsedNumber(input.outerOrdinal, 1);
+  return [
+    ...issues,
+    ...validateRules([
+      {
+        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
+        path: '$.input',
+        code: 'unexpected-worker-input',
+        message: 'Expected fixed input.',
+      },
+      {
+        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
+        path: '$.outer-ordinal',
+        code: 'unexpected-worker-input',
+        message: 'Expected canonical integer syntax.',
+      },
+      {
+        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
+        path: '$.intended-phase',
+        code: 'unexpected-worker-input',
+        message: 'Invalid phase.',
+      },
+      {
+        valid: JSON.stringify(input.sampleIds) ===
+          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
+        path: '$.sample-ids',
+        code: 'unexpected-worker-input',
+        message: 'Invalid sample IDs.',
+      },
+    ]),
+  ];
+}
+
+function createExpectedSampleIds(
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix = `rtc-b04-group-manager-state-fixed-${intendedPhase}-${
+    String(outerOrdinal).padStart(3, '0')
+  }`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function validateResult(
+  input: WebRtcGroupManagerStateInput,
+  result: WebRtcGroupManagerStateResult,
+): RtcBaselineIssueDto[] {
+  return validateRules([
+    {
+      valid: JSON.stringify([result.clientCount, result.desiredPeerCount, result.lookups]) ===
+        JSON.stringify([input.clients, input.desired, input.lookups]),
+      path: '$.rawEvidence.input',
+      code: 'input-mismatch',
+      message: 'Unexpected input.',
+    },
+    {
+      valid: JSON.stringify([result.keysCalls, result.readCalls]) ===
+          JSON.stringify([input.lookups, input.clients * input.lookups]) &&
+        [result.keysCalls, result.readCalls].every(Number.isSafeInteger),
+      path: '$.rawEvidence.calls',
+      code: 'call-count-mismatch',
+      message: 'Unexpected calls.',
+    },
+    {
+      valid: JSON.stringify([result.onlineDesiredPeerCount, result.onlinePeerCount]) ===
+        JSON.stringify([input.desired, input.desired]),
+      path: '$.rawEvidence.state',
+      code: 'state-result-mismatch',
+      message: 'Unexpected state result.',
+    },
+    {
+      valid: Number.isFinite(result.durationMs) && result.durationMs >= 0,
+      path: '$.rawEvidence.durationMs',
+      code: 'invalid-timing',
+      message: 'Expected nonnegative.',
+    },
+  ]);
+}
+
+function collectParsingIssues(
+  results: readonly RtcBaselineResult<number>[],
+): RtcBaselineIssueDto[] {
+  return results.flatMap((result) => result.ok ? [] : result.issues);
+}
+
+function readParsedNumber(result: RtcBaselineResult<number>, fallback: number): number {
+  return result.ok ? result.value : fallback;
+}
+
+function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] {
+  return rules.filter((rule) => !rule.valid).map((rule) =>
+    rtcBaselineIssue(rule.path, rule.code, rule.message)
+  );
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: WebRtcGroupManagerStateResult | null,
+  issues: readonly RtcBaselineIssueDto[],
+): RtcBaselineSampleDto {
+  if (result === null) {
+    return {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity,
+      outcome: 'not-run',
+      evidenceClass: 'synthetic-path',
+      metrics: [],
+      rawEvidence: null,
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    };
+  }
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
+      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
+      : [],
+    rawEvidence: toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function toRawEvidence(result: WebRtcGroupManagerStateResult): RtcBaselineJson {
+  return {
+    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    clientCount: result.clientCount,
+    desiredPeerCount: result.desiredPeerCount,
+    lookups: result.lookups,
+    keysCalls: result.keysCalls,
+    readCalls: result.readCalls,
+    onlineDesiredPeerCount: result.onlineDesiredPeerCount,
+    onlinePeerCount: result.onlinePeerCount,
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseWebRtcGroupManagerStateArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  if (parsed.value.mode === 'accepted') {
+    const worker = parsed.value;
+    console.log(
+      JSON.stringify(
+        await runWebRtcGroupManagerStateAcceptedSamples({
+          worker,
+          run: () => runWebRtcGroupManagerState(worker.input),
+        }),
+      ),
+    );
+    return;
+  }
+  const diagnostic = parsed.value;
+  const results = [];
+  for (let run = 1; run <= diagnostic.runs; run += 1) {
+    results.push({ run, ...await runWebRtcGroupManagerState(diagnostic.input) });
+  }
+  const output = {
+    createdAt: new Date().toISOString(),
+    input: {
+      clientCount: diagnostic.input.clients,
+      desiredPeerCount: diagnostic.input.desired,
+      lookups: diagnostic.input.lookups,
+      runs: diagnostic.runs,
+    },
+    results,
+  };
+  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
+  await Deno.writeTextFile(diagnostic.out, JSON.stringify(output, null, 2));
+  console.log(`Wrote ${diagnostic.out}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
@@ -13,16 +13,17 @@ import {
   type RtcBaselineJson,
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
-  type RtcBaselineSampleIdentityDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   parseRtcBaselineBoundedInteger,
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
-import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
 import {
-  runRtcBaselineAcceptedWorkerSamples,
-} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 export interface WebRtcGroupManagerStateInput {
   readonly clients: number;
@@ -37,14 +38,6 @@ interface WebRtcGroupManagerStateDiagnosticArguments {
   readonly out: string;
 }
 
-export interface WebRtcGroupManagerStateAcceptedArguments {
-  readonly mode: 'accepted';
-  readonly input: WebRtcGroupManagerStateInput;
-  readonly intendedPhase: 'warmup' | 'retained';
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
-}
-
 export interface WebRtcGroupManagerStateResult {
   readonly durationMs: number;
   readonly clientCount: number;
@@ -56,14 +49,6 @@ export interface WebRtcGroupManagerStateResult {
   readonly onlinePeerCount: number;
 }
 
-interface ValidateAcceptedArgumentsInput {
-  readonly options: Readonly<Record<string, string>>;
-  readonly input: WebRtcGroupManagerStateInput;
-  readonly outerOrdinal: RtcBaselineResult<number>;
-  readonly intendedPhase: string | undefined;
-  readonly sampleIds: readonly string[];
-}
-
 interface ValidationRule {
   readonly valid: boolean;
   readonly path: string;
@@ -71,10 +56,6 @@ interface ValidationRule {
   readonly message: string;
 }
 
-const acceptedOptionNames = (
-  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
-  'rtc-inner-runs rtc-clients rtc-desired rtc-lookups'
-).split(' ');
 const acceptedInput: WebRtcGroupManagerStateInput = { clients: 5000, desired: 1000, lookups: 20 };
 
 class CountingClientCache implements ReadableKeyedValues<string, ClientInfo> {
@@ -149,15 +130,27 @@ class CountingClientCache implements ReadableKeyedValues<string, ClientInfo> {
 export function parseWebRtcGroupManagerStateArguments(
   arguments_: readonly string[],
 ): RtcBaselineResult<
-  WebRtcGroupManagerStateDiagnosticArguments | WebRtcGroupManagerStateAcceptedArguments
+  | WebRtcGroupManagerStateDiagnosticArguments
+  | RtcBaselineAcceptedWorker<WebRtcGroupManagerStateInput>
 > {
   const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  if (accepted) {
+    return parseRtcBaselineAcceptedWorker({
+      arguments_,
+      identity: { workloadId: 'RTC-B04', caseId: 'group-manager-state' },
+      toInputKey: () => 'fixed',
+      capabilityOptionNames: ['rtc-clients', 'rtc-desired', 'rtc-lookups'],
+      parseCapability: parseAcceptedCapability,
+    });
+  }
   const parsed = parseRtcBaselineOneTokenOptions(
     arguments_,
-    accepted ? acceptedOptionNames : ['clients', 'desired', 'lookups', 'runs', 'out'],
+    ['clients', 'desired', 'lookups', 'runs', 'out'],
   );
-  if (!parsed.ok) return parsed;
-  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  return parseDiagnosticArguments(parsed.value);
 }
 
 export async function runWebRtcGroupManagerState(
@@ -208,19 +201,15 @@ export async function runWebRtcGroupManagerState(
 }
 
 export function runWebRtcGroupManagerStateAcceptedSamples(input: {
-  readonly worker: WebRtcGroupManagerStateAcceptedArguments;
+  readonly worker: RtcBaselineAcceptedWorker<WebRtcGroupManagerStateInput>;
   readonly run: () => WebRtcGroupManagerStateResult | Promise<WebRtcGroupManagerStateResult>;
 }): Promise<RtcBaselineSampleDto[]> {
-  return runRtcBaselineAcceptedWorkerSamples({
-    worker: {
-      ...input.worker,
-      workloadId: 'RTC-B04',
-      caseId: 'group-manager-state',
-      inputKey: 'fixed',
-    },
+  return runRtcBaselineAcceptedWorker({
+    worker: input.worker,
     run: input.run,
     validate: (result) => validateResult(input.worker.input, result),
-    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+    metrics: (result) => [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: toRawEvidence,
   });
 }
 
@@ -409,9 +398,9 @@ function parseDiagnosticArguments(
   };
 }
 
-function parseAcceptedArguments(
+function parseAcceptedCapability(
   options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcGroupManagerStateAcceptedArguments> {
+): RtcBaselineResult<WebRtcGroupManagerStateInput> {
   const clients = parseRtcBaselineBoundedInteger(
     options['rtc-clients'] ?? '',
     'rtc-clients',
@@ -430,103 +419,20 @@ function parseAcceptedArguments(
     1,
     Number.MAX_SAFE_INTEGER,
   );
-  const outerOrdinal = parseRtcBaselineBoundedInteger(
-    options['outer-ordinal'] ?? '',
-    'outer-ordinal',
-    1,
-    999,
-  );
-  const intendedPhase = options['intended-phase'];
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
-  const parsedInput = {
-    clients: readParsedNumber(clients, acceptedInput.clients),
-    desired: readParsedNumber(desired, acceptedInput.desired),
-    lookups: readParsedNumber(lookups, acceptedInput.lookups),
-  };
-  const issues = [
-    ...collectParsingIssues([clients, desired, lookups, outerOrdinal]),
-    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
-    ...validateAcceptedArguments({
-      options,
-      input: parsedInput,
-      outerOrdinal,
-      intendedPhase,
-      sampleIds,
-    }),
-  ];
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'accepted',
-      input: parsedInput,
-      intendedPhase: intendedPhase as 'warmup' | 'retained',
-      outerOrdinal: readParsedNumber(outerOrdinal, 1),
-      sampleIds,
-    },
-  };
-}
-
-function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
   const expected = {
-    capture: 'worker',
-    workload: 'RTC-B04',
-    'case-id': 'group-manager-state',
-    'input-key': 'fixed',
-    'rtc-inner-runs': '5',
     'rtc-clients': String(acceptedInput.clients),
     'rtc-desired': String(acceptedInput.desired),
     'rtc-lookups': String(acceptedInput.lookups),
   };
-  const issues = Object.entries(expected)
-    .filter(([name, value]) => input.options[name] !== value)
-    .map(([name, value]) =>
-      rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
-    );
-  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
-  const ordinal = readParsedNumber(input.outerOrdinal, 1);
-  return [
-    ...issues,
-    ...validateRules([
-      {
-        valid: JSON.stringify(input.input) === JSON.stringify(acceptedInput),
-        path: '$.input',
-        code: 'unexpected-worker-input',
-        message: 'Expected fixed input.',
-      },
-      {
-        valid: input.outerOrdinal.ok && input.options['outer-ordinal'] === String(ordinal),
-        path: '$.outer-ordinal',
-        code: 'unexpected-worker-input',
-        message: 'Expected canonical integer syntax.',
-      },
-      {
-        valid: ['warmup', 'retained'].includes(input.intendedPhase ?? ''),
-        path: '$.intended-phase',
-        code: 'unexpected-worker-input',
-        message: 'Invalid phase.',
-      },
-      {
-        valid: JSON.stringify(input.sampleIds) ===
-          JSON.stringify(createExpectedSampleIds(phase, ordinal)),
-        path: '$.sample-ids',
-        code: 'unexpected-worker-input',
-        message: 'Invalid sample IDs.',
-      },
-    ]),
+  const issues = [
+    ...collectParsingIssues([clients, desired, lookups]),
+    ...Object.entries(expected)
+      .filter(([name, value]) => options[name] !== value)
+      .map(([name, value]) =>
+        rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)
+      ),
   ];
-}
-
-function createExpectedSampleIds(
-  intendedPhase: 'warmup' | 'retained',
-  outerOrdinal: number,
-): string[] {
-  const prefix = `rtc-b04-group-manager-state-fixed-${intendedPhase}-${
-    String(outerOrdinal).padStart(3, '0')
-  }`;
-  return Array.from(
-    { length: 5 },
-    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
-  );
+  return issues.length > 0 ? { ok: false, issues } : { ok: true, value: acceptedInput };
 }
 
 function validateResult(
@@ -551,7 +457,7 @@ function validateResult(
     },
     {
       valid: JSON.stringify([result.onlineDesiredPeerCount, result.onlinePeerCount]) ===
-        JSON.stringify([input.desired, input.desired]),
+        JSON.stringify([input.desired, input.clients]),
       path: '$.rawEvidence.state',
       code: 'state-result-mismatch',
       message: 'Unexpected state result.',
@@ -581,42 +487,9 @@ function validateRules(rules: readonly ValidationRule[]): RtcBaselineIssueDto[] 
   );
 }
 
-function createSample(
-  identity: RtcBaselineSampleIdentityDto,
-  result: WebRtcGroupManagerStateResult | null,
-  issues: readonly RtcBaselineIssueDto[],
-): RtcBaselineSampleDto {
-  if (result === null) {
-    return {
-      schema: 'rallar.rtc-baseline.sample.v1',
-      identity,
-      outcome: 'not-run',
-      evidenceClass: 'synthetic-path',
-      metrics: [],
-      rawEvidence: null,
-      rawReferences: [],
-      issues,
-      runtimeObservation: null,
-    };
-  }
-  return {
-    schema: 'rallar.rtc-baseline.sample.v1',
-    identity,
-    outcome: issues.length === 0 ? 'passed' : 'failed',
-    evidenceClass: 'synthetic-path',
-    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
-      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
-      : [],
-    rawEvidence: toRawEvidence(result),
-    rawReferences: [],
-    issues,
-    runtimeObservation: null,
-  };
-}
-
 function toRawEvidence(result: WebRtcGroupManagerStateResult): RtcBaselineJson {
   return {
-    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    durationMs: result.durationMs,
     clientCount: result.clientCount,
     desiredPeerCount: result.desiredPeerCount,
     lookups: result.lookups,
@@ -629,20 +502,22 @@ function toRawEvidence(result: WebRtcGroupManagerStateResult): RtcBaselineJson {
 
 async function main(): Promise<void> {
   const parsed = parseWebRtcGroupManagerStateArguments(Deno.args);
-  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
-  if (parsed.value.mode === 'accepted') {
-    const worker = parsed.value;
-    console.log(
-      JSON.stringify(
-        await runWebRtcGroupManagerStateAcceptedSamples({
-          worker,
-          run: () => runWebRtcGroupManagerState(worker.input),
-        }),
-      ),
-    );
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.issues));
+  }
+  const dispatched = await runRtcBaselineAcceptedWorkerCli({
+    parsed: parsed.value,
+    runAccepted: (worker) =>
+      runWebRtcGroupManagerStateAcceptedSamples({
+        worker,
+        run: () => runWebRtcGroupManagerState(worker.input),
+      }),
+    writeOutput: (output) => console.log(output),
+  });
+  if (dispatched.handled) {
     return;
   }
-  const diagnostic = parsed.value;
+  const diagnostic = dispatched.diagnostic;
   const results = [];
   for (let run = 1; run <= diagnostic.runs; run += 1) {
     results.push({ run, ...await runWebRtcGroupManagerState(diagnostic.input) });
@@ -662,4 +537,6 @@ async function main(): Promise<void> {
   console.log(`Wrote ${diagnostic.out}`);
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
@@ -1,20 +1,67 @@
+import { dirname } from 'node:path';
+
 import { WebRtcHeartbeatService } from '@shared/services/WebRtcHeartbeatService.ts';
 
-type CallbackDto = Readonly<{
-  onMessage: (data: unknown) => Promise<void>;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineIssueDto,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
+import {
+  runRtcBaselineAcceptedWorkerSamples,
+} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
-type BenchResult = Readonly<{
-  run: number;
-  durationMs: number;
-  channelCount: number;
-  retainedCallbacks: number;
-  maxCallbacksPerChannel: number;
-}>;
+interface CallbackDto {
+  readonly onMessage: (data: unknown) => Promise<void>;
+}
 
-const OUT = readArg('--out') ?? 'tmp/perf/results/webrtc-heartbeat-callback-churn.json';
-const CHANNELS = Number(readArg('--channels') ?? '10000');
-const RUNS = Number(readArg('--runs') ?? '5');
+export interface WebRtcHeartbeatCallbackChurnInput {
+  readonly channels: number;
+}
+
+interface WebRtcHeartbeatCallbackChurnDiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly input: WebRtcHeartbeatCallbackChurnInput;
+  readonly runs: number;
+  readonly out: string;
+}
+
+export interface WebRtcHeartbeatCallbackChurnAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: WebRtcHeartbeatCallbackChurnInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+export interface WebRtcHeartbeatCallbackChurnResult {
+  readonly durationMs: number;
+  readonly channelCount: number;
+  readonly retainedCallbacks: number;
+  readonly maxCallbacksPerChannel: number;
+}
+
+interface ValidateAcceptedArgumentsInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly channels: number;
+  readonly outerOrdinal: RtcBaselineResult<number>;
+  readonly intendedPhase: string | undefined;
+  readonly sampleIds: readonly string[];
+}
+
+const acceptedOptionNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-inner-runs rtc-channels'
+).split(' ');
+const acceptedChannels = 10000;
 
 class FakeHeartbeatChannel {
   private readonly callbacks = new Map<string, CallbackDto>();
@@ -41,13 +88,27 @@ class FakeHeartbeatChannel {
   }
 }
 
-const results: BenchResult[] = [];
+export function parseWebRtcHeartbeatCallbackChurnArguments(
+  arguments_: readonly string[],
+): RtcBaselineResult<
+  WebRtcHeartbeatCallbackChurnDiagnosticArguments | WebRtcHeartbeatCallbackChurnAcceptedArguments
+> {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedOptionNames : ['channels', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+}
 
-for (let run = 1; run <= RUNS; run++) {
-  const channels = Array.from({ length: CHANNELS }, () => new FakeHeartbeatChannel());
-  const start = performance.now();
+export function runWebRtcHeartbeatCallbackChurn(
+  input: WebRtcHeartbeatCallbackChurnInput,
+): WebRtcHeartbeatCallbackChurnResult {
+  const channels = Array.from({ length: input.channels }, () => new FakeHeartbeatChannel());
+  const startedAt = performance.now();
 
-  for (let index = 0; index < channels.length; index++) {
+  for (let index = 0; index < channels.length; index += 1) {
     const service = new WebRtcHeartbeatService({
       sessionId: `self-${index}`,
       peerSessionId: `peer-${index}`,
@@ -62,34 +123,252 @@ for (let run = 1; run <= RUNS; run++) {
     service.stop();
   }
 
-  const durationMs = performance.now() - start;
-  results.push({
-    run,
-    durationMs,
-    channelCount: CHANNELS,
+  return {
+    durationMs: performance.now() - startedAt,
+    channelCount: input.channels,
     retainedCallbacks: channels.reduce((sum, channel) => sum + channel.callbackCount(), 0),
     maxCallbacksPerChannel: Math.max(...channels.map((channel) => channel.callbackCount())),
+  };
+}
+
+export function runWebRtcHeartbeatCallbackChurnAcceptedSamples(input: {
+  readonly worker: WebRtcHeartbeatCallbackChurnAcceptedArguments;
+  readonly run: () =>
+    | WebRtcHeartbeatCallbackChurnResult
+    | Promise<WebRtcHeartbeatCallbackChurnResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: {
+      ...input.worker,
+      workloadId: 'RTC-B04',
+      caseId: 'heartbeat-callback-churn',
+      inputKey: 'fixed',
+    },
+    run: input.run,
+    validate: (result) => validateResult(input.worker.input, result),
+    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
   });
 }
 
-await Deno.writeTextFile(
-  OUT,
-  JSON.stringify(
-    {
-      createdAt: new Date().toISOString(),
-      input: {
-        channelCount: CHANNELS,
-        runs: RUNS,
-      },
-      results,
+function parseDiagnosticArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcHeartbeatCallbackChurnDiagnosticArguments> {
+  const channels = parseRtcBaselineBoundedInteger(
+    options.channels ?? '10000',
+    'channels',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
+  const issues = [...(!channels.ok ? channels.issues : []), ...(!runs.ok ? runs.issues : [])];
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'diagnostic',
+      input: { channels: channels.ok ? channels.value : 1 },
+      runs: runs.ok ? runs.value : 1,
+      out: options.out ?? 'tmp/perf/results/webrtc-heartbeat-callback-churn.json',
     },
-    null,
-    2,
-  ),
-);
-
-console.log(`Wrote ${OUT}`);
-
-function readArg(name: string): string | undefined {
-  return Deno.args.find((arg) => arg.startsWith(`${name}=`))?.slice(name.length + 1);
+  };
 }
+
+function parseAcceptedArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<WebRtcHeartbeatCallbackChurnAcceptedArguments> {
+  const channels = parseRtcBaselineBoundedInteger(
+    options['rtc-channels'] ?? '',
+    'rtc-channels',
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const intendedPhase = options['intended-phase'];
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const parsedChannels = channels.ok ? channels.value : acceptedChannels;
+  const issues = [
+    ...(!channels.ok ? channels.issues : []),
+    ...(!outerOrdinal.ok ? outerOrdinal.issues : []),
+    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
+    ...validateAcceptedArguments({
+      options,
+      channels: parsedChannels,
+      outerOrdinal,
+      intendedPhase,
+      sampleIds,
+    }),
+  ];
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: { channels: parsedChannels },
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: outerOrdinal.ok ? outerOrdinal.value : 1,
+      sampleIds,
+    },
+  };
+}
+
+function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B04',
+    'case-id': 'heartbeat-callback-churn',
+    'input-key': 'fixed',
+    'rtc-inner-runs': '5',
+    'rtc-channels': String(acceptedChannels),
+  };
+  const issues = Object.entries(expected).flatMap(([name, value]) =>
+    input.options[name] === value
+      ? []
+      : [rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)]
+  );
+  if (input.channels !== acceptedChannels) {
+    issues.push(rtcBaselineIssue('$.input', 'unexpected-worker-input', 'Expected fixed input.'));
+  }
+  if (
+    !input.outerOrdinal.ok ||
+    input.options['outer-ordinal'] !== String(input.outerOrdinal.value)
+  ) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.outer-ordinal',
+        'unexpected-worker-input',
+        'Expected canonical integer syntax.',
+      ),
+    );
+  }
+  if (input.intendedPhase !== 'warmup' && input.intendedPhase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
+  const ordinal = input.outerOrdinal.ok ? input.outerOrdinal.value : 1;
+  if (JSON.stringify(input.sampleIds) !== JSON.stringify(createExpectedSampleIds(phase, ordinal))) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues;
+}
+
+function createExpectedSampleIds(
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix = `rtc-b04-heartbeat-callback-churn-fixed-${intendedPhase}-${
+    String(outerOrdinal).padStart(3, '0')
+  }`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function validateResult(
+  input: WebRtcHeartbeatCallbackChurnInput,
+  result: WebRtcHeartbeatCallbackChurnResult,
+): RtcBaselineIssueDto[] {
+  const issues: RtcBaselineIssueDto[] = [];
+  if (result.channelCount !== input.channels || !Number.isSafeInteger(result.channelCount)) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.channelCount', 'input-mismatch', 'Unexpected input.'),
+    );
+  }
+  if (
+    !Number.isSafeInteger(result.retainedCallbacks) ||
+    !Number.isSafeInteger(result.maxCallbacksPerChannel) ||
+    result.retainedCallbacks !== 0 ||
+    result.maxCallbacksPerChannel !== 0
+  ) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rawEvidence.callbacks',
+        'callback-retention',
+        'Heartbeat callbacks must be removed.',
+      ),
+    );
+  }
+  if (!Number.isFinite(result.durationMs) || result.durationMs < 0) {
+    issues.push(
+      rtcBaselineIssue('$.rawEvidence.durationMs', 'invalid-timing', 'Expected nonnegative.'),
+    );
+  }
+  return issues;
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: WebRtcHeartbeatCallbackChurnResult | null,
+  issues: readonly RtcBaselineIssueDto[],
+): RtcBaselineSampleDto {
+  if (result === null) {
+    return {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity,
+      outcome: 'not-run',
+      evidenceClass: 'synthetic-path',
+      metrics: [],
+      rawEvidence: null,
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    };
+  }
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
+      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
+      : [],
+    rawEvidence: toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function toRawEvidence(result: WebRtcHeartbeatCallbackChurnResult): RtcBaselineJson {
+  return {
+    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    channelCount: result.channelCount,
+    retainedCallbacks: result.retainedCallbacks,
+    maxCallbacksPerChannel: result.maxCallbacksPerChannel,
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseWebRtcHeartbeatCallbackChurnArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  if (parsed.value.mode === 'accepted') {
+    const worker = parsed.value;
+    console.log(
+      JSON.stringify(
+        await runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+          worker,
+          run: () => runWebRtcHeartbeatCallbackChurn(worker.input),
+        }),
+      ),
+    );
+    return;
+  }
+  const diagnostic = parsed.value;
+  const results = [];
+  for (let run = 1; run <= diagnostic.runs; run += 1) {
+    results.push({ run, ...runWebRtcHeartbeatCallbackChurn(diagnostic.input) });
+  }
+  const output = {
+    createdAt: new Date().toISOString(),
+    input: { channelCount: diagnostic.input.channels, runs: diagnostic.runs },
+    results,
+  };
+  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
+  await Deno.writeTextFile(diagnostic.out, JSON.stringify(output, null, 2));
+  console.log(`Wrote ${diagnostic.out}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
@@ -9,10 +9,7 @@ import {
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
-import {
-  parseRtcBaselineBoundedInteger,
-  parseRtcBaselineOneTokenOptions,
-} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { parseRtcBaselineBoundedInteger } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import {
   parseRtcBaselineAcceptedWorker,
   type RtcBaselineAcceptedWorker,
@@ -85,14 +82,7 @@ export function parseWebRtcHeartbeatCallbackChurnArguments(
       parseCapability: parseAcceptedCapability,
     });
   }
-  const parsed = parseRtcBaselineOneTokenOptions(
-    arguments_,
-    ['channels', 'runs', 'out'],
-  );
-  if (!parsed.ok) {
-    return parsed;
-  }
-  return parseDiagnosticArguments(parsed.value);
+  return { ok: true, value: parseDiagnosticArguments(arguments_) };
 }
 
 export function runWebRtcHeartbeatCallbackChurn(
@@ -140,25 +130,29 @@ export function runWebRtcHeartbeatCallbackChurnAcceptedSamples(input: {
 }
 
 function parseDiagnosticArguments(
-  options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcHeartbeatCallbackChurnDiagnosticArguments> {
-  const channels = parseRtcBaselineBoundedInteger(
-    options.channels ?? '10000',
-    'channels',
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const runs = parseRtcBaselineBoundedInteger(options.runs ?? '5', 'runs', 1, 5);
-  const issues = [...(!channels.ok ? channels.issues : []), ...(!runs.ok ? runs.issues : [])];
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'diagnostic',
-      input: { channels: channels.ok ? channels.value : 1 },
-      runs: runs.ok ? runs.value : 1,
-      out: options.out ?? 'tmp/perf/results/webrtc-heartbeat-callback-churn.json',
+  arguments_: readonly string[],
+): WebRtcHeartbeatCallbackChurnDiagnosticArguments {
+  return {
+    mode: 'diagnostic',
+    input: {
+      channels: Number(readDiagnosticArgument(arguments_, '--channels', '10000')),
     },
+    runs: Number(readDiagnosticArgument(arguments_, '--runs', '5')),
+    out: readDiagnosticArgument(
+      arguments_,
+      '--out',
+      'tmp/perf/results/webrtc-heartbeat-callback-churn.json',
+    ),
   };
+}
+
+function readDiagnosticArgument(
+  arguments_: readonly string[],
+  name: string,
+  fallback: string,
+): string {
+  return arguments_.find((argument) => argument.startsWith(`${name}=`))?.slice(name.length + 1) ??
+    fallback;
 }
 
 function parseAcceptedCapability(

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-heartbeat-callback-churn-bench.ts
@@ -8,16 +8,17 @@ import {
   type RtcBaselineJson,
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
-  type RtcBaselineSampleIdentityDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   parseRtcBaselineBoundedInteger,
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
-import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
 import {
-  runRtcBaselineAcceptedWorkerSamples,
-} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 interface CallbackDto {
   readonly onMessage: (data: unknown) => Promise<void>;
@@ -34,14 +35,6 @@ interface WebRtcHeartbeatCallbackChurnDiagnosticArguments {
   readonly out: string;
 }
 
-export interface WebRtcHeartbeatCallbackChurnAcceptedArguments {
-  readonly mode: 'accepted';
-  readonly input: WebRtcHeartbeatCallbackChurnInput;
-  readonly intendedPhase: 'warmup' | 'retained';
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
-}
-
 export interface WebRtcHeartbeatCallbackChurnResult {
   readonly durationMs: number;
   readonly channelCount: number;
@@ -49,18 +42,6 @@ export interface WebRtcHeartbeatCallbackChurnResult {
   readonly maxCallbacksPerChannel: number;
 }
 
-interface ValidateAcceptedArgumentsInput {
-  readonly options: Readonly<Record<string, string>>;
-  readonly channels: number;
-  readonly outerOrdinal: RtcBaselineResult<number>;
-  readonly intendedPhase: string | undefined;
-  readonly sampleIds: readonly string[];
-}
-
-const acceptedOptionNames = (
-  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
-  'rtc-inner-runs rtc-channels'
-).split(' ');
 const acceptedChannels = 10000;
 
 class FakeHeartbeatChannel {
@@ -91,15 +72,27 @@ class FakeHeartbeatChannel {
 export function parseWebRtcHeartbeatCallbackChurnArguments(
   arguments_: readonly string[],
 ): RtcBaselineResult<
-  WebRtcHeartbeatCallbackChurnDiagnosticArguments | WebRtcHeartbeatCallbackChurnAcceptedArguments
+  | WebRtcHeartbeatCallbackChurnDiagnosticArguments
+  | RtcBaselineAcceptedWorker<WebRtcHeartbeatCallbackChurnInput>
 > {
   const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  if (accepted) {
+    return parseRtcBaselineAcceptedWorker({
+      arguments_,
+      identity: { workloadId: 'RTC-B04', caseId: 'heartbeat-callback-churn' },
+      toInputKey: () => 'fixed',
+      capabilityOptionNames: ['rtc-channels'],
+      parseCapability: parseAcceptedCapability,
+    });
+  }
   const parsed = parseRtcBaselineOneTokenOptions(
     arguments_,
-    accepted ? acceptedOptionNames : ['channels', 'runs', 'out'],
+    ['channels', 'runs', 'out'],
   );
-  if (!parsed.ok) return parsed;
-  return accepted ? parseAcceptedArguments(parsed.value) : parseDiagnosticArguments(parsed.value);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  return parseDiagnosticArguments(parsed.value);
 }
 
 export function runWebRtcHeartbeatCallbackChurn(
@@ -132,21 +125,17 @@ export function runWebRtcHeartbeatCallbackChurn(
 }
 
 export function runWebRtcHeartbeatCallbackChurnAcceptedSamples(input: {
-  readonly worker: WebRtcHeartbeatCallbackChurnAcceptedArguments;
+  readonly worker: RtcBaselineAcceptedWorker<WebRtcHeartbeatCallbackChurnInput>;
   readonly run: () =>
     | WebRtcHeartbeatCallbackChurnResult
     | Promise<WebRtcHeartbeatCallbackChurnResult>;
 }): Promise<RtcBaselineSampleDto[]> {
-  return runRtcBaselineAcceptedWorkerSamples({
-    worker: {
-      ...input.worker,
-      workloadId: 'RTC-B04',
-      caseId: 'heartbeat-callback-churn',
-      inputKey: 'fixed',
-    },
+  return runRtcBaselineAcceptedWorker({
+    worker: input.worker,
     run: input.run,
     validate: (result) => validateResult(input.worker.input, result),
-    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+    metrics: (result) => [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }],
+    rawEvidence: toRawEvidence,
   });
 }
 
@@ -172,99 +161,24 @@ function parseDiagnosticArguments(
   };
 }
 
-function parseAcceptedArguments(
+function parseAcceptedCapability(
   options: Readonly<Record<string, string>>,
-): RtcBaselineResult<WebRtcHeartbeatCallbackChurnAcceptedArguments> {
+): RtcBaselineResult<WebRtcHeartbeatCallbackChurnInput> {
   const channels = parseRtcBaselineBoundedInteger(
     options['rtc-channels'] ?? '',
     'rtc-channels',
     1,
     Number.MAX_SAFE_INTEGER,
   );
-  const outerOrdinal = parseRtcBaselineBoundedInteger(
-    options['outer-ordinal'] ?? '',
-    'outer-ordinal',
-    1,
-    999,
-  );
-  const intendedPhase = options['intended-phase'];
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
-  const parsedChannels = channels.ok ? channels.value : acceptedChannels;
   const issues = [
     ...(!channels.ok ? channels.issues : []),
-    ...(!outerOrdinal.ok ? outerOrdinal.issues : []),
-    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
-    ...validateAcceptedArguments({
-      options,
-      channels: parsedChannels,
-      outerOrdinal,
-      intendedPhase,
-      sampleIds,
-    }),
-  ];
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'accepted',
-      input: { channels: parsedChannels },
-      intendedPhase: intendedPhase as 'warmup' | 'retained',
-      outerOrdinal: outerOrdinal.ok ? outerOrdinal.value : 1,
-      sampleIds,
-    },
-  };
-}
-
-function validateAcceptedArguments(input: ValidateAcceptedArgumentsInput): RtcBaselineIssueDto[] {
-  const expected = {
-    capture: 'worker',
-    workload: 'RTC-B04',
-    'case-id': 'heartbeat-callback-churn',
-    'input-key': 'fixed',
-    'rtc-inner-runs': '5',
-    'rtc-channels': String(acceptedChannels),
-  };
-  const issues = Object.entries(expected).flatMap(([name, value]) =>
-    input.options[name] === value
+    ...(options['rtc-channels'] === String(acceptedChannels)
       ? []
-      : [rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${value}.`)]
-  );
-  if (input.channels !== acceptedChannels) {
-    issues.push(rtcBaselineIssue('$.input', 'unexpected-worker-input', 'Expected fixed input.'));
-  }
-  if (
-    !input.outerOrdinal.ok ||
-    input.options['outer-ordinal'] !== String(input.outerOrdinal.value)
-  ) {
-    issues.push(
-      rtcBaselineIssue(
-        '$.outer-ordinal',
-        'unexpected-worker-input',
-        'Expected canonical integer syntax.',
-      ),
-    );
-  }
-  if (input.intendedPhase !== 'warmup' && input.intendedPhase !== 'retained') {
-    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
-  }
-  const phase = input.intendedPhase === 'warmup' ? 'warmup' : 'retained';
-  const ordinal = input.outerOrdinal.ok ? input.outerOrdinal.value : 1;
-  if (JSON.stringify(input.sampleIds) !== JSON.stringify(createExpectedSampleIds(phase, ordinal))) {
-    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
-  }
-  return issues;
-}
-
-function createExpectedSampleIds(
-  intendedPhase: 'warmup' | 'retained',
-  outerOrdinal: number,
-): string[] {
-  const prefix = `rtc-b04-heartbeat-callback-churn-fixed-${intendedPhase}-${
-    String(outerOrdinal).padStart(3, '0')
-  }`;
-  return Array.from(
-    { length: 5 },
-    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
-  );
+      : [rtcBaselineIssue('$.rtc-channels', 'unexpected-worker-input', 'Expected 10000.')]),
+  ];
+  return issues.length > 0
+    ? { ok: false, issues }
+    : { ok: true, value: { channels: acceptedChannels } };
 }
 
 function validateResult(
@@ -299,42 +213,9 @@ function validateResult(
   return issues;
 }
 
-function createSample(
-  identity: RtcBaselineSampleIdentityDto,
-  result: WebRtcHeartbeatCallbackChurnResult | null,
-  issues: readonly RtcBaselineIssueDto[],
-): RtcBaselineSampleDto {
-  if (result === null) {
-    return {
-      schema: 'rallar.rtc-baseline.sample.v1',
-      identity,
-      outcome: 'not-run',
-      evidenceClass: 'synthetic-path',
-      metrics: [],
-      rawEvidence: null,
-      rawReferences: [],
-      issues,
-      runtimeObservation: null,
-    };
-  }
-  return {
-    schema: 'rallar.rtc-baseline.sample.v1',
-    identity,
-    outcome: issues.length === 0 ? 'passed' : 'failed',
-    evidenceClass: 'synthetic-path',
-    metrics: Number.isFinite(result.durationMs) && result.durationMs >= 0
-      ? [{ metric: 'durationMs', unit: 'ms', value: result.durationMs }]
-      : [],
-    rawEvidence: toRawEvidence(result),
-    rawReferences: [],
-    issues,
-    runtimeObservation: null,
-  };
-}
-
 function toRawEvidence(result: WebRtcHeartbeatCallbackChurnResult): RtcBaselineJson {
   return {
-    durationMs: Number.isFinite(result.durationMs) ? result.durationMs : null,
+    durationMs: result.durationMs,
     channelCount: result.channelCount,
     retainedCallbacks: result.retainedCallbacks,
     maxCallbacksPerChannel: result.maxCallbacksPerChannel,
@@ -343,20 +224,22 @@ function toRawEvidence(result: WebRtcHeartbeatCallbackChurnResult): RtcBaselineJ
 
 async function main(): Promise<void> {
   const parsed = parseWebRtcHeartbeatCallbackChurnArguments(Deno.args);
-  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
-  if (parsed.value.mode === 'accepted') {
-    const worker = parsed.value;
-    console.log(
-      JSON.stringify(
-        await runWebRtcHeartbeatCallbackChurnAcceptedSamples({
-          worker,
-          run: () => runWebRtcHeartbeatCallbackChurn(worker.input),
-        }),
-      ),
-    );
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.issues));
+  }
+  const dispatched = await runRtcBaselineAcceptedWorkerCli({
+    parsed: parsed.value,
+    runAccepted: (worker) =>
+      runWebRtcHeartbeatCallbackChurnAcceptedSamples({
+        worker,
+        run: () => runWebRtcHeartbeatCallbackChurn(worker.input),
+      }),
+    writeOutput: (output) => console.log(output),
+  });
+  if (dispatched.handled) {
     return;
   }
-  const diagnostic = parsed.value;
+  const diagnostic = dispatched.diagnostic;
   const results = [];
   for (let run = 1; run <= diagnostic.runs; run += 1) {
     results.push({ run, ...runWebRtcHeartbeatCallbackChurn(diagnostic.input) });
@@ -371,4 +254,6 @@ async function main(): Promise<void> {
   console.log(`Wrote ${diagnostic.out}`);
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -8,17 +8,17 @@ import {
   type RtcBaselineJson,
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
-  type RtcBaselineSampleIdentityDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   parseRtcBaselineBoundedInteger,
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
-import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
 import {
-  runRtcBaselineAcceptedWorkerSamples,
-} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+  parseRtcBaselineAcceptedWorker,
+  type RtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorker,
+  runRtcBaselineAcceptedWorkerCli,
+} from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 export interface RtcMulticastSerializationInput {
   readonly peers: 10 | 100 | 1000;
@@ -31,14 +31,6 @@ interface RtcMulticastSerializationDiagnosticArguments {
   readonly payloadBytes: readonly number[];
   readonly runs: number;
   readonly out: string;
-}
-
-interface RtcMulticastSerializationAcceptedArguments {
-  readonly mode: 'accepted';
-  readonly input: RtcMulticastSerializationInput;
-  readonly intendedPhase: 'warmup' | 'retained';
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
 }
 
 export interface RtcMulticastSerializationResult {
@@ -54,40 +46,47 @@ export interface RtcMulticastSerializationResult {
   readonly allTransportMessagesIdentical: boolean;
 }
 
-interface CreateRtcMulticastIssueInput {
+interface RtcMulticastValidationRule {
   readonly valid: boolean;
   readonly path: string;
   readonly code: string;
   readonly message: string;
 }
 
-interface ValidateAcceptedPhaseAndIdsInput {
-  readonly options: Readonly<Record<string, string>>;
-  readonly input: RtcMulticastSerializationInput;
-  readonly intendedPhase: string | undefined;
-  readonly outerOrdinal: number;
-  readonly sampleIds: readonly string[];
+interface RtcMulticastPayload {
+  readonly text: string;
+  readonly createdAtEpochMs: number;
 }
 
-const acceptedNames = (
-  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
-  'rtc-peers rtc-payload-bytes rtc-inner-runs'
-).split(' ');
 const frozenPeerCounts = new Set<number>([10, 100, 1000]);
 const frozenPayloadBytes = new Set<number>([4096, 65536]);
 
 export function parseRtcMulticastSerializationArguments(
   arguments_: readonly string[],
 ): RtcBaselineResult<
-  RtcMulticastSerializationDiagnosticArguments | RtcMulticastSerializationAcceptedArguments
+  | RtcMulticastSerializationDiagnosticArguments
+  | RtcBaselineAcceptedWorker<RtcMulticastSerializationInput>
 > {
   const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  if (accepted) {
+    return parseRtcBaselineAcceptedWorker({
+      arguments_,
+      identity: {
+        workloadId: 'RTC-B04',
+        caseId: 'multicast-serialization',
+      },
+      toInputKey: (input) => `peers-${input.peers}-payload-${input.payloadBytes}`,
+      capabilityOptionNames: ['rtc-peers', 'rtc-payload-bytes'],
+      parseCapability: parseAcceptedCapability,
+    });
+  }
   const parsed = parseRtcBaselineOneTokenOptions(
     arguments_,
-    accepted ? acceptedNames : ['peer-counts', 'payload-bytes', 'runs', 'out'],
+    ['peer-counts', 'payload-bytes', 'runs', 'out'],
   );
-  if (!parsed.ok) return parsed;
-  if (accepted) return parseAcceptedArguments(parsed.value);
+  if (!parsed.ok) {
+    return parsed;
+  }
   return parseDiagnosticArguments(parsed.value);
 }
 
@@ -145,20 +144,16 @@ export function runRtcMulticastSerialization(
   };
 }
 
-export async function runRtcMulticastSerializationAcceptedSamples(input: {
-  readonly worker: RtcMulticastSerializationAcceptedArguments;
+export function runRtcMulticastSerializationAcceptedSamples(input: {
+  readonly worker: RtcBaselineAcceptedWorker<RtcMulticastSerializationInput>;
   readonly run: () => RtcMulticastSerializationResult | Promise<RtcMulticastSerializationResult>;
 }): Promise<RtcBaselineSampleDto[]> {
-  return runRtcBaselineAcceptedWorkerSamples({
-    worker: {
-      ...input.worker,
-      workloadId: 'RTC-B04',
-      caseId: 'multicast-serialization',
-      inputKey: `peers-${input.worker.input.peers}-payload-${input.worker.input.payloadBytes}`,
-    },
+  return runRtcBaselineAcceptedWorker({
+    worker: input.worker,
     run: input.run,
     validate: (result) => validateResult(input.worker.input, result),
-    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+    metrics: createMetrics,
+    rawEvidence: toRawEvidence,
   });
 }
 
@@ -169,14 +164,20 @@ function parseDiagnosticArguments(
     readOption(options, 'peer-counts', '10,100,1000'),
     'peer-counts',
   );
-  if (!peerCounts.ok) return peerCounts;
+  if (!peerCounts.ok) {
+    return peerCounts;
+  }
   const payloadBytes = parseDiagnosticPositiveIntegers(
     readOption(options, 'payload-bytes', '4096,65536'),
     'payload-bytes',
   );
-  if (!payloadBytes.ok) return payloadBytes;
+  if (!payloadBytes.ok) {
+    return payloadBytes;
+  }
   const runs = parseRtcBaselineBoundedInteger(readOption(options, 'runs', '3'), 'runs', 1, 5);
-  if (!runs.ok) return runs;
+  if (!runs.ok) {
+    return runs;
+  }
   return {
     ok: true as const,
     value: {
@@ -193,36 +194,9 @@ function readOption(options: Readonly<Record<string, string>>, name: string, fal
   return options[name] ?? fallback;
 }
 
-function parseAcceptedArguments(
+function parseAcceptedCapability(
   options: Readonly<Record<string, string>>,
-): RtcBaselineResult<RtcMulticastSerializationAcceptedArguments> {
-  const numeric = parseAcceptedNumericInput(options);
-  const phase = options['intended-phase'];
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
-  const issues = [
-    ...numeric.issues,
-    ...validateAcceptedFixedFields(options, numeric.input),
-    ...validateAcceptedPhaseAndIds({
-      options,
-      input: numeric.input,
-      intendedPhase: phase,
-      outerOrdinal: numeric.outerOrdinal,
-      sampleIds,
-    }),
-  ];
-  return issues.length > 0 ? { ok: false, issues } : {
-    ok: true,
-    value: {
-      mode: 'accepted',
-      input: numeric.input,
-      intendedPhase: phase as 'warmup' | 'retained',
-      outerOrdinal: numeric.outerOrdinal,
-      sampleIds,
-    },
-  };
-}
-
-function parseAcceptedNumericInput(options: Readonly<Record<string, string>>) {
+): RtcBaselineResult<RtcMulticastSerializationInput> {
   const peers = parseRtcBaselineBoundedInteger(options['rtc-peers'] ?? '', 'rtc-peers', 10, 1000);
   const payloadBytes = parseRtcBaselineBoundedInteger(
     options['rtc-payload-bytes'] ?? '',
@@ -230,17 +204,9 @@ function parseAcceptedNumericInput(options: Readonly<Record<string, string>>) {
     4096,
     65536,
   );
-  const outerOrdinal = parseRtcBaselineBoundedInteger(
-    options['outer-ordinal'] ?? '',
-    'outer-ordinal',
-    1,
-    999,
-  );
   const issues = [
     ...(!peers.ok ? peers.issues : []),
     ...(!payloadBytes.ok ? payloadBytes.issues : []),
-    ...(!outerOrdinal.ok ? outerOrdinal.issues : []),
-    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
   ];
   if (peers.ok && !frozenPeerCounts.has(peers.value)) {
     issues.push(
@@ -252,60 +218,34 @@ function parseAcceptedNumericInput(options: Readonly<Record<string, string>>) {
       rtcBaselineIssue('$.rtc-payload-bytes', 'unexpected-worker-input', 'Expected 4096 or 65536.'),
     );
   }
-
-  return {
-    issues,
-    input: {
-      peers: (peers.ok ? peers.value : 10) as 10 | 100 | 1000,
-      payloadBytes: (payloadBytes.ok ? payloadBytes.value : 4096) as 4096 | 65536,
-    },
-    outerOrdinal: outerOrdinal.ok ? outerOrdinal.value : 1,
-  };
-}
-
-function validateAcceptedFixedFields(
-  options: Readonly<Record<string, string>>,
-  input: RtcMulticastSerializationInput,
-) {
-  const expected = {
-    capture: 'worker',
-    workload: 'RTC-B04',
-    'case-id': 'multicast-serialization',
-    'input-key': `peers-${input.peers}-payload-${input.payloadBytes}`,
-    'rtc-peers': String(input.peers),
-    'rtc-payload-bytes': String(input.payloadBytes),
-    'rtc-inner-runs': '5',
-  };
-  return Object.entries(expected).flatMap(([name, expectedValue]) =>
-    options[name] === expectedValue
-      ? []
-      : [rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${expectedValue}.`)]
-  );
-}
-
-function validateAcceptedPhaseAndIds(input: ValidateAcceptedPhaseAndIdsInput) {
-  const issues = [];
-  if (input.options['outer-ordinal'] !== String(input.outerOrdinal)) {
+  if (peers.ok && options['rtc-peers'] !== String(peers.value)) {
     issues.push(
       rtcBaselineIssue(
-        '$.outer-ordinal',
+        '$.rtc-peers',
         'unexpected-worker-input',
         'Expected canonical integer syntax.',
       ),
     );
   }
-  if (input.intendedPhase !== 'warmup' && input.intendedPhase !== 'retained') {
-    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  if (payloadBytes.ok && options['rtc-payload-bytes'] !== String(payloadBytes.value)) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.rtc-payload-bytes',
+        'unexpected-worker-input',
+        'Expected canonical integer syntax.',
+      ),
+    );
   }
-  const expectedSampleIds = createExpectedSampleIds(
-    input.input,
-    input.intendedPhase === 'warmup' ? input.intendedPhase : 'retained',
-    input.outerOrdinal,
-  );
-  if (JSON.stringify(input.sampleIds) !== JSON.stringify(expectedSampleIds)) {
-    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  if (issues.length > 0) {
+    return { ok: false, issues };
   }
-  return issues;
+  return {
+    ok: true,
+    value: {
+      peers: peers.ok ? peers.value as 10 | 100 | 1000 : 10,
+      payloadBytes: payloadBytes.ok ? payloadBytes.value as 4096 | 65536 : 4096,
+    },
+  };
 }
 
 function parseDiagnosticPositiveIntegers(
@@ -322,20 +262,6 @@ function parseDiagnosticPositiveIntegers(
   return issues.length > 0
     ? { ok: false as const, issues }
     : { ok: true as const, value: values.map((entry) => Number(entry)) };
-}
-
-function createExpectedSampleIds(
-  input: RtcMulticastSerializationInput,
-  intendedPhase: 'warmup' | 'retained',
-  outerOrdinal: number,
-): string[] {
-  const prefix =
-    `rtc-b04-multicast-serialization-peers-${input.peers}-payload-${input.payloadBytes}-` +
-    `${intendedPhase}-${String(outerOrdinal).padStart(3, '0')}`;
-  return Array.from(
-    { length: 5 },
-    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
-  );
 }
 
 function validateResult(
@@ -399,52 +325,21 @@ function areExactByteCounts(result: RtcMulticastSerializationResult) {
     result.totalSerializedBytes >= result.originalSerializedBytes * result.transportMessages;
 }
 
-function createIssueWhen(input: CreateRtcMulticastIssueInput) {
+function createIssueWhen(input: RtcMulticastValidationRule) {
   return input.valid ? [] : [rtcBaselineIssue(input.path, input.code, input.message)];
-}
-
-function createSample(
-  identity: RtcBaselineSampleIdentityDto,
-  result: RtcMulticastSerializationResult | null,
-  issues: RtcBaselineSampleDto['issues'],
-): RtcBaselineSampleDto {
-  if (result === null) {
-    return {
-      schema: 'rallar.rtc-baseline.sample.v1',
-      identity,
-      outcome: 'not-run',
-      evidenceClass: 'synthetic-path',
-      metrics: [],
-      rawEvidence: null,
-      rawReferences: [],
-      issues,
-      runtimeObservation: null,
-    };
-  }
-  return {
-    schema: 'rallar.rtc-baseline.sample.v1',
-    identity,
-    outcome: issues.length === 0 ? 'passed' : 'failed',
-    evidenceClass: 'synthetic-path',
-    metrics: createMetrics(result),
-    rawEvidence: toRawEvidence(result),
-    rawReferences: [],
-    issues,
-    runtimeObservation: null,
-  };
 }
 
 function toRawEvidence(result: RtcMulticastSerializationResult): RtcBaselineJson {
   return {
-    peerCount: toJsonNumber(result.peerCount),
-    payloadBytes: toJsonNumber(result.payloadBytes),
-    planDurationMs: toJsonNumber(result.planDurationMs),
-    serializeDurationMs: toJsonNumber(result.serializeDurationMs),
-    originalSerializeDurationMs: toJsonNumber(result.originalSerializeDurationMs),
-    transportMessages: toJsonNumber(result.transportMessages),
-    uniqueSerializedMessages: toJsonNumber(result.uniqueSerializedMessages),
-    totalSerializedBytes: toJsonNumber(result.totalSerializedBytes),
-    originalSerializedBytes: toJsonNumber(result.originalSerializedBytes),
+    peerCount: result.peerCount,
+    payloadBytes: result.payloadBytes,
+    planDurationMs: result.planDurationMs,
+    serializeDurationMs: result.serializeDurationMs,
+    originalSerializeDurationMs: result.originalSerializeDurationMs,
+    transportMessages: result.transportMessages,
+    uniqueSerializedMessages: result.uniqueSerializedMessages,
+    totalSerializedBytes: result.totalSerializedBytes,
+    originalSerializedBytes: result.originalSerializedBytes,
     allTransportMessagesIdentical: result.allTransportMessagesIdentical,
   };
 }
@@ -455,13 +350,7 @@ function createMetrics(result: RtcMulticastSerializationResult) {
     ['originalSerializeDurationMs', result.originalSerializeDurationMs],
     ['serializeDurationMs', result.serializeDurationMs],
   ];
-  return timedMeasurements.flatMap(([metric, value]) =>
-    typeof value === 'number' && Number.isFinite(value) ? [{ metric, unit: 'ms', value }] : []
-  );
-}
-
-function toJsonNumber(value: number): number | null {
-  return Number.isFinite(value) ? value : null;
+  return timedMeasurements.map(([metric, value]) => ({ metric, unit: 'ms', value }));
 }
 
 function createConnectionService(peerIds: readonly string[]) {
@@ -530,7 +419,7 @@ function createOverlayContext(peerIds: readonly string[]) {
   };
 }
 
-function createPayload(payloadBytes: number) {
+function createPayload(payloadBytes: number): RtcMulticastPayload {
   return { text: 'x'.repeat(payloadBytes), createdAtEpochMs: 1 };
 }
 
@@ -543,17 +432,22 @@ function createPeerIds(peerCount: number): readonly string[] {
 
 async function main(): Promise<void> {
   const parsed = parseRtcMulticastSerializationArguments(Deno.args);
-  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
-  if (parsed.value.mode === 'accepted') {
-    const worker = parsed.value;
-    const samples = await runRtcMulticastSerializationAcceptedSamples({
-      worker,
-      run: () => runRtcMulticastSerialization(worker.input),
-    });
-    console.log(JSON.stringify(samples));
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.issues));
+  }
+  const dispatched = await runRtcBaselineAcceptedWorkerCli({
+    parsed: parsed.value,
+    runAccepted: (worker) =>
+      runRtcMulticastSerializationAcceptedSamples({
+        worker,
+        run: () => runRtcMulticastSerialization(worker.input),
+      }),
+    writeOutput: (output) => console.log(output),
+  });
+  if (dispatched.handled) {
     return;
   }
-  const diagnostic = parsed.value;
+  const diagnostic = dispatched.diagnostic;
   const results = [];
   const diagnosticInputs = diagnostic.peerCounts.flatMap((peerCount) =>
     diagnostic.payloadBytes.map((payloadBytes) => ({ peerCount, payloadBytes }))
@@ -581,4 +475,6 @@ async function main(): Promise<void> {
   console.log(JSON.stringify(output, null, 2));
 }
 
-if (import.meta.main) await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -1,6 +1,7 @@
+import { dirname } from 'node:path';
+
 import { newALMulticastMessage } from '@shared/al-contracts/al-contract.ts';
 import { WebRtcOverlayMulticastService } from '@shared/multicast/WebRtcOverlayMulticastService.ts';
-import { dirname } from 'node:path';
 
 import {
   rtcBaselineIssue,

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -1,5 +1,6 @@
 import { newALMulticastMessage } from '@shared/al-contracts/al-contract.ts';
 import { WebRtcOverlayMulticastService } from '@shared/multicast/WebRtcOverlayMulticastService.ts';
+import { dirname } from 'node:path';
 
 import {
   rtcBaselineIssue,
@@ -345,16 +346,21 @@ function validateResult(
       message: 'Expected distinct serialized transport messages.',
     }),
     ...createIssueWhen({
-      valid: Math.min(
-        result.originalSerializedBytes - 1,
-        result.totalSerializedBytes - result.originalSerializedBytes * result.transportMessages,
-      ) >= 0,
+      valid: areExactByteCounts(result),
       path: '$.rawEvidence.bytes',
       code: 'byte-evidence-mismatch',
       message: 'Unexpected bytes.',
     }),
     ...timingIssues,
   ];
+}
+
+function areExactByteCounts(result: RtcMulticastSerializationResult) {
+  return [result.originalSerializedBytes, result.totalSerializedBytes].every(
+    Number.isSafeInteger,
+  ) &&
+    result.originalSerializedBytes > 0 &&
+    result.totalSerializedBytes >= result.originalSerializedBytes * result.transportMessages;
 }
 
 function createIssueWhen(input: CreateRtcMulticastIssueInput) {
@@ -384,15 +390,7 @@ function createSample(
     identity,
     outcome: issues.length === 0 ? 'passed' : 'failed',
     evidenceClass: 'synthetic-path',
-    metrics: [
-      { metric: 'planDurationMs', unit: 'ms', value: result.planDurationMs },
-      {
-        metric: 'originalSerializeDurationMs',
-        unit: 'ms',
-        value: result.originalSerializeDurationMs,
-      },
-      { metric: 'serializeDurationMs', unit: 'ms', value: result.serializeDurationMs },
-    ],
+    metrics: createMetrics(result),
     rawEvidence: toRawEvidence(result),
     rawReferences: [],
     issues,
@@ -402,17 +400,32 @@ function createSample(
 
 function toRawEvidence(result: RtcMulticastSerializationResult): RtcBaselineJson {
   return {
-    peerCount: result.peerCount,
-    payloadBytes: result.payloadBytes,
-    planDurationMs: result.planDurationMs,
-    serializeDurationMs: result.serializeDurationMs,
-    originalSerializeDurationMs: result.originalSerializeDurationMs,
-    transportMessages: result.transportMessages,
-    uniqueSerializedMessages: result.uniqueSerializedMessages,
-    totalSerializedBytes: result.totalSerializedBytes,
-    originalSerializedBytes: result.originalSerializedBytes,
+    peerCount: toJsonNumber(result.peerCount),
+    payloadBytes: toJsonNumber(result.payloadBytes),
+    planDurationMs: toJsonNumber(result.planDurationMs),
+    serializeDurationMs: toJsonNumber(result.serializeDurationMs),
+    originalSerializeDurationMs: toJsonNumber(result.originalSerializeDurationMs),
+    transportMessages: toJsonNumber(result.transportMessages),
+    uniqueSerializedMessages: toJsonNumber(result.uniqueSerializedMessages),
+    totalSerializedBytes: toJsonNumber(result.totalSerializedBytes),
+    originalSerializedBytes: toJsonNumber(result.originalSerializedBytes),
     allTransportMessagesIdentical: result.allTransportMessagesIdentical,
   };
+}
+
+function createMetrics(result: RtcMulticastSerializationResult) {
+  const timedMeasurements: readonly [string, number][] = [
+    ['planDurationMs', result.planDurationMs],
+    ['originalSerializeDurationMs', result.originalSerializeDurationMs],
+    ['serializeDurationMs', result.serializeDurationMs],
+  ];
+  return timedMeasurements.flatMap(([metric, value]) =>
+    typeof value === 'number' && Number.isFinite(value) ? [{ metric, unit: 'ms', value }] : []
+  );
+}
+
+function toJsonNumber(value: number): number | null {
+  return Number.isFinite(value) ? value : null;
 }
 
 function createConnectionService(peerIds: readonly string[]) {
@@ -527,6 +540,7 @@ async function main(): Promise<void> {
     runs: diagnostic.runs,
     results,
   };
+  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
   await Deno.writeTextFile(diagnostic.out, `${JSON.stringify(output, null, 2)}\n`);
   console.log(JSON.stringify(output, null, 2));
 }

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -1,3 +1,4 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { newALMulticastMessage } from '@shared/al-contracts/al-contract.ts';
@@ -9,10 +10,7 @@ import {
   type RtcBaselineResult,
   type RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
-import {
-  parseRtcBaselineBoundedInteger,
-  parseRtcBaselineOneTokenOptions,
-} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { parseRtcBaselineBoundedInteger } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import {
   parseRtcBaselineAcceptedWorker,
   type RtcBaselineAcceptedWorker,
@@ -21,8 +19,8 @@ import {
 } from '../../baseline/acceptance/rtc-baseline-worker-protocol.ts';
 
 export interface RtcMulticastSerializationInput {
-  readonly peers: 10 | 100 | 1000;
-  readonly payloadBytes: 4096 | 65536;
+  readonly peers: number;
+  readonly payloadBytes: number;
 }
 
 interface RtcMulticastSerializationDiagnosticArguments {
@@ -80,18 +78,12 @@ export function parseRtcMulticastSerializationArguments(
       parseCapability: parseAcceptedCapability,
     });
   }
-  const parsed = parseRtcBaselineOneTokenOptions(
-    arguments_,
-    ['peer-counts', 'payload-bytes', 'runs', 'out'],
-  );
-  if (!parsed.ok) {
-    return parsed;
-  }
-  return parseDiagnosticArguments(parsed.value);
+  return { ok: true, value: parseDiagnosticArguments(arguments_) };
 }
 
 export function runRtcMulticastSerialization(
   input: RtcMulticastSerializationInput,
+  run = 1,
 ): RtcMulticastSerializationResult {
   const peerIds = createPeerIds(input.peers);
   const service = new WebRtcOverlayMulticastService(
@@ -102,7 +94,7 @@ export function runRtcMulticastSerialization(
     'self',
     {
       topicId: 'chat',
-      resourceId: `msg-${input.peers}-${input.payloadBytes}`,
+      resourceId: `msg-${input.peers}-${input.payloadBytes}-${run}`,
       contextId: 'group-1',
     },
     { applicationId: 'app-1', workspaceId: 'workspace-1', groupId: 'group-1' },
@@ -146,11 +138,14 @@ export function runRtcMulticastSerialization(
 
 export function runRtcMulticastSerializationAcceptedSamples(input: {
   readonly worker: RtcBaselineAcceptedWorker<RtcMulticastSerializationInput>;
-  readonly run: () => RtcMulticastSerializationResult | Promise<RtcMulticastSerializationResult>;
+  readonly run: (
+    innerOrdinal: number,
+  ) => RtcMulticastSerializationResult | Promise<RtcMulticastSerializationResult>;
 }): Promise<RtcBaselineSampleDto[]> {
+  let innerOrdinal = 0;
   return runRtcBaselineAcceptedWorker({
     worker: input.worker,
-    run: input.run,
+    run: () => input.run(innerOrdinal += 1),
     validate: (result) => validateResult(input.worker.input, result),
     metrics: createMetrics,
     rawEvidence: toRawEvidence,
@@ -158,40 +153,25 @@ export function runRtcMulticastSerializationAcceptedSamples(input: {
 }
 
 function parseDiagnosticArguments(
-  options: Readonly<Record<string, string>>,
-): RtcBaselineResult<RtcMulticastSerializationDiagnosticArguments> {
-  const peerCounts = parseDiagnosticPositiveIntegers(
-    readOption(options, 'peer-counts', '10,100,1000'),
-    'peer-counts',
-  );
-  if (!peerCounts.ok) {
-    return peerCounts;
-  }
-  const payloadBytes = parseDiagnosticPositiveIntegers(
-    readOption(options, 'payload-bytes', '4096,65536'),
-    'payload-bytes',
-  );
-  if (!payloadBytes.ok) {
-    return payloadBytes;
-  }
-  const runs = parseRtcBaselineBoundedInteger(readOption(options, 'runs', '3'), 'runs', 1, 5);
-  if (!runs.ok) {
-    return runs;
-  }
-  return {
-    ok: true as const,
-    value: {
-      mode: 'diagnostic' as const,
-      peerCounts: peerCounts.value,
-      payloadBytes: payloadBytes.value,
-      runs: runs.value,
-      out: readOption(options, 'out', 'tmp/perf/results/rtc-multicast-serialization.json'),
-    },
+  arguments_: readonly string[],
+): RtcMulticastSerializationDiagnosticArguments {
+  const readValue = (name: string, fallback: string) => {
+    const prefix = `--${name}=`;
+    return arguments_.find((argument) => argument.startsWith(prefix))?.slice(prefix.length) ??
+      fallback;
   };
-}
-
-function readOption(options: Readonly<Record<string, string>>, name: string, fallback: string) {
-  return options[name] ?? fallback;
+  const readNumbers = (name: string, fallback: string) =>
+    readValue(name, fallback)
+      .split(',')
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isFinite(value) && value > 0);
+  return {
+    mode: 'diagnostic',
+    peerCounts: readNumbers('peer-counts', '10,100,1000'),
+    payloadBytes: readNumbers('payload-bytes', '4096,65536'),
+    runs: Number(readValue('runs', '3')),
+    out: readValue('out', 'tmp/perf/results/rtc-multicast-serialization.json'),
+  };
 }
 
 function parseAcceptedCapability(
@@ -246,22 +226,6 @@ function parseAcceptedCapability(
       payloadBytes: payloadBytes.ok ? payloadBytes.value as 4096 | 65536 : 4096,
     },
   };
-}
-
-function parseDiagnosticPositiveIntegers(
-  value: string,
-  name: string,
-): RtcBaselineResult<number[]> {
-  const values = value.split(',');
-  const issues = values.flatMap((entry, index) => {
-    const parsed = parseRtcBaselineBoundedInteger(entry, name, 1, Number.MAX_SAFE_INTEGER);
-    return parsed.ok ? [] : [
-      rtcBaselineIssue(`$.${name}[${index}]`, parsed.issues[0]!.code, parsed.issues[0]!.message),
-    ];
-  });
-  return issues.length > 0
-    ? { ok: false as const, issues }
-    : { ok: true as const, value: values.map((entry) => Number(entry)) };
 }
 
 function validateResult(
@@ -430,8 +394,8 @@ function createPeerIds(peerCount: number): readonly string[] {
   );
 }
 
-async function main(): Promise<void> {
-  const parsed = parseRtcMulticastSerializationArguments(Deno.args);
+async function main(arguments_: readonly string[]): Promise<void> {
+  const parsed = parseRtcMulticastSerializationArguments(arguments_);
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.issues));
   }
@@ -440,7 +404,7 @@ async function main(): Promise<void> {
     runAccepted: (worker) =>
       runRtcMulticastSerializationAcceptedSamples({
         worker,
-        run: () => runRtcMulticastSerialization(worker.input),
+        run: (innerOrdinal) => runRtcMulticastSerialization(worker.input, innerOrdinal),
       }),
     writeOutput: (output) => console.log(output),
   });
@@ -456,25 +420,28 @@ async function main(): Promise<void> {
     for (let run = 1; run <= diagnostic.runs; run += 1) {
       results.push({
         run,
-        ...runRtcMulticastSerialization({
-          peers: diagnosticInput.peerCount as 10 | 100 | 1000,
-          payloadBytes: diagnosticInput.payloadBytes as 4096 | 65536,
-        }),
+        ...runRtcMulticastSerialization(
+          {
+            peers: diagnosticInput.peerCount,
+            payloadBytes: diagnosticInput.payloadBytes,
+          },
+          run,
+        ),
       });
     }
   }
   const output = {
-    command: Deno.args,
+    command: process.argv.join(' '),
     peerCounts: diagnostic.peerCounts,
     payloadBytes: diagnostic.payloadBytes,
     runs: diagnostic.runs,
     results,
   };
-  await Deno.mkdir(dirname(diagnostic.out), { recursive: true });
-  await Deno.writeTextFile(diagnostic.out, `${JSON.stringify(output, null, 2)}\n`);
+  mkdirSync(dirname(diagnostic.out), { recursive: true });
+  writeFileSync(diagnostic.out, `${JSON.stringify(output, null, 2)}\n`);
   console.log(JSON.stringify(output, null, 2));
 }
 
 if (import.meta.main) {
-  await main();
+  await main(typeof Deno === 'undefined' ? process.argv.slice(2) : Deno.args);
 }

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -1,55 +1,423 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
-import { performance } from 'node:perf_hooks';
 import { newALMulticastMessage } from '@shared/al-contracts/al-contract.ts';
 import { WebRtcOverlayMulticastService } from '@shared/multicast/WebRtcOverlayMulticastService.ts';
 
-type Args = Readonly<{
-  peerCounts: readonly number[];
-  payloadBytes: readonly number[];
-  runs: number;
-  out: string;
-}>;
+import {
+  rtcBaselineIssue,
+  type RtcBaselineJson,
+  type RtcBaselineResult,
+  type RtcBaselineSampleDto,
+  type RtcBaselineSampleIdentityDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  parseRtcBaselineBoundedInteger,
+  parseRtcBaselineOneTokenOptions,
+} from '../../baseline/command/rtc-baseline-cli-options.ts';
+import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
+// prettier-ignore
+import {
+  runRtcBaselineAcceptedWorkerSamples,
+} from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
-type CaseResult = Readonly<{
-  peerCount: number;
-  payloadBytes: number;
-  run: number;
-  planDurationMs: number;
-  serializeDurationMs: number;
-  originalSerializeDurationMs: number;
-  transportMessages: number;
-  uniqueSerializedMessages: number;
-  totalSerializedBytes: number;
-  originalSerializedBytes: number;
-  allTransportMessagesIdentical: boolean;
-}>;
+export interface RtcMulticastSerializationInput {
+  readonly peers: 10 | 100 | 1000;
+  readonly payloadBytes: 4096 | 65536;
+}
 
-function parseArgs(): Args {
-  const args = process.argv.slice(2);
-  const readValue = (name: string, fallback: string) => {
-    const prefix = `--${name}=`;
-    return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback;
-  };
-  const readNumbers = (name: string, fallback: string) =>
-    readValue(name, fallback)
-      .split(',')
-      .map((value) => Number(value.trim()))
-      .filter((value) => Number.isFinite(value) && value > 0);
+interface RtcMulticastSerializationDiagnosticArguments {
+  readonly mode: 'diagnostic';
+  readonly peerCounts: readonly number[];
+  readonly payloadBytes: readonly number[];
+  readonly runs: number;
+  readonly out: string;
+}
+
+interface RtcMulticastSerializationAcceptedArguments {
+  readonly mode: 'accepted';
+  readonly input: RtcMulticastSerializationInput;
+  readonly intendedPhase: 'warmup' | 'retained';
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
+export interface RtcMulticastSerializationResult {
+  readonly peerCount: number;
+  readonly payloadBytes: number;
+  readonly planDurationMs: number;
+  readonly serializeDurationMs: number;
+  readonly originalSerializeDurationMs: number;
+  readonly transportMessages: number;
+  readonly uniqueSerializedMessages: number;
+  readonly totalSerializedBytes: number;
+  readonly originalSerializedBytes: number;
+  readonly allTransportMessagesIdentical: boolean;
+}
+
+interface CreateRtcMulticastIssueInput {
+  readonly valid: boolean;
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+const acceptedNames = (
+  'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
+  'rtc-peers rtc-payload-bytes rtc-inner-runs'
+).split(' ');
+const frozenPeerCounts = new Set<number>([10, 100, 1000]);
+const frozenPayloadBytes = new Set<number>([4096, 65536]);
+
+export function parseRtcMulticastSerializationArguments(
+  arguments_: readonly string[],
+): RtcBaselineResult<
+  RtcMulticastSerializationDiagnosticArguments | RtcMulticastSerializationAcceptedArguments
+> {
+  const accepted = arguments_.some((argument) => argument.startsWith('--capture='));
+  const parsed = parseRtcBaselineOneTokenOptions(
+    arguments_,
+    accepted ? acceptedNames : ['peer-counts', 'payload-bytes', 'runs', 'out'],
+  );
+  if (!parsed.ok) return parsed;
+  if (accepted) return parseAcceptedArguments(parsed.value);
+  return parseDiagnosticArguments(parsed.value);
+}
+
+export function runRtcMulticastSerialization(
+  input: RtcMulticastSerializationInput,
+): RtcMulticastSerializationResult {
+  const peerIds = createPeerIds(input.peers);
+  const service = new WebRtcOverlayMulticastService(
+    'group-1',
+    createConnectionService(peerIds) as never,
+  );
+  const multicastMessage = newALMulticastMessage(
+    'self',
+    {
+      topicId: 'chat',
+      resourceId: `msg-${input.peers}-${input.payloadBytes}`,
+      contextId: 'group-1',
+    },
+    { applicationId: 'app-1', workspaceId: 'workspace-1', groupId: 'group-1' },
+    'chat.message.v1',
+    createPayload(input.payloadBytes),
+    { qos: { durability: { algo: 'volatile' } } },
+  );
+  const overlayContext = createOverlayContext(peerIds);
+
+  const planStartedAt = performance.now();
+  const plan = service.createOriginatingPlan(multicastMessage, overlayContext as never);
+  const planDurationMs = performance.now() - planStartedAt;
+
+  const originalSerializationStartedAt = performance.now();
+  const originalSerialized = JSON.stringify(multicastMessage);
+  const originalSerializeDurationMs = performance.now() - originalSerializationStartedAt;
+
+  const transportSerializationStartedAt = performance.now();
+  const serializedTransportMessages = plan.transportMessages.map((message) =>
+    JSON.stringify(message)
+  );
+  const serializeDurationMs = performance.now() - transportSerializationStartedAt;
+  const uniqueSerializedMessages = new Set(serializedTransportMessages).size;
 
   return {
-    peerCounts: readNumbers('peer-counts', '10,100,1000'),
-    payloadBytes: readNumbers('payload-bytes', '4096,65536'),
-    runs: Number(readValue('runs', '3')),
-    out: readValue('out', 'tmp/perf/results/rtc-multicast-serialization.json'),
+    peerCount: input.peers,
+    payloadBytes: input.payloadBytes,
+    planDurationMs,
+    serializeDurationMs,
+    originalSerializeDurationMs,
+    transportMessages: plan.transportMessages.length,
+    uniqueSerializedMessages,
+    totalSerializedBytes: serializedTransportMessages.reduce(
+      (total, serializedTransportMessage) => total + serializedTransportMessage.length,
+      0,
+    ),
+    originalSerializedBytes: originalSerialized.length,
+    allTransportMessagesIdentical: uniqueSerializedMessages <= 1,
+  };
+}
+
+export async function runRtcMulticastSerializationAcceptedSamples(input: {
+  readonly worker: RtcMulticastSerializationAcceptedArguments;
+  readonly run: () => RtcMulticastSerializationResult | Promise<RtcMulticastSerializationResult>;
+}): Promise<RtcBaselineSampleDto[]> {
+  return runRtcBaselineAcceptedWorkerSamples({
+    worker: {
+      ...input.worker,
+      workloadId: 'RTC-B04',
+      caseId: 'multicast-serialization',
+      inputKey: `peers-${input.worker.input.peers}-payload-${input.worker.input.payloadBytes}`,
+    },
+    run: input.run,
+    validate: (result) => validateResult(input.worker.input, result),
+    createSample: ({ identity, result, issues }) => createSample(identity, result, issues),
+  });
+}
+
+function parseDiagnosticArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<RtcMulticastSerializationDiagnosticArguments> {
+  const peerCounts = parseDiagnosticPositiveIntegers(
+    readOption(options, 'peer-counts', '10,100,1000'),
+    'peer-counts',
+  );
+  if (!peerCounts.ok) return peerCounts;
+  const payloadBytes = parseDiagnosticPositiveIntegers(
+    readOption(options, 'payload-bytes', '4096,65536'),
+    'payload-bytes',
+  );
+  if (!payloadBytes.ok) return payloadBytes;
+  const runs = parseRtcBaselineBoundedInteger(readOption(options, 'runs', '3'), 'runs', 1, 5);
+  if (!runs.ok) return runs;
+  return {
+    ok: true as const,
+    value: {
+      mode: 'diagnostic' as const,
+      peerCounts: peerCounts.value,
+      payloadBytes: payloadBytes.value,
+      runs: runs.value,
+      out: readOption(options, 'out', 'tmp/perf/results/rtc-multicast-serialization.json'),
+    },
+  };
+}
+
+function readOption(options: Readonly<Record<string, string>>, name: string, fallback: string) {
+  return options[name] ?? fallback;
+}
+
+function parseAcceptedArguments(
+  options: Readonly<Record<string, string>>,
+): RtcBaselineResult<RtcMulticastSerializationAcceptedArguments> {
+  const peers = parseRtcBaselineBoundedInteger(options['rtc-peers'] ?? '', 'rtc-peers', 10, 1000);
+  const payloadBytes = parseRtcBaselineBoundedInteger(
+    options['rtc-payload-bytes'] ?? '',
+    'rtc-payload-bytes',
+    4096,
+    65536,
+  );
+  const outerOrdinal = parseRtcBaselineBoundedInteger(
+    options['outer-ordinal'] ?? '',
+    'outer-ordinal',
+    1,
+    999,
+  );
+  const issues = [
+    ...(!peers.ok ? peers.issues : []),
+    ...(!payloadBytes.ok ? payloadBytes.issues : []),
+    ...(!outerOrdinal.ok ? outerOrdinal.issues : []),
+    ...validateRtcBaselineId(options['baseline-id'] ?? ''),
+  ];
+  if (peers.ok && !frozenPeerCounts.has(peers.value)) {
+    issues.push(
+      rtcBaselineIssue('$.rtc-peers', 'unexpected-worker-input', 'Expected 10, 100, or 1000.'),
+    );
+  }
+  if (payloadBytes.ok && !frozenPayloadBytes.has(payloadBytes.value)) {
+    issues.push(
+      rtcBaselineIssue('$.rtc-payload-bytes', 'unexpected-worker-input', 'Expected 4096 or 65536.'),
+    );
+  }
+
+  const input: RtcMulticastSerializationInput = {
+    peers: (peers.ok ? peers.value : 10) as 10 | 100 | 1000,
+    payloadBytes: (payloadBytes.ok ? payloadBytes.value : 4096) as 4096 | 65536,
+  };
+  const expected = {
+    capture: 'worker',
+    workload: 'RTC-B04',
+    'case-id': 'multicast-serialization',
+    'input-key': `peers-${input.peers}-payload-${input.payloadBytes}`,
+    'rtc-peers': String(input.peers),
+    'rtc-payload-bytes': String(input.payloadBytes),
+    'rtc-inner-runs': '5',
+  };
+  for (const [name, expectedValue] of Object.entries(expected)) {
+    if (options[name] !== expectedValue) {
+      issues.push(
+        rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${expectedValue}.`),
+      );
+    }
+  }
+  if (outerOrdinal.ok && options['outer-ordinal'] !== String(outerOrdinal.value)) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.outer-ordinal',
+        'unexpected-worker-input',
+        'Expected canonical integer syntax.',
+      ),
+    );
+  }
+  const intendedPhase = options['intended-phase'];
+  if (intendedPhase !== 'warmup' && intendedPhase !== 'retained') {
+    issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
+  }
+  const ordinal = outerOrdinal.ok ? outerOrdinal.value : 1;
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const expectedSampleIds = createExpectedSampleIds(
+    input,
+    intendedPhase === 'warmup' ? intendedPhase : 'retained',
+    ordinal,
+  );
+  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedSampleIds)) {
+    issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
+  }
+  return issues.length > 0 ? { ok: false as const, issues } : {
+    ok: true as const,
+    value: {
+      mode: 'accepted' as const,
+      input,
+      intendedPhase: intendedPhase as 'warmup' | 'retained',
+      outerOrdinal: ordinal,
+      sampleIds,
+    },
+  };
+}
+
+function parseDiagnosticPositiveIntegers(
+  value: string,
+  name: string,
+): RtcBaselineResult<number[]> {
+  const values = value.split(',');
+  const issues = values.flatMap((entry, index) => {
+    const parsed = parseRtcBaselineBoundedInteger(entry, name, 1, Number.MAX_SAFE_INTEGER);
+    return parsed.ok ? [] : [
+      rtcBaselineIssue(`$.${name}[${index}]`, parsed.issues[0]!.code, parsed.issues[0]!.message),
+    ];
+  });
+  return issues.length > 0
+    ? { ok: false as const, issues }
+    : { ok: true as const, value: values.map((entry) => Number(entry)) };
+}
+
+function createExpectedSampleIds(
+  input: RtcMulticastSerializationInput,
+  intendedPhase: 'warmup' | 'retained',
+  outerOrdinal: number,
+): string[] {
+  const prefix =
+    `rtc-b04-multicast-serialization-peers-${input.peers}-payload-${input.payloadBytes}-` +
+    `${intendedPhase}-${String(outerOrdinal).padStart(3, '0')}`;
+  return Array.from(
+    { length: 5 },
+    (_value, index) => `${prefix}-${String(index + 1).padStart(3, '0')}`,
+  );
+}
+
+function validateResult(
+  input: RtcMulticastSerializationInput,
+  result: RtcMulticastSerializationResult,
+) {
+  const timingIssues = Object.entries({
+    planDurationMs: result.planDurationMs,
+    originalSerializeDurationMs: result.originalSerializeDurationMs,
+    serializeDurationMs: result.serializeDurationMs,
+  })
+    .flatMap(([metric, value]) =>
+      createIssueWhen(
+        {
+          valid: Number.isFinite(value) && value >= 0,
+          path: `$.rawEvidence.${metric}`,
+          code: 'invalid-timing',
+          message: 'Expected nonnegative.',
+        },
+      )
+    );
+  return [
+    ...createIssueWhen(
+      {
+        valid: JSON.stringify([result.peerCount, result.payloadBytes]) ===
+          JSON.stringify([input.peers, input.payloadBytes]),
+        path: '$.rawEvidence.input',
+        code: 'input-mismatch',
+        message: 'Unexpected multicast input.',
+      },
+    ),
+    ...createIssueWhen({
+      valid: result.transportMessages === input.peers,
+      path: '$.rawEvidence.transportMessages',
+      code: 'transport-count-mismatch',
+      message: 'Unexpected count.',
+    }),
+    ...createIssueWhen({
+      valid:
+        JSON.stringify([result.uniqueSerializedMessages, result.allTransportMessagesIdentical]) ===
+          JSON.stringify([input.peers, false]),
+      path: '$.rawEvidence.uniqueSerializedMessages',
+      code: 'serialization-identity-mismatch',
+      message: 'Expected distinct serialized transport messages.',
+    }),
+    ...createIssueWhen({
+      valid: Math.min(
+        result.originalSerializedBytes - 1,
+        result.totalSerializedBytes - result.originalSerializedBytes * result.transportMessages,
+      ) >= 0,
+      path: '$.rawEvidence.bytes',
+      code: 'byte-evidence-mismatch',
+      message: 'Unexpected bytes.',
+    }),
+    ...timingIssues,
+  ];
+}
+
+function createIssueWhen(input: CreateRtcMulticastIssueInput) {
+  return input.valid ? [] : [rtcBaselineIssue(input.path, input.code, input.message)];
+}
+
+function createSample(
+  identity: RtcBaselineSampleIdentityDto,
+  result: RtcMulticastSerializationResult | null,
+  issues: RtcBaselineSampleDto['issues'],
+): RtcBaselineSampleDto {
+  if (result === null) {
+    return {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity,
+      outcome: 'not-run',
+      evidenceClass: 'synthetic-path',
+      metrics: [],
+      rawEvidence: null,
+      rawReferences: [],
+      issues,
+      runtimeObservation: null,
+    };
+  }
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity,
+    outcome: issues.length === 0 ? 'passed' : 'failed',
+    evidenceClass: 'synthetic-path',
+    metrics: [
+      { metric: 'planDurationMs', unit: 'ms', value: result.planDurationMs },
+      {
+        metric: 'originalSerializeDurationMs',
+        unit: 'ms',
+        value: result.originalSerializeDurationMs,
+      },
+      { metric: 'serializeDurationMs', unit: 'ms', value: result.serializeDurationMs },
+    ],
+    rawEvidence: toRawEvidence(result),
+    rawReferences: [],
+    issues,
+    runtimeObservation: null,
+  };
+}
+
+function toRawEvidence(result: RtcMulticastSerializationResult): RtcBaselineJson {
+  return {
+    peerCount: result.peerCount,
+    payloadBytes: result.payloadBytes,
+    planDurationMs: result.planDurationMs,
+    serializeDurationMs: result.serializeDurationMs,
+    originalSerializeDurationMs: result.originalSerializeDurationMs,
+    transportMessages: result.transportMessages,
+    uniqueSerializedMessages: result.uniqueSerializedMessages,
+    totalSerializedBytes: result.totalSerializedBytes,
+    originalSerializedBytes: result.originalSerializedBytes,
+    allTransportMessagesIdentical: result.allTransportMessagesIdentical,
   };
 }
 
 function createConnectionService(peerIds: readonly string[]) {
   return {
-    input: {
-      sessionId: 'self',
-    },
+    input: { sessionId: 'self' },
     readyPeerIdsForLane: () => [...peerIds],
   };
 }
@@ -59,7 +427,6 @@ function createOverlayContext(peerIds: readonly string[]) {
   const workspaceId = 'workspace-1';
   const groupId = 'group-1';
   const memberSessionIds = ['self', ...peerIds];
-
   return {
     overlayId: groupId,
     room: {
@@ -76,14 +443,8 @@ function createOverlayContext(peerIds: readonly string[]) {
         metadataVersion: 0,
         rosterVersion: 1,
         presenceVersion: 0,
-        created: {
-          atEpochMs: 1,
-          byPrincipalId: 'owner',
-        },
-        updated: {
-          atEpochMs: 1,
-          byPrincipalId: 'owner',
-        },
+        created: { atEpochMs: 1, byPrincipalId: 'owner' },
+        updated: { atEpochMs: 1, byPrincipalId: 'owner' },
       },
       members: memberSessionIds.map((sessionId) => ({
         applicationId,
@@ -92,14 +453,8 @@ function createOverlayContext(peerIds: readonly string[]) {
         principalId: sessionId,
         role: 'member',
         status: 'active',
-        joined: {
-          atEpochMs: 1,
-          byPrincipalId: 'owner',
-        },
-        updated: {
-          atEpochMs: 1,
-          byPrincipalId: 'owner',
-        },
+        joined: { atEpochMs: 1, byPrincipalId: 'owner' },
+        updated: { atEpochMs: 1, byPrincipalId: 'owner' },
       })),
       activeSessions: memberSessionIds.map((sessionId) => ({
         applicationId,
@@ -127,96 +482,53 @@ function createOverlayContext(peerIds: readonly string[]) {
 }
 
 function createPayload(payloadBytes: number) {
-  return {
-    text: 'x'.repeat(payloadBytes),
-    createdAtEpochMs: 1,
-  };
+  return { text: 'x'.repeat(payloadBytes), createdAtEpochMs: 1 };
 }
 
 function createPeerIds(peerCount: number): readonly string[] {
   return Array.from(
     { length: peerCount },
-    (_, index) => `peer-${String(index + 1).padStart(5, '0')}`,
+    (_value, index) => `peer-${String(index + 1).padStart(5, '0')}`,
   );
 }
 
-function runCase(peerCount: number, payloadBytes: number, run: number): CaseResult {
-  const peerIds = createPeerIds(peerCount);
-  const service = new WebRtcOverlayMulticastService(
-    'group-1',
-    createConnectionService(peerIds) as never,
+async function main(): Promise<void> {
+  const parsed = parseRtcMulticastSerializationArguments(Deno.args);
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.issues));
+  if (parsed.value.mode === 'accepted') {
+    const worker = parsed.value;
+    const samples = await runRtcMulticastSerializationAcceptedSamples({
+      worker,
+      run: () => runRtcMulticastSerialization(worker.input),
+    });
+    console.log(JSON.stringify(samples));
+    return;
+  }
+  const diagnostic = parsed.value;
+  const results = [];
+  const diagnosticInputs = diagnostic.peerCounts.flatMap((peerCount) =>
+    diagnostic.payloadBytes.map((payloadBytes) => ({ peerCount, payloadBytes }))
   );
-  const msg = newALMulticastMessage(
-    'self',
-    {
-      topicId: 'chat',
-      resourceId: `msg-${peerCount}-${payloadBytes}-${run}`,
-      contextId: 'group-1',
-    },
-    {
-      applicationId: 'app-1',
-      workspaceId: 'workspace-1',
-      groupId: 'group-1',
-    },
-    'chat.message.v1',
-    createPayload(payloadBytes),
-    {
-      qos: {
-        durability: {
-          algo: 'volatile',
-        },
-      },
-    },
-  );
-  const context = createOverlayContext(peerIds);
-
-  const planStart = performance.now();
-  const plan = service.createOriginatingPlan(msg, context as never);
-  const planDurationMs = performance.now() - planStart;
-
-  const originalStart = performance.now();
-  const originalSerialized = JSON.stringify(msg);
-  const originalSerializeDurationMs = performance.now() - originalStart;
-
-  const serializeStart = performance.now();
-  const serialized = plan.transportMessages.map((message) => JSON.stringify(message));
-  const serializeDurationMs = performance.now() - serializeStart;
-  const uniqueSerializedMessages = new Set(serialized).size;
-
-  return {
-    peerCount,
-    payloadBytes,
-    run,
-    planDurationMs,
-    serializeDurationMs,
-    originalSerializeDurationMs,
-    transportMessages: plan.transportMessages.length,
-    uniqueSerializedMessages,
-    totalSerializedBytes: serialized.reduce((total, value) => total + value.length, 0),
-    originalSerializedBytes: originalSerialized.length,
-    allTransportMessagesIdentical: uniqueSerializedMessages <= 1,
-  };
-}
-
-const args = parseArgs();
-const results: CaseResult[] = [];
-
-for (const peerCount of args.peerCounts) {
-  for (const payloadBytes of args.payloadBytes) {
-    for (let run = 1; run <= args.runs; run += 1) {
-      results.push(runCase(peerCount, payloadBytes, run));
+  for (const diagnosticInput of diagnosticInputs) {
+    for (let run = 1; run <= diagnostic.runs; run += 1) {
+      results.push({
+        run,
+        ...runRtcMulticastSerialization({
+          peers: diagnosticInput.peerCount as 10 | 100 | 1000,
+          payloadBytes: diagnosticInput.payloadBytes as 4096 | 65536,
+        }),
+      });
     }
   }
+  const output = {
+    command: Deno.args,
+    peerCounts: diagnostic.peerCounts,
+    payloadBytes: diagnostic.payloadBytes,
+    runs: diagnostic.runs,
+    results,
+  };
+  await Deno.writeTextFile(diagnostic.out, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(JSON.stringify(output, null, 2));
 }
 
-const output = {
-  command: process.argv.join(' '),
-  peerCounts: args.peerCounts,
-  payloadBytes: args.payloadBytes,
-  runs: args.runs,
-  results,
-};
-
-mkdirSync(dirname(args.out), { recursive: true });
-writeFileSync(args.out, `${JSON.stringify(output, null, 2)}\n`);
-console.log(JSON.stringify(output, null, 2));
+if (import.meta.main) await main();

--- a/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
+++ b/packages/shared-rtc-bench/workloads/multicast/rtc-multicast-serialization-bench.ts
@@ -61,6 +61,14 @@ interface CreateRtcMulticastIssueInput {
   readonly message: string;
 }
 
+interface ValidateAcceptedPhaseAndIdsInput {
+  readonly options: Readonly<Record<string, string>>;
+  readonly input: RtcMulticastSerializationInput;
+  readonly intendedPhase: string | undefined;
+  readonly outerOrdinal: number;
+  readonly sampleIds: readonly string[];
+}
+
 const acceptedNames = (
   'capture baseline-id workload case-id input-key intended-phase outer-ordinal sample-ids ' +
   'rtc-peers rtc-payload-bytes rtc-inner-runs'
@@ -188,6 +196,33 @@ function readOption(options: Readonly<Record<string, string>>, name: string, fal
 function parseAcceptedArguments(
   options: Readonly<Record<string, string>>,
 ): RtcBaselineResult<RtcMulticastSerializationAcceptedArguments> {
+  const numeric = parseAcceptedNumericInput(options);
+  const phase = options['intended-phase'];
+  const sampleIds = (options['sample-ids'] ?? '').split(',');
+  const issues = [
+    ...numeric.issues,
+    ...validateAcceptedFixedFields(options, numeric.input),
+    ...validateAcceptedPhaseAndIds({
+      options,
+      input: numeric.input,
+      intendedPhase: phase,
+      outerOrdinal: numeric.outerOrdinal,
+      sampleIds,
+    }),
+  ];
+  return issues.length > 0 ? { ok: false, issues } : {
+    ok: true,
+    value: {
+      mode: 'accepted',
+      input: numeric.input,
+      intendedPhase: phase as 'warmup' | 'retained',
+      outerOrdinal: numeric.outerOrdinal,
+      sampleIds,
+    },
+  };
+}
+
+function parseAcceptedNumericInput(options: Readonly<Record<string, string>>) {
   const peers = parseRtcBaselineBoundedInteger(options['rtc-peers'] ?? '', 'rtc-peers', 10, 1000);
   const payloadBytes = parseRtcBaselineBoundedInteger(
     options['rtc-payload-bytes'] ?? '',
@@ -218,10 +253,20 @@ function parseAcceptedArguments(
     );
   }
 
-  const input: RtcMulticastSerializationInput = {
-    peers: (peers.ok ? peers.value : 10) as 10 | 100 | 1000,
-    payloadBytes: (payloadBytes.ok ? payloadBytes.value : 4096) as 4096 | 65536,
+  return {
+    issues,
+    input: {
+      peers: (peers.ok ? peers.value : 10) as 10 | 100 | 1000,
+      payloadBytes: (payloadBytes.ok ? payloadBytes.value : 4096) as 4096 | 65536,
+    },
+    outerOrdinal: outerOrdinal.ok ? outerOrdinal.value : 1,
   };
+}
+
+function validateAcceptedFixedFields(
+  options: Readonly<Record<string, string>>,
+  input: RtcMulticastSerializationInput,
+) {
   const expected = {
     capture: 'worker',
     workload: 'RTC-B04',
@@ -231,14 +276,16 @@ function parseAcceptedArguments(
     'rtc-payload-bytes': String(input.payloadBytes),
     'rtc-inner-runs': '5',
   };
-  for (const [name, expectedValue] of Object.entries(expected)) {
-    if (options[name] !== expectedValue) {
-      issues.push(
-        rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${expectedValue}.`),
-      );
-    }
-  }
-  if (outerOrdinal.ok && options['outer-ordinal'] !== String(outerOrdinal.value)) {
+  return Object.entries(expected).flatMap(([name, expectedValue]) =>
+    options[name] === expectedValue
+      ? []
+      : [rtcBaselineIssue(`$.${name}`, 'unexpected-worker-input', `Expected ${expectedValue}.`)]
+  );
+}
+
+function validateAcceptedPhaseAndIds(input: ValidateAcceptedPhaseAndIdsInput) {
+  const issues = [];
+  if (input.options['outer-ordinal'] !== String(input.outerOrdinal)) {
     issues.push(
       rtcBaselineIssue(
         '$.outer-ordinal',
@@ -247,30 +294,18 @@ function parseAcceptedArguments(
       ),
     );
   }
-  const intendedPhase = options['intended-phase'];
-  if (intendedPhase !== 'warmup' && intendedPhase !== 'retained') {
+  if (input.intendedPhase !== 'warmup' && input.intendedPhase !== 'retained') {
     issues.push(rtcBaselineIssue('$.intended-phase', 'unexpected-worker-input', 'Invalid phase.'));
   }
-  const ordinal = outerOrdinal.ok ? outerOrdinal.value : 1;
-  const sampleIds = (options['sample-ids'] ?? '').split(',');
   const expectedSampleIds = createExpectedSampleIds(
-    input,
-    intendedPhase === 'warmup' ? intendedPhase : 'retained',
-    ordinal,
+    input.input,
+    input.intendedPhase === 'warmup' ? input.intendedPhase : 'retained',
+    input.outerOrdinal,
   );
-  if (JSON.stringify(sampleIds) !== JSON.stringify(expectedSampleIds)) {
+  if (JSON.stringify(input.sampleIds) !== JSON.stringify(expectedSampleIds)) {
     issues.push(rtcBaselineIssue('$.sample-ids', 'unexpected-worker-input', 'Invalid sample IDs.'));
   }
-  return issues.length > 0 ? { ok: false as const, issues } : {
-    ok: true as const,
-    value: {
-      mode: 'accepted' as const,
-      input,
-      intendedPhase: intendedPhase as 'warmup' | 'retained',
-      outerOrdinal: ordinal,
-      sampleIds,
-    },
-  };
+  return issues;
 }
 
 function parseDiagnosticPositiveIntegers(


### PR DESCRIPTION
## Goal

Complete the B04 multicast and group-coordination instrumentation locally reviewed after Task 4B, while preserving the existing direct diagnostic contracts and keeping accepted evidence under the baseline controller's confined create-new lifecycle.

## Changes

- Add one package-owned accepted-worker protocol for strict identity parsing, five-sample envelopes, JSON-safe evidence, and causal first-failure accounting.
- Integrate the multicast serialization and four group-coordination workloads with that protocol while keeping capability-specific production setup, operations, timing, validation, and evidence with each workload.
- Preserve the multicast direct Node entry and the four direct Deno entries, including their permissive first-match CLI grammar, caller-selected overwrite output, and existing schemas.
- Add focused accepted, adversarial, identity, failure-remainder, JSON-safety, diagnostic-compatibility, and production-semantic coverage.
- Include the new protocol owner and test in the package's exact executable inventory.

## Acceptance

- Every B04 accepted worker preserves the frozen workload/case/input/sample identities and emits five ordered samples.
- The first failed validation stops execution and records exact causal `not-run` remainder samples.
- Non-finite evidence is explicitly projected to JSON-safe values and every capability-specific numeric and semantic relationship fails closed.
- Multicast calls production `WebRtcOverlayMulticastService.createOriginatingPlan`; group workloads continue to call the production cache, manager, ownership, and heartbeat services.
- Direct diagnostic grammar, output schema, nested output creation, and overwrite behavior remain compatible.
- Production RTC packages, B05/B06/B07, capture, and optimization remain unchanged.

## Validation

- PASS: focused B04 and production-owner suite, 8 files / 76 tests.
- PASS: `npm --workspace @ar-eye-hunter/shared-rtc-bench run check`, including typecheck, 32 files / 300 tests, and all Deno entry checks.
- PASS: repository structure, changed-style, package style, and `git diff --check`. Package style reported 29 advisory facts; changed-style reported no new finding.
- PASS: `npm run test:unit`, 829 files / 7,338 tests with 3 files / 5 tests skipped.
- PASS: `npm run test:repo-governance`, 27 files / 342 tests.
- PASS: `npm run test:ci`, including Deno integration, 39-test and 211-test Playwright suites with configured skips, and 7 full-stack memory tests.
- PASS: `npm run build`; existing large-bundle warnings remain warning-only.
- PASS: clean synthetic integration with latest `main`, including package checks and repository governance.
- EXPECTED RED: compatibility regression tests initially failed 5 cases before the final correction, then passed unchanged.
- SKIPPED: held benchmark matrix, accepted capture, B05/B06/B07, performance optimization, and distributed Hetzner execution; none is required to validate this structural B04 change locally.

## Risk and rollback

The main risk is divergence between strict accepted-worker parsing and permissive historical diagnostic parsing. Dedicated tests cover both paths, and an independent final review reports zero unresolved Critical, Important, or Minor findings. Roll back by reverting the B04 commit range; production RTC code and prior Task 4B owners are untouched.

## Follow-up

None
