### PR TITLE
Hold topology planning while a group is FORMING

### DIFF
--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -42,7 +42,7 @@ import {
   createRtcOverlayTopologyBroadcastMessage,
 } from './materialize-rtc-overlay-topology-broadcast-message.ts';
 import {
-  isGroupTopologyActiveAt,
+  isGroupTopologyPlannableAt,
   selectGroupTopologyPlanningSnapshot,
 } from './select-group-topology-planning-snapshot.ts';
 
@@ -108,7 +108,7 @@ export class GroupTopologyPlanningService {
     previous: RallarOverlayTopologySnapshot | undefined,
     planningIntent: RtcTopologyPlanningIntent = 'full-rebuild',
   ): ReconcileGroupTopologyResult {
-    if (!isGroupTopologyActiveAt(authority.group, authority.nowEpochMs)) {
+    if (!isGroupTopologyPlannableAt(authority.group, authority.nowEpochMs)) {
       return removedTopologyResult(authority.group, previous);
     }
     const filteredRttMeasurements = this.filterRttMeasurementsForGroup(

--- a/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
+++ b/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
@@ -30,6 +30,23 @@ export function isGroupTopologyActiveAt(
   );
 }
 
+/**
+ * The formation window (Phase 5, M7): FORMING holds topology planning, so a
+ * forming group has no planned overlay to establish and no dials to command.
+ * Every other intent state plans -- RECONFIGURING exists precisely to redo
+ * establishment work. Groups with immediate formation are created ACTIVE and
+ * never enter FORMING, which keeps today's behaviour byte-identical for them.
+ */
+export function isGroupTopologyPlannableAt(
+  snapshot: GroupSnapshot,
+  observedAtEpochMs: number,
+): boolean {
+  return (
+    isGroupTopologyActiveAt(snapshot, observedAtEpochMs) &&
+    snapshot.group.lifecycleState !== 'forming'
+  );
+}
+
 export function selectGroupTopologyPlanningSnapshot(
   knownGroup: GroupSnapshot,
   currentGroup: GroupSnapshot | undefined,

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
@@ -184,6 +184,32 @@
       }
     },
     {
+      "name": "topologyHeldWhileForming",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "bodyAnyOf": [
+          {
+            "snapshot": null
+          },
+          {
+            "snapshot": {
+              "state": "removed"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "bobCannotStartEstablishment",
       "type": "http",
       "connection": "primary",
@@ -223,6 +249,33 @@
           "group": {
             "lifecycleState": "establishing",
             "formationEpoch": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "topologyPlannedAfterEstablish",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 100,
+          "backoffMultiplier": 2
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
           }
         }
       }

--- a/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
+++ b/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AuditStamp, Group, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+// prettier-ignore
+import {
+  computeGroupMutation,
+} from '@shared-server/rallar-system/services/group-state-mutations.ts';
+import type {
+  GroupMutationCommand,
+  GroupMutationFacts,
+  GroupMutationRead,
+} from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
+import {
+  canConnectGroupPresenceSession,
+  canGovernGroupMember,
+  canJoinGroup,
+} from '@shared-server/rallar-system/group-policy.ts';
+import { createTestGroup } from '@shared-test/create-test-group.ts';
+
+import {
+  groupMemberStorageKey,
+  groupRef,
+  groupStorageKey,
+  storedEntry,
+} from './mutation/group-mutation-test-runtime.ts';
+
+const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = [
+  'forming',
+  'establishing',
+  'active',
+  'reconfiguring',
+];
+
+/**
+ * The safety-baseline invariant of the lifecycle plan: phases gate
+ * establishment work, never the ability to be in the group. Every membership,
+ * admission, and presence decision must hold in every lifecycle state,
+ * including a group deliberately stuck in FORMING.
+ */
+describe('group lifecycle safety baseline', () => {
+  it('admits joins in every lifecycle state', () => {
+    for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
+      expect(canJoinGroup({
+        snapshot: snapshotIn(lifecycleState),
+        actor: { principalId: 'carol' },
+      })).toEqual({ allowed: true });
+    }
+  });
+
+  it('admits presence sessions for active members in every lifecycle state', () => {
+    for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
+      expect(canConnectGroupPresenceSession({
+        snapshot: snapshotIn(lifecycleState),
+        actor: { principalId: 'alice' },
+        sessionId: 'alice-session',
+      })).toEqual({ allowed: true });
+    }
+  });
+
+  it('lets owners govern members in every lifecycle state', () => {
+    for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
+      expect(canGovernGroupMember({
+        snapshot: snapshotIn(lifecycleState),
+        actor: { principalId: 'alice' },
+        targetPrincipalId: 'bob',
+        action: 'invite',
+      })).toEqual({ allowed: true });
+    }
+  });
+
+  it('computes a join write on a group stuck in FORMING', () => {
+    const computed = computeGroupMutation({
+      command: joinCommand(),
+      read: joinRead('forming'),
+      facts: mutationFacts('carol'),
+    });
+    expect(computed.outcome).toBe('write');
+  });
+
+  it('computes a presence connect write on a group stuck in FORMING', () => {
+    const computed = computeGroupMutation({
+      command: connectPresenceCommand(),
+      read: memberRead('forming', 'alice'),
+      facts: mutationFacts('alice'),
+    });
+    expect(computed.outcome).toBe('write');
+  });
+});
+
+function audit(principalId: string): AuditStamp {
+  return {
+    atEpochMs: 1_000,
+    actor: { kind: 'principal', principalId },
+    reason: null,
+    traceId: null,
+    requestId: 'seed',
+  };
+}
+
+function member(principalId: string, role: GroupMember['role']): GroupMember {
+  return {
+    ...groupRef('pure-room'),
+    principalId,
+    role,
+    status: 'active',
+    joined: audit(principalId),
+    updated: audit(principalId),
+    left: null,
+    removed: null,
+    banned: null,
+    invitedByPrincipalId: null,
+    invitationExpiresAtEpochMs: null,
+  };
+}
+
+function groupIn(lifecycleState: GroupLifecycleState): Group {
+  return createTestGroup({
+    ...groupRef('pure-room'),
+    ownerPrincipalId: 'alice',
+    lifecycleState,
+    formationEpoch: lifecycleState === 'forming' ? 0 : 1,
+    created: audit('alice'),
+    updated: audit('alice'),
+  });
+}
+
+function snapshotIn(lifecycleState: GroupLifecycleState): GroupSnapshot {
+  return {
+    stateRevision: 1,
+    causalRevision: { groupRevision: 1, presenceRevision: 0 },
+    group: groupIn(lifecycleState),
+    members: [member('alice', 'owner'), member('bob', 'member')],
+    activeSessions: [],
+    memberCount: 2,
+    onlineMemberCount: 0,
+  };
+}
+
+function baseRead(lifecycleState: GroupLifecycleState): GroupMutationRead {
+  const actorMember = member('alice', 'owner');
+  return {
+    idempotency: null,
+    group: storedEntry(groupStorageKey(), groupIn(lifecycleState)),
+    expiredGroupEntry: null,
+    actorMember,
+    targetMember: null,
+    authorityMember: null,
+    directorMember: null,
+    actorMemberEntry: storedEntry(groupMemberStorageKey('alice'), actorMember),
+    targetMemberEntry: null,
+    authorityMemberEntry: null,
+    directorMemberEntry: null,
+    targetPresence: null,
+    expiredTargetPresenceEntry: null,
+    targetAdmission: null,
+    authorityAdmission: null,
+    directorAdmission: null,
+    authorityPresenceSessions: [],
+    authorityPresenceSessionEntries: [],
+    presenceSummary: null,
+    lifecyclePolicy: null,
+  } as GroupMutationRead;
+}
+
+function joinRead(lifecycleState: GroupLifecycleState): GroupMutationRead {
+  return {
+    ...baseRead(lifecycleState),
+    actorMember: null,
+    actorMemberEntry: null,
+  } as GroupMutationRead;
+}
+
+function memberRead(
+  lifecycleState: GroupLifecycleState,
+  principalId: string,
+): GroupMutationRead {
+  const stored = baseRead(lifecycleState);
+  return {
+    ...stored,
+    targetMember: stored.actorMember,
+    targetMemberEntry: stored.actorMemberEntry,
+  } as GroupMutationRead;
+}
+
+function joinCommand(): GroupMutationCommand {
+  return {
+    operation: 'joinGroup',
+    aggregateRef: groupRef('pure-room'),
+    commandId: 'safety-join',
+    requestId: 'safety-join',
+    targetPrincipalId: 'carol',
+    input: {
+      inviteToken: null,
+      joinCode: null,
+      actorPrincipalId: 'carol',
+      actorSessionId: 'carol-session',
+      reason: null,
+      traceId: null,
+    },
+  } as GroupMutationCommand;
+}
+
+function connectPresenceCommand(): GroupMutationCommand {
+  return {
+    operation: 'connectPresence',
+    aggregateRef: groupRef('pure-room'),
+    commandId: 'safety-connect',
+    requestId: 'safety-connect',
+    sessionId: 'alice-session',
+    input: {
+      actorPrincipalId: 'alice',
+      actorSessionId: 'alice-session',
+      reason: null,
+      traceId: null,
+      principalId: 'alice',
+      generationId: 'generation-1',
+      connectedAtEpochMs: 2_000,
+      lastHeartbeatAtEpochMs: 2_000,
+      expiresAtEpochMs: 62_000,
+    },
+  } as GroupMutationCommand;
+}
+
+function mutationFacts(principalId: string): GroupMutationFacts {
+  return {
+    nowEpochMs: 2_000,
+    expireAtEpochMs: 253_402_300_799_999,
+    serviceId: 'group-service',
+    eventId: 'event-1',
+    commandHash: `sha256:${'a'.repeat(64)}`,
+    attemptCount: 1,
+    resolvedJoinCode: null,
+    joinCodeVerifier: null,
+    internalAuthority: 'none',
+    formationDamping: 'legacy',
+    authenticatedAuthority: {
+      principalId,
+      sessionId: `${principalId}-session`,
+    },
+  };
+}

