### PR TITLE
Resolve managers everywhere the policy asks for one

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -4479,6 +4479,7 @@ components:
         - lastFormationOutcome
         - establishmentStartedAtEpochMs
         - readiness
+        - managerPrincipalIds
       properties:
         groupRef:
           $ref: '#/components/schemas/GroupRef'
@@ -4500,6 +4501,10 @@ components:
           type: integer
           format: int64
           nullable: true
+        managerPrincipalIds:
+          type: array
+          items:
+            type: string
         readiness:
           type: object
           required: [plannedEdgeCount, observedEdgeCount, observedRate]

--- a/apps/api-v1/src/composition/create-api-v1-route-installers.ts
+++ b/apps/api-v1/src/composition/create-api-v1-route-installers.ts
@@ -67,6 +67,9 @@ export interface ApiV1RouteInstallerRuntime extends ApiV1StateSnapshotRouteRunti
 export interface ApiV1RouteInstallerTopology {
   readonly topologyManagement: graphTopologyRoutes.GraphTopologyRouteTopologyManagement;
   readonly adminClientIds: readonly string[];
+  readonly groupStateRepository: Readonly<{
+    readLifecyclePolicy: graphTopologyRoutes.GraphTopologyRouteDependencies['readLifecyclePolicy'];
+  }>;
 }
 
 export interface ApiV1RouteInstallerAdminServices {
@@ -237,6 +240,7 @@ function createApiV1StateRouteInstallers<
           ),
         requireApiAuthSession: requireSession,
         adminClientIds: input.topology.adminClientIds,
+        readLifecyclePolicy: (ref) => input.topology.groupStateRepository.readLifecyclePolicy(ref),
         now: input.nowEpochMs,
       }),
   ];

--- a/apps/api-v1/src/routes/graph-topology-routes.ts
+++ b/apps/api-v1/src/routes/graph-topology-routes.ts
@@ -12,6 +12,11 @@ import {
   computeGroupFormationReadiness,
 } from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
 import type { GroupFormationView } from '@shared/api/group-lifecycle/group-formation-view.ts';
+// prettier-ignore
+import type {
+  GroupLifecyclePolicyRead,
+} from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
+import { readGroupFormationView } from './group-formation-view-read.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
 import type { Either } from '@shared/resilience/Either.ts';
 import {
@@ -90,6 +95,7 @@ export type GraphTopologyRouteDependencies = Readonly<{
     req: { header(name: string): string | undefined },
   ) => Promise<IssuedAuthSession>;
   adminClientIds: readonly string[];
+  readLifecyclePolicy: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
   now: () => number;
 }>;
 
@@ -341,35 +347,6 @@ async function handlePutTopologyOverride(
   } catch (error) {
     return toErrorResponse(context, error);
   }
-}
-
-async function readGroupFormationView(
-  groupRef: GroupRef,
-  snapshot: GroupSnapshot,
-  deps: GraphTopologyRouteDependencies,
-): Promise<GroupFormationView> {
-  const [authority, view] = await Promise.all([
-    deps.topologyManagement.readTopologyPlanningAuthority(groupRef, undefined, snapshot),
-    deps.topologyManagement.readTopologyView(groupRef) as Promise<
-      Readonly<{ snapshot: RallarOverlayTopologySnapshot | null }>
-    >,
-  ]);
-  const group = authority.group.group;
-  return {
-    groupRef,
-    lifecycleState: group.lifecycleState,
-    formationEpoch: group.formationEpoch,
-    formationAttemptCount: group.formationAttemptCount,
-    lastFormationOutcome: group.lastFormationOutcome,
-    establishmentStartedAtEpochMs: group.establishmentStartedAtEpochMs,
-    readiness: view.snapshot === null
-      ? { plannedEdgeCount: 0, observedEdgeCount: 0, observedRate: 1 }
-      : computeGroupFormationReadiness({
-        planned: view.snapshot,
-        rttMeasurements: authority.rttMeasurements,
-        nowEpochMs: authority.nowEpochMs,
-      }),
-  };
 }
 
 async function readCurrentGroupSnapshot(

--- a/apps/api-v1/src/routes/group-formation-view-read.ts
+++ b/apps/api-v1/src/routes/group-formation-view-read.ts
@@ -1,0 +1,74 @@
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+// prettier-ignore
+import {
+  computeGroupFormationReadiness,
+} from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
+import type { GroupFormationView } from '@shared/api/group-lifecycle/group-formation-view.ts';
+// prettier-ignore
+import {
+  createDefaultGroupLifecyclePolicy,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+// prettier-ignore
+import {
+  resolveGroupLifecycleManagers,
+  toGroupLifecycleElectionKey,
+} from '@shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts';
+// prettier-ignore
+import type {
+  GroupLifecyclePolicyRead,
+} from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GraphTopologyRouteTopologyManagement } from './graph-topology-routes.ts';
+
+export interface ReadGroupFormationViewDependencies {
+  readonly topologyManagement: GraphTopologyRouteTopologyManagement;
+  readonly readLifecyclePolicy: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
+}
+
+export async function readGroupFormationView(
+  groupRef: GroupRef,
+  snapshot: GroupSnapshot,
+  deps: ReadGroupFormationViewDependencies,
+): Promise<GroupFormationView> {
+  const [authority, view] = await Promise.all([
+    deps.topologyManagement.readTopologyPlanningAuthority(groupRef, undefined, snapshot),
+    deps.topologyManagement.readTopologyView(groupRef) as Promise<
+      Readonly<{ snapshot: RallarOverlayTopologySnapshot | null }>
+    >,
+  ]);
+  const group = authority.group.group;
+  const policyRead = await deps.readLifecyclePolicy(groupRef);
+  return {
+    groupRef,
+    lifecycleState: group.lifecycleState,
+    formationEpoch: group.formationEpoch,
+    formationAttemptCount: group.formationAttemptCount,
+    lastFormationOutcome: group.lastFormationOutcome,
+    establishmentStartedAtEpochMs: group.establishmentStartedAtEpochMs,
+    readiness: view.snapshot === null
+      ? { plannedEdgeCount: 0, observedEdgeCount: 0, observedRate: 1 }
+      : computeGroupFormationReadiness({
+        planned: view.snapshot,
+        rttMeasurements: authority.rttMeasurements,
+        nowEpochMs: authority.nowEpochMs,
+      }),
+    managerPrincipalIds: policyRead.status === 'corrupt'
+      // Fail closed: an unreadable stored policy must not resolve authority.
+      ? []
+      : resolveGroupLifecycleManagers({
+        manager: (policyRead.status === 'present'
+          ? policyRead.policy
+          : createDefaultGroupLifecyclePolicy()).manager,
+        ownerPrincipalId: group.ownerPrincipalId,
+        formationElectorate: group.formationElectorate,
+        formationEpoch: group.formationEpoch,
+        groupKey: toGroupLifecycleElectionKey(groupRef),
+        activePrincipalIds: new Set(
+          authority.group.members
+            .filter((member) => member.status === 'active')
+            .map((member) => member.principalId),
+        ),
+        rankByPrincipalId: null,
+      }),
+  };
+}

--- a/apps/api-v1/test/composition/create-api-v1-route-installers.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-route-installers.test.ts
@@ -168,6 +168,9 @@ function createTopology(): ApiV1RouteInstallerTopology {
       readTopologyPlanningAuthority: rejectUnusedOperation,
     },
     adminClientIds: ['admin'],
+    groupStateRepository: {
+      readLifecyclePolicy: () => Promise.resolve({ status: 'absent' as const }),
+    },
   };
 }
 

--- a/apps/api-v1/test/db/pglite-sql-adapter.test.ts
+++ b/apps/api-v1/test/db/pglite-sql-adapter.test.ts
@@ -2459,6 +2459,7 @@ Deno.test(
             graphTopologyRoutes.processTopologyAppInbox(service, authSession, enqueue),
           requireApiAuthSession: () => Promise.resolve(authority),
           adminClientIds: [],
+          readLifecyclePolicy: () => Promise.resolve({ status: 'absent' as const }),
           now: () => nowEpochMs,
         });
         return app;

