### PR TITLE
Make RTC-B05 lifecycle callback validation multiplicity-safe

### DIFF
--- a/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.test.ts
@@ -1,0 +1,268 @@
+import type {
+  RtcBaselineJson,
+  RtcBaselineRuntimeObservationDto,
+  RtcBaselineSampleDto,
+} from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  computeRtcDataChannelBrowserSoakSample,
+} from '../../../workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts';
+
+const baselineId = '20260818-0123456789ab-e2-browser';
+const scriptPath =
+  'packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak.mjs';
+const caseId = 'browser-data-channel-lifecycle';
+const inputKey = 'iterations-25';
+const expectedEvents = [
+  'local-open',
+  'remote-open',
+  'remote-message',
+  'local-close',
+  'remote-close',
+];
+
+const runtimeObservation: RtcBaselineRuntimeObservationDto = {
+  git: {
+    headCommit: '0'.repeat(40),
+    headTree: '1'.repeat(40),
+    ref: 'main',
+    clean: true,
+  },
+  runtime: {
+    node: 'v26.7.0',
+    npm: '11.19.0',
+    deno: '2.9.5',
+    playwright: '1.61.1',
+    chromium: 'Google Chrome for Testing 149.0.7827.55',
+  },
+  host: {
+    os: 'darwin',
+    kernel: '25.6.0',
+    architecture: 'aarch64',
+    logicalCpuCount: 12,
+    cpuModel: 'Apple M2 Max',
+    totalMemoryBytes: 103_079_215_104,
+    executionContext: 'local',
+  },
+  timing: {
+    startedAtUtc: '2026-08-18T13:57:31.000Z',
+    endedAtUtc: '2026-08-18T13:57:32.000Z',
+    monotonicDurationMs: 1000,
+    monotonicSource: 'performance.now',
+  },
+  deviations: [],
+  sourceHashes: [
+    { path: scriptPath, sha256: 'a'.repeat(64), kind: 'source' },
+    {
+      path: 'apps/rallar-black-box/playwright.config.ts',
+      sha256: 'b'.repeat(64),
+      kind: 'config',
+    },
+  ],
+  configurationInputs: [],
+  resolvedConfiguration: [
+    {
+      caseKey: { workloadId: 'RTC-B05', caseId, inputKey },
+      field: 'iterations',
+      value: 25,
+      source: 'default',
+    },
+  ],
+  controllerInputs: [
+    { name: 'baselineId', value: baselineId, secret: false },
+    { name: 'workloadIds', value: 'RTC-B05', secret: false },
+    { name: 'environmentId', value: 'E2-browser', secret: false },
+  ],
+  workerCommand: {
+    redactedArgv: { executable: 'node', arguments: [scriptPath] },
+    projection: { fixedWorkerFlags: [], configurationFlags: [] },
+  },
+  allowlistedEnvironment: {},
+};
+
+function toIteration(index: number, events: readonly RtcBaselineJson[]) {
+  return {
+    index,
+    iterationId: 'rtc-b05-browser-data-channel-lifecycle-iterations-25-warmup-001-001-iteration-' +
+      String(index).padStart(3, '0'),
+    opened: true,
+    closed: true,
+    messageReceived: true,
+    events: [...events],
+    localState: 'closed',
+    remoteState: 'closed',
+    pcAState: 'closed',
+    pcBState: 'closed',
+    openDurationMs: index + 0.25,
+    closeDurationMs: index + 0.5,
+    failure: null,
+  };
+}
+
+function toFirstIteration(
+  events: readonly RtcBaselineJson[],
+  failure: string | null,
+  remoteState: string,
+) {
+  return {
+    ...toIteration(1, events),
+    failure,
+    remoteState,
+  };
+}
+
+function toProducerCommand() {
+  const relativePath =
+    'artifacts/staging/rtc-b05-browser-data-channel-lifecycle-iterations-25-warmup-001.json';
+  return {
+    executable: 'node',
+    arguments: [
+      scriptPath,
+      '--capture=raw-evidence',
+      '--baseline-id=' + baselineId,
+      '--case-id=' + caseId,
+      '--input-key=' + inputKey,
+      '--intended-phase=warmup',
+      '--outer-ordinal=1',
+      '--out=' + relativePath,
+    ],
+  };
+}
+
+function toRawEvidence(iterationEvidence: RtcBaselineJson[]) {
+  return {
+    createdAt: '2026-08-18T13:57:32.000Z',
+    identity: {
+      baselineId,
+      workloadId: 'RTC-B05',
+      caseId,
+      inputKey,
+      intendedPhase: 'warmup',
+      outerOrdinal: 1,
+    },
+    input: { iterations: 25 },
+    producerCommand: toProducerCommand(),
+    durationMs: 600,
+    heap: {
+      beforeBytes: 550_000,
+      afterBytes: 600_000,
+      deltaBytes: 50_000,
+    },
+    soak: {
+      iterations: 25,
+      results: iterationEvidence,
+      openedCount: 25,
+      closedCount: 25,
+      messageReceivedCount: 25,
+      localErrorCount: 0,
+      remoteErrorCount: 0,
+    },
+  };
+}
+
+function createSample(
+  firstIterationEvents: readonly RtcBaselineJson[],
+  firstIterationFailure: string | null = null,
+  firstIterationRemoteState = 'closed',
+): RtcBaselineSampleDto {
+  const iterationEvidence = [
+    toFirstIteration(firstIterationEvents, firstIterationFailure, firstIterationRemoteState),
+    ...Array.from({ length: 24 }, (_, index) => toIteration(index + 2, expectedEvents)),
+  ];
+  return {
+    schema: 'rallar.rtc-baseline.sample.v1',
+    identity: {
+      sampleId: 'rtc-b05-browser-data-channel-lifecycle-iterations-25-warmup-001-001',
+      workloadId: 'RTC-B05',
+      caseId,
+      inputKey,
+      intendedPhase: 'warmup',
+      outerOrdinal: 1,
+      innerOrdinal: 1,
+    },
+    outcome: 'not-run',
+    evidenceClass: 'native-browser',
+    metrics: [],
+    rawEvidence: toRawEvidence(iterationEvidence),
+    rawReferences: [],
+    issues: [],
+    runtimeObservation,
+  };
+}
+
+it('accepts duplicate known success callbacks without changing the raw evidence', () => {
+  const duplicateRemoteOpenEvents = [
+    'local-open',
+    'remote-open',
+    'remote-open',
+    'remote-message',
+    'local-close',
+    'remote-close',
+  ];
+  const staged = createSample(duplicateRemoteOpenEvents);
+  const rawEvidenceBeforeValidation = structuredClone(staged.rawEvidence);
+
+  const computed = computeRtcDataChannelBrowserSoakSample(staged, baselineId);
+
+  expect(computed.outcome).toBe('passed');
+  expect(computed.issues).toEqual([]);
+  expect(computed.rawEvidence).toEqual(rawEvidenceBeforeValidation);
+});
+
+it.each([
+  {
+    description: 'a missing expected callback',
+    events: ['local-open', 'remote-message', 'local-close', 'remote-close'],
+  },
+  {
+    description: 'an error callback',
+    events: [...expectedEvents, 'remote-error'],
+  },
+  {
+    description: 'an unknown callback',
+    events: [...expectedEvents, 'negotiation-needed'],
+  },
+  {
+    description: 'a non-string callback value',
+    events: [...expectedEvents, null],
+  },
+])('rejects $description', ({ events }) => {
+  const computed = computeRtcDataChannelBrowserSoakSample(createSample(events), baselineId);
+
+  expect(computed.outcome).toBe('failed');
+  expect(computed.issues).toContainEqual(
+    expect.objectContaining({
+      path: '$.soak.results[0].events',
+      code: 'iteration-error',
+    }),
+  );
+});
+
+it('rejects a recorded iteration failure even when all expected callbacks occurred', () => {
+  const computed = computeRtcDataChannelBrowserSoakSample(
+    createSample(expectedEvents, 'remote channel failed'),
+    baselineId,
+  );
+
+  expect(computed.outcome).toBe('failed');
+  expect(computed.issues).toContainEqual(
+    expect.objectContaining({
+      path: '$.soak.results[0].events',
+      code: 'iteration-error',
+    }),
+  );
+});
+
+it('rejects incomplete lifecycle cleanup even when all expected callbacks occurred', () => {
+  const computed = computeRtcDataChannelBrowserSoakSample(
+    createSample(expectedEvents, null, 'closing'),
+    baselineId,
+  );
+
+  expect(computed.outcome).toBe('failed');
+  expect(computed.issues).toContainEqual(
+    expect.objectContaining({
+      path: '$.soak.results[0]',
+      code: 'incomplete-lifecycle-cleanup',
+    }),
+  );
+});

