### PR TITLE
Flush RTC baseline CLI output before exit

### DIFF
--- a/packages/shared-rtc-bench/baseline/command/rtc-baseline-cli.ts
+++ b/packages/shared-rtc-bench/baseline/command/rtc-baseline-cli.ts
@@ -4,6 +4,7 @@ import {
   parseRtcBaselineCommand,
   type RtcBaselineParsedCommand,
 } from './rtc-baseline-cli-grammar.ts';
+import { writeRtcBaselineCliOutput } from './write-rtc-baseline-cli-output.ts';
 import type { RtcBaselineEnvelope } from '../runtime/rtc-baseline-envelope.ts';
 
 interface CliInput {
@@ -21,10 +22,9 @@ function captureRequest(command: Extract<RtcBaselineParsedCommand, { kind: 'init
     environmentId: command.environmentId,
     retainedSampleMultiplier: command.retainedSampleMultiplier,
     repeatLink: null,
-    conditionalEnvironmentDecisions:
-      command.conditionalEnvironmentDecision === null
-        ? []
-        : [command.conditionalEnvironmentDecision],
+    conditionalEnvironmentDecisions: command.conditionalEnvironmentDecision === null
+      ? []
+      : [command.conditionalEnvironmentDecision],
     ...(command.repeatOf === null ? {} : { repeatOf: command.repeatOf }),
   };
 }
@@ -113,11 +113,15 @@ export async function runRtcBaselineCli(input: CliInput) {
       input.writeStdout(`${columns.join('\t')}\n`);
     }
   } else if (dispatched.kind === 'repeat-required') {
-    if (dispatched.result.value.workloadIds.length === 0) return 3;
+    if (dispatched.result.value.workloadIds.length === 0) {
+      return 3;
+    }
     input.writeStdout(`${[...dispatched.result.value.workloadIds].sort().join(',')}\n`);
   } else if (dispatched.kind === 'compare-paired') {
     input.writeStdout(`${JSON.stringify(dispatched.result.value)}\n`);
-    if (dispatched.result.value.outcome === 'inconclusive-still-noisy') return 2;
+    if (dispatched.result.value.outcome === 'inconclusive-still-noisy') {
+      return 2;
+    }
   }
   return 0;
 }
@@ -173,8 +177,8 @@ if (import.meta.main) {
   const code = await runRtcBaselineCli({
     args: deno.args,
     envelope: createDefaultRtcBaselineEnvelope(),
-    writeStdout: (value) => deno.stdout.write(new TextEncoder().encode(value)),
-    writeStderr: (value) => deno.stderr.write(new TextEncoder().encode(value)),
+    writeStdout: (value) => writeRtcBaselineCliOutput(deno.stdout, value),
+    writeStderr: (value) => writeRtcBaselineCliOutput(deno.stderr, value),
   });
   deno.exit(code);
 }

--- a/packages/shared-rtc-bench/baseline/command/write-rtc-baseline-cli-output.ts
+++ b/packages/shared-rtc-bench/baseline/command/write-rtc-baseline-cli-output.ts
@@ -1,0 +1,18 @@
+export function writeRtcBaselineCliOutput(
+  writer: { writeSync(bytes: Uint8Array): number },
+  value: string,
+) {
+  const bytes = new TextEncoder().encode(value);
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const remaining = bytes.subarray(offset);
+    const written = writer.writeSync(remaining);
+    if (written <= 0) {
+      throw new Error('Synchronous output writer made no progress.');
+    }
+    if (written > remaining.byteLength) {
+      throw new Error('Synchronous output writer reported an invalid byte count.');
+    }
+    offset += written;
+  }
+}