--- a/apps/api-v1/test/routes/graph-topology-routes.test.ts
+++ b/apps/api-v1/test/routes/graph-topology-routes.test.ts
@@ -627,6 +627,7 @@ function createRouteApp(options: {
     requireApiAuthSession: options.requireApiAuthSession ??
       (() => Promise.resolve(options.session ?? createIssuedSession('owner', 'owner-session'))),
     adminClientIds: options.adminClientIds ?? [],
+    readLifecyclePolicy: () => Promise.resolve({ status: 'absent' as const }),
     graphDiagnostics: {
       readScopedGlobalGraphDiagnostic: options.graphDiagnostics?.readScopedGlobalGraphDiagnostic ??
         ((scope) => Either.ofRight(createGraphResponse({ ...scope, groupId: '__global__' }))),

--- a/packages/shared-server/rallar-system/group-policy.ts
+++ b/packages/shared-server/rallar-system/group-policy.ts
@@ -1,15 +1,20 @@
 import type {
-    Group,
-    GroupMember,
-    GroupPresenceSession,
-    GroupSnapshot,
+  Group,
+  GroupMember,
+  GroupPresenceSession,
+  GroupSnapshot,
 } from '@shared/api/group-types.ts';
 import type {
-    GroupPolicyDenied,
-    GroupPolicyReasonCode,
-    GroupPolicyResult,
+  GroupPolicyDenied,
+  GroupPolicyReasonCode,
+  GroupPolicyResult,
 } from '@shared/api/group-policy-types.ts';
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+// prettier-ignore
+import {
+  resolveGroupLifecycleManagers,
+  toGroupLifecycleElectionKey,
+} from '@shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts';
 // prettier-ignore
 import type {
     GroupLifecycleTransition,
@@ -20,9 +25,9 @@ import {
 } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 
 export type GroupPolicyActor = Readonly<{
-    principalId?: string;
-    sessionId?: string;
-    serviceId?: string;
+  principalId?: string;
+  sessionId?: string;
+  serviceId?: string;
 }>;
 
 /**
@@ -32,335 +37,290 @@ export type GroupPolicyActor = Readonly<{
  * disabled. A stored `group.maxMembers` always wins over the default.
  */
 export type GroupPolicyCapacityConfig = Readonly<{
-    defaultMaxMembers: number | null;
+  defaultMaxMembers: number | null;
 }>;
 
 export type CanJoinGroupInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    nowEpochMs?: number;
-    capacity?: GroupPolicyCapacityConfig;
-    inviteToken?: string;
-    expectedInviteToken?: string;
-    joinCode?: string;
-    expectedJoinCode?: string;
-    joinCodeVerifier?: string;
-    expectedJoinCodeVerifier?: string;
-    joinCodeExpiresAtEpochMs?: number;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  nowEpochMs?: number;
+  capacity?: GroupPolicyCapacityConfig;
+  inviteToken?: string;
+  expectedInviteToken?: string;
+  joinCode?: string;
+  expectedJoinCode?: string;
+  joinCodeVerifier?: string;
+  expectedJoinCodeVerifier?: string;
+  joinCodeExpiresAtEpochMs?: number;
 }>;
 
 export type CanConnectGroupPresenceSessionInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    sessionId: string;
-    nowEpochMs?: number;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  sessionId: string;
+  nowEpochMs?: number;
 }>;
 
 export type CanActivateGroupMemberInput = Readonly<{
-    snapshot: GroupSnapshot;
-    targetPrincipalId: string;
-    nowEpochMs?: number;
-    capacity?: GroupPolicyCapacityConfig;
+  snapshot: GroupSnapshot;
+  targetPrincipalId: string;
+  nowEpochMs?: number;
+  capacity?: GroupPolicyCapacityConfig;
 }>;
 
 export type CanMutateActiveGroupInput = Readonly<{
-    group: Group;
-    nowEpochMs?: number;
+  group: Group;
+  nowEpochMs?: number;
 }>;
 
 export type ShouldPlanGroupPurgeInput = Readonly<{
-    group: Group;
-    nowEpochMs: number;
+  group: Group;
+  nowEpochMs: number;
 }>;
 
 export type CanReadGroupSnapshotInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    nowEpochMs?: number;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  nowEpochMs?: number;
 }>;
 
 export type CanUpdateGroupSnapshotInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    nowEpochMs?: number;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  nowEpochMs?: number;
 }>;
 
-export type GroupReadVisibility =
-    | 'full'
-    | 'invite'
-    | 'directory'
-    | 'none';
+export type GroupReadVisibility = 'full' | 'invite' | 'directory' | 'none';
 
 export type CanChangeGroupLifecycleInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    targetStatus: Group['status'];
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  targetStatus: Group['status'];
 }>;
 
 export type CanCommandGroupLifecycleTransitionInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    policy: GroupLifecyclePolicy;
-    transition: GroupLifecycleTransition;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  policy: GroupLifecyclePolicy;
+  transition: GroupLifecycleTransition;
+  /**
+   * The full active roster at decision time. The policy snapshot on the
+   * mutation path carries only the involved members, and manager
+   * resolution's liveness filter needs every candidate, not just them.
+   */
+  activeMemberPrincipalIds: readonly string[];
 }>;
 
 export type GroupGovernanceAction =
-    | 'invite'
-    | 'remove'
-    | 'ban'
-    | 'unban'
-    | 'promote'
-    | 'demote'
-    | 'transfer-ownership';
+  'invite' | 'remove' | 'ban' | 'unban' | 'promote' | 'demote' | 'transfer-ownership';
 
 export type CanGovernGroupMemberInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    targetPrincipalId: string;
-    action: GroupGovernanceAction;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  targetPrincipalId: string;
+  action: GroupGovernanceAction;
 }>;
 
 export type CanSendRoomMessageInput = Readonly<{
-    snapshot: GroupSnapshot;
-    actor: GroupPolicyActor;
-    senderSessionId: string;
-    minSnapshotVersion?: number;
-    nowEpochMs?: number;
+  snapshot: GroupSnapshot;
+  actor: GroupPolicyActor;
+  senderSessionId: string;
+  minSnapshotVersion?: number;
+  nowEpochMs?: number;
 }>;
 
-const ALLOWED: GroupPolicyResult = {allowed: true};
+const ALLOWED: GroupPolicyResult = { allowed: true };
 
 export class GroupPolicyDeniedError extends Error {
-    public override readonly name = 'GroupPolicyDeniedError';
-    public readonly status = 403;
+  public override readonly name = 'GroupPolicyDeniedError';
+  public readonly status = 403;
 
-    public readonly denial: GroupPolicyDenied;
+  public readonly denial: GroupPolicyDenied;
 
-    public constructor(denial: GroupPolicyDenied) {
-        super(`Forbidden: ${denial.message}`);
-        this.denial = denial;
-    }
+  public constructor(denial: GroupPolicyDenied) {
+    super(`Forbidden: ${denial.message}`);
+    this.denial = denial;
+  }
 }
 
