### PR TITLE
Draw the Vivaldi tie-break directly instead of jittering until it separates

### DIFF
--- a/packages/shared-graph/graph/vivaldi-core.ts
+++ b/packages/shared-graph/graph/vivaldi-core.ts
@@ -5,6 +5,8 @@ export type VivaldiNodeData = {
     readonly rttMs: number;
 };
 
+export type VivaldiRandom = () => number;
+
 export type VivaldiConfig = {
     readonly cc: number;
     readonly ce: number;
@@ -12,7 +14,6 @@ export type VivaldiConfig = {
     readonly minNodeErr: number;
     readonly useL1: boolean;
     readonly useLInf: boolean;
-    readonly jitterScale: number;
 };
 
 export const DEFAULT_VIVALDI_CONFIG: VivaldiConfig = {
@@ -22,12 +23,18 @@ export const DEFAULT_VIVALDI_CONFIG: VivaldiConfig = {
     minNodeErr: 0.0,
     useL1: false,
     useLInf: false,
-    jitterScale: 1.0,
 };
+
+export interface VivaldiNodeInput {
+    readonly dimensions: number;
+    readonly initialError?: number;
+    readonly cfg?: Partial<VivaldiConfig>;
+    readonly random?: VivaldiRandom;
+}
 
 export class Coordinates {
     readonly #cfg: VivaldiConfig;
-    #values: number[];
+    readonly #values: number[];
 
     constructor(values: readonly number[], cfg?: Partial<VivaldiConfig>) {
         this.#cfg = { ...DEFAULT_VIVALDI_CONFIG, ...cfg };
@@ -93,25 +100,44 @@ export class Coordinates {
         return this.subtract(other).norm();
     }
 
-    adjustCoordinates(scale = this.#cfg.jitterScale): void {
-        this.#values = this.#values.map(value => value + scale * (Math.random() * 2 - 1));
-    }
-
-    getDirectionality(remote: Coordinates): Coordinates {
-        let diff = this.subtract(remote);
-        let currentNorm = diff.norm();
-
-        while (currentNorm === 0) {
-            this.adjustCoordinates();
-            diff = this.subtract(remote);
-            currentNorm = diff.norm();
+    computeDirectionality(
+        remote: Coordinates,
+        random: VivaldiRandom = Math.random,
+    ): Coordinates {
+        const difference = this.subtract(remote);
+        const norm = difference.norm();
+        if (norm > 0) {
+            return difference.multiply(1 / norm);
         }
 
-        return diff.multiply(1 / currentNorm);
+        return this.#toRandomUnitVector(random);
     }
 
     isValid(): boolean {
         return this.#values.every(Number.isFinite);
+    }
+
+    // Collocated coordinates have no direction between them, so Vivaldi breaks
+    // the tie with a random one. Drawing the vector directly keeps the function
+    // total: the previous jitter-and-retry loop had no exit other than the
+    // randomness happening to work.
+    #toRandomUnitVector(random: VivaldiRandom): Coordinates {
+        if (this.#values.length === 0) {
+            throw new Error('Direction is undefined for zero-dimensional coordinates');
+        }
+
+        const candidate = new Coordinates(
+            this.#values.map(() => random() * 2 - 1),
+            this.#cfg,
+        );
+        const norm = candidate.norm();
+        if (norm > 0) {
+            return candidate.multiply(1 / norm);
+        }
+
+        const basis = new Array<number>(this.#values.length).fill(0);
+        basis[0] = 1;
+        return new Coordinates(basis, this.#cfg);
     }
 
     #assertSameDimension(other: Coordinates): void {
@@ -125,13 +151,19 @@ export class Coordinates {
 
 export class VivaldiNode {
     readonly #cfg: VivaldiConfig;
+    readonly #random: VivaldiRandom;
     #coords: Coordinates;
     #myError: number;
 
-    constructor(dimensions: number, initialError = 1.0, cfg?: Partial<VivaldiConfig>) {
-        this.#cfg = { ...DEFAULT_VIVALDI_CONFIG, ...cfg };
-        this.#coords = new Coordinates(new Array(dimensions).fill(0), this.#cfg);
-        this.#myError = initialError;
+    constructor(input: VivaldiNodeInput) {
+        if (!Number.isInteger(input.dimensions) || input.dimensions < 1) {
+            throw new Error('Vivaldi node dimensions must be an integer >= 1');
+        }
+
+        this.#cfg = { ...DEFAULT_VIVALDI_CONFIG, ...input.cfg };
+        this.#random = input.random ?? Math.random;
+        this.#coords = new Coordinates(new Array(input.dimensions).fill(0), this.#cfg);
+        this.#myError = input.initialError ?? 1.0;
     }
 
     get coords(): Coordinates {
@@ -166,7 +198,7 @@ export class VivaldiNode {
             this.#myError * (1 - this.#cfg.ce * weight);
         const delta = this.#cfg.cc * weight;
 
-        const direction = this.#coords.getDirectionality(remoteCoords);
+        const direction = this.#coords.computeDirectionality(remoteCoords, this.#random);
         const movement = direction.multiply(delta * diffErr);
         const nextCoords = this.#coords.add(movement);
 

--- a/packages/shared-graph/repository/vivaldi-repository.ts
+++ b/packages/shared-graph/repository/vivaldi-repository.ts
@@ -53,7 +53,7 @@ export function getOrCreateNode(
 ): VivaldiNode {
     return requireVivaldiRepository(manager).setIfAbsent(
         nodeId,
-        () => new VivaldiNode(dimensions, initialError)
+        () => new VivaldiNode({ dimensions, initialError })
     );
 }
 

--- a/packages/tests/shared-graph/coordinates.test.ts
+++ b/packages/tests/shared-graph/coordinates.test.ts
@@ -137,24 +137,24 @@ describe('Coordinates', () => {
         });
     });
 
-    // Only the separated case is pinned here. The collocated case reaches the
-    // random tie-break, which #251 covers.
-    describe('getDirectionality between separated coordinates', () => {
+    // The collocated case is covered in vivaldi-direction.test.ts, which owns
+    // the random tie-break.
+    describe('computeDirectionality between separated coordinates', () => {
         // The difference is this minus remote, so the unit vector points from
         // the remote coordinate toward this one.
         it('points from the remote coordinate toward this one', () => {
             const here = new Coordinates([3, 0]);
             const remote = new Coordinates([0, 0]);
 
-            expect(here.getDirectionality(remote).values).toEqual([1, 0]);
-            expect(remote.getDirectionality(here).values).toEqual([-1, 0]);
+            expect(here.computeDirectionality(remote).values).toEqual([1, 0]);
+            expect(remote.computeDirectionality(here).values).toEqual([-1, 0]);
         });
 
         it('leaves both coordinates untouched', () => {
             const here = new Coordinates([3, 4]);
             const remote = new Coordinates([0, 0]);
 
-            here.getDirectionality(remote);
+            here.computeDirectionality(remote);
 
             expect(here.values).toEqual([3, 4]);
             expect(remote.values).toEqual([0, 0]);
@@ -170,7 +170,7 @@ describe('Coordinates', () => {
             const here = new Coordinates([3, -4], cfg);
             const remote = new Coordinates([0, 0], cfg);
 
-            expect(here.getDirectionality(remote).norm()).toBeCloseTo(1, 12);
+            expect(here.computeDirectionality(remote).norm()).toBeCloseTo(1, 12);
         });
     });
 });

--- a/packages/tests/shared-graph/vivaldi-and-predicted-graph.test.ts
+++ b/packages/tests/shared-graph/vivaldi-and-predicted-graph.test.ts
@@ -187,7 +187,7 @@ describe('shared-graph vivaldi and predicted graph behavior', () => {
     });
 
     it('ignores invalid remote data during direct Vivaldi node updates', () => {
-        const node = new VivaldiNode(2, 0.5);
+        const node = new VivaldiNode({ dimensions: 2, initialError: 0.5 });
         const before = node.toNodeData('peer-a');
 
         node.update({

--- a/packages/tests/shared-graph/vivaldi-direction.test.ts
+++ b/packages/tests/shared-graph/vivaldi-direction.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { Coordinates, VivaldiNode } from '@shared-graph/graph/vivaldi-core.ts';
+
+const SQRT_HALF = Math.SQRT1_2;
+
+// Two fresh nodes both start at the origin, so the tie-break is the common
+// first step between any pair, not an edge case. It used to be a jitter-and-
+// retry loop whose only exit was the randomness happening to work.
+describe('Vivaldi direction between collocated coordinates', () => {
+    it('draws a unit vector from the injected source of randomness', () => {
+        const here = new Coordinates([0, 0]);
+        const remote = new Coordinates([0, 0]);
+
+        const direction = here.computeDirectionality(remote, () => 1);
+
+        expect(direction.values[0]).toBeCloseTo(SQRT_HALF, 12);
+        expect(direction.values[1]).toBeCloseTo(SQRT_HALF, 12);
+        expect(direction.norm()).toBeCloseTo(1, 12);
+    });
+
+    it('leaves the coordinates it was asked about untouched', () => {
+        const here = new Coordinates([0, 0]);
+        const remote = new Coordinates([0, 0]);
+
+        here.computeDirectionality(remote, () => 1);
+
+        expect(here.values).toEqual([0, 0]);
+        expect(remote.values).toEqual([0, 0]);
+    });
+
+    // 0.5 maps to exactly 0, so every drawn component is zero and the draw
+    // cannot separate the points. The old loop spun on this forever; the
+    // fallback basis vector is what makes the function total.
+    it('falls back to a basis vector when the draw is degenerate', () => {
+        const here = new Coordinates([0, 0, 0]);
+        const remote = new Coordinates([0, 0, 0]);
+
+        expect(here.computeDirectionality(remote, () => 0.5).values).toEqual([1, 0, 0]);
+    });
+
+    // Previously an unbounded loop: an empty vector has norm 0 under every
+    // branch, so no amount of jitter could ever separate it.
+    it('rejects a zero-dimensional direction instead of spinning', () => {
+        expect(() => new Coordinates([]).computeDirectionality(new Coordinates([])))
+            .toThrow('Direction is undefined for zero-dimensional coordinates');
+    });
+
+    it('still uses the real difference when the coordinates are separated', () => {
+        const here = new Coordinates([3, 0]);
+        const remote = new Coordinates([0, 0]);
+
+        // The random source would give [1, 0] here if it were consulted.
+        expect(here.computeDirectionality(remote, () => 0.5).values).toEqual([1, 0]);
+    });
+});
+
+describe('VivaldiNode construction', () => {
+    // A zero-dimension node reached the same unbounded loop through update().
+    it.each([
+        { label: 'zero', dimensions: 0 },
+        { label: 'negative', dimensions: -1 },
+        { label: 'fractional', dimensions: 1.5 },
+    ])('rejects $label dimensions', ({ dimensions }) => {
+        expect(() => new VivaldiNode({ dimensions }))
+            .toThrow('Vivaldi node dimensions must be an integer >= 1');
+    });
+});
+
+describe('VivaldiNode.update from the origin', () => {
+    // The step length is cc * weight * diffErr = 0.25 * 0.5 * 50, and nothing
+    // else. The tie-break used to jitter the node's own coordinates on the way
+    // past, so that jitter landed in the result and the step came out longer
+    // than the algorithm calls for.
+    it('moves exactly the computed step length', () => {
+        const node = new VivaldiNode({ dimensions: 2, random: () => 1 });
+
+        node.update({ id: 'peer', coords: [0, 0], err: 1.0, rttMs: 50 });
+
+        expect(node.coords.norm()).toBeCloseTo(6.25, 12);
+        expect(node.coords.values[0]).toBeCloseTo(6.25 * SQRT_HALF, 12);
+        expect(node.coords.values[1]).toBeCloseTo(6.25 * SQRT_HALF, 12);
+    });
+
+    it('is reproducible under a fixed source of randomness', () => {
+        const first = new VivaldiNode({ dimensions: 3, random: () => 0.75 });
+        const second = new VivaldiNode({ dimensions: 3, random: () => 0.75 });
+        const sample = { id: 'peer', coords: [0, 0, 0], err: 1.0, rttMs: 40 } as const;
+
+        first.update(sample);
+        second.update(sample);
+
+        expect(first.coords.values).toEqual(second.coords.values);
+    });
+
+    // err: NaN leaves nextErr non-finite, and that guard sits after the
+    // direction has been computed. While the tie-break mutated the node, a
+    // rejection here had already moved it.
+    it('does not move the node when a late guard rejects the sample', () => {
+        const node = new VivaldiNode({ dimensions: 2, random: () => 1 });
+
+        node.update({ id: 'peer', coords: [0, 0], err: Number.NaN, rttMs: 50 });
+
+        expect(node.coords.values).toEqual([0, 0]);
+        expect(node.myError).toBe(1.0);
+    });
+});


### PR DESCRIPTION
Second slice of #251, on top of #252. This one changes behaviour — twice, both corrections — so the
measurements are below rather than the reasoning.

## The one change that fixes three defects

Collocated coordinates have no direction between them, so Vivaldi breaks the tie with a random one.
That was implemented as a loop: perturb the node's own coordinates, re-measure, repeat until they
separate. Every defect in #251 traces back to that loop, and **drawing the unit vector in one shot
removes all of them at once**:

```ts
computeDirectionality(remote: Coordinates, random: VivaldiRandom = Math.random): Coordinates {
    const difference = this.subtract(remote);
    const norm = difference.norm();
    if (norm > 0) {
        return difference.multiply(1 / norm);
    }
    return this.#toRandomUnitVector(random);
}
```

**1. It could not terminate.** An empty coordinate vector has norm 0 under every branch, and
`jitterScale: 0` adds nothing, so neither could ever separate — both spun forever rather than
failing. Not reachable from the one production construction site
([`vivaldi-repository.ts:56`](https://github.com/intact-software-systems/ar-eye-hunter/blob/main/packages/shared-graph/repository/vivaldi-repository.ts#L56)
passes no config), but the constructor's signature invited both. A degenerate draw now falls back to
a basis vector, zero-dimensional coordinates throw, and node dimensions are validated as an integer
`>= 1`.

**2. It mutated through a query.** `adjustCoordinates` assigned to the receiver, so a `get`-prefixed
method moved the node — and in `update()` the jitter landed *before* the validity guard. A rejected
sample therefore still moved the node. Measured on `main@45319d62` with `err: NaN`, which makes
`nextErr` non-finite and trips that guard:

```
OLD coords after a REJECTED sample (should be [0,0]): [-0.925271, 0.829264]
```

**3. It inflated the step.** The jitter stayed in the coordinates and became the base the movement
was added to. The step should be exactly `cc * weight * diffErr` = `0.25 * 0.5 * 50` = **6.25**.
Eight runs of the first update on `main@45319d62`:

```
6.907112   6.913035   6.575429   6.823124
6.740356   6.635649   7.423247   7.280984
```

Never 6.25 — inflated 5–19%, varying per run. After this change it is 6.25 exactly.

## Why the injected RNG is required, not stylistic

`VivaldiNode` zero-fills its coordinates and has no other path to a non-zero position, so **two fresh
nodes are always collocated and the first update between any pair always takes the tie-break**. None
of the above could be asserted without controlling the draw. `random` follows the same injection
convention as `nowEpochMs` elsewhere in the repo, defaulting to `Math.random`.

`VivaldiNode` takes one named input rather than a fourth positional parameter, per the code standard.
Two call sites updated.

## Legacy removed

`jitterScale` is gone from `VivaldiConfig`. It only ever controlled how many iterations the loop
needed — the drawn vector is normalized, so its scale cancels out of the result entirely — which is
exactly why `0` hung instead of degrading. It had no callers outside `vivaldi-core.ts`.
`adjustCoordinates` is gone with it, and `#values` is now `readonly`.

`getDirectionality` → `computeDirectionality`, which is honest now that it is pure, and matches the
canonical verbs.

## Not in this slice

The `observeRtt` asymmetry — [`vivaldi-service.ts:34-35`](https://github.com/intact-software-systems/ar-eye-hunter/blob/main/packages/shared-graph/vivaldi-service.ts#L34)
updates `fromNode`, then feeds its *post-update* state into `toNode`'s update. That needs the
convergence test from the next slice to land safely.

## Validation

- 11 new tests in `vivaldi-direction.test.ts`: the tie-break draw, non-mutation, the degenerate-draw
  fallback, the zero-dimension throw, dimension validation, the exact step length, reproducibility
  under a fixed draw, and the rejected-sample regression.
- `npx vitest run packages/tests/ packages/shared-rtc-bench/tests/` — **7,494 passed**, 5 skipped.
  The 6 failures in 4 files are the known sandbox `listen EPERM` set, unrelated.
- `npm run typecheck` — clean across every workspace.
- `check:repo-style:changed origin/main HEAD` — PASS.
- `packages/tests/repo/` — 711 passed (coupling and governance gates).

Refs #251.