--- a/packages/shared-rtc-bench/tests/baseline/command/rtc-baseline-cli-process-output.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/command/rtc-baseline-cli-process-output.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../../..');
+const baselineId = `20260818-${process.pid.toString(16).padStart(12, '0')}-e2-browser`;
+const baselineRoot = path.join(repoRoot, 'tmp/perf/rtc-baseline', baselineId);
+
+afterEach(() => rmSync(baselineRoot, { recursive: true, force: true }));
+
+describe('RTC baseline CLI process output', () => {
+  it('flushes every external attempt before process exit', () => {
+    mkdirSync(baselineRoot, { recursive: true });
+    writeFileSync(
+      path.join(baselineRoot, 'manifest.json'),
+      JSON.stringify({
+        schema: 'rallar.rtc-baseline.manifest.v1',
+        request: {
+          schema: 'rallar.rtc-baseline.capture-request.v1',
+          baselineId,
+          workloadIds: ['RTC-B05'],
+          environmentId: 'E2-browser',
+          retainedSampleMultiplier: 1,
+          repeatLink: null,
+          conditionalEnvironmentDecisions: [],
+        },
+        workloadIds: ['RTC-B05'],
+        cases: [
+          {
+            workloadId: 'RTC-B05',
+            caseId: 'browser-data-channel-lifecycle',
+            inputKey: 'iterations-25',
+          },
+        ],
+        outerAttempts: [
+          {
+            workloadId: 'RTC-B05',
+            caseId: 'browser-data-channel-lifecycle',
+            inputKey: 'iterations-25',
+            environmentId: 'E2-browser',
+            intendedPhase: 'warmup',
+            outerOrdinal: 1,
+            sampleIds: ['warmup-sample'],
+          },
+          {
+            workloadId: 'RTC-B05',
+            caseId: 'browser-data-channel-lifecycle',
+            inputKey: 'iterations-25',
+            environmentId: 'E2-browser',
+            intendedPhase: 'retained',
+            outerOrdinal: 1,
+            sampleIds: ['retained-sample'],
+          },
+        ],
+        expectedCohorts: [],
+        repeatLink: null,
+      }),
+    );
+
+    const output = execFileSync(
+      'deno',
+      [
+        'run',
+        '-A',
+        '--config',
+        'packages/shared-rtc-bench/deno.json',
+        'packages/shared-rtc-bench/baseline/command/rtc-baseline-cli.ts',
+        'list-external-attempts',
+        `--baseline-id=${baselineId}`,
+        '--workload=RTC-B05',
+        '--format=tsv',
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+
+    expect(output).toBe(
+      'browser-data-channel-lifecycle\twarmup\t1\tE2-browser\n' +
+        'browser-data-channel-lifecycle\tretained\t1\tE2-browser\n',
+    );
+  });
+});

--- a/packages/shared-rtc-bench/tests/baseline/command/rtc-performance-baseline-cli.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/command/rtc-performance-baseline-cli.test.ts
@@ -4,6 +4,7 @@ import {
   createDefaultRtcBaselineEnvelope,
   runRtcBaselineCli,
 } from '../../../baseline/command/rtc-baseline-cli.ts';
+import { writeRtcBaselineCliOutput } from '../../../baseline/command/write-rtc-baseline-cli-output.ts';
 import type { RtcBaselineEnvelope } from '../../../baseline/runtime/rtc-baseline-envelope.ts';
 
 const conclusiveComparison = {
@@ -50,6 +51,30 @@ async function run(args: readonly string[], envelope = createEnvelope()) {
 }
 
 describe('RTC baseline CLI application', () => {
+  it('writes the complete encoded value across partial synchronous writes', () => {
+    const chunks: string[] = [];
+    const decoder = new TextDecoder();
+
+    writeRtcBaselineCliOutput(
+      {
+        writeSync(bytes) {
+          const written = Math.min(2, bytes.byteLength);
+          chunks.push(decoder.decode(bytes.subarray(0, written)));
+          return written;
+        },
+      },
+      'complete',
+    );
+
+    expect(chunks.join('')).toBe('complete');
+  });
+
+  it('rejects a synchronous writer that makes no progress', () => {
+    expect(() => writeRtcBaselineCliOutput({ writeSync: () => 0 }, 'blocked')).toThrow(
+      'Synchronous output writer made no progress.',
+    );
+  });
+
   it('emits exactly four external-attempt TSV columns without inputKey', async () => {
     const envelope = createEnvelope({
       ok: true,


### PR DESCRIPTION
## What changed

- drain synchronous stdout and stderr writes completely before the RTC baseline CLI exits
- keep the CLI module's existing two-export surface unchanged behind a named output boundary
- add deterministic partial-write and stalled-writer coverage
- add a real Deno subprocess regression proving every external attempt line is emitted

## Why

The RTC-B05 browser lifecycle capture driver consumes `list-external-attempts` output. The executable boundary previously started asynchronous writes and then called `Deno.exit`, so only the first of six attempt lines was reliably observable. Replacing that boundary with a synchronous write-all loop prevents both exit-time loss and legal partial-write truncation.

Output formatting, ordering, exit statuses, persisted evidence, and package exports are unchanged.

## Validation

- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check` (TypeScript, 36 files / 341 tests, Deno check)
- focused CLI tests: 2 files / 9 tests
- Deno formatting check on all four touched files
- changed repository style check
- repository structure check
- `git diff --check`
- live `list-external-attempts` diagnostic emitted all six planned RTC-B05 lines

## Follow-up

After merge, re-anchor the governed RTC-B05 browser lifecycle evidence capture on the then-latest `main` and execute the six planned attempts.