-export function isGroupPolicyDeniedError(
-    error: unknown,
-): error is GroupPolicyDeniedError {
-    return error instanceof GroupPolicyDeniedError;
+export function isGroupPolicyDeniedError(error: unknown): error is GroupPolicyDeniedError {
+  return error instanceof GroupPolicyDeniedError;
 }
 
 export function canJoinGroup(input: CanJoinGroupInput): GroupPolicyResult {
-    const lifecycleDenial = requireActiveGroup(
-        input.snapshot.group,
-        input.nowEpochMs,
-    );
-    if (lifecycleDenial) {
-        return lifecycleDenial;
-    }
+  const lifecycleDenial = requireActiveGroup(input.snapshot.group, input.nowEpochMs);
+  if (lifecycleDenial) {
+    return lifecycleDenial;
+  }
 
-    const principalId = input.actor.principalId;
-    if (!principalId) {
-        return deny('group-policy-denied', 'A principal is required to join a group.');
-    }
+  const principalId = input.actor.principalId;
+  if (!principalId) {
+    return deny('group-policy-denied', 'A principal is required to join a group.');
+  }
 
-    const member = findMember(input.snapshot, principalId);
-    const memberDenial = denyForBlockedMember(member);
-    if (memberDenial) {
-        return memberDenial;
-    }
+  const member = findMember(input.snapshot, principalId);
+  const memberDenial = denyForBlockedMember(member);
+  if (memberDenial) {
+    return memberDenial;
+  }
 
-    if (wouldExceedMemberCap(input.snapshot, member, input.capacity)) {
-        return deny('group-full', 'Group member capacity has been reached.');
-    }
+  if (wouldExceedMemberCap(input.snapshot, member, input.capacity)) {
+    return deny('group-full', 'Group member capacity has been reached.');
+  }
 
-    switch (input.snapshot.group.joinMode) {
-        case 'open':
-            return ALLOWED;
-        case 'invite-only':
-            return canUseInvite(input, member);
-        case 'code':
-            return canUseJoinCode(input);
-    }
+  switch (input.snapshot.group.joinMode) {
+    case 'open':
+      return ALLOWED;
+    case 'invite-only':
+      return canUseInvite(input, member);
+    case 'code':
+      return canUseJoinCode(input);
+  }
 }
 
 export function canConnectGroupPresenceSession(
-    input: CanConnectGroupPresenceSessionInput,
+  input: CanConnectGroupPresenceSessionInput,
 ): GroupPolicyResult {
-    const lifecycleDenial = requireActiveGroup(
-        input.snapshot.group,
-        input.nowEpochMs,
+  const lifecycleDenial = requireActiveGroup(input.snapshot.group, input.nowEpochMs);
+  if (lifecycleDenial) {
+    return lifecycleDenial;
+  }
+
+  const principalId = input.actor.principalId;
+  if (!principalId) {
+    return deny('member-not-active', 'An active group member is required for presence.');
+  }
+
+  const member = findMember(input.snapshot, principalId);
+  const memberDenial = denyForPresenceMember(member);
+  if (memberDenial) {
+    return memberDenial;
+  }
+
+  const cap = input.snapshot.group.maxSessionsPerMember;
+  if (cap !== null) {
+    const liveSessions = input.snapshot.activeSessions.filter(
+      (session) => session.principalId === principalId && isLiveSession(session, input.nowEpochMs),
     );
-    if (lifecycleDenial) {
-        return lifecycleDenial;
+    const alreadyConnected = liveSessions.some((session) => session.sessionId === input.sessionId);
+    if (!alreadyConnected && liveSessions.length >= cap) {
+      return deny(
+        'member-session-limit-reached',
+        'Group member session capacity has been reached.',
+      );
     }
+  }
 
-    const principalId = input.actor.principalId;
-    if (!principalId) {
-        return deny(
-            'member-not-active',
-            'An active group member is required for presence.',
-        );
-    }
+  return ALLOWED;
+}
 
-    const member = findMember(input.snapshot, principalId);
-    const memberDenial = denyForPresenceMember(member);
-    if (memberDenial) {
-        return memberDenial;
-    }
+export function canActivateGroupMember(input: CanActivateGroupMemberInput): GroupPolicyResult {
+  const lifecycleDenial = requireActiveGroup(input.snapshot.group, input.nowEpochMs);
+  if (lifecycleDenial) {
+    return lifecycleDenial;
+  }
 
-    const cap = input.snapshot.group.maxSessionsPerMember;
-    if (cap !== null) {
-        const liveSessions = input.snapshot.activeSessions.filter((session) =>
-            session.principalId === principalId && isLiveSession(session, input.nowEpochMs)
-        );
-        const alreadyConnected = liveSessions.some((session) => session.sessionId === input.sessionId);
-        if (!alreadyConnected && liveSessions.length >= cap) {
-            return deny(
-                'member-session-limit-reached',
-                'Group member session capacity has been reached.',
-            );
-        }
-    }
+  const member = findMember(input.snapshot, input.targetPrincipalId);
+  if (wouldExceedMemberCap(input.snapshot, member, input.capacity)) {
+    return deny('group-full', 'Group member capacity has been reached.');
+  }
 
+  return ALLOWED;
+}
+
+export function canMutateActiveGroup(input: CanMutateActiveGroupInput): GroupPolicyResult {
+  return requireActiveGroup(input.group, input.nowEpochMs) ?? ALLOWED;
+}
+
+export function shouldPlanGroupPurge(input: ShouldPlanGroupPurgeInput): boolean {
+  return (
+    input.group.purgeAfterEpochMs !== null && input.group.purgeAfterEpochMs <= input.nowEpochMs
+  );
+}
+
+export function canReadGroupSnapshot(input: CanReadGroupSnapshotInput): GroupPolicyResult {
+  if (input.snapshot.group.status === 'deleted') {
+    return deny('group-deleted', 'Deleted groups are not readable.');
+  }
+
+  const principalId = input.actor.principalId;
+  if (!principalId) {
+    return deny('group-policy-denied', 'A principal is required to read group state.');
+  }
+
+  const member = findMember(input.snapshot, principalId);
+  const blockedDenial = denyForBlockedMember(member);
+  if (blockedDenial) {
+    return blockedDenial;
+  }
+
+  const visibility = readGroupVisibility(input);
+  if (visibility === 'full') {
     return ALLOWED;
+  }
+
+  return deny('group-policy-denied', 'Only active group members can read full group state.', {
+    visibility,
+  });
 }
 
-export function canActivateGroupMember(
-    input: CanActivateGroupMemberInput,
-): GroupPolicyResult {
-    const lifecycleDenial = requireActiveGroup(
-        input.snapshot.group,
-        input.nowEpochMs,
-    );
-    if (lifecycleDenial) {
-        return lifecycleDenial;
-    }
+export function canUpdateGroupSnapshot(input: CanUpdateGroupSnapshotInput): GroupPolicyResult {
+  const lifecycleDenial = requireActiveGroup(input.snapshot.group, input.nowEpochMs);
+  if (lifecycleDenial) {
+    return lifecycleDenial;
+  }
 
-    const member = findMember(input.snapshot, input.targetPrincipalId);
-    if (wouldExceedMemberCap(input.snapshot, member, input.capacity)) {
-        return deny('group-full', 'Group member capacity has been reached.');
-    }
+  const actorMember = findActorMember(input.snapshot, input.actor);
+  if (!actorMember) {
+    return deny('member-not-active', 'An active group member is required for this operation.');
+  }
 
-    return ALLOWED;
+  const memberDenial = denyForPresenceMember(actorMember);
+  if (memberDenial) {
+    return memberDenial;
+  }
+
+  if (actorMember.role !== 'owner' && actorMember.role !== 'admin') {
+    return deny('forbidden-role', 'Only active group owners/admins can update groups.');
+  }
+
+  return ALLOWED;
 }
 
-export function canMutateActiveGroup(
-    input: CanMutateActiveGroupInput,
-): GroupPolicyResult {
-    return requireActiveGroup(input.group, input.nowEpochMs) ?? ALLOWED;
+export function readGroupVisibility(input: CanReadGroupSnapshotInput): GroupReadVisibility {
+  if (input.snapshot.group.status === 'deleted') {
+    return 'none';
+  }
+
+  const principalId = input.actor.principalId;
+  if (!principalId) {
+    return readDirectoryVisibility(input.snapshot);
+  }
+
+  const member = findMember(input.snapshot, principalId);
+  switch (member?.status) {
+    case 'active':
+      return 'full';
+    case 'invited':
+      return isInviteExpired(member, input.nowEpochMs)
+        ? readDirectoryVisibility(input.snapshot)
+        : 'invite';
+    case 'left':
+    case undefined:
+      return readDirectoryVisibility(input.snapshot);
+    case 'removed':
+    case 'banned':
+      return 'none';
+  }
 }
 
-export function shouldPlanGroupPurge(
-    input: ShouldPlanGroupPurgeInput,
-): boolean {
-    return input.group.purgeAfterEpochMs !== null &&
-        input.group.purgeAfterEpochMs <= input.nowEpochMs;
-}
+export function canChangeGroupLifecycle(input: CanChangeGroupLifecycleInput): GroupPolicyResult {
+  const actorMember = findActorMember(input.snapshot, input.actor);
+  if (!isActiveOwnerOrAdmin(actorMember)) {
+    return deny('forbidden-role', 'Only active group owners/admins can change group lifecycle.');
+  }
 
-export function canReadGroupSnapshot(
-    input: CanReadGroupSnapshotInput,
-): GroupPolicyResult {
-    if (input.snapshot.group.status === 'deleted') {
-        return deny('group-deleted', 'Deleted groups are not readable.');
-    }
-
-    const principalId = input.actor.principalId;
-    if (!principalId) {
-        return deny('group-policy-denied', 'A principal is required to read group state.');
-    }
-
-    const member = findMember(input.snapshot, principalId);
-    const blockedDenial = denyForBlockedMember(member);
-    if (blockedDenial) {
-        return blockedDenial;
-    }
-
-    const visibility = readGroupVisibility(input);
-    if (visibility === 'full') {
-        return ALLOWED;
-    }
-
-    return deny(
-        'group-policy-denied',
-        'Only active group members can read full group state.',
-        {visibility},
-    );
-}
-
-export function canUpdateGroupSnapshot(
-    input: CanUpdateGroupSnapshotInput,
-): GroupPolicyResult {
-    const lifecycleDenial = requireActiveGroup(
-        input.snapshot.group,
-        input.nowEpochMs,
-    );
-    if (lifecycleDenial) {
-        return lifecycleDenial;
-    }
-
-    const actorMember = findActorMember(input.snapshot, input.actor);
-    if (!actorMember) {
-        return deny(
-            'member-not-active',
-            'An active group member is required for this operation.',
-        );
-    }
-
-    const memberDenial = denyForPresenceMember(actorMember);
-    if (memberDenial) {
-        return memberDenial;
-    }
-
-    if (actorMember.role !== 'owner' && actorMember.role !== 'admin') {
-        return deny(
-            'forbidden-role',
-            'Only active group owners/admins can update groups.',
-        );
-    }
-
-    return ALLOWED;
-}
-
-export function readGroupVisibility(
-    input: CanReadGroupSnapshotInput,
-): GroupReadVisibility {
-    if (input.snapshot.group.status === 'deleted') {
-        return 'none';
-    }
-
-    const principalId = input.actor.principalId;
-    if (!principalId) {
-        return readDirectoryVisibility(input.snapshot);
-    }
-
-    const member = findMember(input.snapshot, principalId);
-    switch (member?.status) {
-        case 'active':
-            return 'full';
-        case 'invited':
-            return isInviteExpired(member, input.nowEpochMs)
-                ? readDirectoryVisibility(input.snapshot)
-                : 'invite';
-        case 'left':
-        case undefined:
-            return readDirectoryVisibility(input.snapshot);
-        case 'removed':
-        case 'banned':
-            return 'none';
-    }
-}
-
-export function canChangeGroupLifecycle(
-    input: CanChangeGroupLifecycleInput,
-): GroupPolicyResult {
-    const actorMember = findActorMember(input.snapshot, input.actor);
-    if (!isActiveOwnerOrAdmin(actorMember)) {
-        return deny(
-            'forbidden-role',
-            'Only active group owners/admins can change group lifecycle.',
-        );
-    }
-
-    return ALLOWED;
+  return ALLOWED;
 }
 
 /**
@@ -370,356 +330,308 @@ export function canChangeGroupLifecycle(
  * part of the same decision, so this predicate answers both.
  */
 export function canCommandGroupLifecycleTransition(
-    input: CanCommandGroupLifecycleTransitionInput,
+  input: CanCommandGroupLifecycleTransitionInput,
 ): GroupPolicyResult {
-    const actorMember = findActorMember(input.snapshot, input.actor);
-    const blocked = denyForPresenceMember(actorMember);
-    if (blocked) {
-        return blocked;
-    }
-    const authority = denyForLifecycleInitiator(input);
-    if (authority) {
-        return authority;
-    }
-    const transition = computeGroupLifecycleTransition({
-        transition: input.transition,
-        lifecycleState: input.snapshot.group.lifecycleState,
-        formationEpoch: input.snapshot.group.formationEpoch,
-    });
-    return transition.allowed ? ALLOWED : transition;
+  const actorMember = findActorMember(input.snapshot, input.actor);
+  const blocked = denyForPresenceMember(actorMember);
+  if (blocked) {
+    return blocked;
+  }
+  const authority = denyForLifecycleInitiator(input);
+  if (authority) {
+    return authority;
+  }
+  const transition = computeGroupLifecycleTransition({
+    transition: input.transition,
+    lifecycleState: input.snapshot.group.lifecycleState,
+    formationEpoch: input.snapshot.group.formationEpoch,
+  });
+  return transition.allowed ? ALLOWED : transition;
 }
 
 function denyForLifecycleInitiator(
-    input: CanCommandGroupLifecycleTransitionInput,
+  input: CanCommandGroupLifecycleTransitionInput,
 ): GroupPolicyDenied | undefined {
-    switch (input.policy.establishment.initiator) {
-        case 'any-member':
-            return undefined;
-        case 'server-auto':
-            return deny(
-                'forbidden-role',
-                'Lifecycle transitions are server-initiated under this policy.',
-            );
-        case 'manager':
-            return denyForUnderivedManager(input);
-    }
+  switch (input.policy.establishment.initiator) {
+    case 'any-member':
+      return undefined;
+    case 'server-auto':
+      return deny(
+        'forbidden-role',
+        'Lifecycle transitions are server-initiated under this policy.',
+      );
+    case 'manager':
+      return denyForNonManager(input);
+  }
 }
 
-/**
- * The manager role is a later slice; until it lands the manager is derived
- * where the policy makes that possible and honestly unavailable where it does
- * not. Election variants need the epoch-pinned member set that slice 4 owns.
- */
-function denyForUnderivedManager(
-    input: CanCommandGroupLifecycleTransitionInput,
+function denyForNonManager(
+  input: CanCommandGroupLifecycleTransitionInput,
 ): GroupPolicyDenied | undefined {
-    const principalId = input.actor.principalId;
-    switch (input.policy.manager.selection) {
-        case 'creator':
-            return principalId === input.snapshot.group.ownerPrincipalId
-                ? undefined
-                : deny(
-                    'forbidden-role',
-                    'Only the group manager can command lifecycle transitions.',
-                );
-        case 'assigned':
-            return principalId !== undefined &&
-                    input.policy.manager.assignedPrincipalIds.includes(principalId)
-                ? undefined
-                : deny(
-                    'forbidden-role',
-                    'Only an assigned group manager can command lifecycle transitions.',
-                );
-        case 'none':
-        case 'elected-by-rank':
-        case 'elected-random-deterministic':
-            return deny(
-                'lifecycle-manager-unavailable',
-                'No group manager can be derived under this policy in this release.',
-            );
-    }
+  const managers = resolveGroupLifecycleManagers({
+    manager: input.policy.manager,
+    ownerPrincipalId: input.snapshot.group.ownerPrincipalId,
+    formationElectorate: input.snapshot.group.formationElectorate,
+    formationEpoch: input.snapshot.group.formationEpoch,
+    groupKey: toGroupLifecycleElectionKey(input.snapshot.group),
+    activePrincipalIds: new Set(input.activeMemberPrincipalIds),
+    // No rank source exists in v1 (plan decision 4.2).
+    rankByPrincipalId: null,
+  });
+  if (managers.length === 0) {
+    // The zero-manager fallback: only manager-assigned actions block.
+    return deny('lifecycle-manager-unavailable', 'No group manager resolves under this policy.');
+  }
+  const principalId = input.actor.principalId;
+  return principalId !== undefined && managers.includes(principalId)
+    ? undefined
+    : deny('forbidden-role', 'Only the group manager can command lifecycle transitions.');
 }
 
-export function canGovernGroupMember(
-    input: CanGovernGroupMemberInput,
-): GroupPolicyResult {
-    const actorMember = findActorMember(input.snapshot, input.actor);
-    if (!isActiveOwnerOrAdmin(actorMember)) {
-        return deny(
-            'forbidden-role',
-            'Only active group owners/admins can govern group members.',
-        );
-    }
+export function canGovernGroupMember(input: CanGovernGroupMemberInput): GroupPolicyResult {
+  const actorMember = findActorMember(input.snapshot, input.actor);
+  if (!isActiveOwnerOrAdmin(actorMember)) {
+    return deny('forbidden-role', 'Only active group owners/admins can govern group members.');
+  }
 
-    if (
-        input.action === 'transfer-ownership' &&
-        actorMember.role !== 'owner'
-    ) {
-        return deny(
-            'forbidden-role',
-            'Only active group owners can transfer group ownership.',
-        );
-    }
+  if (input.action === 'transfer-ownership' && actorMember.role !== 'owner') {
+    return deny('forbidden-role', 'Only active group owners can transfer group ownership.');
+  }
 
-    const targetMember = findMember(input.snapshot, input.targetPrincipalId);
-    if (
-        actorMember.role === 'admin' &&
-        targetMember &&
-        (targetMember.role === 'owner' || targetMember.role === 'admin')
-    ) {
-        return deny(
-            'forbidden-role',
-            'Group admins can only govern regular members.',
-        );
-    }
+  const targetMember = findMember(input.snapshot, input.targetPrincipalId);
+  if (
+    actorMember.role === 'admin' &&
+    targetMember &&
+    (targetMember.role === 'owner' || targetMember.role === 'admin')
+  ) {
+    return deny('forbidden-role', 'Group admins can only govern regular members.');
+  }
 
-    if (
-        targetMember &&
-        isLastActiveOwner(input.snapshot, targetMember) &&
-        removesOwner(input.action)
-    ) {
-        return deny('last-owner', 'Cannot leave an active group without an owner.');
-    }
+  if (
+    targetMember &&
+    isLastActiveOwner(input.snapshot, targetMember) &&
+    removesOwner(input.action)
+  ) {
+    return deny('last-owner', 'Cannot leave an active group without an owner.');
+  }
 
-    return ALLOWED;
+  return ALLOWED;
 }
 
-export function canSendRoomMessage(
-    input: CanSendRoomMessageInput,
-): GroupPolicyResult {
-    if (
-        input.minSnapshotVersion !== undefined &&
-        input.snapshot.group.snapshotVersion < input.minSnapshotVersion
-    ) {
-        return deny('group-policy-denied', 'Group snapshot is not fresh enough.');
-    }
+export function canSendRoomMessage(input: CanSendRoomMessageInput): GroupPolicyResult {
+  if (
+    input.minSnapshotVersion !== undefined &&
+    input.snapshot.group.snapshotVersion < input.minSnapshotVersion
+  ) {
+    return deny('group-policy-denied', 'Group snapshot is not fresh enough.');
+  }
 
-    const lifecycleDenial = requireActiveGroup(
-        input.snapshot.group,
-        input.nowEpochMs,
+  const lifecycleDenial = requireActiveGroup(input.snapshot.group, input.nowEpochMs);
+  if (lifecycleDenial) {
+    return lifecycleDenial;
+  }
+
+  const liveSession = input.snapshot.activeSessions.find(
+    (session) =>
+      session.sessionId === input.senderSessionId && isLiveSession(session, input.nowEpochMs),
+  );
+  const principalId = input.actor.principalId ?? liveSession?.principalId;
+  if (!liveSession || !principalId || liveSession.principalId !== principalId) {
+    return deny(
+      'member-not-active',
+      'A live active group session is required to send room messages.',
     );
-    if (lifecycleDenial) {
-        return lifecycleDenial;
-    }
+  }
 
-    const liveSession = input.snapshot.activeSessions.find((session) =>
-        session.sessionId === input.senderSessionId &&
-        isLiveSession(session, input.nowEpochMs)
-    );
-    const principalId = input.actor.principalId ?? liveSession?.principalId;
-    if (!liveSession || !principalId || liveSession.principalId !== principalId) {
-        return deny(
-            'member-not-active',
-            'A live active group session is required to send room messages.',
-        );
-    }
+  const member = findMember(input.snapshot, principalId);
+  const memberDenial = denyForPresenceMember(member);
+  if (memberDenial) {
+    return memberDenial;
+  }
 
-    const member = findMember(input.snapshot, principalId);
-    const memberDenial = denyForPresenceMember(member);
-    if (memberDenial) {
-        return memberDenial;
-    }
-
-    return ALLOWED;
+  return ALLOWED;
 }
 
 function canUseInvite(
-    input: CanJoinGroupInput,
-    member: GroupMember | undefined,
+  input: CanJoinGroupInput,
+  member: GroupMember | undefined,
 ): GroupPolicyResult {
-    if (member?.status === 'active') {
-        return ALLOWED;
-    }
-
-    if (
-        input.inviteToken &&
-        input.expectedInviteToken !== undefined &&
-        input.inviteToken === input.expectedInviteToken
-    ) {
-        return ALLOWED;
-    }
-
-    if (member?.status !== 'invited') {
-        return deny('group-invite-required', 'A valid invite is required to join.');
-    }
-
-    if (
-        member.invitationExpiresAtEpochMs !== null &&
-        input.nowEpochMs !== undefined &&
-        member.invitationExpiresAtEpochMs <= input.nowEpochMs
-    ) {
-        return deny('group-invite-expired', 'Group invite has expired.');
-    }
-
+  if (member?.status === 'active') {
     return ALLOWED;
+  }
+
+  if (
+    input.inviteToken &&
+    input.expectedInviteToken !== undefined &&
+    input.inviteToken === input.expectedInviteToken
+  ) {
+    return ALLOWED;
+  }
+
+  if (member?.status !== 'invited') {
+    return deny('group-invite-required', 'A valid invite is required to join.');
+  }
+
+  if (
+    member.invitationExpiresAtEpochMs !== null &&
+    input.nowEpochMs !== undefined &&
+    member.invitationExpiresAtEpochMs <= input.nowEpochMs
+  ) {
+    return deny('group-invite-expired', 'Group invite has expired.');
+  }
+
+  return ALLOWED;
 }
 
 function canUseJoinCode(input: CanJoinGroupInput): GroupPolicyResult {
-    if (!input.joinCode) {
-        return deny('group-code-required', 'A join code is required to join.');
-    }
+  if (!input.joinCode) {
+    return deny('group-code-required', 'A join code is required to join.');
+  }
 
-    if (
-        input.joinCodeExpiresAtEpochMs !== undefined &&
-        input.nowEpochMs !== undefined &&
-        input.joinCodeExpiresAtEpochMs <= input.nowEpochMs
-    ) {
-        return deny('group-code-invalid', 'Join code is invalid.');
-    }
+  if (
+    input.joinCodeExpiresAtEpochMs !== undefined &&
+    input.nowEpochMs !== undefined &&
+    input.joinCodeExpiresAtEpochMs <= input.nowEpochMs
+  ) {
+    return deny('group-code-invalid', 'Join code is invalid.');
+  }
 
-    if (
-        input.expectedJoinCode !== undefined &&
-        input.joinCode !== input.expectedJoinCode
-    ) {
-        return deny('group-code-invalid', 'Join code is invalid.');
-    }
+  if (input.expectedJoinCode !== undefined && input.joinCode !== input.expectedJoinCode) {
+    return deny('group-code-invalid', 'Join code is invalid.');
+  }
 
-    if (
-        input.expectedJoinCodeVerifier !== undefined &&
-        input.joinCodeVerifier !== input.expectedJoinCodeVerifier
-    ) {
-        return deny('group-code-invalid', 'Join code is invalid.');
-    }
+  if (
+    input.expectedJoinCodeVerifier !== undefined &&
+    input.joinCodeVerifier !== input.expectedJoinCodeVerifier
+  ) {
+    return deny('group-code-invalid', 'Join code is invalid.');
+  }
 
-    return ALLOWED;
+  return ALLOWED;
 }
 
 function requireActiveGroup(
-    group: Group,
-    nowEpochMs: number | undefined,
+  group: Group,
+  nowEpochMs: number | undefined,
 ): GroupPolicyDenied | undefined {
-    if (group.status === 'archived') {
-        return deny('group-archived', 'Group is archived.');
-    }
-    if (group.status === 'deleted') {
-        return deny('group-deleted', 'Group is deleted.');
-    }
-    if (group.status !== 'active') {
-        return deny('group-not-active', 'Group is not active.');
-    }
-    if (
-        group.expiresAtEpochMs !== null &&
-        nowEpochMs !== undefined &&
-        group.expiresAtEpochMs <= nowEpochMs
-    ) {
-        return deny('group-not-active', 'Group has expired.');
-    }
+  if (group.status === 'archived') {
+    return deny('group-archived', 'Group is archived.');
+  }
+  if (group.status === 'deleted') {
+    return deny('group-deleted', 'Group is deleted.');
+  }
+  if (group.status !== 'active') {
+    return deny('group-not-active', 'Group is not active.');
+  }
+  if (
+    group.expiresAtEpochMs !== null &&
+    nowEpochMs !== undefined &&
+    group.expiresAtEpochMs <= nowEpochMs
+  ) {
+    return deny('group-not-active', 'Group has expired.');
+  }
 
-    return undefined;
+  return undefined;
 }
 
 function wouldExceedMemberCap(
-    snapshot: GroupSnapshot,
-    member: GroupMember | undefined,
-    capacity: GroupPolicyCapacityConfig | undefined,
+  snapshot: GroupSnapshot,
+  member: GroupMember | undefined,
+  capacity: GroupPolicyCapacityConfig | undefined,
 ): boolean {
-    const cap = snapshot.group.maxMembers ?? capacity?.defaultMaxMembers ?? null;
-    if (cap === null || member?.status === 'active') {
-        return false;
-    }
+  const cap = snapshot.group.maxMembers ?? capacity?.defaultMaxMembers ?? null;
+  if (cap === null || member?.status === 'active') {
+    return false;
+  }
 
-    return snapshot.group.activeMemberCount >= cap;
+  return snapshot.group.activeMemberCount >= cap;
 }
 
-function denyForBlockedMember(
-    member: GroupMember | undefined,
-): GroupPolicyDenied | undefined {
-    if (member?.status === 'removed') {
-        return deny('member-removed', 'Group member has been removed.');
-    }
-    if (member?.status === 'banned') {
-        return deny('member-banned', 'Group member has been banned.');
-    }
+function denyForBlockedMember(member: GroupMember | undefined): GroupPolicyDenied | undefined {
+  if (member?.status === 'removed') {
+    return deny('member-removed', 'Group member has been removed.');
+  }
+  if (member?.status === 'banned') {
+    return deny('member-banned', 'Group member has been banned.');
+  }
 
-    return undefined;
+  return undefined;
 }
 
-function denyForPresenceMember(
-    member: GroupMember | undefined,
-): GroupPolicyDenied | undefined {
-    const blocked = denyForBlockedMember(member);
-    if (blocked) {
-        return blocked;
-    }
-    if (!member || member.status !== 'active') {
-        return deny(
-            'member-not-active',
-            'An active group member is required for this operation.',
-        );
-    }
+function denyForPresenceMember(member: GroupMember | undefined): GroupPolicyDenied | undefined {
+  const blocked = denyForBlockedMember(member);
+  if (blocked) {
+    return blocked;
+  }
+  if (!member || member.status !== 'active') {
+    return deny('member-not-active', 'An active group member is required for this operation.');
+  }
 
-    return undefined;
+  return undefined;
 }
 
 function readDirectoryVisibility(snapshot: GroupSnapshot): GroupReadVisibility {
-    return snapshot.group.status === 'active' && snapshot.group.joinMode === 'open'
-        ? 'directory'
-        : 'none';
+  return snapshot.group.status === 'active' && snapshot.group.joinMode === 'open'
+    ? 'directory'
+    : 'none';
 }
 
-function isInviteExpired(
-    member: GroupMember,
-    nowEpochMs: number | undefined,
-): boolean {
-    return member.invitationExpiresAtEpochMs !== null &&
-        nowEpochMs !== undefined &&
-        member.invitationExpiresAtEpochMs <= nowEpochMs;
+function isInviteExpired(member: GroupMember, nowEpochMs: number | undefined): boolean {
+  return (
+    member.invitationExpiresAtEpochMs !== null &&
+    nowEpochMs !== undefined &&
+    member.invitationExpiresAtEpochMs <= nowEpochMs
+  );
 }
 
 function findActorMember(
-    snapshot: GroupSnapshot,
-    actor: GroupPolicyActor,
+  snapshot: GroupSnapshot,
+  actor: GroupPolicyActor,
 ): GroupMember | undefined {
-    return actor.principalId ? findMember(snapshot, actor.principalId) : undefined;
+  return actor.principalId ? findMember(snapshot, actor.principalId) : undefined;
 }
 
-function findMember(
-    snapshot: GroupSnapshot,
-    principalId: string,
-): GroupMember | undefined {
-    return snapshot.members.find((member) => member.principalId === principalId);
+function findMember(snapshot: GroupSnapshot, principalId: string): GroupMember | undefined {
+  return snapshot.members.find((member) => member.principalId === principalId);
 }
 
 function isActiveOwnerOrAdmin(member: GroupMember | undefined): member is GroupMember {
-    return member?.status === 'active' &&
-        (member.role === 'owner' || member.role === 'admin');
+  return member?.status === 'active' && (member.role === 'owner' || member.role === 'admin');
 }
 
-function isLastActiveOwner(
-    snapshot: GroupSnapshot,
-    member: GroupMember,
-): boolean {
-    if (member.role !== 'owner' || member.status !== 'active') {
-        return false;
-    }
+function isLastActiveOwner(snapshot: GroupSnapshot, member: GroupMember): boolean {
+  if (member.role !== 'owner' || member.status !== 'active') {
+    return false;
+  }
 
-    return snapshot.group.ownerPrincipalId === member.principalId;
+  return snapshot.group.ownerPrincipalId === member.principalId;
 }
 
 function removesOwner(action: GroupGovernanceAction): boolean {
-    return action === 'remove' ||
-        action === 'ban' ||
-        action === 'demote' ||
-        action === 'transfer-ownership';
+  return (
+    action === 'remove' ||
+    action === 'ban' ||
+    action === 'demote' ||
+    action === 'transfer-ownership'
+  );
 }
 
-function isLiveSession(
-    session: GroupPresenceSession,
-    nowEpochMs: number | undefined,
-): boolean {
-    return session.disconnectedAtEpochMs === null &&
-        (nowEpochMs === undefined || session.expiresAtEpochMs > nowEpochMs);
+function isLiveSession(session: GroupPresenceSession, nowEpochMs: number | undefined): boolean {
+  return (
+    session.disconnectedAtEpochMs === null &&
+    (nowEpochMs === undefined || session.expiresAtEpochMs > nowEpochMs)
+  );
 }
 
 function deny(
-    code: GroupPolicyReasonCode,
-    message: string,
-    details?: Record<string, unknown>,
+  code: GroupPolicyReasonCode,
+  message: string,
+  details?: Record<string, unknown>,
 ): GroupPolicyDenied {
-    return {
-        allowed: false,
-        code,
-        message,
-        details,
-    };
+  return {
+    allowed: false,
+    code,
+    message,
+    details,
+  };
 }

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-lifecycle-transition.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-lifecycle-transition.ts
@@ -91,6 +91,9 @@ export function computeLifecycleTransition(
       ? read.lifecyclePolicy.policy
       : createDefaultGroupLifecyclePolicy();
   const transition = LIFECYCLE_TRANSITION_BY_OPERATION[command.operation];
+  if (read.activeMemberPrincipalIds === null) {
+    throw new TypeError('Lifecycle transition compute requires the roster read');
+  }
   if (facts.internalAuthority === 'formation-criterion') {
     // The criterion evaluator petitions with service authority; the state
     // machine below is the only check that applies. Principals never carry
@@ -107,11 +110,9 @@ export function computeLifecycleTransition(
         },
         policy,
         transition,
+        activeMemberPrincipalIds: read.activeMemberPrincipalIds,
       }),
     );
-  }
-  if (read.activeMemberPrincipalIds === null) {
-    throw new TypeError('Lifecycle transition compute requires the roster read');
   }
   const outcome = computeGroupLifecycleTransition({
     transition,

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1140,6 +1140,31 @@
       "description": "Exercises both legs of the activation criterion: a threshold group auto-activates from the evidence produced by its own establishment planning pass, and a deadline group with unconfirmed links fails formation below the floor -- typed outcome, attempt increment, terminal forming at the attempt cap."
     },
     {
+      "id": "api-v1-group-manager-succession",
+      "recipe": "tests/api-v1/api-v1-group-manager-succession.json",
+      "category": "api-v1-black-box",
+      "mode": "run",
+      "tier": 1,
+      "profiles": [
+        "api-v1-black-box-cluster"
+      ],
+      "expectedExitCode": 0,
+      "artifactName": "api-v1-group-manager-succession",
+      "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
+        "httpServices": [
+          {
+            "name": "Rallar API primary",
+            "env": "RALLAR_API_BASE_URL",
+            "default": "http://127.0.0.1:18080"
+          }
+        ]
+      },
+      "description": "Drives the manager role end to end under an assigned policy: the non-manager owner is denied, the assigned manager establishes, removal passes duty to the next assigned member who completes the phase, and the zero-manager fallback blocks only manager-gated actions -- membership still works and joining the assigned member restores the manager."
+    },
+    {
       "id": "api-v1-group-lifecycle-policy",
       "recipe": "tests/api-v1/api-v1-group-lifecycle-policy.json",
       "category": "api-v1-black-box",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
@@ -240,7 +240,10 @@
           "lastFormationOutcome": {
             "outcome": "activated",
             "observedRate": 1
-          }
+          },
+          "managerPrincipalIds": [
+            "{aliceClientId}"
+          ]
         }
       }
     },
@@ -405,7 +408,10 @@
           "lastFormationOutcome": {
             "outcome": "below-floor",
             "observedRate": 0
-          }
+          },
+          "managerPrincipalIds": [
+            "{aliceClientId}"
+          ]
         }
       }
     }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-manager-succession.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-manager-succession.json
@@ -4,10 +4,10 @@
       "env": "RALLAR_API_BASE_URL",
       "default": "http://127.0.0.1:18080"
     },
-    "applicationId": "group-transitions-{runId}",
+    "applicationId": "manager-succession-{runId}",
     "workspaceId": "default-{runId}",
-    "managedGroupId": "managed-room-{runId}",
-    "plainGroupId": "plain-room-{runId}",
+    "managerGroupId": "succession-room-{runId}",
+    "zeroManagerGroupId": "zero-manager-room-{runId}",
     "aliceUsername": {
       "env": "RALLAR_ALICE_USERNAME",
       "default": "alice"
@@ -127,20 +127,20 @@
       }
     },
     {
-      "name": "createAliceClientState",
+      "name": "createBobClientState",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "PUT",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{aliceClientId}/principal",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/clients/{bobClientId}/principal",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "client-create-alice-{runId}",
-          "username": "{aliceUsername}",
-          "displayName": "Lifecycle manager {runId}",
+          "requestId": "client-create-bob-{runId}",
+          "username": "{bobUsername}",
+          "displayName": "Succession owner {runId}",
           "status": "active",
           "roles": []
         }
@@ -150,27 +150,35 @@
       }
     },
     {
-      "name": "createManagedGroup",
+      "name": "createAssignedGroup",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
         "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "group-create-managed-{runId}",
-          "groupId": "{managedGroupId}",
-          "displayName": "Managed group {runId}",
+          "requestId": "group-create-succession-{runId}",
+          "groupId": "{managerGroupId}",
+          "displayName": "Succession group {runId}",
           "kind": "room",
           "joinMode": "open",
-          "createdByPrincipalId": "{aliceClientId}",
+          "createdByPrincipalId": "{bobClientId}",
           "lifecyclePolicy": {
             "preset": "managed",
             "activation": {
               "mode": "manual"
+            },
+            "manager": {
+              "selection": "assigned",
+              "assignedPrincipalIds": [
+                "{aliceClientId}",
+                "{bobClientId}"
+              ],
+              "count": 1
             }
           }
         }
@@ -179,61 +187,51 @@
         "status": 201,
         "body": {
           "group": {
-            "groupId": "{managedGroupId}",
+            "groupId": "{managerGroupId}",
             "lifecycleState": "forming",
             "formationEpoch": 0,
             "formationElectorate": [
-              "{aliceClientId}"
+              "{bobClientId}"
             ]
           }
         }
       }
     },
     {
-      "name": "topologyHeldWhileForming",
+      "name": "joinAliceToAssignedGroup",
       "type": "http",
       "connection": "primary",
       "request": {
-        "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/topology",
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/join",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "join-alice-succession-{runId}"
         }
       },
       "expect": {
-        "status": 200,
-        "bodyAnyOf": [
-          {
-            "snapshot": null
-          },
-          {
-            "snapshot": {
-              "state": "removed"
-            }
-          }
-        ]
+        "status": 200
       }
     },
     {
-      "name": "formationViewWhileForming",
+      "name": "formationViewManagerIsAlice",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/formation",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/formation",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         }
       },
       "expect": {
         "status": 200,
         "body": {
           "lifecycleState": "forming",
-          "formationEpoch": 0,
-          "formationAttemptCount": 0,
-          "establishmentStartedAtEpochMs": null,
           "managerPrincipalIds": [
             "{aliceClientId}"
           ]
@@ -241,18 +239,18 @@
       }
     },
     {
-      "name": "bobCannotStartEstablishment",
+      "name": "ownerCannotEstablishPastAssignedManager",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/establish",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/lifecycle/establish",
         "headers": {
           "Authorization": "{bobAuthHeader}",
           "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "bob-start-{runId}"
+          "requestId": "establish-bob-denied-{runId}"
         }
       },
       "expect": {
@@ -260,18 +258,18 @@
       }
     },
     {
-      "name": "startEstablishment",
+      "name": "assignedManagerEstablishes",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/establish",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/lifecycle/establish",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
         },
         "body": {
-          "requestId": "start-establishment-{runId}"
+          "requestId": "establish-alice-{runId}"
         }
       },
       "expect": {
@@ -279,80 +277,68 @@
         "body": {
           "group": {
             "lifecycleState": "establishing",
-            "formationEpoch": 1
+            "formationEpoch": 1,
+            "formationElectorate": [
+              "{aliceClientId}",
+              "{bobClientId}"
+            ]
           }
         }
       }
     },
     {
-      "name": "topologyPlannedAfterEstablish",
+      "name": "ownerRemovesTheManager",
       "type": "http",
       "connection": "primary",
       "request": {
-        "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/topology",
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/members/{aliceClientId}/remove",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
-        "poll": {
-          "maxAttempts": 20,
-          "maxDurationMs": 15000,
-          "backoffMs": 100,
-          "backoffMultiplier": 2
+        "body": {
+          "requestId": "remove-alice-{runId}"
         }
       },
       "expect": {
-        "status": 200,
-        "body": {
-          "snapshot": {
-            "state": "active"
-          }
-        }
+        "status": 200
       }
     },
     {
-      "name": "formationViewAfterEstablish",
+      "name": "successionPassesToBob",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/formation",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/formation",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         }
       },
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
-          "formationEpoch": 1,
-          "establishmentStartedAtEpochMs": "integer",
-          "readiness": {
-            "plannedEdgeCount": 0,
-            "observedEdgeCount": 0,
-            "observedRate": 1
-          },
           "managerPrincipalIds": [
-            "{aliceClientId}"
+            "{bobClientId}"
           ]
         }
       }
     },
     {
-      "name": "activateGroup",
+      "name": "successorCompletesThePhase",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/activate",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managerGroupId}/lifecycle/activate",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "activate-{runId}"
+          "requestId": "activate-bob-{runId}"
         }
       },
       "expect": {
@@ -366,68 +352,79 @@
       }
     },
     {
-      "name": "reopenEstablishment",
+      "name": "createZeroManagerGroup",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/reopen",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "reopen-{runId}"
+          "requestId": "group-create-zero-{runId}",
+          "groupId": "{zeroManagerGroupId}",
+          "displayName": "Zero manager group {runId}",
+          "kind": "room",
+          "joinMode": "open",
+          "createdByPrincipalId": "{bobClientId}",
+          "lifecyclePolicy": {
+            "preset": "managed",
+            "activation": {
+              "mode": "manual"
+            },
+            "manager": {
+              "selection": "assigned",
+              "assignedPrincipalIds": [
+                "{aliceClientId}"
+              ],
+              "count": 1
+            }
+          }
         }
       },
       "expect": {
-        "status": 200,
+        "status": 201,
         "body": {
           "group": {
-            "lifecycleState": "reconfiguring",
-            "formationEpoch": 3
+            "lifecycleState": "forming"
           }
         }
       }
     },
     {
-      "name": "reactivateGroup",
+      "name": "zeroManagerViewIsEmpty",
       "type": "http",
       "connection": "primary",
       "request": {
-        "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/activate",
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroManagerGroupId}/formation",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
-        },
-        "body": {
-          "requestId": "reactivate-{runId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         }
       },
       "expect": {
         "status": 200,
         "body": {
-          "group": {
-            "lifecycleState": "active",
-            "formationEpoch": 4
-          }
+          "managerPrincipalIds": []
         }
       }
     },
     {
-      "name": "startFromActiveIsDenied",
+      "name": "zeroManagerBlocksOnlyManagerActions",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/establish",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroManagerGroupId}/lifecycle/establish",
         "headers": {
-          "Authorization": "{aliceAuthHeader}",
-          "x-client-id": "{aliceClientId}"
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
         },
         "body": {
-          "requestId": "start-from-active-{runId}"
+          "requestId": "establish-zero-denied-{runId}"
         }
       },
       "expect": {
@@ -435,33 +432,42 @@
       }
     },
     {
-      "name": "createPlainGroup",
+      "name": "membershipStaysSafeWithZeroManagers",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroManagerGroupId}/join",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
         },
         "body": {
-          "requestId": "group-create-plain-{runId}",
-          "groupId": "{plainGroupId}",
-          "displayName": "Plain group {runId}",
-          "kind": "room",
-          "joinMode": "open",
-          "createdByPrincipalId": "{aliceClientId}"
+          "requestId": "join-alice-zero-{runId}"
         }
       },
       "expect": {
-        "status": 201,
+        "status": 200
+      }
+    },
+    {
+      "name": "joiningTheAssignedMemberRestoresTheManager",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroManagerGroupId}/formation",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        }
+      },
+      "expect": {
+        "status": 200,
         "body": {
-          "group": {
-            "groupId": "{plainGroupId}",
-            "lifecycleState": "active",
-            "formationEpoch": 0
-          }
+          "managerPrincipalIds": [
+            "{aliceClientId}"
+          ]
         }
       }
     }

