### PR TITLE
Add the group lifecycle policy contract, defaults and validation, with the plan behind it

### DIFF
--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy-presets.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy-presets.ts
@@ -1,0 +1,151 @@
+import type {
+    GroupLifecyclePolicy,
+    GroupLifecyclePolicyPresetName,
+} from './group-lifecycle-policy.ts';
+
+/**
+ * The default is `optimistic`, which is the behaviour a group has when no
+ * policy is supplied at all: formation collapses to zero length, admission
+ * stays open, and application data flows. Every other preset is a departure
+ * from it.
+ */
+export function createDefaultGroupLifecyclePolicy(): GroupLifecyclePolicy {
+    return resolveGroupLifecyclePolicyPreset('optimistic');
+}
+
+export function resolveGroupLifecyclePolicyPreset(
+    name: GroupLifecyclePolicyPresetName,
+): GroupLifecyclePolicy {
+    switch (name) {
+        case 'optimistic':
+            return OPTIMISTIC_POLICY;
+        case 'managed':
+            return MANAGED_POLICY;
+        case 'match':
+            return MATCH_POLICY;
+        case 'drop-in-social':
+            return DROP_IN_SOCIAL_POLICY;
+    }
+}
+
+const OPTIMISTIC_POLICY: GroupLifecyclePolicy = {
+    formation: 'immediate',
+    manager: {
+        selection: 'none',
+        assignedPrincipalIds: [],
+        count: 1,
+        succession: 'none',
+    },
+    establishment: {
+        transports: 'rtc-and-ws',
+        initiator: 'any-member',
+        maxConcurrentEdgeSetups: 64,
+    },
+    activation: {
+        mode: 'manual',
+        successRate: 0,
+        minimumViableRate: 0,
+        deadlineMs: 0,
+        maxFormationAttempts: 1,
+        strictConfirmation: false,
+    },
+    admission: {
+        mode: 'open',
+        untilEpochMs: null,
+        untilMemberCount: null,
+    },
+    data: { preActivationAppData: 'allowed' },
+};
+
+const MANAGED_POLICY: GroupLifecyclePolicy = {
+    formation: 'phased',
+    manager: {
+        selection: 'creator',
+        assignedPrincipalIds: [],
+        count: 1,
+        succession: 'next-by-selection',
+    },
+    establishment: {
+        transports: 'rtc-and-ws',
+        initiator: 'manager',
+        maxConcurrentEdgeSetups: 32,
+    },
+    activation: {
+        mode: 'threshold-or-deadline',
+        successRate: 0.95,
+        minimumViableRate: 0.5,
+        deadlineMs: 30_000,
+        maxFormationAttempts: 3,
+        strictConfirmation: false,
+    },
+    admission: {
+        mode: 'manager-approval',
+        untilEpochMs: null,
+        untilMemberCount: null,
+    },
+    data: { preActivationAppData: 'allowed' },
+};
+
+/**
+ * The floor equals the success rate, which is how this preset asks for
+ * all-or-nothing: a session that is not fully connected does not start rather
+ * than starting degraded. `strictConfirmation` stays false because the per-edge
+ * confirmation ledger is not implemented; setting it true is rejected.
+ */
+const MATCH_POLICY: GroupLifecyclePolicy = {
+    formation: 'phased',
+    manager: {
+        selection: 'elected-by-rank',
+        assignedPrincipalIds: [],
+        count: 1,
+        succession: 'next-by-selection',
+    },
+    establishment: {
+        transports: 'rtc-preferred',
+        initiator: 'manager',
+        maxConcurrentEdgeSetups: 16,
+    },
+    activation: {
+        mode: 'threshold-or-deadline',
+        successRate: 1,
+        minimumViableRate: 1,
+        deadlineMs: 20_000,
+        maxFormationAttempts: 2,
+        strictConfirmation: false,
+    },
+    admission: {
+        mode: 'closed',
+        untilEpochMs: null,
+        untilMemberCount: null,
+    },
+    data: { preActivationAppData: 'blocked-until-active' },
+};
+
+const DROP_IN_SOCIAL_POLICY: GroupLifecyclePolicy = {
+    formation: 'immediate',
+    manager: {
+        selection: 'none',
+        assignedPrincipalIds: [],
+        count: 1,
+        succession: 'none',
+    },
+    establishment: {
+        transports: 'rtc-and-ws',
+        initiator: 'server-auto',
+        maxConcurrentEdgeSetups: 64,
+    },
+    activation: {
+        mode: 'threshold',
+        successRate: 0.8,
+        minimumViableRate: 0.25,
+        deadlineMs: 0,
+        maxFormationAttempts: 5,
+        strictConfirmation: false,
+    },
+    admission: {
+        mode: 'open',
+        untilEpochMs: null,
+        untilMemberCount: 50,
+    },
+    data: { preActivationAppData: 'allowed' },
+};

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
@@ -1,0 +1,136 @@
+import type { PrincipalId } from '../group-types.ts';
+
+export type GroupLifecycleState =
+    | 'forming'
+    | 'establishing'
+    | 'active'
+    | 'reconfiguring';
+
+export type GroupFormationMode =
+    | 'phased'
+    | 'immediate';
+
+export type GroupManagerSelection =
+    | 'none'
+    | 'creator'
+    | 'assigned'
+    | 'elected-by-rank'
+    | 'elected-random-deterministic';
+
+export type GroupManagerSuccession =
+    | 'next-by-selection'
+    | 'none';
+
+export type GroupEstablishmentTransports =
+    | 'rtc-and-ws'
+    | 'ws-only'
+    | 'rtc-preferred';
+
+export type GroupEstablishmentInitiator =
+    | 'manager'
+    | 'any-member'
+    | 'server-auto';
+
+export type GroupActivationMode =
+    | 'threshold'
+    | 'deadline'
+    | 'manual'
+    | 'threshold-or-deadline';
+
+export type GroupAdmissionMode =
+    | 'open'
+    | 'manager-approval'
+    | 'closed';
+
+export type GroupPreActivationAppData =
+    | 'allowed'
+    | 'blocked-until-active';
+
+export type GroupManagerPolicy = Readonly<{
+    selection: GroupManagerSelection;
+    assignedPrincipalIds: readonly PrincipalId[];
+    count: number;
+    succession: GroupManagerSuccession;
+}>;
+
+export type GroupEstablishmentPolicy = Readonly<{
+    transports: GroupEstablishmentTransports;
+    initiator: GroupEstablishmentInitiator;
+    maxConcurrentEdgeSetups: number;
+}>;
+
+/**
+ * Two rates rather than one: at or above `successRate` the group activates, at
+ * or above `minimumViableRate` it activates degraded, and below the floor it
+ * does not activate at all. A single rate cannot distinguish a group that is
+ * usably connected from one that is not, so `minimumViableRate` equal to
+ * `successRate` is how a caller asks for all-or-nothing.
+ */
+export type GroupActivationCriterion = Readonly<{
+    mode: GroupActivationMode;
+    successRate: number;
+    minimumViableRate: number;
+    deadlineMs: number;
+    maxFormationAttempts: number;
+    strictConfirmation: boolean;
+}>;
+
+/** `null` means the constraint does not apply, which composes with any mode. */
+export type GroupAdmissionPolicy = Readonly<{
+    mode: GroupAdmissionMode;
+    untilEpochMs: number | null;
+    untilMemberCount: number | null;
+}>;
+
+export type GroupDataPolicy = Readonly<{
+    preActivationAppData: GroupPreActivationAppData;
+}>;
+
+export type GroupLifecyclePolicy = Readonly<{
+    formation: GroupFormationMode;
+    manager: GroupManagerPolicy;
+    establishment: GroupEstablishmentPolicy;
+    activation: GroupActivationCriterion;
+    admission: GroupAdmissionPolicy;
+    data: GroupDataPolicy;
+}>;
+
+export const GROUP_LIFECYCLE_POLICY_PRESET_NAMES = [
+    'optimistic',
+    'managed',
+    'match',
+    'drop-in-social',
+] as const;
+
+export type GroupLifecyclePolicyPresetName =
+    typeof GROUP_LIFECYCLE_POLICY_PRESET_NAMES[number];
+
+/** Sparse external input. Absent fields take the preset or server default. */
+export type GroupLifecyclePolicyInput = Readonly<{
+    preset?: GroupLifecyclePolicyPresetName;
+    formation?: GroupFormationMode;
+    manager?: Partial<GroupManagerPolicy>;
+    establishment?: Partial<GroupEstablishmentPolicy>;
+    activation?: Partial<GroupActivationCriterion>;
+    admission?: Partial<GroupAdmissionPolicy>;
+    data?: Partial<GroupDataPolicy>;
+}>;
+
+export const GROUP_LIFECYCLE_POLICY_ISSUE_CODES = [
+    'manager-initiator-without-manager',
+    'viable-rate-above-success-rate',
+    'threshold-mode-requires-positive-rate',
+    'deadline-mode-requires-positive-deadline',
+    'assigned-selection-requires-principals',
+    'manager-count-exceeds-assigned-principals',
+    'strict-confirmation-unsupported',
+] as const;
+
+export type GroupLifecyclePolicyIssueCode =
+    typeof GROUP_LIFECYCLE_POLICY_ISSUE_CODES[number];
+
+export type GroupLifecyclePolicyIssue = Readonly<{
+    code: GroupLifecyclePolicyIssueCode;
+    field: string;
+    message: string;
+}>;

