### PR TITLE
Add the pinned benchmark environment, and run the state-write pooling control

### DIFF
--- a/docker-compose.perf-bench.yml
+++ b/docker-compose.perf-bench.yml
@@ -1,0 +1,40 @@
+# Pinned PostgreSQL for the API-v1 state-write benchmark (issue #157).
+#
+# Separate from docker-compose.yml on purpose. The dev container is deliberately
+# convenient — unpinned tag, autovacuum on, no resource reservation — and those
+# are exactly the properties that make benchmark medians drift between runs.
+# This file is the controlled counterpart, and every value below is pinned
+# because scripts/perf/validate-api-v1-state-write-environment.mjs compares it
+# for exact equality.
+#
+# Port 5433 so it can coexist with the dev container, and no named volume so a
+# `down -v` genuinely returns an empty data directory.
+#
+# Usage:
+#   docker compose -f docker-compose.perf-bench.yml down -v
+#   docker compose -f docker-compose.perf-bench.yml up -d --wait
+#   DATABASE_URL=postgres://app:app@localhost:5433/appdb npm run db:migrate
+#
+# The pooling protocol also requires no other containers and no other benchmark
+# processes running; stop the dev container first or the captured
+# container_overlap_count will not be zero.
+services:
+  perf-bench-postgres:
+    image: postgres@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+    container_name: rallar-perf-bench-postgres
+    command: postgres -c autovacuum=off
+    shm_size: 268435456
+    mem_limit: 4294967296
+    memswap_limit: 4294967296
+    cpus: 4
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: appdb
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U app -d appdb" ]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/playground/rtc-design/baselines/2026-08-15-state-write-pooling-control-results.md
+++ b/playground/rtc-design/baselines/2026-08-15-state-write-pooling-control-results.md
@@ -1,0 +1,122 @@
+# State-write pooling control: the comparator's resource gate has no noise band
+
+Date: 2026-08-15
+Issue: #157
+Commits: approved-base `bc705968`, candidate `c9e18904`
+
+## What this run was for
+
+Three consecutive phases reported the API-v1 state-write perf comparison as
+"environment-limited": an identical-code control failed the comparator, so no
+candidate verdict could be trusted. Issue #157 attributed this to developer-machine
+noise and pointed at an order-balanced A-B-B-A pooling protocol as the escalation.
+That escalation had never been executed, because nothing in the repository could
+produce the environment descriptor each pooling source requires.
+
+The tooling now exists (`docker-compose.perf-bench.yml`,
+`scripts/perf/capture-api-v1-state-write-environment.mjs`), so this is the first
+actual execution of the protocol.
+
+## Design
+
+A literal main-vs-main control is impossible: `pool-api-v1-state-write-results.mjs`
+rejects equal approved-base and candidate commits. The control therefore uses two
+distinct commits whose runtime code is provably identical.
+
+`git diff bc705968 c9e18904` is exactly four files — a new compose file, a README
+section, the new capture script, and a one-word `export` on the validator. Nothing
+under `packages/**` or `apps/**` changed, and the benchmark exercises the AppInbox
+write paths in `packages/shared-server`. **The true performance effect is exactly
+zero**, so every difference measured below is noise by construction.
+
+Four positions ran in A-B-B-A order — approved-base, candidate, candidate,
+approved-base — each against a freshly recreated pinned container with its own
+migration, at `--warmup=1 --runs=9 --concurrency=10`. All four captured environment
+descriptors are byte-identical (md5 `2ef098449b6bef0910ba2125f9d81752`).
+
+## Result: pooling fixed the timing metrics
+
+The metrics that failed in phase 4 — throughput and latency, compared against ±5%
+bands — **passed cleanly**. Phase 4's naive single pairing reported shared
+throughput at −8.1%; the pooled comparison reports no throughput or latency finding
+at all. For what it was built to do, pooling plus a pinned environment worked.
+
+## Result: what still fails is not noise sensitivity
+
+All eight remaining findings are resource counters, and they fail for a different
+reason. `compare-api-v1-state-write-results.mjs` compares latency and throughput
+with a `0.05` tolerance, but compares four resource metrics with **strict `>` and no
+tolerance at all**:
+
+```js
+if (candidateMedian > baselineMedian && !hasRecordedReason(candidate, name, `${container}.${metric}`)) {
+  errors.push(`${name} median ${container}.${metric} increased without a recorded reason: ...`);
+}
+```
+
+Measured drift on byte-identical code, pooled over 18 runs per role:
+
+| workload | metric | drift |
+| --- | --- | --- |
+| uncontended | `postgres.transactionDurationMs` | +0.122% |
+| uncontended | `sql.statements` | +0.204% |
+| shared | `sql.rowsRead` | +0.147% |
+| shared | `sql.statements` | +0.317% |
+| shared | `sql.serializedResultBytes` | +0.383% |
+| shared | `postgres.transactionDurationMs` | +1.550% |
+| hot | `postgres.transactionDurationMs` | +1.409% |
+| hot | `sql.statements` | +2.655% |
+
+These counters are not deterministic. The workloads contend deliberately —
+the `hot` workload drove 4,516 conflicts and 11,716 attempts for 6,300 accepted
+mutations in one position — and the number of retry attempts depends on timing.
+Statement counts, rows read, and transaction duration all follow attempt counts, so
+they vary run to run even when the code does not.
+
+A strict-inequality gate on a stochastic counter is unsatisfiable. It is not
+measuring a regression; it is measuring which side of a coin flip the median landed
+on. Roughly half of all identical-code runs will fail it, on any hardware, however
+well pinned.
+
+## Revised diagnosis for #157
+
+The issue's framing — developer-machine noise, remedied by pooling — is half right.
+Pooling did stabilize the timing comparison. But the residual failure is a gate
+design problem, not an environment problem:
+
+- The four resource metrics need a tolerance band, calibrated from the drift this
+  control measured. The observed floor on identical code is up to **+2.7%**.
+- The existing escape hatch (`hasRecordedReason`) is built for *intentional*
+  regressions with a substantive written justification. It is the wrong instrument
+  for measurement noise, and requiring a written reason for a coin flip trains
+  reviewers to write meaningless ones.
+
+Until the band exists, "environment-limited" remains the honest verdict for these
+four metrics — but it should be recorded as *gate-limited*, and no amount of
+environment pinning will change it.
+
+## Incidental findings
+
+- **Artifact size is close to a hard runtime limit.** A 9-run artifact is
+  506,420,464 bytes against Node's 536,870,888-byte maximum string length — 5.67%
+  headroom — and `readFile(path, 'utf8')` is how both the pooling script and the
+  comparator ingest them. Pooled artifacts are 493 MB (8.11% headroom) because they
+  are written compactly rather than pretty-printed. A modest increase in run count
+  or per-run detail breaks both scripts with `ERR_STRING_TOO_LONG`. Pooling and
+  comparison also need roughly 12 GB of heap (`--max-old-space-size=12288`).
+- **The capture script rejected its own first run**, because the dev container was
+  still up and `container_overlap_count` was not zero. That is the intended
+  behavior and it caught a real protocol violation before it reached a verdict.
+
+## Reproduction
+
+```sh
+docker stop ar-eye-hunter-postgres
+docker compose -f docker-compose.perf-bench.yml down -v
+docker compose -f docker-compose.perf-bench.yml up -d --wait
+DATABASE_URL=postgres://app:app@localhost:5433/appdb npm run db:migrate
+# preflight capture, 9-run benchmark, postflight capture, per position
+# then write-api-v1-state-write-pooled-results.mjs and compare-api-v1-state-write-results.mjs
+```
+
+Full procedure in `scripts/perf/README.md`, section "Pinned Benchmark Environment".