--- a/packages/shared/api/group-lifecycle/group-formation-view.ts
+++ b/packages/shared/api/group-lifecycle/group-formation-view.ts
@@ -1,8 +1,5 @@
 import type { GroupRef } from '../group-types.ts';
-import type {
-    GroupFormationOutcome,
-    GroupLifecycleState,
-} from './group-lifecycle-policy.ts';
+import type { GroupFormationOutcome, GroupLifecycleState } from './group-lifecycle-policy.ts';
 import type { GroupFormationReadiness } from './compute-group-formation-readiness.ts';
 
 /**
@@ -12,11 +9,17 @@ import type { GroupFormationReadiness } from './compute-group-formation-readines
  * is the recorded decision from the criterion's last evaluation.
  */
 export type GroupFormationView = Readonly<{
-    groupRef: GroupRef;
-    lifecycleState: GroupLifecycleState;
-    formationEpoch: number;
-    formationAttemptCount: number;
-    lastFormationOutcome: GroupFormationOutcome | null;
-    establishmentStartedAtEpochMs: number | null;
-    readiness: GroupFormationReadiness;
+  groupRef: GroupRef;
+  lifecycleState: GroupLifecycleState;
+  formationEpoch: number;
+  formationAttemptCount: number;
+  lastFormationOutcome: GroupFormationOutcome | null;
+  establishmentStartedAtEpochMs: number | null;
+  readiness: GroupFormationReadiness;
+  /**
+   * The managers resolved from the policy and the epoch-pinned electorate at
+   * read time -- who may command manager-gated actions right now. Empty when
+   * the policy selects none or no candidate survives the liveness filter.
+   */
+  managerPrincipalIds: readonly string[];
 }>;

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy-presets.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy-presets.ts
@@ -95,7 +95,10 @@ const MANAGED_POLICY: GroupLifecyclePolicy = {
 const MATCH_POLICY: GroupLifecyclePolicy = {
     formation: 'phased',
     manager: {
-        selection: 'elected-by-rank',
+        // elected-by-rank has no rank source in v1 (plan decision 4.2); the
+        // deterministic election gives the preset a working manager until one
+        // lands.
+        selection: 'elected-random-deterministic',
         assignedPrincipalIds: [],
         count: 1,
         succession: 'next-by-selection',

--- a/packages/shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts
+++ b/packages/shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts
@@ -1,5 +1,14 @@
 import { rendezvousScore } from '../../rtc/rendezvous-score.ts';
+import type { GroupRef } from '../group-types.ts';
 import type { GroupManagerPolicy } from './group-lifecycle-policy.ts';
+
+/**
+ * The one election-key derivation. Every resolver of the same group must key
+ * the rendezvous hash identically or replicas would elect different managers.
+ */
+export function toGroupLifecycleElectionKey(ref: GroupRef): string {
+  return `${ref.applicationId}:${ref.workspaceId}:${ref.groupId}`;
+}
 
 export interface ResolveGroupLifecycleManagersInput {
   readonly manager: GroupManagerPolicy;

--- a/packages/tests/shared-server/group-policy.test.ts
+++ b/packages/tests/shared-server/group-policy.test.ts
@@ -426,12 +426,16 @@ describe('group policy helpers', () => {
                 actor: ACTOR,
                 policy: resolveGroupLifecyclePolicyPreset('optimistic'),
                 transition: 'start-establishment',
+                activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
             })),
             expectCode(canCommandGroupLifecycleTransition({
-                snapshot: snapshot({lifecycleState: 'forming'}),
+                // An empty electorate resolves zero managers, covering the
+                // lifecycle-manager-unavailable reason code.
+                snapshot: snapshot({lifecycleState: 'forming', formationElectorate: []}),
                 actor: ACTOR,
                 policy: resolveGroupLifecyclePolicyPreset('match'),
                 transition: 'start-establishment',
+                activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
             })),
         ]);
 
@@ -548,6 +552,10 @@ function snapshot(
         ownerPrincipalId: options.ownerPrincipalId ?? members.find((entry) =>
             entry.status === 'active' && entry.role === 'owner'
         )?.principalId ?? 'alice',
+        ...(options.lifecycleState === undefined ? {} : {lifecycleState: options.lifecycleState}),
+        ...(options.formationElectorate === undefined
+            ? {}
+            : {formationElectorate: options.formationElectorate}),
     });
     const group: Group = options.status === 'archived'
         ? {

--- a/packages/tests/shared-server/group-state/group-lifecycle-command-policy.test.ts
+++ b/packages/tests/shared-server/group-state/group-lifecycle-command-policy.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   resolveGroupLifecyclePolicyPreset,
 } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import type { GroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { Group, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
 import { createTestGroup } from '../../create-test-group.ts';
@@ -50,16 +51,35 @@ function snapshot(overrides: Partial<Group>, members: readonly GroupMember[]): G
   };
 }
 
