### PR TITLE
Make RTC baseline processing memory-bounded

### DIFF
--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-artifact-projection.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-artifact-projection.ts
@@ -1,0 +1,280 @@
+import type {
+  RtcBaselineCohortIdentityDto,
+  RtcBaselineEnvironmentId,
+  RtcBaselineIssueDto,
+  RtcBaselineRawReferenceDto,
+  RtcBaselineResult,
+  RtcBaselineRuntimeObservationDto,
+  RtcBaselineSampleDto,
+  RtcBaselineSampleIdentityDto,
+  RtcBaselineSampleOutcomeDto,
+} from '../contracts/rtc-baseline-contracts.ts';
+import {
+  validateRtcBaselineRetainedSampleObservations,
+  validateRtcBaselineStoredArtifact,
+} from '../contracts/rtc-baseline-artifact-validation.ts';
+import { computeRtcBaselineMetricObservations } from '../catalog/rtc-baseline-workload-manifest.ts';
+import type {
+  RtcBaselineCohortOutcomeRecord,
+  RtcBaselineStoredArtifact,
+  RtcBaselineSummaryArtifactRecord,
+} from './rtc-baseline-evidence-layout.ts';
+import { canonicalizeRtcBaselineRawReferences } from './rtc-baseline-evidence-layout.ts';
+import type { RtcBaselineMetricObservation } from './rtc-baseline-statistics.ts';
+
+export interface RtcBaselineArtifactProjection {
+  readonly sampleOutcomes: readonly RtcBaselineSampleOutcomeDto[];
+  readonly cohortOutcomes: readonly RtcBaselineCohortOutcomeRecord[];
+  readonly failures: readonly RtcBaselineFailureOutcomeRecord[];
+  readonly metricObservations: readonly RtcBaselineMetricObservation[];
+  readonly rawReferences: readonly RtcBaselineRawReferenceDto[];
+  readonly artifactIssues: readonly RtcBaselineIssueDto[];
+}
+
+export interface RtcBaselineFailureOutcomeRecord {
+  readonly identity: RtcBaselineSampleIdentityDto | RtcBaselineCohortIdentityDto;
+  readonly outcome: 'failed' | 'not-run';
+  readonly issues: readonly RtcBaselineIssueDto[];
+}
+
+export interface RtcBaselineArtifactProjector {
+  appendFailureOutcome(failure: RtcBaselineFailureOutcomeRecord): Promise<RtcBaselineResult<void>>;
+  appendStoredArtifact(artifact: RtcBaselineStoredArtifact): Promise<RtcBaselineResult<void>>;
+  getProjection(): RtcBaselineArtifactProjection;
+}
+
+interface CreateRtcBaselineArtifactProjectorInput {
+  readonly environmentId: RtcBaselineEnvironmentId;
+  readonly environmentObservation: RtcBaselineRuntimeObservationDto | null;
+  readonly conflictingSampleCode: string;
+  readonly conflictingSampleMessage: (sampleId: string) => string;
+  readonly sha256: (bytes: Uint8Array) => Promise<string>;
+}
+
+const encoder = new TextEncoder();
+
+function successful(): RtcBaselineResult<void> {
+  return { ok: true, value: undefined };
+}
+
+function failed(code: string, message: string): RtcBaselineResult<never> {
+  return { ok: false, issues: [{ path: '$.samples', code, message }] };
+}
+
+function toIndexedSampleIssues(
+  issues: readonly RtcBaselineIssueDto[],
+  sampleIndex: number,
+): RtcBaselineIssueDto[] {
+  return issues.map((issue) => ({
+    ...issue,
+    path: issue.path.replace('$.samples[0]', `$.samples[${sampleIndex}]`),
+  }));
+}
+
+function toSampleOutcome(sample: RtcBaselineSampleDto): RtcBaselineSampleOutcomeDto {
+  return { identity: sample.identity, outcome: sample.outcome, issues: sample.issues };
+}
+
+export function createRtcBaselineArtifactProjector(
+  projectorInput: CreateRtcBaselineArtifactProjectorInput,
+): RtcBaselineArtifactProjector {
+  const sampleDigestById = new Map<string, string>();
+  const sampleOutcomes: RtcBaselineSampleOutcomeDto[] = [];
+  const cohortOutcomes: RtcBaselineCohortOutcomeRecord[] = [];
+  const failures: RtcBaselineFailureOutcomeRecord[] = [];
+  const metricObservations: RtcBaselineMetricObservation[] = [];
+  const rawReferences: RtcBaselineRawReferenceDto[] = [];
+  const artifactIssues: RtcBaselineIssueDto[] = [];
+
+  async function appendSample(sample: RtcBaselineSampleDto): Promise<RtcBaselineResult<void>> {
+    let digest: string;
+    try {
+      digest = await projectorInput.sha256(encoder.encode(JSON.stringify(sample)));
+    } catch (error) {
+      return failed('hash-failed', error instanceof Error ? error.message : String(error));
+    }
+    const existingDigest = sampleDigestById.get(sample.identity.sampleId);
+    if (existingDigest !== undefined) {
+      return existingDigest === digest
+        ? successful()
+        : failed(
+            projectorInput.conflictingSampleCode,
+            projectorInput.conflictingSampleMessage(sample.identity.sampleId),
+          );
+    }
+
+    const sampleIndex = sampleDigestById.size;
+    sampleDigestById.set(sample.identity.sampleId, digest);
+    artifactIssues.push(
+      ...validateRtcBaselineStoredArtifact(sample),
+      ...toIndexedSampleIssues(
+        validateRtcBaselineRetainedSampleObservations(projectorInput.environmentObservation, [
+          sample,
+        ]),
+        sampleIndex,
+      ),
+    );
+    sampleOutcomes.push(toSampleOutcome(sample));
+    metricObservations.push(
+      ...computeRtcBaselineMetricObservations([sample], projectorInput.environmentId),
+    );
+    rawReferences.push(...sample.rawReferences);
+    return successful();
+  }
+
+  async function appendSamples(
+    samples: readonly RtcBaselineSampleDto[],
+  ): Promise<RtcBaselineResult<void>> {
+    for (const sample of samples) {
+      const appended = await appendSample(sample);
+      if (!appended.ok) {
+        return appended;
+      }
+    }
+    return successful();
+  }
+
+  async function appendStoredArtifact(
+    artifact: RtcBaselineStoredArtifact,
+  ): Promise<RtcBaselineResult<void>> {
+    if (artifact.schema === 'rallar.rtc-baseline.sample.v1') {
+      return appendSample(artifact);
+    }
+    artifactIssues.push(...validateRtcBaselineStoredArtifact(artifact));
+    if (artifact.schema === 'rallar.rtc-baseline.external-attempt.v1') {
+      return appendSamples(artifact.samples);
+    }
+    if (artifact.schema === 'rallar.rtc-baseline.external-cohort.v1') {
+      cohortOutcomes.push({
+        identity: artifact.identity,
+        outcome: artifact.outcome,
+        issues: artifact.issues,
+      });
+      return appendSamples(artifact.samples);
+    }
+    return successful();
+  }
+
+  async function appendFailureOutcome(
+    failure: RtcBaselineFailureOutcomeRecord,
+  ): Promise<RtcBaselineResult<void>> {
+    const projected = {
+      identity: failure.identity,
+      outcome: failure.outcome,
+      issues: failure.issues,
+    };
+    failures.push(projected);
+    if ('sampleId' in failure.identity) {
+      sampleOutcomes.push({
+        identity: failure.identity,
+        outcome: failure.outcome,
+        issues: failure.issues,
+      });
+    }
+    return successful();
+  }
+
+  function getProjection(): RtcBaselineArtifactProjection {
+    return {
+      sampleOutcomes,
+      cohortOutcomes,
+      failures,
+      metricObservations,
+      rawReferences,
+      artifactIssues,
+    };
+  }
+
+  return { appendFailureOutcome, appendStoredArtifact, getProjection };
+}
+
+export function projectRtcBaselineArtifactOutcomes(input: {
+  sampleOutcomes: readonly RtcBaselineSampleOutcomeDto[];
+  cohortOutcomes: readonly RtcBaselineCohortOutcomeRecord[];
+  failures: readonly RtcBaselineFailureOutcomeRecord[];
+}) {
+  const samples = new Map(
+    input.sampleOutcomes.map(({ identity, outcome, issues }) => [
+      identity.sampleId,
+      { identity, outcome, issues },
+    ]),
+  );
+  const cohorts = new Map(
+    input.cohortOutcomes.map(({ identity, outcome, issues }) => [
+      identity.cohortId,
+      { identity, outcome, issues },
+    ]),
+  );
+  for (const failure of input.failures) {
+    if ('sampleId' in failure.identity) {
+      samples.set(failure.identity.sampleId, {
+        identity: failure.identity,
+        outcome: failure.outcome,
+        issues: failure.issues,
+      });
+    } else {
+      cohorts.set(failure.identity.cohortId, {
+        identity: failure.identity,
+        outcome: 'failed',
+        issues: failure.issues,
+      });
+    }
+  }
+  return {
+    sampleOutcomes: [...samples.values()].sort((left, right) =>
+      left.identity.sampleId.localeCompare(right.identity.sampleId),
+    ),
+    cohortOutcomes: [...cohorts.values()].sort((left, right) =>
+      left.identity.cohortId.localeCompare(right.identity.cohortId),
+    ),
+  };
+}
+
+export function validateRtcBaselineArtifactOutcomeReconciliation(input: {
+  sampleOutcomes: readonly RtcBaselineSampleOutcomeDto[];
+  rawReferences: readonly RtcBaselineRawReferenceDto[];
+  cohorts: readonly RtcBaselineCohortOutcomeRecord[];
+  failures: readonly RtcBaselineFailureOutcomeRecord[];
+  summary: RtcBaselineSummaryArtifactRecord;
+}) {
+  const outcomes = projectRtcBaselineArtifactOutcomes({
+    sampleOutcomes: input.sampleOutcomes,
+    cohortOutcomes: input.cohorts,
+    failures: input.failures,
+  });
+  const issues: RtcBaselineIssueDto[] = [];
+  if (JSON.stringify(outcomes.sampleOutcomes) !== JSON.stringify(input.summary.sampleOutcomes)) {
+    issues.push({
+      path: '$.summary.sampleOutcomes',
+      code: 'sample-outcome-mismatch',
+      message: 'Summary sample outcomes differ from retained artifacts.',
+    });
+  }
+  if (JSON.stringify(outcomes.cohortOutcomes) !== JSON.stringify(input.summary.cohortOutcomes)) {
+    issues.push({
+      path: '$.summary.cohortOutcomes',
+      code: 'cohort-outcome-mismatch',
+      message: 'Summary cohort outcomes differ from retained artifacts.',
+    });
+  }
+  const storedRaw = canonicalizeRtcBaselineRawReferences(input.rawReferences);
+  const summaryRaw = canonicalizeRtcBaselineRawReferences(input.summary.rawReferences);
+  if (!storedRaw.ok) {
+    issues.push(...storedRaw.issues);
+  }
+  if (!summaryRaw.ok) {
+    issues.push(...summaryRaw.issues);
+  }
+  if (
+    storedRaw.ok &&
+    summaryRaw.ok &&
+    JSON.stringify(storedRaw.value) !== JSON.stringify(summaryRaw.value)
+  ) {
+    issues.push({
+      path: '$.summary.rawReferences',
+      code: 'raw-reference-mismatch',
+      message: 'Summary raw references differ from retained samples.',
+    });
+  }
+  return issues;
+}

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-artifact-reader.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-artifact-reader.ts
@@ -1,0 +1,211 @@
+import { decodeRtcBaselineStoredJson } from '../contracts/rtc-baseline-artifact-decoding.ts';
+import type {
+  RtcBaselineCaptureManifestDto,
+  RtcBaselineEnvironmentDto,
+  RtcBaselineIssueDto,
+  RtcBaselineJson,
+  RtcBaselineResult,
+} from '../contracts/rtc-baseline-contracts.ts';
+// prettier-ignore
+import {
+  validateRtcBaselineStoredArtifact,
+} from '../contracts/rtc-baseline-artifact-validation.ts';
+import { decodeRtcBaselineFailureOutcome } from '../acceptance/rtc-baseline-failure-accounting.ts';
+import {
+  classifyRtcBaselineArtifactPath,
+  inspectRtcBaselineChecksumEntries,
+  inspectRtcBaselineStoredArtifactBytes,
+  RTC_BASELINE_CHECKSUM_FILE,
+  type RtcBaselineSummaryArtifactRecord,
+  type RtcBaselineVerifiedStoredArtifact,
+  validateRtcBaselineChecksumMembership,
+} from './rtc-baseline-evidence-layout.ts';
+import {
+  createRtcBaselineArtifactProjector,
+  type RtcBaselineArtifactProjection,
+  type RtcBaselineArtifactProjector,
+} from './rtc-baseline-artifact-projection.ts';
+
+export interface RtcBaselineFinalizedReaderDependencies {
+  readJson(baselineId: string, path: string): Promise<RtcBaselineResult<RtcBaselineJson>>;
+  readBytes(baselineId: string, path: string): Promise<RtcBaselineResult<Uint8Array>>;
+  listArtifactPaths(baselineId: string): Promise<RtcBaselineResult<string[]>>;
+  sha256(bytes: Uint8Array): Promise<string>;
+}
+
+export interface RtcBaselineReadFinalizedArtifacts {
+  readonly retainedPaths: readonly string[];
+  readonly checksumEntries: ReadonlyMap<string, string>;
+  readonly issues: RtcBaselineIssueDto[];
+  readonly environment?: RtcBaselineEnvironmentDto;
+  readonly manifest?: RtcBaselineCaptureManifestDto;
+  readonly summary?: RtcBaselineSummaryArtifactRecord;
+  readonly projection?: RtcBaselineArtifactProjection;
+}
+
+interface RtcBaselineArtifactReadState {
+  issues: RtcBaselineIssueDto[];
+  environment?: RtcBaselineEnvironmentDto;
+  manifest?: RtcBaselineCaptureManifestDto;
+  summary?: RtcBaselineSummaryArtifactRecord;
+  projector?: RtcBaselineArtifactProjector;
+}
+
+interface ReadVerifiedStoredArtifactInput {
+  readonly dependencies: RtcBaselineFinalizedReaderDependencies;
+  readonly baselineId: string;
+  readonly relativePath: string;
+  readonly expectedSha256: string;
+}
+
+function failed(path: string, code: string, message: string): RtcBaselineResult<never> {
+  return { ok: false, issues: [{ path, code, message }] };
+}
+
+async function readVerifiedStoredArtifact(
+  input: ReadVerifiedStoredArtifactInput,
+): Promise<RtcBaselineResult<RtcBaselineVerifiedStoredArtifact>> {
+  const bytes = await input.dependencies.readBytes(input.baselineId, input.relativePath);
+  if (!bytes.ok) {
+    return bytes;
+  }
+  if ((await input.dependencies.sha256(bytes.value)) !== input.expectedSha256) {
+    return failed(
+      `$.${input.relativePath}`,
+      'checksum-mismatch',
+      'Stored bytes do not match the SHA-256 checksum.',
+    );
+  }
+  return inspectRtcBaselineStoredArtifactBytes({
+    relativePath: input.relativePath,
+    bytes: bytes.value,
+  });
+}
+
+async function appendDecodedArtifact(
+  state: RtcBaselineArtifactReadState,
+  artifact: RtcBaselineVerifiedStoredArtifact,
+  sha256: (bytes: Uint8Array) => Promise<string>,
+): Promise<void> {
+  if (artifact.kind === null || artifact.json === null) {
+    return;
+  }
+  const decoded = decodeRtcBaselineStoredJson(artifact.kind, artifact.json);
+  if (!decoded.ok) {
+    state.issues.push(...decoded.issues);
+    return;
+  }
+  if (decoded.value.schema === 'rallar.rtc-baseline.environment.v1') {
+    state.environment = decoded.value;
+    state.issues.push(...validateRtcBaselineStoredArtifact(decoded.value));
+    state.projector = createRtcBaselineArtifactProjector({
+      environmentId: decoded.value.environmentId,
+      environmentObservation: decoded.value.observation,
+      conflictingSampleCode: 'conflicting-sample',
+      conflictingSampleMessage: () => 'Duplicate sample bodies differ.',
+      sha256,
+    });
+    return;
+  }
+  if (decoded.value.schema === 'rallar.rtc-baseline.manifest.v1') {
+    state.manifest = decoded.value;
+  }
+  if (decoded.value.schema === 'rallar.rtc-baseline.summary.v1') {
+    state.summary = decoded.value;
+  }
+  if (state.projector) {
+    const appended = await state.projector.appendStoredArtifact(decoded.value);
+    if (!appended.ok) {
+      state.issues.push(...appended.issues);
+    }
+    return;
+  }
+  state.issues.push(...validateRtcBaselineStoredArtifact(decoded.value));
+}
+
+async function appendFailureArtifact(
+  state: RtcBaselineArtifactReadState,
+  artifact: RtcBaselineVerifiedStoredArtifact,
+  relativePath: string,
+): Promise<void> {
+  if (classifyRtcBaselineArtifactPath(relativePath) !== 'failure-outcome') {
+    return;
+  }
+  const decoded = decodeRtcBaselineFailureOutcome(artifact.json, relativePath);
+  if (!decoded.ok) {
+    state.issues.push(...decoded.issues);
+    return;
+  }
+  if (state.projector) {
+    const appended = await state.projector.appendFailureOutcome(decoded.value);
+    if (!appended.ok) {
+      state.issues.push(...appended.issues);
+    }
+  }
+}
+
+async function appendArtifactPath(
+  dependencies: RtcBaselineFinalizedReaderDependencies,
+  state: RtcBaselineArtifactReadState,
+  input: { baselineId: string; relativePath: string; expectedSha256: string },
+): Promise<void> {
+  const stored = await readVerifiedStoredArtifact({
+    dependencies,
+    ...input,
+  });
+  if (!stored.ok) {
+    state.issues.push(...stored.issues);
+    return;
+  }
+  await appendDecodedArtifact(state, stored.value, dependencies.sha256);
+  await appendFailureArtifact(state, stored.value, input.relativePath);
+}
+
+export function createRtcBaselineFinalizedArtifactReader(
+  dependencies: RtcBaselineFinalizedReaderDependencies,
+) {
+  async function read(
+    baselineId: string,
+  ): Promise<RtcBaselineResult<RtcBaselineReadFinalizedArtifacts>> {
+    const checksumBytes = await dependencies.readBytes(baselineId, RTC_BASELINE_CHECKSUM_FILE);
+    if (!checksumBytes.ok) {
+      return checksumBytes;
+    }
+    const listed = await dependencies.listArtifactPaths(baselineId);
+    if (!listed.ok) {
+      return listed;
+    }
+    const retainedPaths = [...listed.value].sort();
+    const { entries, issues } = inspectRtcBaselineChecksumEntries(checksumBytes.value);
+    const state: RtcBaselineArtifactReadState = { issues };
+    issues.push(...validateRtcBaselineChecksumMembership(retainedPaths, entries));
+    for (const relativePath of retainedPaths) {
+      const expectedSha256 = entries.get(relativePath);
+      if (expectedSha256 !== undefined) {
+        await appendArtifactPath(dependencies, state, {
+          baselineId,
+          relativePath,
+          expectedSha256,
+        });
+      }
+    }
+    const projection = state.projector?.getProjection();
+    if (projection) {
+      issues.push(...projection.artifactIssues);
+    }
+    return {
+      ok: true,
+      value: {
+        retainedPaths,
+        checksumEntries: entries,
+        issues,
+        environment: state.environment,
+        manifest: state.manifest,
+        summary: state.summary,
+        projection,
+      },
+    };
+  }
+
+  return { read };
+}

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-comparison.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-comparison.ts
@@ -1,0 +1,156 @@
+import type { RtcBaselineResult } from '../contracts/rtc-baseline-contracts.ts';
+import type {
+  RtcBaselineComparisonChoice,
+  RtcBaselineComparisonChoiceInput,
+  RtcBaselinePairedComparison,
+  RtcBaselinePairedComparisonInput,
+} from './rtc-baseline-evidence-layout.ts';
+import {
+  compareRtcBaselinePersistedMetrics,
+  evaluateRtcBaselineWorkloadRepeatOutcome,
+  rtcBaselineTriggeredWorkloads,
+} from './rtc-baseline-statistics.ts';
+// prettier-ignore
+import type {
+  RtcBaselineFinalizedArtifactVerifier,
+} from './rtc-baseline-finalized-verification.ts';
+
+function failed(path: string, code: string, message: string): RtcBaselineResult<never> {
+  return { ok: false, issues: [{ path, code, message }] };
+}
+
+async function readComparisonChoice(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+  input: RtcBaselineComparisonChoiceInput,
+): Promise<RtcBaselineResult<RtcBaselineComparisonChoice>> {
+  const { primaryBaselineId, comparisonBaselineId, inputPath, workloadId } = input;
+  const primary = await verifier.readVerifiedArtifacts(primaryBaselineId);
+  if (!primary.ok) {
+    return primary;
+  }
+  const repeatRequired = rtcBaselineTriggeredWorkloads(primary.value).includes(workloadId);
+  const selectedId = repeatRequired ? `${primaryBaselineId}-repeat-01` : primaryBaselineId;
+  if (comparisonBaselineId !== selectedId) {
+    return failed(
+      inputPath,
+      'invalid-comparison-baseline',
+      repeatRequired
+        ? 'A noisy primary requires its exact -repeat-01 baseline.'
+        : 'A stable primary must compare from itself.',
+    );
+  }
+  const selected =
+    selectedId === primaryBaselineId ? primary : await verifier.readVerifiedArtifacts(selectedId);
+  if (!selected.ok) {
+    return selected;
+  }
+  const linked = await verifier.validateRepeatLink(selectedId, selected.value.summary);
+  if (!linked.ok) {
+    return linked;
+  }
+  const context = primary.value.environment.observation?.host.executionContext;
+  const repeatEvaluation =
+    context === undefined
+      ? { ok: true as const, value: { repeatRequired: false, stillNoisy: false } }
+      : evaluateRtcBaselineWorkloadRepeatOutcome({
+          primaryMetrics: primary.value.summary.metricSummaries,
+          repeatMetrics: selected.value.summary.metricSummaries,
+          workloadId,
+          executionContext: context,
+        });
+  if (!repeatEvaluation.ok) {
+    return repeatEvaluation;
+  }
+  const environment = selected.value.environment;
+  if (environment.observation === null) {
+    return failed(
+      '$.environment.observation',
+      'missing-runtime-observation',
+      'Comparison baselines require a runtime observation.',
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      primary: primary.value.summary,
+      selected: selected.value.summary,
+      selectedId,
+      repeatRequired,
+      stillNoisy: repeatEvaluation.value.stillNoisy,
+      environment: { ...environment, observation: environment.observation },
+    },
+  };
+}
+
+async function readPairedComparison(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+  input: RtcBaselinePairedComparisonInput,
+): Promise<RtcBaselineResult<RtcBaselinePairedComparison>> {
+  const primary = await readComparisonChoice(verifier, {
+    primaryBaselineId: input.primaryBaselineId,
+    comparisonBaselineId: input.primaryComparisonCohortId,
+    inputPath: '$.primaryComparisonCohortId',
+    workloadId: input.workloadId,
+  });
+  if (!primary.ok) {
+    return primary;
+  }
+  const candidate = await readComparisonChoice(verifier, {
+    primaryBaselineId: input.candidateBaselineId,
+    comparisonBaselineId: input.candidateComparisonCohortId,
+    inputPath: '$.candidateComparisonCohortId',
+    workloadId: input.workloadId,
+  });
+  if (!candidate.ok) {
+    return candidate;
+  }
+  const compared = compareRtcBaselinePersistedMetrics({
+    baselineEnvironment: primary.value.environment,
+    candidateEnvironment: candidate.value.environment,
+    baselineMetrics: primary.value.selected.metricSummaries,
+    candidateMetrics: candidate.value.selected.metricSummaries,
+    workloadId: input.workloadId,
+  });
+  if (!compared.ok) {
+    return compared;
+  }
+  const value = {
+    primary: {
+      primaryBaselineId: input.primaryBaselineId,
+      comparisonBaselineId: primary.value.selectedId,
+      repeatRequired: primary.value.repeatRequired,
+    },
+    candidate: {
+      primaryBaselineId: input.candidateBaselineId,
+      comparisonBaselineId: candidate.value.selectedId,
+      repeatRequired: candidate.value.repeatRequired,
+    },
+    comparisons: compared.value,
+  };
+  if (primary.value.stillNoisy || candidate.value.stillNoisy) {
+    return {
+      ok: true,
+      value: {
+        outcome: 'inconclusive-still-noisy',
+        ...value,
+        issues: [
+          {
+            path: '$.comparisons',
+            code: 'repeat-still-noisy',
+            message: 'Selected repeat is noisy.',
+          },
+        ],
+      },
+    };
+  }
+  return { ok: true, value: { outcome: 'conclusive', ...value } };
+}
+
+export function createRtcBaselineFinalizedComparisonReader(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+) {
+  return {
+    readPairedComparison: (input: RtcBaselinePairedComparisonInput) =>
+      readPairedComparison(verifier, input),
+  };
+}

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-evidence.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-evidence.ts
@@ -4,9 +4,8 @@ import {
 } from './rtc-baseline-evidence-layout.ts';
 import type { RtcBaselineCohortOutcomeRecord } from './rtc-baseline-evidence-layout.ts';
 import {
-  validateRtcBaselineCompleteAccounting,
   validateRtcBaselineArtifactReconciliation,
-  validateRtcBaselineRetainedSampleObservations,
+  validateRtcBaselineCompleteAccounting,
   validateRtcBaselineStoredArtifact,
 } from '../contracts/rtc-baseline-artifact-validation.ts';
 import type {
@@ -14,14 +13,11 @@ import type {
   RtcBaselineConditionalEnvironmentDecisionDto,
   RtcBaselineEnvironmentDto,
   RtcBaselineEnvironmentId,
-  RtcBaselineExternalAttemptDto,
-  RtcBaselineExternalCohortDto,
   RtcBaselineIssueDto,
   RtcBaselineRawReferenceDto,
   RtcBaselineRepeatLinkDto,
   RtcBaselineResult,
   RtcBaselineRuntimeObservationDto,
-  RtcBaselineSampleDto,
   RtcBaselineSampleOutcomeDto,
   RtcBaselineWorkloadId,
 } from '../contracts/rtc-baseline-contracts.ts';
@@ -31,16 +27,14 @@ import type {
   RtcBaselineMetricSummary,
 } from './rtc-baseline-statistics.ts';
 import { summarizeRtcBaselineMetricPartitions } from './rtc-baseline-statistics.ts';
+// prettier-ignore
+import { computeRtcBaselineExpectedSampleIdentities } from
+  '../catalog/rtc-baseline-workload-manifest.ts';
 import {
-  computeRtcBaselineExpectedSampleIdentities,
-  computeRtcBaselineMetricObservations,
-  projectRtcBaselineStoredOutcomes,
-  validateRtcBaselineStoredOutcomeReconciliation,
-} from '../catalog/rtc-baseline-workload-manifest.ts';
-import type {
-  RtcBaselineFailureArtifact,
-  RtcBaselineNotRunArtifact,
-} from '../acceptance/rtc-baseline-failure-accounting.ts';
+  projectRtcBaselineArtifactOutcomes,
+  type RtcBaselineArtifactProjection,
+  validateRtcBaselineArtifactOutcomeReconciliation,
+} from './rtc-baseline-artifact-projection.ts';
 
 interface PersistedFinalizationFailure {
   schema: 'rallar.rtc-baseline.finalization-failure.v1';
@@ -87,11 +81,7 @@ export interface RtcBaselineFinalizedSummary {
   metricSummaries: readonly (MetricGrouping & RtcBaselineMetricSummary)[];
   rawReferences: readonly RtcBaselineRawReferenceDto[];
 }
-export interface RtcBaselineCollectedSampleOutcome extends RtcBaselineSampleOutcomeDto {
-  runtimeObservation?: RtcBaselineRuntimeObservationDto | null;
-  rawReferences?: readonly RtcBaselineRawReferenceDto[];
-}
-export interface CollectedArtifacts {
+export interface RtcBaselineCollectedArtifacts extends RtcBaselineArtifactProjection {
   environment: Omit<RtcBaselineEnvironmentDto, 'observation'> & {
     observation: RtcBaselineRuntimeObservationDto;
   };
@@ -100,45 +90,35 @@ export interface CollectedArtifacts {
   environmentId: RtcBaselineEnvironmentId;
   repeatLink: RtcBaselineRepeatLinkDto | null;
   conditionalEnvironmentDecisions: readonly RtcBaselineConditionalEnvironmentDecisionDto[];
-  sampleOutcomes: readonly RtcBaselineCollectedSampleOutcome[];
-  externalAttempts: readonly RtcBaselineExternalAttemptDto[];
-  cohortOutcomes: readonly RtcBaselineExternalCohortDto[];
-  failures: readonly (RtcBaselineFailureArtifact | RtcBaselineNotRunArtifact)[];
-  samples: readonly RtcBaselineSampleDto[];
-  retainedArtifacts: readonly { relativePath: string; bytes: Uint8Array }[];
+  retainedArtifactPaths: readonly string[];
 }
 interface Dependencies extends RtcBaselineFinalizationLockPort {
-  collectArtifacts(baselineId: string): Promise<RtcBaselineResult<CollectedArtifacts>>;
-  validateCompleteAccounting(value: CollectedArtifacts): RtcBaselineIssueDto[];
-  validateReconciliation(value: CollectedArtifacts): RtcBaselineIssueDto[];
+  collectArtifacts(baselineId: string): Promise<RtcBaselineResult<RtcBaselineCollectedArtifacts>>;
   partitionMetricObservations(
     value: readonly RtcBaselineMetricObservation[],
   ): RtcBaselineResult<RtcBaselineMetricPartition[]>;
   summarizeMetricValues(values: readonly number[]): RtcBaselineMetricSummary;
-  readRawBytes(baselineId: string, relativePath: string): Promise<RtcBaselineResult<Uint8Array>>;
+  readBytes(baselineId: string, relativePath: string): Promise<RtcBaselineResult<Uint8Array>>;
   sha256(bytes: Uint8Array): Promise<string>;
 }
 export interface RtcBaselineFinalizedEvidence {
   finalize(input: { baselineId: string }): Promise<RtcBaselineResult<RtcBaselineFinalizedSummary>>;
 }
 export function projectRtcBaselineFinalizedOutcomes(
-  value: Pick<CollectedArtifacts, 'sampleOutcomes' | 'cohortOutcomes' | 'failures'>,
+  value: Pick<RtcBaselineCollectedArtifacts, 'sampleOutcomes' | 'cohortOutcomes' | 'failures'>,
 ) {
-  return projectRtcBaselineStoredOutcomes(value);
+  return projectRtcBaselineArtifactOutcomes(value);
 }
 
 export function validateRtcBaselineCollectedArtifacts(
-  value: CollectedArtifacts,
+  value: RtcBaselineCollectedArtifacts,
   baselineId: string,
 ) {
   const outcomes = projectRtcBaselineFinalizedOutcomes(value);
   return [
-    ...validateRtcBaselineRetainedSampleObservations(value.environment.observation, value.samples),
+    ...value.artifactIssues,
     ...validateRtcBaselineStoredArtifact(value.environment),
     ...validateRtcBaselineStoredArtifact(value.manifest),
-    ...value.samples.flatMap(validateRtcBaselineStoredArtifact),
-    ...value.externalAttempts.flatMap(validateRtcBaselineStoredArtifact),
-    ...value.cohortOutcomes.flatMap(validateRtcBaselineStoredArtifact),
     ...validateRtcBaselineArtifactReconciliation({
       baselineId,
       environment: value.environment,
@@ -189,10 +169,13 @@ export function createRtcBaselineFinalizedEvidence(
     const failWith = (failureId: string, issues: RtcBaselineIssueDto[]) =>
       fail(writer, { baselineId: input.baselineId, failureId, issues });
     const collected = await dependencies.collectArtifacts(input.baselineId);
-    if (!collected.ok) return failWith('finalization-artifact-collection', collected.issues);
+    if (!collected.ok) {
+      return failWith('finalization-artifact-collection', collected.issues);
+    }
     const artifactIssues = validateRtcBaselineCollectedArtifacts(collected.value, input.baselineId);
-    if (artifactIssues.length > 0)
+    if (artifactIssues.length > 0) {
       return failWith('finalization-artifact-validation', artifactIssues);
+    }
     const outcomes = projectRtcBaselineFinalizedOutcomes(collected.value);
     const accounting = [
       ...validateRtcBaselineCompleteAccounting({
@@ -200,29 +183,38 @@ export function createRtcBaselineFinalizedEvidence(
         expectedCohorts: collected.value.manifest.expectedCohorts,
         ...outcomes,
       }),
-      ...dependencies.validateCompleteAccounting(collected.value),
+      ...validateRtcBaselineCompleteAccounting({
+        expectedSamples: computeRtcBaselineExpectedSampleIdentities(collected.value.manifest),
+        expectedCohorts: collected.value.manifest.expectedCohorts,
+        sampleOutcomes: collected.value.sampleOutcomes,
+        cohortOutcomes: collected.value.cohortOutcomes,
+      }),
     ];
-    if (accounting.length > 0) return failWith('finalization-accounting', accounting);
-    const reconciliation = dependencies.validateReconciliation(collected.value);
-    if (reconciliation.length > 0) return failWith('finalization-reconciliation', reconciliation);
+    if (accounting.length > 0) {
+      return failWith('finalization-accounting', accounting);
+    }
     const partitioned = dependencies.partitionMetricObservations(
-      computeRtcBaselineMetricObservations(collected.value.samples, collected.value.environmentId),
+      collected.value.metricObservations,
     );
-    if (!partitioned.ok) return failWith('finalization-statistics', partitioned.issues);
+    if (!partitioned.ok) {
+      return failWith('finalization-statistics', partitioned.issues);
+    }
     const metricSummaries = summarizeRtcBaselineMetricPartitions(
       partitioned.value,
       dependencies.summarizeMetricValues,
     );
-    const canonicalRaw = canonicalizeRtcBaselineRawReferences(
-      collected.value.samples.flatMap((sample) => sample.rawReferences),
-    );
-    if (!canonicalRaw.ok) return failWith('finalization-raw-reference', canonicalRaw.issues);
+    const canonicalRaw = canonicalizeRtcBaselineRawReferences(collected.value.rawReferences);
+    if (!canonicalRaw.ok) {
+      return failWith('finalization-raw-reference', canonicalRaw.issues);
+    }
     const rawReferences = canonicalRaw.value;
-    const retainedRawArtifacts: Array<{ relativePath: string; bytes: Uint8Array }> = [];
+    const checksumEntries: Array<{ sha256: string; relativePath: string }> = [];
     for (let index = 0; index < rawReferences.length; index += 1) {
       const reference = rawReferences[index];
-      const bytes = await dependencies.readRawBytes(input.baselineId, reference.relativePath);
-      if (!bytes.ok) return failWith('finalization-raw-reference', bytes.issues);
+      const bytes = await dependencies.readBytes(input.baselineId, reference.relativePath);
+      if (!bytes.ok) {
+        return failWith('finalization-raw-reference', bytes.issues);
+      }
       const issues: RtcBaselineIssueDto[] = [];
       if (bytes.value.byteLength !== reference.bytes) {
         issues.push(
@@ -254,8 +246,10 @@ export function createRtcBaselineFinalizedEvidence(
           ),
         );
       }
-      if (issues.length > 0) return failWith('finalization-raw-reference', issues);
-      retainedRawArtifacts.push({ relativePath: reference.relativePath, bytes: bytes.value });
+      if (issues.length > 0) {
+        return failWith('finalization-raw-reference', issues);
+      }
+      checksumEntries.push({ relativePath: reference.relativePath, sha256: digest });
     }
     const summary = {
       schema: 'rallar.rtc-baseline.summary.v1' as const,
@@ -268,21 +262,26 @@ export function createRtcBaselineFinalizedEvidence(
       metricSummaries,
       rawReferences,
     };
-    const outcomeIssues = validateRtcBaselineStoredOutcomeReconciliation({
+    const outcomeIssues = validateRtcBaselineArtifactOutcomeReconciliation({
       sampleOutcomes: collected.value.sampleOutcomes,
-      samples: collected.value.samples,
+      rawReferences: collected.value.rawReferences,
       cohorts: collected.value.cohortOutcomes,
       failures: collected.value.failures,
       summary,
     });
-    if (outcomeIssues.length > 0) return failWith('finalization-reconciliation', outcomeIssues);
+    if (outcomeIssues.length > 0) {
+      return failWith('finalization-reconciliation', outcomeIssues);
+    }
     const summaryBytes = new TextEncoder().encode(JSON.stringify(summary));
-    const checksumEntries = [];
     try {
-      for (const artifact of [...collected.value.retainedArtifacts, ...retainedRawArtifacts]) {
+      for (const relativePath of collected.value.retainedArtifactPaths) {
+        const artifact = await dependencies.readBytes(input.baselineId, relativePath);
+        if (!artifact.ok) {
+          return failWith('finalization-summary-publication', artifact.issues);
+        }
         checksumEntries.push({
-          sha256: await dependencies.sha256(artifact.bytes),
-          relativePath: artifact.relativePath,
+          sha256: await dependencies.sha256(artifact.value),
+          relativePath,
         });
       }
       checksumEntries.push({

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-reader.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-reader.ts
@@ -1,76 +1,42 @@
-import { decodeRtcBaselineStoredJson } from '../contracts/rtc-baseline-artifact-decoding.ts';
+// prettier-ignore
 import {
-  RTC_BASELINE_CHECKSUM_FILE,
-  RTC_BASELINE_SUMMARY_FILE,
-  classifyRtcBaselineArtifactPath,
-  inspectRtcBaselineChecksumEntries,
-  inspectRtcBaselineStoredArtifactBytes,
-  validateRtcBaselineChecksumMembership,
-  validateRtcBaselineRawArtifactIntegrity,
-  validateRtcBaselineRawArtifactMembership,
-  validateRtcBaselineRepeatLinkIdentity,
-  validateRtcBaselineRepeatPrimaryDigest,
-  type RtcBaselineReaderInput,
-  type RtcBaselineComparisonChoice,
-  type RtcBaselineComparisonChoiceInput,
-  type RtcBaselineFinalizedArtifactValidation,
-  type RtcBaselinePairedComparison,
-  type RtcBaselinePairedComparisonInput,
-  type RtcBaselineRepeatRequirement,
-  type RtcBaselineSummaryArtifactRecord,
-  type RtcBaselineVerifiedArtifacts,
-  type RtcBaselineVerifiedRepeatPrimary,
-  type RtcBaselineVerifiedStoredArtifact,
-} from './rtc-baseline-evidence-layout.ts';
-import {
-  compareRtcBaselinePersistedMetrics,
-  evaluateRtcBaselineWorkloadRepeatOutcome,
-  partitionRtcBaselineMetricObservations,
-  rtcBaselineTriggeredWorkloads,
-  summarizeRtcBaselineMetricPartitions,
-  validateRtcBaselinePersistedMetricSummaries,
-} from './rtc-baseline-statistics.ts';
-import {
-  computeRtcBaselineExpectedSampleIdentities,
-  computeRtcBaselineMetricObservations,
   createRtcBaselineExternalAttemptReader,
-  validateRtcBaselineStoredOutcomeReconciliation,
 } from '../catalog/rtc-baseline-workload-manifest.ts';
 import type {
   RtcBaselineAttemptLocatorDto,
-  RtcBaselineCaptureManifestDto,
-  RtcBaselineEnvironmentDto,
-  RtcBaselineExternalCohortDto,
-  RtcBaselineIssueDto,
-  RtcBaselineJson,
   RtcBaselineResult,
-  RtcBaselineSampleDto,
   RtcBaselineWorkloadId,
 } from '../contracts/rtc-baseline-contracts.ts';
+import type {
+  RtcBaselineFinalizedArtifactValidation,
+  RtcBaselinePairedComparison,
+  RtcBaselinePairedComparisonInput,
+  RtcBaselineReaderInput,
+  RtcBaselineRepeatRequirement,
+  RtcBaselineVerifiedRepeatPrimary,
+} from './rtc-baseline-evidence-layout.ts';
+import { rtcBaselineTriggeredWorkloads } from './rtc-baseline-statistics.ts';
 import {
-  validateRtcBaselineCompleteAccounting,
-  validateRtcBaselineArtifactReconciliation,
-  validateRtcBaselinePassingSummary,
-  validateRtcBaselineRetainedSampleObservations,
-  validateRtcBaselineStoredArtifact,
-} from '../contracts/rtc-baseline-artifact-validation.ts';
-import {
-  decodeRtcBaselineFailureOutcome,
-  type RtcBaselineFailureOutcomeArtifact,
-} from '../acceptance/rtc-baseline-failure-accounting.ts';
+  createRtcBaselineFinalizedArtifactVerifier,
+  type RtcBaselineFinalizedArtifactVerifier,
+} from './rtc-baseline-finalized-verification.ts';
+// prettier-ignore
+import { createRtcBaselineFinalizedComparisonReader } from './rtc-baseline-finalized-comparison.ts';
+// prettier-ignore
+import type {
+  RtcBaselineFinalizedReaderDependencies,
+} from './rtc-baseline-finalized-artifact-reader.ts';
+
+// prettier-ignore
+export type {
+  RtcBaselineFinalizedReaderDependencies,
+} from './rtc-baseline-finalized-artifact-reader.ts';
 export type { RtcBaselineFinalizedArtifactValidation } from './rtc-baseline-evidence-layout.ts';
 export type {
   RtcBaselinePairedComparison,
   RtcBaselineRepeatRequirement,
   RtcBaselineVerifiedRepeatPrimary,
 } from './rtc-baseline-evidence-layout.ts';
-
-export interface RtcBaselineFinalizedReaderDependencies {
-  readJson(baselineId: string, path: string): Promise<RtcBaselineResult<RtcBaselineJson>>;
-  readBytes(baselineId: string, path: string): Promise<RtcBaselineResult<Uint8Array>>;
-  listArtifactPaths(baselineId: string): Promise<RtcBaselineResult<string[]>>;
-  sha256(bytes: Uint8Array): Promise<string>;
-}
 
 export interface RtcBaselineFinalizedReader {
   readExternalAttempts(input: {
@@ -91,345 +57,85 @@ export interface RtcBaselineFinalizedReader {
   ): Promise<RtcBaselineResult<RtcBaselinePairedComparison>>;
 }
 
-const issue = (path: string, code: string, message: string): RtcBaselineIssueDto => ({
-  path,
-  code,
-  message,
-});
 function failed(path: string, code: string, message: string): RtcBaselineResult<never> {
-  return { ok: false, issues: [issue(path, code, message)] };
+  return { ok: false, issues: [{ path, code, message }] };
 }
+
+async function readBaselineValidation(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+  input: RtcBaselineReaderInput,
+): Promise<RtcBaselineResult<RtcBaselineFinalizedArtifactValidation>> {
+  const verified = await verifier.readVerifiedArtifacts(input.baselineId);
+  if (!verified.ok) {
+    return verified;
+  }
+  const linked = await verifier.validateRepeatLink(input.baselineId, verified.value.summary);
+  return linked.ok ? { ok: true, value: verified.value.validation } : linked;
+}
+
+async function readVerifiedRepeatPrimary(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+  input: RtcBaselineReaderInput,
+): Promise<RtcBaselineResult<RtcBaselineVerifiedRepeatPrimary>> {
+  const verified = await verifier.readVerifiedArtifacts(input.baselineId);
+  if (!verified.ok) {
+    return verified;
+  }
+  if (
+    input.baselineId.endsWith('-repeat-01') ||
+    verified.value.environment.repeatLink !== null ||
+    verified.value.manifest.repeatLink !== null
+  ) {
+    return failed(
+      '$.baselineId',
+      'invalid-repeat-primary',
+      'A repeat primary must be an unlinked non-repeat finalized baseline.',
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      environment: verified.value.environment,
+      manifest: verified.value.manifest,
+      summarySha256: verified.value.summarySha256,
+      triggeredWorkloadIds: rtcBaselineTriggeredWorkloads(verified.value),
+    },
+  };
+}
+
+async function readRepeatRequirement(
+  verifier: RtcBaselineFinalizedArtifactVerifier,
+  input: RtcBaselineReaderInput,
+): Promise<RtcBaselineResult<RtcBaselineRepeatRequirement>> {
+  const verified = await verifier.readVerifiedArtifacts(input.baselineId);
+  if (!verified.ok) {
+    return verified;
+  }
+  const linked = await verifier.validateRepeatLink(input.baselineId, verified.value.summary);
+  if (!linked.ok) {
+    return linked;
+  }
+  const workloadIds = rtcBaselineTriggeredWorkloads(verified.value);
+  if (verified.value.summary.repeatLink !== null && workloadIds.length > 0) {
+    return failed(
+      '$.metricSummaries',
+      'repeat-still-noisy',
+      'Controlled repeat remains above its coefficient-of-variation threshold.',
+    );
+  }
+  return { ok: true, value: { workloadIds } };
+}
+
 export function createRtcBaselineFinalizedReader(
   dependencies: RtcBaselineFinalizedReaderDependencies,
 ): RtcBaselineFinalizedReader {
-  async function readRtcBaselineVerifiedStoredArtifact(
-    baselineId: string,
-    relativePath: string,
-    expectedSha256: string,
-  ): Promise<RtcBaselineResult<RtcBaselineVerifiedStoredArtifact>> {
-    const bytes = await dependencies.readBytes(baselineId, relativePath);
-    if (!bytes.ok) return bytes;
-    if ((await dependencies.sha256(bytes.value)) !== expectedSha256)
-      return failed(
-        `$.${relativePath}`,
-        'checksum-mismatch',
-        'Stored bytes do not match the SHA-256 checksum.',
-      );
-    return inspectRtcBaselineStoredArtifactBytes({ relativePath, bytes: bytes.value });
-  }
-  async function validateRtcBaselineVerifiedRepeatLink(
-    baselineId: string,
-    summary: RtcBaselineSummaryArtifactRecord,
-  ): Promise<RtcBaselineResult<void>> {
-    const identity = validateRtcBaselineRepeatLinkIdentity(baselineId, summary.repeatLink);
-    if (!identity.ok || summary.repeatLink === null) return identity;
-    const primaryId = summary.repeatLink.primaryBaselineId;
-    const checksumBytes = await dependencies.readBytes(primaryId, RTC_BASELINE_CHECKSUM_FILE);
-    if (!checksumBytes.ok) return checksumBytes;
-    const checksums = inspectRtcBaselineChecksumEntries(checksumBytes.value);
-    if (checksums.issues.length > 0) return { ok: false, issues: checksums.issues };
-    const checksum = validateRtcBaselineRepeatPrimaryDigest({
-      summary,
-      sha256: checksums.entries.get(RTC_BASELINE_SUMMARY_FILE) ?? '',
-      source: 'checksum',
-    });
-    if (!checksum.ok) return checksum;
-    const primaryBytes = await dependencies.readBytes(primaryId, RTC_BASELINE_SUMMARY_FILE);
-    if (!primaryBytes.ok) return primaryBytes;
-    return validateRtcBaselineRepeatPrimaryDigest({
-      summary,
-      sha256: await dependencies.sha256(primaryBytes.value),
-      source: 'summary-bytes',
-    });
-  }
-  const validateRepeatLink = validateRtcBaselineVerifiedRepeatLink;
-  const readExternalAttempts = createRtcBaselineExternalAttemptReader(dependencies.readJson);
-  async function readVerifiedArtifacts(
-    input: RtcBaselineReaderInput,
-  ): Promise<RtcBaselineResult<RtcBaselineVerifiedArtifacts>> {
-    const checksumBytes = await dependencies.readBytes(input.baselineId, 'SHA256SUMS');
-    if (!checksumBytes.ok) return checksumBytes;
-    const listed = await dependencies.listArtifactPaths(input.baselineId);
-    if (!listed.ok) return listed;
-    const retainedPaths = [...listed.value].sort();
-    const { entries, issues } = inspectRtcBaselineChecksumEntries(checksumBytes.value);
-    let environment: RtcBaselineEnvironmentDto | undefined;
-    let manifest: RtcBaselineCaptureManifestDto | undefined;
-    let summary: RtcBaselineSummaryArtifactRecord | undefined;
-    const cohorts: RtcBaselineExternalCohortDto[] = [];
-    const failures: RtcBaselineFailureOutcomeArtifact[] = [];
-    const retained = new Map<string, RtcBaselineSampleDto>();
-    const retain = (sample: RtcBaselineSampleDto) => {
-      const existing = retained.get(sample.identity.sampleId);
-      if (existing && JSON.stringify(existing) !== JSON.stringify(sample))
-        issues.push(issue('$.samples', 'conflicting-sample', 'Duplicate sample bodies differ.'));
-      else retained.set(sample.identity.sampleId, sample);
-    };
-    issues.push(...validateRtcBaselineChecksumMembership(retainedPaths, entries));
-    for (const path of retainedPaths) {
-      const expected = entries.get(path);
-      if (!expected) continue;
-      const stored = await readRtcBaselineVerifiedStoredArtifact(input.baselineId, path, expected);
-      if (!stored.ok) issues.push(...stored.issues);
-      else if (stored.value.kind && stored.value.json !== null) {
-        const decoded = decodeRtcBaselineStoredJson(stored.value.kind, stored.value.json);
-        if (!decoded.ok) issues.push(...decoded.issues);
-        else {
-          issues.push(...validateRtcBaselineStoredArtifact(decoded.value));
-          if (decoded.value.schema === 'rallar.rtc-baseline.environment.v1')
-            environment = decoded.value;
-          if (decoded.value.schema === 'rallar.rtc-baseline.manifest.v1') manifest = decoded.value;
-          if (decoded.value.schema === 'rallar.rtc-baseline.summary.v1') summary = decoded.value;
-          if (decoded.value.schema === 'rallar.rtc-baseline.sample.v1') retain(decoded.value);
-          if (
-            decoded.value.schema === 'rallar.rtc-baseline.external-attempt.v1' ||
-            decoded.value.schema === 'rallar.rtc-baseline.external-cohort.v1'
-          )
-            decoded.value.samples.forEach(retain);
-          if (decoded.value.schema === 'rallar.rtc-baseline.external-cohort.v1')
-            cohorts.push(decoded.value);
-        }
-      } else if (classifyRtcBaselineArtifactPath(path) === 'failure-outcome') {
-        const decoded = decodeRtcBaselineFailureOutcome(stored.value.json, path);
-        if (decoded.ok) failures.push(decoded.value);
-        else issues.push(...decoded.issues);
-      }
-    }
-    const samples = [...retained.values()];
-    if (manifest && summary) {
-      issues.push(
-        ...validateRtcBaselineCompleteAccounting({
-          expectedSamples: computeRtcBaselineExpectedSampleIdentities(manifest),
-          expectedCohorts: manifest.expectedCohorts,
-          sampleOutcomes: summary.sampleOutcomes,
-          cohortOutcomes: summary.cohortOutcomes,
-        }),
-      );
-      const partitioned = partitionRtcBaselineMetricObservations(
-        computeRtcBaselineMetricObservations(samples, manifest.request.environmentId),
-      );
-      if (!partitioned.ok) issues.push(...partitioned.issues);
-      else {
-        const expected = summarizeRtcBaselineMetricPartitions(partitioned.value);
-        issues.push(
-          ...validateRtcBaselinePersistedMetricSummaries(expected, summary.metricSummaries),
-        );
-      }
-      issues.push(
-        ...validateRtcBaselineStoredOutcomeReconciliation({
-          sampleOutcomes: samples,
-          samples,
-          cohorts,
-          failures,
-          summary,
-        }),
-      );
-      issues.push(...validateRtcBaselinePassingSummary(summary));
-    }
-    if (environment && manifest && summary) {
-      issues.push(
-        ...validateRtcBaselineArtifactReconciliation({
-          baselineId: input.baselineId,
-          environment,
-          manifest,
-          summary,
-        }),
-      );
-    }
-    if (environment)
-      issues.push(
-        ...validateRtcBaselineRetainedSampleObservations(environment.observation, samples),
-      );
-    if (summary) {
-      issues.push(
-        ...validateRtcBaselineRawArtifactMembership({
-          retainedArtifactPaths: retainedPaths,
-          rawReferencePaths: summary.rawReferences.map((reference) => reference.relativePath),
-        }),
-        ...validateRtcBaselineRawArtifactIntegrity({
-          rawReferences: summary.rawReferences,
-          checksumEntries: entries,
-        }),
-      );
-    }
-    if (issues.length > 0) return { ok: false as const, issues };
-    const summarySha256 = entries.get('summary.json');
-    if (!environment || !manifest || !summary || !summarySha256)
-      return failed(
-        '$.retainedArtifactPaths',
-        'missing-finalized-artifact',
-        'Environment, manifest, summary, and summary checksum are required.',
-      );
-    return {
-      ok: true,
-      value: {
-        environment,
-        manifest,
-        summary,
-        summarySha256,
-        validation: {
-          baselineId: input.baselineId,
-          retainedArtifactPaths: retainedPaths,
-          checksumEntryCount: entries.size,
-        },
-      },
-    };
-  }
-  async function readBaselineValidation(input: RtcBaselineReaderInput) {
-    const verified = await readVerifiedArtifacts(input);
-    if (!verified.ok) return verified;
-    const linked = await validateRepeatLink(input.baselineId, verified.value.summary);
-    return linked.ok ? { ok: true as const, value: verified.value.validation } : linked;
-  }
-  async function readVerifiedRepeatPrimary(
-    input: RtcBaselineReaderInput,
-  ): Promise<RtcBaselineResult<RtcBaselineVerifiedRepeatPrimary>> {
-    const verified = await readVerifiedArtifacts(input);
-    if (!verified.ok) return verified;
-    if (
-      input.baselineId.endsWith('-repeat-01') ||
-      verified.value.environment.repeatLink !== null ||
-      verified.value.manifest.repeatLink !== null
-    )
-      return failed(
-        '$.baselineId',
-        'invalid-repeat-primary',
-        'A repeat primary must be an unlinked non-repeat finalized baseline.',
-      );
-    return {
-      ok: true as const,
-      value: {
-        environment: verified.value.environment,
-        manifest: verified.value.manifest,
-        summarySha256: verified.value.summarySha256,
-        triggeredWorkloadIds: rtcBaselineTriggeredWorkloads(verified.value),
-      },
-    };
-  }
-  async function readRepeatRequirement(
-    input: RtcBaselineReaderInput,
-  ): Promise<RtcBaselineResult<RtcBaselineRepeatRequirement>> {
-    const validated = await readVerifiedArtifacts(input);
-    if (!validated.ok) return validated;
-    const summary = validated.value.summary;
-    const linked = await validateRepeatLink(input.baselineId, summary);
-    if (!linked.ok) return linked;
-    const workloadIds = rtcBaselineTriggeredWorkloads(validated.value);
-    if (summary.repeatLink !== null && workloadIds.length > 0)
-      return failed(
-        '$.metricSummaries',
-        'repeat-still-noisy',
-        'Controlled repeat remains above its coefficient-of-variation threshold.',
-      );
-    return { ok: true as const, value: { workloadIds } };
-  }
-  async function comparisonChoice(input: RtcBaselineComparisonChoiceInput) {
-    const { primaryBaselineId, comparisonBaselineId, inputPath, workloadId } = input;
-    const primary = await readVerifiedArtifacts({ baselineId: primaryBaselineId });
-    if (!primary.ok) return primary;
-    const repeatRequired = rtcBaselineTriggeredWorkloads(primary.value).includes(workloadId);
-    const selectedId = repeatRequired ? `${primaryBaselineId}-repeat-01` : primaryBaselineId;
-    if (comparisonBaselineId !== selectedId) {
-      return failed(
-        inputPath,
-        'invalid-comparison-baseline',
-        repeatRequired
-          ? 'A noisy primary requires its exact -repeat-01 baseline.'
-          : 'A stable primary must compare from itself.',
-      );
-    }
-    const selected =
-      selectedId === primaryBaselineId
-        ? primary
-        : await readVerifiedArtifacts({ baselineId: selectedId });
-    if (!selected.ok) return selected;
-    const linked = await validateRepeatLink(selectedId, selected.value.summary);
-    if (!linked.ok) return linked;
-    const context = primary.value.environment.observation?.host.executionContext;
-    const repeatEvaluation =
-      context === undefined
-        ? { ok: true as const, value: { repeatRequired: false, stillNoisy: false } }
-        : evaluateRtcBaselineWorkloadRepeatOutcome({
-            primaryMetrics: primary.value.summary.metricSummaries,
-            repeatMetrics: selected.value.summary.metricSummaries,
-            workloadId,
-            executionContext: context,
-          });
-    if (!repeatEvaluation.ok) return repeatEvaluation;
-    const environment = selected.value.environment;
-    if (environment.observation === null)
-      return failed(
-        '$.environment.observation',
-        'missing-runtime-observation',
-        'Comparison baselines require a runtime observation.',
-      );
-    return {
-      ok: true as const,
-      value: {
-        primary: primary.value.summary,
-        selected: selected.value.summary,
-        selectedId,
-        repeatRequired,
-        stillNoisy: repeatEvaluation.value.stillNoisy,
-        environment: { ...environment, observation: environment.observation },
-      },
-    };
-  }
-  async function readPairedComparison(
-    input: RtcBaselinePairedComparisonInput,
-  ): Promise<RtcBaselineResult<RtcBaselinePairedComparison>> {
-    const primary = await comparisonChoice({
-      primaryBaselineId: input.primaryBaselineId,
-      comparisonBaselineId: input.primaryComparisonCohortId,
-      inputPath: '$.primaryComparisonCohortId',
-      workloadId: input.workloadId,
-    });
-    if (!primary.ok) return primary;
-    const candidate = await comparisonChoice({
-      primaryBaselineId: input.candidateBaselineId,
-      comparisonBaselineId: input.candidateComparisonCohortId,
-      inputPath: '$.candidateComparisonCohortId',
-      workloadId: input.workloadId,
-    });
-    if (!candidate.ok) return candidate;
-    const compared = compareRtcBaselinePersistedMetrics({
-      baselineEnvironment: primary.value.environment,
-      candidateEnvironment: candidate.value.environment,
-      baselineMetrics: primary.value.selected.metricSummaries,
-      candidateMetrics: candidate.value.selected.metricSummaries,
-      workloadId: input.workloadId,
-    });
-    if (!compared.ok) return compared;
-    const value = {
-      primary: {
-        primaryBaselineId: input.primaryBaselineId,
-        comparisonBaselineId: primary.value.selectedId,
-        repeatRequired: primary.value.repeatRequired,
-      },
-      candidate: {
-        primaryBaselineId: input.candidateBaselineId,
-        comparisonBaselineId: candidate.value.selectedId,
-        repeatRequired: candidate.value.repeatRequired,
-      },
-      comparisons: compared.value,
-    };
-    const stillNoisy = primary.value.stillNoisy || candidate.value.stillNoisy;
-    return stillNoisy
-      ? {
-          ok: true as const,
-          value: {
-            outcome: 'inconclusive-still-noisy' as const,
-            ...value,
-            issues: [issue('$.comparisons', 'repeat-still-noisy', 'Selected repeat is noisy.')],
-          },
-        }
-      : { ok: true as const, value: { outcome: 'conclusive' as const, ...value } };
-  }
+  const verifier = createRtcBaselineFinalizedArtifactVerifier(dependencies);
+  const comparisonReader = createRtcBaselineFinalizedComparisonReader(verifier);
   return {
-    readExternalAttempts,
-    readBaselineValidation,
-    readVerifiedRepeatPrimary,
-    readRepeatRequirement,
-    readPairedComparison,
+    readExternalAttempts: createRtcBaselineExternalAttemptReader(dependencies.readJson),
+    readBaselineValidation: (input) => readBaselineValidation(verifier, input),
+    readVerifiedRepeatPrimary: (input) => readVerifiedRepeatPrimary(verifier, input),
+    readRepeatRequirement: (input) => readRepeatRequirement(verifier, input),
+    readPairedComparison: comparisonReader.readPairedComparison,
   };
 }

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-verification.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-verification.ts
@@ -1,0 +1,193 @@
+// prettier-ignore
+import { computeRtcBaselineExpectedSampleIdentities } from
+  '../catalog/rtc-baseline-workload-manifest.ts';
+import type { RtcBaselineResult } from '../contracts/rtc-baseline-contracts.ts';
+import {
+  validateRtcBaselineArtifactReconciliation,
+  validateRtcBaselineCompleteAccounting,
+  validateRtcBaselinePassingSummary,
+} from '../contracts/rtc-baseline-artifact-validation.ts';
+import {
+  inspectRtcBaselineChecksumEntries,
+  RTC_BASELINE_CHECKSUM_FILE,
+  RTC_BASELINE_SUMMARY_FILE,
+  type RtcBaselineSummaryArtifactRecord,
+  type RtcBaselineVerifiedArtifacts,
+  validateRtcBaselineRawArtifactIntegrity,
+  validateRtcBaselineRawArtifactMembership,
+  validateRtcBaselineRepeatLinkIdentity,
+  validateRtcBaselineRepeatPrimaryDigest,
+} from './rtc-baseline-evidence-layout.ts';
+import {
+  partitionRtcBaselineMetricObservations,
+  summarizeRtcBaselineMetricPartitions,
+  validateRtcBaselinePersistedMetricSummaries,
+} from './rtc-baseline-statistics.ts';
+import {
+  createRtcBaselineFinalizedArtifactReader,
+  type RtcBaselineFinalizedReaderDependencies,
+  type RtcBaselineReadFinalizedArtifacts,
+} from './rtc-baseline-finalized-artifact-reader.ts';
+// prettier-ignore
+import {
+  validateRtcBaselineArtifactOutcomeReconciliation,
+} from './rtc-baseline-artifact-projection.ts';
+
+export interface RtcBaselineFinalizedArtifactVerifier {
+  readVerifiedArtifacts(
+    baselineId: string,
+  ): Promise<RtcBaselineResult<RtcBaselineVerifiedArtifacts>>;
+  validateRepeatLink(
+    baselineId: string,
+    summary: RtcBaselineSummaryArtifactRecord,
+  ): Promise<RtcBaselineResult<void>>;
+}
+
+function failed(path: string, code: string, message: string): RtcBaselineResult<never> {
+  return { ok: false, issues: [{ path, code, message }] };
+}
+
+function validateProjectedArtifacts(value: RtcBaselineReadFinalizedArtifacts): void {
+  if (!value.manifest || !value.summary || !value.projection) {
+    return;
+  }
+  value.issues.push(
+    ...validateRtcBaselineCompleteAccounting({
+      expectedSamples: computeRtcBaselineExpectedSampleIdentities(value.manifest),
+      expectedCohorts: value.manifest.expectedCohorts,
+      sampleOutcomes: value.summary.sampleOutcomes,
+      cohortOutcomes: value.summary.cohortOutcomes,
+    }),
+  );
+  const partitioned = partitionRtcBaselineMetricObservations(value.projection.metricObservations);
+  if (!partitioned.ok) {
+    value.issues.push(...partitioned.issues);
+  } else {
+    const expected = summarizeRtcBaselineMetricPartitions(partitioned.value);
+    value.issues.push(
+      ...validateRtcBaselinePersistedMetricSummaries(expected, value.summary.metricSummaries),
+    );
+  }
+  value.issues.push(
+    ...validateRtcBaselineArtifactOutcomeReconciliation({
+      sampleOutcomes: value.projection.sampleOutcomes,
+      rawReferences: value.projection.rawReferences,
+      cohorts: value.projection.cohortOutcomes,
+      failures: value.projection.failures,
+      summary: value.summary,
+    }),
+    ...validateRtcBaselinePassingSummary(value.summary),
+  );
+}
+
+function validateArtifactSet(baselineId: string, value: RtcBaselineReadFinalizedArtifacts): void {
+  if (value.environment && value.manifest && value.summary) {
+    value.issues.push(
+      ...validateRtcBaselineArtifactReconciliation({
+        baselineId,
+        environment: value.environment,
+        manifest: value.manifest,
+        summary: value.summary,
+      }),
+    );
+  }
+  if (value.summary) {
+    value.issues.push(
+      ...validateRtcBaselineRawArtifactMembership({
+        retainedArtifactPaths: [...value.retainedPaths],
+        rawReferencePaths: value.summary.rawReferences.map((reference) => reference.relativePath),
+      }),
+      ...validateRtcBaselineRawArtifactIntegrity({
+        rawReferences: value.summary.rawReferences,
+        checksumEntries: value.checksumEntries,
+      }),
+    );
+  }
+}
+
+function toVerifiedArtifacts(
+  baselineId: string,
+  value: RtcBaselineReadFinalizedArtifacts,
+): RtcBaselineResult<RtcBaselineVerifiedArtifacts> {
+  if (value.issues.length > 0) {
+    return { ok: false, issues: value.issues };
+  }
+  const summarySha256 = value.checksumEntries.get(RTC_BASELINE_SUMMARY_FILE);
+  if (!value.environment || !value.manifest || !value.summary || !summarySha256) {
+    return failed(
+      '$.retainedArtifactPaths',
+      'missing-finalized-artifact',
+      'Environment, manifest, summary, and summary checksum are required.',
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      environment: value.environment,
+      manifest: value.manifest,
+      summary: value.summary,
+      summarySha256,
+      validation: {
+        baselineId,
+        retainedArtifactPaths: [...value.retainedPaths],
+        checksumEntryCount: value.checksumEntries.size,
+      },
+    },
+  };
+}
+
+async function validateRepeatLink(
+  dependencies: RtcBaselineFinalizedReaderDependencies,
+  baselineId: string,
+  summary: RtcBaselineSummaryArtifactRecord,
+): Promise<RtcBaselineResult<void>> {
+  const identity = validateRtcBaselineRepeatLinkIdentity(baselineId, summary.repeatLink);
+  if (!identity.ok || summary.repeatLink === null) {
+    return identity;
+  }
+  const primaryId = summary.repeatLink.primaryBaselineId;
+  const checksumBytes = await dependencies.readBytes(primaryId, RTC_BASELINE_CHECKSUM_FILE);
+  if (!checksumBytes.ok) {
+    return checksumBytes;
+  }
+  const checksums = inspectRtcBaselineChecksumEntries(checksumBytes.value);
+  if (checksums.issues.length > 0) {
+    return { ok: false, issues: checksums.issues };
+  }
+  const checksum = validateRtcBaselineRepeatPrimaryDigest({
+    summary,
+    sha256: checksums.entries.get(RTC_BASELINE_SUMMARY_FILE) ?? '',
+    source: 'checksum',
+  });
+  if (!checksum.ok) {
+    return checksum;
+  }
+  const primaryBytes = await dependencies.readBytes(primaryId, RTC_BASELINE_SUMMARY_FILE);
+  if (!primaryBytes.ok) {
+    return primaryBytes;
+  }
+  return validateRtcBaselineRepeatPrimaryDigest({
+    summary,
+    sha256: await dependencies.sha256(primaryBytes.value),
+    source: 'summary-bytes',
+  });
+}
+
+export function createRtcBaselineFinalizedArtifactVerifier(
+  dependencies: RtcBaselineFinalizedReaderDependencies,
+): RtcBaselineFinalizedArtifactVerifier {
+  const artifactReader = createRtcBaselineFinalizedArtifactReader(dependencies);
+  return {
+    async readVerifiedArtifacts(baselineId) {
+      const read = await artifactReader.read(baselineId);
+      if (!read.ok) {
+        return read;
+      }
+      validateProjectedArtifacts(read.value);
+      validateArtifactSet(baselineId, read.value);
+      return toVerifiedArtifacts(baselineId, read.value);
+    },
+    validateRepeatLink: (baselineId, summary) =>
+      validateRepeatLink(dependencies, baselineId, summary),
+  };
+}

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-adapters.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-adapters.ts
@@ -4,6 +4,9 @@ import type {
   RtcBaselineRuntimeObservationDto,
 } from '../contracts/rtc-baseline-contracts.ts';
 import type { RtcBaselineFilePort } from '../evidence/rtc-baseline-evidence-store.ts';
+import { createRtcBaselineDenoFilePort } from './rtc-baseline-deno-file-port.ts';
+import type { RtcBaselineDenoPort } from './rtc-baseline-deno-port.ts';
+export type { RtcBaselineDenoPort } from './rtc-baseline-deno-port.ts';
 
 interface CommandInput {
   executable: string;
@@ -13,41 +16,6 @@ export interface RtcBaselineCommandOutput {
   exitStatus: number;
   stdout: string;
   stderr: string;
-}
-interface RuntimeFileInfo {
-  isFile: boolean;
-  isDirectory: boolean;
-  isSymlink: boolean;
-}
-interface RuntimeDirectoryEntry extends RuntimeFileInfo {
-  name: string;
-}
-interface RuntimeErrorConstructor {
-  new (...args: string[]): Error;
-}
-export interface RtcBaselineDenoPort {
-  envGet(name: string): string | undefined;
-  build: { os: string; arch: string };
-  version: { deno: string };
-  lstat(path: string): Promise<RuntimeFileInfo>;
-  mkdir(path: string, options: { recursive: boolean }): Promise<void>;
-  readFile(path: string): Promise<Uint8Array>;
-  writeFile(path: string, bytes: Uint8Array, options: { createNew: boolean }): Promise<void>;
-  remove(path: string, options: { recursive: boolean }): Promise<void>;
-  readDir(path: string): AsyncIterable<RuntimeDirectoryEntry>;
-  command(
-    executable: string,
-    arguments_: readonly string[],
-  ): Promise<{ code: number; stdout: Uint8Array; stderr: Uint8Array }>;
-  now(): Date;
-  performanceNow(): number;
-  systemMemoryInfo(): { total: number };
-  availableParallelism(): number;
-  errors?: {
-    NotFound?: RuntimeErrorConstructor;
-    AlreadyExists?: RuntimeErrorConstructor;
-    PermissionDenied?: RuntimeErrorConstructor;
-  };
 }
 interface ProcessPort {
   run(input: CommandInput): Promise<RtcBaselineResult<RtcBaselineCommandOutput>>;
@@ -109,7 +77,9 @@ export function createDenoRtcBaselineAdapters(
         stdout: decoder.decode(output.stdout),
         stderr: decoder.decode(output.stderr),
       };
-      if (output.code === 0) return { ok: true, value };
+      if (output.code === 0) {
+        return { ok: true, value };
+      }
       return {
         ok: false,
         issues: [
@@ -136,67 +106,27 @@ export function createDenoRtcBaselineAdapters(
     trim: boolean,
   ): Promise<RtcBaselineResult<string>> {
     const result = await run({ executable: 'git', arguments: arguments_ });
-    if (!result.ok) return result;
+    if (!result.ok) {
+      return result;
+    }
     return { ok: true, value: trim ? result.value.stdout.trim() : result.value.stdout };
   }
 
-  const filePort = {
-    async inspectPath(path: string) {
-      try {
-        const value = await runtime.lstat(path);
-        if (value.isSymlink) return { kind: 'symlink' as const };
-        if (value.isDirectory) return { kind: 'directory' as const };
-        if (value.isFile) return { kind: 'file' as const };
-        return { kind: 'other' as const };
-      } catch (error) {
-        const NotFound = runtime.errors?.NotFound;
-        if (NotFound && error instanceof NotFound) return null;
-        throw error;
-      }
-    },
-    createDirectory: (path: string, options: { recursive: boolean }) =>
-      runtime.mkdir(path, options),
-    writeFileCreateNew: (path: string, bytes: Uint8Array) =>
-      runtime.writeFile(path, bytes, { createNew: true }),
-    readFile: (path: string) => runtime.readFile(path),
-    removeFile: (path: string) => runtime.remove(path, { recursive: false }),
-    removeDirectory: (path: string) => runtime.remove(path, { recursive: true }),
-    classifyError(error: Error) {
-      if (runtime.errors?.AlreadyExists && error instanceof runtime.errors.AlreadyExists) {
-        return 'already-exists' as const;
-      }
-      if (runtime.errors?.PermissionDenied && error instanceof runtime.errors.PermissionDenied) {
-        return 'permission-denied' as const;
-      }
-      return 'other' as const;
-    },
-    async listDirectory(path: string) {
-      const entries = [];
-      for await (const entry of runtime.readDir(path)) {
-        entries.push({
-          name: entry.name,
-          kind: entry.isSymlink
-            ? ('symlink' as const)
-            : entry.isDirectory
-              ? ('directory' as const)
-              : entry.isFile
-                ? ('file' as const)
-                : ('other' as const),
-        });
-      }
-      return entries;
-    },
-  };
+  const filePort = createRtcBaselineDenoFilePort(runtime);
 
   async function sha256(bytes: Uint8Array) {
-    const copy = new Uint8Array(bytes.byteLength);
-    copy.set(bytes);
-    return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256', copy.buffer)));
+    const digestInput =
+      bytes.buffer instanceof ArrayBuffer
+        ? new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+        : new Uint8Array(bytes);
+    return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256', digestInput)));
   }
 
   async function readGitRef() {
     const symbolic = await gitValue(['symbolic-ref', '--short', '-q', 'HEAD'], true);
-    if (symbolic.ok) return symbolic;
+    if (symbolic.ok) {
+      return symbolic;
+    }
     const details = symbolic.issues[0]?.details;
     if (
       typeof details !== 'object' ||
@@ -222,7 +152,9 @@ export function createDenoRtcBaselineAdapters(
         const values: Record<string, string> = {};
         for (const name of names) {
           const value = runtime.envGet(name);
-          if (value !== undefined) values[name] = value;
+          if (value !== undefined) {
+            values[name] = value;
+          }
         }
         return values;
       },
@@ -230,18 +162,24 @@ export function createDenoRtcBaselineAdapters(
     runtimeHost: {
       async read() {
         const kernel = await run({ executable: 'uname', arguments: ['-r'] });
-        if (!kernel.ok) throw new Error(kernel.issues[0]!.message);
+        if (!kernel.ok) {
+          throw new Error(kernel.issues[0]!.message);
+        }
         let cpuModel: string;
         if (runtime.build.os === 'linux') {
           const cpuInfo = decoder.decode(await runtime.readFile('/proc/cpuinfo'));
           cpuModel = /^model name\s*:\s*(.+)$/m.exec(cpuInfo)?.[1]?.trim() ?? '';
-          if (cpuModel.length === 0) throw new Error('Linux CPU model is unavailable.');
+          if (cpuModel.length === 0) {
+            throw new Error('Linux CPU model is unavailable.');
+          }
         } else {
           const cpu = await run({
             executable: 'sysctl',
             arguments: ['-n', 'machdep.cpu.brand_string'],
           });
-          if (!cpu.ok) throw new Error(cpu.issues[0]!.message);
+          if (!cpu.ok) {
+            throw new Error(cpu.issues[0]!.message);
+          }
           cpuModel = cpu.value.stdout.trim();
         }
         return {

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-file-port.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-file-port.ts
@@ -1,0 +1,56 @@
+import type { RtcBaselineFilePort } from '../evidence/rtc-baseline-evidence-store.ts';
+import type { RtcBaselineDenoPort } from './rtc-baseline-deno-port.ts';
+
+export function createRtcBaselineDenoFilePort(runtime: RtcBaselineDenoPort): RtcBaselineFilePort {
+  return {
+    async inspectPath(path: string) {
+      try {
+        const value = await runtime.lstat(path);
+        if (value.isSymlink) {
+          return { kind: 'symlink' as const };
+        }
+        if (value.isDirectory) {
+          return { kind: 'directory' as const };
+        }
+        if (value.isFile) {
+          return { kind: 'file' as const };
+        }
+        return { kind: 'other' as const };
+      } catch (error) {
+        const NotFound = runtime.errors?.NotFound;
+        if (NotFound && error instanceof NotFound) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    createDirectory: (path, options) => runtime.mkdir(path, options),
+    writeFileCreateNew: (path, bytes) => runtime.writeFile(path, bytes, { createNew: true }),
+    readFile: (path) => runtime.readFile(path),
+    removeFile: (path) => runtime.remove(path, { recursive: false }),
+    removeDirectory: (path) => runtime.remove(path, { recursive: true }),
+    classifyError(error) {
+      if (runtime.errors?.AlreadyExists && error instanceof runtime.errors.AlreadyExists) {
+        return 'already-exists';
+      }
+      if (runtime.errors?.PermissionDenied && error instanceof runtime.errors.PermissionDenied) {
+        return 'permission-denied';
+      }
+      return 'other';
+    },
+    async listDirectory(path) {
+      const entries = [];
+      for await (const entry of runtime.readDir(path)) {
+        const kind = entry.isSymlink
+          ? ('symlink' as const)
+          : entry.isDirectory
+            ? ('directory' as const)
+            : entry.isFile
+              ? ('file' as const)
+              : ('other' as const);
+        entries.push({ name: entry.name, kind });
+      }
+      return entries;
+    },
+  };
+}

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-finalization.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-finalization.ts
@@ -1,39 +1,29 @@
+import { decodeRtcBaselineStoredJson } from '../contracts/rtc-baseline-artifact-decoding.ts';
 import {
-  decodeRtcBaselineExternalAttempt,
-  decodeRtcBaselineExternalCohort,
-  decodeRtcBaselineFinalizationFailure,
-  decodeRtcBaselineSample,
-} from '../contracts/rtc-baseline-artifact-decoding.ts';
-import {
-  isRtcBaselineExternalAttemptDto,
-  isRtcBaselineExternalCohortDto,
-  isRtcBaselineFinalizationFailureDto,
-  isRtcBaselineSampleDto,
   rtcBaselineIssue,
   type RtcBaselineJson,
   type RtcBaselineResult,
 } from '../contracts/rtc-baseline-contracts.ts';
 import {
-  validateRtcBaselineCompleteAccounting,
-  validateRtcBaselineReconciliation,
-} from '../contracts/rtc-baseline-artifact-validation.ts';
-import { requireRtcBaselineDecodedType } from '../contracts/rtc-baseline-decoding.ts';
-// prettier-ignore
-import { computeRtcBaselineExpectedSampleIdentities } from
-  '../catalog/rtc-baseline-workload-manifest.ts';
-import {
   decodeRtcBaselineFailureOutcome,
-  isRtcBaselineSampleFailureOutcomeArtifact,
   resolveRtcBaselineAcceptedArtifactPath,
 } from '../acceptance/rtc-baseline-failure-accounting.ts';
-import { classifyRtcBaselineArtifactPath } from '../evidence/rtc-baseline-evidence-layout.ts';
+import {
+  classifyRtcBaselineArtifactPath,
+  type RtcBaselineArtifactKind,
+} from '../evidence/rtc-baseline-evidence-layout.ts';
 import type {
   RtcBaselineLockedWriter,
   RtcBaselineStoredFile,
 } from '../evidence/rtc-baseline-evidence-store.ts';
 import {
+  createRtcBaselineArtifactProjector,
+  type RtcBaselineArtifactProjection,
+  type RtcBaselineArtifactProjector,
+} from '../evidence/rtc-baseline-artifact-projection.ts';
+import {
   createRtcBaselineFinalizedEvidence,
-  type CollectedArtifacts,
+  type RtcBaselineCollectedArtifacts,
   type RtcBaselineFinalizationLockedWriter,
   type RtcBaselineFinalizedEvidence,
 } from '../evidence/rtc-baseline-finalized-evidence.ts';
@@ -47,23 +37,22 @@ import {
 } from '../evidence/rtc-baseline-statistics.ts';
 import type { RtcBaselineDenoEvidence } from './rtc-baseline-deno-evidence.ts';
 
-interface RtcBaselineResultArtifactCollection {
-  readonly sampleOutcomes: CollectedArtifacts['sampleOutcomes'][number][];
-  readonly externalAttempts: CollectedArtifacts['externalAttempts'][number][];
-  readonly cohortOutcomes: CollectedArtifacts['cohortOutcomes'][number][];
-  readonly samples: CollectedArtifacts['samples'][number][];
-  readonly failures: CollectedArtifacts['failures'][number][];
-}
-
 type RtcBaselineClassifiedArtifactKind = NonNullable<
   ReturnType<typeof classifyRtcBaselineArtifactPath>
 >;
 
 interface AppendRtcBaselineResultArtifactInput {
-  readonly collection: RtcBaselineResultArtifactCollection;
+  readonly projector: RtcBaselineArtifactProjector;
   readonly kind: RtcBaselineClassifiedArtifactKind;
   readonly artifactJson: RtcBaselineJson;
   readonly relativePath: string;
+}
+
+interface CollectRtcBaselineResultArtifactsInput {
+  readonly evidence: RtcBaselineDenoEvidence;
+  readonly baselineId: string;
+  readonly listedFiles: readonly RtcBaselineStoredFile[];
+  readonly projector: RtcBaselineArtifactProjector;
 }
 
 export interface RtcBaselineDenoFinalization {
@@ -84,157 +73,48 @@ function unsupportedArtifactPath(relativePath: string) {
   };
 }
 
-function appendUniqueSamples(
-  collection: RtcBaselineResultArtifactCollection,
-  incoming: readonly CollectedArtifacts['samples'][number][],
-) {
-  for (const sample of incoming) {
-    const existing = collection.samples.find(
-      (value) => value.identity.sampleId === sample.identity.sampleId,
-    );
-    if (existing && JSON.stringify(existing) !== JSON.stringify(sample)) {
-      return rtcBaselineIssue(
-        '$.samples',
-        'conflicting-sample-duplicate',
-        `Sample ${sample.identity.sampleId} has unequal accepted representations.`,
-      );
-    }
-    if (!existing) {
-      collection.samples.push(sample);
-      collection.sampleOutcomes.push({
-        identity: sample.identity,
-        outcome: sample.outcome,
-        issues: sample.issues,
-      });
-    }
-  }
-  return null;
-}
-
-function appendRtcBaselineSample(
-  collection: RtcBaselineResultArtifactCollection,
-  sampleJson: RtcBaselineJson,
-): RtcBaselineResult<void> {
-  const decoded = requireRtcBaselineDecodedType(
-    decodeRtcBaselineSample(sampleJson),
-    isRtcBaselineSampleDto,
+function isStoredResultArtifactKind(
+  kind: RtcBaselineClassifiedArtifactKind,
+): kind is RtcBaselineArtifactKind {
+  return (
+    kind === 'sample' ||
+    kind === 'external-attempt' ||
+    kind === 'external-cohort' ||
+    kind === 'finalization-failure'
   );
-  if (!decoded.ok) {
-    return decoded;
-  }
-  const duplicate = appendUniqueSamples(collection, [decoded.value]);
-  return duplicate ? { ok: false, issues: [duplicate] } : { ok: true, value: undefined };
 }
 
-function appendRtcBaselineExternalAttempt(
-  collection: RtcBaselineResultArtifactCollection,
-  attemptJson: RtcBaselineJson,
-): RtcBaselineResult<void> {
-  const decoded = requireRtcBaselineDecodedType(
-    decodeRtcBaselineExternalAttempt(attemptJson),
-    isRtcBaselineExternalAttemptDto,
-  );
-  if (!decoded.ok) {
-    return decoded;
-  }
-  collection.externalAttempts.push(decoded.value);
-  const duplicate = appendUniqueSamples(collection, decoded.value.samples);
-  return duplicate ? { ok: false, issues: [duplicate] } : { ok: true, value: undefined };
-}
-
-function appendRtcBaselineExternalCohort(
-  collection: RtcBaselineResultArtifactCollection,
-  cohortJson: RtcBaselineJson,
-): RtcBaselineResult<void> {
-  const decoded = requireRtcBaselineDecodedType(
-    decodeRtcBaselineExternalCohort(cohortJson),
-    isRtcBaselineExternalCohortDto,
-  );
-  if (!decoded.ok) {
-    return decoded;
-  }
-  collection.cohortOutcomes.push(decoded.value);
-  const duplicate = appendUniqueSamples(collection, decoded.value.samples);
-  return duplicate ? { ok: false, issues: [duplicate] } : { ok: true, value: undefined };
-}
-
-function appendRtcBaselineFailureOutcome(
-  collection: RtcBaselineResultArtifactCollection,
-  failureJson: RtcBaselineJson,
-  relativePath: string,
-): RtcBaselineResult<void> {
-  const decoded = decodeRtcBaselineFailureOutcome(failureJson, relativePath);
-  if (!decoded.ok) {
-    return decoded;
-  }
-  collection.failures.push(decoded.value);
-  if (isRtcBaselineSampleFailureOutcomeArtifact(decoded.value)) {
-    collection.sampleOutcomes.push(decoded.value);
-  }
-  return { ok: true, value: undefined };
-}
-
-function appendRtcBaselineResultArtifact(
+async function appendRtcBaselineResultArtifact(
   artifactInput: AppendRtcBaselineResultArtifactInput,
-): RtcBaselineResult<void> {
+): Promise<RtcBaselineResult<void>> {
   if (artifactInput.kind === 'failure-outcome') {
-    return appendRtcBaselineFailureOutcome(
-      artifactInput.collection,
+    const decoded = decodeRtcBaselineFailureOutcome(
       artifactInput.artifactJson,
       artifactInput.relativePath,
     );
+    return decoded.ok ? artifactInput.projector.appendFailureOutcome(decoded.value) : decoded;
   }
-  if (artifactInput.kind === 'sample') {
-    return appendRtcBaselineSample(artifactInput.collection, artifactInput.artifactJson);
+  if (!isStoredResultArtifactKind(artifactInput.kind)) {
+    return unsupportedArtifactPath(artifactInput.relativePath);
   }
-  if (artifactInput.kind === 'external-attempt') {
-    return appendRtcBaselineExternalAttempt(artifactInput.collection, artifactInput.artifactJson);
-  }
-  if (artifactInput.kind === 'external-cohort') {
-    return appendRtcBaselineExternalCohort(artifactInput.collection, artifactInput.artifactJson);
-  }
-  if (artifactInput.kind === 'finalization-failure') {
-    const decoded = requireRtcBaselineDecodedType(
-      decodeRtcBaselineFinalizationFailure(artifactInput.artifactJson),
-      isRtcBaselineFinalizationFailureDto,
-    );
-    return decoded.ok ? { ok: true, value: undefined } : decoded;
-  }
-  return {
-    ok: false,
-    issues: [
-      rtcBaselineIssue(
-        `$.${artifactInput.relativePath}`,
-        'unsupported-artifact-path',
-        'Unsupported.',
-      ),
-    ],
-  };
+  const decoded = decodeRtcBaselineStoredJson(artifactInput.kind, artifactInput.artifactJson);
+  return decoded.ok ? artifactInput.projector.appendStoredArtifact(decoded.value) : decoded;
 }
 
 async function collectRtcBaselineResultArtifacts(
-  evidence: RtcBaselineDenoEvidence,
-  baselineId: string,
-  listedFiles: readonly RtcBaselineStoredFile[],
-): Promise<RtcBaselineResult<RtcBaselineResultArtifactCollection>> {
-  const collection: RtcBaselineResultArtifactCollection = {
-    sampleOutcomes: [],
-    externalAttempts: [],
-    cohortOutcomes: [],
-    samples: [],
-    failures: [],
-  };
-  for (const listedFile of listedFiles) {
+  input: CollectRtcBaselineResultArtifactsInput,
+): Promise<RtcBaselineResult<RtcBaselineArtifactProjection>> {
+  for (const listedFile of input.listedFiles) {
     const kind = classifyRtcBaselineArtifactPath(listedFile.relativePath);
     if (kind === null) {
       return unsupportedArtifactPath(listedFile.relativePath);
     }
-    const artifact = await evidence.store.readJson(baselineId, listedFile.relativePath);
+    const artifact = await input.evidence.store.readJson(input.baselineId, listedFile.relativePath);
     if (!artifact.ok) {
       return artifact;
     }
-    const appended = appendRtcBaselineResultArtifact({
-      collection,
+    const appended = await appendRtcBaselineResultArtifact({
+      projector: input.projector,
       kind,
       artifactJson: artifact.value,
       relativePath: listedFile.relativePath,
@@ -243,29 +123,14 @@ async function collectRtcBaselineResultArtifacts(
       return appended;
     }
   }
-  return { ok: true, value: collection };
-}
-
-async function readRtcBaselineRetainedArtifacts(
-  evidence: RtcBaselineDenoEvidence,
-  baselineId: string,
-  relativePaths: readonly string[],
-): Promise<RtcBaselineResult<CollectedArtifacts['retainedArtifacts']>> {
-  const retainedArtifacts: CollectedArtifacts['retainedArtifacts'][number][] = [];
-  for (const relativePath of relativePaths) {
-    const bytes = await evidence.store.readBytes(baselineId, relativePath);
-    if (!bytes.ok) {
-      return bytes;
-    }
-    retainedArtifacts.push({ relativePath, bytes: bytes.value });
-  }
-  return { ok: true as const, value: retainedArtifacts };
+  return { ok: true, value: input.projector.getProjection() };
 }
 
 async function collectRtcBaselineArtifacts(
   evidence: RtcBaselineDenoEvidence,
+  sha256: (bytes: Uint8Array) => Promise<string>,
   baselineId: string,
-): Promise<RtcBaselineResult<CollectedArtifacts>> {
+): Promise<RtcBaselineResult<RtcBaselineCollectedArtifacts>> {
   const reconciliation = await evidence.reconcileAcceptedOperation('finalize', { baselineId });
   if (reconciliation.length > 0) {
     return { ok: false, issues: reconciliation };
@@ -289,17 +154,22 @@ async function collectRtcBaselineArtifacts(
   if (!listed.ok) {
     return listed;
   }
-  const collection = await collectRtcBaselineResultArtifacts(evidence, baselineId, listed.value);
-  if (!collection.ok) {
-    return collection;
-  }
-  const retained = await readRtcBaselineRetainedArtifacts(evidence, baselineId, [
-    'environment.json',
-    'manifest.json',
-    ...listed.value.map((entry) => entry.relativePath),
-  ]);
-  if (!retained.ok) {
-    return retained;
+  const projector = createRtcBaselineArtifactProjector({
+    environmentId: manifest.value.request.environmentId,
+    environmentObservation: observation,
+    conflictingSampleCode: 'conflicting-sample-duplicate',
+    conflictingSampleMessage: (sampleId) =>
+      `Sample ${sampleId} has unequal accepted representations.`,
+    sha256,
+  });
+  const projection = await collectRtcBaselineResultArtifacts({
+    evidence,
+    baselineId,
+    listedFiles: listed.value,
+    projector,
+  });
+  if (!projection.ok) {
+    return projection;
   }
   return {
     ok: true,
@@ -310,8 +180,12 @@ async function collectRtcBaselineArtifacts(
       environmentId: manifest.value.request.environmentId,
       repeatLink: manifest.value.repeatLink,
       conditionalEnvironmentDecisions: manifest.value.request.conditionalEnvironmentDecisions,
-      ...collection.value,
-      retainedArtifacts: retained.value,
+      retainedArtifactPaths: [
+        'environment.json',
+        'manifest.json',
+        ...listed.value.map((entry) => entry.relativePath),
+      ],
+      ...projection.value,
     },
   };
 }
@@ -383,26 +257,10 @@ export function createRtcBaselineDenoFinalization(
   const finalizedEvidence = createRtcBaselineFinalizedEvidence({
     withFinalizationLock: (baselineId, operation) =>
       withRtcBaselineFinalizationLock(evidence, baselineId, operation),
-    collectArtifacts: (baselineId) => collectRtcBaselineArtifacts(evidence, baselineId),
-    validateCompleteAccounting: (value) =>
-      validateRtcBaselineCompleteAccounting({
-        expectedSamples: computeRtcBaselineExpectedSampleIdentities(value.manifest),
-        expectedCohorts: value.manifest.expectedCohorts,
-        sampleOutcomes: value.sampleOutcomes,
-        cohortOutcomes: value.cohortOutcomes,
-      }),
-    validateReconciliation: (value) =>
-      value.sampleOutcomes.flatMap((sample) =>
-        sample.runtimeObservation
-          ? validateRtcBaselineReconciliation(
-              value.environment.observation,
-              sample.runtimeObservation,
-            )
-          : [],
-      ),
+    collectArtifacts: (baselineId) => collectRtcBaselineArtifacts(evidence, sha256, baselineId),
     partitionMetricObservations: partitionRtcBaselineMetricObservations,
     summarizeMetricValues: computeRtcBaselineMetricSummary,
-    readRawBytes: evidence.store.readBytes,
+    readBytes: evidence.store.readBytes,
     sha256,
   });
   return { finalizedEvidence, finalizedReader };

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-port.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-port.ts
@@ -1,0 +1,38 @@
+interface RtcBaselineDenoFileInfo {
+  isFile: boolean;
+  isDirectory: boolean;
+  isSymlink: boolean;
+}
+
+interface RtcBaselineDenoDirectoryEntry extends RtcBaselineDenoFileInfo {
+  name: string;
+}
+
+interface RtcBaselineDenoErrorConstructor {
+  new (...args: string[]): Error;
+}
+
+export interface RtcBaselineDenoPort {
+  envGet(name: string): string | undefined;
+  build: { os: string; arch: string };
+  version: { deno: string };
+  lstat(path: string): Promise<RtcBaselineDenoFileInfo>;
+  mkdir(path: string, options: { recursive: boolean }): Promise<void>;
+  readFile(path: string): Promise<Uint8Array>;
+  writeFile(path: string, bytes: Uint8Array, options: { createNew: boolean }): Promise<void>;
+  remove(path: string, options: { recursive: boolean }): Promise<void>;
+  readDir(path: string): AsyncIterable<RtcBaselineDenoDirectoryEntry>;
+  command(
+    executable: string,
+    arguments_: readonly string[],
+  ): Promise<{ code: number; stdout: Uint8Array; stderr: Uint8Array }>;
+  now(): Date;
+  performanceNow(): number;
+  systemMemoryInfo(): { total: number };
+  availableParallelism(): number;
+  errors?: {
+    NotFound?: RtcBaselineDenoErrorConstructor;
+    AlreadyExists?: RtcBaselineDenoErrorConstructor;
+    PermissionDenied?: RtcBaselineDenoErrorConstructor;
+  };
+}

--- a/packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-memory-bounds-scenario.ts
+++ b/packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-memory-bounds-scenario.ts
@@ -1,0 +1,379 @@
+import {
+  createDenoRtcBaselineAdapters,
+  type RtcBaselineDenoPort,
+} from '../../../baseline/runtime/rtc-baseline-deno-adapters.ts';
+import { createRtcBaselineDenoFinalization } from '../../../baseline/runtime/rtc-baseline-deno-finalization.ts';
+import type { RtcBaselineDenoEvidence } from '../../../baseline/runtime/rtc-baseline-deno-evidence.ts';
+import type {
+  RtcBaselineCaptureManifestDto,
+  RtcBaselineEnvironmentDto,
+  RtcBaselineJson,
+  RtcBaselineResult,
+  RtcBaselineRuntimeObservationDto,
+  RtcBaselineSampleDto,
+} from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import type {
+  RtcBaselineFileStore,
+  RtcBaselineStoredFile,
+} from '../../../baseline/evidence/rtc-baseline-evidence-store.ts';
+
+interface MemoryPeak {
+  readonly heapUsed: number;
+  readonly rss: number;
+}
+
+interface MemoryMeasurement {
+  readonly durationMs: number;
+  readonly peak: MemoryPeak;
+}
+
+interface MemoryBoundsScenarioResult {
+  readonly sampleCount: number;
+  readonly sourcePayloadBytes: number;
+  readonly finalization: MemoryMeasurement;
+  readonly validation: MemoryMeasurement;
+}
+
+interface ScenarioConfig {
+  readonly sampleCount: number;
+  readonly samplePayloadBytes: number;
+}
+
+interface MemorySampler {
+  getPeak(): MemoryPeak;
+  reset(): void;
+  sample(): void;
+}
+
+const baselineId = '20260818-22bb4919c92f-e1-local';
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function readPositiveIntegerArgument(name: string): number {
+  const prefix = `--${name}=`;
+  const raw = Deno.args.find((argument) => argument.startsWith(prefix))?.slice(prefix.length);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`Expected --${name}=<positive-safe-integer>.`);
+  }
+  return value;
+}
+
+function createMemorySampler(): MemorySampler {
+  let peak: MemoryPeak = { heapUsed: 0, rss: 0 };
+  function sample() {
+    const current = Deno.memoryUsage();
+    peak = {
+      heapUsed: Math.max(peak.heapUsed, current.heapUsed),
+      rss: Math.max(peak.rss, current.rss),
+    };
+  }
+  return {
+    getPeak: () => peak,
+    reset() {
+      peak = { heapUsed: 0, rss: 0 };
+      sample();
+    },
+    sample,
+  };
+}
+
+function collectGarbage() {
+  const garbageCollect = Reflect.get(globalThis, 'gc');
+  if (typeof garbageCollect === 'function') {
+    garbageCollect();
+  }
+}
+
+function createRuntimeObservation(): RtcBaselineRuntimeObservationDto {
+  return {
+    git: {
+      headCommit: 'a'.repeat(40),
+      headTree: 'b'.repeat(40),
+      ref: 'codex/rtc-memory-bounds',
+      clean: true,
+    },
+    runtime: { node: '26', npm: '11', deno: '2.9.5', playwright: '1', chromium: '139' },
+    host: {
+      os: 'darwin',
+      kernel: '25.0.0',
+      architecture: 'arm64',
+      logicalCpuCount: 12,
+      cpuModel: 'generated-corpus',
+      totalMemoryBytes: 96 * 1024 * 1024 * 1024,
+      executionContext: 'local',
+    },
+    timing: {
+      startedAtUtc: '2026-08-18T10:00:00.000Z',
+      endedAtUtc: '2026-08-18T10:00:01.000Z',
+      monotonicDurationMs: 1_000,
+      monotonicSource: 'performance.now',
+    },
+    deviations: [],
+    sourceHashes: [],
+    configurationInputs: [],
+    resolvedConfiguration: [],
+    controllerInputs: [],
+    workerCommand: {
+      redactedArgv: { executable: 'deno', arguments: [] },
+      projection: { fixedWorkerFlags: [], configurationFlags: [] },
+    },
+    allowlistedEnvironment: {},
+  };
+}
+
+function sampleId(innerOrdinal: number) {
+  return `rtc-b01-scale-payload-retained-001-${String(innerOrdinal).padStart(3, '0')}`;
+}
+
+function createManifest(sampleCount: number): RtcBaselineCaptureManifestDto {
+  const sampleIds = Array.from({ length: sampleCount }, (_, index) => sampleId(index + 1));
+  const request = {
+    schema: 'rallar.rtc-baseline.capture-request.v1' as const,
+    baselineId,
+    workloadIds: ['RTC-B01' as const],
+    environmentId: 'E1-local' as const,
+    retainedSampleMultiplier: 1 as const,
+    repeatLink: null,
+    conditionalEnvironmentDecisions: [],
+  };
+  return {
+    schema: 'rallar.rtc-baseline.manifest.v1',
+    request,
+    workloadIds: request.workloadIds,
+    cases: [{ workloadId: 'RTC-B01', caseId: 'scale', inputKey: 'payload' }],
+    outerAttempts: [
+      {
+        workloadId: 'RTC-B01',
+        caseId: 'scale',
+        inputKey: 'payload',
+        environmentId: 'E1-local',
+        intendedPhase: 'retained',
+        outerOrdinal: 1,
+        sampleIds,
+      },
+    ],
+    expectedCohorts: [],
+    repeatLink: null,
+  };
+}
+
+function createEnvironment(
+  observation: RtcBaselineRuntimeObservationDto,
+): RtcBaselineEnvironmentDto {
+  return {
+    schema: 'rallar.rtc-baseline.environment.v1',
+    baselineId,
+    workloadIds: ['RTC-B01'],
+    environmentId: 'E1-local',
+    repeatLink: null,
+    conditionalEnvironmentDecisions: [],
+    observation,
+  };
+}
+
+function createSample(
+  innerOrdinal: number,
+  samplePayloadBytes: number,
+  observation: RtcBaselineRuntimeObservationDto,
+): RtcBaselineSampleDto {
+  const payloadPrefix = `${innerOrdinal}:`;
+  const rawEvidence = payloadPrefix + 'x'.repeat(samplePayloadBytes - payloadPrefix.length);
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity: {
+      sampleId: sampleId(innerOrdinal),
+      workloadId: 'RTC-B01',
+      caseId: 'scale',
+      inputKey: 'payload',
+      intendedPhase: 'retained',
+      outerOrdinal: 1,
+      innerOrdinal,
+    },
+    outcome: 'passed',
+    evidenceClass: 'synthetic-path',
+    metrics: [{ metric: 'durationMs', unit: 'ms', value: innerOrdinal }],
+    rawEvidence,
+    rawReferences: [],
+    issues: [],
+    runtimeObservation: observation,
+  };
+}
+
+function sampleOrdinal(relativePath: string): number | null {
+  const match = /^results\/samples\/sample-(\d+)\.json$/.exec(relativePath);
+  return match ? Number(match[1]) : null;
+}
+
+function successful<T>(value: T): RtcBaselineResult<T> {
+  return { ok: true, value };
+}
+
+function failed(path: string): RtcBaselineResult<never> {
+  return {
+    ok: false,
+    issues: [{ path: `$.${path}`, code: 'missing-generated-artifact', message: 'Missing.' }],
+  };
+}
+
+function createGeneratedEvidence(
+  config: ScenarioConfig,
+  sampler: MemorySampler,
+  sha256: (bytes: Uint8Array) => Promise<string>,
+): RtcBaselineDenoEvidence {
+  const observation = createRuntimeObservation();
+  const environment = createEnvironment(observation);
+  const manifest = createManifest(config.sampleCount);
+  const resultFiles: RtcBaselineStoredFile[] = Array.from(
+    { length: config.sampleCount },
+    (_, index) => ({ relativePath: `results/samples/sample-${index + 1}.json`, kind: 'file' }),
+  );
+  const publishedBytes = new Map<string, Uint8Array>();
+
+  function generatedBytes(relativePath: string): Uint8Array | null {
+    if (relativePath === 'environment.json') {
+      return encoder.encode(JSON.stringify(environment));
+    }
+    if (relativePath === 'manifest.json') {
+      return encoder.encode(JSON.stringify(manifest));
+    }
+    const ordinal = sampleOrdinal(relativePath);
+    return ordinal === null
+      ? (publishedBytes.get(relativePath) ?? null)
+      : encoder.encode(
+          JSON.stringify(createSample(ordinal, config.samplePayloadBytes, observation)),
+        );
+  }
+
+  async function readBytes(_baselineId: string, relativePath: string) {
+    sampler.sample();
+    const bytes = generatedBytes(relativePath);
+    sampler.sample();
+    return bytes === null ? failed(relativePath) : successful(bytes);
+  }
+
+  async function readJson(_baselineId: string, relativePath: string) {
+    const bytes = await readBytes(baselineId, relativePath);
+    if (!bytes.ok) {
+      return bytes;
+    }
+    const json: RtcBaselineJson = JSON.parse(decoder.decode(bytes.value));
+    sampler.sample();
+    return successful(json);
+  }
+
+  async function writeJsonCreateNew(
+    _baselineId: string,
+    relativePath: string,
+    value: RtcBaselineJson | object,
+  ) {
+    publishedBytes.set(relativePath, encoder.encode(`${JSON.stringify(value)}\n`));
+    return successful(undefined);
+  }
+
+  const store: RtcBaselineFileStore = {
+    initializeBaseline: async () => successful(undefined),
+    writeJsonCreateNew,
+    readBytes,
+    readJson,
+    async listArtifacts(_baselineId, relativePath) {
+      if (relativePath === 'results') {
+        return successful(resultFiles);
+      }
+      if (relativePath === 'artifacts') {
+        return successful([]);
+      }
+      return failed(relativePath);
+    },
+    async withFinalizationLock(_baselineId, operation) {
+      return operation({
+        writeJsonCreateNew,
+        async publishSummary(_publishedBaselineId, summaryBytes, checksumBytes) {
+          publishedBytes.set('summary.json', summaryBytes);
+          publishedBytes.set('SHA256SUMS', checksumBytes);
+          return successful(undefined);
+        },
+      });
+    },
+  };
+
+  return {
+    store,
+    readManifest: async () => successful(manifest),
+    readEnvironment: async () => successful(environment),
+    reconcileAcceptedOperation: async () => [],
+  };
+}
+
+function createUnusedDenoPort(): RtcBaselineDenoPort {
+  const unused = async (): Promise<never> => {
+    throw new Error('The generated evidence scenario does not use the Deno file/process port.');
+  };
+  return {
+    envGet: () => undefined,
+    build: Deno.build,
+    version: Deno.version,
+    lstat: unused,
+    mkdir: unused,
+    readFile: unused,
+    writeFile: unused,
+    remove: unused,
+    async *readDir(): AsyncIterable<never> {
+      throw new Error('The generated evidence scenario does not enumerate the Deno file port.');
+    },
+    command: unused,
+    now: () => new Date('2026-08-18T10:00:00.000Z'),
+    performanceNow: () => performance.now(),
+    systemMemoryInfo: () => ({ total: 96 * 1024 * 1024 * 1024 }),
+    availableParallelism: () => 12,
+  };
+}
+
+async function runScenario(config: ScenarioConfig): Promise<MemoryBoundsScenarioResult> {
+  const sampler = createMemorySampler();
+  const adapterSha256 = createDenoRtcBaselineAdapters(createUnusedDenoPort()).sha256;
+  const sha256 = async (bytes: Uint8Array) => {
+    sampler.sample();
+    const digest = await adapterSha256(bytes);
+    sampler.sample();
+    return digest;
+  };
+  const evidence = createGeneratedEvidence(config, sampler, sha256);
+  const { finalizedEvidence, finalizedReader } = createRtcBaselineDenoFinalization(
+    evidence,
+    sha256,
+  );
+
+  sampler.reset();
+  const finalizationStartedAt = performance.now();
+  const finalized = await finalizedEvidence.finalize({ baselineId });
+  const finalizationDurationMs = performance.now() - finalizationStartedAt;
+  if (!finalized.ok) {
+    throw new Error(JSON.stringify(finalized.issues));
+  }
+  const finalizationPeak = sampler.getPeak();
+
+  collectGarbage();
+  sampler.reset();
+  const validationStartedAt = performance.now();
+  const validated = await finalizedReader.readBaselineValidation({ baselineId });
+  const validationDurationMs = performance.now() - validationStartedAt;
+  if (!validated.ok) {
+    throw new Error(JSON.stringify(validated.issues));
+  }
+
+  return {
+    sampleCount: config.sampleCount,
+    sourcePayloadBytes: config.sampleCount * config.samplePayloadBytes,
+    finalization: { durationMs: finalizationDurationMs, peak: finalizationPeak },
+    validation: { durationMs: validationDurationMs, peak: sampler.getPeak() },
+  };
+}
+
+if (import.meta.main) {
+  const result = await runScenario({
+    sampleCount: readPositiveIntegerArgument('samples'),
+    samplePayloadBytes: readPositiveIntegerArgument('payload-bytes'),
+  });
+  console.log(JSON.stringify(result));
+}

--- a/packages/shared-rtc-bench/tests/baseline/evidence/rtc-performance-baseline-finalization.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/evidence/rtc-performance-baseline-finalization.test.ts
@@ -1,16 +1,37 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createRtcBaselineFinalizedEvidence,
+  type RtcBaselineCollectedArtifacts,
   type RtcBaselineFinalizationLockedWriter,
 } from '../../../baseline/evidence/rtc-baseline-finalized-evidence.ts';
+import { computeRtcBaselineMetricObservations } from '../../../baseline/catalog/rtc-baseline-workload-manifest.ts';
+import type { RtcBaselineSampleDto } from '../../../baseline/contracts/rtc-baseline-contracts.ts';
 import {
   computeRtcBaselineMetricSummary,
   partitionRtcBaselineMetricObservations,
 } from '../../../baseline/evidence/rtc-baseline-statistics.ts';
 const emptyCollectedJson =
   '{"environment":{"schema":"rallar.rtc-baseline.environment.v1","baselineId":"20260807-0123456789ab-e1-local","workloadIds":["RTC-B01"],"environmentId":"E1-local","repeatLink":null,"conditionalEnvironmentDecisions":[],"observation":{"git":{"headCommit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","headTree":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","ref":"codex/rtc","clean":true},"runtime":{"node":"24","npm":"11","deno":"2","playwright":"1","chromium":"139"},"host":{"os":"darwin","kernel":"24.6.0","architecture":"arm64","logicalCpuCount":10,"cpuModel":"Apple M4","totalMemoryBytes":1,"executionContext":"local"},"timing":{"startedAtUtc":"2026-08-07T10:00:00.000Z","endedAtUtc":"2026-08-07T10:00:01.000Z","monotonicDurationMs":1000,"monotonicSource":"performance.now"},"deviations":[],"sourceHashes":[],"configurationInputs":[],"resolvedConfiguration":[],"controllerInputs":[],"workerCommand":{"redactedArgv":{"executable":"deno","arguments":[]},"projection":{"fixedWorkerFlags":[],"configurationFlags":[]}},"allowlistedEnvironment":{}}},"manifest":{"schema":"rallar.rtc-baseline.manifest.v1","request":{"schema":"rallar.rtc-baseline.capture-request.v1","baselineId":"20260807-0123456789ab-e1-local","workloadIds":["RTC-B01"],"environmentId":"E1-local","retainedSampleMultiplier":1,"repeatLink":null,"conditionalEnvironmentDecisions":[]},"workloadIds":["RTC-B01"],"cases":[],"outerAttempts":[],"expectedCohorts":[{"cohortId":"cohort-failed","workloadId":"RTC-B01","memberSampleIds":[]}],"repeatLink":null},"workloadIds":["RTC-B01"],"environmentId":"E1-local","repeatLink":null,"conditionalEnvironmentDecisions":[],"sampleOutcomes":[],"cohortOutcomes":[],"failures":[{"artifactKind":"failure","failureId":"failure-cohort-cohort-failed","identity":{"cohortId":"cohort-failed","workloadId":"RTC-B01","memberSampleIds":[]},"outcome":"failed","causalFailureId":null,"issues":[{"path":"$.cohort","code":"producer-failed","message":"producer failed"}],"rawEvidence":null}],"samples":[],"retainedArtifacts":[],"rawReferences":[{"relativePath":"raw.json","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bytes":0}]}';
-const emptyCollected = { ...JSON.parse(emptyCollectedJson), externalAttempts: [] };
-const retainedSample = {
+const decodedCollected = JSON.parse(emptyCollectedJson);
+const emptyCollected: RtcBaselineCollectedArtifacts = {
+  environment: decodedCollected.environment,
+  manifest: {
+    ...decodedCollected.manifest,
+    expectedCohorts: [],
+  },
+  workloadIds: decodedCollected.workloadIds,
+  environmentId: decodedCollected.environmentId,
+  repeatLink: decodedCollected.repeatLink,
+  conditionalEnvironmentDecisions: decodedCollected.conditionalEnvironmentDecisions,
+  sampleOutcomes: [],
+  cohortOutcomes: [],
+  failures: [],
+  metricObservations: [],
+  rawReferences: [],
+  artifactIssues: [],
+  retainedArtifactPaths: [],
+};
+const retainedSample: RtcBaselineSampleDto = {
   schema: 'rallar.rtc-baseline.sample.v1',
   identity: {
     sampleId: 'rtc-b01-peer-connection-diagnostics-burst-pairs-500-retained-001-001',
@@ -29,17 +50,18 @@ const retainedSample = {
   issues: [],
   runtimeObservation: emptyCollected.environment.observation,
 };
-const collectedWithRawSample = { ...emptyCollected, samples: [retainedSample] };
+const collectedWithRawSample = {
+  ...emptyCollected,
+  rawReferences: retainedSample.rawReferences,
+};
 function finalizationDependencies(overrides: Record<string, unknown> = {}) {
   const configured = {
     collectArtifacts: async () => ({ ok: true as const, value: emptyCollected }),
-    validateCompleteAccounting: () => [],
-    validateReconciliation: () => [],
     partitionMetricObservations: () => ({ ok: true as const, value: [] }),
     summarizeMetricValues: () => {
       throw new Error('not called');
     },
-    readRawBytes: async () => ({ ok: true as const, value: new Uint8Array() }),
+    readBytes: async () => ({ ok: true as const, value: new Uint8Array() }),
     sha256: async () => 'a'.repeat(64),
     publishSummary: async () => ({ ok: true as const, value: undefined }),
     writeFinalizationFailure: async () => ({ ok: true as const, value: undefined }),
@@ -59,11 +81,13 @@ function finalizationDependencies(overrides: Record<string, unknown> = {}) {
   } as unknown as Parameters<typeof createRtcBaselineFinalizedEvidence>[0];
 }
 describe('RTC baseline finalization', () => {
-  it('validates accounting and reconciliation before grouping and publication', async () => {
+  it('publishes a deterministic summary and checksums from compact projections', async () => {
     const calls: string[] = [];
     const publishSummary = vi.fn(async (_baselineId, summaryBytes, checksumBytes) => {
       calls.push(
-        `publish:${new TextDecoder().decode(summaryBytes)}:${new TextDecoder().decode(checksumBytes)}`,
+        `publish:${new TextDecoder().decode(summaryBytes)}:${new TextDecoder().decode(
+          checksumBytes,
+        )}`,
       );
       return { ok: true as const, value: undefined };
     });
@@ -79,48 +103,53 @@ describe('RTC baseline finalization', () => {
       },
       collectArtifacts: async () => {
         calls.push('collect');
+        const samples = [
+          retainedSample,
+          {
+            ...retainedSample,
+            identity: {
+              ...retainedSample.identity,
+              sampleId: 'rtc-b01-heap-case-heap-1-retained-001-001',
+              caseId: 'heap-case',
+              inputKey: 'heap-1',
+            },
+            metrics: [{ metric: 'heapBytes', unit: 'bytes', value: 1024 }],
+            rawReferences: [],
+          },
+        ];
         return {
           ok: true,
           value: {
             ...emptyCollected,
-            samples: [
-              retainedSample,
-              {
-                ...retainedSample,
-                identity: {
-                  ...retainedSample.identity,
-                  sampleId: 'rtc-b01-heap-case-heap-1-retained-001-001',
-                  caseId: 'heap-case',
-                  inputKey: 'heap-1',
-                },
-                metrics: [{ metric: 'heapBytes', unit: 'bytes', value: 1024 }],
-                rawReferences: [],
-              },
-            ],
-            retainedArtifacts: [
-              {
-                relativePath: 'environment.json',
-                bytes: new TextEncoder().encode('environment'),
-              },
-              {
-                relativePath: 'manifest.json',
-                bytes: new TextEncoder().encode('manifest'),
-              },
-              {
-                relativePath: 'results/samples/sample.json',
-                bytes: new TextEncoder().encode('sample'),
-              },
+            manifest: {
+              ...emptyCollected.manifest,
+              outerAttempts: samples.map((sample) => ({
+                workloadId: sample.identity.workloadId,
+                caseId: sample.identity.caseId,
+                inputKey: sample.identity.inputKey,
+                environmentId: emptyCollected.environmentId,
+                intendedPhase: sample.identity.intendedPhase,
+                outerOrdinal: sample.identity.outerOrdinal,
+                sampleIds: [sample.identity.sampleId],
+              })),
+            },
+            sampleOutcomes: samples.map((sample) => ({
+              identity: sample.identity,
+              outcome: sample.outcome,
+              issues: sample.issues,
+            })),
+            metricObservations: computeRtcBaselineMetricObservations(
+              samples,
+              emptyCollected.environmentId,
+            ),
+            rawReferences: samples.flatMap((sample) => sample.rawReferences),
+            retainedArtifactPaths: [
+              'environment.json',
+              'manifest.json',
+              'results/samples/sample.json',
             ],
           },
         };
-      },
-      validateCompleteAccounting: (value) => {
-        calls.push(`account:${value.manifest.schema}:${value.sampleOutcomes.length}`);
-        return [];
-      },
-      validateReconciliation: (value) => {
-        calls.push(`reconcile:${value.environment.schema}:${value.cohortOutcomes.length}`);
-        return [];
       },
       partitionMetricObservations: (observations) => {
         calls.push('partition');
@@ -130,23 +159,16 @@ describe('RTC baseline finalization', () => {
         calls.push('summarize');
         return computeRtcBaselineMetricSummary(values);
       },
-      readRawBytes: async () => ({ ok: true, value: new TextEncoder().encode('raw') }),
+      readBytes: async () => ({ ok: true, value: new TextEncoder().encode('raw') }),
       sha256: async () => 'a'.repeat(64),
     });
     const summaryText =
-      '{"schema":"rallar.rtc-baseline.summary.v1","baselineId":"20260807-0123456789ab-e1-local","workloadIds":["RTC-B01"],"environmentId":"E1-local","repeatLink":null,"conditionalEnvironmentDecisions":[],"sampleOutcomes":[],"cohortOutcomes":[{"identity":{"cohortId":"cohort-failed","workloadId":"RTC-B01","memberSampleIds":[]},"outcome":"failed","issues":[{"path":"$.cohort","code":"producer-failed","message":"producer failed"}]}],"metricSummaries":[{"workloadId":"RTC-B01","caseId":"heap-case","inputKey":"heap-1","metric":"heapBytes","unit":"bytes","count":1,"minimum":1024,"median":1024,"maximum":1024,"mad":0,"coefficientOfVariation":0},{"workloadId":"RTC-B01","caseId":"peer-connection-diagnostics-burst","inputKey":"pairs-500","metric":"durationMs","unit":"ms","count":1,"minimum":10,"median":10,"maximum":10,"mad":0,"coefficientOfVariation":0}],"rawReferences":[{"relativePath":"artifacts/raw.bin","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bytes":3}]}';
+      '{"schema":"rallar.rtc-baseline.summary.v1","baselineId":"20260807-0123456789ab-e1-local","workloadIds":["RTC-B01"],"environmentId":"E1-local","repeatLink":null,"conditionalEnvironmentDecisions":[],"sampleOutcomes":[{"identity":{"sampleId":"rtc-b01-heap-case-heap-1-retained-001-001","workloadId":"RTC-B01","caseId":"heap-case","inputKey":"heap-1","intendedPhase":"retained","outerOrdinal":1,"innerOrdinal":1},"outcome":"passed","issues":[]},{"identity":{"sampleId":"rtc-b01-peer-connection-diagnostics-burst-pairs-500-retained-001-001","workloadId":"RTC-B01","caseId":"peer-connection-diagnostics-burst","inputKey":"pairs-500","intendedPhase":"retained","outerOrdinal":1,"innerOrdinal":1},"outcome":"passed","issues":[]}],"cohortOutcomes":[],"metricSummaries":[{"workloadId":"RTC-B01","caseId":"heap-case","inputKey":"heap-1","metric":"heapBytes","unit":"bytes","count":1,"minimum":1024,"median":1024,"maximum":1024,"mad":0,"coefficientOfVariation":0},{"workloadId":"RTC-B01","caseId":"peer-connection-diagnostics-burst","inputKey":"pairs-500","metric":"durationMs","unit":"ms","count":1,"minimum":10,"median":10,"maximum":10,"mad":0,"coefficientOfVariation":0}],"rawReferences":[{"relativePath":"artifacts/raw.bin","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bytes":3}]}';
     expect(await finalizer.finalize({ baselineId: '20260807-0123456789ab-e1-local' })).toEqual({
       ok: true,
       value: JSON.parse(summaryText),
     });
-    expect(calls.slice(0, 6)).toEqual([
-      'lock:start',
-      'collect',
-      'account:rallar.rtc-baseline.manifest.v1:0',
-      'reconcile:rallar.rtc-baseline.environment.v1:0',
-      'partition',
-      'summarize',
-    ]);
+    expect(calls.slice(0, 4)).toEqual(['lock:start', 'collect', 'partition', 'summarize']);
     expect([publishSummary.mock.calls.length, calls.at(-1)]).toEqual([1, 'lock:end']);
     expect(publishSummary).toHaveBeenCalledWith(
       '20260807-0123456789ab-e1-local',
@@ -164,7 +186,7 @@ describe('RTC baseline finalization', () => {
     const publishSummary = vi.fn();
     const writeFailure = vi.fn(async () => ({ ok: true as const, value: undefined }));
     const rawBytes = new TextEncoder().encode('x');
-    const readRawBytes = vi.fn(async () => ({ ok: true as const, value: rawBytes }));
+    const readBytes = vi.fn(async () => ({ ok: true as const, value: rawBytes }));
     const finalizer = createRtcBaselineFinalizedEvidence({
       withFinalizationLock: async (_baselineId, operation) =>
         operation({ publishSummary, writeFinalizationFailure: writeFailure }),
@@ -172,24 +194,17 @@ describe('RTC baseline finalization', () => {
         ok: true,
         value: {
           ...emptyCollected,
-          samples: [
-            {
-              ...retainedSample,
-              rawReferences: [
-                { relativePath: 'artifacts/raw.json', sha256: 'b'.repeat(64), bytes: 2 },
-                { relativePath: 'artifacts/raw.json', sha256: 'b'.repeat(64), bytes: 2 },
-              ],
-            },
+          rawReferences: [
+            { relativePath: 'artifacts/raw.json', sha256: 'b'.repeat(64), bytes: 2 },
+            { relativePath: 'artifacts/raw.json', sha256: 'b'.repeat(64), bytes: 2 },
           ],
         },
       }),
-      validateCompleteAccounting: () => [],
-      validateReconciliation: () => [],
       partitionMetricObservations: () => ({ ok: true, value: [] }),
       summarizeMetricValues: () => {
         throw new Error('not called');
       },
-      readRawBytes,
+      readBytes,
       sha256: async () => 'c'.repeat(64),
     });
     const result = await finalizer.finalize({ baselineId: '20260807-0123456789ab-e1-local' });
@@ -209,7 +224,7 @@ describe('RTC baseline finalization', () => {
       ],
     });
     expect(publishSummary).not.toHaveBeenCalled();
-    expect(readRawBytes).toHaveBeenCalledTimes(1);
+    expect(readBytes).toHaveBeenCalledTimes(1);
     expect(writeFailure).toHaveBeenCalledWith('20260807-0123456789ab-e1-local', {
       schema: 'rallar.rtc-baseline.finalization-failure.v1',
       baselineId: '20260807-0123456789ab-e1-local',
@@ -299,7 +314,7 @@ describe('RTC baseline finalization', () => {
     [
       {
         collectArtifacts: async () => ({ ok: true, value: collectedWithRawSample }),
-        readRawBytes: async () => ({
+        readBytes: async () => ({
           ok: false,
           issues: [{ path: '$.raw', code: 'read-failed', message: 'raw failed' }],
         }),
@@ -313,7 +328,13 @@ describe('RTC baseline finalization', () => {
           ok: true,
           value: {
             ...emptyCollected,
-            samples: [{ ...retainedSample, runtimeObservation: null }],
+            artifactIssues: [
+              {
+                path: '$.samples[0].runtimeObservation',
+                code: 'missing-runtime-observation',
+                message: 'Metric samples require observation.',
+              },
+            ],
           },
         }),
       },
@@ -323,15 +344,6 @@ describe('RTC baseline finalization', () => {
         message: 'Metric samples require observation.',
       },
       'finalization-artifact-validation',
-    ],
-    [
-      {
-        validateReconciliation: () => [
-          { path: '$.git', code: 'git-mismatch', message: 'commit changed' },
-        ],
-      },
-      { path: '$.git', code: 'git-mismatch', message: 'commit changed' },
-      'finalization-reconciliation',
     ],
     [
       {

--- a/packages/shared-rtc-bench/tests/baseline/evidence/rtc-performance-baseline-memory-bounds.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/evidence/rtc-performance-baseline-memory-bounds.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from 'node:child_process';
+
+interface ScenarioMeasurement {
+  readonly sampleCount: number;
+  readonly sourcePayloadBytes: number;
+  readonly finalization: { readonly peak: { readonly heapUsed: number; readonly rss: number } };
+  readonly validation: { readonly peak: { readonly heapUsed: number; readonly rss: number } };
+}
+
+const scenarioPath =
+  'packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-memory-bounds-scenario.ts';
+
+it('finalizes and validates a corpus larger than the constrained heap without retaining it', () => {
+  const result = spawnSync(
+    'deno',
+    [
+      'run',
+      '--no-check',
+      '--config=packages/shared-rtc-bench/deno.json',
+      '--v8-flags=--max-old-space-size=64,--expose-gc',
+      scenarioPath,
+      '--samples=640',
+      '--payload-bytes=131072',
+    ],
+    { encoding: 'utf8', timeout: 120_000 },
+  );
+
+  expect(result.status, result.stderr).toBe(0);
+  const measurement = JSON.parse(result.stdout) as ScenarioMeasurement;
+  expect(measurement).toMatchObject({
+    sampleCount: 640,
+    sourcePayloadBytes: 83_886_080,
+    finalization: { peak: { heapUsed: expect.any(Number), rss: expect.any(Number) } },
+    validation: { peak: { heapUsed: expect.any(Number), rss: expect.any(Number) } },
+  });
+}, 120_000);


### PR DESCRIPTION
## Goal

Fixes #267 by making RTC baseline finalization and validation memory-bounded without changing the evidence protocol.

## Changes

- Read, checksum, and discard retained artifact bytes sequentially instead of retaining the complete corpus.
- Project accepted samples into compact outcomes, metrics, raw references, issues, and per-sample digests.
- Split finalized-artifact reading, verification, comparison, and Deno file-port ownership into focused modules.
- Add a deterministic generated-corpus regression that runs finalization and validation with a 64 MiB V8 heap.

## Acceptance

- The previous implementation reproduced a fatal out-of-memory failure for 640 samples / 83,886,080 source payload bytes under a 64 MiB V8 heap; this commit passes that corpus.
- A generated corpus of 6,666 samples / 2,333,100,000 source payload bytes passes with a 4 GiB V8 heap limit.
- The large run peaked at 68,822,432 heap bytes during finalization and 77,529,120 heap bytes during validation.
- Deterministic summary/checksum output and existing failure-accounting and integrity behavior remain covered by the package tests.

## Validation

- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check` — PASS: TypeScript, 33 Vitest files / 310 tests, and Deno production checks.
- `deno check --config=packages/shared-rtc-bench/deno.json packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-memory-bounds-scenario.ts` — PASS.
- Large generated-corpus scenario (6,666 × 350,000 bytes) — PASS: finalization 5,324.8 ms; validation 4,828.4 ms.
- Prettier, commit diff check, repository structure, and evidence-test style checks — PASS.
- Baseline style audit — PASS with 13 non-blocking warnings confined to untouched files; changed files have no findings.

## Risk and rollback

Risk is concentrated in internal projection order and sequential rereads during finalization and validation. Public protocol DTOs, workload counts, thresholds, and production RTC behavior are unchanged. Reverting commit c8f367ba4d2238577c2c9af7d20a95fc99373d0f restores the prior retention behavior; no persisted-format migration is required.

## Follow-up

- #271 tracks the unrelated stale finalization-lock recovery behavior discovered during investigation.
