### PR TITLE
perf: add B05 native Chromium lifecycle evidence

### DIFF
--- a/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-evidence-acceptance.ts
+++ b/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-evidence-acceptance.ts
@@ -295,6 +295,7 @@ export function createRtcBaselineEvidenceAcceptance(
       (attempt) => attempt.sampleIds[0] === owner.identity.sampleId,
     )!;
     const accepted = decodeRtcBaselineAcceptedAttempt(staged.value, {
+      baselineId: input.baselineId,
       expectedOuter,
       rawResultRelativePath: input.rawResultRelativePath,
       producerExitStatus: input.producerExitStatus,

--- a/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-failure-accounting.ts
+++ b/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-failure-accounting.ts
@@ -20,6 +20,10 @@ import type {
   RtcBaselineWorkloadId,
 } from '../contracts/rtc-baseline-contracts.ts';
 import {
+  computeRtcDataChannelBrowserSoakAttempt,
+  RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT,
+} from '../../workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts';
+import {
   RTC_BASELINE_ACCEPTED_ARTIFACT_DIRECTORIES,
   RTC_BASELINE_CAUSAL_NOT_RUN_ISSUE,
   RTC_BASELINE_FAILURE_ARTIFACT_FIELDS,
@@ -213,12 +217,24 @@ export function validateRtcBaselineAcceptedCohort(
 
 export function decodeRtcBaselineAcceptedAttempt(
   value: RtcBaselineJson,
-  input: Omit<Parameters<typeof validateRtcBaselineAcceptedAttempt>[0], 'attempt'>,
+  input: Omit<Parameters<typeof validateRtcBaselineAcceptedAttempt>[0], 'attempt'> & {
+    readonly baselineId: string;
+  },
 ) {
-  return validateRtcBaselineDecoded(decodeRtcBaselineExternalAttempt(value), (attempt) => [
+  const decoded = validateRtcBaselineDecoded(decodeRtcBaselineExternalAttempt(value), (attempt) => [
     ...validateRtcBaselineExternalAttempt(attempt),
     ...validateRtcBaselineAcceptedAttempt({ ...input, attempt }),
   ]);
+  if (
+    !decoded.ok ||
+    input.expectedOuter.workloadId !== RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.workloadId
+  ) {
+    return decoded;
+  }
+  return {
+    ok: true as const,
+    value: computeRtcDataChannelBrowserSoakAttempt(decoded.value, input.baselineId),
+  };
 }
 
 export function decodeRtcBaselineAcceptedCohort(

--- a/packages/shared-rtc-bench/tests/architecture/rtc-benchmark-executable-inventory.test.ts
+++ b/packages/shared-rtc-bench/tests/architecture/rtc-benchmark-executable-inventory.test.ts
@@ -63,6 +63,7 @@ const sourcePaths = [
   'topology-delivery/run-rtc-topology-delivery-log-workloads.ts',
   'topology-replay/replay-drain-operation-counts.ts',
   'workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs',
+  'workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts',
   'workloads/data-channel/rtc-data-channel-close-retention-bench.ts',
   'workloads/data-channel/rtc-data-channel-drain-bench.ts',
   'workloads/data-channel/rtc-data-channel-error-reference-bench.ts',

--- a/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-performance-baseline-evidence-acceptance.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-performance-baseline-evidence-acceptance.test.ts
@@ -157,7 +157,8 @@ function externalInput(workloadId: 'RTC-B01' | 'RTC-B05' | 'RTC-B06') {
   };
 }
 
-function stagedAttempt(workloadId: 'RTC-B05' | 'RTC-B06') {
+function stagedExternalAttempt() {
+  const workloadId = 'RTC-B06' as const;
   const input = externalInput(workloadId);
   const manifest = manifestFor(workloadId);
   const outer = manifest.outerAttempts[0]!;
@@ -196,9 +197,7 @@ function stagedAttempt(workloadId: 'RTC-B05' | 'RTC-B06') {
         issues: [],
       },
     ],
-    samples: [
-      passedSample(identity, workloadId === 'RTC-B05' ? 'native-browser' : 'local-full-stack'),
-    ],
+    samples: [passedSample(identity, 'local-full-stack')],
     issues: [],
   };
 }
@@ -295,21 +294,9 @@ describe('RTC baseline evidence acceptance', () => {
     expect(await result).toEqual(rejected(path, 'entry-ownership', message));
   });
 
-  it('accepts valid browser and external samples and writes every normalized field', async () => {
+  it('accepts a valid external sample and writes every normalized field', async () => {
     const writes: unknown[] = [];
-    const browserAttempt = stagedAttempt('RTC-B05');
-    const browser = createRtcBaselineEvidenceAcceptance(
-      dependencies({
-        readManifest: async () => ({ ok: true, value: manifestFor('RTC-B05') }),
-        readStagedJson: async () => ({ ok: true, value: browserAttempt }),
-        writeAcceptedArtifact: collectWrites(writes),
-      }),
-    );
-    expect(await browser.recordBrowser(externalInput('RTC-B05'))).toEqual({
-      ok: true,
-      value: { acceptedSampleCount: 1 },
-    });
-    const externalAttempt = stagedAttempt('RTC-B06');
+    const externalAttempt = stagedExternalAttempt();
     const external = createRtcBaselineEvidenceAcceptance(
       dependencies({
         readManifest: async () => ({ ok: true, value: manifestFor('RTC-B06') }),
@@ -321,7 +308,7 @@ describe('RTC baseline evidence acceptance', () => {
       ok: true,
       value: { acceptedSampleCount: 1 },
     });
-    expect(writes).toEqual([browserAttempt, externalAttempt]);
+    expect(writes).toEqual([externalAttempt]);
     Object.assign(externalAttempt.samples[0]!, { outcome: 'failed', issues: [producerIssue] });
     Object.assign(externalAttempt.sampleOutcomes[0]!, {
       outcome: 'failed',

--- a/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak.test.ts
@@ -1,14 +1,1044 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createRtcBaselineEvidenceAcceptance } from '../../../baseline/acceptance/rtc-baseline-evidence-acceptance.ts';
+import type {
+  RtcBaselineCaptureManifestDto,
+  RtcBaselineEnvironmentDto,
+  RtcBaselineExternalAttemptDto,
+  RtcBaselineJson,
+  RtcBaselineRuntimeObservationDto,
+} from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import { isRtcBaselineExternalAttemptDto } from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+
+vi.mock('@playwright/test', () => ({
+  chromium: { launch: vi.fn() },
+}));
+
+interface BrowserSoakModule {
+  runRtcDataChannelBrowserSoakCli(
+    argumentsList: readonly string[],
+    dependencies?: {
+      baselineRootPath?: string;
+      launchBrowser?: () => Promise<FakeBrowser>;
+      nowUtc?: () => string;
+    },
+  ): Promise<{ mode: 'diagnostic' | 'raw-evidence'; outputPath: string; output: unknown }>;
+}
+
+interface FakeBrowser {
+  newPage(): Promise<FakePage>;
+  close(): Promise<void>;
+}
+
+interface FakePage {
+  context(): {
+    newCDPSession(): Promise<{
+      send(command: string): Promise<unknown>;
+    }>;
+  };
+  setContent(html: string): Promise<void>;
+  evaluate(
+    operation: unknown,
+    argument?: { iterationCount: number; iterationIdPrefix: string },
+  ): Promise<unknown>;
+}
+
+const scriptPath =
+  'packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs';
+const caseId = 'browser-data-channel-lifecycle';
+const inputKey = 'iterations-25';
+const primaryBaselineId = '20260815-0d2221b3af34-e2-browser';
+const repeatBaselineId = `${primaryBaselineId}-repeat-01`;
+const fixedNow = '2026-08-15T18:00:00.000Z';
+const originalArgv = process.argv;
+let browserSoak: BrowserSoakModule;
+
+const initializedRuntimeObservation: RtcBaselineRuntimeObservationDto = {
+  git: {
+    headCommit: '0'.repeat(40),
+    headTree: '1'.repeat(40),
+    ref: 'codex/shared-rtc-bench-task-6-b05',
+    clean: true,
+  },
+  runtime: {
+    node: 'v24.0.0',
+    npm: '11.0.0',
+    deno: '2.0.0',
+    playwright: '1.0.0',
+    chromium: 'Chromium 140.0.0',
+  },
+  host: {
+    os: 'darwin',
+    kernel: '25.0.0',
+    architecture: 'arm64',
+    logicalCpuCount: 10,
+    cpuModel: 'Test CPU',
+    totalMemoryBytes: 16_000_000_000,
+    executionContext: 'local',
+  },
+  timing: {
+    startedAtUtc: '2026-08-15T17:59:00.000Z',
+    endedAtUtc: '2026-08-15T17:59:01.000Z',
+    monotonicDurationMs: 1000,
+    monotonicSource: 'performance.now',
+  },
+  deviations: [],
+  sourceHashes: [
+    { path: scriptPath, sha256: 'a'.repeat(64), kind: 'source' },
+    {
+      path: 'apps/rallar-black-box/playwright.config.ts',
+      sha256: 'b'.repeat(64),
+      kind: 'config',
+    },
+  ],
+  configurationInputs: [],
+  resolvedConfiguration: [
+    {
+      caseKey: { workloadId: 'RTC-B05', caseId, inputKey },
+      field: 'iterations',
+      value: 25,
+      source: 'default',
+    },
+  ],
+  controllerInputs: [
+    { name: 'baselineId', value: primaryBaselineId, secret: false },
+    { name: 'workloadIds', value: 'RTC-B05', secret: false },
+    { name: 'environmentId', value: 'E2-browser', secret: false },
+  ],
+  workerCommand: {
+    redactedArgv: { executable: 'node', arguments: [scriptPath] },
+    projection: { fixedWorkerFlags: [], configurationFlags: [] },
+  },
+  allowlistedEnvironment: {},
+};
+
+function sampleId(phase: 'warmup' | 'retained', outerOrdinal: number) {
+  return [
+    'rtc-b05-browser-data-channel-lifecycle-iterations-25',
+    phase,
+    String(outerOrdinal).padStart(3, '0'),
+    '001',
+  ].join('-');
+}
+
+function outerAttempt(phase: 'warmup' | 'retained', outerOrdinal: number) {
+  return {
+    workloadId: 'RTC-B05' as const,
+    caseId,
+    inputKey,
+    environmentId: 'E2-browser' as const,
+    intendedPhase: phase,
+    outerOrdinal,
+    sampleIds: [sampleId(phase, outerOrdinal)],
+  };
+}
+
+function manifest(
+  baselineId: string,
+  retainedSampleMultiplier: 1 | 2,
+): RtcBaselineCaptureManifestDto {
+  const retainedAttemptCount = retainedSampleMultiplier === 1 ? 5 : 10;
+  const repeatLink =
+    retainedSampleMultiplier === 1
+      ? null
+      : { primaryBaselineId, primarySummarySha256: 'c'.repeat(64) };
+  return {
+    schema: 'rallar.rtc-baseline.manifest.v1',
+    request: {
+      schema: 'rallar.rtc-baseline.capture-request.v1',
+      baselineId,
+      workloadIds: ['RTC-B05'],
+      environmentId: 'E2-browser',
+      retainedSampleMultiplier,
+      repeatLink,
+      conditionalEnvironmentDecisions: [],
+    },
+    workloadIds: ['RTC-B05'],
+    cases: [{ workloadId: 'RTC-B05', caseId, inputKey }],
+    outerAttempts: [
+      outerAttempt('warmup', 1),
+      ...Array.from({ length: retainedAttemptCount }, (_, index) =>
+        outerAttempt('retained', index + 1),
+      ),
+    ],
+    expectedCohorts: [],
+    repeatLink,
+  };
+}
+
+function environment(captureManifest: RtcBaselineCaptureManifestDto): RtcBaselineEnvironmentDto {
+  const observation = initializedRuntimeObservation;
+  return {
+    schema: 'rallar.rtc-baseline.environment.v1',
+    baselineId: captureManifest.request.baselineId,
+    workloadIds: ['RTC-B05'],
+    environmentId: 'E2-browser',
+    repeatLink: captureManifest.repeatLink,
+    conditionalEnvironmentDecisions: [],
+    observation: {
+      ...observation,
+      controllerInputs: observation.controllerInputs.map((entry) =>
+        entry.name === 'baselineId'
+          ? { ...entry, value: captureManifest.request.baselineId }
+          : entry,
+      ),
+    },
+  };
+}
+
+function rawRelativePath(phase: 'warmup' | 'retained', outerOrdinal: number) {
+  return [
+    'artifacts/staging/rtc-b05-browser-data-channel-lifecycle-iterations-25',
+    phase,
+    `${String(outerOrdinal).padStart(3, '0')}.json`,
+  ].join('-');
+}
+
+function writeInitializedBaseline(
+  rootPath: string,
+  captureManifest: RtcBaselineCaptureManifestDto,
+) {
+  const baselinePath = join(rootPath, captureManifest.request.baselineId);
+  mkdirSync(join(baselinePath, 'artifacts/staging'), { recursive: true });
+  writeFileSync(join(baselinePath, 'manifest.json'), `${JSON.stringify(captureManifest)}\n`);
+  writeFileSync(
+    join(baselinePath, 'environment.json'),
+    `${JSON.stringify(environment(captureManifest))}\n`,
+  );
+  return baselinePath;
+}
+
+function rawArguments(
+  baselineId: string,
+  phase: 'warmup' | 'retained',
+  outerOrdinal: number,
+  rawResultRelativePath = rawRelativePath(phase, outerOrdinal),
+) {
+  return [
+    '--capture=raw-evidence',
+    `--baseline-id=${baselineId}`,
+    `--case-id=${caseId}`,
+    `--input-key=${inputKey}`,
+    `--intended-phase=${phase}`,
+    `--outer-ordinal=${outerOrdinal}`,
+    `--out=${rawResultRelativePath}`,
+  ];
+}
+
+function completedSoak(iterationCount: number, iterationIdPrefix: string) {
+  const results = Array.from({ length: iterationCount }, (_, index) => ({
+    index: index + 1,
+    iterationId: `${iterationIdPrefix}-iteration-${String(index + 1).padStart(3, '0')}`,
+    opened: true,
+    closed: true,
+    messageReceived: true,
+    events: ['local-open', 'remote-open', 'remote-message', 'local-close', 'remote-close'],
+    localState: 'closed',
+    remoteState: 'closed',
+    pcAState: 'closed',
+    pcBState: 'closed',
+    openDurationMs: index + 0.25,
+    closeDurationMs: index + 0.5,
+    failure: null,
+  }));
+  return {
+    iterations: iterationCount,
+    results,
+    openedCount: iterationCount,
+    closedCount: iterationCount,
+    messageReceivedCount: iterationCount,
+    localErrorCount: 0,
+    remoteErrorCount: 0,
+  };
+}
+
+class FakeDataChannel {
+  readyState = 'connecting';
+  counterpart?: FakeDataChannel;
+  onopen?: () => void;
+  onclose?: () => void;
+  onerror?: () => void;
+  onmessage?: () => void;
+
+  open() {
+    this.readyState = 'open';
+    this.onopen?.();
+  }
+
+  send() {
+    this.counterpart?.onmessage?.();
+  }
+
+  close() {
+    if (this.readyState === 'closed') return;
+    this.readyState = 'closed';
+    this.onclose?.();
+    const counterpart = this.counterpart;
+    if (counterpart && counterpart.readyState !== 'closed') {
+      counterpart.readyState = 'closed';
+      counterpart.onclose?.();
+    }
+  }
+}
+
+class FakePeerConnection {
+  static unpaired?: FakePeerConnection;
+  connectionState = 'new';
+  onicecandidate?: () => void;
+  ondatachannel?: (event: { channel: FakeDataChannel }) => void;
+  partner?: FakePeerConnection;
+  localChannel?: FakeDataChannel;
+
+  constructor() {
+    if (FakePeerConnection.unpaired) {
+      this.partner = FakePeerConnection.unpaired;
+      this.partner.partner = this;
+      FakePeerConnection.unpaired = undefined;
+    } else {
+      FakePeerConnection.unpaired = this;
+    }
+  }
+
+  createDataChannel() {
+    this.localChannel = new FakeDataChannel();
+    return this.localChannel;
+  }
+
+  async createOffer() {
+    return {};
+  }
+
+  async createAnswer() {
+    return {};
+  }
+
+  async setLocalDescription() {}
+
+  async setRemoteDescription() {
+    if (!this.partner?.localChannel) return;
+    const remoteChannel = new FakeDataChannel();
+    remoteChannel.counterpart = this.partner.localChannel;
+    this.partner.localChannel.counterpart = remoteChannel;
+    this.ondatachannel?.({ channel: remoteChannel });
+    this.connectionState = 'connected';
+    this.partner.connectionState = 'connected';
+    this.partner.localChannel.open();
+    remoteChannel.open();
+  }
+
+  async addIceCandidate() {}
+
+  close() {
+    this.connectionState = 'closed';
+  }
+}
+
+function semanticBrowser() {
+  const close = vi.fn(async () => undefined);
+  const evaluate = vi.fn(async (operation: unknown, argument?: unknown) => {
+    if (typeof operation !== 'function') throw new Error('Expected a browser operation');
+    return argument === undefined ? await operation() : await operation(argument);
+  });
+  const page: FakePage = {
+    context: () => ({
+      newCDPSession: async () => ({
+        send: async (command: string) =>
+          command === 'Performance.getMetrics'
+            ? { metrics: [{ name: 'JSHeapUsedSize', value: 1000 }] }
+            : {},
+      }),
+    }),
+    setContent: async () => undefined,
+    evaluate,
+  };
+  return {
+    browser: { newPage: async () => page, close },
+    close,
+    evaluate,
+  };
+}
+
+function fakeBrowser(
+  soakFactory: (iterationCount: number, iterationIdPrefix: string) => unknown = completedSoak,
+  heapValues: readonly (number | null)[] = [1000, 1000],
+) {
+  const close = vi.fn(async () => undefined);
+  let heapReadIndex = 0;
+  const evaluate = vi.fn(
+    async (
+      _operation: unknown,
+      argument?: { iterationCount: number; iterationIdPrefix: string },
+    ) => (argument ? soakFactory(argument.iterationCount, argument.iterationIdPrefix) : undefined),
+  );
+  const page: FakePage = {
+    context: () => ({
+      newCDPSession: async () => ({
+        send: async (command: string) => {
+          if (command !== 'Performance.getMetrics') return {};
+          const heapValue = heapValues[heapReadIndex++] ?? null;
+          return {
+            metrics: heapValue === null ? [] : [{ name: 'JSHeapUsedSize', value: heapValue }],
+          };
+        },
+      }),
+    }),
+    setContent: async () => undefined,
+    evaluate,
+  };
+  const browser: FakeBrowser = {
+    newPage: async () => page,
+    close,
+  };
+  return { browser, close, evaluate };
+}
+
+function readJson(path: string): RtcBaselineJson {
+  return JSON.parse(readFileSync(path, 'utf8')) as RtcBaselineJson;
+}
+
+function readExternalAttempt(path: string): RtcBaselineExternalAttemptDto & RtcBaselineJson {
+  const value = readJson(path);
+  if (!isRtcBaselineExternalAttemptDto(value)) {
+    throw new Error(`Expected an RTC baseline external attempt at ${path}`);
+  }
+  return value as RtcBaselineExternalAttemptDto & RtcBaselineJson;
+}
+
+function rtcB05IterationIds(rawEvidence: RtcBaselineJson): readonly string[] {
+  if (
+    typeof rawEvidence !== 'object' ||
+    rawEvidence === null ||
+    Array.isArray(rawEvidence) ||
+    typeof rawEvidence.soak !== 'object' ||
+    rawEvidence.soak === null ||
+    Array.isArray(rawEvidence.soak) ||
+    !Array.isArray(rawEvidence.soak.results)
+  ) {
+    throw new Error('Expected RTC-B05 raw evidence with iteration results');
+  }
+  return rawEvidence.soak.results.map((entry) => {
+    if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      Array.isArray(entry) ||
+      typeof entry.iterationId !== 'string'
+    ) {
+      throw new Error('Expected an RTC-B05 iteration identity');
+    }
+    return entry.iterationId;
+  });
+}
+
+function rtcB05JsonObject(value: RtcBaselineJson, description: string) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Expected object-shaped RTC-B05 ${description}`);
+  }
+  return value;
+}
+
+function createAcceptance(
+  captureManifest: RtcBaselineCaptureManifestDto,
+  staged: RtcBaselineJson,
+  written: unknown[],
+) {
+  const readStagedJson = vi.fn(async () => ({ ok: true as const, value: staged }));
+  const acceptance = createRtcBaselineEvidenceAcceptance({
+    initializeStore: async () => ({ ok: true, value: undefined }),
+    readManifest: async () => ({ ok: true, value: captureManifest }),
+    writeAcceptedArtifact: async (_baselineId, artifact) => {
+      written.push(artifact);
+      return { ok: true, value: undefined };
+    },
+    readStagedJson,
+    runFreshWorker: async () => ({ outcomes: [] }),
+    reconcileAcceptedOperation: async () => [],
+  });
+  return { acceptance, readStagedJson };
+}
+
+function assertAcceptedAttemptIdentity(input: {
+  staged: RtcBaselineExternalAttemptDto;
+  phase: 'warmup' | 'retained';
+  outerOrdinal: number;
+  relativePath: string;
+}) {
+  const expectedSampleId = sampleId(input.phase, input.outerOrdinal);
+  expect(input.staged).toMatchObject({
+    schema: 'rallar.rtc-baseline.external-attempt.v1',
+    locator: {
+      workloadId: 'RTC-B05',
+      caseId,
+      inputKey,
+      intendedPhase: input.phase,
+      outerOrdinal: input.outerOrdinal,
+      environmentId: 'E2-browser',
+      rawResultRelativePath: input.relativePath,
+    },
+    producerExitStatus: 0,
+    sampleOutcomes: [{ identity: { sampleId: expectedSampleId }, outcome: 'passed', issues: [] }],
+    samples: [
+      {
+        identity: { sampleId: expectedSampleId },
+        outcome: 'passed',
+        evidenceClass: 'native-browser',
+        issues: [],
+      },
+    ],
+    issues: [],
+  });
+}
+
+function assertAcceptedMeasurement(input: {
+  staged: RtcBaselineExternalAttemptDto;
+  baselineId: string;
+  phase: 'warmup' | 'retained';
+  outerOrdinal: number;
+  captureManifest: RtcBaselineCaptureManifestDto;
+}) {
+  const sample = input.staged.samples[0];
+  expect(sample.rawEvidence).toMatchObject({
+    identity: {
+      baselineId: input.baselineId,
+      workloadId: 'RTC-B05',
+      caseId,
+      inputKey,
+      intendedPhase: input.phase,
+      outerOrdinal: input.outerOrdinal,
+    },
+  });
+  const iterationIds = rtcB05IterationIds(sample.rawEvidence);
+  expect(iterationIds).toHaveLength(25);
+  expect(new Set(iterationIds).size).toBe(25);
+  expect(sample.metrics.filter(({ metric }) => metric === 'openDurationMs')).toHaveLength(25);
+  expect(sample.metrics.filter(({ metric }) => metric === 'closeDurationMs')).toHaveLength(25);
+  expect(sample.runtimeObservation).toEqual(environment(input.captureManifest).observation);
+}
+
+function failedSoak(iterationCount: number, iterationIdPrefix: string) {
+  const soak = completedSoak(iterationCount, iterationIdPrefix);
+  return {
+    ...soak,
+    closedCount: 24,
+    remoteErrorCount: 1,
+    results: soak.results.map((entry, index) =>
+      index === 0
+        ? {
+            ...entry,
+            closed: false,
+            remoteState: 'closing',
+            events: [...entry.events, 'remote-error'],
+          }
+        : entry,
+    ),
+  };
+}
+
+function expectCausalArtifacts(written: readonly unknown[]) {
+  expect(written).toEqual([
+    expect.objectContaining({
+      artifactKind: 'failure',
+      identity: expect.objectContaining({
+        sampleId: sampleId('retained', 2),
+        outerOrdinal: 2,
+      }),
+    }),
+    expect.objectContaining({
+      artifactKind: 'not-run',
+      identity: expect.objectContaining({ sampleId: sampleId('retained', 3) }),
+    }),
+    expect.objectContaining({
+      artifactKind: 'not-run',
+      identity: expect.objectContaining({ sampleId: sampleId('retained', 4) }),
+    }),
+    expect.objectContaining({
+      artifactKind: 'not-run',
+      identity: expect.objectContaining({ sampleId: sampleId('retained', 5) }),
+    }),
+  ]);
+}
+
+const acceptedRawScenarios = [
+  {
+    baselineId: primaryBaselineId,
+    multiplier: 1 as const,
+    attempts: [
+      { phase: 'warmup' as const, outerOrdinal: 1 },
+      { phase: 'retained' as const, outerOrdinal: 1 },
+      { phase: 'retained' as const, outerOrdinal: 2 },
+      { phase: 'retained' as const, outerOrdinal: 3 },
+      { phase: 'retained' as const, outerOrdinal: 4 },
+      { phase: 'retained' as const, outerOrdinal: 5 },
+    ],
+  },
+  {
+    baselineId: repeatBaselineId,
+    multiplier: 2 as const,
+    attempts: [
+      { phase: 'warmup' as const, outerOrdinal: 1 },
+      { phase: 'retained' as const, outerOrdinal: 1 },
+      { phase: 'retained' as const, outerOrdinal: 2 },
+      { phase: 'retained' as const, outerOrdinal: 3 },
+      { phase: 'retained' as const, outerOrdinal: 4 },
+      { phase: 'retained' as const, outerOrdinal: 5 },
+      { phase: 'retained' as const, outerOrdinal: 6 },
+      { phase: 'retained' as const, outerOrdinal: 7 },
+      { phase: 'retained' as const, outerOrdinal: 8 },
+      { phase: 'retained' as const, outerOrdinal: 9 },
+      { phase: 'retained' as const, outerOrdinal: 10 },
+    ],
+  },
+];
+
+beforeAll(async () => {
+  process.argv = [process.execPath, 'vitest'];
+  browserSoak = (await import(
+    // @ts-expect-error The Node entrypoint is JavaScript and owns no TypeScript declaration.
+    '../../../workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs'
+  )) as BrowserSoakModule;
+  process.argv = originalArgv;
+});
+
+afterAll(() => {
+  process.argv = originalArgv;
+});
 
 it('keeps the browser lifecycle entry syntactically valid without running B05', () => {
-  const result = spawnSync(
-    'node',
-    [
-      '--check',
-      'packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs',
-    ],
-    { encoding: 'utf8' },
-  );
+  const result = spawnSync('node', ['--check', scriptPath], { encoding: 'utf8' });
   expect(result.stderr).toBe('');
   expect(result.status).toBe(0);
+});
+
+it('preserves the diagnostic CLI while measuring only through an injected browser', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'rtc-b05-diagnostic-'));
+  const outputPath = join(directory, 'diagnostic.json');
+  writeFileSync(outputPath, 'old diagnostic\n');
+  const launched = semanticBrowser();
+  const hadPeerConnection = Reflect.has(globalThis, 'RTCPeerConnection');
+  const priorPeerConnection = Reflect.get(globalThis, 'RTCPeerConnection');
+  Reflect.set(globalThis, 'RTCPeerConnection', FakePeerConnection);
+
+  try {
+    const result = await browserSoak.runRtcDataChannelBrowserSoakCli(
+      ['--iterations=2', `--out=${outputPath}`],
+      {
+        launchBrowser: async () => launched.browser,
+        nowUtc: () => fixedNow,
+      },
+    );
+
+    expect(result.mode).toBe('diagnostic');
+    expect(readJson(outputPath)).toMatchObject({
+      createdAt: fixedNow,
+      input: { iterations: 2 },
+      soak: { iterations: 2, openedCount: 2, closedCount: 2 },
+    });
+    expect(launched.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      iterationCount: 2,
+      iterationIdPrefix: 'diagnostic',
+    });
+    expect(launched.close).toHaveBeenCalledOnce();
+  } finally {
+    FakePeerConnection.unpaired = undefined;
+    if (hadPeerConnection) Reflect.set(globalThis, 'RTCPeerConnection', priorPeerConnection);
+    else Reflect.deleteProperty(globalThis, 'RTCPeerConnection');
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+it.each(acceptedRawScenarios)(
+  'stages one create-new accepted raw file for every immutable $baselineId process identity',
+  async ({ baselineId, multiplier, attempts }) => {
+    const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-raw-'));
+    const captureManifest = manifest(baselineId, multiplier);
+    const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+    const manifestBefore = readFileSync(join(baselinePath, 'manifest.json'), 'utf8');
+
+    try {
+      for (const { phase, outerOrdinal } of attempts) {
+        const launched = fakeBrowser();
+        const relativePath = rawRelativePath(phase, outerOrdinal);
+        await browserSoak.runRtcDataChannelBrowserSoakCli(
+          rawArguments(baselineId, phase, outerOrdinal),
+          {
+            baselineRootPath: rootPath,
+            launchBrowser: async () => launched.browser,
+            nowUtc: () => fixedNow,
+          },
+        );
+        const staged = readExternalAttempt(join(baselinePath, relativePath));
+        assertAcceptedAttemptIdentity({ staged, phase, outerOrdinal, relativePath });
+        assertAcceptedMeasurement({ staged, baselineId, phase, outerOrdinal, captureManifest });
+        const written: unknown[] = [];
+        const { acceptance } = createAcceptance(captureManifest, staged, written);
+        const accepted = await acceptance.recordBrowser({
+          baselineId,
+          locator: { workloadId: 'RTC-B05', caseId, inputKey, intendedPhase: phase, outerOrdinal },
+          producerExitStatus: 0,
+          rawResultRelativePath: relativePath,
+        });
+        expect(accepted).toEqual({ ok: true, value: { acceptedSampleCount: 1 } });
+        expect(written).toEqual([staged]);
+        expect(launched.close).toHaveBeenCalledOnce();
+      }
+      expect(readFileSync(join(baselinePath, 'manifest.json'), 'utf8')).toBe(manifestBefore);
+      expect(captureManifest.outerAttempts).toHaveLength(attempts.length);
+      const lastAttempt = attempts.at(-1)!;
+      const launchBrowser = vi.fn(async () => fakeBrowser().browser);
+      await expect(
+        browserSoak.runRtcDataChannelBrowserSoakCli(
+          rawArguments(baselineId, lastAttempt.phase, lastAttempt.outerOrdinal),
+          { baselineRootPath: rootPath, launchBrowser },
+        ),
+      ).rejects.toThrow('already exists');
+      expect(launchBrowser).not.toHaveBeenCalled();
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  },
+);
+
+it('rejects bounds, overrides, path escapes, and changed accepted matrices before launch', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-invalid-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const launched = fakeBrowser();
+  const launchBrowser = vi.fn(async () => launched.browser);
+
+  try {
+    const invalidArguments = [
+      [...rawArguments(primaryBaselineId, 'retained', 1), '--iterations=25'],
+      rawArguments(primaryBaselineId, 'retained', 0),
+      rawArguments(primaryBaselineId, 'retained', 1000),
+      rawArguments(primaryBaselineId, 'retained', 1, '../outside.json'),
+      rawArguments(primaryBaselineId, 'retained', 1, 'artifacts/staging/other.json'),
+    ];
+    for (const argumentsList of invalidArguments) {
+      await expect(
+        browserSoak.runRtcDataChannelBrowserSoakCli(argumentsList, {
+          baselineRootPath: rootPath,
+          launchBrowser,
+        }),
+      ).rejects.toThrow();
+    }
+
+    const changedManifest = {
+      ...captureManifest,
+      outerAttempts: captureManifest.outerAttempts.slice(0, -1),
+    };
+    writeFileSync(join(baselinePath, 'manifest.json'), `${JSON.stringify(changedManifest)}\n`);
+    await expect(
+      browserSoak.runRtcDataChannelBrowserSoakCli(rawArguments(primaryBaselineId, 'retained', 1), {
+        baselineRootPath: rootPath,
+        launchBrowser,
+      }),
+    ).rejects.toThrow('manifest');
+
+    expect(launchBrowser).not.toHaveBeenCalled();
+    expect(existsSync(join(rootPath, 'outside.json'))).toBe(false);
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('rejects changed initialized B05 controller identity before browser launch', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-environment-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const initializedEnvironment = environment(captureManifest);
+  const launchBrowser = vi.fn(async () => fakeBrowser().browser);
+  if (initializedEnvironment.observation === null) {
+    throw new Error('Expected an initialized B05 runtime observation');
+  }
+  const changedObservation = {
+    ...initializedEnvironment.observation,
+    controllerInputs: initializedEnvironment.observation.controllerInputs.map((entry) =>
+      entry.name === 'environmentId' ? { ...entry, value: 'E1-local' } : entry,
+    ),
+  };
+  writeFileSync(
+    join(baselinePath, 'environment.json'),
+    `${JSON.stringify({ ...initializedEnvironment, observation: changedObservation })}\n`,
+  );
+
+  try {
+    await expect(
+      browserSoak.runRtcDataChannelBrowserSoakCli(rawArguments(primaryBaselineId, 'warmup', 1), {
+        baselineRootPath: rootPath,
+        launchBrowser,
+      }),
+    ).rejects.toThrow('environment');
+    expect(launchBrowser).not.toHaveBeenCalled();
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('rejects a staged payload whose locator differs from the bridge command', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-payload-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const relativePath = rawRelativePath('warmup', 1);
+
+  try {
+    await browserSoak.runRtcDataChannelBrowserSoakCli(
+      rawArguments(primaryBaselineId, 'warmup', 1),
+      { baselineRootPath: rootPath, launchBrowser: async () => fakeBrowser().browser },
+    );
+    const staged = readExternalAttempt(join(baselinePath, relativePath));
+    staged.locator.outerOrdinal = 2;
+    const written: unknown[] = [];
+    const { acceptance } = createAcceptance(captureManifest, staged, written);
+    const result = await acceptance.recordBrowser({
+      baselineId: primaryBaselineId,
+      locator: {
+        workloadId: 'RTC-B05',
+        caseId,
+        inputKey,
+        intendedPhase: 'warmup',
+        outerOrdinal: 1,
+      },
+      producerExitStatus: 0,
+      rawResultRelativePath: relativePath,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([
+        expect.objectContaining({ code: 'attempt-locator-mismatch' }),
+      ]),
+    });
+    expect(written[0]).toEqual(expect.objectContaining({ artifactKind: 'failure' }));
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('recomputes B05 lifecycle invariants after the bridge reads staged evidence', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-bridge-validation-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const relativePath = rawRelativePath('warmup', 1);
+
+  try {
+    await browserSoak.runRtcDataChannelBrowserSoakCli(
+      rawArguments(primaryBaselineId, 'warmup', 1),
+      { baselineRootPath: rootPath, launchBrowser: async () => fakeBrowser().browser },
+    );
+    const staged = readExternalAttempt(join(baselinePath, relativePath));
+    const rawEvidence = staged.samples[0].rawEvidence;
+    if (typeof rawEvidence !== 'object' || rawEvidence === null || Array.isArray(rawEvidence)) {
+      throw new Error('Expected object-shaped RTC-B05 raw evidence');
+    }
+    const soak = Reflect.get(rawEvidence, 'soak');
+    if (typeof soak !== 'object' || soak === null || Array.isArray(soak)) {
+      throw new Error('Expected object-shaped RTC-B05 soak evidence');
+    }
+    Reflect.set(soak, 'openedCount', 24);
+
+    const written: unknown[] = [];
+    const { acceptance } = createAcceptance(captureManifest, staged, written);
+    const result = await acceptance.recordBrowser({
+      baselineId: primaryBaselineId,
+      locator: {
+        workloadId: 'RTC-B05',
+        caseId,
+        inputKey,
+        intendedPhase: 'warmup',
+        outerOrdinal: 1,
+      },
+      producerExitStatus: 0,
+      rawResultRelativePath: relativePath,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([expect.objectContaining({ code: 'incomplete-open-count' })]),
+    });
+    expect(written[0]).toEqual(expect.objectContaining({ artifactKind: 'failure' }));
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('binds staged raw baseline identity to the trusted record-browser baseline', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-baseline-binding-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const relativePath = rawRelativePath('warmup', 1);
+
+  try {
+    await browserSoak.runRtcDataChannelBrowserSoakCli(
+      rawArguments(primaryBaselineId, 'warmup', 1),
+      { baselineRootPath: rootPath, launchBrowser: async () => fakeBrowser().browser },
+    );
+    const staged = readExternalAttempt(join(baselinePath, relativePath));
+    const sample = staged.samples[0];
+    const rawEvidence = rtcB05JsonObject(sample.rawEvidence, 'raw evidence');
+    const rawIdentity = rtcB05JsonObject(rawEvidence.identity, 'raw identity');
+    const producerCommand = rtcB05JsonObject(rawEvidence.producerCommand, 'producer command');
+    const changedBaselineId = '20260815-ffffffffffff-e2-browser';
+    rawIdentity.baselineId = changedBaselineId;
+    producerCommand.arguments = [scriptPath, ...rawArguments(changedBaselineId, 'warmup', 1)];
+    if (sample.runtimeObservation === null) {
+      throw new Error('Expected initialized RTC-B05 runtime observation');
+    }
+    sample.runtimeObservation.controllerInputs = sample.runtimeObservation.controllerInputs.map(
+      (entry) => (entry.name === 'baselineId' ? { ...entry, value: changedBaselineId } : entry),
+    );
+
+    const written: unknown[] = [];
+    const { acceptance } = createAcceptance(captureManifest, staged, written);
+    const result = await acceptance.recordBrowser({
+      baselineId: primaryBaselineId,
+      locator: {
+        workloadId: 'RTC-B05',
+        caseId,
+        inputKey,
+        intendedPhase: 'warmup',
+        outerOrdinal: 1,
+      },
+      producerExitStatus: 0,
+      rawResultRelativePath: relativePath,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([expect.objectContaining({ code: 'baseline-id-mismatch' })]),
+    });
+    expect(written[0]).toEqual(expect.objectContaining({ artifactKind: 'failure' }));
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('projects lifecycle failures and the bridge preserves the exact causal remainder', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-failure-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const launched = fakeBrowser(failedSoak);
+  const relativePath = rawRelativePath('retained', 2);
+
+  try {
+    await browserSoak.runRtcDataChannelBrowserSoakCli(
+      rawArguments(primaryBaselineId, 'retained', 2),
+      {
+        baselineRootPath: rootPath,
+        launchBrowser: async () => launched.browser,
+        nowUtc: () => fixedNow,
+      },
+    );
+    const staged = readExternalAttempt(join(baselinePath, relativePath));
+    const written: unknown[] = [];
+    const { acceptance, readStagedJson } = createAcceptance(captureManifest, staged, written);
+    const bridgeInput = {
+      baselineId: primaryBaselineId,
+      locator: {
+        workloadId: 'RTC-B05' as const,
+        caseId,
+        inputKey,
+        intendedPhase: 'retained' as const,
+        outerOrdinal: 2,
+      },
+      producerExitStatus: 0,
+      rawResultRelativePath: relativePath,
+    };
+
+    const result = await acceptance.recordBrowser(bridgeInput);
+    expect(result).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([
+        expect.objectContaining({ code: 'incomplete-close-count' }),
+        expect.objectContaining({ code: 'remote-error-count' }),
+      ]),
+    });
+    expectCausalArtifacts(written);
+
+    written.length = 0;
+    readStagedJson.mockClear();
+    const producerFailure = await acceptance.recordBrowser({
+      ...bridgeInput,
+      producerExitStatus: 9,
+    });
+    expect(producerFailure).toMatchObject({
+      ok: false,
+      issues: [expect.objectContaining({ code: 'producer-exit-status' })],
+    });
+    expect(readStagedJson).not.toHaveBeenCalled();
+    expect(written).toHaveLength(4);
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('fails raw evidence when Chromium exposes only one forced-GC heap value', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-heap-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const launched = fakeBrowser(completedSoak, [1000, null]);
+  const relativePath = rawRelativePath('warmup', 1);
+
+  try {
+    await browserSoak.runRtcDataChannelBrowserSoakCli(
+      rawArguments(primaryBaselineId, 'warmup', 1),
+      {
+        baselineRootPath: rootPath,
+        launchBrowser: async () => launched.browser,
+      },
+    );
+    const staged = readExternalAttempt(join(baselinePath, relativePath));
+    expect(staged.sampleOutcomes).toEqual([
+      expect.objectContaining({
+        outcome: 'failed',
+        issues: [expect.objectContaining({ code: 'incomplete-heap-metrics' })],
+      }),
+    ]);
+    expect(staged.samples[0].metrics.map(({ metric }) => metric)).not.toContain('heapAfterBytes');
+    const written: unknown[] = [];
+    const { acceptance } = createAcceptance(captureManifest, staged, written);
+    const accepted = await acceptance.recordBrowser({
+      baselineId: primaryBaselineId,
+      locator: {
+        workloadId: 'RTC-B05',
+        caseId,
+        inputKey,
+        intendedPhase: 'warmup',
+        outerOrdinal: 1,
+      },
+      producerExitStatus: 0,
+      rawResultRelativePath: relativePath,
+    });
+    expect(accepted).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([
+        expect.objectContaining({ code: 'incomplete-heap-metrics' }),
+      ]),
+    });
+    expect(launched.close).toHaveBeenCalledOnce();
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
+});
+
+it('closes the browser and leaves no raw file when native execution throws', async () => {
+  const rootPath = mkdtempSync(join(tmpdir(), 'rtc-b05-cleanup-'));
+  const captureManifest = manifest(primaryBaselineId, 1);
+  const baselinePath = writeInitializedBaseline(rootPath, captureManifest);
+  const launched = fakeBrowser();
+  launched.evaluate.mockRejectedValueOnce(new Error('page failed'));
+  const relativePath = rawRelativePath('warmup', 1);
+
+  try {
+    await expect(
+      browserSoak.runRtcDataChannelBrowserSoakCli(rawArguments(primaryBaselineId, 'warmup', 1), {
+        baselineRootPath: rootPath,
+        launchBrowser: async () => launched.browser,
+      }),
+    ).rejects.toThrow('page failed');
+    expect(launched.close).toHaveBeenCalledOnce();
+    expect(existsSync(join(baselinePath, relativePath))).toBe(false);
+  } finally {
+    rmSync(rootPath, { recursive: true, force: true });
+  }
 });

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
@@ -1,0 +1,530 @@
+import type {
+  RtcBaselineExternalAttemptDto,
+  RtcBaselineIssueDto,
+  RtcBaselineJson,
+  RtcBaselineRuntimeObservationDto,
+  RtcBaselineSampleDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import { rtcBaselineIssue } from '../../baseline/contracts/rtc-baseline-contracts.ts';
+
+export const RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT = {
+  workloadId: 'RTC-B05',
+  caseId: 'browser-data-channel-lifecycle',
+  inputKey: 'iterations-25',
+  environmentId: 'E2-browser',
+  iterations: 25,
+  scriptPath:
+    'packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs',
+  playwrightConfigPath: 'apps/rallar-black-box/playwright.config.ts',
+} as const;
+
+const baselineIdPattern = /^\d{8}-[0-9a-f]{12}-e2-browser(?:-repeat-01)?$/;
+const expectedEvents = [
+  'local-close',
+  'local-open',
+  'remote-close',
+  'remote-message',
+  'remote-open',
+];
+
+function toJsonObject(value: RtcBaselineJson | undefined): Record<string, RtcBaselineJson> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, RtcBaselineJson>)
+    : null;
+}
+
+function same(
+  left: object | string | number | boolean | null | undefined,
+  right: object | string | number | boolean | null | undefined,
+) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function pad(value: number) {
+  return String(value).padStart(3, '0');
+}
+
+function acceptedRawRelativePath(intendedPhase: string, outerOrdinal: number) {
+  return [
+    'artifacts/staging/rtc-b05-browser-data-channel-lifecycle-iterations-25',
+    intendedPhase,
+    `${pad(outerOrdinal)}.json`,
+  ].join('-');
+}
+
+function expectedProducerArguments(baselineId: string, identity: RtcBaselineSampleDto['identity']) {
+  return [
+    RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.scriptPath,
+    '--capture=raw-evidence',
+    `--baseline-id=${baselineId}`,
+    `--case-id=${RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.caseId}`,
+    `--input-key=${RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.inputKey}`,
+    `--intended-phase=${identity.intendedPhase}`,
+    `--outer-ordinal=${identity.outerOrdinal}`,
+    `--out=${acceptedRawRelativePath(identity.intendedPhase, identity.outerOrdinal)}`,
+  ];
+}
+
+function validateRawIdentity(
+  rawEvidence: Record<string, RtcBaselineJson>,
+  identity: RtcBaselineSampleDto['identity'],
+  baselineId: string,
+) {
+  const rawIdentity = toJsonObject(rawEvidence.identity);
+  if (rawIdentity === null) {
+    return [
+      rtcBaselineIssue(
+        '$.identity',
+        'invalid-raw-identity',
+        'Raw evidence identity must be an object.',
+      ),
+    ];
+  }
+  const expected = {
+    workloadId: identity.workloadId,
+    caseId: identity.caseId,
+    inputKey: identity.inputKey,
+    intendedPhase: identity.intendedPhase,
+    outerOrdinal: identity.outerOrdinal,
+  };
+  const actual = Object.fromEntries(
+    Object.keys(expected).map((field) => [field, rawIdentity[field]]),
+  );
+  const issues: RtcBaselineIssueDto[] = [];
+  if (!same(actual, expected)) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.identity',
+        'raw-identity-mismatch',
+        'Raw identity must match the sample identity.',
+      ),
+    );
+  }
+  if (rawIdentity.baselineId !== baselineId) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.identity.baselineId',
+        'baseline-id-mismatch',
+        'Raw baseline identity must match the trusted record-browser baseline.',
+      ),
+    );
+  } else if (!baselineIdPattern.test(baselineId)) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.identity.baselineId',
+        'invalid-baseline-id',
+        'Raw baseline identity is invalid.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function validateProducerCommand(
+  rawEvidence: Record<string, RtcBaselineJson>,
+  identity: RtcBaselineSampleDto['identity'],
+  baselineId: string,
+) {
+  const producerCommand = toJsonObject(rawEvidence.producerCommand);
+  if (producerCommand === null) {
+    return [
+      rtcBaselineIssue(
+        '$.producerCommand',
+        'invalid-producer-command',
+        'Raw producer command must be complete.',
+      ),
+    ];
+  }
+  const valid =
+    producerCommand.executable === 'node' &&
+    same(producerCommand.arguments, expectedProducerArguments(baselineId, identity));
+  return valid
+    ? []
+    : [
+        rtcBaselineIssue(
+          '$.producerCommand',
+          'producer-command-mismatch',
+          'Raw producer command must match the immutable B05 invocation.',
+        ),
+      ];
+}
+
+function validateHeap(heapValue: RtcBaselineJson | undefined) {
+  const heap = toJsonObject(heapValue);
+  if (heap === null) {
+    return [rtcBaselineIssue('$.heap', 'invalid-heap-metrics', 'Heap metrics must be an object.')];
+  }
+  const values = [heap.beforeBytes, heap.afterBytes, heap.deltaBytes];
+  if (values.every((value) => value === null)) return [];
+  if (!values.every((value) => typeof value === 'number' && Number.isFinite(value))) {
+    return [
+      rtcBaselineIssue(
+        '$.heap',
+        'incomplete-heap-metrics',
+        'Heap metrics must be absent or complete.',
+      ),
+    ];
+  }
+  const [beforeBytes, afterBytes, deltaBytes] = values as number[];
+  if (beforeBytes < 0 || afterBytes < 0 || deltaBytes !== afterBytes - beforeBytes) {
+    return [
+      rtcBaselineIssue(
+        '$.heap.deltaBytes',
+        'heap-delta-mismatch',
+        'Heap delta must equal after minus before.',
+      ),
+    ];
+  }
+  return [];
+}
+
+function validateIterationTiming(iteration: Record<string, RtcBaselineJson>, index: number) {
+  const issues: RtcBaselineIssueDto[] = [];
+  if (
+    iteration.opened !== true ||
+    typeof iteration.openDurationMs !== 'number' ||
+    !Number.isFinite(iteration.openDurationMs) ||
+    iteration.openDurationMs < 0
+  ) {
+    issues.push(
+      rtcBaselineIssue(
+        `$.soak.results[${index}].openDurationMs`,
+        'invalid-open-lifecycle',
+        'Iteration must open with a nonnegative duration.',
+      ),
+    );
+  }
+  if (
+    iteration.closed !== true ||
+    typeof iteration.closeDurationMs !== 'number' ||
+    !Number.isFinite(iteration.closeDurationMs) ||
+    iteration.closeDurationMs < 0
+  ) {
+    issues.push(
+      rtcBaselineIssue(
+        `$.soak.results[${index}].closeDurationMs`,
+        'invalid-close-lifecycle',
+        'Iteration must close with a nonnegative duration.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function validateIterationCleanup(iteration: Record<string, RtcBaselineJson>, index: number) {
+  const issues: RtcBaselineIssueDto[] = [];
+  if (iteration.messageReceived !== true) {
+    issues.push(
+      rtcBaselineIssue(
+        `$.soak.results[${index}].messageReceived`,
+        'message-not-received',
+        'Remote channel must receive the sent payload.',
+      ),
+    );
+  }
+  const finalStates = [
+    iteration.localState,
+    iteration.remoteState,
+    iteration.pcAState,
+    iteration.pcBState,
+  ];
+  if (!finalStates.every((state) => state === 'closed')) {
+    issues.push(
+      rtcBaselineIssue(
+        `$.soak.results[${index}]`,
+        'incomplete-lifecycle-cleanup',
+        'Channels and peer connections must finish closed.',
+      ),
+    );
+  }
+  const events = Array.isArray(iteration.events) ? iteration.events : [];
+  const eventNames = events.filter((event): event is string => typeof event === 'string').sort();
+  if (!same(eventNames, expectedEvents) || iteration.failure !== null) {
+    issues.push(
+      rtcBaselineIssue(
+        `$.soak.results[${index}].events`,
+        'iteration-error',
+        'Iteration recorded an incomplete lifecycle or operation error.',
+      ),
+    );
+  }
+  return issues;
+}
+
+function validateIteration(
+  iterationValue: RtcBaselineJson,
+  index: number,
+  iterationIdPrefix: string,
+) {
+  const iteration = toJsonObject(iterationValue);
+  if (iteration === null) {
+    return [
+      rtcBaselineIssue(
+        `$.soak.results[${index}]`,
+        'invalid-iteration-evidence',
+        'Iteration evidence must be an object.',
+      ),
+    ];
+  }
+  const expectedId = `${iterationIdPrefix}-iteration-${pad(index + 1)}`;
+  const identityIssues =
+    iteration.index === index + 1 && iteration.iterationId === expectedId
+      ? []
+      : [
+          rtcBaselineIssue(
+            `$.soak.results[${index}].iterationId`,
+            'iteration-identity-mismatch',
+            'Iteration identity is not unique and ordered.',
+          ),
+        ];
+  return [
+    ...identityIssues,
+    ...validateIterationTiming(iteration, index),
+    ...validateIterationCleanup(iteration, index),
+  ];
+}
+
+function validateSoak(rawEvidence: Record<string, RtcBaselineJson>, iterationIdPrefix: string) {
+  const soak = toJsonObject(rawEvidence.soak);
+  if (soak === null || !Array.isArray(soak.results)) {
+    return [rtcBaselineIssue('$.soak', 'invalid-soak-evidence', 'Soak evidence must be complete.')];
+  }
+  const count = RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.iterations;
+  const issues: RtcBaselineIssueDto[] = [];
+  if (soak.iterations !== count || soak.results.length !== count) {
+    issues.push(
+      rtcBaselineIssue(
+        '$.soak.results',
+        'iteration-count-mismatch',
+        'RTC-B05 requires 25 iterations.',
+      ),
+    );
+  }
+  const countChecks = [
+    ['openedCount', count, 'incomplete-open-count', 'RTC-B05 requires 25 opens.'],
+    ['closedCount', count, 'incomplete-close-count', 'RTC-B05 requires 25 closes.'],
+    [
+      'messageReceivedCount',
+      count,
+      'incomplete-message-count',
+      'RTC-B05 requires 25 received messages.',
+    ],
+    ['localErrorCount', 0, 'local-error-count', 'RTC-B05 requires zero local errors.'],
+    ['remoteErrorCount', 0, 'remote-error-count', 'RTC-B05 requires zero remote errors.'],
+  ] as const;
+  const countIssues = countChecks
+    .filter(([field, expected]) => soak[field] !== expected)
+    .map(([field, _expected, code, message]) => rtcBaselineIssue(`$.soak.${field}`, code, message));
+  return [
+    ...issues,
+    ...countIssues,
+    ...soak.results.flatMap((iteration, index) =>
+      validateIteration(iteration, index, iterationIdPrefix),
+    ),
+  ];
+}
+
+function validateMeasurement(
+  rawEvidence: Record<string, RtcBaselineJson>,
+  iterationIdPrefix: string,
+) {
+  const duration = rawEvidence.durationMs;
+  const durationIssues =
+    typeof duration === 'number' && Number.isFinite(duration) && duration >= 0
+      ? []
+      : [
+          rtcBaselineIssue(
+            '$.durationMs',
+            'invalid-duration',
+            'Soak duration must be nonnegative.',
+          ),
+        ];
+  return [
+    ...durationIssues,
+    ...validateSoak(rawEvidence, iterationIdPrefix),
+    ...validateHeap(rawEvidence.heap),
+  ];
+}
+
+export function validateRtcDataChannelBrowserSoakRuntimeObservation(
+  observation: RtcBaselineRuntimeObservationDto | null,
+  baselineId: string,
+) {
+  if (observation === null) {
+    return [
+      rtcBaselineIssue(
+        '$.runtimeObservation',
+        'missing-runtime-observation',
+        'B05 requires its initialized runtime observation.',
+      ),
+    ];
+  }
+  const contract = RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT;
+  const expectedSources = [
+    { path: contract.scriptPath, kind: 'source' },
+    { path: contract.playwrightConfigPath, kind: 'config' },
+  ];
+  const sourceIdentities = observation.sourceHashes.map(({ path, kind }) => ({ path, kind }));
+  const hashesValid = observation.sourceHashes.every(({ sha256 }) => /^[0-9a-f]{64}$/.test(sha256));
+  const expectedConfiguration = [
+    {
+      caseKey: {
+        workloadId: contract.workloadId,
+        caseId: contract.caseId,
+        inputKey: contract.inputKey,
+      },
+      field: 'iterations',
+      value: contract.iterations,
+      source: 'default',
+    },
+  ];
+  const expectedControllers = [
+    { name: 'baselineId', value: baselineId, secret: false },
+    { name: 'workloadIds', value: contract.workloadId, secret: false },
+    { name: 'environmentId', value: contract.environmentId, secret: false },
+  ];
+  const expectedWorker = {
+    redactedArgv: { executable: 'node', arguments: [contract.scriptPath] },
+    projection: { fixedWorkerFlags: [], configurationFlags: [] },
+  };
+  const valid =
+    same(observation.deviations, []) &&
+    same(sourceIdentities, expectedSources) &&
+    hashesValid &&
+    same(observation.configurationInputs, []) &&
+    same(observation.resolvedConfiguration, expectedConfiguration) &&
+    same(observation.controllerInputs, expectedControllers) &&
+    same(observation.workerCommand, expectedWorker);
+  return valid
+    ? []
+    : [
+        rtcBaselineIssue(
+          '$.runtimeObservation',
+          'runtime-observation-mismatch',
+          'Runtime observation must match the initialized B05 identity and configuration.',
+        ),
+      ];
+}
+
+function validateRawEvidence(sample: RtcBaselineSampleDto, baselineId: string) {
+  const rawEvidence = toJsonObject(sample.rawEvidence);
+  if (rawEvidence === null) {
+    return [
+      rtcBaselineIssue(
+        '$.rawEvidence',
+        'invalid-raw-evidence',
+        'B05 raw evidence must be an object.',
+      ),
+    ];
+  }
+  const inputValid = same(rawEvidence.input, {
+    iterations: RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.iterations,
+  });
+  const createdAtValid =
+    typeof rawEvidence.createdAt === 'string' && Number.isFinite(Date.parse(rawEvidence.createdAt));
+  return [
+    ...validateRawIdentity(rawEvidence, sample.identity, baselineId),
+    ...validateProducerCommand(rawEvidence, sample.identity, baselineId),
+    ...validateMeasurement(rawEvidence, sample.identity.sampleId),
+    ...(!inputValid
+      ? [
+          rtcBaselineIssue(
+            '$.input.iterations',
+            'input-mismatch',
+            'B05 requires exactly 25 iterations.',
+          ),
+        ]
+      : []),
+    ...(!createdAtValid
+      ? [
+          rtcBaselineIssue(
+            '$.createdAt',
+            'invalid-created-at',
+            'Raw evidence creation time is invalid.',
+          ),
+        ]
+      : []),
+    ...validateRtcDataChannelBrowserSoakRuntimeObservation(sample.runtimeObservation, baselineId),
+    ...(sample.rawReferences.length === 0
+      ? []
+      : [
+          rtcBaselineIssue(
+            '$.rawReferences',
+            'unexpected-raw-reference',
+            'B05 stages evidence inline.',
+          ),
+        ]),
+  ];
+}
+
+function computeFiniteMetric(
+  value: RtcBaselineJson | undefined,
+  metric: string,
+  unit: string,
+): RtcBaselineSampleDto['metrics'] {
+  return typeof value === 'number' && Number.isFinite(value) ? [{ metric, unit, value }] : [];
+}
+
+function computeIterationMetrics(resultValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
+  const result = toJsonObject(resultValue);
+  return result === null
+    ? []
+    : [
+        ...computeFiniteMetric(result.openDurationMs, 'openDurationMs', 'ms'),
+        ...computeFiniteMetric(result.closeDurationMs, 'closeDurationMs', 'ms'),
+      ];
+}
+
+function computeHeapMetrics(
+  heapValue: RtcBaselineJson | undefined,
+): RtcBaselineSampleDto['metrics'] {
+  const heap = toJsonObject(heapValue);
+  const values = [heap?.beforeBytes, heap?.afterBytes, heap?.deltaBytes];
+  return values.every((value) => typeof value === 'number' && Number.isFinite(value))
+    ? [
+        { metric: 'heapBeforeBytes', unit: 'bytes', value: values[0] as number },
+        { metric: 'heapAfterBytes', unit: 'bytes', value: values[1] as number },
+        { metric: 'heapDeltaBytes', unit: 'bytes', value: values[2] as number },
+      ]
+    : [];
+}
+
+function computeMetrics(rawEvidenceValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
+  const rawEvidence = toJsonObject(rawEvidenceValue);
+  if (rawEvidence === null) return [];
+  const soak = toJsonObject(rawEvidence.soak);
+  const results = Array.isArray(soak?.results) ? soak.results : [];
+  return [
+    ...computeFiniteMetric(rawEvidence.durationMs, 'durationMs', 'ms'),
+    ...results.flatMap(computeIterationMetrics),
+    ...computeHeapMetrics(rawEvidence.heap),
+  ];
+}
+
+export function computeRtcDataChannelBrowserSoakSample(
+  sample: RtcBaselineSampleDto,
+  baselineId: string,
+): RtcBaselineSampleDto {
+  const issues = validateRawEvidence(sample, baselineId);
+  return {
+    ...sample,
+    outcome: issues.length === 0 ? ('passed' as const) : ('failed' as const),
+    metrics: computeMetrics(sample.rawEvidence),
+    issues,
+  };
+}
+
+export function computeRtcDataChannelBrowserSoakAttempt(
+  attempt: RtcBaselineExternalAttemptDto,
+  baselineId: string,
+): RtcBaselineExternalAttemptDto {
+  const samples = attempt.samples.map((sample) =>
+    computeRtcDataChannelBrowserSoakSample(sample, baselineId),
+  );
+  return {
+    ...attempt,
+    sampleOutcomes: samples.map(({ identity, outcome, issues }) => ({ identity, outcome, issues })),
+    samples,
+    issues: samples.flatMap(({ issues }) => issues),
+  };
+}

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs
@@ -1,148 +1,632 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { chromium } from '@playwright/test';
 
-function readArg(name, fallback) {
-  const prefix = `--${name}=`;
-  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? fallback;
+import {
+  computeRtcDataChannelBrowserSoakSample,
+  RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT,
+  validateRtcDataChannelBrowserSoakRuntimeObservation,
+} from './rtc-data-channel-browser-soak-validation.ts';
+
+const {
+  workloadId: WORKLOAD_ID,
+  caseId: CASE_ID,
+  inputKey: INPUT_KEY,
+  environmentId: ENVIRONMENT_ID,
+  iterations: ACCEPTED_ITERATIONS,
+  scriptPath: SCRIPT_PATH,
+} = RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT;
+const DEFAULT_DIAGNOSTIC_OUT = 'tmp/perf/results/rtc-data-channel-browser-soak.json';
+const DEFAULT_BASELINE_ROOT = 'tmp/perf/rtc-baseline';
+const BASELINE_ID_PATTERN = /^\d{8}-[0-9a-f]{12}-e2-browser(?:-repeat-01)?$/;
+
+function fail(message) {
+  throw new Error(`RTC-B05: ${message}`);
 }
 
-const iterations = Number(readArg('iterations', '25'));
-const out = readArg('out', 'tmp/perf/results/rtc-data-channel-browser-soak.json');
+function readOptions(argumentsList) {
+  const options = new Map();
+  for (const [index, argument] of argumentsList.entries()) {
+    if (!argument.startsWith('--') || !argument.includes('=')) {
+      fail(`argument ${index + 1} must use --name=value syntax`);
+    }
+    const separator = argument.indexOf('=');
+    const name = argument.slice(2, separator);
+    if (options.has(name)) {
+      fail(`option --${name} may appear only once`);
+    }
+    options.set(name, argument.slice(separator + 1));
+  }
+  return options;
+}
 
-const browser = await chromium.launch({
-  headless: true,
-});
+function requiredOption(options, name) {
+  const value = options.get(name);
+  if (value === undefined || value.length === 0) {
+    fail(`option --${name} is required`);
+  }
+  return value;
+}
 
-try {
-  const page = await browser.newPage();
-  const cdp = await page.context().newCDPSession(page);
-  await cdp.send('Performance.enable');
+function boundedInteger({ value, name, minimum, maximum }) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    fail(`option --${name} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return parsed;
+}
 
-  const readHeapUsed = async () => {
-    await cdp.send('HeapProfiler.collectGarbage').catch(() => undefined);
-    const metrics = await cdp.send('Performance.getMetrics');
-    return metrics.metrics.find((metric) => metric.name === 'JSHeapUsedSize')?.value;
+function parseDiagnosticCommand(options) {
+  const iterations = boundedInteger({
+    value: options.get('iterations') ?? '25',
+    name: 'iterations',
+    minimum: 1,
+    maximum: 10_000,
+  });
+  return {
+    mode: 'diagnostic',
+    iterations,
+    outputPath: options.get('out') ?? DEFAULT_DIAGNOSTIC_OUT,
   };
+}
 
-  await page.setContent('<!doctype html><title>RTC DataChannel soak</title>');
-  const heapBefore = await readHeapUsed();
-  const startedAt = performance.now();
-  const soak = await page.evaluate(async (iterationCount) => {
-    async function waitFor(predicate, timeoutMs = 5000) {
+function parseRawEvidenceCommand(options) {
+  const allowed = new Set([
+    'capture',
+    'baseline-id',
+    'case-id',
+    'input-key',
+    'intended-phase',
+    'outer-ordinal',
+    'out',
+  ]);
+  for (const name of options.keys()) {
+    if (!allowed.has(name)) {
+      fail(`option --${name} cannot override the accepted raw-evidence workload`);
+    }
+  }
+  const baselineId = requiredOption(options, 'baseline-id');
+  if (!BASELINE_ID_PATTERN.test(baselineId)) {
+    fail('baseline ID does not match the accepted E2 browser grammar');
+  }
+  const intendedPhase = requiredOption(options, 'intended-phase');
+  if (intendedPhase !== 'warmup' && intendedPhase !== 'retained') {
+    fail('option --intended-phase must be warmup or retained');
+  }
+  return {
+    mode: 'raw-evidence',
+    baselineId,
+    caseId: requiredOption(options, 'case-id'),
+    inputKey: requiredOption(options, 'input-key'),
+    intendedPhase,
+    outerOrdinal: boundedInteger({
+      value: requiredOption(options, 'outer-ordinal'),
+      name: 'outer-ordinal',
+      minimum: 1,
+      maximum: 999,
+    }),
+    rawResultRelativePath: requiredOption(options, 'out'),
+  };
+}
+
+function parseCommand(argumentsList) {
+  const options = readOptions(argumentsList);
+  return options.get('capture') === 'raw-evidence'
+    ? parseRawEvidenceCommand(options)
+    : parseDiagnosticCommand(options);
+}
+
+function pad(value) {
+  return String(value).padStart(3, '0');
+}
+
+function acceptedSampleId(intendedPhase, outerOrdinal) {
+  return [
+    'rtc-b05-browser-data-channel-lifecycle-iterations-25',
+    intendedPhase,
+    pad(outerOrdinal),
+    '001',
+  ].join('-');
+}
+
+function acceptedRawRelativePath(intendedPhase, outerOrdinal) {
+  return [
+    'artifacts/staging/rtc-b05-browser-data-channel-lifecycle-iterations-25',
+    intendedPhase,
+    `${pad(outerOrdinal)}.json`,
+  ].join('-');
+}
+
+function expectedOuterAttempts(retainedSampleMultiplier) {
+  const retainedCount = retainedSampleMultiplier === 1 ? 5 : 10;
+  const attempt = (intendedPhase, outerOrdinal) => ({
+    workloadId: WORKLOAD_ID,
+    caseId: CASE_ID,
+    inputKey: INPUT_KEY,
+    environmentId: ENVIRONMENT_ID,
+    intendedPhase,
+    outerOrdinal,
+    sampleIds: [acceptedSampleId(intendedPhase, outerOrdinal)],
+  });
+  return [
+    attempt('warmup', 1),
+    ...Array.from({ length: retainedCount }, (_, index) => attempt('retained', index + 1)),
+  ];
+}
+
+function readJson(path, artifactName) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(
+      `${artifactName} could not be read as JSON: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+}
+
+function same(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function validateRepeatContract(manifest, baselineId) {
+  const repeat = baselineId.endsWith('-repeat-01');
+  const multiplier = manifest.request?.retainedSampleMultiplier;
+  if (multiplier !== (repeat ? 2 : 1)) {
+    fail('manifest retained-sample multiplier does not match the baseline identity');
+  }
+  const repeatLink = manifest.request?.repeatLink;
+  if (!repeat && repeatLink !== null) {
+    fail('primary manifest must not contain a repeat link');
+  }
+  if (
+    repeat &&
+    (repeatLink?.primaryBaselineId !== baselineId.replace(/-repeat-01$/, '') ||
+      !/^[0-9a-f]{64}$/.test(repeatLink?.primarySummarySha256 ?? ''))
+  ) {
+    fail('repeat manifest must link to the exact primary summary');
+  }
+  if (!same(manifest.repeatLink, repeatLink)) {
+    fail('manifest repeat link differs from its request');
+  }
+  return multiplier;
+}
+
+function validateManifest(manifest, command) {
+  const request = manifest.request;
+  if (
+    manifest.schema !== 'rallar.rtc-baseline.manifest.v1' ||
+    request?.schema !== 'rallar.rtc-baseline.capture-request.v1' ||
+    request.baselineId !== command.baselineId ||
+    request.environmentId !== ENVIRONMENT_ID
+  ) {
+    fail('manifest identity does not match the raw-evidence command');
+  }
+  if (
+    !same(request.workloadIds, [WORKLOAD_ID]) ||
+    !same(manifest.workloadIds, [WORKLOAD_ID]) ||
+    !same(manifest.cases, [{ workloadId: WORKLOAD_ID, caseId: CASE_ID, inputKey: INPUT_KEY }]) ||
+    !same(request.conditionalEnvironmentDecisions, []) ||
+    !same(manifest.expectedCohorts, [])
+  ) {
+    fail('manifest changes the immutable RTC-B05 workload');
+  }
+  const multiplier = validateRepeatContract(manifest, command.baselineId);
+  if (!same(manifest.outerAttempts, expectedOuterAttempts(multiplier))) {
+    fail('manifest outer process identities differ from the accepted RTC-B05 matrix');
+  }
+  const outerAttempt = manifest.outerAttempts.find(
+    (entry) =>
+      entry.workloadId === WORKLOAD_ID &&
+      entry.caseId === command.caseId &&
+      entry.inputKey === command.inputKey &&
+      entry.intendedPhase === command.intendedPhase &&
+      entry.outerOrdinal === command.outerOrdinal,
+  );
+  if (!outerAttempt) {
+    fail('manifest does not predeclare the requested RTC-B05 outer process identity');
+  }
+  return outerAttempt;
+}
+
+function validateEnvironment(environment, manifest) {
+  if (
+    environment.schema !== 'rallar.rtc-baseline.environment.v1' ||
+    environment.baselineId !== manifest.request.baselineId ||
+    environment.environmentId !== ENVIRONMENT_ID ||
+    !same(environment.workloadIds, [WORKLOAD_ID]) ||
+    !same(environment.repeatLink, manifest.repeatLink) ||
+    !same(environment.conditionalEnvironmentDecisions, []) ||
+    environment.observation === null
+  ) {
+    fail('environment identity does not match the immutable manifest');
+  }
+  const observation = environment.observation;
+  const issues = validateRtcDataChannelBrowserSoakRuntimeObservation(
+    observation,
+    manifest.request.baselineId,
+  );
+  if (issues.length > 0) {
+    fail(`environment changes the accepted RTC-B05 configuration or provenance: ${issues[0].code}`);
+  }
+  return observation;
+}
+
+function assertDirectory(path, label) {
+  if (!existsSync(path)) {
+    fail(`${label} directory does not exist`);
+  }
+  const status = lstatSync(path);
+  if (status.isSymbolicLink() || !status.isDirectory()) {
+    fail(`${label} must be a non-symlink directory`);
+  }
+}
+
+function readRawCaptureContext(command, baselineRootPath) {
+  const baselinePath = join(baselineRootPath, command.baselineId);
+  assertDirectory(baselineRootPath, 'baseline root');
+  assertDirectory(baselinePath, 'baseline');
+  assertDirectory(join(baselinePath, 'artifacts'), 'artifact');
+  assertDirectory(join(baselinePath, 'artifacts/staging'), 'staging');
+  const manifest = readJson(join(baselinePath, 'manifest.json'), 'manifest');
+  const outerAttempt = validateManifest(manifest, command);
+  const expectedRelativePath = acceptedRawRelativePath(
+    outerAttempt.intendedPhase,
+    outerAttempt.outerOrdinal,
+  );
+  if (command.rawResultRelativePath !== expectedRelativePath) {
+    fail(`raw output path must equal ${expectedRelativePath}`);
+  }
+  const outputPath = join(baselinePath, expectedRelativePath);
+  if (existsSync(outputPath)) {
+    fail(`raw output already exists at ${expectedRelativePath}`);
+  }
+  const environment = readJson(join(baselinePath, 'environment.json'), 'environment');
+  return {
+    outerAttempt,
+    outputPath,
+    runtimeObservation: validateEnvironment(environment, manifest),
+  };
+}
+
+async function measureBrowserLifecycle(iterations, iterationIdPrefix, dependencies) {
+  const browser = await dependencies.launchBrowser({ headless: true });
+  try {
+    const page = await browser.newPage();
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Performance.enable');
+    const readHeapUsed = async () => {
+      await cdp.send('HeapProfiler.collectGarbage').catch(() => undefined);
+      const metrics = await cdp.send('Performance.getMetrics');
+      return metrics.metrics?.find((metric) => metric.name === 'JSHeapUsedSize')?.value ?? null;
+    };
+    await page.setContent('<!doctype html><title>RTC DataChannel soak</title>');
+    await installPageLifecycleOperations(page);
+    const heapBefore = await readHeapUsed();
+    const startedAt = performance.now();
+    const soak = await runPageLifecycle(page, { iterationCount: iterations, iterationIdPrefix });
+    const durationMs = performance.now() - startedAt;
+    const heapAfter = await readHeapUsed();
+    return {
+      durationMs,
+      heap: {
+        beforeBytes: heapBefore,
+        afterBytes: heapAfter,
+        deltaBytes: heapBefore === null || heapAfter === null ? null : heapAfter - heapBefore,
+      },
+      soak,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+async function installPageLifecycleOperations(page) {
+  await installPageLifecycleNamespace(page);
+  await installPageLifecycleWait(page);
+  await installPageLifecycleState(page);
+  await installPageLifecycleOpen(page);
+  await installPageLifecycleClose(page);
+  await installPageLifecycleIteration(page);
+}
+
+async function installPageLifecycleNamespace(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05 = {};
+  });
+}
+
+async function installPageLifecycleWait(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05.waitFor = async (predicate, timeoutMs = 5000) => {
       const started = performance.now();
       while (performance.now() - started < timeoutMs) {
         if (predicate()) return true;
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
       }
       return false;
-    }
+    };
+  });
+}
 
-    async function runIteration(index) {
-      const pcA = new RTCPeerConnection({
-        iceServers: [],
-      });
-      const pcB = new RTCPeerConnection({
-        iceServers: [],
-      });
+async function installPageLifecycleState(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05.createIterationState = (index) => {
+      const pcA = new RTCPeerConnection({ iceServers: [] });
+      const pcB = new RTCPeerConnection({ iceServers: [] });
       const events = [];
-
+      let channelB;
+      let messageReceived = false;
       pcA.onicecandidate = (event) => {
         if (event.candidate) void pcB.addIceCandidate(event.candidate);
       };
       pcB.onicecandidate = (event) => {
         if (event.candidate) void pcA.addIceCandidate(event.candidate);
       };
-
       const channelA = pcA.createDataChannel(`soak-${index}`);
-      let channelB;
       pcB.ondatachannel = (event) => {
         channelB = event.channel;
         channelB.onopen = () => events.push('remote-open');
         channelB.onclose = () => events.push('remote-close');
         channelB.onerror = () => events.push('remote-error');
+        channelB.onmessage = () => {
+          messageReceived = true;
+          events.push('remote-message');
+        };
       };
       channelA.onopen = () => events.push('local-open');
       channelA.onclose = () => events.push('local-close');
       channelA.onerror = () => events.push('local-error');
+      return {
+        pcA,
+        pcB,
+        channelA,
+        events,
+        channelB: () => channelB,
+        messageReceived: () => messageReceived,
+      };
+    };
+  });
+}
 
-      const offer = await pcA.createOffer();
-      await pcA.setLocalDescription(offer);
-      await pcB.setRemoteDescription(offer);
-      const answer = await pcB.createAnswer();
-      await pcB.setLocalDescription(answer);
-      await pcA.setRemoteDescription(answer);
-
-      const opened = await waitFor(
-        () => channelA.readyState === 'open' && channelB?.readyState === 'open',
+async function installPageLifecycleOpen(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05.openChannels = async (state) => {
+      const startedAt = performance.now();
+      const offer = await state.pcA.createOffer();
+      await state.pcA.setLocalDescription(offer);
+      await state.pcB.setRemoteDescription(offer);
+      const answer = await state.pcB.createAnswer();
+      await state.pcB.setLocalDescription(answer);
+      await state.pcA.setRemoteDescription(answer);
+      const opened = await globalThis.rtcB05.waitFor(
+        () => state.channelA.readyState === 'open' && state.channelB()?.readyState === 'open',
       );
-      if (!opened) {
-        pcA.close();
-        pcB.close();
-        return {
-          index,
-          opened,
-          events,
-          localState: channelA.readyState,
-          remoteState: channelB?.readyState,
-        };
+      return { opened, durationMs: performance.now() - startedAt };
+    };
+  });
+}
+
+async function installPageLifecycleClose(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05.sendAndClose = async (state, index) => {
+      state.channelA.send(JSON.stringify({ index, ok: true }));
+      await globalThis.rtcB05.waitFor(state.messageReceived);
+      const startedAt = performance.now();
+      state.channelA.close();
+      const closed = await globalThis.rtcB05.waitFor(
+        () => state.channelA.readyState === 'closed' && state.channelB()?.readyState === 'closed',
+      );
+      return { closed, durationMs: performance.now() - startedAt };
+    };
+  });
+}
+
+async function installPageLifecycleIteration(page) {
+  await page.evaluate(() => {
+    globalThis.rtcB05.runIteration = async (index, iterationIdPrefix) => {
+      const state = globalThis.rtcB05.createIterationState(index);
+      let opened = false;
+      let closed = false;
+      let openDurationMs = null;
+      let closeDurationMs = null;
+      let failure = null;
+      try {
+        const open = await globalThis.rtcB05.openChannels(state);
+        opened = open.opened;
+        openDurationMs = open.durationMs;
+        if (opened) {
+          const close = await globalThis.rtcB05.sendAndClose(state, index);
+          closed = close.closed;
+          closeDurationMs = close.durationMs;
+        }
+      } catch (error) {
+        failure = error instanceof Error ? error.message : String(error);
+        state.events.push('iteration-error');
+      } finally {
+        if (state.channelA.readyState !== 'closed') state.channelA.close();
+        if (state.channelB() && state.channelB().readyState !== 'closed') state.channelB().close();
+        state.pcA.close();
+        state.pcB.close();
+        await new Promise((resolveTask) => setTimeout(resolveTask, 0));
       }
-
-      channelA.send(JSON.stringify({ index, ok: true }));
-      channelA.close();
-      await waitFor(() => channelA.readyState === 'closed' && channelB?.readyState === 'closed');
-      pcA.close();
-      pcB.close();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
       return {
         index,
+        iterationId: `${iterationIdPrefix}-iteration-${String(index).padStart(3, '0')}`,
         opened,
-        events,
-        localState: channelA.readyState,
-        remoteState: channelB?.readyState,
-        pcAState: pcA.connectionState,
-        pcBState: pcB.connectionState,
+        closed,
+        messageReceived: state.messageReceived(),
+        events: state.events,
+        localState: state.channelA.readyState,
+        remoteState: state.channelB()?.readyState ?? 'missing',
+        pcAState: state.pcA.connectionState,
+        pcBState: state.pcB.connectionState,
+        openDurationMs,
+        closeDurationMs,
+        failure,
       };
-    }
-
-    const results = [];
-    for (let index = 1; index <= iterationCount; index += 1) {
-      results.push(await runIteration(index));
-    }
-
-    return {
-      iterations: iterationCount,
-      results,
-      openedCount: results.filter((result) => result.opened).length,
-      closedCount: results.filter(
-        (result) => result.localState === 'closed' && result.remoteState === 'closed',
-      ).length,
-      localErrorCount: results.filter((result) => result.events.includes('local-error')).length,
-      remoteErrorCount: results.filter((result) => result.events.includes('remote-error')).length,
     };
-  }, iterations);
-  const durationMs = performance.now() - startedAt;
-  const heapAfter = await readHeapUsed();
+  });
+}
 
-  const output = {
-    createdAt: new Date().toISOString(),
-    input: {
-      iterations,
-    },
-    durationMs,
-    heap: {
-      beforeBytes: heapBefore,
-      afterBytes: heapAfter,
-      deltaBytes:
-        heapBefore === undefined || heapAfter === undefined ? undefined : heapAfter - heapBefore,
-    },
-    soak,
+async function runPageLifecycle(page, input) {
+  return page.evaluate(async ({ iterationCount, iterationIdPrefix }) => {
+    const results = [];
+    try {
+      for (let index = 1; index <= iterationCount; index += 1) {
+        results.push(await globalThis.rtcB05.runIteration(index, iterationIdPrefix));
+      }
+      return {
+        iterations: iterationCount,
+        results,
+        openedCount: results.filter(({ opened }) => opened).length,
+        closedCount: results.filter(({ closed }) => closed).length,
+        messageReceivedCount: results.filter(({ messageReceived }) => messageReceived).length,
+        localErrorCount: results.filter(({ events }) => events.includes('local-error')).length,
+        remoteErrorCount: results.filter(({ events }) => events.includes('remote-error')).length,
+      };
+    } finally {
+      delete globalThis.rtcB05;
+    }
+  }, input);
+}
+
+function createAcceptedSample({ command, context, measurement, argumentsList, nowUtc }) {
+  const sampleIdentity = {
+    sampleId: context.outerAttempt.sampleIds[0],
+    workloadId: WORKLOAD_ID,
+    caseId: CASE_ID,
+    inputKey: INPUT_KEY,
+    intendedPhase: command.intendedPhase,
+    outerOrdinal: command.outerOrdinal,
+    innerOrdinal: 1,
   };
+  const identity = {
+    baselineId: command.baselineId,
+    workloadId: WORKLOAD_ID,
+    caseId: CASE_ID,
+    inputKey: INPUT_KEY,
+    intendedPhase: command.intendedPhase,
+    outerOrdinal: command.outerOrdinal,
+  };
+  return computeRtcDataChannelBrowserSoakSample(
+    {
+      schema: 'rallar.rtc-baseline.sample.v1',
+      identity: sampleIdentity,
+      outcome: 'not-run',
+      evidenceClass: 'native-browser',
+      metrics: [],
+      rawEvidence: {
+        createdAt: nowUtc(),
+        identity,
+        input: { iterations: ACCEPTED_ITERATIONS },
+        producerCommand: {
+          executable: 'node',
+          arguments: [SCRIPT_PATH, ...argumentsList],
+        },
+        ...measurement,
+      },
+      rawReferences: [],
+      issues: [],
+      runtimeObservation: context.runtimeObservation,
+    },
+    command.baselineId,
+  );
+}
 
-  mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, `${JSON.stringify(output, null, 2)}\n`);
-  console.log(`Wrote ${out}`);
-} finally {
-  await browser.close();
+function toExternalAttempt({ command, context, measurement, argumentsList, nowUtc }) {
+  const sample = createAcceptedSample({
+    command,
+    context,
+    measurement,
+    argumentsList,
+    nowUtc,
+  });
+  return {
+    schema: 'rallar.rtc-baseline.external-attempt.v1',
+    locator: {
+      workloadId: WORKLOAD_ID,
+      caseId: CASE_ID,
+      inputKey: INPUT_KEY,
+      environmentId: ENVIRONMENT_ID,
+      intendedPhase: command.intendedPhase,
+      outerOrdinal: command.outerOrdinal,
+      rawResultRelativePath: command.rawResultRelativePath,
+    },
+    producerExitStatus: 0,
+    producerFacts: {
+      databaseUrl: 'absent',
+      allScenariosPresent: false,
+      allScenariosRaw: null,
+      retentionSoakPresent: false,
+      retentionSoakRaw: null,
+      retentionCyclesPresent: false,
+      retentionCyclesRaw: null,
+      iceModePresent: false,
+      iceModeRaw: null,
+    },
+    sampleOutcomes: [{ identity: sample.identity, outcome: sample.outcome, issues: sample.issues }],
+    samples: [sample],
+    issues: sample.issues,
+  };
+}
+
+function writeJson(path, value, createNew) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: createNew ? 'wx' : 'w',
+  });
+}
+
+export async function runRtcDataChannelBrowserSoakCli(argumentsList, overrides = {}) {
+  const command = parseCommand(argumentsList);
+  const dependencies = {
+    baselineRootPath: overrides.baselineRootPath ?? DEFAULT_BASELINE_ROOT,
+    launchBrowser: overrides.launchBrowser ?? ((options) => chromium.launch(options)),
+    nowUtc: overrides.nowUtc ?? (() => new Date().toISOString()),
+  };
+  if (command.mode === 'diagnostic') {
+    const measurement = await measureBrowserLifecycle(
+      command.iterations,
+      'diagnostic',
+      dependencies,
+    );
+    const output = {
+      createdAt: dependencies.nowUtc(),
+      input: { iterations: command.iterations },
+      ...measurement,
+    };
+    mkdirSync(dirname(command.outputPath), { recursive: true });
+    writeJson(command.outputPath, output, false);
+    return { mode: command.mode, outputPath: command.outputPath, output };
+  }
+  const context = readRawCaptureContext(command, dependencies.baselineRootPath);
+  const measurement = await measureBrowserLifecycle(
+    ACCEPTED_ITERATIONS,
+    context.outerAttempt.sampleIds[0],
+    dependencies,
+  );
+  const output = toExternalAttempt({
+    command,
+    context,
+    measurement,
+    argumentsList,
+    nowUtc: dependencies.nowUtc,
+  });
+  writeJson(context.outputPath, output, true);
+  return { mode: command.mode, outputPath: context.outputPath, output };
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === invokedPath) {
+  try {
+    const result = await runRtcDataChannelBrowserSoakCli(process.argv.slice(2));
+    console.log(`Wrote ${result.outputPath}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Goal

Deliver the authorized RTC performance Task 6 B05 native Chromium data-channel lifecycle raw-evidence behavior while preserving the existing diagnostic CLI.

## Changes

- Adds immutable manifest, environment, matrix, output-path, and create-new staging checks before browser launch.
- Measures 25 sequential native data-channel open, message, close, cleanup, timing, error, and optional heap observations in one fresh browser process per outer attempt.
- Adds one canonical Node and Deno validator that binds raw identity to the trusted baseline and recomputes metrics, outcomes, and failure projections from staged facts.
- Extends focused semantic, adversarial, failure-accounting, inventory, primary, repeat, diagnostic, and cleanup coverage.

## Acceptance

- Primary and repeat process matrices, native-browser evidence class, exact producer command, runtime observation, iteration identities, lifecycle events, final closure, and causal remainder are enforced.
- The generic non-B05 acceptance path remains compatible, and the diagnostic CLI remains available.
- No real B05 Chromium workload or B01-B05 capture was run; no measurement anchor was frozen and no later RTC task was activated.

## Validation

- Focused B05: 1 file, 12 tests passed.
- Shared RTC bench check: TypeScript, 32 files / 311 tests, and Deno entrypoint checks passed.
- Repository CI: unit 836 files / 7,421 tests; Deno 146 passed; standard Playwright 39 passed / 46 skipped; Recipe Console 211 passed / 1 skipped; memory full stack 7 passed.
- Repository build passed with existing chunk-size warnings; changed-file style passed; legacy review found no candidates; repository structure passed with one reviewed singleton note for the plan-reserved browser-lifecycle test directory.
- Independent review: Critical 0, Important 0.

## Risk and rollback

Risk is limited to the B05 evidence producer and its acceptance bridge. Main advancements through 3bf1f57fee5690850063cf57f53105314aec4531 were compatibility-reviewed; their app-startup and state-write benchmark changes do not overlap the B05 owners. The feature commit was rebased onto that exact main head. Revert commit eb232f5687ba61e61441b0c641e993c7ade38e39 to roll back the change.

## Follow-up

None. B05 capture, measurement-anchor freeze, B06, and B07 remain inactive.