### PR TITLE
Scan tests in the style checker and stage what blocks a branch

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -132,8 +132,13 @@ pull request and cannot be deferred through an issue to complete the work.
   backstop — worsened means crossing a metric tier or same-tier growth of more than
   max(10% of the merge-base magnitude, 25 units); every other rule treats any magnitude growth as worsened.
 - Checker tolerance is not authority to retain noncompliance and does not define touched-file standards closure.
-- Tests, mocks, stories, fixtures, and generated artifacts are excluded from the default production-code checker, but
-  not from the human-readable standard.
+- The full-repository checker reports tests, mocks, fixtures, and support tooling alongside
+  production. Generated and vendored artifacts stay out of both the checker and the standard.
+- Enforcement on tests is staged. Feature-branch CI blocks a changed test file only on
+  `line.width`, `boundary.unknown`, and `construction.forward-capture`; every other rule is
+  reported for review without blocking. A rule joins that set once it has been measured against the
+  test corpus, as `file.length` was. Staging is keyed on the path, so a directory-level layout
+  finding under a test tree is staged the same way a file-level one is.
 - A deliberate exception requires explicit human approval and a short rationale in the task handoff. Existing violations
   are not precedent.
 

--- a/packages/tests/repo/repo-style-check.test.ts
+++ b/packages/tests/repo/repo-style-check.test.ts
@@ -244,17 +244,33 @@ describe('repo style checker', () => {
     expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
   });
 