-function withInitiator(
+interface CommandCase {
+  readonly overrides: Partial<Group>;
+  readonly members: readonly GroupMember[];
+  readonly actorPrincipalId: string;
+  readonly policy: GroupLifecyclePolicy;
+  readonly transition?: GroupLifecycleTransition;
+  /** Defaults to every active member of `members`; override to model departures. */
+  readonly activeMemberPrincipalIds?: readonly string[];
+}
+
+function command(commandCase: CommandCase) {
+  return canCommandGroupLifecycleTransition({
+    snapshot: snapshot(commandCase.overrides, commandCase.members),
+    actor: { principalId: commandCase.actorPrincipalId },
+    policy: commandCase.policy,
+    transition: commandCase.transition ?? 'start-establishment',
+    activeMemberPrincipalIds:
+      commandCase.activeMemberPrincipalIds ??
+      commandCase.members
+        .filter((candidate) => candidate.status === 'active')
+        .map((candidate) => candidate.principalId),
+  });
+}
+
+function withManager(
   policy: GroupLifecyclePolicy,
-  establishment: Partial<GroupLifecyclePolicy['establishment']>,
-  manager: Partial<GroupLifecyclePolicy['manager']> = {},
+  manager: Partial<GroupLifecyclePolicy['manager']>,
 ): GroupLifecyclePolicy {
-  return {
-    ...policy,
-    establishment: { ...policy.establishment, ...establishment },
-    manager: { ...policy.manager, ...manager },
-  };
+  return { ...policy, manager: { ...policy.manager, ...manager } };
 }
 
 const OPTIMISTIC = resolveGroupLifecyclePolicyPreset('optimistic');
@@ -69,112 +89,152 @@ const DROP_IN = resolveGroupLifecyclePolicyPreset('drop-in-social');
 
 describe('canCommandGroupLifecycleTransition', () => {
   it('lets any active member start establishment under any-member', () => {
-    const result = canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'forming' }, [member('alice', 'owner'), member('bob', 'member')]),
-      actor: { principalId: 'bob' },
+    const result = command({
+      overrides: { lifecycleState: 'forming' },
+      members: [member('alice', 'owner'), member('bob', 'member')],
+      actorPrincipalId: 'bob',
       policy: OPTIMISTIC,
-      transition: 'start-establishment',
     });
     expect(result).toEqual({ allowed: true });
   });
 
   it('requires an active membership before any policy question', () => {
-    const result = canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'forming' }, [member('alice', 'owner')]),
-      actor: { principalId: 'mallory' },
+    const result = command({
+      overrides: { lifecycleState: 'forming' },
+      members: [member('alice', 'owner')],
+      actorPrincipalId: 'mallory',
       policy: OPTIMISTIC,
-      transition: 'start-establishment',
     });
     expect(result).toMatchObject({ allowed: false, code: 'member-not-active' });
   });
 