--- a/packages/shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts
@@ -1,0 +1,134 @@
+import type {
+    GroupActivationCriterion,
+    GroupAdmissionPolicy,
+    GroupDataPolicy,
+    GroupEstablishmentPolicy,
+    GroupLifecyclePolicy,
+    GroupLifecyclePolicyInput,
+    GroupManagerPolicy,
+} from './group-lifecycle-policy.ts';
+import {
+    createDefaultGroupLifecyclePolicy,
+    resolveGroupLifecyclePolicyPreset,
+} from './group-lifecycle-policy-presets.ts';
+
+export const MAX_GROUP_FORMATION_DEADLINE_MS = 600_000;
+export const MAX_GROUP_MANAGERS = 16;
+export const MAX_GROUP_CONCURRENT_EDGE_SETUPS = 256;
+export const MAX_GROUP_FORMATION_ATTEMPTS = 16;
+export const MAX_GROUP_ADMISSION_MEMBER_COUNT = 100_000;
+
+/**
+ * Sparse client input to a complete policy: the preset (or the optimistic
+ * default) supplies every field the caller omitted, and every numeric field is
+ * clamped to a server bound. Clamping is deliberately silent and total, so a
+ * caller cannot produce an out-of-range policy; contradictions between fields
+ * are a separate concern and belong to validateGroupLifecyclePolicy.
+ */
+export function toNormalizedGroupLifecyclePolicy(
+    input: GroupLifecyclePolicyInput = {},
+): GroupLifecyclePolicy {
+    const base = input.preset === undefined
+        ? createDefaultGroupLifecyclePolicy()
+        : resolveGroupLifecyclePolicyPreset(input.preset);
+
+    return {
+        formation: input.formation ?? base.formation,
+        manager: toManagerPolicy(base.manager, input.manager),
+        establishment: toEstablishmentPolicy(base.establishment, input.establishment),
+        activation: toActivationCriterion(base.activation, input.activation),
+        admission: toAdmissionPolicy(base.admission, input.admission),
+        data: toDataPolicy(base.data, input.data),
+    };
+}
+
+function toManagerPolicy(
+    base: GroupManagerPolicy,
+    input: Partial<GroupManagerPolicy> | undefined,
+): GroupManagerPolicy {
+    return {
+        selection: input?.selection ?? base.selection,
+        assignedPrincipalIds: input?.assignedPrincipalIds ?? base.assignedPrincipalIds,
+        count: toClampedInteger(input?.count ?? base.count, 1, MAX_GROUP_MANAGERS),
+        succession: input?.succession ?? base.succession,
+    };
+}
+
+function toEstablishmentPolicy(
+    base: GroupEstablishmentPolicy,
+    input: Partial<GroupEstablishmentPolicy> | undefined,
+): GroupEstablishmentPolicy {
+    return {
+        transports: input?.transports ?? base.transports,
+        initiator: input?.initiator ?? base.initiator,
+        maxConcurrentEdgeSetups: toClampedInteger(
+            input?.maxConcurrentEdgeSetups ?? base.maxConcurrentEdgeSetups,
+            1,
+            MAX_GROUP_CONCURRENT_EDGE_SETUPS,
+        ),
+    };
+}
+
+function toActivationCriterion(
+    base: GroupActivationCriterion,
+    input: Partial<GroupActivationCriterion> | undefined,
+): GroupActivationCriterion {
+    return {
+        mode: input?.mode ?? base.mode,
+        successRate: toClampedRate(input?.successRate ?? base.successRate),
+        minimumViableRate: toClampedRate(input?.minimumViableRate ?? base.minimumViableRate),
+        deadlineMs: toClampedInteger(
+            input?.deadlineMs ?? base.deadlineMs,
+            0,
+            MAX_GROUP_FORMATION_DEADLINE_MS,
+        ),
+        maxFormationAttempts: toClampedInteger(
+            input?.maxFormationAttempts ?? base.maxFormationAttempts,
+            1,
+            MAX_GROUP_FORMATION_ATTEMPTS,
+        ),
+        strictConfirmation: input?.strictConfirmation ?? base.strictConfirmation,
+    };
+}
+
+function toAdmissionPolicy(
+    base: GroupAdmissionPolicy,
+    input: Partial<GroupAdmissionPolicy> | undefined,
+): GroupAdmissionPolicy {
+    const untilEpochMs = input?.untilEpochMs === undefined
+        ? base.untilEpochMs
+        : input.untilEpochMs;
+    const untilMemberCount = input?.untilMemberCount === undefined
+        ? base.untilMemberCount
+        : input.untilMemberCount;
+
+    return {
+        mode: input?.mode ?? base.mode,
+        untilEpochMs: untilEpochMs === null
+            ? null
+            : toClampedInteger(untilEpochMs, 0, Number.MAX_SAFE_INTEGER),
+        untilMemberCount: untilMemberCount === null
+            ? null
+            : toClampedInteger(untilMemberCount, 1, MAX_GROUP_ADMISSION_MEMBER_COUNT),
+    };
+}
+
+function toDataPolicy(
+    base: GroupDataPolicy,
+    input: Partial<GroupDataPolicy> | undefined,
+): GroupDataPolicy {
+    return {
+        preActivationAppData: input?.preActivationAppData ?? base.preActivationAppData,
+    };
+}
+
+function toClampedRate(value: number): number {
+    return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+}
+
+function toClampedInteger(value: number, minimum: number, maximum: number): number {
+    if (!Number.isFinite(value)) {
+        return minimum;
+    }
+    return Math.min(maximum, Math.max(minimum, Math.trunc(value)));
+}