-  it('excludes test and mock paths from production warnings', () => {
+  // Tests are in scope for the standard, so the full checker reports them. Enforcement is staged
+  // separately in the changed-range gate; this checker is warning-only either way.
+  it('reports test and mock paths alongside production', () => {
     const longLine = `const value = '${'x'.repeat(110)}';`;
     const fixtureRoot = createFixture({
       'tests/example.ts': longLine,
       'mocks/example.ts': longLine,
     });
 
+    const output = runChecker(fixtureRoot);
+
+    expect(output).toContain('tests/example.ts');
+    expect(output).toContain('mocks/example.ts');
+    expect(output).toContain('[line.width]');
+  });
+
+  it('still excludes generated artifacts from the checker entirely', () => {
+    const longLine = `const value = '${'x'.repeat(110)}';`;
+    const fixtureRoot = createFixture({
+      'schema.generated.ts': longLine,
+      'generated/example.ts': longLine,
+    });
+
     expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
   });
 
-  it('does not include excluded sources in layout directory counts', () => {
+  it('counts test sources in layout directory counts but never generated ones', () => {
     const fixtureRoot = createFixture({
       ...Object.fromEntries(
         Array.from({ length: 20 }, (_, index) => [
@@ -285,10 +301,12 @@ describe('repo style checker', () => {
 
     const result = runChecker(fixtureRoot, '--layout-only');
 
-    expect(result).not.toContain('[layout.directory-density]');
-    expect(result).not.toContain('[layout.feature-prefix-cluster]');
-    expect(result).toContain('layout.directory-density=0');
-    expect(result).toContain('layout.feature-prefix-cluster=0');
+    // tests/ and mocks/ hold 21 files each and are scanned now, so both are dense enough to
+    // report. generated/ holds 21 too and must still contribute nothing.
+    expect(result).toContain('[layout.directory-density]');
+    expect(result).toContain('/tests');
+    expect(result).toContain('/mocks');
+    expect(result).not.toContain('/generated');
   });
 
   it('excludes test-runner configuration files from production warnings', () => {

--- a/packages/tests/repo/repo-style-structural-lineage-fixtures.ts
+++ b/packages/tests/repo/repo-style-structural-lineage-fixtures.ts
@@ -101,6 +101,14 @@ export function writeBoundarySummaryVariantLoader(root: string): string {
     'export function isProductionCodeFile(file) {',
     '  return /\\/(?:apps|packages)\\/.*\\.[cm]?[jt]sx?$/u.test(file);',
     '}',
+    // The changed-style checker also asks which sources are tests and which rules are enforced on
+    // them. This fixture only produces production paths, so both answers are the production ones.
+    'export function isTestSourceFile() {',
+    '  return false;',
+    '}',
+    'export function isTestEnforcedFinding() {',
+    '  return true;',
+    '}',
     'export async function collectProductionSources(roots) {',
     "  return [{ file: path.join(roots[0], 'apps/example/target-a.ts'), raw: 'target' }];",
     '}',

--- a/packages/tests/repo/repo-style-test-calibration.test.ts
+++ b/packages/tests/repo/repo-style-test-calibration.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, it } from 'vitest';
 import {
   isProductionCodeFile,
   isNonProductionPath,
+  isTestEnforcedFinding,
+  isTestSourceFile,
   resolveFileLineBackstop,
+  testEnforcedRuleIds,
 } from '../../../scripts/repo-style-check/repository-scan.mjs';
 
 const repoRoot = process.cwd();
@@ -33,12 +36,39 @@ describe('repo style test calibration', () => {
     expect(resolveFileLineBackstop('apps/api-v1/src/main.ts')).toBe(1200);
   });
 
-  // The wider backstop is prepared, not yet reachable: collectProductionSources filters test paths
-  // out of the scan entirely, so no test file is measured until the test scan is enabled. This
-  // pins that honestly rather than letting the calibration read as though it were already live.
-  it('records that the scan still excludes the files the wider backstop is for', () => {
+  it('scans test sources without counting them as production', () => {
     expect(isProductionCodeFile('packages/tests/shared/queue.test.ts')).toBe(false);
-    expect(isProductionCodeFile('packages/shared/queuebox/ResourceEntry.ts')).toBe(true);
+    expect(isTestSourceFile('packages/tests/shared/queue.test.ts')).toBe(true);
+    expect(isTestSourceFile('packages/tests/create-test-group.ts')).toBe(true);
+    expect(isTestSourceFile('apps/api-v1/test/db/pglite-sql-adapter.test.ts')).toBe(true);
+    expect(isTestSourceFile('packages/shared/queuebox/ResourceEntry.ts')).toBe(false);
+  });
+
+  it('blocks only the staged rules when the changed file is a test', () => {
+    const testFile = 'packages/tests/shared/queue.test.ts';
+
+    expect([...testEnforcedRuleIds].toSorted()).toEqual([
+      'boundary.unknown',
+      'construction.forward-capture',
+      'line.width',
+    ]);
+    expect(isTestEnforcedFinding(testFile, 'line.width')).toBe(true);
+    expect(isTestEnforcedFinding(testFile, 'boundary.unknown')).toBe(true);
+    expect(isTestEnforcedFinding(testFile, 'file.cognitive-load')).toBe(false);
+    expect(isTestEnforcedFinding(testFile, 'file.length')).toBe(false);
+  });
+
+  // Layout findings are reported against a directory, which has no extension. Keying the staging on
+  // the file kind would let those through as if the directory were production.
+  it('stages a directory-level finding under the test tree the same way', () => {
+    expect(isTestEnforcedFinding('packages/tests/repo', 'layout.directory-density')).toBe(false);
+    expect(isTestEnforcedFinding('packages/shared', 'layout.directory-density')).toBe(true);
+  });
+
+  it('leaves every rule blocking on production paths', () => {
+    for (const ruleId of ['line.width', 'file.cognitive-load', 'file.length', 'boundary.unknown']) {
+      expect(isTestEnforcedFinding('packages/shared/queuebox/ResourceEntry.ts', ruleId)).toBe(true);
+    }
   });
 
   it('states both backstops in the authority the checker implements', () => {

--- a/scripts/check-changed-repo-style.mjs
+++ b/scripts/check-changed-repo-style.mjs
@@ -5,6 +5,8 @@ import path from 'node:path';
 import {
   collectProductionSources,
   isProductionCodeFile,
+  isTestEnforcedFinding,
+  isTestSourceFile,
   scanProductionSources,
 } from './repo-style-check/repository-scan.mjs';
 import {
@@ -70,7 +72,7 @@ async function main() {
   });
   const governedTargetSources =
     targetReference === worktreeTarget
-      ? await collectProductionSources([repoRoot])
+      ? await collectProductionSources([repoRoot], { includeTests: true })
       : readRevisionProductionSources(repoRoot, targetCommit);
   const baseSources = toBaseSources({
     repoRoot,
@@ -78,16 +80,13 @@ async function main() {
     targetSources: governedTargetSources,
     changes,
   });
-  const baseFindings = scanProductionSources({
-    repoRoot,
-    sources: baseSources,
-    options: scanOptions,
-  }).findings;
-  const targetFindings = scanProductionSources({
-    repoRoot,
-    sources: governedTargetSources,
-    options: scanOptions,
-  }).findings;
+  const baseFindings = toEnforcedFindings(
+    scanProductionSources({ repoRoot, sources: baseSources, options: scanOptions }).findings,
+  );
+  const targetFindings = toEnforcedFindings(
+    scanProductionSources({ repoRoot, sources: governedTargetSources, options: scanOptions })
+      .findings,
+  );
   const newFindings = subtractExistingFindings({
     repoRoot,
     baseFindings,
@@ -107,6 +106,13 @@ async function main() {
     governanceIssues: reviewedDispositionContext.issues,
   });
 }
+
+const isGovernedSourceFile = (file) => isProductionCodeFile(file) || isTestSourceFile(file);
+
+// Both sides of the comparison are filtered, so a rule that is not yet enforced on tests never
+// enters the base or the target set and cannot register as new or worsened.
+const toEnforcedFindings = (findings) =>
+  findings.filter((entry) => isTestEnforcedFinding(entry.file, entry.ruleId));
 
 function printChangedFindings(result) {
   for (const issue of result.governanceIssues) {
@@ -149,7 +155,7 @@ function readChanges(mergeBase, targetReference, repoRoot) {
   return changes.filter((change) =>
     [change.source, change.target]
       .filter(Boolean)
-      .some((file) => isProductionCodeFile(path.join(repoRoot, file))),
+      .some((file) => isGovernedSourceFile(path.join(repoRoot, file))),
   );
 }
 
@@ -185,7 +191,7 @@ function toBaseSources(input) {
     const baseSource = readRevisionFile(input.mergeBase, change.source);
     if (
       baseSource !== undefined &&
-      isProductionCodeFile(path.join(input.repoRoot, change.source))
+      isGovernedSourceFile(path.join(input.repoRoot, change.source))
     ) {
       sourceByPath.set(change.source, {
         file: path.join(input.repoRoot, change.source),
@@ -322,7 +328,7 @@ function readRevisionProductionSources(repoRoot, revision) {
   return runGit(['ls-tree', '-r', '--name-only', revision])
     .split('\n')
     .filter(Boolean)
-    .filter((file) => isProductionCodeFile(path.join(repoRoot, file)))
+    .filter((file) => isGovernedSourceFile(path.join(repoRoot, file)))
     .map((file) => ({
       file: path.join(repoRoot, file),
       raw: readRevisionFile(revision, file),

--- a/scripts/repo-style-check.mjs
+++ b/scripts/repo-style-check.mjs
@@ -49,7 +49,9 @@ async function main() {
     objectInterfaces: args.has('--object-interfaces'),
     cognitiveMetrics: args.has('--cognitive-metrics'),
   };
-  const sources = await collectProductionSources(scanRoots);
+  // Tests are in scope for the standard's universal rules, so the warning-only full scan reports
+  // them. Which of those rules block a branch is decided separately, in the changed-range gate.
+  const sources = await collectProductionSources(scanRoots, { includeTests: true });
   const result = scanProductionSources({
     repoRoot: path.resolve(process.cwd()),
     sources,

--- a/scripts/repo-style-check/repository-scan.mjs
+++ b/scripts/repo-style-check/repository-scan.mjs
@@ -129,9 +129,12 @@ export async function resolveScanRoots(candidates) {
   return existingRoots;
 }
 
-export async function collectProductionSources(scanRoots) {
+export async function collectProductionSources(scanRoots, options = {}) {
   const nestedFiles = await Promise.all(scanRoots.map(collectSourceFiles));
-  const productionFiles = nestedFiles.flat().filter(isProductionCodeFile).sort();
+  const accept = options.includeTests
+    ? (file) => isProductionCodeFile(file) || isTestSourceFile(file)
+    : isProductionCodeFile;
+  const productionFiles = nestedFiles.flat().filter(accept).sort();
   return Promise.all(
     productionFiles.map(async (file) => ({ file, raw: await fs.readFile(file, 'utf8') })),
   );
@@ -341,6 +344,53 @@ async function collectSourceFiles(current) {
 // beyond production sources: collectProductionSources still filters test paths out entirely.
 export function resolveFileLineBackstop(file) {
   return isNonProductionPath(file) ? limits.testFileLineCount : limits.fileLineCount;
+}
+
+// Human-authored test sources: the same file kinds the production predicate accepts, minus its
+// test-path and test-filename exclusions. Generated, vendored, and runner-config files stay out of
+// both. The standard applies its universal rules here; which of them are enforced is separate.
+// Which rules block a branch when the changed file is a test. The standard applies universally, but
+// enforcement is staged: these three are unambiguous on any corpus and carry the highest value here
+// -- boundary.unknown is what reports `as unknown as`. The file metrics and layout rules stay
+// warning-only for tests until each is measured against the test corpus the way file.length was.
+export const testEnforcedRuleIds = new Set([
+  'line.width',
+  'boundary.unknown',
+  'construction.forward-capture',
+]);
+
+// Keyed on the path, not the file kind: layout findings are reported against a directory, which has
+// no extension and would otherwise fall through as if it were production.
+export function isTestEnforcedFinding(file, ruleId) {
+  if (typeof file !== 'string') {
+    return true;
+  }
+  return !isNonProductionPath(file) || testEnforcedRuleIds.has(ruleId);
+}
+
+export function isTestSourceFile(file) {
+  const normalized = file.replace(/\\/gu, '/').toLowerCase();
+  if (!checkedExtensions.has(path.extname(normalized))) {
+    return false;
+  }
+  if (isProductionCodeFile(file)) {
+    return false;
+  }
+  const parts = normalized.split('/');
+  const base = parts[parts.length - 1];
+  if (isTestRunnerConfigFile(base)) {
+    return false;
+  }
+  if (
+    parts.some((part) => part === 'node_modules' || generatedPathPartPattern.test(part))
+  ) {
+    return false;
+  }
+  return !(
+    /\.generated(?:\.d)?\.[cm]?(?:t|j)sx?$/u.test(base) ||
+    /\.gen(?:\.d)?\.[cm]?(?:t|j)sx?$/u.test(base) ||
+    /\.pb(?:\.d)?\.[cm]?(?:t|j)sx?$/u.test(base)
+  );
 }
 
 export function isProductionCodeFile(file) {


### PR DESCRIPTION
Steps 3 and 4. **Stacked on #289** — review that first; this PR's base is `claude/repo-style-test-calibration`.

## Step 3 — the full scan reports tests

The standard already applies its universal rules to tests; only the checker excluded them, leaving 43% of the repository's hand-written TypeScript with no automated structural discipline.

**5,562 → 9,906 findings.** That scan is warning-only, so **no gate moves.**

`isTestSourceFile` accepts the file kinds the production predicate accepts, minus its test-path and test-filename exclusions. Generated and vendored artifacts stay out of both — which required fixing the generated-path guard to test each path *segment* rather than the whole path, or `generated/example.ts` leaked through.

## Step 4 — staged enforcement on the blocking gate

A changed test file fails feature-branch CI only on:

| Rule | Why first |
| --- | --- |
| `boundary.unknown` | Reports `as unknown as` — ~40% of the test tree's findings, and the exact construct four campaigns just removed from these same files |
| `line.width` | Universal; no corpus argument against it |
| `construction.forward-capture` | Universal section of the standard |

Everything else is reported for review without blocking, until measured against the test corpus the way `file.length` was in #289.

**Both sides of the comparison are filtered**, so a not-yet-enforced rule cannot enter the base or target set and register as new or worsened.

## Two things I got wrong first, and what they changed

**Staging keyed on the file kind let directory findings through.** `layout.directory-density` is reported against a directory, which has no extension — so `isTestSourceFile` returned false and it was treated as production. My own new test file pushed `packages/tests/repo` over the density threshold and the gate blocked on a rule that is not in the enforced set. Staging is now keyed on the path, which works for both.

**The predicate threw on a finding with no file.** It now defaults to enforced, which is the safe direction.

## Verified by mutation, all four directions

| Probe | Result |
| --- | --- |
| `line.width` violation in a test file | **FAIL** — blocks |
| `boundary.unknown` (`as unknown as`) in a test file | **FAIL** — blocks |
| `file.cognitive-load` (60 branches) in a test file | **PASS** — staged out |
| `line.width` violation in production | **FAIL** — unchanged |

All probes reverted; worktree clean.

## Governance tests updated, not deleted

Two encoded the old exclusion. They now assert the new behaviour:

- the checker **reports** tests and mocks alongside production;
- it **still ignores generated artifacts entirely**;
- it **counts a dense test directory** while never counting a generated one.

The structural-lineage fixture stubs the scanner module with a fake, so it gains the two exports the changed checker now imports — the interface grew and the stub had to follow.

## Verification

`test:unit` 7,764 passed · `test:repo-governance` 361 passed · `typecheck` exit 0 · `check:repo-style` exit 0 · `check:repo-style:changed` PASS · `check-test-structure-coupling --changed` PASS.

## Remaining

Step 5: measure the held-back rules against the test corpus one at a time and promote each into the enforced set. `file.cognitive-load` and `file.responsibility-count` are the obvious next candidates — both are already *stricter* on tests than production, so they may promote with no calibration at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)