-  it('derives the manager from the owner under managed (selection creator)', () => {
+  it('resolves the manager to the creator under managed', () => {
     const members = [member('alice', 'owner'), member('bob', 'admin')];
-    const forming = snapshot({ lifecycleState: 'forming', ownerPrincipalId: 'alice' }, members);
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: forming,
-      actor: { principalId: 'alice' },
-      policy: MANAGED,
-      transition: 'start-establishment',
-    })).toEqual({ allowed: true });
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: forming,
-      actor: { principalId: 'bob' },
-      policy: MANAGED,
-      transition: 'start-establishment',
-    })).toMatchObject({ allowed: false, code: 'forbidden-role' });
+    const forming: Partial<Group> = { lifecycleState: 'forming', ownerPrincipalId: 'alice' };
+    expect(
+      command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MANAGED }),
+    ).toEqual({ allowed: true });
+    expect(
+      command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MANAGED }),
+    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
   });
 
-  it('derives assigned managers from the policy list', () => {
-    const policy = withInitiator(MANAGED, {}, {
+  it('honours assigned order and count: only the first count are managers', () => {
+    const policy = withManager(MANAGED, {
       selection: 'assigned',
-      assignedPrincipalIds: ['bob'],
+      assignedPrincipalIds: ['bob', 'carol'],
+      count: 1,
     });
-    const members = [member('alice', 'owner'), member('bob', 'member')];
-    const forming = snapshot({ lifecycleState: 'forming' }, members);
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: forming,
-      actor: { principalId: 'bob' },
-      policy,
-      transition: 'start-establishment',
-    })).toEqual({ allowed: true });
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: forming,
-      actor: { principalId: 'alice' },
-      policy,
-      transition: 'start-establishment',
-    })).toMatchObject({ allowed: false, code: 'forbidden-role' });
+    const members = [member('alice', 'owner'), member('bob', 'member'), member('carol', 'member')];
+    const forming: Partial<Group> = { lifecycleState: 'forming' };
+    expect(command({ overrides: forming, members, actorPrincipalId: 'bob', policy })).toEqual({
+      allowed: true,
+    });
+    expect(
+      command({ overrides: forming, members, actorPrincipalId: 'carol', policy }),
+    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
   });
 
