### PR TITLE
Correct the group-formation plan status to match the default branch

### DIFF
--- a/playground/rtc-design/2026-08-08-group-formation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-08-group-formation-implementation-plan.md
@@ -1,6 +1,31 @@
 # Group Formation Implementation Plan (2026-08-08)
 
-Status: proposed plan; implementation not started.
+Status: **Phases 0–4 landed on the default branch. Phase 5 is next and not started.**
+
+| Phase | State | Delivery | Measured results |
+| --- | --- | --- | --- |
+| 0 — Metrics and baseline | Landed | — | `baselines/2026-08-08-formation-burst-baseline.md` |
+| 1 — Overlay precedence | Landed | PR #138 | `baselines/2026-08-09-phase1-overlay-precedence-results.md` |
+| 2 — Server damping (M1) | Landed | PR #152 | `baselines/2026-08-11-phase2-server-damping-results.md` |
+| 3 — Delta dissemination | Landed | PR #214 | `baselines/2026-08-13-phase3-delta-dissemination-results.md` |
+| 4 — Stable topology evolution (M6, M8, M11, M9) | Landed | PR #223 | `baselines/2026-08-15-phase4-stable-topology-evolution-results.md` |
+| 5 — Formation epochs (M7) + activation reconciliation | Not started | — | — |
+| 6 — Contention and scale-out polish | Measurement-gated | — | — |
+
+Carried into Phase 5 from the landed phases:
+
+- `RALLAR_GROUP_STATE_DISSEMINATION` deliberately still defaults to `dual-emit`.
+  Phase 4 proved the churn stream consumes cleanly under `delta-primary` with both
+  per-change snapshot topics at zero bytes, and both flip preconditions landed in
+  PR #228 (delta-mode recipe twins; RTT-path cache re-verification). The flip and
+  the retirement of `snapshot-per-change` are tracked in issue #231.
+- Phase 4's incremental planner falls back to a full rebuild when the incremental
+  **tree** remove path produces an invariant-violating graph, which costs a
+  discarded repair plus a full rebuild. `incrementalPlanInvariantFallbackCount`
+  makes the rate observable; tracked in issue #230.
+
+This file records the plan and its phase state. It is not a governance record:
+delivery is driven by the live pull request per `plans/README.md`.
 
 Staged plan to make Rallar group formation convergent (eventually
 consistent), fault tolerant, and permissive/optimistic at scale — covering


### PR DESCRIPTION
## Why

`playground/rtc-design/2026-08-08-group-formation-implementation-plan.md` still opened with:

> Status: proposed plan; implementation not started.

Phases 0–4 have landed on the default branch, each with a measured results document in
`baselines/`. Anyone opening the file to decide what to work on next was being told the program had
not begun.

## What changed

A per-phase status table with the delivering PR and the results document for each landed phase:

| Phase | State | Delivery |
| --- | --- | --- |
| 0 — Metrics and baseline | Landed | — |
| 1 — Overlay precedence | Landed | #138 |
| 2 — Server damping (M1) | Landed | #152 |
| 3 — Delta dissemination | Landed | #214 |
| 4 — Stable topology evolution | Landed | #223 |
| 5 — Formation epochs + activation reconciliation | Not started | — |
| 6 — Contention and scale-out polish | Measurement-gated | — |

It also carries forward the two things the landed phases deliberately left open, so they are visible
at the point where the next phase gets planned rather than only in the issue tracker:

- `RALLAR_GROUP_STATE_DISSEMINATION` still defaults to `dual-emit`. Phase 4 proved the churn stream
  consumes cleanly under `delta-primary` with both per-change snapshot topics at zero bytes, and
  both flip preconditions landed in #228. The flip itself is #231.
- The incremental **tree** remove path can produce an invariant-violating graph, which the planner
  absorbs by discarding the repair and doing a full rebuild — paying for both.
  `incrementalPlanInvariantFallbackCount` makes the rate observable. Tracked as #230.

## Scope

Documentation only; no runtime code touched.

`plans/` is untouched on purpose — its README states those documents are inert historical reference
that "do not control current repository work or pull-request delivery". This file is a design/program
document rather than a governance record, and the change says so explicitly so it is not mistaken
for one.

## Validation

`npm run check:repo-style:changed` PASS against `8746c9e0`.