--- a/packages/shared/api/group-lifecycle/validate-group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/validate-group-lifecycle-policy.ts
@@ -1,0 +1,120 @@
+import { Either } from '../../resilience/Either.ts';
+
+import type {
+    GroupLifecyclePolicy,
+    GroupLifecyclePolicyIssue,
+} from './group-lifecycle-policy.ts';
+
+/**
+ * Contradictions between fields, which clamping cannot catch: a clamp keeps one
+ * value in range, this rejects combinations that are individually legal and
+ * jointly unreachable. Returns every issue rather than the first, so a caller
+ * fixes one policy document once.
+ */
+export function validateGroupLifecyclePolicy(
+    policy: GroupLifecyclePolicy,
+): Either<readonly GroupLifecyclePolicyIssue[], GroupLifecyclePolicy> {
+    const issues: GroupLifecyclePolicyIssue[] = [
+        ...toManagerIssues(policy),
+        ...toActivationIssues(policy),
+    ];
+
+    return issues.length === 0
+        ? Either.ofRight(policy)
+        : Either.ofLeft(issues);
+}
+
+function toManagerIssues(
+    policy: GroupLifecyclePolicy,
+): readonly GroupLifecyclePolicyIssue[] {
+    const issues: GroupLifecyclePolicyIssue[] = [];
+    const { manager, establishment } = policy;
+
+    // Nobody could ever start establishment, so the group would hold in FORMING
+    // for its whole life.
+    if (manager.selection === 'none' && establishment.initiator === 'manager') {
+        issues.push({
+            code: 'manager-initiator-without-manager',
+            field: 'establishment.initiator',
+            message:
+                'establishment.initiator is manager but manager.selection is none, ' +
+                'so no principal can ever start establishment',
+        });
+    }
+
+    if (manager.selection === 'assigned' && manager.assignedPrincipalIds.length === 0) {
+        issues.push({
+            code: 'assigned-selection-requires-principals',
+            field: 'manager.assignedPrincipalIds',
+            message: 'manager.selection is assigned but no principals were assigned',
+        });
+    }
+
+    if (
+        manager.selection === 'assigned' &&
+        manager.assignedPrincipalIds.length > 0 &&
+        manager.count > manager.assignedPrincipalIds.length
+    ) {
+        issues.push({
+            code: 'manager-count-exceeds-assigned-principals',
+            field: 'manager.count',
+            message: 'manager.count exceeds the number of assigned principals',
+        });
+    }
+
+    return issues;
+}
+
+function toActivationIssues(
+    policy: GroupLifecyclePolicy,
+): readonly GroupLifecyclePolicyIssue[] {
+    const issues: GroupLifecyclePolicyIssue[] = [];
+    const { activation } = policy;
+
+    if (activation.minimumViableRate > activation.successRate) {
+        issues.push({
+            code: 'viable-rate-above-success-rate',
+            field: 'activation.minimumViableRate',
+            message:
+                'activation.minimumViableRate is above activation.successRate, ' +
+                'which leaves no rate at which the group activates degraded',
+        });
+    }
+
+    if (usesThreshold(activation.mode) && activation.successRate <= 0) {
+        issues.push({
+            code: 'threshold-mode-requires-positive-rate',
+            field: 'activation.successRate',
+            message: 'activation.mode requires a threshold but successRate is not positive',
+        });
+    }
+
+    if (usesDeadline(activation.mode) && activation.deadlineMs <= 0) {
+        issues.push({
+            code: 'deadline-mode-requires-positive-deadline',
+            field: 'activation.deadlineMs',
+            message: 'activation.mode requires a deadline but deadlineMs is not positive',
+        });
+    }
+
+    // The per-edge confirmation ledger this selects is not implemented. The
+    // field exists so the intent can be expressed and answered, rather than
+    // silently accepted and ignored.
+    if (activation.strictConfirmation) {
+        issues.push({
+            code: 'strict-confirmation-unsupported',
+            field: 'activation.strictConfirmation',
+            message: 'activation.strictConfirmation is not supported in this release',
+        });
+    }
+
+    return issues;
+}
+
+function usesThreshold(mode: GroupLifecyclePolicy['activation']['mode']): boolean {
+    return mode === 'threshold' || mode === 'threshold-or-deadline';
+}
+
+function usesDeadline(mode: GroupLifecyclePolicy['activation']['mode']): boolean {
+    return mode === 'deadline' || mode === 'threshold-or-deadline';
+}

