### PR TITLE
Calibrate the style checker's file limits for the test corpus

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -342,6 +342,16 @@ data-literal discount replaces registry entries for declarative files: large
 schema, manifest, and lookup data needs no exception while the code around it
 stays navigable.
 
+Test files carry a `1,500`-line backstop instead. The tiers above are calibrated
+on the production corpus; measured the same way, the test corpus is 13-23%
+longer at every percentile and its p99 is 1,242 lines, so `1,500` preserves the
+same "top ~1% of files" meaning the production number carries. No other file
+metric is relaxed for tests: the test corpus is roughly half as cognitively
+dense as production at every percentile (p95 49 against 75, p99 116 against
+161), and `0.4%` of test files export twelve or more runtime values against
+`2.5%` of production files. A cohesive suite is worth more than a split one,
+and the cost of splitting it is not repaid by a metric tests already satisfy.
+
 An existing file already inside a warning tier enters touched-file standards
 closure when changed. Resolve its applicable tier and cohesion noncompliance
 throughout the touched file, using a coherent responsibility split when needed.
@@ -355,6 +365,15 @@ including blank lines and comments:
 - `50-60` physical lines: required separation review;
 - `>60` physical lines: refactor or record an approved symbol-level exception in
   [the repo code-style exception registry](../../../../docs/repo-code-style-exceptions.md).
+
+These thresholds apply to named functions, including test helpers and fixture
+builders, which already satisfy them more often than production functions do
+(`6.2%` over forty lines against `8.0%`). They do not apply to a `describe`,
+`it`, or `test` body. Those are suite structure rather than functions: a
+`describe` body has a median of 124 lines and a p85 of 363, so a forty-line
+function target would demand splitting one cohesive suite across files, which
+is the cognitive overhead this standard's first principle rejects. File metrics
+govern the suite; the function thresholds govern the helpers it calls.
 
 Route handlers retain the stricter `<=30`-line target. Split route modules by
 business action, normally `*-read.ts`, `*-write.ts`, and `*-admin.ts`. Shared

--- a/packages/tests/repo/repo-style-test-calibration.test.ts
+++ b/packages/tests/repo/repo-style-test-calibration.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isProductionCodeFile,
+  isNonProductionPath,
+  resolveFileLineBackstop,
+} from '../../../scripts/repo-style-check/repository-scan.mjs';
+
+const repoRoot = process.cwd();
+
+function readStyleAuthority(): string {
+  return readFileSync(
+    path.join(repoRoot, '.agents/skills/rallar-code-writing/references/repo-code-style.md'),
+    'utf8',
+  );
+}
+
+function readScanner(): string {
+  return readFileSync(
+    path.join(repoRoot, 'scripts/repo-style-check/repository-scan.mjs'),
+    'utf8',
+  );
+}
+
+describe('repo style test calibration', () => {
+  it('gives test files the wider navigation backstop the test corpus was measured against', () => {
+    expect(resolveFileLineBackstop('packages/tests/shared/queue.test.ts')).toBe(1500);
+    expect(resolveFileLineBackstop('apps/api-v1/test/db/pglite-sql-adapter.test.ts')).toBe(1500);
+    expect(resolveFileLineBackstop('packages/shared/queuebox/ResourceEntry.ts')).toBe(1200);
+    expect(resolveFileLineBackstop('apps/api-v1/src/main.ts')).toBe(1200);
+  });
+
+  // The wider backstop is prepared, not yet reachable: collectProductionSources filters test paths
+  // out of the scan entirely, so no test file is measured until the test scan is enabled. This
+  // pins that honestly rather than letting the calibration read as though it were already live.
+  it('records that the scan still excludes the files the wider backstop is for', () => {
+    expect(isProductionCodeFile('packages/tests/shared/queue.test.ts')).toBe(false);
+    expect(isProductionCodeFile('packages/shared/queuebox/ResourceEntry.ts')).toBe(true);
+  });
+
+  it('states both backstops in the authority the checker implements', () => {
+    const authority = readStyleAuthority();
+
+    expect(authority).toContain('`1,200` physical lines');
+    expect(authority).toContain('`1,500`-line backstop');
+  });
+
+  // The calibration is deliberately narrow: only physical length differs. Cognitive load and
+  // responsibility count are stricter on the test corpus than on production, so relaxing them
+  // would loosen a rule tests already satisfy.
+  it('relaxes no file metric for tests other than physical length', () => {
+    const scanner = readScanner();
+
+    expect(scanner).not.toContain('testCognitiveLoad');
+    expect(scanner).not.toContain('testResponsibilityCount');
+    expect(scanner).not.toContain('testHandlerComplexity');
+  });
+
+  it('resolves conventional role qualifiers before reading a filename stem', () => {
+    const layoutRules = readFileSync(
+      path.join(repoRoot, 'scripts/repo-style-check/layout-rules.mjs'),
+      'utf8',
+    );
+
+    expect(layoutRules).toContain('fileRoleQualifierPattern');
+    expect(layoutRules).toContain('.replace(fileRoleQualifierPattern');
+  });
+
+  it('classifies the test tree as non-production so the wider backstop applies to it', () => {
+    expect(isNonProductionPath('packages/tests/shared/queue.test.ts')).toBe(true);
+    expect(isNonProductionPath('apps/api-v1/test/db/pglite-sql-adapter.test.ts')).toBe(true);
+    expect(isNonProductionPath('packages/shared/queuebox/ResourceEntry.ts')).toBe(false);
+    expect(isNonProductionPath('apps/api-v1/src/main.ts')).toBe(false);
+  });
+});

