### PR TITLE
Pin the observeRtt update ordering that #251 proposed changing

### DIFF
--- a/packages/tests/shared-graph/vivaldi-pair-update.test.ts
+++ b/packages/tests/shared-graph/vivaldi-pair-update.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { observeRtt } from '@shared-graph/vivaldi-service.ts';
+import { clearAllNodes, getNodeById } from '@shared-graph/repository/vivaldi-repository.ts';
+import { configureTestCacheRepositories } from '../cache-repository-config.ts';
+
+const TARGET_RTT_MS = 50;
+
+// These run through observeRtt itself, so the nodes come from the repository
+// with the live Math.random. That is the point: the property below has to hold
+// without controlling the draw.
+function observePairDistance(samples: number): number {
+    clearAllNodes();
+
+    for (let sample = 0; sample < samples; sample++) {
+        observeRtt({
+            sessionIdFrom: 'session-a',
+            sessionIdTo: 'session-b',
+            rttMs: TARGET_RTT_MS,
+            createdAtEpochMs: 0,
+            version: 1,
+        });
+    }
+
+    const from = getNodeById('session-a');
+    const to = getNodeById('session-b');
+    if (!from || !to) {
+        throw new Error('observeRtt did not create both nodes');
+    }
+
+    return from.coords.subtract(to.coords).norm();
+}
+
+function observePairPosition(samples: number): number[] {
+    observePairDistance(samples);
+    return getNodeById('session-a')!.coords.values;
+}
+
+describe('observeRtt pair updates', () => {
+    beforeEach(() => {
+        configureTestCacheRepositories();
+        clearAllNodes();
+    });
+
+    // The control for everything below. Two fresh nodes are collocated, so the
+    // first update takes the random tie-break and the pair lands somewhere
+    // different in space every time. Without this, a stable distance could just
+    // mean the randomness was not reached.
+    it('places the pair somewhere different on every run', () => {
+        const positions = Array.from({ length: 8 }, () => observePairPosition(1).join(','));
+
+        expect(new Set(positions).size).toBeGreaterThan(1);
+    });
+
+    // observeRtt updates the from-node and then feeds its *new* state into the
+    // to-node's update. That coupling is what makes the separation between them
+    // independent of the direction the pair happened to pick: the second node
+    // moves directly away from where the first one just went.
+    //
+    // Predicted RTT reads this distance and nothing else, so the ordering is
+    // load-bearing. Snapshotting both nodes before either update -- which looks
+    // like the obvious symmetry fix -- makes both take independent tie-breaks
+    // and turns this distance back into a random variable.
+    // Agreement is to ~15 significant digits rather than bit-for-bit: the drawn
+    // unit vector is only unit-length up to rounding, so the cancellation
+    // leaves a last-place difference that varies with the draw. The margin here
+    // is still 10 orders of magnitude tighter than the spread the snapshot
+    // ordering produces, which ranges from 0.9 to 12.4 after one observation.
+    it.each([
+        { samples: 1, expected: 11.71875 },
+        { samples: 2, expected: 20.819243499393782 },
+    ])('separates the pair by $expected after $samples', ({ samples, expected }) => {
+        const distances = Array.from({ length: 8 }, () => observePairDistance(samples));
+
+        for (const distance of distances) {
+            expect(distance).toBeCloseTo(expected, 9);
+        }
+    });
+
+    it('converges to the measured RTT regardless of the draw', () => {
+        const distances = Array.from({ length: 8 }, () => observePairDistance(100));
+
+        for (const distance of distances) {
+            expect(distance).toBeCloseTo(TARGET_RTT_MS, 9);
+            expect(distance).toBeCloseTo(distances[0], 9);
+        }
+    });
+});


### PR DESCRIPTION
Final slice of #251 — and it **retracts** the change that slice was supposed to make.

## What I claimed, and why it was wrong

I filed the sequential pair update in
[`observeRtt`](https://github.com/intact-software-systems/ar-eye-hunter/blob/main/packages/shared-graph/vivaldi-service.ts#L34)
as a defect: it updates the from-node, then feeds that node's **post-update** state into the
to-node's update, so a symmetric measurement is processed asymmetrically. The proposed fix was to
snapshot both nodes before either update — which is what distributed Vivaldi does, where the two
endpoints are separate processes that never see each other's post-update state.

Both endpoints are simulated in **one process** here, and that changes the answer. Measured over 400
trials per horizon:

| Horizon | Sequential (current) | Snapshot (proposed) |
| --- | --- | --- |
| 1 observation | `11.7188` every run | mean `8.5015`, spread `0.9099` – `12.3620` |
| 2 observations | `20.8192` every run | mean `18.9346`, spread `13.2506` – `21.8274` |
| 5 observations | `37.2621` every run | mean `36.8772`, spread `34.4006` – `38.1286` |
| 200 observations | `50.0000` | `50.0000` |

The sequential coupling is doing real work. Two fresh nodes are collocated, so the first update takes
a random tie-break — but because the second node then moves directly away from where the first one
just went, **the separation between them does not depend on the direction the pair picked**.
Snapshotting makes both take independent tie-breaks, and the pair can land nearly on top of itself.

Predicted RTT reads that pair distance and nothing else, so the ordering is load-bearing rather than
incidental. The obvious-looking symmetry fix would have injected noise into the exact quantity the
algorithm exists to estimate, with no benefit at steady state.

## So this pins the property instead of changing the code

The tests run through `observeRtt` itself, with the live `Math.random` — the property has to hold
without controlling the draw.

The first test is the **control**: it asserts the pair does land somewhere different on every run.
Without it, a stable distance could just mean the randomness was never reached, which is how a test
passes for the wrong reason.

Agreement is to ~15 significant digits, not bit-for-bit. My first draft asserted exact equality and
failed on the first run at `11.718750000000002` — the drawn unit vector is only unit-length up to
rounding, so the cancellation leaves a last-place difference that varies with the draw. The
assertion now matches that, and the margin is still ten orders of magnitude tighter than the spread
the snapshot ordering produces.

## Verification

| Mutation to `vivaldi-service.ts` | Result |
| --- | --- |
| snapshot both before either update (the change I proposed) | caught |
| update only the from-node | caught |
| swap which node updates first | **not caught — correct**, the two roles are symmetric so the distance is genuinely identical |

- `npx vitest run packages/tests/shared-graph/` — 31 files, 138 passed.
- `npx tsc -p packages/shared-graph/tsconfig.json --noEmit` — clean.
- `check:repo-style:changed origin/main HEAD` — PASS.
- `packages/tests/repo/` — 711 passed.

## Closing out #251

With this, all five findings are resolved: the hang, the mutation-through-a-query, the step
inflation, the missing convergence coverage, and this one — which turned out to be a property worth
protecting rather than a defect worth fixing.

Refs #251.