--- a/packages/tests/shared/group-lifecycle-policy.test.ts
+++ b/packages/tests/shared/group-lifecycle-policy.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+    GROUP_LIFECYCLE_POLICY_PRESET_NAMES,
+    type GroupLifecyclePolicy,
+    type GroupLifecyclePolicyIssueCode,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import {
+    createDefaultGroupLifecyclePolicy,
+    resolveGroupLifecyclePolicyPreset,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import {
+    MAX_GROUP_FORMATION_DEADLINE_MS,
+    MAX_GROUP_MANAGERS,
+    toNormalizedGroupLifecyclePolicy,
+} from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
+import { validateGroupLifecyclePolicy } from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
+
+function toIssueCodes(policy: GroupLifecyclePolicy): readonly GroupLifecyclePolicyIssueCode[] {
+    return validateGroupLifecyclePolicy(policy).left?.map((issue) => issue.code) ?? [];
+}
+
+describe('group lifecycle policy defaults', () => {
+    // The property the whole workstream rests on: a group created without a
+    // policy behaves exactly as groups behave today. If this ever changes,
+    // every existing group silently changes behaviour.
+    it('defaults to the optimistic preset, which is today behaviour', () => {
+        const policy = createDefaultGroupLifecyclePolicy();
+
+        expect(policy).toEqual(resolveGroupLifecyclePolicyPreset('optimistic'));
+        expect(policy.formation).toBe('immediate');
+        expect(policy.admission.mode).toBe('open');
+        expect(policy.data.preActivationAppData).toBe('allowed');
+        expect(policy.manager.selection).toBe('none');
+    });
+
+    it('normalizes absent input to the default', () => {
+        expect(toNormalizedGroupLifecyclePolicy()).toEqual(createDefaultGroupLifecyclePolicy());
+        expect(toNormalizedGroupLifecyclePolicy({})).toEqual(createDefaultGroupLifecyclePolicy());
+    });
+
+    it.each(GROUP_LIFECYCLE_POLICY_PRESET_NAMES)('ships %s as a valid policy', (name) => {
+        expect(toIssueCodes(resolveGroupLifecyclePolicyPreset(name))).toEqual([]);
+    });
+
+    // The floor equalling the success rate is how match asks for
+    // all-or-nothing, which is what replaced the removed fail-formation.
+    it('gives match an all-or-nothing criterion', () => {
+        const match = resolveGroupLifecyclePolicyPreset('match');
+
+        expect(match.activation.minimumViableRate).toBe(match.activation.successRate);
+        expect(match.admission.mode).toBe('closed');
+        expect(match.data.preActivationAppData).toBe('blocked-until-active');
+    });
+});
+
+describe('group lifecycle policy normalization', () => {
+    it('layers sparse input over the named preset', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            preset: 'managed',
+            admission: { mode: 'closed' },
+        });
+
+        expect(policy.admission.mode).toBe('closed');
+        expect(policy.formation).toBe('phased');
+        expect(policy.establishment.initiator).toBe('manager');
+    });
+
+    it.each([
+        { field: 'above one', input: 1.5, expected: 1 },
+        { field: 'below zero', input: -0.5, expected: 0 },
+        { field: 'not a number', input: Number.NaN, expected: 0 },
+    ])('clamps a rate $field', ({ input, expected }) => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            activation: { successRate: input },
+        });
+
+        expect(policy.activation.successRate).toBe(expected);
+    });
+
+    it('clamps integer knobs to their server bounds', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { count: 9_999 },
+            activation: { deadlineMs: 60 * 60 * 1000 },
+        });
+
+        expect(policy.manager.count).toBe(MAX_GROUP_MANAGERS);
+        expect(policy.activation.deadlineMs).toBe(MAX_GROUP_FORMATION_DEADLINE_MS);
+    });
+
+    // null and undefined mean different things here: undefined defers to the
+    // preset, null explicitly clears the constraint. Treating them alike would
+    // make a capacity limit impossible to remove.
+    it('separates an omitted constraint from an explicitly cleared one', () => {
+        const inherited = toNormalizedGroupLifecyclePolicy({ preset: 'drop-in-social' });
+        const cleared = toNormalizedGroupLifecyclePolicy({
+            preset: 'drop-in-social',
+            admission: { untilMemberCount: null },
+        });
+
+        expect(inherited.admission.untilMemberCount).toBe(50);
+        expect(cleared.admission.untilMemberCount).toBeNull();
+    });
+});
+
+describe('group lifecycle policy validation', () => {
+    // The combination the design document allowed and no clamp can catch:
+    // nobody is ever able to start establishment, so the group holds in
+    // FORMING for its whole life.
+    it('rejects a manager initiator with no manager selection', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { selection: 'none' },
+            establishment: { initiator: 'manager' },
+        });
+
+        expect(toIssueCodes(policy)).toContain('manager-initiator-without-manager');
+    });
+
+    it('rejects a floor above the success rate', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            activation: { mode: 'threshold', successRate: 0.5, minimumViableRate: 0.9 },
+        });
+
+        expect(toIssueCodes(policy)).toContain('viable-rate-above-success-rate');
+    });
+
+    it.each([
+        {
+            label: 'a threshold mode with no rate',
+            input: { mode: 'threshold' as const, successRate: 0, minimumViableRate: 0 },
+            code: 'threshold-mode-requires-positive-rate' as const,
+        },
+        {
+            label: 'a deadline mode with no deadline',
+            input: { mode: 'deadline' as const, deadlineMs: 0 },
+            code: 'deadline-mode-requires-positive-deadline' as const,
+        },
+    ])('rejects $label', ({ input, code }) => {
+        expect(toIssueCodes(toNormalizedGroupLifecyclePolicy({ activation: input })))
+            .toContain(code);
+    });
+
+    it('rejects assigned selection without principals', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { selection: 'assigned', assignedPrincipalIds: [] },
+        });
+
+        expect(toIssueCodes(policy)).toContain('assigned-selection-requires-principals');
+    });
+
+    it('rejects more managers than assigned principals', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { selection: 'assigned', assignedPrincipalIds: ['a'], count: 2 },
+        });
+
+        expect(toIssueCodes(policy)).toContain('manager-count-exceeds-assigned-principals');
+    });
+
+    // The field exists so the intent can be expressed and answered rather than
+    // silently accepted and ignored; the ledger it selects is not built.
+    it('rejects strict confirmation as unsupported', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            activation: { strictConfirmation: true },
+        });
+
+        expect(toIssueCodes(policy)).toContain('strict-confirmation-unsupported');
+    });
+
+    // A caller should be able to fix one policy document once, rather than
+    // resubmitting to discover the next problem.
+    it('reports every issue rather than stopping at the first', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { selection: 'none' },
+            establishment: { initiator: 'manager' },
+            activation: {
+                mode: 'threshold',
+                successRate: 0,
+                minimumViableRate: 0,
+                strictConfirmation: true,
+            },
+        });
+
+        expect(toIssueCodes(policy)).toEqual(
+            expect.arrayContaining([
+                'manager-initiator-without-manager',
+                'threshold-mode-requires-positive-rate',
+                'strict-confirmation-unsupported',
+            ]),
+        );
+    });
+
+    it('returns the policy on the right when it is coherent', () => {
+        const policy = createDefaultGroupLifecyclePolicy();
+
+        expect(validateGroupLifecyclePolicy(policy).right).toEqual(policy);
+    });
+});

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -1,0 +1,191 @@
+# Group Lifecycle Control Plane — Implementation Plan (2026-08-17)
+
+Status: **planned, not started.** Implements
+`2026-08-08-group-lifecycle-and-policy-model.md` and, with it, Phase 5's formation window (M7) from
+`2026-08-08-group-formation-implementation-plan.md`. These are one workstream, not two: Phase 5's
+formation window is this document's FORMING state with a policy-driven trigger instead of a timer.
+Building them separately means building the timer version and then replacing it.
+
+## The property that makes this shippable
+
+**An absent policy document is the `optimistic` preset, which is today's behaviour exactly.** FORMING
+collapses to zero length, establishment and activation happen at creation, admission stays open, data
+flows. Every existing group keeps its current behaviour with no migration, and every slice below can
+land dark. If a slice cannot preserve this, the slice is wrong.
+
+## Decisions taken (2026-08-17)
+
+| # | Decision |
+| --- | --- |
+| 1 | **Placement is split.** The policy document is its own scoped document, mirroring `rallar-system/topology/config/persistence/` (codec, repository, storage keys, exact-mutation reader). The lifecycle enum and activation epoch — small, hot, and read by every admission and activation decision — live on the group aggregate so they serialize with membership under compare-and-set. |
+| 2 | **`RECONFIGURING` is a distinct intent state**, not `ESTABLISHING` plus a flag. |
+| 3 | **Formation can fail, but not terminally.** `ActivationCriterion` gains a `minimumViableRate` floor distinct from `successRate`. At or above the floor but below `successRate` the group activates degraded. **Below the floor the group does not activate**: a typed reason is recorded, an attempt counter increments, and intent returns to FORMING under policy backoff. No terminal `FAILED` intent state — the group stays joinable and retryable throughout. The two rates subsume the design's `onDeadline` field, which is dropped: a floor equal to the success rate is all-or-nothing, and anything below it already means do-not-activate. |
+| 4 | **Full policy vocabulary in v1**, including Admission and Data policies. |
+| 5 | **`strictConfirmation` is present in the schema, defaults `false`, and `true` returns a typed unsupported-in-this-release rejection** at validation. |
+
+Decision 1 splits what the design document bundled. Policy is cold, near-static and largish; lifecycle
+state is tiny and coupled to membership. Co-locating them forced a false choice between contention on
+the hottest row and a cross-document staleness window. Split, each lands cleanly — the residual
+staleness is on policy reads, which is tolerable precisely because policy is near-static.
+
+Decision 5 keeps the vocabulary complete without pulling the entire unimplemented activation design
+(five-lane work table, per-edge claim/expand, retry, abort sweep) into the first delivery. The `match`
+preset therefore ships **without** per-edge confirmation, and that gap is explicit rather than
+silently half-working.
+
+## Corrections to the design document
+
+Six things in `2026-08-08-group-lifecycle-and-policy-model.md` do not hold as written. All are folded
+into the slices below.
+
+1. **`ESTABLISHING` was ambiguous.** The document routes re-establishment "back to ESTABLISHING while
+   remaining app-ACTIVE", so one state meant both never-been-active and was-active-now-repairing —
+   which have opposite semantics under `blocked-until-active`. Resolved by decision 2.
+2. **`fail-formation` had no destination, and the criterion had no floor.** The intent state machine
+   has no terminal failure state, and adding one contradicts the invariant that a stuck phase "must
+   degrade to *not yet established*, never to an outage". But formation genuinely can fail, and with
+   a single `successRate` the design treats 94% and 5% connectivity identically — so
+   `activate-degraded` at 5% would declare a group ACTIVE that cannot carry the application's data.
+   Resolved by decision 3: a `minimumViableRate` floor separates degraded-but-usable from
+   not-viable, and below the floor the group does not activate. This is a recoverable outcome, not
+   a terminal state, which is what distinguishes it from the outage the invariant forbids.
+3. **A deadlock was expressible.** `ManagerPolicy.selection: none` with
+   `EstablishmentPolicy.initiator: manager` leaves nobody able to start establishment, and the
+   document promises clamps only on *numeric* knobs. **Fix:** a cross-field validity predicate at
+   policy normalization, returning all issues as a typed value.
+4. **Deterministic election flaps during the phase that needs it.** `elected-random-deterministic`
+   is deterministic over *member identities*, but membership changes throughout FORMING — so the
+   manager changes as people join, exactly while the manager is who must trigger establishment.
+   **Fix:** pin the election input to the member set at a **formation epoch** boundary; the epoch
+   advances only on explicit transition, never on join.
+5. **A never-activating group never enforced its admission policy.** `drop-in social` is `immediate`
+   + `threshold` + `open-until-capacity(N)`; if the threshold is never met the group never reaches
+   ACTIVE, so a *post-activation* policy never binds and joins stay unbounded but for `maxMembers`.
+   **Fix:** admission binds on **entry to the phase it names**, not on activation.
+6. **Policy mutability was unspecified per field.** **Fix:** each field declares one of `immutable`,
+   `mutable-any-phase`, or `mutable-with-supersession`; the last re-evaluates the running phase.
+
+## Slices
+
+Each slice is independently shippable and preserves the property above.
+
+### Slice 1 — Policy contract, defaults and validation — **delivered**
+
+The policy contract, presets, server defaults, per-field clamps, and the cross-field validity
+predicate (correction 3). Sparse client input has its own contract, normalized at the boundary.
+Nothing reads a policy, so no behaviour changes.
+
+Tests: the validity matrix, including the `none` + `manager` deadlock, capacity/deadline bounds, and
+that an absent document normalizes to `optimistic`.
+
+Three departures from this plan as written, all deliberate:
+
+- **Persistence and the `GROUP_CREATE` wiring moved to slice 2.** Persisting a document nothing reads
+  would put an AppInbox mutation-path change — with its black-box recipes and medium-scale gate —
+  into a slice that otherwise carries no risk. It lands with its first reader.
+- **`onDeadline` is removed from the contract entirely.** It has nothing left to decide once the
+  criterion carries two rates: between the floor and the success rate the outcome is degraded, below
+  the floor the group does not activate. Setting `minimumViableRate` equal to `successRate` is how a
+  caller asks for all-or-nothing, which is strictly more expressive than the two-valued enum it
+  replaces and is exactly what the `match` preset now does.
+- **The files live in `packages/shared/api/group-lifecycle/`.** The changed-style gate rejected them
+  at the top level: `packages/shared/api` passed its directory-density threshold and added to an
+  already-flagged `group` prefix cluster. Four files that are one coherent feature is the feature
+  ownership the rule asks for.
+
+Also found while implementing: `packages/shared/api/group-policy-types.ts` already holds the
+enforcement *decision* vocabulary — `GroupPolicyReasonCode` and `GroupPolicyResult`. **Slice 5's
+admission rules extend that vocabulary rather than paralleling it.**
+
+Risk: none realized. No behaviour change by construction.
+
+### Slice 2 — Lifecycle state, transitions, and the FORMING gate
+
+The intent enum (`FORMING`/`ESTABLISHING`/`ACTIVE`/`RECONFIGURING`) and activation epoch on the group
+aggregate. AppInbox transition commands — `start-establishment`, `activate`, `reopen-establishment` —
+each with an authorization predicate over (principal, role, policy, current state) and typed
+rejections, alongside the existing `GROUP_*` command set. FORMING holds topology planning and
+commanded dials: **this is Phase 5's M7 formation window.**
+
+**The safety-baseline invariant is the first test written, not the last.** Membership mutations,
+presence and WS connectivity must work in every state, including a group deliberately stuck in
+FORMING. Phases gate establishment work and the app-visible `active` signal — never the ability to be
+in the group.
+
+Risk: highest in the plan. This is where gating first touches live behaviour, and where the
+`immediate`-collapses-to-zero path must be proven byte-identical to today.
+
+### Slice 3 — Activation criterion and readiness
+
+`threshold` / `deadline` / `manual` / `threshold-or-deadline`, evaluated against two rates:
+`successRate` for full activation and `minimumViableRate` as the floor below which the group does not
+activate at all. `activate-degraded` applies only between them. Below the floor, intent returns to
+FORMING with a typed reason and an incremented attempt counter, under policy backoff.
+
+Readiness derives from observed edge state — RTT and liveness evidence against the planned overlay —
+as the fraction of planned edges observed connected.
+
+The read surface must carry enough for an application to explain itself to a user: intent state,
+observed rate, last formation outcome with its reason, and attempt count. A group that repeatedly
+fails to reach its floor is a product event, not a silent retry.
+
+Scope note: this builds **only the readiness derivation**, not the full six-state RTC activation
+projection (`INACTIVE`…`FAILED`), which has no implementation today and remains a separate concern.
+Intent is authoritative; this observation feeds the criterion and nothing else.
+
+### Slice 4 — Manager role
+
+`ManagerPolicy` (`selection`, `count`, `succession`), building on the existing
+`GROUP_DIRECTOR_APPOINT` command and payload contracts rather than new trust machinery. Election uses
+the existing `rendezvous-score.ts` primitive, pinned to the formation epoch (correction 4). Zero-manager
+fallback is explicit: manager absence blocks only manager-assigned actions, never group safety.
+
+### Slice 5 — Admission and data policies
+
+`AdmissionPolicy` at the existing `group-policy.ts` gate, where `maxMembers`, `maxSessionsPerMember`
+and invite checks already enforce — binding on phase entry (correction 5). `manager-approval` parks a
+join as pending, extending the existing invite/acceptance flow rather than adding a subsystem.
+`DataPolicy.preActivationAppData` gates WS-relayed application data.
+
+Risk: touches the hot, well-covered join path. Every new rule is an added predicate at an existing
+enforcement point, never a parallel path.
+
+### Slice 6 — Read surface and scenario matrix
+
+Lifecycle state joins the group snapshot and read APIs beside the readiness derivation, so
+applications and tests read intent and observation side by side. The design document's ten named
+scenarios land as black-box recipes at the 6/20/50 tiers where scale matters.
+
+`strict-confirmation` becomes a negative test in v1: setting `strictConfirmation: true` returns the
+typed unsupported rejection.
+
+## Deferred, explicitly
+
+- **Per-edge confirm-or-fail batch machinery** — the whole activation design. Gated behind
+  `strictConfirmation: true`, which v1 rejects. The posture decision (observed convergence as
+  default) is recorded product-owner decision 2 and is supported by the Phase 0–4 evidence in
+  `2026-08-17-phase5-establishment-posture-decision.md`.
+- **The six-state RTC activation status projection.** Slice 3 builds only the readiness fraction.
+- **The `match` preset's per-edge audit trail and server-side pacing.** The preset ships and, with
+  the `minimumViableRate` floor, it now also gets honest failure: below the floor a match does not
+  activate, and with `closed` admission and `blocked-until-active` data, nothing starts. What v1
+  does not give it is the per-edge ledger — a disputed session has "we were at 94%" rather than
+  "edge (player3, player7) never confirmed at T, ICE failure" — and server-controlled establishment
+  ordering. For a competitive product that is a real gap; it is narrower than a preset that simply
+  does not work.
+
+## Validation
+
+Per-slice: focused unit tests, then black-box recipes for any REST surface change in the same change
+per repo rule, then the api-v1 mutation-path gates for slices 2 and 5.
+
+Whole-workstream acceptance is the design document's scenario matrix, plus one property asserted at
+every slice boundary: **a group with no policy document behaves exactly as it does on `main` today.**
+
+## Open, to settle during execution
+
+- Pending-admission representation for `manager-approval`: extend invites, or a dedicated
+  pending-membership state. Decide when slice 5 is planned; extending invites is the lower-coupling
+  default.
+- Rank source for `elected-by-rank`. Application-supplied member metadata is the least-coupled
+  default.

