### PR TITLE
Store the group lifecycle policy as a group-scoped document

### DIFF
--- a/packages/shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts
@@ -1,0 +1,82 @@
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+// prettier-ignore
+import {
+  validateGroupLifecyclePolicy,
+} from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
+import type { GroupRef } from '@shared/api/group-types.ts';
+
+import { RuntimeStateJsonStore } from '../../../runtime-state/RuntimeStateJsonStore.ts';
+import type { RuntimeStateRepositoryLike } from '../../../runtime-state/RuntimeStateRepository.ts';
+import { groupStateGroupStorageKey } from './group-state-storage-keys.ts';
+
+export const GROUP_LIFECYCLE_POLICIES_NAMESPACE = 'group-state:lifecycle-policies';
+
+type StoredGroupLifecyclePolicy = Readonly<{
+  groupRef: GroupRef;
+  policy: GroupLifecyclePolicy;
+}>;
+
+/**
+ * `absent` and `corrupt` are separate outcomes on purpose. A neighbouring store
+ * decodes a bad row as absent because failing open there only costs a rebuild;
+ * here it would silently reopen a group whose stored policy closed it. Storage
+ * therefore reports what it found and the enforcement point decides, rather
+ * than one failure posture being baked in before there is an enforcer.
+ */
+export type GroupLifecyclePolicyRead =
+  | Readonly<{ status: 'absent' }>
+  | Readonly<{ status: 'present'; policy: GroupLifecyclePolicy }>
+  | Readonly<{ status: 'corrupt'; reason: string }>;
+
+export class GroupLifecyclePolicyRepository extends RuntimeStateJsonStore {
+  readonly runtimeRepository: RuntimeStateRepositoryLike;
+
+  constructor(runtimeRepository: RuntimeStateRepositoryLike) {
+    super(runtimeRepository);
+    this.runtimeRepository = runtimeRepository;
+  }
+
+  async readPolicy(ref: GroupRef): Promise<GroupLifecyclePolicyRead> {
+    const stored = await this.getValue<StoredGroupLifecyclePolicy>(
+      GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+      groupStateGroupStorageKey(ref),
+    );
+    if (stored === undefined) {
+      return { status: 'absent' };
+    }
+    if (!isSameGroupRef(stored.groupRef, ref)) {
+      return {
+        status: 'corrupt',
+        reason: 'stored policy identity differs from the requested group',
+      };
+    }
+    if (stored.policy === null || typeof stored.policy !== 'object') {
+      return { status: 'corrupt', reason: 'stored policy is not an object' };
+    }
+
+    return validateGroupLifecyclePolicy(stored.policy).fold<GroupLifecyclePolicyRead>(
+      (issues) => ({
+        status: 'corrupt',
+        reason: 'stored policy is no longer coherent: ' +
+          issues.map((issue) => issue.code).join(', '),
+      }),
+      (policy) => ({ status: 'present', policy }),
+    );
+  }
+
+  async writePolicy(ref: GroupRef, policy: GroupLifecyclePolicy): Promise<void> {
+    await this.putValue(
+      GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+      groupStateGroupStorageKey(ref),
+      { groupRef: ref, policy } satisfies StoredGroupLifecyclePolicy,
+    );
+  }
+}
+
+function isSameGroupRef(left: GroupRef | undefined, right: GroupRef): boolean {
+  return (
+    left?.applicationId === right.applicationId &&
+    left?.workspaceId === right.workspaceId &&
+    left?.groupId === right.groupId
+  );
+}