-  it('reports elected managers as unavailable until election lands', () => {
-    const result = canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'forming' }, [member('alice', 'owner')]),
-      actor: { principalId: 'alice' },
-      policy: MATCH,
-      transition: 'start-establishment',
+  it('passes manager duty to the next assigned member when the first departs', () => {
+    const policy = withManager(MANAGED, {
+      selection: 'assigned',
+      assignedPrincipalIds: ['bob', 'carol'],
+      count: 1,
     });
-    expect(result).toMatchObject({
-      allowed: false,
-      code: 'lifecycle-manager-unavailable',
+    const members = [member('alice', 'owner'), member('carol', 'member')];
+    const result = command({
+      overrides: { lifecycleState: 'forming' },
+      members,
+      actorPrincipalId: 'carol',
+      policy,
+      activeMemberPrincipalIds: ['alice', 'carol'],
     });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('elects deterministically from the pinned electorate under match', () => {
+    // Epoch 0 pins the creator alone, so the sole electable manager is alice.
+    const members = [member('alice', 'owner'), member('bob', 'member')];
+    const forming: Partial<Group> = { lifecycleState: 'forming', formationElectorate: ['alice'] };
+    expect(
+      command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MATCH }),
+    ).toEqual({ allowed: true });
+    expect(
+      command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MATCH }),
+    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
+  });
+
+  it('keeps the zero-manager fallback typed when nothing resolves', () => {
+    // A legacy row decodes an empty electorate: elected selection resolves
+    // nobody until the next epoch advance re-pins it.
+    expect(
+      command({
+        overrides: { lifecycleState: 'forming', formationElectorate: [] },
+        members: [member('alice', 'owner')],
+        actorPrincipalId: 'alice',
+        policy: MATCH,
+      }),
+    ).toMatchObject({ allowed: false, code: 'lifecycle-manager-unavailable' });
+    // A departed creator with no succession leaves a hole, never a stand-in.
+    expect(
+      command({
+        overrides: { lifecycleState: 'forming', ownerPrincipalId: 'dana' },
+        members: [member('alice', 'admin')],
+        actorPrincipalId: 'alice',
+        policy: withManager(MANAGED, { succession: 'none' }),
+      }),
+    ).toMatchObject({ allowed: false, code: 'lifecycle-manager-unavailable' });
+  });
+
+  it('reports elected-by-rank as unavailable while no rank source exists', () => {
+    const result = command({
+      overrides: { lifecycleState: 'forming' },
+      members: [member('alice', 'owner')],
+      actorPrincipalId: 'alice',
+      policy: withManager(MATCH, { selection: 'elected-by-rank' }),
+    });
+    expect(result).toMatchObject({ allowed: false, code: 'lifecycle-manager-unavailable' });
   });
 
   it('denies principal commands under server-auto', () => {
-    const result = canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'forming' }, [member('alice', 'owner')]),
-      actor: { principalId: 'alice' },
+    const result = command({
+      overrides: { lifecycleState: 'forming' },
+      members: [member('alice', 'owner')],
+      actorPrincipalId: 'alice',
       policy: DROP_IN,
-      transition: 'start-establishment',
     });
     expect(result).toMatchObject({ allowed: false, code: 'forbidden-role' });
   });
 
   it('folds state validity into the same decision', () => {
-    const result = canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'active' }, [member('alice', 'owner')]),
-      actor: { principalId: 'alice' },
+    const result = command({
+      overrides: { lifecycleState: 'active' },
+      members: [member('alice', 'owner')],
+      actorPrincipalId: 'alice',
       policy: OPTIMISTIC,
-      transition: 'start-establishment',
     });