--- a/playground/rtc-design/2026-08-17-phase5-establishment-posture-decision.md
+++ b/playground/rtc-design/2026-08-17-phase5-establishment-posture-decision.md
@@ -1,0 +1,142 @@
+# Phase 5 Decision — Establishment Posture
+
+Status: **the ruling already exists; this is the evidence behind it.**
+
+`2026-08-08-group-lifecycle-and-policy-model.md` recorded decision 2 as a product-owner decision on
+2026-08-08: threshold-based **observed convergence is the default** activation criterion, with the
+per-edge confirm-or-fail batch machinery retained as the establishment-phase implementation and the
+strict-policy option, surfaced as `ActivationCriterion.strictConfirmation`. That decision was taken
+on design judgment before Phases 3 and 4 had been measured.
+
+This brief was first drafted as a request for a ruling. It is not one. What it supplies is the
+Phase 0–4 measurement evidence that the earlier decision was made without, and a ground-truth audit
+of what is actually implemented. Both support the recorded decision.
+
+**What remains outstanding is the recording.** The lifecycle document says the activation design
+"records this at its Phase 5 decision point ... to be reflected there when that document is next
+revised." That revision has not happened: `plans/rallar-distributed-group-rtc-activation-design.md`
+still presents the posture as an open decision.
+
+## What is being decided
+
+Whether **per-edge confirmations are the default or the exception** when a group establishes its RTC
+overlay.
+
+- **Observed convergence.** The server publishes the planned overlay as the accepted, desired
+  topology. Browsers converge toward it under the existing budgeted/retained/damped reconciler. The
+  server derives activation status from observed edge state — RTT and liveness reports — against a
+  readiness threshold.
+- **Per-edge command/confirm.** The server keeps the planned topology out of the accepted store,
+  commands each edge through `group_batch` and `ASYNC_REMOTE_QUEUE`, collects per-edge confirmations,
+  and promotes the plan to accepted only on an acceptable terminal batch result.
+
+This is not a choice about whether `group_batch` exists. Both options keep it as the plan, audit and
+readiness record. What is being decided is whether **per-edge confirmation gates promotion**.
+
+## Ground truth in the code today
+
+The decision is often framed as "keep the design we already have, or replace it." That framing is
+wrong, and it is the single most important input here:
+
+| Component | Status |
+| --- | --- |
+| `group_batch` | **Not implemented.** No table, no type, no reference in `packages/**` or `apps/**`. |
+| `ASYNC_REMOTE_QUEUE` | **Not implemented.** Same. |
+| RTC activation status projection (`INITIALISING` / `RECONFIGURING` / `ACTIVE` / `DEGRADED`) | **Not implemented.** No occurrence of `INITIALISING` anywhere in the codebase. |
+| Retained-peer machinery in `WebRtcGroupManager` | **Exists.** `retainedPeerConnections`, `retainedOrder`, `disconnectExpiredRetainedPeers`, budget-preserving eviction. |
+| RTT / liveness reporting | **Exists.** `RttMeasurementInfo` flows through the RTT topic and refinement service. |
+
+The activation design is 1,638 lines of specification with **zero** implementation. Choosing per-edge
+confirm means building Flows 1–7 plus the abort sweep, the five-lane work table, conditional remote
+transitions, retry/timeout and capacity predicates from scratch. Choosing observed convergence means
+building the status projection and a readiness threshold over signals that already flow.
+
+Neither option is the status quo. One is markedly more construction than the other.
+
+## How Phases 0–4 changed the economics
+
+The activation design was written when publishing a desired overlay was expensive and unstable.
+Phases 1–4 removed both objections — which is precisely why the plan defers this decision to now.
+
+**Publishing the desired topology is now cheap.** Phase 3 took the N=50 burst from 254,951,157 bytes
+to 13.2 MB under `delta-primary`, a 19.3× reduction, and `delta-primary` is now the default since
+#231. Snapshot traffic had been 96.1% of baseline egress at N=50; it is gone.
+
+**Republishing is now rare.** Phase 2 collapsed burst recomputes to 1–5 executed/published, and an
+idle formed group produces 0 expansions, 0 broadcasts and 0 recomputes.
+
+**Republishing is now stable.** This is the decisive one. Before Phase 4, planning was a function of
+*arrival order*, not of the member set: a same-set reorder at N=50 churned 180 edges, about 93% of
+the combined edge slots of the two plans, and the tree tier full-rebuilt on every join in the 5–15
+band. Observed convergence against a plan that reshuffles on reorder would have thrashed
+indefinitely. M6 made planning a function of the member set, which is what makes "publish desired and
+let them converge" terminate at all.
+
+**The flap loop that would prevent settling is closed.** Every teardown used to reset the peer's
+connection-attempt budget. M11 closed that reset-on-removal hazard in Phase 4.
+
+Read together: the four preconditions observed convergence needs — cheap publication, rare
+publication, stable plans, and non-resetting retry budgets — were each delivered by a different
+landed phase. That is not a coincidence; it is what the plan meant by "the substrate the activation
+design assumed exists."
+
+## Option A — observed convergence as default
+
+**What it buys.** Far less machinery to build, and one fewer distributed-consistency surface. It also
+**eliminates two mandatory browser-side rules**: the design requires commanded-edge retention and
+command-origin validation *only because* it deliberately keeps the planned topology out of the
+accepted store. If planned equals accepted, there is no divergence window, so there is nothing to
+retain against and no command channel to authenticate. The design states plainly that without those
+rules "the reconciler closes commanded connections on the next presence-triggered reconcile and
+activation cannot complete" — a failure mode Option A does not have.
+
+**What it costs.** Readiness becomes a threshold over reported state rather than a completion signal.
+A group can sit in `DEGRADED` without a precise per-edge reason. There is no proof that a specific
+edge was attempted and failed, only that the group did not reach threshold. Establishment pacing is
+whatever the browser's existing dial budget provides, not a server-controlled rate.
+
+## Option B — per-edge command/confirm as default
+
+**What it buys.** A hard per-edge audit trail; server-controlled establishment pacing; a deterministic
+completion signal; and `PARTIAL` promotion gated on proving the confirmed edges still satisfy the
+configured connectivity and degree invariants.
+
+**What it costs.** The full construction listed above, plus the two mandatory browser-side rules and
+the divergence window they exist to manage. Every one of those is a new place for the system to get
+stuck between planned and accepted.
+
+## Assessment against the recorded decision
+
+The evidence supports decision 2 as recorded: **Option A as the default, Option B as an opt-in policy
+preset** for groups needing a per-edge audit trail or strict establishment pacing. The lifecycle
+model already expresses exactly that shape as `ActivationCriterion.strictConfirmation`, defaulting to
+`false`.
+
+The substantive argument is not "less code." It is that Option B's hardest requirements are
+consequences of its own central choice. The retention rule, the origin-validation rule, the
+divergence window, and the stale-promotion handling all exist because planned topology is withheld
+from the accepted store. Paying that complexity is right when per-edge auditability is the goal, and
+wrong when it is not.
+
+The `group-lifecycle-and-policy-model.md` document already frames activation criteria as declarative
+policy presets, so "confirm-gated establishment" fits as a preset without a second code path.
+
+## What the ruling unblocks
+
+Either way, Phase 5 then implements: the formation window (hold planning while `INITIALISING` until
+join-rate quiescence or a window cap, plan once, publish epoch 1), and the activation status
+projection. The ruling determines whether epoch-1 publication is confirmation-gated.
+
+Validation bar is unchanged: time-to-usable ≈ immediate, time-to-epoch-1 ≈ window + one plan, total
+recomputes during formation ≈ 1–3, convergence to epoch 1 across all browsers, and a Hetzner
+small-tier distributed manifest.
+
+## Questions I cannot answer for you
+
+1. **Is there a product or compliance requirement for a per-edge audit trail?** If yes, Option B is
+   the default regardless of cost, and this brief is moot.
+2. **What readiness threshold makes a group `ACTIVE`?** Option A needs a number — all planned edges,
+   a fraction, or connectivity-invariant satisfaction. The invariant check already exists for
+   Option B's `PARTIAL` path and could serve both.
+3. **Does establishment pacing matter at the target scale?** Option A inherits the browser dial
+   budget. If N=50 bursts need server-side pacing beyond that, the case for Option B strengthens.


