### PR TITLE
Settle slice 5 admission and land its dark core

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -4615,7 +4615,7 @@ components:
           enum: [owner, admin, member]
         status:
           type: string
-          enum: [invited, active, left, removed, banned]
+          enum: [invited, pending, active, left, removed, banned]
         joined:
           allOf:
             - $ref: '#/components/schemas/AuditStamp'
@@ -4786,6 +4786,7 @@ components:
             - group-archived
             - group-deleted
             - member-invited
+            - member-admission-requested
             - member-joined
             - member-left
             - member-removed

--- a/packages/shared-server/rallar-system/group-policy.ts
+++ b/packages/shared-server/rallar-system/group-policy.ts
@@ -305,6 +305,8 @@ export function readGroupVisibility(input: CanReadGroupSnapshotInput): GroupRead
       return isInviteExpired(member, input.nowEpochMs)
         ? readDirectoryVisibility(input.snapshot)
         : 'invite';
+    case 'pending':
+      return 'invite';
     case 'left':
     case undefined:
       return readDirectoryVisibility(input.snapshot);

--- a/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts
@@ -141,6 +141,8 @@ function validateMembershipOperationInput(
       return;
     case 'upsertMember':
       if (input.role !== null) requireOneOf(input.role, ['owner', 'admin', 'member'], 'Group role');
+      // 'pending' is deliberately absent: only the admission decision may
+      // compute it, never client input (plan decision 5.1).
       requireOneOf(
         input.status,
         ['invited', 'active', 'left', 'removed', 'banned'],

--- a/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-operation-input.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-operation-input.ts
@@ -153,6 +153,8 @@ function validateMembershipMutationInput(
       if (input.role !== undefined) {
         requireOneOf(input.role, ['owner', 'admin', 'member'], 'Group role');
       }
+      // 'pending' is deliberately absent: only the admission decision may
+      // compute it, never client input (plan decision 5.1).
       requireOneOf(
         input.status,
         ['invited', 'active', 'left', 'removed', 'banned'],

--- a/packages/shared-server/rallar-system/group-state/mutation/membership/transition-group-member-lifecycle.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/membership/transition-group-member-lifecycle.ts
@@ -60,7 +60,7 @@ export function transitionGroupMemberLifecycle(
   status: GroupMemberStatus,
   audit: AuditStamp,
 ): GroupMember {
-  if (status === 'invited') {
+  if (status === 'invited' || status === 'pending') {
     return {
       ...member,
       status,
@@ -93,6 +93,8 @@ export function groupMemberEventType(status: GroupMemberStatus): GroupEventType 
   switch (status) {
     case 'invited':
       return 'member-invited';
+    case 'pending':
+      return 'member-admission-requested';
     case 'active':
       return 'member-joined';
     case 'left':

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-persistence-codec.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-persistence-codec.ts
@@ -125,7 +125,7 @@ export function normalizePersistedGroupMember(value: unknown, ref: GroupRef): Gr
   );
   const status = legacy.status;
   const joined =
-    status === 'invited'
+    status === 'invited' || status === 'pending'
       ? null
       : Object.hasOwn(legacy, 'joined')
         ? normalizeNullablePersistedGroupAudit(legacy.joined, 'Stored member joined')

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -162,7 +162,11 @@ export function validateStoredMember(
   validateScopedRecord(value, ref, label);
   requireNonEmptyString(value.principalId, `${label} principalId`);
   requireOneOf(value.role, ['owner', 'admin', 'member'], `${label} role`);
-  requireOneOf(value.status, ['invited', 'active', 'left', 'removed', 'banned'], `${label} status`);
+  requireOneOf(
+    value.status,
+    ['invited', 'pending', 'active', 'left', 'removed', 'banned'],
+    `${label} status`,
+  );
   if (value.joined !== null) validateAuditStamp(value.joined, `${label} joined`);
   validateAuditStamp(value.updated, `${label} updated`);
   for (const key of ['left', 'removed', 'banned'] as const) {
@@ -181,8 +185,8 @@ export function validateStoredMember(
       throw new TypeError(`${label} terminal lifecycle audits are inconsistent`);
     }
   }
-  if (value.status === 'invited' && value.joined !== null) {
-    throw new TypeError(`${label} invited member joined must be null`);
+  if ((value.status === 'invited' || value.status === 'pending') && value.joined !== null) {
+    throw new TypeError(`${label} invited/pending member joined must be null`);
   }
   if (value.status === 'active' && value.joined === null) {
     throw new TypeError(`${label} active member joined is required`);

--- a/packages/shared-server/rallar-system/persisted-group-event.ts
+++ b/packages/shared-server/rallar-system/persisted-group-event.ts
@@ -17,6 +17,7 @@ const GROUP_EVENT_TYPES: Readonly<Record<GroupEventType, true>> = {
     'group-archived': true,
     'group-deleted': true,
     'member-invited': true,
+    'member-admission-requested': true,
     'member-joined': true,
     'member-left': true,
     'member-removed': true,

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -179,6 +179,7 @@ const GROUP_EVENT_TYPES = [
   'group-archived',
   'group-deleted',
   'member-invited',
+  'member-admission-requested',
   'member-joined',
   'member-left',
   'member-removed',
@@ -818,7 +819,7 @@ function validateGroupMember(value: unknown, ref: GroupRef): void {
   enumValue(member.role, ['owner', 'admin', 'member'], 'GroupSnapshot.member.role');
   enumValue(
     member.status,
-    ['invited', 'active', 'left', 'removed', 'banned'],
+    ['invited', 'pending', 'active', 'left', 'removed', 'banned'],
     'GroupSnapshot.member.status',
   );
   nullableAudit(member.joined, 'GroupSnapshot.member.joined');
@@ -831,8 +832,8 @@ function validateGroupMember(value: unknown, ref: GroupRef): void {
     member.invitationExpiresAtEpochMs,
     'GroupSnapshot.member.invitationExpiresAtEpochMs',
   );
-  if (member.status === 'invited' && member.joined !== null) {
-    fail('GroupSnapshot invited member joined must be null');
+  if ((member.status === 'invited' || member.status === 'pending') && member.joined !== null) {
+    fail('GroupSnapshot invited/pending member joined must be null');
   }
   if (member.status === 'active' && member.joined === null) {
     fail('GroupSnapshot active member joined is required');

--- a/packages/shared/api/group-lifecycle/compute-group-admission-decision.ts
+++ b/packages/shared/api/group-lifecycle/compute-group-admission-decision.ts
@@ -1,0 +1,73 @@
+import type { GroupPolicyDenied } from '../group-policy-types.ts';
+import type {
+    GroupAdmissionPolicy,
+    GroupLifecycleState,
+} from './group-lifecycle-policy.ts';
+
+export interface ComputeGroupAdmissionDecisionInput {
+    readonly admission: GroupAdmissionPolicy;
+    readonly lifecycleState: GroupLifecycleState;
+    readonly activeMemberCount: number;
+    /**
+     * Whether the joining principal holds an unexpired invite. An invite is
+     * the group's consent, so it bypasses `manager-approval` parking — but
+     * never the `closed` mode or the window constraints, which are timing and
+     * capacity facts independent of consent (plan decision 5.1).
+     */
+    readonly invited: boolean;
+    readonly nowEpochMs: number;
+}
+
+export type GroupAdmissionDecision =
+    | Readonly<{ kind: 'admit' }>
+    | Readonly<{ kind: 'park' }>
+    | Readonly<{ kind: 'deny'; denial: GroupPolicyDenied }>;
+
+/**
+ * The admission decision, binding per mode as plan decision 5.2 fixes
+ * correction 5: the window constraints and `manager-approval` bind in every
+ * lifecycle state from creation, while `closed` binds outside FORMING — the
+ * roster freezes when establishment begins, and a below-floor return to
+ * FORMING re-opens the lobby. The windows degrade any mode to closed once
+ * they pass, so they are decided first.
+ */
+export function computeGroupAdmissionDecision(
+    input: ComputeGroupAdmissionDecisionInput,
+): GroupAdmissionDecision {
+    const { admission } = input;
+
+    if (admission.untilEpochMs !== null && input.nowEpochMs >= admission.untilEpochMs) {
+        return deny(
+            'group-admission-deadline-passed',
+            'Group admission closed at its deadline.',
+        );
+    }
+
+    if (
+        admission.untilMemberCount !== null &&
+        input.activeMemberCount >= admission.untilMemberCount
+    ) {
+        return deny(
+            'group-admission-capacity-reached',
+            'Group admission closed at its member-count limit.',
+        );
+    }
+
+    switch (admission.mode) {
+        case 'open':
+            return { kind: 'admit' };
+        case 'closed':
+            return input.lifecycleState === 'forming'
+                ? { kind: 'admit' }
+                : deny('group-admission-closed', 'Group admission is closed outside formation.');
+        case 'manager-approval':
+            return input.invited ? { kind: 'admit' } : { kind: 'park' };
+    }
+}
+
+function deny(
+    code: GroupPolicyDenied['code'],
+    message: string,
+): GroupAdmissionDecision {
+    return { kind: 'deny', denial: { allowed: false, code, message } };
+}

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
@@ -130,6 +130,7 @@ export type GroupLifecyclePolicyInput = Readonly<{
 
 export const GROUP_LIFECYCLE_POLICY_ISSUE_CODES = [
     'manager-initiator-without-manager',
+    'manager-approval-without-manager',
     'viable-rate-above-success-rate',
     'threshold-mode-requires-positive-rate',
     'deadline-mode-requires-positive-deadline',

--- a/packages/shared/api/group-lifecycle/validate-group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/validate-group-lifecycle-policy.ts
@@ -62,6 +62,19 @@ function toManagerIssues(
         });
     }
 
+    // Nobody could ever grant a parked join. Transient zero-manager states
+    // stay legal (invite is the recovery channel); only the permanently
+    // granterless combination is invalid (plan decision 5.3).
+    if (policy.admission.mode === 'manager-approval' && manager.selection === 'none') {
+        issues.push({
+            code: 'manager-approval-without-manager',
+            field: 'admission.mode',
+            message:
+                'admission.mode is manager-approval but manager.selection is none, ' +
+                'so no principal could ever grant a pending admission',
+        });
+    }
+
     return issues;
 }
 

--- a/packages/shared/api/group-policy-types.ts
+++ b/packages/shared/api/group-policy-types.ts
@@ -16,6 +16,9 @@ export const GROUP_POLICY_REASON_CODES = [
     'last-owner',
     'lifecycle-transition-invalid',
     'lifecycle-manager-unavailable',
+    'group-admission-closed',
+    'group-admission-deadline-passed',
+    'group-admission-capacity-reached',
 ] as const;
 
 export type GroupPolicyReasonCode =

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -287,7 +287,11 @@ function validateDeltaMember(
   sameGroupRef(member, ref, label);
   nonEmptyString(member.principalId, `${label}.principalId`);
   enumValue(member.role, ['owner', 'admin', 'member'], `${label}.role`);
-  enumValue(member.status, ['invited', 'active', 'left', 'removed', 'banned'], `${label}.status`);
+  enumValue(
+    member.status,
+    ['invited', 'pending', 'active', 'left', 'removed', 'banned'],
+    `${label}.status`,
+  );
   nullableAudit(member.joined, `${label}.joined`);
   validateAudit(member.updated, `${label}.updated`);
   nullableAudit(member.left, `${label}.left`);
@@ -295,8 +299,8 @@ function validateDeltaMember(
   nullableAudit(member.banned, `${label}.banned`);
   nullableString(member.invitedByPrincipalId, `${label}.invitedByPrincipalId`);
   nullablePositiveInteger(member.invitationExpiresAtEpochMs, `${label}.invitationExpiresAtEpochMs`);
-  if (member.status === 'invited' && member.joined !== null) {
-    fail(`${label} invited member joined must be null`);
+  if ((member.status === 'invited' || member.status === 'pending') && member.joined !== null) {
+    fail(`${label} invited/pending member joined must be null`);
   }
   if (member.status === 'active' && member.joined === null) {
     fail(`${label} active member joined is required`);

--- a/packages/shared/api/group-types.ts
+++ b/packages/shared/api/group-types.ts
@@ -13,7 +13,7 @@ export type ActorId = string;
 
 export type GroupStatus = 'active' | 'archived' | 'deleted';
 
-export type GroupMemberStatus = 'invited' | 'active' | 'left' | 'removed' | 'banned';
+export type GroupMemberStatus = 'invited' | 'pending' | 'active' | 'left' | 'removed' | 'banned';
 
 export type GroupRole = 'owner' | 'admin' | 'member';
 
@@ -131,6 +131,16 @@ export type GroupMember = GroupMemberBase &
         removed: null;
         banned: null;
       }>
+    // The consent-mirror of `invited`: the principal has asked to join and a
+    // lifecycle manager has not yet granted it (plan decision 5.1). Never
+    // client-suppliable; only the admission decision computes it.
+    | Readonly<{
+        status: 'pending';
+        joined: null;
+        left: null;
+        removed: null;
+        banned: null;
+      }>
     | Readonly<{
         status: 'active';
         joined: AuditStamp;
@@ -241,6 +251,7 @@ export type GroupEventType =
   | 'group-archived'
   | 'group-deleted'
   | 'member-invited'
+  | 'member-admission-requested'
   | 'member-joined'
   | 'member-left'
   | 'member-removed'

--- a/packages/tests/api-v1/client-and-group-state-repositories.test.ts
+++ b/packages/tests/api-v1/client-and-group-state-repositories.test.ts
@@ -1429,6 +1429,7 @@ function createGroupMember(
     };
     switch (status) {
         case 'invited':
+        case 'pending':
             return {
                 ...base,
                 status,

--- a/packages/tests/shared-server/group-policy.test.ts
+++ b/packages/tests/shared-server/group-policy.test.ts
@@ -28,6 +28,10 @@ import { createTestGroup } from '../create-test-group.ts';
 import {
     resolveGroupLifecyclePolicyPreset,
 } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+// prettier-ignore
+import {
+    computeGroupAdmissionDecision,
+} from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
 
 const NOW = 1_000;
 const ACTOR: GroupPolicyActor = {
@@ -189,6 +193,12 @@ describe('group policy helpers', () => {
         expect(readGroupVisibility({
             snapshot: snapshot({
                 members: [member('alice', {status: 'invited'})],
+            }),
+            actor: ACTOR,
+        })).toBe('invite');
+        expect(readGroupVisibility({
+            snapshot: snapshot({
+                members: [member('alice', {status: 'pending'})],
             }),
             actor: ACTOR,
         })).toBe('invite');
@@ -437,6 +447,27 @@ describe('group policy helpers', () => {
                 transition: 'start-establishment',
                 activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
             })),
+            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
+                admission: {mode: 'closed', untilEpochMs: null, untilMemberCount: null},
+                lifecycleState: 'active',
+                activeMemberCount: 1,
+                invited: false,
+                nowEpochMs: NOW,
+            }))),
+            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
+                admission: {mode: 'open', untilEpochMs: NOW, untilMemberCount: null},
+                lifecycleState: 'forming',
+                activeMemberCount: 1,
+                invited: false,
+                nowEpochMs: NOW,
+            }))),
+            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
+                admission: {mode: 'open', untilEpochMs: null, untilMemberCount: 1},
+                lifecycleState: 'forming',
+                activeMemberCount: 1,
+                invited: false,
+                nowEpochMs: NOW,
+            }))),
         ]);
 
         expect([...GROUP_POLICY_REASON_CODES].filter((code) => !coveredCodes.has(code)))
@@ -499,6 +530,12 @@ function denied(code: GroupPolicyReasonCode) {
         allowed: false,
         code,
     };
+}
+
+function toAdmissionResult(
+    decision: ReturnType<typeof computeGroupAdmissionDecision>,
+): ReturnType<typeof canJoinGroup> {
+    return decision.kind === 'deny' ? decision.denial : {allowed: true};
 }
 
 function expectCode(result: ReturnType<typeof canJoinGroup>): GroupPolicyReasonCode {
@@ -613,10 +650,10 @@ function member(
     if (options.status === 'banned') {
         return {...common, status: 'banned', left: null, removed: null, banned: options.banned ?? audit(1)};
     }
-    if (options.status === 'invited') {
+    if (options.status === 'invited' || options.status === 'pending') {
         return {
             ...common,
-            status: 'invited',
+            status: options.status,
             joined: null,
             left: null,
             removed: null,

--- a/packages/tests/shared-server/group-state/mutation/transition-group-member-lifecycle.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/transition-group-member-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { AuditStamp } from '@shared/api/group-types.ts';
+import {
+  groupMemberEventType,
+  transitionGroupMemberLifecycle,
+} from '@shared-server/rallar-system/group-state/mutation/membership/transition-group-member-lifecycle.ts';
+
+const STAMP: AuditStamp = {
+  atEpochMs: 1_700_000_000_000,
+  actor: { kind: 'principal', principalId: 'alice' },
+  reason: null,
+  traceId: null,
+  requestId: null,
+};
+
+const BASE = {
+  applicationId: 'app',
+  workspaceId: 'ws',
+  groupId: 'room-1',
+  principalId: 'alice',
+  role: 'member' as const,
+  joined: null,
+  updated: STAMP,
+  left: null,
+  removed: null,
+  banned: null,
+  invitedByPrincipalId: null,
+  invitationExpiresAtEpochMs: null,
+};
+
+describe('group member lifecycle transitions for pending admission', () => {
+  // The park: a pending member carries no joined stamp and no terminal
+  // stamps, exactly like an invited member (plan decision 5.1).
+  it('parks with cleared stamps', () => {
+    const member = transitionGroupMemberLifecycle(BASE, 'pending', STAMP);
+
+    expect(member.status).toBe('pending');
+    expect(member.joined).toBeNull();
+    expect(member.left).toBeNull();
+    expect(member.removed).toBeNull();
+    expect(member.banned).toBeNull();
+  });
+
+  it('grant stamps joined exactly like invite acceptance', () => {
+    const pending = transitionGroupMemberLifecycle(BASE, 'pending', STAMP);
+    const granted = transitionGroupMemberLifecycle(pending, 'active', STAMP);
+
+    expect(granted.status).toBe('active');
+    expect(granted.joined).toEqual(STAMP);
+  });
+
+  it('decline mirrors invite revoke into left', () => {
+    const pending = transitionGroupMemberLifecycle(BASE, 'pending', STAMP);
+    const declined = transitionGroupMemberLifecycle(pending, 'left', STAMP);
+
+    expect(declined.status).toBe('left');
+    expect(declined.left).toEqual(STAMP);
+    expect(declined.banned).toBeNull();
+  });
+
+  it('maps the park to its own event type', () => {
+    expect(groupMemberEventType('pending')).toBe('member-admission-requested');
+  });
+});

--- a/packages/tests/shared/authoritative-state-validation.test.ts
+++ b/packages/tests/shared/authoritative-state-validation.test.ts
@@ -70,6 +70,20 @@ describe('authoritative network state validation', () => {
             ...group,
             members: [{ ...group.members[0], joined: null }],
         }, scope)).toThrow(/joined/);
+        expect(() => validateAuthoritativeGroupSnapshot({
+            ...group,
+            members: [
+                group.members[0],
+                { ...group.members[0], principalId: 'parker', status: 'pending', joined: null },
+            ],
+        }, scope)).not.toThrow();
+        expect(() => validateAuthoritativeGroupSnapshot({
+            ...group,
+            members: [
+                group.members[0],
+                { ...group.members[0], principalId: 'parker', status: 'pending' },
+            ],
+        }, scope)).toThrow(/joined/);
 
         const topology = {
             sourceGroupStateCausalRevision: group.causalRevision,

--- a/packages/tests/shared/group-admission-decision.test.ts
+++ b/packages/tests/shared/group-admission-decision.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+    computeGroupAdmissionDecision,
+    type ComputeGroupAdmissionDecisionInput,
+} from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
+import type {
+    GroupAdmissionPolicy,
+    GroupLifecycleState,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+
+const NOW = 1_700_000_000_000;
+const STATES: readonly GroupLifecycleState[] = [
+    'forming',
+    'establishing',
+    'active',
+    'reconfiguring',
+];
+
+function decision(
+    admission: Partial<GroupAdmissionPolicy>,
+    overrides: Partial<Omit<ComputeGroupAdmissionDecisionInput, 'admission'>> = {},
+) {
+    return computeGroupAdmissionDecision({
+        admission: { mode: 'open', untilEpochMs: null, untilMemberCount: null, ...admission },
+        lifecycleState: 'forming',
+        activeMemberCount: 2,
+        invited: false,
+        nowEpochMs: NOW,
+        ...overrides,
+    });
+}
+
+function deniedCode(result: ReturnType<typeof computeGroupAdmissionDecision>): string | null {
+    return result.kind === 'deny' ? result.denial.code : null;
+}
+
+describe('group admission decision', () => {
+    it('admits open mode in every lifecycle state', () => {
+        for (const lifecycleState of STATES) {
+            expect(decision({ mode: 'open' }, { lifecycleState })).toEqual({ kind: 'admit' });
+        }
+    });
+
+    // Plan decision 5.2: closed binds outside FORMING — the roster freezes
+    // when establishment begins, and a below-floor return to FORMING
+    // re-opens the lobby.
+    it('closed admits only while forming', () => {
+        expect(decision({ mode: 'closed' }, { lifecycleState: 'forming' }))
+            .toEqual({ kind: 'admit' });
+        for (const lifecycleState of ['establishing', 'active', 'reconfiguring'] as const) {
+            expect(deniedCode(decision({ mode: 'closed' }, { lifecycleState })))
+                .toBe('group-admission-closed');
+        }
+    });
+
+    // An invite is the group's consent, so it bypasses the consent mode —
+    // but closed and the windows are timing/capacity facts, not consent.
+    it('an invite bypasses manager-approval parking and nothing else', () => {
+        expect(decision({ mode: 'manager-approval' }, { invited: true }))
+            .toEqual({ kind: 'admit' });
+        expect(deniedCode(decision({ mode: 'closed' }, {
+            lifecycleState: 'active',
+            invited: true,
+        }))).toBe('group-admission-closed');
+        expect(deniedCode(decision({ mode: 'manager-approval', untilMemberCount: 2 }, {
+            invited: true,
+        }))).toBe('group-admission-capacity-reached');
+    });
+
+    it('manager-approval parks an uninvited join in every lifecycle state', () => {
+        for (const lifecycleState of STATES) {
+            expect(decision({ mode: 'manager-approval' }, { lifecycleState }))
+                .toEqual({ kind: 'park' });
+        }
+    });
+
+    // Correction 5's own motivating case: the window binds without the group
+    // ever activating.
+    it('the member-count window closes admission regardless of lifecycle state', () => {
+        for (const lifecycleState of STATES) {
+            expect(deniedCode(decision({ untilMemberCount: 2 }, { lifecycleState })))
+                .toBe('group-admission-capacity-reached');
+        }
+        expect(decision({ untilMemberCount: 3 })).toEqual({ kind: 'admit' });
+    });
+
+    it('the deadline window closes admission once now reaches it', () => {
+        expect(deniedCode(decision({ untilEpochMs: NOW })))
+            .toBe('group-admission-deadline-passed');
+        expect(deniedCode(decision({ untilEpochMs: NOW - 1 })))
+            .toBe('group-admission-deadline-passed');
+        expect(decision({ untilEpochMs: NOW + 1 })).toEqual({ kind: 'admit' });
+    });
+
+    it('a passed window denies rather than parks under manager-approval', () => {
+        expect(deniedCode(decision({ mode: 'manager-approval', untilEpochMs: NOW })))
+            .toBe('group-admission-deadline-passed');
+        expect(deniedCode(decision({ mode: 'manager-approval', untilMemberCount: 1 })))
+            .toBe('group-admission-capacity-reached');
+    });
+});

--- a/packages/tests/shared/group-lifecycle-policy.test.ts
+++ b/packages/tests/shared/group-lifecycle-policy.test.ts
@@ -115,6 +115,20 @@ describe('group lifecycle policy validation', () => {
         expect(toIssueCodes(policy)).toContain('manager-initiator-without-manager');
     });
 
+    // The slice-5 sibling deadlock: nobody could ever grant a parked join
+    // (plan decision 5.3). Transient zero-manager states stay legal; only
+    // the permanently granterless combination is invalid.
+    it('rejects manager-approval admission with no manager selection', () => {
+        const policy = toNormalizedGroupLifecyclePolicy({
+            manager: { selection: 'none' },
+            admission: { mode: 'manager-approval' },
+        });
+
+        expect(toIssueCodes(policy)).toContain('manager-approval-without-manager');
+        expect(toIssueCodes(toNormalizedGroupLifecyclePolicy({ preset: 'managed' })))
+            .toHaveLength(0);
+    });
+
     it('rejects a floor above the success rate', () => {
         const policy = toNormalizedGroupLifecyclePolicy({
             activation: { mode: 'threshold', successRate: 0.5, minimumViableRate: 0.9 },

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -1,6 +1,6 @@
 # Group Lifecycle Control Plane — Implementation Plan (2026-08-17)
 
-Status: **in execution — slices 1–3 delivered** (slice 2 as PRs #263/#264/#266/#268/#270/#272, slice 3 as #277/#282). Implements
+Status: **in execution — slices 1–4 delivered** (slice 2 as PRs #263/#264/#266/#268/#270/#272, slice 3 as #277/#282, slice 4 as #286/#287). Implements
 `2026-08-08-group-lifecycle-and-policy-model.md` and, with it, Phase 5's formation window (M7) from
 `2026-08-08-group-formation-implementation-plan.md`. These are one workstream, not two: Phase 5's
 formation window is this document's FORMING state with a policy-driven trigger instead of a timer.
@@ -165,7 +165,7 @@ Intent is authoritative; this observation feeds the criterion and nothing else.
 | 3.4 | **Native `next_ts` scheduling replaced the planned requeue contract.** Landing it exposed a pre-existing skew: naive timestamp columns hold UTC wall clocks but the queue SQL compared them with session-zone `now()`; fixed with `(now() at time zone 'UTC')` throughout the resource-inbox SQL, pinned under deliberately skewed PGlite sessions. The timer consumer keeps a not-due throw as clock-skew defense. |
 | 3.5 | **The operator-driven transitions recipe pins `activation.mode: manual`** — the managed preset's default `threshold-or-deadline` would auto-activate underneath its deterministic state walk now that the evidence leg is live. |
 
-### Slice 4 — Manager role
+### Slice 4 — Manager role — **delivered**
 
 `ManagerPolicy` (`selection`, `count`, `succession`). Election uses the existing
 `rendezvous-score.ts` primitive, pinned to the formation epoch (correction 4). Zero-manager fallback
@@ -182,6 +182,15 @@ is explicit: manager absence blocks only manager-assigned actions, never group s
 `selection: 'none'` — wrong, from a faulty extraction. The presets have carried
 `managed: creator` and `match: elected-by-rank` since slice 1; decision 2.2's interim predicate is
 what makes the managed creator work today, and the elected variants are what this slice activates.*
+
+#### Decisions taken during slice 4 execution (2026-08-19)
+
+| # | Decision |
+| --- | --- |
+| 4.3 | **Delivered as 4a (PR #286) and 4b (PR #287).** 4a, dark: `formationElectorate` on the aggregate — creation pins `[creator]`, every accepted transition re-pins to the active member set at the boundary — plus the pure `resolveGroupLifecycleManagers`. 4b: decision 2.2's interim predicate became the real resolution at both consumers — `canCommandGroupLifecycleTransition` and the formation view — with decision 4.2's preset switch and the manager-succession recipe. The predicate gained a live-roster input fed from the mutation read: the policy snapshot carries only the involved members, and the liveness filter needs every candidate. |
+| 4.4 | **`assigned` honours declared order and `count`.** The assigned list is the ranking and `count` takes from it; the interim predicate had treated it as an unordered authority set. |
+| 4.5 | **Succession is operation order, not a mechanism.** One resolution function: `next-by-selection` filters the ranking to live members before taking `count`, so successors fill; `none` takes before filtering, so departures leave holes, never successors. The order applies uniformly to every selection, which is how creator succession continues into the epoch-pinned election ranking. |
+| 4.6 | **The formation view carries `managerPrincipalIds`**, resolved at read time by the same pure function from a policy read added to the route dependencies, so an application can show who may act. The view moved out of `graph-topology-routes.ts` into its own `group-formation-view-read.ts` (the `*-read.ts` split pattern). |
 
 ### Slice 5 — Admission and data policies
 
@@ -241,7 +250,6 @@ every slice boundary: **a group with no policy document behaves exactly as it do
   default.
 - Rank source for `elected-by-rank`. Application-supplied member metadata is the least-coupled
   default.
-- Where the epoch-pinned electorate lives (correction 4). Nothing currently records the member set
-  at an epoch boundary, so slice 4 must either persist the electorate (or the election result) on
-  the aggregate at each epoch-advancing transition, or define the electorate derivably. Decide at
-  slice 4 planning.
+- ~~Where the epoch-pinned electorate lives (correction 4).~~ Settled at slice 4 planning as
+  decision 4.1: the aggregate records the electorate at each epoch-advancing transition, and
+  resolution stays pure.

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -202,6 +202,17 @@ join as pending, extending the existing invite/acceptance flow rather than addin
 Risk: touches the hot, well-covered join path. Every new rule is an added predicate at an existing
 enforcement point, never a parallel path.
 
+#### Decisions taken during slice 5 planning (2026-08-19)
+
+Recorded with their alternatives in `2026-08-19-pending-admission-representation-analysis.md`.
+
+| # | Decision |
+| --- | --- |
+| 5.1 | **Pending admission is a sixth member status, `pending`** — the consent-mirror of `invited` (an invite is the group's consent awaiting the principal's; a pending join is the principal's consent awaiting the group's), extending the invite/acceptance machinery per the recorded default. Grant completes `pending → active` (`member-joined`); decline mirrors invite revoke to `left`, so re-requesting stays possible and `banned` remains the keep-out tool; invited members bypass parking; both join surfaces — the join route and self-upsert activation — take the same admission decision. |
+| 5.2 | **Correction 5 fixed per mode**: `manager-approval` and the `untilEpochMs`/`untilMemberCount` windows bind in every state from creation; **`closed` binds outside FORMING**, so the roster freezes when establishment begins and a below-floor return to FORMING re-opens the lobby. `joinMode` is the credential; admission is the consent-and-timing overlay. |
+| 5.3 | **Grant/decline are manager-only**, resolved via `resolveGroupLifecycleManagers` at the command. Zero-manager recovery is governance's own consent channel — invite, then accept — never a widened grant authority. A new cross-field validity issue, `manager-approval-without-manager`, rejects `selection: 'none'` with `manager-approval` at creation; transient zero-manager states stay legal. |
+| 5.4 | **Delivered as 5a/5b/5c**: 5a the dark core (status arm, pure admission decision, validity rule — no behaviour change); 5b the admission wiring, grant/decline commands, recipes, and the medium-scale gate; 5c the `preActivationAppData` gate on the WS relay separately (different runtime surface, no AppInbox mutation), with the CRDT topics explicitly exempt. |
+
 ### Slice 6 — Read surface and scenario matrix
 
 Lifecycle state joins the group snapshot and read APIs beside the readiness derivation, so
@@ -245,9 +256,9 @@ every slice boundary: **a group with no policy document behaves exactly as it do
 
 ## Open, to settle during execution
 
-- Pending-admission representation for `manager-approval`: extend invites, or a dedicated
-  pending-membership state. Decide when slice 5 is planned; extending invites is the lower-coupling
-  default.
+- ~~Pending-admission representation for `manager-approval`.~~ Settled at slice 5 planning as
+  decision 5.1: a sixth member status extending the invite/acceptance machinery
+  (`2026-08-19-pending-admission-representation-analysis.md`).
 - Rank source for `elected-by-rank`. Application-supplied member metadata is the least-coupled
   default.
 - ~~Where the epoch-pinned electorate lives (correction 4).~~ Settled at slice 4 planning as

--- a/playground/rtc-design/2026-08-19-pending-admission-representation-analysis.md
+++ b/playground/rtc-design/2026-08-19-pending-admission-representation-analysis.md
@@ -1,0 +1,302 @@
+# Pending Admission and the Slice 5 Gates — Analysis (2026-08-19)
+
+Status: **analysis for a decision**, requested at slice 5 planning. The question, open since the
+design document: when a join arrives under `admission.mode: 'manager-approval'`, what represents the
+parked join — an extension of the existing invite/acceptance machinery (the recorded lower-coupling
+default) or a dedicated pending-membership state? Settling it forces the neighboring decisions this
+slice needs anyway: which lifecycle phase each admission mode binds in (correction 5), who may
+grant, how pending admissions interact with formation epochs and timers, where the
+`preActivationAppData` gate sits, the slice split, and the recipe plan.
+
+One fact frames everything: **the managed preset has declared `admission: manager-approval` since
+slice 1, unenforced.** Slice 5 is where the dimension turns on, so every managed-preset group
+changes join behaviour the day the gate wires in — a behaviour change that recipes must pin, not
+discover.
+
+## What exists today
+
+**The join gate** (`canJoinGroup`, `packages/shared-server/rallar-system/group-policy.ts:150-179`):
+business-status guard, principal required, blocked-member denial, member cap
+(`activeMemberCount >= maxMembers`), then a switch on `joinMode`
+(`open` / `invite-only` / `code`). Lifecycle intent gates nothing on this path — joins, presence,
+and messaging check only the business `status`. The gate fires once, inside `computeJoin`
+(`mutation/membership/compute-group-membership-mutation.ts:48-64`), and the same compute writes
+`status: 'active'` atomically — there is no two-step admit anywhere.
+
+**An invite is not an entity — it is a member row.** `GroupMemberStatus` is
+`'invited' | 'active' | 'left' | 'removed' | 'banned'` (`group-types.ts:16`), a discriminated union
+with per-status audit stamps, one row per principal, one canonical transition function
+(`transitionGroupMemberLifecycle`) and one status→event mapping (`groupMemberEventType`). Invite
+create is governance (`canGovernGroupMember`, owner/admin) writing `status: 'invited'` with
+`invitedByPrincipalId` and a 7-day default TTL; **acceptance is the same `computeJoin` path as an
+ordinary join** (`GROUP_INVITE_ACCEPT` → `toJoinCommand`); revoke transitions to `'left'`; there is
+no decline command and no background reaper — invite expiry is checked lazily. The
+`GROUP_JOIN`/`GROUP_INVITE_*` inbox family is already internally named the **admission** descriptor
+family, and its routes live in `register-group-admission-routes.ts` behind the `join-admission`
+rate quota.
+
+**Manager resolution is free at any enforcement point.** `resolveGroupLifecycleManagers` is pure
+over (policy, recorded electorate, epoch, live roster) — slice 4b already pays for grant/decline
+authorization; the only cost at a new call site is having the policy and roster in scope.
+
+**The mutation read is deliberately narrow.** `lifecyclePolicy` and the active roster load only for
+lifecycle-transition operations (`read-group-mutation.ts:110-115`), and
+`validate-group-mutation-read.ts:106-131` *forbids* the roster read on every other operation. The
+join path reads neither today — extending both, symmetrically with the validator, is part of this
+slice's wiring.
+
+**The WS relay choke point** is `RallarServerWsFacade.handle → authorizeDynamicTopic`
+(`ws-topic-router.ts:423,691-722`) → `createGroupRoomWsAuthorizer` → `canSendRoomMessage`. The
+authorizer already pays one durable snapshot read per room message, so `lifecycleState` is free
+there; the policy document is not on the snapshot and nothing on the relay path reads it. The CRDT
+live topics (`room.crdt`/`app.crdt`) flow through the **same** authorizer.
+
+## The symmetry that decides the shape
+
+Membership completion is two consents. An **invite** records the group's consent first
+(governance), and acceptance is the principal's consent landing second — completing to `active`. A
+**pending admission** is the exact mirror: the join records the principal's consent first, and a
+grant is the group's consent landing second — completing to `active`. The machinery for
+"a member row parked in a non-active status, completed by the missing consent, with typed exits"
+already exists; `manager-approval` needs the mirrored arm of it, not a new subsystem.
+
+Two corollaries fall straight out:
+
+- **An invited member's join does not park.** The group's consent already exists — the invite.
+  Acceptance stays today's path, byte-identical, under every admission mode.
+- **Grant is not a new kind of thing.** It is the same shape as acceptance: the second consent
+  transitions the row to `active` and emits `member-joined`.
+
+## Option A — a sixth member status, `pending` (extend the machinery) — recommended
+
+The `GroupMember` union gains a `pending` arm (`joined: null`, no new base fields), the transition
+function and event mapping gain the arm, and `computeJoin` under a parking admission decision writes
+`status: 'pending'` with one new event type (`member-admission-requested`) instead of `'active'`.
+Grant transitions `pending → active` (`member-joined`); decline mirrors invite revoke,
+`pending → 'left'` (`member-left`), so a declined principal may re-request (bounded by the existing
+`join-admission` quota) while `banned` remains the tool for keeping someone out. Withdrawal is the
+existing leave command.
+
+What the existing machinery answers for free, verified against the code:
+
+- **Presence, messaging, electorate, managers**: every `status === 'active'` filter already
+  excludes pending — a pending member cannot connect presence, send room messages, enter
+  `activeMemberCount`, the formation electorate, or manager resolution.
+- **Capacity**: pending members are invisible to the cap exactly as invited members are; the grant
+  re-runs the cap and the admission window in a fresh AppInbox attempt (conflicts retry with fresh
+  authorization by doctrine), so a park that outlives its window is denied honestly at grant time.
+- **Visibility**: `readGroupVisibility` gives pending the existing `'invite'` tier — enough to see
+  you are parked; managers see the queue in the full member list with no new read surface.
+- **Idempotency**: a retried join with the same requestId replays the parked receipt; a new
+  requestId re-parks as a no-op (same guard as the `active` no-op). Grant is a distinct command,
+  which the permanent-receipt semantics require anyway.
+
+The honest costs:
+
+- The status-vocabulary census: every exhaustive switch over `GroupMemberStatus` grows an arm —
+  union, transition function, event mapping, visibility, persistence validators, OpenAPI enums —
+  plus one new event type through `GroupEventType` and the state-write evidence registries. This is
+  the member-status analog of the 4a field census: mechanical, enumerable, and the kind of change
+  the exhaustive switches were built to police.
+- Two new mutation commands (grant/decline) through the ~10-registry command census and the
+  routing-owner analyzer, with the dispatch-classifier fall-through only provable by executing a
+  request — the recipe does exactly that.
+- **Both join surfaces must take the same decision.** Self-upsert activation
+  (`PUT .../members/{self}` with `status: 'active'`) re-runs `canJoinGroup` today; under
+  `manager-approval` it must land `pending` exactly like the join route, or the park is bypassable
+  by switching endpoints. Admin activation of another principal (`canActivateGroupMember`) stays
+  governance — it *is* a grant, expressed through the existing surface.
+- Invite-row precedence: an invite and a request occupy the same row. The rule is the symmetry
+  rule: whichever consent lands second completes to `active`; a governance invite issued to a
+  `pending` member is a grant.
+
+## Option B — a dedicated pending-membership state
+
+A pending-admissions collection beside the member list (aggregate field or scoped document), with
+its own grant/decline paths. Rejected: it is precisely the "parallel path" the slice rule forbids —
+a second membership-adjacent store needing its own persistence, snapshot/delta surface, visibility,
+presence-coupling and capacity answers, all of which the member row already gives. Its one genuine
+advantage — no growth of the member-status union — buys nothing, because every consumer of the
+union would still need to learn the new collection to answer "is this principal in the group?".
+
+## Also considered — reuse `'invited'` with a marker
+
+Parking a join as a synthetic invite inverts the consent direction dishonestly: `invited` means the
+group has consented and visibility/TTL semantics assume it. A marker field distinguishing the two
+would make one status mean opposite things — worse than a sixth status on every axis.
+
+## Recommendation
+
+**Option A**, with the invited-bypass, decline-to-`left`, and both-surfaces rules above. It is the
+design document's own sentence made concrete — "building on the existing invite/acceptance flow
+rather than a new subsystem" — and it keeps the slice rule intact: every new behaviour is an added
+predicate or an added arm at an existing enforcement point.
+
+Two supporting rules ride along:
+
+- **Grant/decline authorization is manager-only** (`resolveGroupLifecycleManagers` at the command,
+  same zero-extra-cost resolution as 4b), *not* widened to owner/admin. Governance already has its
+  own consent channel — the invite — so an owner in a zero-manager group recovers by inviting (the
+  group's consent), never by impersonating a manager. This keeps "manager-approval" meaning what it
+  says while preserving the slice 4 invariant that manager absence blocks only manager-assigned
+  actions: membership recovery stays possible through governance. The manager-succession recipe's
+  zero-manager safety leg survives as exactly this invite-recovery path.
+- **A new cross-field validity issue, `manager-approval-without-manager`**: `admission.mode:
+  'manager-approval'` with `manager.selection: 'none'` can never grant and is rejected at policy
+  validation beside the `manager-initiator-without-manager` deadlock it rhymes with. Transient
+  zero-manager states (assigned manager not yet joined, all managers departed) stay legal —
+  recoverable via invite — only the *permanently* granterless combination is invalid.
+
+## Admission binding phases (settling correction 5 per mode)
+
+Correction 5 says admission binds on entry to the phase it names, not on activation. The shipped
+vocabulary dropped the phase-suffixed names, so the binding phase must be fixed per mode:
+
+| Mode / field | Binds | Rationale |
+| --- | --- | --- |
+| `open` | never gates | — |
+| `manager-approval` | every state, from creation | The managed archetype is curated membership from the lobby onward; a mode with no phase in its name is a standing rule. |
+| `untilEpochMs` / `untilMemberCount` | every state, from creation | Absolute windows; correction 5's own example (drop-in social never activating) demands they bind without activation. When the window closes the mode degrades to `closed`. |
+| `closed` | **every state except FORMING** — *decision to confirm* | See below. |
+
+`closed` is the one genuine choice. The design table said "no joins after activation"; binding at
+ACTIVE entry (design-literal) leaves ESTABLISHING joinable — exactly when the match preset
+(`successRate: 1`) is counting planned edges, so a join then re-plans the overlay and guarantees
+the deadline fails. Binding on exit from FORMING freezes the roster when establishment begins,
+which is what `closed` exists to protect, and a below-floor return to FORMING honestly re-opens the
+lobby to replace the member who could not connect. Recommended: **binds outside FORMING**.
+(Always-closed is expressible but useless — nobody could ever join, which `joinMode: invite-only`
+with no invites already says better.)
+
+`joinMode` and admission compose rather than overlap: `joinMode` is the credential — how a
+principal proves entitlement (open / invite / code) — and admission is the consent-and-timing
+overlay — whether joining is currently possible and whether it completes or parks.
+
+## The formation-timer/epoch interaction
+
+Stated explicitly, per dimension, because a pending admission can straddle epochs (parked during
+ESTABLISHING, granted after a below-floor return to FORMING advanced the epoch and re-armed
+timers):
+
+1. **A pending admission survives epoch advances — by construction, not by rule.** An epoch
+   advance writes the group row, an event, a receipt, and outbox entries; member rows are untouched
+   (`compute-lifecycle-transition.ts:155`, `members: []`). Nothing epoch-keys membership state, so a
+   join parked in epoch 3 is grantable in epoch 5 with no carried machinery. Formation-timer
+   entries stale-drop by epoch; pending rows are not timer entries and are unaffected.
+2. **Grant authorization is evaluated at grant time against the current epoch.** The pending row
+   records no epoch (correctly — it is a consent, not a formation fact); the grant command resolves
+   managers from the *current* electorate, epoch, and live roster, exactly like any manager-gated
+   command. A manager elected after the park can grant it; a manager who departed since cannot.
+3. **A grant in each lifecycle state means exactly what an ordinary join means there today:**
+   - **FORMING**: the member becomes active; planning is held (decision 2.4), and they enter the
+     electorate at the next `start-establishment` pin — full stability, no interaction.
+   - **ESTABLISHING / RECONFIGURING**: the membership write bumps `snapshotVersion`, the
+     group-revision work item re-plans the overlay including the new member, the readiness
+     denominator grows, and the criterion re-evaluates on the new evidence — possibly deferring
+     threshold or hitting the deadline into a below-floor return. That is the same consequence an
+     open join has in that state on `main` today, and it is honest: activation claims the planned
+     overlay is connected, and the roster is part of the plan.
+   - **ACTIVE**: a plain join; the overlay re-plans under ACTIVE as it does for any join.
+4. **Granting mid-ESTABLISHING takes effect now, not at the next epoch — deliberately.** Deferring
+   grants to an epoch boundary would need an epoch-keyed grant queue: a parallel path, forbidden by
+   the slice rule, solving a problem the model already solves twice over. Manager stability is
+   already epoch-pinned (a granted member cannot enter the electorate mid-epoch; under
+   `assigned`/`creator` they enter only the liveness filter, which is 4b's recorded
+   joining-restores-the-manager semantics). And roster stability during establishment is what
+   `closed` admission is *for* — an archetype that wants a frozen mesh declares it; under
+   `manager-approval` the timing judgment belongs to the manager holding the grant.
+
+In short: **it composes with no new machinery**, and each of the four statements above is pinned by
+a recipe leg rather than left as prose.
+
+## The `preActivationAppData` gate
+
+One added denial at the existing per-message policy predicate, plus acquisition:
+
+- **Predicate**: `canSendRoomMessage` gains the resolved data-policy value in its input and denies
+  with a new reason code (`group-data-blocked-until-active`) when
+  `preActivationAppData === 'blocked-until-active'` and `snapshot.group.lifecycleState !== 'active'`.
+  `lifecycleState` is already on the snapshot the authorizer loads per message.
+- **Acquisition with a lifecycle short-circuit**: the api-v1 authorizer reads the policy **only
+  when the group is not ACTIVE** — steady-state room traffic (active groups) pays zero additional
+  reads; the short pre-activation window pays one policy get on a path already doing a durable
+  snapshot read. Absent policy → `allowed` (the workstream's no-policy invariant); corrupt policy →
+  fail closed, matching the repository's own doctrine and the match preset's integrity posture.
+- **CRDT topics are explicitly exempt.** `room.crdt`/`app.crdt` share the choke point; without an
+  explicit classification the gate silently blocks pre-activation collaborative documents, which
+  the terminology doctrine separates from match authority ("Rallar CRDT = collaborative authored
+  documents, not competitive match authority"). The exemption is a visible topic-id classification
+  at the authorizer, not an accident of ordering. *(Default taken unless objected: the gate covers
+  plain WS-relayed app data only.)*
+- Out of scope, unchanged: RTC data-channel traffic (`realtime.room` is peer-to-peer; the server
+  only signals), presence/state-sync/signaling/RTT reserved topics (activation must remain
+  reachable), and the pre-existing ungated `scope: 'all'` broadcast hole.
+
+## Slice split
+
+Mirroring 2/3/4 (dark core, then wiring), with the data gate split out because it lives on a
+different runtime surface (WS relay, no AppInbox mutation):
+
+- **5a — dark core.** The `pending` status arm through the full status census; the pure admission
+  decision (`computeGroupAdmissionDecision(admission, lifecycleState, activeMemberCount, now) →
+  admit | park | typed denial`) beside the policy contract in
+  `packages/shared/api/group-lifecycle/`; new reason codes extending `GroupPolicyReasonCode`; the
+  `manager-approval-without-manager` validity rule; unit matrices (binding-phase table, decision
+  matrix, pending transitions including leave-from-pending and invite-on-pending precedence).
+  Nothing constructs a `pending` row and no gate wires in: no behaviour change except the validity
+  rejection of a combination no preset ships.
+- **5b — admission wiring, commands, recipes.** The read-phase extension (policy + what the
+  admission decision needs, for join/accept/upsert-activation, with the read-validator kept
+  symmetric); `computeJoin` and upsert-activation take the decision; grant/decline commands through
+  the command census, routes in the existing admission route file under the `join-admission` quota;
+  OpenAPI; the recipes below; the mandatory medium-scale gate.
+- **5c — data-policy gate and recipe.** The `canSendRoomMessage` predicate + authorizer policy read
+  + CRDT classification + its recipe. Small, independent, separately revertible.
+
+(A two-way split folding 5c into 5b is workable if three PRs feel heavy; the data gate's different
+blast radius is the argument for three.)
+
+## Recipe plan
+
+New recipes (cluster profile, beside the lifecycle recipes; registered in `recipe-matrix.json`):
+
+1. **`api-v1-group-admission-approval`** — the managed preset's behaviour change, pinned:
+   uninvited join parks (`members[].status: 'pending'` in the 200 snapshot); non-manager grant
+   denied `forbidden-role`; manager grants → active (roster + formation view); manager declines →
+   `left`, re-request succeeds; invited member joins straight to active (bypass); the **epoch
+   leg** — park during ESTABLISHING, drive fail-formation to FORMING (epoch advance), grant in the
+   later epoch succeeds and the member enters the next electorate pin; the **zero-manager leg** —
+   managed group with an unjoined assigned manager: join parks, nobody grants, owner invites →
+   accept → active → manager restored (the succession safety property, now under real admission).
+2. **`api-v1-group-admission-windows`** — capacity-on-phase-entry: `untilMemberCount: N` on a group
+   that never activates — joins to N succeed, N+1 is denied with the typed code (correction 5
+   pinned); an `untilEpochMs` leg with a short window and polling. A `closed` leg: joins denied
+   outside FORMING, allowed again after a below-floor return to FORMING.
+3. **`api-v1-group-data-policy`** (5c) — `blocked-until-active` policy with manual activation: WS
+   room message pre-activation NACKed (typed code), CRDT envelope flows pre-activation (exemption
+   pinned), activate, the same message flows.
+
+Existing-recipe impact (from a full sweep — exactly four recipes carry a `lifecyclePolicy`):
+
+- **`api-v1-group-manager-succession`** and **`api-v1-group-formation-criterion`** each have joins
+  into managed groups that would newly park. Both recipes pin manager duty and criterion legs, not
+  admission — so both get an explicit `admission: { mode: 'open' }` override at creation
+  (the decision-3.5 pattern: pin the dimension you are not testing), and the admission behaviour
+  itself is pinned in the dedicated recipe above.
+- **`api-v1-group-lifecycle-transitions`** (no joins) is exposure-only; **`api-v1-group-lifecycle-policy`**
+  already creates a `closed`-override group and gains one join-denial assertion so the stricter
+  behaviour is pinned rather than silent.
+- The formation burst/churn/join-admission recipes and all `examples/` create optimistic groups —
+  unaffected.
+
+Validation per the plan: focused unit tests → the new/updated recipes →
+`test:api-v1:black-box:postgres:medium-scale` (hot join path; constants and assertions untouched),
+plus the OpenAPI/pinned-literal updates the status enum ripples into.
+
+## Defaults taken unless objected
+
+Decline lands `'left'` (re-requestable; `banned` is the keep-out tool). No pending TTL in v1 (no
+reaper exists; lazy expiry can follow the invite pattern later). Parked joins return HTTP 200 with
+the snapshot showing `pending` (no new status code). Grant/decline ride the `join-admission` rate
+quota. CRDT exemption from the data gate as above. Admin upsert-activation of another principal
+remains governance (it is a grant through the existing surface).

--- a/playground/rtc-design/2026-08-19-pending-admission-representation-analysis.md
+++ b/playground/rtc-design/2026-08-19-pending-admission-representation-analysis.md
@@ -293,6 +293,13 @@ Validation per the plan: focused unit tests → the new/updated recipes →
 `test:api-v1:black-box:postgres:medium-scale` (hot join path; constants and assertions untouched),
 plus the OpenAPI/pinned-literal updates the status enum ripples into.
 
+## Decision taken (owner, 2026-08-19)
+
+All four recommendations, as recommended: the sixth member status (option A) with the
+invited-bypass and both-surfaces rules; `closed` binds outside FORMING; grant/decline manager-only
+with invite-based zero-manager recovery and the `manager-approval-without-manager` validity rule;
+the 5a/5b/5c split. Recorded as plan decisions 5.1–5.4.
+
 ## Defaults taken unless objected
 
 Decline lands `'left'` (re-requestable; `banned` is the keep-out tool). No pending TTL in v1 (no


### PR DESCRIPTION
Slice 5 planning plus 5a of the group lifecycle control plane workstream.

**Plan refresh.** Slice 4 is marked delivered (4a #286, 4b #287) with its execution decisions
recorded (4.3–4.6): the live-roster predicate input, `assigned` honouring order and count,
succession as operation order, and the formation view's `managerPrincipalIds` with the
`group-formation-view-read.ts` extraction. Every remaining plan claim was re-verified against the
code; none drifted.

**Decision analysis.** `playground/rtc-design/2026-08-19-pending-admission-representation-analysis.md`
settles the open pending-admission question and its neighbours, recorded as plan decisions 5.1–5.4:
pending admission is a sixth member status (the consent-mirror of `invited`), correction 5's binding
phases are fixed per mode with `closed` binding outside FORMING, grant/decline are manager-only with
invite-based zero-manager recovery, and delivery is 5a/5b/5c. The analysis states the
formation-epoch interaction explicitly: pending rows survive epoch advances by construction, grants
bind at grant time against the current electorate, and mid-ESTABLISHING grants behave exactly as
ordinary joins do today — no new machinery.

**5a dark core.** The `pending` member status through the full status census (union arm, transition
function, `member-admission-requested` event, invite visibility tier, all three state validators,
persistence codec, OpenAPI enums), the pure `computeGroupAdmissionDecision` with three new admission
reason codes, and the `manager-approval-without-manager` validity rule. Client input still cannot
supply `pending` — only the admission decision may compute it. Nothing constructs a pending row and
no gate wires in: no behaviour change. The wiring, grant/decline commands, and recipes follow as 5b;
the `preActivationAppData` gate as 5c.

**Validation.** `test:unit` (full suite), `test:deno`, api-v1 `deno task check`,
`check:browser-bundles`, and `check:repo-style:changed origin/main HEAD` (PASS, zero findings) all
green locally. `test:api-v1:black-box:postgres:medium-scale`: PASSED, success=2748 failure=0.
Playwright suites left to CI (sandboxed loopback binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)