--- a/packages/tests/shared-server/group-lifecycle-policy-repository.test.ts
+++ b/packages/tests/shared-server/group-lifecycle-policy-repository.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
+// prettier-ignore
+import {
+    createDefaultGroupLifecyclePolicy,
+    resolveGroupLifecyclePolicyPreset,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import type { GroupRef } from '@shared/api/group-types.ts';
+// prettier-ignore
+import {
+    GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+    GroupLifecyclePolicyRepository,
+} from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
+// prettier-ignore
+import {
+    groupStateGroupStorageKey,
+} from '@shared-server/rallar-system/group-state/persistence/group-state-storage-keys.ts';
+import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
+
+const GROUP: GroupRef = {
+    applicationId: 'app-1',
+    workspaceId: 'ws-1',
+    groupId: 'group-1',
+};
+
+function createRepository(): GroupLifecyclePolicyRepository {
+    return new GroupLifecyclePolicyRepository(new FakeRuntimeStateRepository());
+}
+
+async function storeRaw(
+    repository: GroupLifecyclePolicyRepository,
+    ref: GroupRef,
+    value: unknown,
+): Promise<void> {
+    await repository.runtimeRepository.upsert(
+        GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+        groupStateGroupStorageKey(ref),
+        JSON.stringify(value),
+        NEVER_EXPIRE_AT_TIMESTAMP,
+    );
+}
+
+describe('GroupLifecyclePolicyRepository', () => {
+    // Absent is the common case and has to stay cheap and unambiguous: every
+    // group that exists today has no stored policy.
+    it('reads an unwritten group as absent', async () => {
+        expect(await createRepository().readPolicy(GROUP)).toEqual({ status: 'absent' });
+    });
+
+    it('round-trips a stored policy', async () => {
+        const repository = createRepository();
+        const policy = resolveGroupLifecyclePolicyPreset('managed');
+
+        await repository.writePolicy(GROUP, policy);
+
+        expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy });
+    });
+
+    it('keeps policies of different groups apart', async () => {
+        const repository = createRepository();
+        const other: GroupRef = { ...GROUP, groupId: 'group-2' };
+
+        await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
+
+        expect(await repository.readPolicy(other)).toEqual({ status: 'absent' });
+    });
+
+    // A row written under one group's key that carries another group's identity
+    // is corruption, not an absent policy. Reporting it as absent would let a
+    // closed group read as open.
+    it('reports a foreign identity as corrupt rather than absent', async () => {
+        const repository = createRepository();
+
+        await storeRaw(repository, GROUP, {
+            groupRef: { ...GROUP, groupId: 'someone-else' },
+            policy: createDefaultGroupLifecyclePolicy(),
+        });
+
+        const read = await repository.readPolicy(GROUP);
+
+        expect(read.status).toBe('corrupt');
+    });
+
+    it.each([
+        { label: 'a non-object policy', policy: 'not-a-policy' },
+        { label: 'a null policy', policy: null },
+    ])('reports $label as corrupt', async ({ policy }) => {
+        const repository = createRepository();
+
+        await storeRaw(repository, GROUP, { groupRef: GROUP, policy });
+
+        expect((await repository.readPolicy(GROUP)).status).toBe('corrupt');
+    });
+
+    // A policy stored under rules it no longer satisfies is reported rather
+    // than served. The enforcement point decides what to do; storage does not
+    // quietly substitute a permissive default.
+    it('reports a stored policy that no longer validates as corrupt', async () => {
+        const repository = createRepository();
+        const incoherent = {
+            ...createDefaultGroupLifecyclePolicy(),
+            manager: {
+                selection: 'none',
+                assignedPrincipalIds: [],
+                count: 1,
+                succession: 'none',
+            },
+            establishment: {
+                transports: 'rtc-and-ws',
+                initiator: 'manager',
+                maxConcurrentEdgeSetups: 8,
+            },
+        };
+
+        await storeRaw(repository, GROUP, { groupRef: GROUP, policy: incoherent });
+
+        const read = await repository.readPolicy(GROUP);
+
+        expect(read.status).toBe('corrupt');
+        expect(read.status === 'corrupt' && read.reason)
+            .toContain('manager-initiator-without-manager');
+    });
+
+    it('overwrites a previously stored policy', async () => {
+        const repository = createRepository();
+        const replacement = resolveGroupLifecyclePolicyPreset('drop-in-social');
+
+        await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
+        await repository.writePolicy(GROUP, replacement);
+
+        expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy: replacement });
+    });
+});


### PR DESCRIPTION
First part of slice 2, and the persistence deferred out of slice 1. Storage only — **nothing reads a
policy through this yet**, so no behaviour changes.

## Sub-slicing slice 2

The plan flags slice 2 as its highest risk, and it carries three independent changes plus slice 1's
deferred persistence. Splitting it so each lands verifiable on its own:

| | Content | State |
| --- | --- | --- |
| **2a** | Policy persistence, then the create-path wiring: request field, OpenAPI schema, boundary decode → normalize → validate → typed rejection | **this PR is the store** |
| 2b | Lifecycle enum and activation epoch on the aggregate, the three transition commands, the authorization predicate. State tracked, nothing consults it | next |
| 2c | FORMING gates topology planning — the behaviour change, and Phase 5's M7 | after |

Each preserves the load-bearing property: an absent policy is the `optimistic` preset, which is
today's behaviour.

## What is here

`GroupLifecyclePolicyRepository` — a group-scoped document, per the placement decision that the
policy is cold near-static configuration and does not belong on the hot group aggregate.

It follows `RtcTopologyInputFingerprintRepository`: a small typed `RuntimeStateJsonStore` over
`groupStateGroupStorageKey`, rather than the 1,529-line topology-config persistence tree, which is
mostly specific to generation targets and invariant slots.

## One deliberate departure from that precedent

The fingerprint store decodes a malformed row **as absent**, and says why: failing open there costs
only a rebuild.

That posture is wrong here. A group whose stored policy *closed* it would, on a corrupt row, read as
a group with no policy — which is to say an open one. Absent and corrupt are not the same fact and
this store does not conflate them:

```ts
export type GroupLifecyclePolicyRead =
  | Readonly<{ status: 'absent' }>
  | Readonly<{ status: 'present'; policy: GroupLifecyclePolicy }>
  | Readonly<{ status: 'corrupt'; reason: string }>;
```

The enforcement point decides what a corrupt policy means — and it does not exist yet. Baking a
permissive default into storage now would answer that question by accident, months before anyone
asks it. A stored policy that no longer satisfies validation is reported the same way, with the
failing issue codes in `reason`.

## Verification

8 tests: absent for an unwritten group, round-trip, per-group isolation, overwrite, and the three
corrupt paths — foreign identity, non-object payload, and a policy that no longer validates.

- `packages/tests/shared-server/` and `packages/tests/repo/` — 2,698 passed, 5 skipped.
- `npx tsc -p packages/shared-server/tsconfig.json --noEmit` — clean.
- `check:repo-style:changed origin/main HEAD` — PASS. It first caught two over-width lines, now
  wrapped.

## Next in 2a

`CreateGroupRequest.lifecyclePolicy`, its OpenAPI schema, the boundary decode that normalizes and
validates with a typed rejection carrying every issue, and the write into this store inside the
`GROUP_CREATE` transaction. That part touches the mutation path and brings black-box recipes and the
medium-scale gate with it, which is why the store lands first.