### PR DESCRIPTION
Slice 1 of the group lifecycle control plane, plus the two working documents it implements. The code
is pure contract and pure functions — **nothing reads a policy yet, so no behaviour changes.**

## The property everything else depends on

**An absent policy is the `optimistic` preset, which is today's behaviour**: formation collapses to
zero length, admission stays open, application data flows. Every later slice can then land dark and
no existing group migrates. It is asserted directly rather than left implicit, and the mutation run
below confirms the assertion bites.

## What is here

Four files under `packages/shared/api/group-lifecycle/`:

- **The contract.** Lifecycle states, the six policy sections, the four presets, and the issue codes.
- **Presets and the default.** `optimistic`, `managed`, `match`, `drop-in-social`.
- **Normalization.** Sparse client input gets its own contract per the code standard, and the preset
  or default supplies every omitted field. Numeric knobs are clamped **silently and totally**, so a
  caller cannot express an out-of-range policy.
- **Validation.** Contradictions between fields, which clamping structurally cannot catch — a clamp
  keeps one value in range and cannot see a combination that is jointly unreachable. Returns *every*
  issue rather than the first, so a caller fixes one document once.

Plus the two planning documents under `playground/rtc-design/`: the implementation plan recording the
six product-owner decisions and the six things in the 2026-08-08 lifecycle design that did not hold
as written, and the posture brief carrying the Phase 0–4 measurements behind recorded decision 2.
Both are corrected to match what this slice actually did rather than what was planned.

