### PR TITLE
Pin Coordinates behaviour before changing its direction logic

### DIFF
--- a/packages/tests/shared-graph/coordinates.test.ts
+++ b/packages/tests/shared-graph/coordinates.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import { Coordinates } from '@shared-graph/graph/vivaldi-core.ts';
+
+// Coordinates is the oracle that compute-predicted-rtt-ms.test.ts checks the
+// optimized distance loop against, so the class certifying that function had no
+// tests of its own. These pin the arithmetic, the three norms and the guards
+// directly, before any change to the direction logic.
+describe('Coordinates', () => {
+    describe('construction and access', () => {
+        it('copies the values it is given', () => {
+            const input = [1, 2, 3];
+            const coords = new Coordinates(input);
+
+            input[0] = 99;
+
+            expect(coords.values).toEqual([1, 2, 3]);
+        });
+
+        it('hands out a copy rather than the backing array', () => {
+            const coords = new Coordinates([1, 2, 3]);
+
+            coords.values[0] = 99;
+
+            expect(coords.values).toEqual([1, 2, 3]);
+        });
+
+        // A clone that silently reverted to the default L2 norm would still
+        // look correct in every test that does not override the norm.
+        it('carries the config through clone', () => {
+            const coords = new Coordinates([3, -4], { useL1: true });
+
+            expect(coords.clone().norm()).toBe(7);
+        });
+    });
+
+    describe('arithmetic', () => {
+        it('adds and subtracts componentwise without mutating either operand', () => {
+            const left = new Coordinates([1, 2]);
+            const right = new Coordinates([10, 20]);
+
+            expect(left.add(right).values).toEqual([11, 22]);
+            expect(left.subtract(right).values).toEqual([-9, -18]);
+            expect(left.values).toEqual([1, 2]);
+            expect(right.values).toEqual([10, 20]);
+        });
+
+        it('scales componentwise', () => {
+            expect(new Coordinates([1, -2, 0.5]).multiply(-2).values).toEqual([-2, 4, -1]);
+        });
+
+        // Every operation rebuilds from the receiver's config, so a result keeps
+        // measuring itself the way its source did.
+        it('carries the config through arithmetic', () => {
+            const coords = new Coordinates([3, -4], { useL1: true });
+
+            expect(coords.multiply(2).norm()).toBe(14);
+            expect(coords.add(new Coordinates([0, 0])).norm()).toBe(7);
+            expect(coords.subtract(new Coordinates([0, 0])).norm()).toBe(7);
+        });
+
+        it.each([
+            { operation: 'add' },
+            { operation: 'subtract' },
+        ] as const)('rejects a dimension mismatch in $operation', ({ operation }) => {
+            const two = new Coordinates([1, 2]);
+            const three = new Coordinates([1, 2, 3]);
+
+            expect(() => two[operation](three)).toThrow('Coordinate dimension mismatch: 2 !== 3');
+            expect(() => three[operation](two)).toThrow('Coordinate dimension mismatch: 3 !== 2');
+        });
+    });
+
+    describe('norms', () => {
+        // One vector under all three norms: 5, 7 and 4 are distinct, so a norm
+        // silently falling back to another branch cannot pass.
+        it.each([
+            { norm: 'L2 by default', cfg: {}, expected: 5 },
+            { norm: 'L1 when configured', cfg: { useL1: true }, expected: 7 },
+            { norm: 'L-infinity when configured', cfg: { useLInf: true }, expected: 4 },
+            // Setting both is not an error; norm() tests L-infinity first, and
+            // computePredictedRttMs mirrors that precedence.
+            {
+                norm: 'L-infinity ahead of L1 when both are set',
+                cfg: { useL1: true, useLInf: true },
+                expected: 4,
+            },
+        ])('measures $norm', ({ cfg, expected }) => {
+            expect(new Coordinates([3, -4], cfg).norm()).toBe(expected);
+        });
+
+        // Vacuously zero under every branch, since each folds over no
+        // components. This is what leaves a zero-dimension direction undefined.
+        it.each([
+            { norm: 'L2', cfg: {} },
+            { norm: 'L1', cfg: { useL1: true } },
+            { norm: 'L-infinity', cfg: { useLInf: true } },
+        ])('measures an empty vector as zero under $norm', ({ cfg }) => {
+            expect(new Coordinates([], cfg).norm()).toBe(0);
+        });
+
+        it.each([
+            { norm: 'L2', cfg: {}, expected: 5 },
+            { norm: 'L1', cfg: { useL1: true }, expected: 7 },
+            { norm: 'L-infinity', cfg: { useLInf: true }, expected: 4 },
+        ])('computes distance as the norm of the difference under $norm', ({ cfg, expected }) => {
+            const here = new Coordinates([3, -4], cfg);
+            const remote = new Coordinates([0, 0], cfg);
+
+            expect(here.distance(remote)).toBe(expected);
+            expect(remote.distance(here)).toBe(expected);
+        });
+
+        it('measures zero distance between identical coordinates', () => {
+            const values = [3, -7, 11];
+
+            expect(new Coordinates(values).distance(new Coordinates(values))).toBe(0);
+        });
+    });
+
+    describe('isValid', () => {
+        it.each([
+            { label: 'NaN', values: [1, Number.NaN] },
+            { label: 'positive infinity', values: [Number.POSITIVE_INFINITY, 1] },
+            { label: 'negative infinity', values: [1, Number.NEGATIVE_INFINITY] },
+        ])('rejects $label', ({ values }) => {
+            expect(new Coordinates(values).isValid()).toBe(false);
+        });
+
+        it('accepts finite values including zero and negatives', () => {
+            expect(new Coordinates([0, -1, 2.5]).isValid()).toBe(true);
+        });
+
+        // Vacuously true: there is no non-finite component to find. isValid is
+        // therefore no guard against a zero-dimension vector.
+        it('accepts an empty vector', () => {
+            expect(new Coordinates([]).isValid()).toBe(true);
+        });
+    });
+
+    // Only the separated case is pinned here. The collocated case reaches the
+    // random tie-break, which #251 covers.
+    describe('getDirectionality between separated coordinates', () => {
+        // The difference is this minus remote, so the unit vector points from
+        // the remote coordinate toward this one.
+        it('points from the remote coordinate toward this one', () => {
+            const here = new Coordinates([3, 0]);
+            const remote = new Coordinates([0, 0]);
+
+            expect(here.getDirectionality(remote).values).toEqual([1, 0]);
+            expect(remote.getDirectionality(here).values).toEqual([-1, 0]);
+        });
+
+        it('leaves both coordinates untouched', () => {
+            const here = new Coordinates([3, 4]);
+            const remote = new Coordinates([0, 0]);
+
+            here.getDirectionality(remote);
+
+            expect(here.values).toEqual([3, 4]);
+            expect(remote.values).toEqual([0, 0]);
+        });
+
+        // Normalized by the configured norm rather than the Euclidean one, so
+        // under L1 or L-infinity the result is a unit vector only in that metric.
+        it.each([
+            { norm: 'L2', cfg: {} },
+            { norm: 'L1', cfg: { useL1: true } },
+            { norm: 'L-infinity', cfg: { useLInf: true } },
+        ])('returns a unit vector under $norm', ({ cfg }) => {
+            const here = new Coordinates([3, -4], cfg);
+            const remote = new Coordinates([0, 0], cfg);
+
+            expect(here.getDirectionality(remote).norm()).toBeCloseTo(1, 12);
+        });
+    });
+});


