### PR TITLE
Finish the admission command census in four stale test expectations

### DIFF
--- a/apps/api-v1/test/group-state/register-group-state-routes.test.ts
+++ b/apps/api-v1/test/group-state/register-group-state-routes.test.ts
@@ -104,7 +104,7 @@ const GROUP_STATE_ROUTE_MATCHES: readonly GroupStateRouteMatch[] = [
 ];
 
 Deno.test(
-  'group state route registration retains all 24 Hono handlers in predecessor order',
+  'group state route registration retains all 26 Hono handlers in predecessor order',
   () => {
     const runtime = createGroupStateRouteTestRuntime({ installStateAuthentication: false });
     const registeredRoutes = (runtime.app as unknown as {
@@ -127,6 +127,8 @@ Deno.test(
       `POST ${GROUP_ROUTE_PATH}/join-code/rotate`,
       `POST ${GROUP_ROUTE_PATH}/invites/:principalId`,
       `POST ${GROUP_ROUTE_PATH}/invites/:principalId/revoke`,
+      `POST ${GROUP_ROUTE_PATH}/admissions/:principalId/grant`,
+      `POST ${GROUP_ROUTE_PATH}/admissions/:principalId/decline`,
       `POST ${GROUP_ROUTE_PATH}/members/:principalId/remove`,
       `POST ${GROUP_ROUTE_PATH}/members/:principalId/ban`,
       `POST ${GROUP_ROUTE_PATH}/members/:principalId/unban`,

--- a/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
+++ b/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
@@ -165,10 +165,13 @@ function baseRead(lifecycleState: GroupLifecycleState): GroupMutationRead {
 }
 
 function joinRead(lifecycleState: GroupLifecycleState): GroupMutationRead {
+  // Joining consults the admission policy, so its read carries one; absent is
+  // the open admission this baseline asserts survives a group stuck in FORMING.
   return {
     ...baseRead(lifecycleState),
     actorMember: null,
     actorMemberEntry: null,
+    lifecyclePolicy: { status: 'absent' },
   } as GroupMutationRead;
 }
 

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-storage-revision.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-storage-revision.test.ts
@@ -180,7 +180,8 @@ function mutationRead(storageRevision: number): GroupMutationRead {
     authorityPresenceSessions: [],
     authorityPresenceSessionEntries: [],
     presenceSummary: null,
-    lifecyclePolicy: null,
+    // upsertMember consults the admission policy; absent means open admission.
+    lifecyclePolicy: { status: 'absent' },
     activeMemberPrincipalIds: null,
   } as GroupMutationRead;
 }

--- a/packages/tests/shared-server/mutation-route-owner-analysis.test.ts
+++ b/packages/tests/shared-server/mutation-route-owner-analysis.test.ts
@@ -95,12 +95,12 @@ describe('Mutation route owner analysis contracts', () => {
     }
   });
 
-  it('maps all 54 entrypoints and 50 types to real registrations and owners', () => {
+  it('maps all 56 entrypoints and 52 types to real registrations and owners', () => {
     const inventory = routingContract.MUTATION_ROUTE_INVENTORY;
     const validate = routingContract.validateMutationRouteInventory;
 
-    expect(inventory).toHaveLength(54);
-    expect(new Set(inventory.map((entry) => entry.type)).size).toBe(50);
+    expect(inventory).toHaveLength(56);
+    expect(new Set(inventory.map((entry) => entry.type)).size).toBe(52);
     expect(validate(inventory)).toEqual([]);
   });
 


### PR DESCRIPTION
Fixes the red `main` at [run 32297732605](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/32297732605) (Release Gate → **Run root CI suite**).

## What broke

Slice 5b ([#297](https://github.com/intact-software-systems/ar-eye-hunter/pull/297)) landed the admission commands but left four test expectations describing the pre-admission world.

**Two registries went unrevised where a sibling was updated.**

| Test | Was | Now |
| --- | --- | --- |
| `packages/tests/shared-server/mutation-route-owner-analysis.test.ts` | 54 entrypoints / 50 AppInbox types | 56 / 52 |
| `apps/api-v1/test/group-state/register-group-state-routes.test.ts` | 24 ordered Hono handlers | 26, with grant/decline |

#297 moved the inventory to 56/52 and updated the identical constants in `mutation-route-owner-boundary-traversal.test.ts` — but not the pair in `mutation-route-owner-analysis.test.ts`. The route-registration test pins an exact ordered handler list; `admissions/:principalId/grant` and `.../decline` register between invite revoke and member remove, so the expectation gains them there.

**Two hand-built mutation reads were invalidated by the widened read contract.** `joinGroup` and `upsertMember` are now admission-consulting operations, so `validateGroupMutationRead` requires their read to carry the lifecycle policy that `readGroupMutation` loads:

```
TypeError: Group mutation read is missing the lifecycle policy read
```

Both fixtures model a group with **no stored policy**, which is the repository's `{ status: 'absent' }` — open admission, exactly the behaviour each test was already asserting. Affects `group-lifecycle-safety-baseline.test.ts` and `group-presence-summary-storage-revision.test.ts`.

## Why the Deno failure was invisible

`test:ci` chains its stages with `&&`:

```
npm run test:unit && npm run test:deno && npm run test:e2e && npm run test:full-stack:memory
```

`test:unit` failing aborted the run before `test:deno` could report the route-registration regression. It only surfaced by running the stages independently — worth knowing for the next red-main triage.

## Validation

| Gate | Result |
| --- | --- |
| `npm run test:unit` | pass — 883 files, 7792 tests, 0 failures |
| `npm run test:deno` | pass |
| `npm run test:e2e` | pass — 250 tests |
| `npm run typecheck` | pass |
| `npm run build` | pass |
| `npm run check:repo-style:changed -- origin/main HEAD` | pass — no new findings |
| `npm run test:full-stack:memory` | **not run locally** |

`test:full-stack:memory` binds `localhost:18080`, which another session's Deno servers currently hold (18080–18082); Playwright's `reuseExistingServer` would silently attach to a foreign server and produce a meaningless result. Branch CI covers it.

## Follow-ups not taken here (kept the hotfix minimal)

- `GroupMutationRead`'s doc comments in `group-mutation-contracts.ts` still say `lifecyclePolicy` and `activeMemberPrincipalIds` are "loaded only for the lifecycle transition operations". #297 widened both to the admission operations, so those two comments are now inaccurate.
- `register-group-state-routes.test.ts`'s second test ("matches all 21 public method and path contracts") does not exercise the new grant/decline routes. It passes — it asserts no completeness — but the admission routes have no per-route contract coverage there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)