--- a/scripts/repo-style-check/layout-rules.mjs
+++ b/scripts/repo-style-check/layout-rules.mjs
@@ -4,6 +4,12 @@ import { parse } from '@babel/parser';
 import { compareCodeUnits, compareFindings, toFinding } from './layout-findings.mjs';
 
 const typeScriptSuffixPattern = /(?:\.d)?\.(?:ts|tsx|mts|cts)$/u;
+// A filename may carry conventional role qualifiers before its extension -- `.test`,
+// `.browser.test`, `.config`, `.worker`. Those describe the file's role, not its name, so
+// they are removed before the kebab-case and generic-stem checks read the owning noun.
+const fileRoleQualifiers =
+  'test|spec|browser|worker|config|typecheck|full-stack|recipe-console|exhaustive';
+const fileRoleQualifierPattern = new RegExp(`(?:\\.(?:${fileRoleQualifiers}))+$`, 'u');
 const kebabCasePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const toWordSet = (value) => new Set(value.split(' '));
 const genericFileStems = toWordSet('utils types helpers contracts runtime middleware');
@@ -381,7 +387,8 @@ function getFeaturePrefix(file, directoryTokens) {
 }
 const hasRoomToken = (name) => /(?:^|-)(?:room|rooms)(?:-|$)/u.test(toKebabCase(name));
 const toRelativeFile = (repoRoot, file) => path.relative(repoRoot, file).split(path.sep).join('/');
