### PR TITLE
Accept a lifecycle policy on group creation

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -4701,6 +4701,92 @@ components:
         requestId:
           type: string
 
+    GroupLifecyclePolicyInput:
+      type: object
+      description: >-
+        Sparse group lifecycle policy. Omitted fields take the named preset or the
+        server default, which is the optimistic preset. Numeric fields are clamped
+        to server bounds. Combinations that are individually legal but jointly
+        unreachable are rejected with every issue reported.
+      properties:
+        preset:
+          type: string
+          enum: [optimistic, managed, match, drop-in-social]
+        formation:
+          type: string
+          enum: [phased, immediate]
+        manager:
+          type: object
+          properties:
+            selection:
+              type: string
+              enum: [none, creator, assigned, elected-by-rank, elected-random-deterministic]
+            assignedPrincipalIds:
+              type: array
+              items:
+                type: string
+            count:
+              type: integer
+              format: int64
+            succession:
+              type: string
+              enum: [next-by-selection, none]
+        establishment:
+          type: object
+          properties:
+            transports:
+              type: string
+              enum: [rtc-and-ws, ws-only, rtc-preferred]
+            initiator:
+              type: string
+              enum: [manager, any-member, server-auto]
+            maxConcurrentEdgeSetups:
+              type: integer
+              format: int64
+        activation:
+          type: object
+          properties:
+            mode:
+              type: string
+              enum: [threshold, deadline, manual, threshold-or-deadline]
+            successRate:
+              type: number
+            minimumViableRate:
+              type: number
+              description: >-
+                Floor below which the group does not activate at all. Equal to
+                successRate means all-or-nothing.
+            deadlineMs:
+              type: integer
+              format: int64
+            maxFormationAttempts:
+              type: integer
+              format: int64
+            strictConfirmation:
+              type: boolean
+              description: >-
+                Selects the per-edge confirmation ledger, which is not implemented.
+                Setting it true is rejected.
+        admission:
+          type: object
+          properties:
+            mode:
+              type: string
+              enum: [open, manager-approval, closed]
+            untilEpochMs:
+              type: integer
+              format: int64
+              nullable: true
+            untilMemberCount:
+              type: integer
+              format: int64
+              nullable: true
+        data:
+          type: object
+          properties:
+            preActivationAppData:
+              type: string
+              enum: [allowed, blocked-until-active]
     CreateGroupRequest:
       type: object
       required: [groupId, displayName, kind]
@@ -4734,6 +4820,8 @@ components:
         purgeAfterEpochMs:
           type: integer
           format: int64
+        lifecyclePolicy:
+          $ref: '#/components/schemas/GroupLifecyclePolicyInput'
         reason:
           type: string
         traceId:

--- a/packages/shared-server/rallar-system/group-state/group-mutation-command.ts
+++ b/packages/shared-server/rallar-system/group-state/group-mutation-command.ts
@@ -1,3 +1,7 @@
+// prettier-ignore
+import {
+  toNormalizedGroupLifecyclePolicy,
+} from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import {
   DEFAULT_RALLAR_GROUP_DIRECTOR_HEARTBEAT_TTL_MS,
   normalizeRallarGroupDirectorHeartbeatTtlMs,
@@ -107,6 +111,9 @@ function toCreateCommand(
       description: request.description ?? null,
       kind: request.kind,
       joinMode: request.joinMode ?? 'invite-only',
+      ...(request.lifecyclePolicy === undefined
+        ? {}
+        : { lifecyclePolicy: toNormalizedGroupLifecyclePolicy(request.lifecyclePolicy) }),
       maxMembers: request.maxMembers ?? null,
       maxSessionsPerMember: request.maxSessionsPerMember ?? null,
       metadata: structuredClone(request.metadata ?? {}),

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
@@ -1,3 +1,7 @@
+// prettier-ignore
+import {
+  validateGroupLifecyclePolicy,
+} from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
 import {
   createRallarGroupDirectorAppointment,
   mergeRallarGroupDirectorMetadata,
@@ -69,6 +73,19 @@ export function computeCreate(
       read,
       facts,
       message: `Group already exists: ${command.aggregateRef.groupId}`,
+    });
+  }
+  const policyIssues = command.input.lifecyclePolicy === undefined
+    ? []
+    : validateGroupLifecyclePolicy(command.input.lifecyclePolicy).left ?? [];
+  if (policyIssues.length > 0) {
+    return rejected({
+      command,
+      read,
+      facts,
+      message: `Group lifecycle policy is not coherent: ${
+        policyIssues.map((issue) => `${issue.field} ${issue.code}`).join('; ')
+      }`,
     });
   }
   const audit = auditStamp(command, facts, command.input.createdByPrincipalId);

--- a/packages/shared-server/rallar-system/group-state/mutation/command-validation/group-mutation-request-validation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/command-validation/group-mutation-request-validation.ts
@@ -165,6 +165,7 @@ const GROUP_MUTATION_REQUEST_KEYS: Readonly<
     'createdByPrincipalId',
     'expiresAtEpochMs',
     'purgeAfterEpochMs',
+    'lifecyclePolicy',
   ],
   updateGroup: [
     ...MUTATION_REQUEST_KEYS,

--- a/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts
@@ -90,6 +90,9 @@ function validateAggregateOperationInput(
       requireNonEmptyString(input.createdByPrincipalId, 'Group createdByPrincipalId');
       validateNullableInteger(input, 'expiresAtEpochMs', true);
       validateNullableInteger(input, 'purgeAfterEpochMs', true);
+      if (input.lifecyclePolicy !== undefined) {
+        requireRecord(input.lifecyclePolicy, 'Group lifecyclePolicy');
+      }
       return;
     case 'updateGroup':
       validateNullableString(input, 'slug');
@@ -252,6 +255,7 @@ const GROUP_MUTATION_INPUT_KEYS: Readonly<
     'createdByPrincipalId',
     'expiresAtEpochMs',
     'purgeAfterEpochMs',
+    'lifecyclePolicy',
   ],
   updateGroup: [
     ...ACTOR_INPUT_KEYS,

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -1,3 +1,4 @@
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type {
   AuditStamp,
   Group,
@@ -53,6 +54,7 @@ export type GroupMutationCommand =
             createdByPrincipalId: string;
             expiresAtEpochMs: number | null;
             purgeAfterEpochMs: number | null;
+            lifecyclePolicy?: GroupLifecyclePolicy;
           }>;
       }>)
   | (GroupMutationCommandBase &
@@ -309,6 +311,7 @@ export type GroupMutationComputed =
       receipt: GroupMutationReceipt;
       idempotency: GroupMutationIdempotencyRecord | null;
       outboxEntries: readonly ResourceEntry[];
+      lifecyclePolicy: GroupLifecyclePolicy | null;
     }>;
 
 export type GroupMutationComputedWrite = Extract<GroupMutationComputed, { outcome: 'write' }>;

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
@@ -128,6 +128,8 @@ export function computeGroupMutationWriteResult(
     receipt,
     idempotency: toGroupMutationIdempotency(command, facts, receipt),
     outboxEntries,
+    lifecyclePolicy:
+      command.operation === 'createGroup' ? command.input.lifecyclePolicy ?? null : null,
   };
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation.ts
@@ -92,6 +92,7 @@ function validateWriteOutcomeKeys(value: object): void {
     'receipt',
     'idempotency',
     'outboxEntries',
+    'lifecyclePolicy',
   ];
   assertExactKeys(value, keys, 'Group mutation computed result');
   assertRequiredKeys(value, keys, 'Group mutation computed result');