--- a/playground/rtc-design/baselines/2026-08-15-state-write-pooling-control-results.md
+++ b/playground/rtc-design/baselines/2026-08-15-state-write-pooling-control-results.md
@@ -95,6 +95,34 @@ Until the band exists, "environment-limited" remains the honest verdict for thes
 four metrics — but it should be recorded as *gate-limited*, and no amount of
 environment pinning will change it.
 
+## Known limitation: the `image_id` pin is store-dependent
+
+`postgres@sha256:081f1bc7…` is a **multi-architecture OCI image index**, not a
+per-architecture image. `docker manifest inspect` on it returns an index listing
+amd64, arm, and other platform manifests, each with its own digest.
+
+This machine runs the **containerd image store** (`docker info` reports
+`io.containerd.snapshotter.v1`), and under that store `docker image inspect`
+reports the *index* digest as the image `Id` and resolves `Architecture` to the
+host's. That is why the capture satisfies the validator's pin
+`image_id == sha256:081f1bc7…` exactly.
+
+Under the classic dockerd image store, `Id` is the per-architecture config digest,
+which is a different sha. The `image_id` pin would then not match, and the
+descriptor would be rejected even though the same image is running. The pins
+`image_ref` and `repo_digest` are the index digest and are stable across stores;
+only `image_id` carries this coupling.
+
+The practical consequence is that the pinned environment is reproducible on hosts
+using the containerd image store, and its portability elsewhere — notably to CI,
+which is typically classic dockerd on amd64 — is **unproven**. I have not tested a
+classic-store host, so this is reasoned from the store's documented behavior rather
+than measured. It also further supports the inference that the validator's pins were
+originally captured on a containerd-store arm64 machine.
+
+If the protocol is ever meant to run in CI, `image_id` is the field to revisit
+first.
+
 ## Incidental findings
 
 - **Artifact size is close to a hard runtime limit.** A 9-run artifact is

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -211,6 +211,63 @@ Loop-driving CLI values are bounded safe integers: warmup runs 1–10, measured
 runs 1–100, and concurrency 1–256. Task 0B further requires exactly one warmup,
 at least three measured runs, and concurrency 10.
 