-const toTypeScriptStem = (fileName) => fileName.replace(typeScriptSuffixPattern, '');
+const toTypeScriptStem = (fileName) =>
+  fileName.replace(typeScriptSuffixPattern, '').replace(fileRoleQualifierPattern, '');
 const sampleFileNames = (fileNames) =>
   [...fileNames].sort().slice(0, layoutLimits.displayedFileSampleCount).join(', ');
 function groupBy(values, toKey) {

--- a/scripts/repo-style-check/repository-scan.mjs
+++ b/scripts/repo-style-check/repository-scan.mjs
@@ -85,6 +85,10 @@ const testRunnerConfigExtensions = new Set([
 ]);
 const limits = {
   fileLineCount: 1200,
+  // Test files are 13-23% longer than production at every percentile, and the test corpus
+  // p99 is 1,242 lines. 1,500 keeps the backstop at the same "top ~1% of files" meaning the
+  // production number carries, so a cohesive suite is not split to satisfy a production shape.
+  testFileLineCount: 1500,
   lineWidth: 100,
   handlerLineCount: 30,
   handlerComplexity: 8,
@@ -198,11 +202,12 @@ function isAmbientDeclarationFile(file) {
 function addFileMeasurementFindings(findings, sourceText) {
   const { lines } = sourceText;
   const navigationLength = resolveNavigationFileLength(sourceText);
-  if (navigationLength > limits.fileLineCount) {
+  const fileLineCount = resolveFileLineBackstop(sourceText.file);
+  if (navigationLength > fileLineCount) {
     findings.push(
       finding(
         'file.length',
-        `File length ${navigationLength} > ${limits.fileLineCount} navigation backstop ` +
+        `File length ${navigationLength} > ${fileLineCount} navigation backstop ` +
           `after the data-literal discount (${lines.length} physical lines). Split along ` +
           'real ownership; density review is owned by the cognitive-load tiers.',
       ),
@@ -329,6 +334,13 @@ async function collectSourceFiles(current) {
     }
   }
   return files;
+}
+
+// Which backstop a file answers to. Test files were measured to sit 13-23% longer than production
+// at every percentile, so they carry the wider one. This currently only affects callers that scan
+// beyond production sources: collectProductionSources still filters test paths out entirely.
+export function resolveFileLineBackstop(file) {
+  return isNonProductionPath(file) ? limits.testFileLineCount : limits.fileLineCount;
 }
 
 export function isProductionCodeFile(file) {


### PR DESCRIPTION
Steps 1 and 2 of bringing tests under the style checker: fix the rules that are provably wrong on test files, and calibrate the file limits against the test corpus. **The scan still excludes tests** — enabling it is the next step, and this PR is deliberately inert until then.

## The kebab-case rule reported every test file in the repo

`toTypeScriptStem` strips only the TypeScript extension, so `relic-game.test.ts` reduced to `relic-game.test` — and the dot fails the kebab pattern. That is **1,029 `.test.ts` files**, every one a false positive, waiting to fire the moment tests are scanned.

Conventional role qualifiers now come off before the stem is read: `.test`, `.spec`, `.browser.test`, `.config`, `.worker`, `.full-stack.config`. A genuinely non-kebab name is still reported.

It also clears **two production false positives** — `layout.filename-style` drops 414 → 412 on the production scan.

## Calibration: one number changes

Measured with the checker's own metric modules, at the same p85/p95/p99 the production tiers use.

| Metric | Tests | Production | Decision |
| --- | --- | --- | --- |
| File length (discounted) p85/p95/p99 | 336 / 629 / **1,242** | 282 / 515 / 1,099 | **1,500 backstop for tests** |
| Cognitive load p85/p95/p99 | 18 / 49 / 116 | 38 / 75 / 161 | unchanged |
| ≥12 runtime exports | 0.4% of files | 2.5% of files | unchanged |
| Named functions >40 lines | 6.2% | 8.0% | unchanged |

Tests run 13–23% longer at every percentile and their p99 already exceeds the 1,200 backstop, so 1,500 preserves the "top ~1% of files" meaning 1,200 carries for production.

**Nothing else is relaxed, because the corpus does not support it.** Tests are about half as cognitively dense as production, and both `file.cognitive-load` and `file.responsibility-count` are *stricter* on tests already. Widening them would loosen rules tests currently pass.

## The function rule cannot see the code in question

`extractFunctionSignatures` finds named declarations. In `direct-resource-outbox.test.ts` it reports 25 functions in a file with 20 `it(` blocks, and every name is a `createXxx` helper — the `it()` bodies are arrow callbacks passed as arguments, which it never measures.

Measured separately:

| Block | p50 | p85 | p95 | max | >40 lines |
| --- | --- | --- | --- | --- | --- |
| `it`/`test` | 26 | 53 | 88 | 673 | 26.3% |
| `describe` | 124 | 363 | 649 | 3,453 | 86.6% |

A `describe` body is a **file-level construct**, not a function. Holding it to a forty-line target would demand splitting one cohesive suite across files — the cognitive overhead the standard's first principle rejects. The authority now records that the thresholds govern named functions (test helpers included, and they comply better than production does) and not suite bodies.

## Deliberately inert

`resolveFileLineBackstop` names the choice so it can be tested directly, but it is reachable only from callers that scan beyond production sources — `collectProductionSources` still filters test paths out entirely. **No test file is measured by this PR.**

I found that by checking whether my own new branch was reachable, and it was not. The accompanying test pins the inert state explicitly rather than letting the calibration read as though it were live:

```ts
it('records that the scan still excludes the files the wider backstop is for', () => {
  expect(isProductionCodeFile('packages/tests/shared/queue.test.ts')).toBe(false);
  expect(isProductionCodeFile('packages/shared/queuebox/ResourceEntry.ts')).toBe(true);
});
```

## Verification

`test:unit` 7,760 passed · `typecheck` exit 0 · `test:repo-governance` 360 passed · `check:repo-style` exit 0 (the checker holds itself to its own rules — it caught my first patch at 127 columns) · `check:repo-style:changed` PASS · `check-test-structure-coupling --changed` PASS · production `file.length` findings unchanged at 2.

## Caveats

The `describe`/`it` percentiles come from indentation-based brace matching, not a parser, so treat them as close-but-approximate. Production percentiles were derived from my own corpus definition (1,530 files) rather than the 1,676 the standard cites, so the shape is comparable but the absolute numbers are not identical to how the existing tiers were struck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)