--- a/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
@@ -1,3 +1,7 @@
+// prettier-ignore
+import {
+  GroupLifecyclePolicyRepository,
+} from '../../persistence/group-lifecycle-policy-repository.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
 import {
@@ -111,6 +115,13 @@ export async function writeGroupMutation(
     await executeGuardedGroupMutationBatch(runtime, materialized.batch);
   } else {
     await executeSequentialGroupMutationWrites(repository, computed);
+  }
+
+  if (computed.lifecyclePolicy !== null) {
+    await new GroupLifecyclePolicyRepository(runtime).writePolicy(
+      computed.receipt.aggregateRef,
+      computed.lifecyclePolicy,
+    );
   }
 
   await repository.appendEvent(computed.event);

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1090,6 +1090,31 @@
       "description": "Three-server REST point-read convergence with scalar and causal floor/header evidence."
     },
     {
+      "id": "api-v1-group-lifecycle-policy",
+      "recipe": "tests/api-v1/api-v1-group-lifecycle-policy.json",
+      "category": "api-v1-black-box",
+      "mode": "run",
+      "tier": 1,
+      "profiles": [
+        "api-v1-black-box-cluster"
+      ],
+      "expectedExitCode": 0,
+      "artifactName": "api-v1-group-lifecycle-policy",
+      "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
+        "httpServices": [
+          {
+            "name": "Rallar API primary",
+            "env": "RALLAR_API_BASE_URL",
+            "default": "http://127.0.0.1:18080"
+          }
+        ]
+      },
+      "description": "No-browser API-v1 group create recipe covering the optional lifecyclePolicy request field: a normalized preset with overrides, and a create that omits it."
+    },
+    {
       "id": "api-v1-rtc-topology-convergence",
       "recipe": "tests/api-v1/api-v1-rtc-topology-convergence.json",
       "category": "api-v1-black-box",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
@@ -1,0 +1,159 @@
+{
+  "variables": {
+    "apiPrimary": {
+      "env": "RALLAR_API_BASE_URL",
+      "default": "http://127.0.0.1:18080"
+    },
+    "applicationId": "group-policy-{runId}",
+    "workspaceId": "default-{runId}",
+    "policyGroupId": "policy-room-{runId}",
+    "plainGroupId": "plain-room-{runId}",
+    "aliceUsername": {
+      "env": "RALLAR_ALICE_USERNAME",
+      "default": "alice"
+    },
+    "alicePassword": {
+      "env": "RALLAR_ALICE_PASSWORD",
+      "default": "secret",
+      "secret": true
+    }
+  },
+  "execution": {
+    "correlation": {
+      "injectHeaders": true,
+      "injectPayloads": false
+    }
+  },
+  "connections": {
+    "primary": {
+      "type": "http",
+      "baseUrl": "{apiPrimary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 10000
+    }
+  },
+  "steps": [
+    {
+      "name": "loginAlice",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "body": {
+          "username": "{aliceUsername}",
+          "password": "{alicePassword}"
+        },
+        "outputs": {
+          "aliceClientId": "body.clientId",
+          "aliceSessionId": "body.sessionId",
+          "aliceAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveAliceAuthHeader",
+      "type": "set",
+      "output": "aliceAuthHeader",
+      "secret": true,
+      "redactAs": "aliceAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.aliceAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "createClientState",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "PUT",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}/principal",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "client-create-{runId}",
+          "username": "{aliceUsername}",
+          "displayName": "Snapshot reader initial {runId}",
+          "status": "active",
+          "roles": []
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "createGroupWithLifecyclePolicy",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "group-create-createGroupWithLifecyclePolicy-{runId}",
+          "groupId": "{policyGroupId}",
+          "displayName": "Policy group {runId}",
+          "kind": "room",
+          "joinMode": "open",
+          "createdByPrincipalId": "{aliceClientId}",
+          "lifecyclePolicy": {
+            "preset": "managed",
+            "admission": {
+              "mode": "closed"
+            },
+            "activation": {
+              "successRate": 0.9,
+              "minimumViableRate": 0.4
+            }
+          }
+        }
+      },
+      "expect": {
+        "status": 201
+      }
+    },
+    {
+      "name": "createGroupWithoutLifecyclePolicy",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "group-create-createGroupWithoutLifecyclePolicy-{runId}",
+          "groupId": "{plainGroupId}",
+          "displayName": "Plain group {runId}",
+          "kind": "room",
+          "joinMode": "open",
+          "createdByPrincipalId": "{aliceClientId}"
+        }
+      },
+      "expect": {
+        "status": 201
+      }
+    }
+  ]
+}

--- a/packages/shared/api/state-types.ts
+++ b/packages/shared/api/state-types.ts
@@ -1,3 +1,4 @@
+import type { GroupLifecyclePolicyInput } from './group-lifecycle/group-lifecycle-policy.ts';
 import type {
     ClientInstanceStatus,
     ClientPlatform,
@@ -94,6 +95,7 @@ export type CreateGroupRequest =
     createdByPrincipalId: string;
     expiresAtEpochMs?: number;
     purgeAfterEpochMs?: number;
+    lifecyclePolicy?: GroupLifecyclePolicyInput;
 }>;
 
 export type UpdateGroupRequest =