### PR DESCRIPTION
First slice of #251. Characterization only — **no source change** — so the behaviour changes in the
next slice show up as a test diff rather than hiding inside it.

## Why this file first

`Coordinates` had no tests of its own. It appears in
[`compute-predicted-rtt-ms.test.ts`](https://github.com/intact-software-systems/ar-eye-hunter/blob/main/packages/tests/shared-graph/compute-predicted-rtt-ms.test.ts)
only as the **oracle** that the optimized `computePredictedRttMs` loop is checked against — so the
untested class is what certifies the tested function. That indirect use covers `subtract`, `norm`
and `distance`; everything else was uncovered.

## What is pinned

- **Defensive copying** on both construction and the `values` getter.
- **Config propagation** through `clone` and through `add` / `subtract` / `multiply`. A result that
  silently reverted to the default L2 norm would look correct in every test that does not override
  the norm.
- **The dimension guard** on `add` *and* `subtract`, in both directions, including the message.
- **All three norms** on one vector — `5`, `7`, `4` are distinct, so a branch falling through to
  another cannot pass — plus the L-infinity-over-L1 precedence that `computePredictedRttMs` mirrors.
- **Empty vectors**: `norm()` is zero under every branch and `isValid()` is vacuously true. Those two
  together are what leave a zero-dimension direction undefined, which is the hang in #251.
- **`getDirectionality` between separated coordinates**: orientation (the difference is `this` minus
  `remote`, so the vector points from the remote coordinate toward this one), non-mutation, and that
  the result is normalized by the *configured* norm rather than the Euclidean one.

## What is deliberately not here

The collocated direction path. It reaches the random tie-break and the unbounded loop, which the
next slice replaces — pinning it now would mean writing assertions to delete.

## Verification

29 tests. Passing on the first run proves nothing about a characterization test, so each behaviour
was confirmed to **fail** under a deliberate mutation of `vivaldi-core.ts`:

| Mutation | Result |
| --- | --- |
| construction does not copy its input | caught |
| `values` returns the backing array | caught |
| `clone` drops the config | caught |
| `add` does not carry the config | caught |
| `add` subtracts | caught |
| `norm` checks L1 before L-infinity | caught |
| direction is reversed | caught |
| dimension guard removed | caught |

`vivaldi-core.ts` was restored after each; the diff on this branch is one new file.

- `npx vitest run packages/tests/shared-graph/` — 28 files, 115 passed.
- `npx tsc -p packages/shared-graph/tsconfig.json --noEmit` — clean.
- `check:repo-style:changed origin/main HEAD` — PASS.
- `packages/tests/repo/` — 711 passed (coupling and governance gates).

Refs #251.
