### PR TITLE
Fix RTC-B05 attempt metric aggregation

### DIFF
--- a/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/rtc-data-channel-browser-soak.test.ts
@@ -512,8 +512,22 @@ function assertAcceptedMeasurement(input: {
   const iterationIds = rtcB05IterationIds(sample.rawEvidence);
   expect(iterationIds).toHaveLength(25);
   expect(new Set(iterationIds).size).toBe(25);
-  expect(sample.metrics.filter(({ metric }) => metric === 'openDurationMs')).toHaveLength(25);
-  expect(sample.metrics.filter(({ metric }) => metric === 'closeDurationMs')).toHaveLength(25);
+  expect(
+    sample.metrics.filter(({ metric }) =>
+      ['firstOpenDurationMs', 'steadyOpenMedianDurationMs'].includes(metric),
+    ),
+  ).toEqual([
+    { metric: 'firstOpenDurationMs', unit: 'ms', value: 0.25 },
+    { metric: 'steadyOpenMedianDurationMs', unit: 'ms', value: 12.75 },
+  ]);
+  expect(
+    sample.metrics.filter(({ metric }) =>
+      ['firstCloseDurationMs', 'steadyCloseMedianDurationMs'].includes(metric),
+    ),
+  ).toEqual([
+    { metric: 'firstCloseDurationMs', unit: 'ms', value: 0.5 },
+    { metric: 'steadyCloseMedianDurationMs', unit: 'ms', value: 13 },
+  ]);
   expect(sample.runtimeObservation).toEqual(environment(input.captureManifest).observation);
 }
 

--- a/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/summarize-rtc-b05.test.ts
+++ b/packages/shared-rtc-bench/tests/workloads/browser-lifecycle/summarize-rtc-b05.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RtcBaselineJson } from '../../../baseline/contracts/rtc-baseline-contracts.ts';
+import {
+  computeRtcBaselineMetricSummary,
+  requiresRtcBaselineRepeat,
+} from '../../../baseline/evidence/rtc-baseline-statistics.ts';
+import { summarizeRtcB05 } from '../../../workloads/browser-lifecycle/summarize-rtc-b05.ts';
+
+function createRawEvidence(openDurationsMs: readonly number[]): RtcBaselineJson {
+  return {
+    durationMs: 600,
+    heap: {
+      beforeBytes: 550_000,
+      afterBytes: 600_000,
+      deltaBytes: 50_000,
+    },
+    soak: {
+      results: openDurationsMs.map((openDurationMs, index) => ({
+        openDurationMs,
+        closeDurationMs: openDurationMs + 0.25,
+        index: index + 1,
+      })),
+    },
+  };
+}
+
+function computeSteadyOpenMedianDuration(openDurationsMs: readonly number[]) {
+  const metric = summarizeRtcB05(createRawEvidence(openDurationsMs)).find(
+    ({ metric: metricName }) => metricName === 'steadyOpenMedianDurationMs',
+  );
+  if (!metric) {
+    throw new Error('Expected RTC-B05 steady-open median metric');
+  }
+  return metric.value;
+}
+
+describe('RTC-B05 browser lifecycle metrics', () => {
+  it('projects one first and one steady median timing for each lifecycle phase', () => {
+    const metrics = summarizeRtcB05(
+      createRawEvidence(Array.from({ length: 25 }, (_, index) => index + 1.25)),
+    );
+
+    expect(metrics).toEqual([
+      { metric: 'durationMs', unit: 'ms', value: 600 },
+      { metric: 'firstOpenDurationMs', unit: 'ms', value: 1.25 },
+      { metric: 'steadyOpenMedianDurationMs', unit: 'ms', value: 13.75 },
+      { metric: 'firstCloseDurationMs', unit: 'ms', value: 1.5 },
+      { metric: 'steadyCloseMedianDurationMs', unit: 'ms', value: 14 },
+      { metric: 'heapBeforeBytes', unit: 'bytes', value: 550_000 },
+      { metric: 'heapAfterBytes', unit: 'bytes', value: 600_000 },
+      { metric: 'heapDeltaBytes', unit: 'bytes', value: 50_000 },
+    ]);
+  });
+
+  it('keeps isolated steady-iteration spikes out of the repeat decision', () => {
+    const steadyOpenMedians = Array.from({ length: 5 }, (_, attemptIndex) =>
+      computeSteadyOpenMedianDuration(
+        Array.from({ length: 25 }, (_, iterationIndex) =>
+          iterationIndex === 0 ? 13 : iterationIndex === attemptIndex + 1 ? 20 : 7,
+        ),
+      ),
+    );
+
+    expect(steadyOpenMedians).toEqual([7, 7, 7, 7, 7]);
+    expect(
+      requiresRtcBaselineRepeat(computeRtcBaselineMetricSummary(steadyOpenMedians), 'local'),
+    ).toBe(false);
+  });
+
+  it('still requests a repeat when steady timing drifts between outer attempts', () => {
+    const steadyOpenMedians = [7, 8, 9, 10, 11].map((steadyDurationMs) =>
+      computeSteadyOpenMedianDuration([13, ...Array<number>(24).fill(steadyDurationMs)]),
+    );
+
+    expect(steadyOpenMedians).toEqual([7, 8, 9, 10, 11]);
+    expect(
+      requiresRtcBaselineRepeat(computeRtcBaselineMetricSummary(steadyOpenMedians), 'local'),
+    ).toBe(true);
+  });
+});

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/rtc-data-channel-browser-soak-validation.ts
@@ -6,6 +6,7 @@ import type {
   RtcBaselineSampleDto,
 } from '../../baseline/contracts/rtc-baseline-contracts.ts';
 import { rtcBaselineIssue } from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import { summarizeRtcB05 } from './summarize-rtc-b05.ts';
 
 export const RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT = {
   workloadId: 'RTC-B05',
@@ -135,15 +136,18 @@ function validateProducerCommand(
       ),
     ];
   }
