### PR TITLE
Test that Vivaldi coordinates actually converge

### DIFF
--- a/packages/tests/shared-graph/vivaldi-convergence.test.ts
+++ b/packages/tests/shared-graph/vivaldi-convergence.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { VivaldiNode, type VivaldiConfig } from '@shared-graph/graph/vivaldi-core.ts';
+
+// The peer sits at the origin, so the node's own norm is the predicted RTT to
+// it. A fixed draw makes the tie-break on the first sample reproducible; every
+// sample after that is separated and fully deterministic anyway.
+function toTrajectory(
+    input: Readonly<{
+        rttMs: number;
+        samples: number;
+        remoteErr?: number;
+        initialError?: number;
+        cfg?: Partial<VivaldiConfig>;
+        node?: VivaldiNode;
+    }>,
+): Readonly<{ node: VivaldiNode; predicted: number[]; errors: number[] }> {
+    const node = input.node ?? new VivaldiNode({
+        dimensions: 2,
+        initialError: input.initialError,
+        cfg: input.cfg,
+        random: () => 1,
+    });
+    const predicted: number[] = [];
+    const errors: number[] = [];
+
+    for (let sample = 0; sample < input.samples; sample++) {
+        node.update({
+            id: 'peer',
+            coords: [0, 0],
+            err: input.remoteErr ?? 1.0,
+            rttMs: input.rttMs,
+        });
+        predicted.push(node.coords.norm());
+        errors.push(node.myError);
+    }
+
+    return { node, predicted, errors };
+}
+
+function isMonotonic(values: readonly number[], direction: 'up' | 'down'): boolean {
+    return values.every((value, index) =>
+        index === 0 ||
+        (direction === 'up' ? value > values[index - 1] : value < values[index - 1])
+    );
+}
+
+describe('VivaldiNode.update convergence', () => {
+    // The first two steps are hand-checkable and anchor the constants, so a
+    // change to cc, ce or the weighting cannot hide behind the long runs below.
+    // Step 1: cc * weight * diffErr = 0.25 * 0.5 * 50 = 6.25.
+    // Step 2: 6.25 + 0.125 * (50 - 6.25) = 11.71875.
+    // Error 2: 0.875 * 0.25 + 1.0 * 0.75 = 0.96875.
+    it('takes the exact steps the constants call for', () => {
+        const { predicted, errors } = toTrajectory({ rttMs: 50, samples: 2 });
+
+        expect(predicted[0]).toBeCloseTo(6.25, 12);
+        expect(predicted[1]).toBeCloseTo(11.71875, 12);
+        expect(errors[0]).toBe(1.0);
+        expect(errors[1]).toBeCloseTo(0.96875, 12);
+    });
+
+    it('approaches the measured RTT from below without overshooting', () => {
+        const { predicted } = toTrajectory({ rttMs: 50, samples: 200 });
+
+        expect(isMonotonic(predicted, 'up')).toBe(true);
+        expect(Math.max(...predicted)).toBeLessThan(50);
+        expect(predicted[predicted.length - 1]).toBeGreaterThan(49);
+    });
+
+    // The sign of diffErr has to work in both directions: a node that is
+    // already too far away must be pulled back in, not pushed further out.
+    it('moves back toward the peer when it is too far away', () => {
+        const settled = toTrajectory({ rttMs: 50, samples: 200 });
+        expect(settled.predicted[199]).toBeGreaterThan(49);
+
+        const corrected = toTrajectory({ rttMs: 10, samples: 200, node: settled.node });
+
+        expect(isMonotonic(corrected.predicted, 'down')).toBe(true);
+        expect(corrected.predicted[199]).toBeLessThan(10.5);
+        expect(corrected.predicted[199]).toBeGreaterThan(10);
+    });
+
+    it('decays the error once the samples start agreeing', () => {
+        const { errors } = toTrajectory({ rttMs: 50, samples: 200 });
+
+        // The first sample lands on the clamp, so decay is measured from there.
+        expect(isMonotonic(errors.slice(1), 'down')).toBe(true);
+        expect(errors[199]).toBeLessThan(0.05);
+    });
+});
+
+describe('VivaldiNode.update error clamping', () => {
+    // A settled node told the peer is 1ms away sees a sample error of roughly
+    // 494, which without the clamp would leave myError far above 1.
+    it('clamps at maxNodeErr when a sample contradicts the position', () => {
+        const settled = toTrajectory({ rttMs: 500, samples: 200 });
+        expect(settled.node.myError).toBeLessThan(0.05);
+
+        settled.node.update({ id: 'peer', coords: [0, 0], err: 0.0, rttMs: 1 });
+
+        expect(settled.node.myError).toBe(1.0);
+    });
+
+    it('honours a custom maxNodeErr', () => {
+        const { node } = toTrajectory({
+            rttMs: 50,
+            samples: 1,
+            initialError: 1.0,
+            cfg: { maxNodeErr: 0.6 },
+        });
+
+        expect(node.myError).toBe(0.6);
+    });
+
+    // Without a floor the error decays toward zero asymptotically, so a
+    // configured floor is the only way to observe the lower clamp at all.
+    it('stops decaying at minNodeErr', () => {
+        const { errors } = toTrajectory({
+            rttMs: 50,
+            samples: 300,
+            cfg: { minNodeErr: 0.4 },
+        });
+
+        expect(errors[19]).toBe(0.4);
+        expect(errors[299]).toBe(0.4);
+    });
+
+    it('keeps the error inside its bounds throughout a run', () => {
+        const { errors } = toTrajectory({ rttMs: 50, samples: 200 });
+
+        expect(errors.every((error) => error >= 0.0 && error <= 1.0)).toBe(true);
+    });
+});


