### PR TITLE
Declare runId in the group lifecycle policy recipe

### DIFF
--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
@@ -16,6 +16,10 @@
       "env": "RALLAR_ALICE_PASSWORD",
       "default": "secret",
       "secret": true
+    },
+    "runId": {
+      "env": "RALLAR_BB_RUN_ID",
+      "default": "local"
     }
   },
   "execution": {


### PR DESCRIPTION
Fixes the red medium-scale gate on `main`.

## What broke

The recipe I added in #263 failed with `Cannot resolve placeholder {runId}` at its **third** step — `createClientState`, copied verbatim from `api-v1-state-read-convergence`. Not either of the new create steps the recipe exists to cover.

`runId` is a **declared** variable (`env: RALLAR_BB_RUN_ID`, `default: local`), not one the runner injects implicitly. I built the recipe by deriving its prelude from that source recipe and copying variables selectively — and dropped the `runId` declaration while keeping every step and variable that interpolates it. Four of my own variables reference `{runId}`.

That one failure cascaded: API v1 Medium-Scale Postgres → Release Gate → Branch Release Gate. The other five recipes in the `api-v1-black-box-cluster` profile passed, and every other check on #263 was green.

## Why nothing local caught it

The matrix-shape tests in `packages/tests/shared-test/` validate recipe **structure**, not execution — a placeholder that fails to resolve only shows up when the recipe runs against live services, which needs the cluster profile. I reported those tests as the recipe "passing its validation gates", which was true of what they check and misleading about what it implied.

## Fix

One line: declare `runId` in the recipe's `variables` block, matching every other recipe in the profile.

`packages/tests/shared-test/` passes (2 failures are the known sandbox `listen EPERM` pair).