--- a/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.test.ts
@@ -225,6 +225,10 @@ it.each([
     description: 'a non-string callback value',
     events: [...expectedEvents, null],
   },
+  {
+    description: 'an object callback value that cannot be coerced to a string',
+    events: [...expectedEvents, { toString: null }],
+  },
 ])('rejects $description', ({ events }) => {
   const computed = computeRtcDataChannelBrowserSoakSample(createSample(events), baselineId);
 
@@ -263,6 +267,23 @@ it('rejects incomplete lifecycle cleanup even when all expected callbacks occurr
     expect.objectContaining({
       path: '$.soak.results[0]',
       code: 'incomplete-lifecycle-cleanup',
+    }),
+  );
+});
+
+it('rejects heap evidence with missing fields', () => {
+  const staged = createSample(expectedEvents);
+  const rawEvidence = staged.rawEvidence as Record<string, RtcBaselineJson>;
+  const computed = computeRtcDataChannelBrowserSoakSample(
+    { ...staged, rawEvidence: { ...rawEvidence, heap: {} } },
+    baselineId,
+  );
+
+  expect(computed.outcome).toBe('failed');
+  expect(computed.issues).toContainEqual(
+    expect.objectContaining({
+      path: '$.heap',
+      code: 'incomplete-heap-metrics',
     }),
   );
 });

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
@@ -135,18 +135,15 @@ function validateProducerCommand(
       ),
     ];
   }