--- a/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+
 import { resolveGroupTopologyConfig } from '@shared-server/rallar-system/topology/config/group-topology-config.ts';
 import { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
@@ -60,7 +62,87 @@ describe('GroupTopologyPlanningService', () => {
       },
     });
   });
+
+  it('holds topology planning while the group is FORMING', () => {
+    const forming = groupWithSessionsIn('forming');
+    const service = createPlanningService({ group: forming });
+
+    const result = service.computeTopologyFromAuthority(
+      planningAuthority(forming),
+      undefined,
+    );
+
+    expect(result.snapshot.state).toBe('removed');
+    expect(Object.values(result.snapshot.nextHopsBySessionId).flat()).toEqual([]);
+  });
+
+  it('drops a previously planned topology when the group returns to FORMING', () => {
+    const active = groupWithSessionsIn('active');
+    const service = createPlanningService({ group: active });
+    const planned = service.computeTopologyFromAuthority(
+      planningAuthority(active),
+      undefined,
+    );
+    expect(planned.snapshot.state).not.toBe('removed');
+
+    const forming = groupWithSessionsIn('forming');
+    const held = createPlanningService({ group: forming }).computeTopologyFromAuthority(
+      planningAuthority(forming),
+      planned.snapshot,
+    );
+    expect(held.snapshot.state).toBe('removed');
+  });
+
+  it('plans in every non-forming lifecycle state', () => {
+    for (const lifecycleState of ['establishing', 'active', 'reconfiguring'] as const) {
+      const group = groupWithSessionsIn(lifecycleState);
+      const service = createPlanningService({ group });
+
+      const result = service.computeTopologyFromAuthority(
+        planningAuthority(group),
+        undefined,
+      );
+
+      expect(result.snapshot.state).not.toBe('removed');
+      expect(result.snapshot.activeSessionIds).toEqual(['session-a', 'session-b']);
+    }
+  });
 });