## Two corrections from the design review, encoded

**The expressible deadlock.** `manager.selection: none` with `establishment.initiator: manager` was
legal in the design document and means nobody can ever start establishment — the group holds in
FORMING for its whole life. The design promised clamps only on *numeric* knobs, so nothing caught it.
Now rejected.

**The activation criterion carries two rates.** At or above `successRate` the group activates; at or
above `minimumViableRate` it activates degraded; below the floor it does not activate. A single rate
treats 94% and 5% connectivity identically, which would declare a group ACTIVE that cannot carry the
application's data.

This **subsumes the design's `onDeadline` field entirely** and it is gone: setting the floor equal to
the success rate is how a caller asks for all-or-nothing, which is exactly what `match` does. Strictly
more expressive than the two-valued enum it replaces.

`strictConfirmation` exists in the schema and is **rejected when true**. The per-edge confirmation
ledger it selects is not implemented, so the field lets the intent be expressed and answered rather
than silently accepted and ignored.

## Scope deliberately not taken

**Persistence and the `GROUP_CREATE` wiring are not here.** The plan put them in this slice; I moved
them out. Persisting a document nothing reads would put an AppInbox mutation-path change — with its
black-box recipes and medium-scale gate — into a slice that otherwise carries no risk at all. It
lands in slice 2 alongside its first reader. Flagging it rather than quietly narrowing.