-  const valid = producerCommand.executable === 'node' &&
+  const valid =
+    producerCommand.executable === 'node' &&
     same(producerCommand.arguments, expectedProducerArguments(baselineId, identity));
-  return valid ? [] : [
-    rtcBaselineIssue(
-      '$.producerCommand',
-      'producer-command-mismatch',
-      'Raw producer command must match the immutable B05 invocation.',
-    ),
-  ];
+  return valid
+    ? []
+    : [
+        rtcBaselineIssue(
+          '$.producerCommand',
+          'producer-command-mismatch',
+          'Raw producer command must match the immutable B05 invocation.',
+        ),
+      ];
 }
 
 function validateHeap(heapValue: RtcBaselineJson | undefined) {
@@ -244,7 +248,8 @@ function validateIterationCleanup(iteration: Record<string, RtcBaselineJson>, in
   }
   const events = Array.isArray(iteration.events) ? iteration.events : [];
   const uniqueEvents = new Set(events);
-  const lifecycleEventsComplete = uniqueEvents.size === expectedEvents.length &&
+  const lifecycleEventsComplete =
+    uniqueEvents.size === expectedEvents.length &&
     expectedEvents.every((eventName) => uniqueEvents.has(eventName));
   if (!lifecycleEventsComplete || iteration.failure !== null) {
     issues.push(
@@ -274,15 +279,16 @@ function validateIteration(
     ];
   }
   const expectedId = `${iterationIdPrefix}-iteration-${pad(index + 1)}`;
-  const identityIssues = iteration.index === index + 1 && iteration.iterationId === expectedId
-    ? []
-    : [
-      rtcBaselineIssue(
-        `$.soak.results[${index}].iterationId`,
-        'iteration-identity-mismatch',
-        'Iteration identity is not unique and ordered.',
-      ),
-    ];
+  const identityIssues =
+    iteration.index === index + 1 && iteration.iterationId === expectedId
+      ? []
+      : [
+          rtcBaselineIssue(
+            `$.soak.results[${index}].iterationId`,
+            'iteration-identity-mismatch',
+            'Iteration identity is not unique and ordered.',
+          ),
+        ];
   return [
     ...identityIssues,
     ...validateIterationTiming(iteration, index),
@@ -325,7 +331,7 @@ function validateSoak(rawEvidence: Record<string, RtcBaselineJson>, iterationIdP
     ...issues,
     ...countIssues,
     ...soak.results.flatMap((iteration, index) =>
-      validateIteration(iteration, index, iterationIdPrefix)
+      validateIteration(iteration, index, iterationIdPrefix),
     ),
   ];
 }
@@ -335,15 +341,16 @@ function validateMeasurement(
   iterationIdPrefix: string,
 ) {
   const duration = rawEvidence.durationMs;
-  const durationIssues = typeof duration === 'number' && Number.isFinite(duration) && duration >= 0
-    ? []
-    : [
-      rtcBaselineIssue(
-        '$.durationMs',
-        'invalid-duration',
-        'Soak duration must be nonnegative.',
-      ),
-    ];
+  const durationIssues =
+    typeof duration === 'number' && Number.isFinite(duration) && duration >= 0
+      ? []
+      : [
+          rtcBaselineIssue(
+            '$.durationMs',
+            'invalid-duration',
+            'Soak duration must be nonnegative.',
+          ),
+        ];
   return [
     ...durationIssues,
     ...validateSoak(rawEvidence, iterationIdPrefix),
@@ -392,20 +399,23 @@ export function validateRtcDataChannelBrowserSoakRuntimeObservation(
     redactedArgv: { executable: 'node', arguments: [contract.scriptPath] },
     projection: { fixedWorkerFlags: [], configurationFlags: [] },
   };
-  const valid = same(observation.deviations, []) &&
+  const valid =
+    same(observation.deviations, []) &&
     same(sourceIdentities, expectedSources) &&
     hashesValid &&
     same(observation.configurationInputs, []) &&
     same(observation.resolvedConfiguration, expectedConfiguration) &&
     same(observation.controllerInputs, expectedControllers) &&
     same(observation.workerCommand, expectedWorker);
-  return valid ? [] : [
-    rtcBaselineIssue(
-      '$.runtimeObservation',
-      'runtime-observation-mismatch',
-      'Runtime observation must match the initialized B05 identity and configuration.',
-    ),
-  ];
+  return valid
+    ? []
+    : [
+        rtcBaselineIssue(
+          '$.runtimeObservation',
+          'runtime-observation-mismatch',
+          'Runtime observation must match the initialized B05 identity and configuration.',
+        ),
+      ];
 }
 
 function validateRawEvidence(sample: RtcBaselineSampleDto, baselineId: string) {
@@ -422,82 +432,40 @@ function validateRawEvidence(sample: RtcBaselineSampleDto, baselineId: string) {
   const inputValid = same(rawEvidence.input, {
     iterations: RTC_DATA_CHANNEL_BROWSER_SOAK_CONTRACT.iterations,
   });
-  const createdAtValid = typeof rawEvidence.createdAt === 'string' &&
-    Number.isFinite(Date.parse(rawEvidence.createdAt));
+  const createdAtValid =
+    typeof rawEvidence.createdAt === 'string' && Number.isFinite(Date.parse(rawEvidence.createdAt));
   return [
     ...validateRawIdentity(rawEvidence, sample.identity, baselineId),
     ...validateProducerCommand(rawEvidence, sample.identity, baselineId),
     ...validateMeasurement(rawEvidence, sample.identity.sampleId),
     ...(!inputValid
       ? [
-        rtcBaselineIssue(
-          '$.input.iterations',
-          'input-mismatch',
-          'B05 requires exactly 25 iterations.',
-        ),
-      ]
+          rtcBaselineIssue(
+            '$.input.iterations',
+            'input-mismatch',
+            'B05 requires exactly 25 iterations.',
+          ),
+        ]
       : []),
     ...(!createdAtValid
       ? [
-        rtcBaselineIssue(
-          '$.createdAt',
-          'invalid-created-at',
-          'Raw evidence creation time is invalid.',
-        ),
-      ]
+          rtcBaselineIssue(
+            '$.createdAt',
+            'invalid-created-at',
+            'Raw evidence creation time is invalid.',
+          ),
+        ]
       : []),
     ...validateRtcDataChannelBrowserSoakRuntimeObservation(sample.runtimeObservation, baselineId),
-    ...(sample.rawReferences.length === 0 ? [] : [
-      rtcBaselineIssue(
-        '$.rawReferences',
-        'unexpected-raw-reference',
-        'B05 stages evidence inline.',
-      ),
-    ]),
-  ];
-}
-
-function computeFiniteMetric(
-  value: RtcBaselineJson | undefined,
-  metric: string,
-  unit: string,
-): RtcBaselineSampleDto['metrics'] {
-  return typeof value === 'number' && Number.isFinite(value) ? [{ metric, unit, value }] : [];
-}
-
-function computeIterationMetrics(resultValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
-  const result = toJsonObject(resultValue);
-  return result === null ? [] : [
-    ...computeFiniteMetric(result.openDurationMs, 'openDurationMs', 'ms'),
-    ...computeFiniteMetric(result.closeDurationMs, 'closeDurationMs', 'ms'),
-  ];
-}
-
-function computeHeapMetrics(
-  heapValue: RtcBaselineJson | undefined,
-): RtcBaselineSampleDto['metrics'] {
-  const heap = toJsonObject(heapValue);
-  const values = [heap?.beforeBytes, heap?.afterBytes, heap?.deltaBytes];
-  return values.every((value) => typeof value === 'number' && Number.isFinite(value))
-    ? [
-      { metric: 'heapBeforeBytes', unit: 'bytes', value: values[0] as number },
-      { metric: 'heapAfterBytes', unit: 'bytes', value: values[1] as number },
-      { metric: 'heapDeltaBytes', unit: 'bytes', value: values[2] as number },
-    ]
-    : [];
-}
-
-function computeMetrics(rawEvidenceValue: RtcBaselineJson): RtcBaselineSampleDto['metrics'] {
-  const rawEvidence = toJsonObject(rawEvidenceValue);
-  if (rawEvidence === null) {
-    return [];
-  }
-  const soak = toJsonObject(rawEvidence.soak);
-  const results = Array.isArray(soak?.results) ? soak.results : [];
-  return [
-    ...computeFiniteMetric(rawEvidence.durationMs, 'durationMs', 'ms'),
-    ...results.flatMap(computeIterationMetrics),
-    ...computeHeapMetrics(rawEvidence.heap),
+    ...(sample.rawReferences.length === 0
+      ? []
+      : [
+          rtcBaselineIssue(
+            '$.rawReferences',
+            'unexpected-raw-reference',
+            'B05 stages evidence inline.',
+          ),
+        ]),
   ];
 }
 
@@ -509,7 +477,7 @@ export function computeRtcDataChannelBrowserSoakSample(
   return {
     ...sample,
     outcome: issues.length === 0 ? ('passed' as const) : ('failed' as const),
-    metrics: computeMetrics(sample.rawEvidence),
+    metrics: summarizeRtcB05(sample.rawEvidence),
     issues,
   };
 }
@@ -519,7 +487,7 @@ export function computeRtcDataChannelBrowserSoakAttempt(
   baselineId: string,
 ): RtcBaselineExternalAttemptDto {
   const samples = attempt.samples.map((sample) =>
-    computeRtcDataChannelBrowserSoakSample(sample, baselineId)
+    computeRtcDataChannelBrowserSoakSample(sample, baselineId),
   );
   return {
     ...attempt,

--- a/packages/shared-rtc-bench/workloads/browser-lifecycle/summarize-rtc-b05.ts
+++ b/packages/shared-rtc-bench/workloads/browser-lifecycle/summarize-rtc-b05.ts
@@ -1,0 +1,91 @@
+import type {
+  RtcBaselineJson,
+  RtcBaselineSampleDto,
+} from '../../baseline/contracts/rtc-baseline-contracts.ts';
+import * as baselineStatistics from '../../baseline/evidence/rtc-baseline-statistics.ts';
+
+function toJsonObject(value: RtcBaselineJson | undefined): Record<string, RtcBaselineJson> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, RtcBaselineJson>)
+    : null;
+}
+
+function computeFiniteMetric(
+  value: RtcBaselineJson | undefined,
+  metric: string,
+  unit: string,
+): RtcBaselineSampleDto['metrics'] {
+  return typeof value === 'number' && Number.isFinite(value) ? [{ metric, unit, value }] : [];
+}
+
+function computeFiniteMetricValues(
+  iterations: readonly Record<string, RtcBaselineJson>[],
+  field: 'openDurationMs' | 'closeDurationMs',
+) {
+  return iterations.flatMap((iteration) => {
+    const value = iteration[field];
+    return typeof value === 'number' && Number.isFinite(value) ? [value] : [];
+  });
+}
+
+function computeMedianMetric(
+  values: readonly number[],
+  metric: string,
+  unit: string,
+): RtcBaselineSampleDto['metrics'] {
+  return values.length === 0
+    ? []
+    : [{ metric, unit, value: baselineStatistics.computeRtcBaselineMetricSummary(values).median }];
+}
+
+function computeLifecycleMetrics(results: readonly RtcBaselineJson[]) {
+  const firstIteration = toJsonObject(results[0]);
+  const steadyIterations = results
+    .slice(1)
+    .map(toJsonObject)
+    .filter((iteration) => iteration !== null);
+  return [
+    ...computeFiniteMetric(firstIteration?.openDurationMs, 'firstOpenDurationMs', 'ms'),
+    ...computeMedianMetric(
+      computeFiniteMetricValues(steadyIterations, 'openDurationMs'),
+      'steadyOpenMedianDurationMs',
+      'ms',
+    ),
+    ...computeFiniteMetric(firstIteration?.closeDurationMs, 'firstCloseDurationMs', 'ms'),
+    ...computeMedianMetric(
+      computeFiniteMetricValues(steadyIterations, 'closeDurationMs'),
+      'steadyCloseMedianDurationMs',
+      'ms',
+    ),
+  ];
+}
+
+function computeHeapMetrics(
+  heapValue: RtcBaselineJson | undefined,
+): RtcBaselineSampleDto['metrics'] {
+  const heap = toJsonObject(heapValue);
+  const values = [heap?.beforeBytes, heap?.afterBytes, heap?.deltaBytes];
+  return values.every((value) => typeof value === 'number' && Number.isFinite(value))
+    ? [
+        { metric: 'heapBeforeBytes', unit: 'bytes', value: values[0] as number },
+        { metric: 'heapAfterBytes', unit: 'bytes', value: values[1] as number },
+        { metric: 'heapDeltaBytes', unit: 'bytes', value: values[2] as number },
+      ]
+    : [];
+}
+
+export function summarizeRtcB05(
+  rawEvidenceValue: RtcBaselineJson,
+): RtcBaselineSampleDto['metrics'] {
+  const rawEvidence = toJsonObject(rawEvidenceValue);
+  if (rawEvidence === null) {
+    return [];
+  }
+  const soak = toJsonObject(rawEvidence.soak);
+  const results = Array.isArray(soak?.results) ? soak.results : [];
+  return [
+    ...computeFiniteMetric(rawEvidence.durationMs, 'durationMs', 'ms'),
+    ...computeLifecycleMetrics(results),
+    ...computeHeapMetrics(rawEvidence.heap),
+  ];
+}


### PR DESCRIPTION
## Goal

Correct RTC-B05 repeat detection so its statistical observations match the independent outer-attempt sampling unit.

## Changes

- Preserve every raw per-iteration open and close timing in the browser lifecycle evidence.
- Project one first-open, steady-open median, first-close, and steady-close median metric per outer sample.
- Keep duration and heap metrics unchanged.
- Separate B05 metric summarization from evidence validation and add focused statistical regression coverage.
- Apply touched-file formatting closure to the browser soak validator.

## Acceptance

- Each lifecycle metric contributes exactly one value per outer sample.
- A single inner-iteration spike does not manufacture a repeat requirement.
- Genuine drift between outer attempts still requires a repeat.
- The real browser producer still records all lifecycle iterations and completes with zero errors.

## Validation

- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check` — TypeScript passed, 37 test files and 344 tests passed, Deno checks passed.
- Focused RTC-B05 Vitest — 3 files and 24 tests passed.
- Prettier check — all four touched TypeScript files passed.
- Changed and focused repository-style checks — passed with no findings.
- Repository structure check — passed.
- Changed production legacy review — no candidates.
- Retained primary and repeat evidence replay — all projected timing CVs stayed below the local repeat threshold.
- Real Chromium producer smoke — 2 opens, messages, and closes; zero local or remote errors.
- Independent review — no actionable findings.

## Risk and rollback

The governed metric names change from pooled `openDurationMs` and `closeDurationMs` observations to first and steady-attempt metrics. Raw evidence and historical artifacts remain intact. Reverting this commit restores the old projection if an unexpected downstream consumer is found.

## Follow-up

After this PR merges, rerun the full RTC-B05 browser lifecycle capture on the then-latest `main` and publish the corrected lifecycle evidence.