+
+function groupWithSessionsIn(
+  lifecycleState: GroupLifecycleState,
+): ReturnType<typeof createTopologyTestGroupSnapshot> {
+  const base = createTopologyTestGroupSnapshot();
+  const sessions = ['session-a', 'session-b'].map((sessionId) => ({
+    ...createTopologyTestGroupRef(),
+    principalId: sessionId,
+    sessionId,
+    generationId: `generation-${sessionId}`,
+    generationVersion: 1,
+    status: 'active' as const,
+    connectedAtEpochMs: 1,
+    lastHeartbeatAtEpochMs: 1_999,
+    expiresAtEpochMs: 60_000,
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+  }));
+  return {
+    ...base,
+    group: { ...base.group, lifecycleState, formationEpoch: 1 },
+    activeSessions: sessions,
+    onlineMemberCount: sessions.length,
+  };
+}
+
+function planningAuthority(group: ReturnType<typeof createTopologyTestGroupSnapshot>) {
+  return {
+    group,
+    config: resolveGroupTopologyConfig({}),
+    kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+    rttMeasurements: [],
+    nowEpochMs: 2_000,
+  };
+}
 
 function createPlanningService(input: {
   group: ReturnType<typeof createTopologyTestGroupSnapshot>;

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -127,6 +127,12 @@ The lifecycle rejection vocabulary extends `GroupPolicyReasonCode`
 (`lifecycle-transition-invalid`, `lifecycle-manager-unavailable`) rather than
 paralleling it, per the slice 1 finding.
 
+#### Decision taken during the FORMING gate (2026-08-18)
+
+| # | Decision |
+| --- | --- |
+| 2.4 | **Only FORMING holds topology planning.** The gate is one predicate (`isGroupTopologyPlannableAt`) at the single planning choke point; a forming group takes the same removed-topology branch as an archived one. ESTABLISHING, ACTIVE, and RECONFIGURING all plan — RECONFIGURING exists precisely to redo establishment work, so holding planning there would defeat its purpose. Commanded dials follow the plan automatically: with no planned overlay there is nothing to materialize into `overlay.topology` broadcasts. The admin `reconfigureGroupTopology` path deliberately bypasses the gate as an operator escape hatch. |
+
 ### Slice 3 — Activation criterion and readiness
 
 `threshold` / `deadline` / `manual` / `threshold-or-deadline`, evaluated against two rates:


### PR DESCRIPTION
## What

Slice 2c — the first real behaviour change in the lifecycle workstream, and Phase 5's M7 formation window.

`isGroupTopologyPlannableAt` (business-active ∧ `lifecycleState !== 'forming'`) gates the single planning choke point, `computeTopologyFromAuthority`. A forming group takes the same removed-topology branch as an archived one: no planned overlay, nothing to establish, and — since dials materialize from the plan — no `overlay.topology` broadcasts. Both the local and the persistent/outbox planning paths flow through this one decision.

**Decisions** (recorded as plan addendum 2.4):
- Only FORMING holds planning. ESTABLISHING, ACTIVE, and RECONFIGURING all plan — RECONFIGURING exists precisely to redo establishment work.
- The admin `reconfigureGroupTopology` path deliberately bypasses the gate as an operator escape hatch.

**Byte-identical for today's groups**: immediate-formation groups are created ACTIVE and never enter FORMING. Every pre-existing planning test passes unchanged (81/81 in the planning suite).

**Release needs no wiring**: the `start-establishment` write already enqueues topology work carrying the post-transition snapshot. Verified live: forming → `state:"removed"`, v0; after establish → `state:"active"`, v1.

## Safety baseline first

Per the plan's directive, `group-lifecycle-safety-baseline.test.ts` was written and proven green **before** the gate existed: joins, presence sessions, and member governance hold in every lifecycle state, including a group deliberately stuck in FORMING. Phases gate establishment work — never the ability to be in the group.

## Validation

| Gate | Result |
|---|---|
| Safety baseline (pre-gate and post-gate) | 5/5 |
| Planning suite | 81/81, pre-existing tests untouched |
| `npm run test:unit` | 7615 passed; only the 4 known sandbox port-bind files |
| `npm run test:deno` | exit 0 |
| `npm run typecheck` | clean |
| Black-box memory profile (isolated) | **23/23**, transitions recipe 15/15 with held-plan + planned-after-establish steps |
| Isolated control on clean `main` | 22/22 (matched methodology) |
| `check:repo-style:changed` | `PASS` |

**Methodology note:** initial local black-box runs showed failures in `formation-burst-medium` and `admin-operations` that turned out to be cross-session port contamination — a concurrent flake-investigation session runs cluster suites on 18080–18082, and in memory mode the secondary URL defaults to 18080 even when the primary moves. The isolated control pair above (main 22/22 vs this branch 23/23) is the valid evidence; the mechanism is recorded in project memory.

**Deferred locally:** the postgres medium-scale run — the 5432 database is in active use by the flake-investigation session, and sharing it would contaminate both. The Branch Release Gate runs the full postgres suite on an isolated runner and is the authoritative check here; the gate also does not touch the group mutation path itself (it changes the downstream topology worker's decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)