-    expect(result).toMatchObject({
-      allowed: false,
-      code: 'lifecycle-transition-invalid',
-    });
+    expect(result).toMatchObject({ allowed: false, code: 'lifecycle-transition-invalid' });
   });
 
   it('authorizes activate and reopen-establishment against their own source states', () => {
     const members = [member('alice', 'owner')];
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'establishing' }, members),
-      actor: { principalId: 'alice' },
-      policy: OPTIMISTIC,
-      transition: 'activate',
-    })).toEqual({ allowed: true });
-    expect(canCommandGroupLifecycleTransition({
-      snapshot: snapshot({ lifecycleState: 'active' }, members),
-      actor: { principalId: 'alice' },
-      policy: OPTIMISTIC,
-      transition: 'reopen-establishment',
-    })).toEqual({ allowed: true });
+    expect(
+      command({
+        overrides: { lifecycleState: 'establishing' },
+        members,
+        actorPrincipalId: 'alice',
+        policy: OPTIMISTIC,
+        transition: 'activate',
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      command({
+        overrides: { lifecycleState: 'active' },
+        members,
+        actorPrincipalId: 'alice',
+        policy: OPTIMISTIC,
+        transition: 'reopen-establishment',
+      }),
+    ).toEqual({ allowed: true });
   });
 });

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -175,13 +175,13 @@ is explicit: manager absence blocks only manager-assigned actions, never group s
 
 | # | Decision |
 | --- | --- |
+| 4.2 | **The match preset elects `elected-random-deterministic` in v1.** `elected-by-rank` has no possible rank source yet — the `GroupMember` contract carries no application metadata — so it stays in the vocabulary and resolves zero managers (typed `lifecycle-manager-unavailable`) until a source lands. Deviation from the design table recorded; see the deferred item below so it is not forgotten. |
 | 4.1 | **Aggregate-recorded election; authority stays pure** (option A of `2026-08-18-manager-role-basis-analysis.md`). Epoch-advancing transitions record the electorate on the aggregate beside `formationEpoch`; manager resolution is a pure function over (policy, recorded electorate, epoch, live member statuses) — rendezvous ranking keyed on the epoch, still-active filter, first `count`, with succession `next-by-selection` filtering before taking and `none` taking before filtering. Departure needs zero extra writes. The plan's original "build on `GROUP_DIRECTOR_APPOINT`" sentence is amended: the aggregate-state *pattern* is what survives; the session-scoped, heartbeat-leased, claim-based semantics deliberately do not, because manager liveness is membership, not heartbeats. The director remains the browser work delegate. |
 
-This slice also switches the shipped presets' manager dimension on: every preset currently ships
-`selection: 'none'` (deliberate — decision 2.2's honest unavailability applied to defaults), so
-`managed` moving to creator-with-succession and `match` to elected-by-rank is where preset users
-first see manager behaviour. The no-policy property is untouched: `optimistic` keeps
-`selection: 'none'`.
+*Correction (2026-08-18): an earlier revision of this note claimed every preset ships
+`selection: 'none'` — wrong, from a faulty extraction. The presets have carried
+`managed: creator` and `match: elected-by-rank` since slice 1; decision 2.2's interim predicate is
+what makes the managed creator work today, and the elected variants are what this slice activates.*
 
 ### Slice 5 — Admission and data policies
 
@@ -212,6 +212,11 @@ typed unsupported rejection.
   default) is recorded product-owner decision 2 and is supported by the Phase 0–4 evidence in
   `2026-08-17-phase5-establishment-posture-decision.md`.
 - **The six-state RTC activation status projection.** Slice 3 builds only the readiness fraction.
+- **The `elected-by-rank` rank source** (decision 4.2). The selection ships in the vocabulary and
+  resolves zero managers until the `GroupMember` contract gains an application-supplied rank (the
+  plan's least-coupled default) or another source is chosen. Whoever picks this up: the resolution
+  already takes `rankByPrincipalId` as input, so the work is the member-contract field, its join
+  plumbing, and swapping the `match` preset back from `elected-random-deterministic`.
 - **The `match` preset's per-edge audit trail and server-side pacing.** The preset ships and, with
   the `minimumViableRate` floor, it now also gets honest failure: below the floor a match does not
   activate, and with `closed` admission and `blocked-until-active` data, nothing starts. What v1


### PR DESCRIPTION
## Summary

Slice 4b of the group lifecycle control plane: the interim manager predicate (decision 2.2) becomes 4a's real resolution, wired at both consumers, and the manager role is live end to end.

- **Authorization** — `canCommandGroupLifecycleTransition` resolves managers from the policy, the epoch-pinned electorate, and the live roster (a new predicate input fed from the mutation read), so the elected selections work, `assigned` honours order and `count` (a deliberate narrowing of the interim any-assigned check), and succession passes duty to the next candidate with zero extra writes. The zero-manager fallback stays typed: nothing resolving blocks only manager-gated actions, never membership or safety.
- **Match preset** — elects `elected-random-deterministic` in v1 (plan decision 4.2, owner-selected): `elected-by-rank` has no possible rank source yet — the `GroupMember` contract carries no application metadata — so it stays in the vocabulary resolving nobody, and the deferred-items section records the follow-up (member rank field, join plumbing, preset swap-back) so it is not forgotten.
- **Read surface** — the formation view gains `managerPrincipalIds`, resolved at read time from a policy read added to the route dependencies; the composition moved to its own `group-formation-view-read.ts` module per the route-split convention. OpenAPI updated.
- **Recipes** — the new `api-v1-group-manager-succession` drives the role end to end under an assigned policy (18/18): the non-manager owner is denied, the assigned manager establishes, removal passes duty to the successor who completes the phase, and with zero managers membership still works — joining the assigned member restores the manager. The transitions and criterion recipes pin `managerPrincipalIds` in their view assertions.
- **Plan** — corrects an earlier faulty note of mine (the presets have carried `managed: creator` and `match: elected-by-rank` since slice 1; a bad extraction claimed all-`'none'`), records decision 4.2, and adds the elected-by-rank deferral.

## Validation

- `npm run typecheck` — pass (tests-typecheck ratchet green)
- `npm run check:repo-style:changed -- origin/main HEAD` — pass (no new findings; the route file's cognitive-load growth resolved by the view-reader extraction)
- Vitest shared + shared-server sweep — 4753 passed; the reshaped policy suite is 12/12 and the reason-code census fixture now forwards the lifecycle fields; the two known sandbox port-bind files pass unsandboxed (22/22)
- `apps/api-v1 deno task check` + `deno task test` — 471/471
- Black-box memory base profile — 22/22 recipes
- Black-box cluster profile against a fresh memory server — succession 18/18, transitions 17/17, criterion 14/14; `state-topology-churn` failed once on a login rate limit (my ad-hoc server lacked `RALLAR_LOGIN_IP_RATE_LIMIT`) and re-passed 125/125 with both limits set; `api-v1-crdt-app-inbox` remains the known env-limited local case CI covers
- `npm run test:api-v1:black-box:postgres:medium-scale` — 2748/2748 operations, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)