### PR TITLE
Resolve principal snapshot audience from the row payload when the cache lags

### DIFF
--- a/packages/shared-server/rallar-system/state-sync-routing.ts
+++ b/packages/shared-server/rallar-system/state-sync-routing.ts
@@ -16,6 +16,7 @@ import {
 } from './snapshot-presence.ts';
 import {
     parseStateSyncPayload,
+    readClientSnapshotStateSyncPayload,
     sameScope,
     type StateSyncScope,
 } from './state-sync/state-sync-payload.ts';
@@ -35,7 +36,15 @@ export function resolveStateSyncRecipients(
 ): readonly WsServerResolvedRecipient[] | undefined {
     const principalTarget = readALPrincipalBroadcastTarget(message);
     if (principalTarget) {
-        return resolvePrincipalRecipients(webSocketServer, principalTarget, options);
+        const payloadSnapshot = readClientSnapshotStateSyncPayload(message);
+        return resolvePrincipalRecipients(
+            webSocketServer,
+            {
+                principalRef: principalTarget,
+                payloadSnapshots: payloadSnapshot ? [payloadSnapshot] : [],
+            },
+            options,
+        );
     }
     const payload = parseStateSyncPayload(message);
     if (!payload) {
@@ -118,6 +127,16 @@ export function sendStateSyncMessage(
     return sent;
 }
 
+interface PrincipalRecipientTarget {
+    readonly principalRef: ClientPrincipalRef;
+    /**
+     * Authoritative client snapshots carried by the row itself. The mutation
+     * that produced the row may have committed on another server, so the
+     * local cache does not yet list the very session the snapshot announces.
+     */
+    readonly payloadSnapshots: readonly ClientSnapshot[];
+}
+
 /**
  * Scope 'principal' resolves at delivery time to the principal's own live
  * sessions plus live sessions of groups the principal is an active member of.
@@ -126,11 +145,15 @@ export function sendStateSyncMessage(
  */
 function resolvePrincipalRecipients(
     webSocketServer: JsonWebSocketServer,
-    principalRef: ClientPrincipalRef,
+    target: PrincipalRecipientTarget,
     options: StateSyncRoutingOptions,
 ): readonly WsServerResolvedRecipient[] {
-    const clientSnapshots = options.readClientSnapshots?.() ??
-        clientStateSnapshotsRepository.getAllClientStateSnapshots();
+    const principalRef = target.principalRef;
+    const clientSnapshots = [
+        ...(options.readClientSnapshots?.() ??
+            clientStateSnapshotsRepository.getAllClientStateSnapshots()),
+        ...target.payloadSnapshots,
+    ];
     const ownRecipients = clientSnapshots
         .filter((snapshot) =>
             sameScope(snapshot.principal, principalRef) &&

--- a/packages/shared-server/rallar-system/state-sync/state-sync-payload.ts
+++ b/packages/shared-server/rallar-system/state-sync/state-sync-payload.ts
@@ -53,6 +53,20 @@ export function readGroupSnapshotStateSyncPayload(
         : undefined;
 }
 
+/**
+ * The authoritative client snapshot carried by a state-sync row, when the row
+ * is a client snapshot. Delivery-time audience resolution may use it when a
+ * process-local cache lags the row: the mutation that produced the row may
+ * have committed on another server, so the local cache does not yet list the
+ * very session the snapshot announces.
+ */
+export function readClientSnapshotStateSyncPayload(
+    message: ALMessage,
+): ClientSnapshot | undefined {
+    const payload = parseStateSyncPayload(message);
+    return payload && payload.kind === 'client' ? payload.snapshot : undefined;
+}
+
 export function parseStateSyncPayload(message: ALMessage): StateSyncPayload | undefined {
     try {
         switch (message.payload.typeId) {

--- a/packages/tests/shared-server/state-sync-principal-audience.test.ts
+++ b/packages/tests/shared-server/state-sync-principal-audience.test.ts
@@ -73,6 +73,50 @@ describe('principal state-sync audience', () => {
     ]);
   });
 
+  // Regression: in a cluster, the connect mutation can commit on a server other
+  // than the one hosting the socket. That host's cache then still predates the
+  // row, and resolving from the cache alone drops the snapshot that would have
+  // installed it (observed as the api-v1-rtc-topology-convergence CI flake).
+  it('resolves the row payload sessions when the local cache lags the mutation', () => {
+    const message = toPrincipalStampedMessage('alice', ['alice-session-1']);
+    const webSocketServer = createOpenConnections(['alice-session-1']);
+
+    const recipients = resolveStateSyncRecipients(webSocketServer, message, {
+      readClientSnapshots: () => [],
+      readGroupSnapshots: () => [],
+      now: () => NOW_EPOCH_MS,
+    });
+
+    expect(recipients).toBeDefined();
+    expect(recipients!.map((recipient) => recipient.connectionId)).toEqual(['alice-session-1']);
+  });
+
+  it('ignores a payload snapshot whose principal differs from the stamped target', () => {
+    const message = toPrincipalStampedMessage('alice', ['alice-session-1']);
+    const forged: ALMessage = {
+      ...message,
+      targets: {
+        mode: 'broadcast',
+        scope: 'principal',
+        principalRef: {
+          applicationId: 'app-1',
+          workspaceId: 'workspace-1',
+          principalId: 'bob',
+        },
+      },
+    };
+    const webSocketServer = createOpenConnections(['alice-session-1']);
+
+    const recipients = resolveStateSyncRecipients(webSocketServer, forged, {
+      readClientSnapshots: () => [],
+      readGroupSnapshots: () => [],
+      now: () => NOW_EPOCH_MS,
+    });
+
+    expect(recipients).toBeDefined();
+    expect(recipients).toEqual([]);
+  });
+
   it('never falls through to every open connection, even for an unknown payload type', () => {
     const message = toPrincipalStampedMessage('alice', ['alice-session-1']);
     const forged: ALMessage = {


### PR DESCRIPTION
## Goal

Eliminate the `api-v1-rtc-topology-convergence` Branch Release Gate flake by closing the cross-server WebSocket delivery hole that caused it. The recipe's assertion was correct and is unchanged: a client that opens an authorised WS connection must receive its `client-state.snapshot`.

## Changes

- `packages/shared-server/rallar-system/state-sync-routing.ts` — a principal-target state-sync row now resolves its audience against the client snapshot carried by the row itself in addition to the process-local snapshot cache, via a new `PrincipalRecipientTarget` input contract. Live-session and open-connection filters still gate every recipient, and a payload for a different principal adds nothing.
- `packages/shared-server/rallar-system/state-sync/state-sync-payload.ts` — new `readClientSnapshotStateSyncPayload`, mirroring the existing `readGroupSnapshotStateSyncPayload` boundary.
- `packages/tests/shared-server/state-sync-principal-audience.test.ts` — regression test for the lagging-cache delivery (fails without the fix) plus a forged-target guard.

Root cause, proven from the attempt-1 logs and server-log artifacts of run 32121097130: in the three-server cluster any server's AppInbox worker can process an authorised-ws connect, so the server hosting the socket can receive the `client-state.snapshot` WS_OUTBOX fanout before its local cache lists the new session. `resolvePrincipalRecipients` read only that cache, resolved `no-recipients`, and the best-effort row was dropped — the very message that would have installed the cache entry. The group-snapshot path already documents and implements payload-based audience resolution for this exact hazard (`ws-server-target-resolver.ts`); this PR gives the principal path the same treatment.

## Acceptance

- `wsPrimaryAuthorizationReady` in `api-v1-rtc-topology-convergence` receives the snapshot even when a different server processes the connect command: the new regression test encodes the failing configuration (empty local cache, open socket, payload snapshot) and passes.
- A principal-target row still never falls through to every open connection, and a payload snapshot cannot widen the audience beyond the stamped principal (guard test).

## Validation

- Passed: new regression test (verified red without the fix); `npx vitest run packages/tests/shared-server` (1995 passed, 5 skipped); `npx tsc -p packages/shared-server/tsconfig.json`; `apps/api-v1 deno task check`; `npm run check:repo-style:changed -- origin/main HEAD`; five local Postgres cluster executions of `api-v1-rtc-topology-convergence` (all `success=36 failure=0`, four of them full 6/6 `api-v1-black-box-cluster` matrix passes).
- Skipped: `npm run test:ci` full sweep locally (branch CI runs it on this push); repeated CI-side soak of the flake, since the race depends on inbox worker scheduling — the regression test covers it deterministically.
- Not a cause of the other cited red run: 32073677534 failed on `api-v1-group-lifecycle-policy` (`Cannot resolve placeholder {runId}`), already fixed on main (#264); `api-v1-rtc-topology-convergence` passed in that run.

## Risk and rollback

Low: the change only widens delivery-time audience resolution with the row's own validated payload, filtered by the same live-session and open-connection checks; worst case a just-disconnecting session receives one final snapshot, consistent with at-least-once delivery. Revert the single commit to roll back.

## Follow-up

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)