### PR DESCRIPTION
Third slice of #251, on top of #254. Tests only — no source change.

## The gap

`update()` is the Vivaldi algorithm itself, and its only test asserted that two malformed samples
changed nothing. **Nothing covered a successful update**: not that coordinates move toward the
measured RTT, not that repeated samples converge, not that the error decays or clamps at either end.

## Exact where it is checkable, properties where it is not

The first two steps are anchored exactly, because they follow from the constants by hand:

| Step | Derivation | Value |
| --- | --- | --- |
| 1 | `cc * weight * diffErr` = `0.25 * 0.5 * 50` | `6.25` |
| 2 | `6.25 + 0.125 * (50 - 6.25)` | `11.71875` |
| error 2 | `0.875 * 0.25 + 1.0 * 0.75` | `0.96875` |

Those pin `cc`, `ce` and the error weighting against anything that would otherwise hide inside a long
run. The 200-sample runs assert **properties** instead — monotonic approach from below, no
overshoot, within 1ms of the measured RTT — rather than a float chain nobody can verify by reading.

Measured trajectory, for reference:

```
n=  1  d= 6.250000  err=1.00000000
n=  2  d=11.718750  err=0.96875000
n= 10  d=34.666363  err=0.53329663
n= 50  d=47.461992  err=0.09953888
n=200  d=49.455241  err=0.02170078
```

## Both directions, both clamps

**Direction.** A settled node fed a *smaller* RTT has to be pulled back in, not pushed further out.
That is the only thing pinning the sign of `diffErr`: converging at 50 then switching to 10 gives a
monotonic decrease to `10.117246`.

**Upper clamp.** Needs a node settled far out and then told the peer is 1ms away, which produces a
sample error near 494. Without the clamp `myError` would land far above 1.

**Lower clamp.** Unobservable at the default floor of `0`, since the error only decays toward it
asymptotically — so it is tested against a configured floor of `0.4`, where the error stops exactly
on it by sample 20 and stays there through sample 300.

## Verification

Passing proves nothing on its own, so every assertion was confirmed to **fail** under a deliberate
mutation of `vivaldi-core.ts`:

| Mutation | Result |
| --- | --- |
| `cc` nudged 0.25 → 0.26 | caught |
| `ce` nudged 0.5 → 0.51 | caught |
| weight uses the remote error | caught |
| `diffErr` sign flipped | caught |
| `sampleError` drops the absolute value | caught |
| upper clamp removed | caught |
| lower clamp removed | caught |
| movement ignores the step size | caught |
| error decay term dropped | caught |

`vivaldi-core.ts` was restored after each; the diff on this branch is one new file.

- `npx vitest run packages/tests/shared-graph/` — 30 files, 134 passed.
- `npx tsc -p packages/shared-graph/tsconfig.json --noEmit` — clean.
- `check:repo-style:changed origin/main HEAD` — PASS.
- `packages/tests/repo/` — 711 passed.

## Next

This is the coverage that makes the last slice safe: `observeRtt` at
[`vivaldi-service.ts:34-35`](https://github.com/intact-software-systems/ar-eye-hunter/blob/main/packages/shared-graph/vivaldi-service.ts#L34)
updates `fromNode` and then feeds its *post-update* state into `toNode`'s update, so a symmetric
measurement produces an asymmetric outcome.

Refs #251.