-  const valid =
-    producerCommand.executable === 'node' &&
+  const valid = producerCommand.executable === 'node' &&
     same(producerCommand.arguments, expectedProducerArguments(baselineId, identity));
-  return valid
-    ? []
-    : [
-        rtcBaselineIssue(
-          '$.producerCommand',
-          'producer-command-mismatch',
-          'Raw producer command must match the immutable B05 invocation.',
-        ),
-      ];
+  return valid ? [] : [
+    rtcBaselineIssue(
+      '$.producerCommand',
+      'producer-command-mismatch',
+      'Raw producer command must match the immutable B05 invocation.',
+    ),
+  ];
 }
 
 function validateHeap(heapValue: RtcBaselineJson | undefined) {
@@ -155,7 +152,9 @@ function validateHeap(heapValue: RtcBaselineJson | undefined) {
     return [rtcBaselineIssue('$.heap', 'invalid-heap-metrics', 'Heap metrics must be an object.')];
   }
   const values = [heap.beforeBytes, heap.afterBytes, heap.deltaBytes];
-  if (values.every((value) => value === null)) return [];
+  if (values.every((value) => value === null)) {
+    return [];
+  }
   if (!values.every((value) => typeof value === 'number' && Number.isFinite(value))) {
     return [
       rtcBaselineIssue(
@@ -238,8 +237,13 @@ function validateIterationCleanup(iteration: Record<string, RtcBaselineJson>, in
     );
   }
   const events = Array.isArray(iteration.events) ? iteration.events : [];
-  const eventNames = events.filter((event): event is string => typeof event === 'string').sort();
-  if (!same(eventNames, expectedEvents) || iteration.failure !== null) {
+  const eventNames = events.filter((event): event is string => typeof event === 'string');
+  const everyEventKnown = eventNames.length === events.length &&
+    eventNames.every((eventName) => expectedEvents.includes(eventName));
+  const everyExpectedEventObserved = expectedEvents.every((expectedEvent) =>
+    eventNames.includes(expectedEvent)
+  );
+  if (!everyEventKnown || !everyExpectedEventObserved || iteration.failure !== null) {
     issues.push(
       rtcBaselineIssue(
         `$.soak.results[${index}].events`,
@@ -267,16 +271,15 @@ function validateIteration(
     ];
   }
   const expectedId = `${iterationIdPrefix}-iteration-${pad(index + 1)}`;
-  const identityIssues =
-    iteration.index === index + 1 && iteration.iterationId === expectedId
-      ? []
-      : [
-          rtcBaselineIssue(
-            `$.soak.results[${index}].iterationId`,
-            'iteration-identity-mismatch',
-            'Iteration identity is not unique and ordered.',
-          ),
-        ];
+  const identityIssues = iteration.index === index + 1 && iteration.iterationId === expectedId
+    ? []
+    : [
+      rtcBaselineIssue(
+        `$.soak.results[${index}].iterationId`,
+        'iteration-identity-mismatch',
+        'Iteration identity is not unique and ordered.',
+      ),
+    ];
   return [
     ...identityIssues,
     ...validateIterationTiming(iteration, index),
@@ -319,7 +322,7 @@ function validateSoak(rawEvidence: Record<string, RtcBaselineJson>, iterationIdP
     ...issues,
     ...countIssues,
     ...soak.results.flatMap((iteration, index) =>
-      validateIteration(iteration, index, iterationIdPrefix),
+      validateIteration(iteration, index, iterationIdPrefix)
     ),
   ];
 }
@@ -329,16 +332,15 @@ function validateMeasurement(
   iterationIdPrefix: string,
 ) {
   const duration = rawEvidence.durationMs;
-  const durationIssues =
-    typeof duration === 'number' && Number.isFinite(duration) && duration >= 0
-      ? []
-      : [
-          rtcBaselineIssue(
-            '$.durationMs',
-            'invalid-duration',
-            'Soak duration must be nonnegative.',
-          ),
-        ];
+  const durationIssues = typeof duration === 'number' && Number.isFinite(duration) && duration >= 0
+    ? []
+    : [
+      rtcBaselineIssue(
+        '$.durationMs',
+        'invalid-duration',
+        'Soak duration must be nonnegative.',
+      ),
+    ];
   return [
     ...durationIssues,
     ...validateSoak(rawEvidence, iterationIdPrefix),
@@ -387,23 +389,20 @@ export function validateRtcDataChannelBrowserSoakRuntimeObservation(
     redactedArgv: { executable: 'node', arguments: [contract.scriptPath] },
     projection: { fixedWorkerFlags: [], configurationFlags: [] },
   };
-  const valid =
-    same(observation.deviations, []) &&
+  const valid = same(observation.deviations, []) &&
     same(sourceIdentities, expectedSources) &&
     hashesValid &&
     same(observation.configurationInputs, []) &&
     same(observation.resolvedConfiguration, expectedConfiguration) &&
     same(observation.controllerInputs, expectedControllers) &&
     same(observation.workerCommand, expectedWorker);
-  return valid
-    ? []
-    : [
-        rtcBaselineIssue(
-          '$.runtimeObservation',
-          'runtime-observation-mismatch',
-          'Runtime observation must match the initialized B05 identity and configuration.',
-        ),
-      ];
+  return valid ? [] : [
+    rtcBaselineIssue(
+      '$.runtimeObservation',
+      'runtime-observation-mismatch',
+      'Runtime observation must match the initialized B05 identity and configuration.',
+    ),
+  ];
 }
 
 function validateRawEvidence(sample: RtcBaselineSampleDto, baselineId: string) {
@@ -420,40 +419,38 @@ function validateRawEvidence(sample: RtcBaselineSampleDto, baselineId: string) {
   const inputValid = same(rawEvidence.input, {
     iterations: RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.iterations,
   });
-  const createdAtValid =
-    typeof rawEvidence.createdAt === 'string' && Number.isFinite(Date.parse(rawEvidence.createdAt));
+  const createdAtValid = typeof rawEvidence.createdAt === 'string' &&
+    Number.isFinite(Date.parse(rawEvidence.createdAt));
   return [
     ...validateRawIdentity(rawEvidence, sample.identity, baselineId),
     ...validateProducerCommand(rawEvidence, sample.identity, baselineId),
     ...validateMeasurement(rawEvidence, sample.identity.sampleId),
     ...(!inputValid
       ? [
-          rtcBaselineIssue(
-            '$.input.iterations',
-            'input-mismatch',
-            'B05 requires exactly 25 iterations.',
-          ),
-        ]
+        rtcBaselineIssue(
+          '$.input.iterations',
+          'input-mismatch',
+          'B05 requires exactly 25 iterations.',
+        ),
+      ]
       : []),
     ...(!createdAtValid
       ? [
-          rtcBaselineIssue(
-            '$.createdAt',
-            'invalid-created-at',
-            'Raw evidence creation time is invalid.',
-          ),
-        ]
+        rtcBaselineIssue(
+          '$.createdAt',
+          'invalid-created-at',
+          'Raw evidence creation time is invalid.',
+        ),
+      ]
       : []),
     ...validateRtcDataChannelBrowserSoakRuntimeObservation(sample.runtimeObservation, baselineId),
-    ...(sample.rawReferences.length === 0
-      ? []
-      : [
-          rtcBaselineIssue(
-            '$.rawReferences',
-            'unexpected-raw-reference',
-            'B05 stages evidence inline.',
-          ),
-        ]),
+    ...(sample.rawReferences.length === 0 ? [] : [
+      rtcBaselineIssue(
+        '$.rawReferences',
+        'unexpected-raw-reference',
+        'B05 stages evidence inline.',
+      ),
+    ]),
   ];
 }
 
@@ -467,12 +464,10 @@ function computeFiniteMetric(
 
 function computeIterationMetrics(resultValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
   const result = toJsonObject(resultValue);
-  return result === null
-    ? []
-    : [
-        ...computeFiniteMetric(result.openDurationMs, 'openDurationMs', 'ms'),
-        ...computeFiniteMetric(result.closeDurationMs, 'closeDurationMs', 'ms'),
-      ];
+  return result === null ? [] : [
+    ...computeFiniteMetric(result.openDurationMs, 'openDurationMs', 'ms'),
+    ...computeFiniteMetric(result.closeDurationMs, 'closeDurationMs', 'ms'),
+  ];
 }
 
 function computeHeapMetrics(
@@ -482,16 +477,18 @@ function computeHeapMetrics(
   const values = [heap?.beforeBytes, heap?.afterBytes, heap?.deltaBytes];
   return values.every((value) => typeof value === 'number' && Number.isFinite(value))
     ? [
-        { metric: 'heapBeforeBytes', unit: 'bytes', value: values[0] as number },
-        { metric: 'heapAfterBytes', unit: 'bytes', value: values[1] as number },
-        { metric: 'heapDeltaBytes', unit: 'bytes', value: values[2] as number },
-      ]
+      { metric: 'heapBeforeBytes', unit: 'bytes', value: values[0] as number },
+      { metric: 'heapAfterBytes', unit: 'bytes', value: values[1] as number },
+      { metric: 'heapDeltaBytes', unit: 'bytes', value: values[2] as number },
+    ]
     : [];
 }
 
 function computeMetrics(rawEvidenceValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
   const rawEvidence = toJsonObject(rawEvidenceValue);
-  if (rawEvidence === null) return [];
+  if (rawEvidence === null) {
+    return [];
+  }
   const soak = toJsonObject(rawEvidence.soak);
   const results = Array.isArray(soak?.results) ? soak.results : [];
   return [
@@ -519,7 +516,7 @@ export function computeRtcDataChannelBrowserSoakAttempt(
   baselineId: string,
 ): RtcBaselineExternalAttemptDto {
   const samples = attempt.samples.map((sample) =>
-    computeRtcDataChannelBrowserSoakSample(sample, baselineId),
+    computeRtcDataChannelBrowserSoakSample(sample, baselineId)
   );
   return {
     ...attempt,

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
@@ -152,7 +152,8 @@ function validateHeap(heapValue: RtcBaselineJson | undefined) {
     return [rtcBaselineIssue('$.heap', 'invalid-heap-metrics', 'Heap metrics must be an object.')];
   }
   const values = [heap.beforeBytes, heap.afterBytes, heap.deltaBytes];
-  if (values.every((value) => value === null)) {
+  const heapMetricsAbsent = values.map((value) => value === null).every(Boolean);
+  if (heapMetricsAbsent) {
     return [];
   }
   if (!values.every((value) => typeof value === 'number' && Number.isFinite(value))) {
@@ -165,7 +166,12 @@ function validateHeap(heapValue: RtcBaselineJson | undefined) {
     ];
   }
   const [beforeBytes, afterBytes, deltaBytes] = values as number[];
-  if (beforeBytes < 0 || afterBytes < 0 || deltaBytes !== afterBytes - beforeBytes) {
+  const heapMetricsConsistent = [
+    beforeBytes >= 0,
+    afterBytes >= 0,
+    deltaBytes === afterBytes - beforeBytes,
+  ].every(Boolean);
+  if (!heapMetricsConsistent) {
     return [
       rtcBaselineIssue(
         '$.heap.deltaBytes',
@@ -237,13 +243,10 @@ function validateIterationCleanup(iteration: Record<string, RtcBaselineJson>, in
     );
   }
   const events = Array.isArray(iteration.events) ? iteration.events : [];
-  const eventNames = events.filter((event): event is string => typeof event === 'string');
-  const everyEventKnown = eventNames.length === events.length &&
-    eventNames.every((eventName) => expectedEvents.includes(eventName));
-  const everyExpectedEventObserved = expectedEvents.every((expectedEvent) =>
-    eventNames.includes(expectedEvent)
-  );
-  if (!everyEventKnown || !everyExpectedEventObserved || iteration.failure !== null) {
+  const uniqueEvents = new Set(events);
+  const lifecycleEventsComplete = uniqueEvents.size === expectedEvents.length &&
+    expectedEvents.every((eventName) => uniqueEvents.has(eventName));
+  if (!lifecycleEventsComplete || iteration.failure !== null) {
     issues.push(
       rtcBaselineIssue(
         `$.soak.results[${index}].events`,


### PR DESCRIPTION
## Goal

Make RTC-B05 acceptance reflect browser lifecycle semantics: each expected successful callback must occur, but a browser may deliver a known success callback more than once without invalidating an otherwise complete and clean lifecycle.

Fixes #278.

## Changes

- Validate callback names as a fail-closed unique set and require every expected success callback at least once.
- Preserve duplicate successful callbacks in raw evidence; the validator does not sort, deduplicate, normalize, or coerce captured values.
- Keep rejection behavior for missing, error, unknown, non-string, failure-bearing, count-incomplete, and unclean lifecycle evidence.
- Add a focused semantic test around the exported RTC-B05 sample computation with a complete 25-iteration fixture.
- Apply the nearest Deno formatter and touched-file closure to both changed human-authored files. No support files entered the closure.

## Acceptance

- Duplicate known success callbacks produce a passed RTC-B05 sample with unchanged raw evidence.
- Every expected callback remains mandatory.
- Error, unknown, non-string, and coercion-hostile object event values remain fail-closed.
- Non-null iteration failures and unclean final states remain rejected.
- Missing heap fields remain distinct from explicitly absent heap metrics and are rejected.
- No public export, persisted format, protocol, or producer behavior changes.

## Validation

Passed:

- TDD red: duplicate-success evidence failed against the original exact-array validator; a coercion-hostile object then reproduced an uncaught sort failure; missing heap fields reproduced an unintended acceptance during CI remediation.
- Focused Vitest: 1 file, 9 tests passed after all fixes.
- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check`: TypeScript passed, 35 test files / 338 tests passed, and Deno checks passed.
- `deno fmt --check` for both touched files.
- Focused repository style: no issues.
- Exact changed-style gate against the PR base: no new or worsened findings.
- Full repository style: exit 0 with the existing warning-only repository backlog.
- Repository structure and `git diff --check` passed.
- Fresh browser diagnostic: 25/25 iterations completed with no failures and all final remote states closed; raw callbacks contained 26 `remote-open` events.
- Preserved Task 9 raw evidence recomputed as passed with no issues and byte-equivalent raw evidence.
- Independent code review: ready, with no Critical or Important findings after remediation.

Skipped:

- Governed RTC-B05 recapture. A clean governed baseline belongs after this fix reaches a new clean latest `main`; the diagnostic and preserved artifact were used here without replacing the failed evidence.

## Risk and rollback

Risk is limited to RTC-B05 acceptance semantics. The producer and evidence contracts are unchanged, and all failure paths remain fail-closed. Reverting this PR's two commits restores exact-event-array acceptance and removes the focused tests.

## Follow-up

After merge, recapture Task 9 RTC-B05 evidence from the new clean latest `main` and close the browser lifecycle evidence slice if the governed capture passes.
