### PR TITLE
Give the state-write resource metrics the tolerance the timing ones have

### DIFF
--- a/packages/tests/shared-server/group-state-server-structure-performance-policy.test.ts
+++ b/packages/tests/shared-server/group-state-server-structure-performance-policy.test.ts
@@ -372,7 +372,7 @@ function evaluateSharedRows(candidateRows: number): string[] {
 
 function resourceRegressionError(candidate: number): string {
   return (
-    'shared median sql.rowsRead increased without a recorded reason: ' +
+    'shared median sql.rowsRead regressed by more than 5% without a recorded reason: ' +
     `baseline=1, candidate=${candidate}`
   );
 }

--- a/packages/tests/shared-server/state-write-performance-harness.test.ts
+++ b/packages/tests/shared-server/state-write-performance-harness.test.ts
@@ -179,6 +179,43 @@ describe('API-v1 state-write final durable evidence', { timeout: 30_000 }, () =>
     }
   });
 
+  // Resource counters follow retry attempt counts, which follow timing, so an
+  // identical-code control drifts (up to +2.7% measured, issue #157). The gate
+  // has to absorb that drift and still catch a real resource regression.
+  it('tolerates resource variance within 5% and rejects beyond it', () => {
+    const withinTolerance = createStateWritePerformanceArtifact();
+    setResourceAdverseRatio(withinTolerance, 0.04);
+    expect(
+      compareStateWriteArtifacts(createStateWritePerformanceArtifact(), withinTolerance),
+    ).toEqual([]);
+
+    const beyondTolerance = createStateWritePerformanceArtifact();
+    setResourceAdverseRatio(beyondTolerance, 0.06);
+    expect(
+      compareStateWriteArtifacts(createStateWritePerformanceArtifact(), beyondTolerance),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'uncontended median sql.serializedResultBytes regressed by more than 5% ' +
+            'without a recorded reason',
+        ),
+        expect.stringContaining(
+          'hot median sql.serializedResultBytes regressed by more than 5% ' +
+            'without a recorded reason',
+        ),
+      ]),
+    );
+  });
+
+  it('lets a recorded reason authorize a resource regression beyond the band', () => {
+    const authorized = createStateWritePerformanceArtifact();
+    setResourceAdverseRatio(authorized, 0.06);
+    authorized.regressionReasons = [...STATE_WRITE_REASONS];
+    expect(
+      compareStateWriteArtifacts(createStateWritePerformanceArtifact(), authorized),
+    ).toEqual([]);
+  });
+
   it('preserves scale, retry-exhaustion, latency, throughput, and resource gates', () => {
     const baseline = createStateWritePerformanceArtifact();
     const candidate = createStateWritePerformanceArtifact();
@@ -368,6 +405,19 @@ function queueResource(data: object, msgId?: string): string {
     ...(msgId === undefined ? {} : { id: { msgId } }),
     payload: { resource: JSON.stringify({ data }) },
   });
+}
+
+// Scales serializedResultBytes rather than statements: the fixture's statement
+// count is 20, too coarse for 4% and 6% to land on different integers.
+function setResourceAdverseRatio(artifact: any, ratio: number): void {
+  for (const workload of artifact.workloads) {
+    for (const sample of workload.samples) {
+      sample.sql.serializedResultBytes = Math.round(
+        sample.sql.serializedResultBytes * (1 + ratio),
+      );
+    }
+    refreshStateWritePerformanceWorkload(workload);
+  }
 }
 
 function setThroughputAdverseRatio(artifact: any, ratio: number): void {

--- a/scripts/perf/compare-api-v1-state-write-results.mjs
+++ b/scripts/perf/compare-api-v1-state-write-results.mjs
@@ -82,6 +82,40 @@ const REGRESSION_REASON_METRICS = new Set([
   'postgres.transactionDurationMs',
 ]);
 
+const RESOURCE_REGRESSION_METRICS = [
+  ['sql', 'statements'],
+  ['sql', 'rowsRead'],
+  ['sql', 'serializedResultBytes'],
+  ['postgres', 'transactionDurationMs'],
+];
+
+/**
+ * These four are stochastic, not deterministic. The workloads contend
+ * deliberately, so retry attempt counts vary with timing, and statement counts,
+ * rows read, and transaction duration all follow attempt counts. An
+ * order-balanced control on byte-identical code measured drift up to +2.7%,
+ * scaling with contention: +0.2% on `uncontended` (100 groups), +1.6% on
+ * `shared` (5), +2.7% on `hot` (1). They therefore share the tolerance already
+ * used for latency and throughput rather than being compared for strict
+ * increase, which no identical-code run could satisfy. Exceeding the band still
+ * requires a recorded reason. Evidence: issue #157 and
+ * `playground/rtc-design/baselines/2026-08-15-state-write-pooling-control-results.md`.
+ */
+export const RESOURCE_REGRESSION_RATIO = 0.05;
+
+/**
+ * The child structure policy suppresses findings from this comparator by exact
+ * string equality, so both sides must build the message here rather than each
+ * formatting its own copy.
+ */
+export function toStateWriteResourceRegressionMessage(input) {
+  return (
+    `${input.workload} median ${input.metric} regressed by more than ` +
+    `${RESOURCE_REGRESSION_RATIO * 100}% without a recorded reason: ` +
+    `baseline=${input.baselineMedian}, candidate=${input.candidateMedian}`
+  );
+}
+
 export function validateStateWriteArtifact(artifact) {
   try {
     return validateStateWriteArtifactInternal(artifact);
@@ -193,23 +227,20 @@ function compareStateWriteArtifactsInternal(baseline, candidate) {
   for (const name of WORKLOADS.keys()) {
     const baselineWorkload = baselineByName.get(name);
     const candidateWorkload = candidateByName.get(name);
-    for (
-      const [container, metric] of [
-        ['sql', 'statements'],
-        ['sql', 'rowsRead'],
-        ['sql', 'serializedResultBytes'],
-        ['postgres', 'transactionDurationMs'],
-      ]
-    ) {
+    for (const [container, metric] of RESOURCE_REGRESSION_METRICS) {
       const baselineMedian = baselineWorkload[container][metric];
       const candidateMedian = candidateWorkload[container][metric];
       if (
-        candidateMedian > baselineMedian &&
+        candidateMedian > baselineMedian * (1 + RESOURCE_REGRESSION_RATIO) &&
         !hasRecordedReason(candidate, name, `${container}.${metric}`)
       ) {
         errors.push(
-          `${name} median ${container}.${metric} increased without a recorded reason: ` +
-            `baseline=${baselineMedian}, candidate=${candidateMedian}`,
+          toStateWriteResourceRegressionMessage({
+            workload: name,
+            metric: `${container}.${metric}`,
+            baselineMedian,
+            candidateMedian,
+          }),
         );
       }
     }

--- a/scripts/perf/compare-group-state-server-structure-performance.mjs
+++ b/scripts/perf/compare-group-state-server-structure-performance.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'node:url';
 import {
   compareStateWriteArtifacts,
   isSubstantiveRegressionReason,
+  toStateWriteResourceRegressionMessage,
 } from './compare-api-v1-state-write-results.mjs';
 import { ORDER_BALANCED_STATE_WRITE_PROTOCOL } from './pool-api-v1-state-write-results.mjs';
 
@@ -335,10 +336,12 @@ function toStructureThroughputBandError(workloadName, baseline, candidate) {
 }
 
 function toResourceRegressionError(input) {
-  return (
-    `${input.workloadName} median ${metricName(input.descriptor)} increased without a ` +
-    `recorded reason: baseline=${input.baselineValue}, candidate=${input.candidateValue}`
-  );
+  return toStateWriteResourceRegressionMessage({
+    workload: input.workloadName,
+    metric: metricName(input.descriptor),
+    baselineMedian: input.baselineValue,
+    candidateMedian: input.candidateValue,
+  });
 }
 
 function metricName(descriptor) {


### PR DESCRIPTION
Closes the actionable half of #157.

## The defect

`compare-api-v1-state-write-results.mjs` compared latency and throughput with **±5% bands**, but
compared four resource metrics with **strict `>` and no tolerance at all**:

```js
if (candidateMedian > baselineMedian && !hasRecordedReason(...)) { errors.push(...) }
```

Those four — `sql.statements`, `sql.rowsRead`, `sql.serializedResultBytes`,
`postgres.transactionDurationMs` — are **stochastic**. The workloads contend deliberately, so retry
attempt counts vary with timing, and statement counts, rows read, and transaction duration all
follow attempt counts.

## The evidence

The first execution of the order-balanced pooling protocol (#232) measured the drift on
**byte-identical code**, and it scales with contention:

| workload | groups | worst drift |
| --- | --- | --- |
| `uncontended` | 100 | +0.204% |
| `shared` | 5 | +1.550% |
| `hot` | 1 | **+2.655%** |

A strict-inequality gate on a stochastic counter cannot be satisfied on any hardware, however well
pinned. Roughly half of all identical-code runs fail it by construction — which is exactly why three
consecutive phases reported this comparison as "environment-limited".

## The change

The four metrics now share the `0.05` ratio already used for latency and throughput. That leaves
about 2× headroom over the measured floor while staying far below the magnitudes real resource
regressions produce — the planner regression fixed in #229 was **+130%**, and an extra query per
command in a 700-command workload is a double-digit jump. This band will not hide the class of
defect the gate exists to catch.

Exceeding the band still requires a recorded reason. That inverts the semantics in the right
direction: a written justification is now what you supply for a genuine regression you are
accepting, not a toll owed on a coin flip. The validator's ≥10-non-whitespace-character rule was
plainly written to stop filler, and demanding prose for noise is how that rule gets hollowed out.

## A coupling this surfaced

`compare-group-state-server-structure-performance.mjs` suppresses this comparator's findings by
**exact string equality**, and was rebuilding the message by hand in its own
`toResourceRegressionError`. Any wording change here would have silently un-suppressed those
findings — a failure mode with no test coverage and no visible symptom.

Both sides now build the message from one exported helper,
`toStateWriteResourceRegressionMessage`, so they cannot drift apart again.

## Deliberately not changed

That child policy keeps its own `GROUP_STATE_SERVER_STRUCTURE_EQUIVALENCE_RATIO = 0.015`, which is
**below the measured floor for `hot` (+2.655%)**. So the structure-equivalence comparison remains
subject to the same problem this PR fixes for the general gate.

I left it alone on purpose: 1.5% encodes a deliberate *equivalence* claim for a specific structural
refactor proof, which is a stricter and different purpose than regression detection. Widening it is
a judgement call about that proof's strength, not a bug fix, and it should be made knowingly.

## Validation

- `packages/tests/shared-server/` + `packages/tests/repo/` — **328 files / 2,629 tests passed**,
  5 skipped.
- New coverage: variance within the band passes, variance beyond it fails, and a recorded reason
  authorizes a beyond-band regression.
- `npm run check:repo-style:changed` PASS against `3bf1f57f`.

One test-authoring note for future readers: the new helper scales
`sql.serializedResultBytes` rather than `sql.statements`, because the fixture's statement count is
20 and 4% and 6% both round to 21 — too coarse to sit on opposite sides of the band.

## Calibration caveat

`0.05` is chosen for consistency with the existing timing ratio and for its headroom over a
**single** control run. That run establishes the floor is not zero and reaches ~2.7%; it does not
bound the tail. If `hot` later proves marginal, the right response is a wider band for `hot`
specifically rather than widening all three workloads.