## A note on the directory

The changed-style gate rejected the first attempt: `packages/shared/api` went past its
directory-density threshold and added to an already-flagged `group` prefix cluster. The gate warns
against creating folders mechanically — but four files that are one coherent feature is exactly the
feature ownership the rule asks for, so they live in `group-lifecycle/` rather than being flattened
or artificially merged. Gate passes.

Also found while implementing: `packages/shared/api/group-policy-types.ts` already owns the
enforcement *decision* vocabulary — `GroupPolicyReasonCode` and `GroupPolicyResult`. Slice 5's
admission rules extend it rather than paralleling it, and the plan now records that.

## Verification

22 tests. Passing proves little on its own, so each behaviour was confirmed to **fail** under a
deliberate mutation:

| Mutation | Result |
| --- | --- |
| default is no longer `optimistic` | caught |
| `match` floor drops below its success rate | caught |
| rate clamp removed | caught |
| integer clamp removed | caught |
| explicit `null` conflated with omitted | caught |
| deadlock check removed | caught |
| floor-above-success check removed | caught |
| strict-confirmation check removed | caught |
| only the first issue is reported | caught |

- `npx vitest run packages/tests/ packages/shared-rtc-bench/tests/` — **7,575 passed**, 5 skipped.
  The 6 failures in 4 files are the known sandbox `listen EPERM` set, unrelated.
- `npm run typecheck` — clean across every workspace.
- `check:repo-style:changed origin/main HEAD` — PASS.
- `packages/tests/repo/` — 711 passed.