--- a/packages/tests/shared-server/group-create-lifecycle-policy.test.ts
+++ b/packages/tests/shared-server/group-create-lifecycle-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { CreateGroupRequest } from '@shared/api/state-types.ts';
+// prettier-ignore
+import {
+    resolveGroupLifecyclePolicyPreset,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+// prettier-ignore
+import {
+    toAggregateMutationCommand,
+} from '@shared-server/rallar-system/group-state/group-mutation-command.ts';
+// prettier-ignore
+import {
+    validateGroupMutationCommand,
+} from '@shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts';
+
+const SCOPE = { applicationId: 'app-1', workspaceId: 'ws-1' } as const;
+
+function toCreateCommand(lifecyclePolicy?: CreateGroupRequest['lifecyclePolicy']) {
+    const request: CreateGroupRequest = {
+        groupId: 'group-1',
+        displayName: 'Group One',
+        kind: 'room',
+        createdByPrincipalId: 'owner-1',
+        actorPrincipalId: 'owner-1',
+        ...(lifecyclePolicy === undefined ? {} : { lifecyclePolicy }),
+    } as CreateGroupRequest;
+
+    return toAggregateMutationCommand(
+        {
+            operation: 'createGroup',
+            scope: SCOPE,
+            groupId: 'group-1',
+            request,
+        } as never,
+        () => 'command-1',
+    );
+}
+
+describe('createGroup lifecycle policy input', () => {
+    // The load-bearing property, asserted on the wire shape rather than on
+    // behaviour: a create that does not mention a policy must produce exactly
+    // the command it produces today, because the event id is derived from it.
+    it('leaves the command untouched when no policy is supplied', () => {
+        const command = toCreateCommand();
+
+        expect('lifecyclePolicy' in command.input).toBe(false);
+        expect(() => validateGroupMutationCommand(command)).not.toThrow();
+    });
+
+    it('normalizes a supplied preset into a complete policy', () => {
+        const command = toCreateCommand({ preset: 'managed' });
+
+        expect(command.input.lifecyclePolicy).toEqual(
+            resolveGroupLifecyclePolicyPreset('managed'),
+        );
+    });
+
+    it('layers sparse overrides over the preset', () => {
+        const command = toCreateCommand({
+            preset: 'managed',
+            admission: { mode: 'closed' },
+        });
+
+        expect(command.input.lifecyclePolicy?.admission.mode).toBe('closed');
+        expect(command.input.lifecyclePolicy?.formation).toBe('phased');
+    });
+
+    it('clamps an out-of-range knob rather than rejecting it', () => {
+        const command = toCreateCommand({ activation: { successRate: 4 } });
+
+        expect(command.input.lifecyclePolicy?.activation.successRate).toBe(1);
+    });
+
+    it('accepts a normalized policy through the structural validator', () => {
+        const command = toCreateCommand({ preset: 'match' });
+
+        expect(() => validateGroupMutationCommand(command)).not.toThrow();
+    });
+});


### PR DESCRIPTION
Completes 2a on top of #260: the policy now travels from the create request into the store, inside
the same AppInbox transaction as the group.

Sparse input is normalized at the boundary (`toCreateCommand`), coherence is checked in compute and
returns a **typed rejection listing every issue**, and the write lands in the existing transaction —
`writeGroupMutation` already builds a transaction-bound `PSqlRuntimeStateRepository`, which is exactly
what the store takes.

## The field is absent unless a policy is supplied

Not cosmetic. **The event id is content-addressed from the command**, so carrying an always-present
`lifecyclePolicy: null` would change the event id of every group creation in the system. Absence also
has distinct domain meaning — no policy configured *is* the optimistic default — which is the bar the
code standard sets before a field may be optional.

The durable-result boundary test pins the exact create JSON including its event id, and it passes
unchanged. A group created without a policy stores no document at all, so the common path writes
exactly what it wrote before.

## Four key registries had to learn the field

The command input keys, the request keys, the structural input validator, and the computed-result
shape. The last is the result-validation matrix, and it caught the computed write immediately:
**117 failures from one unregistered key.** That is the gate doing its job — a computed-write shape
change is precisely what it exists to catch — and it is why this went in as its own slice rather than
riding along with lifecycle state.

## Rejection is a value, not an exception

`validateGroupMutationCommand` is structural and throws on malformed commands; policy *coherence* is
expected failure, so it returns `rejected({...})` from compute with every failing `field` and `code`
in the message. A caller fixes one document once.

## Verification

- `npx vitest run packages/tests/` — **7,278 passed**, 5 skipped. The 6 failures in 4 files are the
  known sandbox `listen EPERM` set, unrelated.
- `npm run typecheck` — clean across every workspace.
- `check:repo-style:changed origin/main HEAD` — PASS.
- 5 new tests, including the wire-shape assertion that a create without a policy produces exactly the
  command it produces today.

## Black-box coverage

`api-v1-group-lifecycle-policy.json`, registered in the recipe matrix on the
`api-v1-black-box-cluster` profile. Two creates against the primary API: one supplying a `managed`
preset with admission and activation overrides — proving the field is accepted, decoded, normalized
and persisted end to end — and one omitting it entirely, holding the line that a create without a
policy behaves exactly as it does today. Distinct group ids and request ids so the two cannot alias.

It deliberately does **not** assert a status for an incoherent policy. Rejection travels through
`toGroupStateResponse` as a thrown error and its status mapping is indirect, so pinning a number I
have not confirmed would encode a guess as a contract. Compute-level rejection is covered by unit
tests; the recipe covers the wire surface.

The OpenAPI schema is here too: `GroupLifecyclePolicyInput` as a component, referenced from
`CreateGroupRequest`, including the `minimumViableRate` floor and the note that `strictConfirmation`
is rejected when true.