+## Pinned Benchmark Environment
+
+The dev container in `docker-compose.yml` is deliberately convenient — floating
+tag, autovacuum on, no resource reservation — and those are the properties that
+make medians drift between otherwise identical runs (issue #157).
+`docker-compose.perf-bench.yml` is its controlled counterpart: the digest,
+command, shm size, memory, and CPU count are all pinned because
+`validate-api-v1-state-write-environment.mjs` compares them for exact equality.
+It listens on 5433 and declares no named volume, so `down -v` genuinely returns
+an empty data directory.
+
+Every governed PostgreSQL setting except `autovacuum` is simply the PostgreSQL
+16 default, so the pinned environment is stock PG16 with autovacuum off, 4 GiB
+memory, 4 CPUs, and 256 MiB of shared memory.
+
+The pooling protocol also requires no other running containers and no other
+running benchmark process, so stop the dev container first.
+
+```sh
+docker stop ar-eye-hunter-postgres
+docker compose -f docker-compose.perf-bench.yml down -v
+docker compose -f docker-compose.perf-bench.yml up -d --wait
+DATABASE_URL=postgres://app:app@localhost:5433/appdb npm run db:migrate
+```
+
+`capture-api-v1-state-write-environment.mjs` emits the governed descriptor that
+each pooling source requires. Capture is two-stage because the field semantics
+bracket the run: preflight row counts and the preflight maintenance counter
+describe the database the benchmark started against, and the postflight
+maintenance counter proves no automatic maintenance ran during it.
+
+```sh
+node scripts/perf/capture-api-v1-state-write-environment.mjs \
+  --stage preflight --container rallar-perf-bench-postgres \
+  --database-url postgres://app:app@localhost:5433/appdb \
+  --out tmp/perf/env/position-1-preflight.json
+
+# run the benchmark here
+
+node scripts/perf/capture-api-v1-state-write-environment.mjs \
+  --stage postflight --container rallar-perf-bench-postgres \
+  --database-url postgres://app:app@localhost:5433/appdb \
+  --preflight tmp/perf/env/position-1-preflight.json \
+  --out tmp/perf/env/position-1.txt
+```
+
+The postflight stage validates before writing, so a descriptor that reaches
+disk is one the pooling protocol accepts. A non-empty preflight database, a
+container restarted mid-run, or an overlapping container fails the capture
+rather than surviving into a verdict.
+
+The order-balanced protocol runs four positions — approved-base, candidate,
+candidate, approved-base — each against a freshly recreated container, and
+`write-api-v1-state-write-pooled-results.mjs` pools them. Note that it rejects
+equal approved-base and candidate commits, so an identical-code control needs
+two distinct commits whose runtime code does not differ.
+
 ## Focused Runtime Harness
 
 Run the full focused harness with three measured runs:

--- a/scripts/perf/capture-api-v1-state-write-environment.mjs
+++ b/scripts/perf/capture-api-v1-state-write-environment.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+// Produces the governed environment descriptor that
+// validate-api-v1-state-write-environment.mjs checks and that the A-B-B-A
+// pooling protocol requires per source (issue #157).
+//
+// Capture is two-stage because the field semantics bracket the benchmark:
+// preflight row counts and the preflight maintenance counter describe the
+// database the run started against, while the postflight maintenance counter
+// proves no automatic maintenance ran during it. Stage one writes a JSON
+// sidecar, stage two completes it and emits the descriptor text.
+
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { arch } from 'node:os';
+import { dirname } from 'node:path';
+import { parseArgs, promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+import {
+  ENVIRONMENT_FIELDS,
+  validateApiV1StateWriteEnvironment,
+} from './validate-api-v1-state-write-environment.mjs';
+
+const execFileAsync = promisify(execFile);
+
+const GOVERNED_TABLES = [
+  'app_data_store',
+  'client_state_events',
+  'group_state_events',
+  'resource_inbox',
+  'resource_inbox_results',
+  'runtime_state_store',
+];
+
+const GOVERNED_SETTINGS = [
+  'server_version',
+  'autovacuum',
+  'track_counts',
+  'shared_buffers',
+  'work_mem',
+  'maintenance_work_mem',
+  'effective_cache_size',
+  'random_page_cost',
+  'effective_io_concurrency',
+  'synchronous_commit',
+  'fsync',
+  'full_page_writes',
+  'max_wal_size',
+  'checkpoint_timeout',
+  'jit',
+  'max_parallel_workers_per_gather',
+];
+
+const MAINTENANCE_SQL =
+  'SELECT coalesce(sum(autovacuum_count + autoanalyze_count), 0) FROM pg_stat_user_tables';
+
+const BENCHMARK_PROCESS_MARKER = 'api-v1-state-write-concurrency-bench';
+
+export async function captureApiV1StateWriteEnvironment(argumentsInput = process.argv.slice(2)) {
+  const options = readCaptureOptions(argumentsInput);
+  const captured = options.stage === 'preflight'
+    ? await readPreflightCapture(options)
+    : await readPostflightCapture(options);
+  await mkdir(dirname(options.out), { recursive: true });
+  await writeFile(options.out, captured.text);
+  console.log(`Wrote ${options.out}`);
+}
+
+async function readPreflightCapture(options) {
+  const container = await readContainerRecord(options.container);
+  const image = await readImageRecord(container.imageId);
+  const postgres = await readPostgresRecord(options);
+  const record = {
+    ...image,
+    ...container.record,
+    ...postgres,
+    ...(await readToolchainRecord()),
+    ...(await readOverlapRecord(options.container)),
+    host_architecture: arch(),
+  };
+  assertPreflightIsClean(record);
+  return { text: `${JSON.stringify({ containerId: container.id, record }, null, 2)}\n` };
+}
+
+async function readPostflightCapture(options) {
+  const sidecar = JSON.parse(await readFile(options.preflight, 'utf8'));
+  const container = await readContainerRecord(options.container);
+  if (container.id !== sidecar.containerId) {
+    throw new TypeError('container identity changed between preflight and postflight capture');
+  }
+  const maintenance = await readScalar(options, MAINTENANCE_SQL);
+  const record = { ...sidecar.record, postflight_automatic_maintenance_count: maintenance };
+  const text = toEnvironmentText(record);
+  const errors = validateApiV1StateWriteEnvironment(text);
+  if (errors.length > 0) {
+    throw new TypeError(`captured environment is not governed-valid: ${errors.join('; ')}`);
+  }
+  return { text };
+}
+
+// The pooled comparison only means anything if every source ran against an
+// equivalently empty database, so a dirty preflight fails here rather than
+// surviving into a verdict.
+function assertPreflightIsClean(record) {
+  const dirty = ENVIRONMENT_FIELDS.filter(
+    (field) => field.startsWith('preflight_') && record[field] !== '0',
+  );
+  if (dirty.length > 0) {
+    throw new TypeError(`preflight database is not empty: ${dirty.join(', ')}`);
+  }
+}
+
+async function readContainerRecord(container) {
+  const inspected = JSON.parse(await readDockerJson(['container', 'inspect', container]));
+  const host = inspected.HostConfig;
+  return {
+    id: inspected.Id,
+    imageId: inspected.Image,
+    record: {
+      platform: inspected.Platform,
+      command: inspected.Config.Cmd.join(' '),
+      shm_size: String(host.ShmSize),
+      memory: String(host.Memory),
+      memory_swap: String(host.MemorySwap),
+      nano_cpus: String(host.NanoCpus),
+      cpu_period: String(host.CpuPeriod),
+      cpu_quota: String(host.CpuQuota),
+      cpu_set: host.CpusetCpus,
+      fresh_container: String(inspected.RestartCount === 0),
+    },
+  };
+}
+
+async function readImageRecord(imageId) {
+  const inspected = JSON.parse(await readDockerJson(['image', 'inspect', imageId]));
+  const repoDigest = inspected.RepoDigests[0];
+  return {
+    image_ref: repoDigest,
+    image_id: inspected.Id,
+    repo_digest: repoDigest,
+    image_architecture: inspected.Architecture,
+    image_os: inspected.Os,
+    entrypoint: inspected.Config.Entrypoint[0],
+  };
+}
+
+async function readDockerJson(argumentsInput) {
+  const { stdout } = await execFileAsync('docker', [...argumentsInput, '--format', '{{json .}}']);
+  return stdout;
+}
+
+async function readPostgresRecord(options) {
+  const settings = await readPsqlPairs(
+    options,
+    `SELECT name, setting FROM pg_settings WHERE name IN (${toSqlList(GOVERNED_SETTINGS)})`,
+  );
+  const rows = await readPsqlPairs(options, toRowCountSql());
+  return {
+    ...settings,
+    ...rows,
+    preflight_automatic_maintenance_count: await readScalar(options, MAINTENANCE_SQL),
+  };
+}
+
+function toRowCountSql() {
+  return GOVERNED_TABLES.map(
+    (table) => `SELECT 'preflight_${table}_rows' AS name, count(*)::text AS setting FROM ${table}`,
+  ).join(' UNION ALL ');
+}
+
+function toSqlList(values) {
+  return values.map((value) => `'${value}'`).join(', ');
+}
+
+async function readPsqlPairs(options, sql) {
+  const stdout = await readPsql(options, sql);
+  const record = {};
+  for (const line of stdout.split('\n').filter((value) => value.length > 0)) {
+    const separator = line.indexOf('=');
+    record[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return record;
+}
+
+async function readScalar(options, sql) {
+  return (await readPsql(options, sql)).trim();
+}
+
+async function readPsql(options, sql) {
+  const { stdout } = await execFileAsync('docker', [
+    'exec',
+    options.container,
+    'psql',
+    '-U',
+    options.databaseUser,
+    '-d',
+    options.databaseName,
+    '-At',
+    '-F=',
+    '-c',
+    sql,
+  ]);
+  return stdout;
+}
+
+async function readToolchainRecord() {
+  const deno = await readCommandOutput('deno', ['--version']);
+  return {
+    node: process.versions.node,
+    npm: await readCommandOutput('npm', ['--version']),
+    deno: readDenoComponent(deno, 'deno'),
+    deno_v8: readDenoComponent(deno, 'v8'),
+    deno_typescript: readDenoComponent(deno, 'typescript'),
+    docker: await readCommandOutput('docker', ['version', '--format', '{{.Server.Version}}']),
+    docker_compose: await readCommandOutput('docker', ['compose', 'version', '--short']),
+  };
+}
+
+function readDenoComponent(versionText, name) {
+  const line = versionText.split('\n').find((value) => value.startsWith(`${name} `));
+  return line === undefined ? '' : line.slice(name.length + 1).split(' ')[0];
+}
+
+async function readOverlapRecord(container) {
+  const { stdout } = await execFileAsync('docker', ['ps', '--format', '{{.Names}}']);
+  const others = stdout.split('\n').filter((name) => name.length > 0 && name !== container);
+  return {
+    container_overlap_count: String(others.length),
+    benchmark_process_overlap_count: String(await readBenchmarkProcessCount()),
+  };
+}
+
+async function readBenchmarkProcessCount() {
+  const { stdout } = await execFileAsync('ps', ['-A', '-o', 'command=']);
+  return stdout
+    .split('\n')
+    .filter((line) => line.includes(BENCHMARK_PROCESS_MARKER) && !line.includes('ps -A')).length;
+}
+
+async function readCommandOutput(command, argumentsInput) {
+  const { stdout } = await execFileAsync(command, argumentsInput);
+  return stdout.trim();
+}
+
+function toEnvironmentText(record) {
+  const missing = ENVIRONMENT_FIELDS.filter((field) => typeof record[field] !== 'string');
+  if (missing.length > 0) {
+    throw new TypeError(`captured environment is missing fields: ${missing.join(', ')}`);
+  }
+  return `${ENVIRONMENT_FIELDS.map((field) => `${field}=${record[field]}`).join('\n')}\n`;
+}
+
+function readCaptureOptions(argumentsInput) {
+  const { values } = parseArgs({
+    args: argumentsInput,
+    options: {
+      stage: { type: 'string' },
+      container: { type: 'string' },
+      'database-url': { type: 'string' },
+      preflight: { type: 'string' },
+      out: { type: 'string' },
+    },
+    strict: true,
+  });
+  if (values.stage !== 'preflight' && values.stage !== 'postflight') {
+    throw new TypeError('--stage must be preflight or postflight');
+  }
+  if (values.stage === 'postflight' && typeof values.preflight !== 'string') {
+    throw new TypeError('--preflight is required for the postflight stage');
+  }
+  for (const name of ['container', 'database-url', 'out']) {
+    if (typeof values[name] !== 'string' || values[name].length === 0) {
+      throw new TypeError(`--${name} is required`);
+    }
+  }
+  return { ...toDatabaseIdentity(values['database-url']), ...values, out: values.out };
+}
+
+function toDatabaseIdentity(databaseUrl) {
+  const parsed = new URL(databaseUrl);
+  return {
+    databaseUser: decodeURIComponent(parsed.username),
+    databaseName: decodeURIComponent(parsed.pathname.replace(/^\//, '')),
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await captureApiV1StateWriteEnvironment();
+}

--- a/scripts/perf/validate-api-v1-state-write-environment.mjs
+++ b/scripts/perf/validate-api-v1-state-write-environment.mjs
@@ -3,7 +3,7 @@ const PINNED_POSTGRES_IMAGE =
 const PINNED_POSTGRES_IMAGE_ID =
   'sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171';
 
-const ENVIRONMENT_FIELDS = [
+export const ENVIRONMENT_FIELDS = [
   'image_ref',
   'image_id',
   'repo_digest',


### PR DESCRIPTION
## Goal

Unblock #157 and report what running its escalation actually found.

The issue tracked the API-v1 state-write perf comparison reporting
"environment-limited" for three consecutive phases, and pointed at an order-balanced
A-B-B-A pooling protocol as the remedy. That escalation had never been executed,
because nothing in the repository could produce the environment descriptor each
pooling source requires.

## Correcting an earlier report

I previously recorded on #157 that the protocol was "not executable on this machine
as specified". That was wrong, and the correction matters because it is what made
the rest possible. `postgres@sha256:081f1bc7…` is already in the local image store,
is **arm64-native**, and its image id and repo digest match the validator's pins
exactly. Starting it with the required flags reproduces **9/9** governed container
fields and **15/15** GUCs. Only one blocker was real: nothing emitted the descriptor.

Every governed PostgreSQL setting except `autovacuum` is simply a PG16 default, so
the pinned environment is stock PG16 with autovacuum off under a 4 GiB / 4 CPU /
256 MiB shm reservation — not an exotic configuration.

## Changes

- **`docker-compose.perf-bench.yml`** — pins digest, command, shm size, memory, and
  CPU count. Port 5433 so it coexists with the dev container; no named volume so
  `down -v` returns a genuinely empty data directory.
- **`scripts/perf/capture-api-v1-state-write-environment.mjs`** — emits the 50-field
  descriptor. Two-stage because the field semantics bracket the run: preflight row
  counts describe the database the benchmark started against, the postflight
  counter proves no automatic maintenance ran during it. It validates before
  writing, so a descriptor on disk is one the protocol accepts.
- **`ENVIRONMENT_FIELDS` becomes an export** so emitter and validator share one
  schema instead of duplicating a 50-name list.
- **Results document** recording the control run.

## What the control found

A literal main-vs-main control is impossible — pooling rejects equal
approved-base and candidate commits. The control uses two distinct commits whose
runtime code is provably identical: `git diff` is four files (compose, README,
capture script, one-word export) with **nothing under `packages/**` or `apps/**`**.
True effect is exactly zero.

Four positions, A-B-B-A, each on a freshly recreated container with its own
migration, 9 measured runs at concurrency 10. All four descriptors byte-identical.

**Pooling worked for what it was built for.** Throughput and latency use ±5% bands.
Phase 4's naive pairing reported shared throughput at −8.1%; the pooled comparison
reports **no throughput or latency finding at all**.

**What still fails is a gate design problem, not noise sensitivity.** Four resource
counters are compared with strict `>` and no tolerance:

```js
if (candidateMedian > baselineMedian && !hasRecordedReason(...)) { errors.push(...) }
```

Drift on byte-identical code, pooled over 18 runs per role:

| workload | metric | drift |
| --- | --- | --- |
| uncontended | `postgres.transactionDurationMs` | +0.122% |
| uncontended | `sql.statements` | +0.204% |
| shared | `sql.rowsRead` | +0.147% |
| shared | `sql.statements` | +0.317% |
| shared | `sql.serializedResultBytes` | +0.383% |
| shared | `postgres.transactionDurationMs` | +1.550% |
| hot | `postgres.transactionDurationMs` | +1.409% |
| hot | `sql.statements` | +2.655% |

These counters are not deterministic — the workloads contend deliberately, and
statement counts follow retry attempt counts, which follow timing. A
strict-inequality gate on a stochastic counter is unsatisfiable on any hardware.
Roughly half of all identical-code runs fail it by construction.

The four metrics need a tolerance band calibrated from this drift; the observed
floor is **+2.7%**. The existing `hasRecordedReason` escape hatch is built for
intentional regressions with written justification, and is the wrong instrument for
a coin flip.

## Incidental limits found by running it

- A 9-run artifact is **506,420,464 bytes** against Node's **536,870,888**-byte
  maximum string length — **5.67% headroom** — and both the pooling script and the
  comparator ingest artifacts with `readFile(path, 'utf8')`. Pooled artifacts are
  493 MB (8.11% headroom) only because they are written compactly. A modest increase
  in run count or per-run detail breaks both with `ERR_STRING_TOO_LONG`.
- Pooling and comparison need roughly 12 GB of heap.
- The capture script rejected its own first run because the dev container was still
  up and `container_overlap_count` was not zero — intended behavior, catching a real
  protocol violation before it reached a verdict.

## Validation

- `npm run check:repo-style:changed` PASS against `bc705968`.
- Full A-B-B-A protocol executed end to end; pooling and comparison both ran to
  completion.
- No runtime code is touched, so no test suites are affected. The benchmark
  artifacts (~3 GB) were removed after the run per the repository's artifact policy.
- Dev container and its data restored after the run.

## Follow-up

Calibrating and adding the tolerance band is deliberately **not** in this PR — it
changes a governed gate's semantics and deserves its own review with this drift
data as input.