### PR TITLE
Gate pre-activation app data and close the unauthorized relay path

### DIFF
--- a/apps/api-v1/src/composition/create-default-rallar-server.ts
+++ b/apps/api-v1/src/composition/create-default-rallar-server.ts
@@ -175,7 +175,9 @@ export function createDefaultRallarServer(
     repositories: defaultRepositoryManager,
     appDataRepository: new PSqlAppDataRepository(database),
     ws: {
-      authorizeRoomMessage: createApiV1RoomWsAuthorizer(runtime.groupStateService),
+      authorizeRoomMessage: createApiV1RoomWsAuthorizer(runtime.groupStateService, {
+        readLifecyclePolicy: (ref) => topology.groupStateRepository.readLifecyclePolicy(ref),
+      }),
       ...options.ws,
     },
     systemInstallers,

--- a/apps/api-v1/src/group-state/register-group-admission-routes.ts
+++ b/apps/api-v1/src/group-state/register-group-admission-routes.ts
@@ -8,6 +8,7 @@ import type {
   RevokeGroupInviteRequest,
   RotateGroupJoinCodeRequest,
 } from '@shared/api/state-types.ts';
+import { toPendingMemberGroupSnapshot } from '@shared/api/group-client-views.ts';
 import type {
   AuthenticatedGroupMutationEnqueue,
 } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
@@ -74,7 +75,9 @@ function registerJoinGroupRoute(
           ),
         });
 
-        return context.json(written.snapshot);
+        return context.json(
+          toPendingMemberGroupSnapshot(written.snapshot, authSession.clientId),
+        );
       } catch (error) {
         return toGroupStateErrorResponse(context, error);
       }
@@ -111,7 +114,9 @@ function registerAcceptGroupInviteRoute(
           ),
         });
 
-        return context.json(written.snapshot);
+        return context.json(
+          toPendingMemberGroupSnapshot(written.snapshot, authSession.clientId),
+        );
       } catch (error) {
         return toGroupStateErrorResponse(context, error);
       }

--- a/apps/api-v1/src/group-state/register-group-membership-routes.ts
+++ b/apps/api-v1/src/group-state/register-group-membership-routes.ts
@@ -23,6 +23,7 @@ import {
 } from './group-state-route-contracts.ts';
 import { toGroupStateErrorResponse } from './group-state-route-errors.ts';
 import { readGroupStateRouteRequest } from './read-group-state-route-request.ts';
+import { toPendingMemberGroupSnapshot } from '@shared/api/group-client-views.ts';
 import { toGroupStateCommand } from './to-group-state-command.ts';
 import { toGroupStateResponse } from './to-group-state-response.ts';
 
@@ -242,8 +243,7 @@ function registerUpsertSelfGroupMemberRoute(
       try {
         const authSession = await dependencies.requireApiAuthSession(context.req);
         const scope = toGroupStateRouteScope(context);
-        const groupId = context.req.param('groupId');
-        const principalId = context.req.param('principalId');
+        const { groupId, principalId } = context.req.param();
         requireGroupAdmissionQuota('join-admission', { ...scope, groupId }, authSession.clientId);
         authorization.assertSelfPrincipal(authSession.clientId, principalId);
         const request = await readGroupStateRouteRequest<UpsertGroupMemberRequest>(context);
@@ -263,7 +263,8 @@ function registerUpsertSelfGroupMemberRoute(
             GroupStateWritten
           >(authSession, command),
         });
-        return context.json(written.snapshot);
+        const body = toPendingMemberGroupSnapshot(written.snapshot, authSession.clientId);
+        return context.json(body);
       } catch (error) {
         return toGroupStateErrorResponse(context, error);
       }

--- a/apps/api-v1/src/services/ws-topic-room-authorizer.ts
+++ b/apps/api-v1/src/services/ws-topic-room-authorizer.ts
@@ -1,11 +1,31 @@
 import { createGroupRoomWsAuthorizer } from '@shared-server/rallar-system/services/ws-topic-room-authorizer.ts';
 import type { CachedGroupStateService } from '@shared-server/rallar-system/services/cached-group-state-service.ts';
+// prettier-ignore
+import type {
+  GroupLifecyclePolicyRead,
+} from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GroupRef } from '@shared/api/group-types.ts';
+
+export interface ApiV1RoomWsAuthorizerDependencies {
+  readonly readLifecyclePolicy: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
+}
 
 export function createApiV1RoomWsAuthorizer(
   groupStateService: Pick<CachedGroupStateService, 'readCurrentSnapshot'>,
+  dependencies: ApiV1RoomWsAuthorizerDependencies,
 ) {
   return createGroupRoomWsAuthorizer({
     findGroupSnapshotByRef: async (ref) =>
       await groupStateService.readCurrentSnapshot(ref),
+    readPreActivationAppData: async (ref) => {
+      const read = await dependencies.readLifecyclePolicy(ref);
+      // Absent preserves the workstream invariant: a group with no policy
+      // document behaves exactly as it does on main. Corrupt fails closed --
+      // an unreadable stored policy must not read as permissive, and this
+      // value is only consulted before activation.
+      if (read.status === 'absent') return 'allowed';
+      if (read.status === 'corrupt') return 'blocked-until-active';
+      return read.policy.data.preActivationAppData;
+    },
   });
 }

--- a/apps/api-v1/test/services/ws-topic-room-authorizer.test.ts
+++ b/apps/api-v1/test/services/ws-topic-room-authorizer.test.ts
@@ -3,8 +3,20 @@ import { newALEventRoute, newALMulticastMessage } from '@shared/al-contracts/al-
 import type { AuditStamp, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { GroupStateService } from '@shared-server/rallar-system/services/group-state-service.ts';
 import { createCachedGroupStateService } from '@shared-server/rallar-system/services/cached-group-state-service.ts';
+// prettier-ignore
+import {
+  resolveGroupLifecyclePolicyPreset,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+// prettier-ignore
+import type {
+  ApiV1RoomWsAuthorizerDependencies,
+} from '../../src/services/ws-topic-room-authorizer.ts';
 import { createApiV1RoomWsAuthorizer } from '../../src/services/ws-topic-room-authorizer.ts';
 import { createTestGroup } from '../../../../packages/tests/create-test-group.ts';
+
+const ABSENT_POLICY: ApiV1RoomWsAuthorizerDependencies = {
+  readLifecyclePolicy: () => Promise.resolve({ status: 'absent' }),
+};
 
 Deno.test('API room authorization reads the current scoped group snapshot', async () => {
   const snapshot = createSnapshot();
@@ -14,7 +26,7 @@ Deno.test('API room authorization reads the current scoped group snapshot', asyn
       requestedRef = ref;
       return Promise.resolve(snapshot);
     },
-  });
+  }, ABSENT_POLICY);
   const message = newALMulticastMessage(
     'session-1',
     newALEventRoute('room.chat', 'group-1', 'message-1'),
@@ -39,7 +51,7 @@ Deno.test('API room authorization reads the current scoped group snapshot', asyn
 Deno.test('API room authorization fails closed without a scoped group reference', async () => {
   const authorizer = createApiV1RoomWsAuthorizer({
     readCurrentSnapshot: () => Promise.resolve(createSnapshot()),
-  });
+  }, ABSENT_POLICY);
   const message = {
     ...newALMulticastMessage(
       'session-1',
@@ -90,7 +102,7 @@ Deno.test('API room authorization observes remote bans and deletion across warm 
       return Promise.resolve(current);
     }),
   });
-  const authorizer = createApiV1RoomWsAuthorizer(serverB);
+  const authorizer = createApiV1RoomWsAuthorizer(serverB, ABSENT_POLICY);
   const message = newALMulticastMessage(
     'session-1',
     newALEventRoute('room.chat', 'group-1', 'message-1'),
@@ -134,6 +146,120 @@ Deno.test('API room authorization observes remote bans and deletion across warm 
   assert.equal(revisionProbes, 0);
   assert.equal(stableReads, 3);
 });
+
+Deno.test('API room authorization blocks pre-activation app data when policy says so', async () => {
+  const snapshot = createEstablishingSnapshot();
+  const authorizer = createApiV1RoomWsAuthorizer({
+    readCurrentSnapshot: () => Promise.resolve(snapshot),
+  }, {
+    readLifecyclePolicy: () =>
+      Promise.resolve({
+        status: 'present',
+        policy: resolveGroupLifecyclePolicyPreset('match'),
+      }),
+  });
+
+  const decision = await authorizer(roomChatInput(snapshot));
+
+  assert.equal(typeof decision, 'object');
+  assert.equal((decision as { authorized: boolean }).authorized, false);
+  assert.match(
+    (decision as { logMessage?: string }).logMessage ?? '',
+    /group-data-blocked-until-active/,
+  );
+});
+
+Deno.test('API room authorization fails closed on a corrupt policy before activation', async () => {
+  const snapshot = createEstablishingSnapshot();
+  const authorizer = createApiV1RoomWsAuthorizer({
+    readCurrentSnapshot: () => Promise.resolve(snapshot),
+  }, {
+    readLifecyclePolicy: () =>
+      Promise.resolve({ status: 'corrupt', reason: 'unreadable stored policy' }),
+  });
+
+  const decision = await authorizer(roomChatInput(snapshot));
+
+  assert.equal((decision as { authorized: boolean }).authorized, false);
+});
+
+Deno.test('API room authorization reads no policy for active groups', async () => {
+  const snapshot = createSnapshot();
+  let policyReads = 0;
+  const authorizer = createApiV1RoomWsAuthorizer({
+    readCurrentSnapshot: () => Promise.resolve(snapshot),
+  }, {
+    readLifecyclePolicy: () => {
+      policyReads += 1;
+      return Promise.resolve({ status: 'absent' });
+    },
+  });
+
+  const decision = await authorizer(roomChatInput(snapshot));
+
+  assert.equal(decision, true);
+  assert.equal(policyReads, 0);
+});
+
+Deno.test('API room authorization exempts the CRDT topics from the data-policy gate', async () => {
+  const snapshot = createEstablishingSnapshot();
+  let policyReads = 0;
+  const authorizer = createApiV1RoomWsAuthorizer({
+    readCurrentSnapshot: () => Promise.resolve(snapshot),
+  }, {
+    readLifecyclePolicy: () => {
+      policyReads += 1;
+      return Promise.resolve({
+        status: 'present',
+        policy: resolveGroupLifecyclePolicyPreset('match'),
+      });
+    },
+  });
+  const message = newALMulticastMessage(
+    'session-1',
+    newALEventRoute('room.crdt', 'group-1', 'message-1'),
+    snapshot.group,
+    'crdt.update.v1',
+    { update: 'payload' },
+  );
+
+  const decision = await authorizer({
+    message,
+    roomId: 'group-1',
+    roomRef: snapshot.group,
+    senderId: 'session-1',
+    topicId: 'room.crdt',
+    typeId: 'crdt.update.v1',
+  });
+
+  assert.equal(decision, true);
+  assert.equal(policyReads, 0);
+});
+
+function roomChatInput(snapshot: GroupSnapshot) {
+  return {
+    message: newALMulticastMessage(
+      'session-1',
+      newALEventRoute('room.chat', 'group-1', 'message-1'),
+      snapshot.group,
+      'chat.message.v1',
+      { text: 'hello' },
+    ),
+    roomId: 'group-1',
+    roomRef: snapshot.group,
+    senderId: 'session-1',
+    topicId: 'room.chat',
+    typeId: 'chat.message.v1',
+  };
+}
+
+function createEstablishingSnapshot(): GroupSnapshot {
+  const snapshot = createSnapshot();
+  return {
+    ...snapshot,
+    group: { ...snapshot.group, lifecycleState: 'establishing', formationEpoch: 1 },
+  };
+}
 
 function createIndependentCache(
   readDurable: () => Promise<GroupSnapshot | undefined>,

--- a/packages/shared-server/rallar-facade/ws-topic-router.ts
+++ b/packages/shared-server/rallar-facade/ws-topic-router.ts
@@ -1,4 +1,9 @@
-import { type ALMessage, type ALTargets, readALTargetGroupRef, } from '@shared/al-contracts/al-contract.ts';
+import {
+    type ALMessage,
+    type ALTargets,
+    isRoomScopedALMessage,
+    readALTargetGroupRef,
+} from '@shared/al-contracts/al-contract.ts';
 import type { ALNackReason } from '@shared/al-contracts/al-control.ts';
 import { isALControlTypeId, newALNackControlMessage, } from '@shared/al-contracts/al-control.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
@@ -725,11 +730,7 @@ export class RallarServerWsFacade {
         message: ALMessage,
         definition?: RallarServerWsTopicDefinition<unknown>,
     ): boolean {
-        return definition?.scope === 'room' ||
-            message.route.topicId.startsWith('room.') ||
-            message.targets?.mode === 'multicast' ||
-            (message.targets?.mode === 'broadcast' &&
-                message.targets.scope === 'room');
+        return definition?.scope === 'room' || isRoomScopedALMessage(message);
     }
 
     private readRoomId(message: ALMessage): string | undefined {

--- a/packages/shared-server/rallar-system/group-policy.ts
+++ b/packages/shared-server/rallar-system/group-policy.ts
@@ -9,7 +9,10 @@ import type {
   GroupPolicyReasonCode,
   GroupPolicyResult,
 } from '@shared/api/group-policy-types.ts';
-import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import type {
+  GroupLifecyclePolicy,
+  GroupPreActivationAppData,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import {
   resolveGroupLifecycleManagers,
   toGroupLifecycleElectionKey,
@@ -120,6 +123,12 @@ export type CanSendRoomMessageInput = Readonly<{
   senderSessionId: string;
   minSnapshotVersion?: number;
   nowEpochMs?: number;
+  /**
+   * The group's resolved data-policy value; absent when the caller's
+   * transport does not gate application data (plan decision 5.4). CRDT
+   * topics are classified out at the authorizer, never here.
+   */
+  preActivationAppData?: GroupPreActivationAppData;
 }>;
 
 const ALLOWED: GroupPolicyResult = { allowed: true };
@@ -499,6 +508,16 @@ export function canSendRoomMessage(input: CanSendRoomMessageInput): GroupPolicyR
   const memberDenial = denyForPresenceMember(member);
   if (memberDenial) {
     return memberDenial;
+  }
+
+  if (
+    input.preActivationAppData === 'blocked-until-active' &&
+    input.snapshot.group.lifecycleState !== 'active'
+  ) {
+    return deny(
+      'group-data-blocked-until-active',
+      'Application data is blocked until the group activates.',
+    );
   }
 
   return ALLOWED;

--- a/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-admission-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-admission-mutation.ts
@@ -88,14 +88,7 @@ export function computeGrantGroupAdmission(
       capacity: facts.capacity,
     }),
   );
-  const windows = computeGroupAdmissionDecision({
-    admission: policy.admission,
-    lifecycleState: stored.value.lifecycleState,
-    activeMemberCount: stored.value.activeMemberCount,
-    invited: true,
-    nowEpochMs: facts.nowEpochMs,
-  });
-  if (windows.kind === 'deny') throw new GroupPolicyDeniedError(windows.denial);
+  assertGroupAdmissionWindowsOpen(read, facts);
   const audit = auditStamp(command, facts, command.input.actorPrincipalId ?? undefined);
   return computeGroupMembershipWrite({
     command,
@@ -134,6 +127,30 @@ export function computeDeclineGroupAdmission(
     members: [transitionGroupMemberLifecycle({ ...existing, updated: audit }, 'left', audit)],
     eventType: 'member-left',
   });
+}
+
+/**
+ * The window constraints bind on every path that lands a member `active`
+ * from a non-active status — grant, invite acceptance, and governance
+ * activation alike (plan decision 5.2). `invited: true` is the group's
+ * consent, so only the windows and the closed mode can deny here.
+ */
+export function assertGroupAdmissionWindowsOpen(
+  read: GroupMutationRead,
+  facts: GroupMutationFacts,
+): void {
+  if (read.group === null) {
+    throw new GroupMutationRejectedError('Group not found');
+  }
+  const policy = requireReadableLifecyclePolicy(read);
+  const decision = computeGroupAdmissionDecision({
+    admission: policy.admission,
+    lifecycleState: read.group.value.lifecycleState,
+    activeMemberCount: read.group.value.activeMemberCount,
+    invited: true,
+    nowEpochMs: facts.nowEpochMs,
+  });
+  if (decision.kind === 'deny') throw new GroupPolicyDeniedError(decision.denial);
 }
 
 function requireReadableLifecyclePolicy(read: GroupMutationRead): GroupLifecyclePolicy {

--- a/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-membership-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-membership-mutation.ts
@@ -33,7 +33,10 @@ import {
   groupMemberEventType,
   transitionGroupMemberLifecycle,
 } from './transition-group-member-lifecycle.ts';
-import { resolveAdmittedMemberStatus } from './compute-group-admission-mutation.ts';
+import {
+  assertGroupAdmissionWindowsOpen,
+  resolveAdmittedMemberStatus,
+} from './compute-group-admission-mutation.ts';
 
 const DEFAULT_GROUP_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
 
@@ -253,11 +256,18 @@ export function computeUpsertMember(
   // Self-activation is the second join surface: it takes the same admission
   // decision as the join command, so it parks where a join would park
   // (plan decision 5.1). Admin activation stays governance — it is a grant
-  // expressed through the existing surface.
+  // expressed through the existing surface. An already-active member is not
+  // joining: their re-upsert bypasses admission exactly as computeJoin's
+  // active no-op does, never demoting or re-gating an existing membership.
   const status =
-    isSelf && command.input.status === 'active'
+    isSelf && command.input.status === 'active' && existing?.status !== 'active'
       ? resolveAdmittedMemberStatus({ read, facts, existing })
       : command.input.status;
+  // Governance activation is the group's consent, but the admission windows
+  // and the closed mode still bind — the same re-check grant runs.
+  if (!isSelf && status === 'active' && existing?.status !== 'active') {
+    assertGroupAdmissionWindowsOpen(read, facts);
+  }
   const role = command.input.role ?? existing?.role ?? 'member';
   const invitedByPrincipalId =
     command.input.invitedByPrincipalId ?? existing?.invitedByPrincipalId ?? null;

--- a/packages/shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts
@@ -116,12 +116,15 @@ async function readGroupMutationSequentially(
   command: GroupMutationCommand,
   lifecyclePolicy: GroupMutationRead['lifecyclePolicy'],
 ): Promise<GroupMutationRead> {
+  const primary = await readSequentialPrimaryEntries(repository, command);
+  // Read after the group entry whose revision anchors the write guard:
+  // membership writes bump that revision, so a roster older than the guard
+  // could pin a stale electorate the compare-and-set would never catch.
   const activeMemberPrincipalIds =
     isGroupLifecycleTransitionOperation(command.operation) ||
     isGroupAdmissionDecisionOperation(command.operation)
       ? toActiveMemberPrincipalIds(await repository.listMembers(command.aggregateRef))
       : null;
-  const primary = await readSequentialPrimaryEntries(repository, command);
   const identities = resolveSequentialIdentities(command, primary.groupRead.value?.value);
   const related = await readGroupMutationRelatedEntries({
     repository,

--- a/packages/shared-server/rallar-system/middleware/RallarMiddleware.ts
+++ b/packages/shared-server/rallar-system/middleware/RallarMiddleware.ts
@@ -160,6 +160,10 @@ export function createRallarMiddleware(
       inboundStores: options.inboundStores,
       outboundStores: options.outboundStores,
       deliveryDiagnostics: options.wsDeliveryDiagnostics,
+      // This runtime installs the topic router, which owns room-scoped
+      // fanout behind its room authorizer; ALM forwarding of those messages
+      // here would bypass that authorization.
+      forwardsRoomScopedMessages: false,
     },
   );
   const queuePubSubBridgeReadiness = options.queuePubSubBridge

--- a/packages/shared-server/rallar-system/services/ws-topic-room-authorizer.ts
+++ b/packages/shared-server/rallar-system/services/ws-topic-room-authorizer.ts
@@ -1,6 +1,14 @@
 import { readALTargetGroupRef } from '@shared/al-contracts/al-contract.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { readGroupVersion, } from '@shared/api/group-client-views.ts';
+// prettier-ignore
+import type {
+    GroupPreActivationAppData,
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import {
+    RALLAR_CRDT_APP_TOPIC_ID,
+    RALLAR_CRDT_ROOM_TOPIC_ID,
+} from '@shared/crdt/crdt-types.ts';
 import type {
     RallarServerWsRoomAuthorizationDecision,
     RallarServerWsRoomAuthorizer,
@@ -23,6 +31,14 @@ export type CreateGroupRoomWsAuthorizerOptions = Readonly<{
     resolveGroupRef?: (
         input: Parameters<RallarServerWsRoomAuthorizer>[0],
     ) => MaybePromise<GroupRef | undefined>;
+    /**
+     * Resolves the group's data-policy value for the pre-activation gate
+     * (plan decision 5.4). Absent when the runtime supplies no policy
+     * source, which leaves application data ungated -- today's behaviour.
+     */
+    readPreActivationAppData?: (
+        ref: GroupRef,
+    ) => MaybePromise<GroupPreActivationAppData>;
     now?: RallarSnapshotPresenceClock;
 }>;
 
@@ -82,6 +98,7 @@ export function createGroupRoomWsAuthorizer(
             };
         }
 
+        const preActivationAppData = await resolvePreActivationAppData(options, input, snapshot);
         const policyResult = canSendRoomMessage({
             snapshot,
             actor: {
@@ -90,6 +107,7 @@ export function createGroupRoomWsAuthorizer(
             senderSessionId: input.senderId,
             minSnapshotVersion,
             nowEpochMs: options.now?.() ?? Date.now(),
+            ...(preActivationAppData === undefined ? {} : { preActivationAppData }),
         });
         if (!policyResult.allowed) {
             return toPolicyDeniedDecision(input.roomId, policyResult, serverSnapshotVersion);
@@ -97,6 +115,35 @@ export function createGroupRoomWsAuthorizer(
 
         return true;
     };
+}
+
+/**
+ * The data-policy gate covers plain WS-relayed application data only. The
+ * CRDT live topics share this choke point but are exempt by name: CRDT
+ * authority is the AppInbox append path, the topic only fans out committed
+ * updates, and collaborative documents stay alive while the group forms
+ * (plan decision 5.4). Active groups pay no policy read at all --
+ * `blocked-until-active` can only bind before activation.
+ */
+async function resolvePreActivationAppData(
+    options: CreateGroupRoomWsAuthorizerOptions,
+    input: Parameters<RallarServerWsRoomAuthorizer>[0],
+    snapshot: GroupSnapshot,
+): Promise<GroupPreActivationAppData | undefined> {
+    if (
+        input.topicId === RALLAR_CRDT_ROOM_TOPIC_ID ||
+        input.topicId === RALLAR_CRDT_APP_TOPIC_ID
+    ) {
+        return undefined;
+    }
+    if (snapshot.group.lifecycleState === 'active' || !options.readPreActivationAppData) {
+        return undefined;
+    }
+    return await options.readPreActivationAppData({
+        applicationId: snapshot.group.applicationId,
+        workspaceId: snapshot.group.workspaceId,
+        groupId: snapshot.group.groupId,
+    });
 }
 
 function toPolicyDeniedDecision(

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1072,6 +1072,31 @@
       "description": "Pins the admission binding phases: the member-count window closes joins in a group that never activates, the epoch-ms window denies after its deadline, and closed admits only while forming -- denying during establishment and activation, and reopening after a below-floor return to forming."
     },
     {
+      "id": "api-v1-group-data-policy",
+      "recipe": "tests/api-v1/api-v1-group-data-policy.json",
+      "category": "api-v1-black-box",
+      "mode": "run",
+      "tier": 1,
+      "profiles": [
+        "api-v1-black-box-cluster"
+      ],
+      "expectedExitCode": 0,
+      "artifactName": "api-v1-group-data-policy",
+      "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
+        "httpServices": [
+          {
+            "name": "Rallar API primary",
+            "env": "RALLAR_API_BASE_URL",
+            "default": "http://127.0.0.1:18080"
+          }
+        ]
+      },
+      "description": "Pins the preActivationAppData gate: under blocked-until-active a room-scoped WS app-data send is NACKed unauthorized before activation and never reaches other members, then flows end to end once the manager activates the group."
+    },
+    {
       "id": "api-v1-rtc-topology-convergence",
       "recipe": "tests/api-v1/api-v1-rtc-topology-convergence.json",
       "category": "api-v1-black-box",

--- a/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-group-causal-evidence.ts
+++ b/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-group-causal-evidence.ts
@@ -23,7 +23,12 @@ const GROUP_PUBLIC_RESULT_EVENT_POLICY: Readonly<Record<string, GroupPublicResul
   },
   GROUP_INVITE_CREATE: { eventTypes: ['member-invited'], allowsNoOp: true },
   GROUP_INVITE_REVOKE: { eventTypes: ['member-left'], allowsNoOp: true },
-  GROUP_INVITE_ACCEPT: { eventTypes: ['member-joined'], allowsNoOp: true },
+  // Acceptance shares computeJoin: an uninvited caller on an open-join
+  // manager-approval group parks here exactly as a plain join would.
+  GROUP_INVITE_ACCEPT: {
+    eventTypes: ['member-joined', 'member-admission-requested'],
+    allowsNoOp: true,
+  },
   GROUP_ADMISSION_GRANT: { eventTypes: ['member-joined'], allowsNoOp: true },
   GROUP_ADMISSION_DECLINE: { eventTypes: ['member-left'], allowsNoOp: true },
   GROUP_JOIN_CODE_ROTATE: { eventTypes: ['group-updated'], allowsNoOp: false },

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
@@ -592,8 +592,8 @@
           "x-client-id": "{aliceClientId}"
         },
         "poll": {
-          "maxAttempts": 20,
-          "maxDurationMs": 15000,
+          "maxAttempts": 40,
+          "maxDurationMs": 30000,
           "backoffMs": 250,
           "backoffMultiplier": 2
         }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-windows.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-windows.json
@@ -353,8 +353,8 @@
           "x-client-id": "{aliceClientId}"
         },
         "poll": {
-          "maxAttempts": 20,
-          "maxDurationMs": 15000,
+          "maxAttempts": 40,
+          "maxDurationMs": 30000,
           "backoffMs": 250,
           "backoffMultiplier": 2
         }
@@ -552,8 +552,8 @@
           "x-client-id": "{aliceClientId}"
         },
         "poll": {
-          "maxAttempts": 20,
-          "maxDurationMs": 15000,
+          "maxAttempts": 40,
+          "maxDurationMs": 30000,
           "backoffMs": 250,
           "backoffMultiplier": 2
         }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-data-policy.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-data-policy.json
@@ -1,0 +1,587 @@
+{
+  "variables": {
+    "apiPrimary": {
+      "env": "RALLAR_API_BASE_URL",
+      "default": "http://127.0.0.1:18080"
+    },
+    "rallarWsBaseUrl": {
+      "env": "RALLAR_WS_BASE_URL",
+      "default": "ws://127.0.0.1:18080"
+    },
+    "applicationId": "data-policy-{runId}",
+    "workspaceId": "default-{runId}",
+    "groupId": "data-policy-room-{runId}",
+    "aliceUsername": {
+      "env": "RALLAR_ALICE_USERNAME",
+      "default": "alice"
+    },
+    "alicePassword": {
+      "env": "RALLAR_ALICE_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
+    "bobUsername": {
+      "env": "RALLAR_BOB_USERNAME",
+      "default": "bob"
+    },
+    "bobPassword": {
+      "env": "RALLAR_BOB_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
+    "runId": {
+      "env": "RALLAR_BB_RUN_ID",
+      "default": "local"
+    }
+  },
+  "execution": {
+    "correlation": {
+      "injectHeaders": true,
+      "injectPayloads": false
+    }
+  },
+  "connections": {
+    "primary": {
+      "type": "http",
+      "baseUrl": "{apiPrimary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 10000
+    },
+    "wsAlice": {
+      "type": "ws",
+      "timeoutMs": 10000
+    },
+    "wsBob": {
+      "type": "ws",
+      "timeoutMs": 10000
+    }
+  },
+  "steps": [
+    {
+      "name": "loginAlice",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "body": {
+          "username": "{aliceUsername}",
+          "password": "{alicePassword}"
+        },
+        "outputs": {
+          "aliceClientId": "body.clientId",
+          "aliceSessionId": "body.sessionId",
+          "aliceAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveAliceAuthHeader",
+      "type": "set",
+      "output": "aliceAuthHeader",
+      "secret": true,
+      "redactAs": "aliceAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.aliceAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "loginBob",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login",
+        "body": {
+          "username": "{bobUsername}",
+          "password": "{bobPassword}"
+        },
+        "outputs": {
+          "bobClientId": "body.clientId",
+          "bobSessionId": "body.sessionId",
+          "bobAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveBobAuthHeader",
+      "type": "set",
+      "output": "bobAuthHeader",
+      "secret": true,
+      "redactAs": "bobAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.bobAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "createBlockedDataGroup",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "group-create-data-policy-{runId}",
+          "groupId": "{groupId}",
+          "displayName": "Data policy group {runId}",
+          "kind": "room",
+          "joinMode": "open",
+          "createdByPrincipalId": "{aliceClientId}",
+          "lifecyclePolicy": {
+            "formation": "phased",
+            "manager": {
+              "selection": "assigned",
+              "assignedPrincipalIds": [
+                "{aliceClientId}"
+              ],
+              "count": 1
+            },
+            "establishment": {
+              "initiator": "manager"
+            },
+            "activation": {
+              "mode": "manual"
+            },
+            "admission": {
+              "mode": "open"
+            },
+            "data": {
+              "preActivationAppData": "blocked-until-active"
+            }
+          }
+        }
+      },
+      "expect": {
+        "status": 201,
+        "body": {
+          "group": {
+            "groupId": "{groupId}",
+            "lifecycleState": "forming"
+          }
+        }
+      }
+    },
+    {
+      "name": "bobJoinsTheLobby",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/join",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "body": {
+          "requestId": "join-bob-data-policy-{runId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "members": [
+            {
+              "principalId": "{bobClientId}",
+              "status": "active"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "connectAlicePresence",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "PUT",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/sessions/{aliceSessionId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "presence-alice-data-policy-{runId}",
+          "generationId": "generation-{runId}",
+          "principalId": "{aliceClientId}"
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "connectBobPresence",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "PUT",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/sessions/{bobSessionId}",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "body": {
+          "requestId": "presence-bob-data-policy-{runId}",
+          "generationId": "generation-{runId}",
+          "principalId": "{bobClientId}"
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "createAliceWsTicket",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/ws-ticket",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "outputs": {
+          "aliceWsTicket": {
+            "path": "body.ticket",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveAliceWsUrl",
+      "type": "set",
+      "output": "aliceWsUrl",
+      "secret": true,
+      "redactAs": "aliceWsUrl",
+      "transform": {
+        "concat": [
+          {
+            "path": "variables.rallarWsBaseUrl"
+          },
+          "/api/ws/",
+          {
+            "path": "outputs.aliceSessionId"
+          },
+          "?ticket=",
+          {
+            "urlEncode": {
+              "path": "outputs.aliceWsTicket"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "openAliceWs",
+      "type": "ws.open",
+      "connection": "wsAlice",
+      "request": {
+        "url": "{aliceWsUrl}",
+        "timeoutMs": 10000
+      }
+    },
+    {
+      "name": "createBobWsTicket",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/ws-ticket",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "outputs": {
+          "bobWsTicket": {
+            "path": "body.ticket",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveBobWsUrl",
+      "type": "set",
+      "output": "bobWsUrl",
+      "secret": true,
+      "redactAs": "bobWsUrl",
+      "transform": {
+        "concat": [
+          {
+            "path": "variables.rallarWsBaseUrl"
+          },
+          "/api/ws/",
+          {
+            "path": "outputs.bobSessionId"
+          },
+          "?ticket=",
+          {
+            "urlEncode": {
+              "path": "outputs.bobWsTicket"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "openBobWs",
+      "type": "ws.open",
+      "connection": "wsBob",
+      "request": {
+        "url": "{bobWsUrl}",
+        "timeoutMs": 10000
+      }
+    },
+    {
+      "name": "blockedSendIsNackedBeforeActivation",
+      "type": "ws.send",
+      "connection": "wsBob",
+      "request": {
+        "send": {
+          "id": {
+            "v": 2,
+            "msgId": "data-policy-blocked-{runId}",
+            "ts": 0,
+            "senderId": "{bobSessionId}",
+            "sessionId": "{bobSessionId}",
+            "traceId": "data-policy-blocked-trace-{runId}"
+          },
+          "route": {
+            "topicId": "room.match",
+            "resourceId": "data-policy-resource-{runId}",
+            "contextId": "{applicationId}:{workspaceId}"
+          },
+          "targets": {
+            "mode": "broadcast",
+            "scope": "room",
+            "groupRef": {
+              "applicationId": "{applicationId}",
+              "workspaceId": "{workspaceId}",
+              "groupId": "{groupId}"
+            }
+          },
+          "delivery": {
+            "reliability": "best-effort",
+            "ack": "none"
+          },
+          "payload": {
+            "typeId": "room.match.v1",
+            "contentType": "application/json",
+            "resource": "{\"move\":\"early\",\"runId\":\"{runId}\"}"
+          }
+        },
+        "outputs": {
+          "blockedNackResource": "matchedMessage.data.payload.resource"
+        }
+      },
+      "expect": {
+        "connection": "wsBob",
+        "withinMs": 10000,
+        "message": {
+          "payload": {
+            "typeId": "al.control.nack.v1"
+          }
+        }
+      }
+    },
+    {
+      "name": "parseBlockedNack",
+      "type": "set",
+      "output": "blockedNack",
+      "transform": {
+        "jsonParse": {
+          "path": "outputs.blockedNackResource"
+        }
+      }
+    },
+    {
+      "name": "assertBlockedNackShape",
+      "type": "assert",
+      "actual": {
+        "msgId": "{blockedNack.msgId}",
+        "reason": "{blockedNack.reason}"
+      },
+      "expect": {
+        "missingActualValue": "MISSING",
+        "body": {
+          "msgId": "data-policy-blocked-{runId}",
+          "reason": "unauthorized"
+        }
+      }
+    },
+    {
+      "name": "aliceNeverReceivesTheBlockedMessage",
+      "type": "ws.wait",
+      "connection": "wsAlice",
+      "expect": {
+        "connection": "wsAlice",
+        "withinMs": 4000,
+        "absent": {
+          "id": {
+            "msgId": "data-policy-blocked-{runId}"
+          }
+        }
+      }
+    },
+    {
+      "name": "managerEstablishes",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/establish",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "establish-data-policy-{runId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "establishing",
+            "formationEpoch": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "managerActivates",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/activate",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "requestId": "activate-data-policy-{runId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "active",
+            "formationEpoch": 2
+          }
+        }
+      }
+    },
+    {
+      "name": "activatedSendReachesAlice",
+      "type": "ws.send",
+      "connection": "wsBob",
+      "request": {
+        "send": {
+          "id": {
+            "v": 2,
+            "msgId": "data-policy-active-{runId}",
+            "ts": 0,
+            "senderId": "{bobSessionId}",
+            "sessionId": "{bobSessionId}",
+            "traceId": "data-policy-active-trace-{runId}"
+          },
+          "route": {
+            "topicId": "room.match",
+            "resourceId": "data-policy-resource-{runId}",
+            "contextId": "{applicationId}:{workspaceId}"
+          },
+          "targets": {
+            "mode": "broadcast",
+            "scope": "room",
+            "groupRef": {
+              "applicationId": "{applicationId}",
+              "workspaceId": "{workspaceId}",
+              "groupId": "{groupId}"
+            }
+          },
+          "delivery": {
+            "reliability": "best-effort",
+            "ack": "none"
+          },
+          "payload": {
+            "typeId": "room.match.v1",
+            "contentType": "application/json",
+            "resource": "{\"move\":\"legit\",\"runId\":\"{runId}\"}"
+          }
+        }
+      },
+      "expect": {
+        "connection": "wsAlice",
+        "withinMs": 10000,
+        "message": {
+          "id": {
+            "msgId": "data-policy-active-{runId}"
+          },
+          "route": {
+            "topicId": "room.match"
+          },
+          "payload": {
+            "typeId": "room.match.v1",
+            "resource": "{\"move\":\"legit\",\"runId\":\"{runId}\"}"
+          }
+        }
+      }
+    },
+    {
+      "name": "closeBobWs",
+      "type": "ws.close",
+      "connection": "wsBob",
+      "request": {
+        "code": 1000,
+        "reason": "data-policy recipe done"
+      }
+    },
+    {
+      "name": "closeAliceWs",
+      "type": "ws.close",
+      "connection": "wsAlice",
+      "request": {
+        "code": 1000,
+        "reason": "data-policy recipe done"
+      }
+    }
+  ]
+}

--- a/packages/shared/al-contracts/al-contract.ts
+++ b/packages/shared/al-contracts/al-contract.ts
@@ -342,6 +342,19 @@ export function readALMulticastTargetGroupRef(message: ALMessage): GroupRef | un
     return toALGroupRef(targets.groupRef);
 }
 
+/**
+ * Whether a message addresses a room audience by its own shape — a `room.`
+ * topic, a multicast, or a room-scoped broadcast. Room-scoped delivery is
+ * owned by the topic router behind its room authorizer; transports must not
+ * relay these on their own, or the authorization is bypassed.
+ */
+export function isRoomScopedALMessage(message: ALMessage): boolean {
+    return message.route.topicId.startsWith('room.') ||
+        message.targets?.mode === 'multicast' ||
+        (message.targets?.mode === 'broadcast' &&
+            message.targets.scope === 'room');
+}
+
 export function readALTargetGroupRef(message: ALMessage): GroupRef | undefined {
     const targets = message.targets;
     if (targets?.mode === 'multicast') {

--- a/packages/shared/alm/ALInboundMessageRuntime.ts
+++ b/packages/shared/alm/ALInboundMessageRuntime.ts
@@ -53,13 +53,20 @@ export type ALInboundMessageRuntimeInput = Readonly<{
         fromPeerId: string,
         plan: ALMessageHandlingPlan,
     ) => Promise<void>;
+    /**
+     * Per-message forwarding capability, reconciled at admission so a
+     * message this transport will not relay never records a forward
+     * effect and acks as delivered, not forwarded. Absent means every
+     * message `forwardMessage` can carry is forwardable.
+     */
+    canForwardMessage?: (msg: ALMessage) => boolean;
     stores?: ALInboundRuntimeStores;
 }>;
 
 type AdmissionComputeDependencies = Readonly<{
     selfPeerId: string;
     toInboxEntry: (msg: ALMessage) => ResourceEntry;
-    canForward: boolean;
+    canForward: (msg: ALMessage) => boolean;
 }>;
 
 export type AdmissionComputedDto = Readonly<{
@@ -200,7 +207,7 @@ export class ALInboundMessageRuntime {
         const plan = read.plan;
         const mutations: ALInboundAdmissionMutation[] = [];
         const durableEffects: ALInboundDurableEffectWrite[] = [];
-        const shouldForward = dependencies.canForward && plan.forwarding.enabled;
+        const shouldForward = dependencies.canForward(read.msg) && plan.forwarding.enabled;
         const completedPendingAcks: ALCompletedPendingAck[] = [];
 
         if (plan.dropReason) {
@@ -301,7 +308,11 @@ export class ALInboundMessageRuntime {
             }
         }
 
-        if (shouldForward && plan.ack.enabled && plan.ack.deferred && plan.ack.toPeerId) {
+        // The plan defers subtree acks on the assumption it will forward; a
+        // runtime that will not forward this message has no subtree to wait
+        // for and must ack immediately instead of never.
+        const ackDeferred = plan.ack.deferred && shouldForward;
+        if (shouldForward && plan.ack.enabled && ackDeferred && plan.ack.toPeerId) {
             const transition = trackPendingAckSnapshot(
                 read.msg.id.msgId,
                 read.pendingAck,
@@ -332,7 +343,7 @@ export class ALInboundMessageRuntime {
             }
         }
 
-        if (plan.ack.enabled && plan.ack.toPeerId && !plan.ack.deferred) {
+        if (plan.ack.enabled && plan.ack.toPeerId && !ackDeferred) {
             durableEffects.push(
                 this.toAckEffect(
                     dependencies.selfPeerId,
@@ -727,7 +738,9 @@ export class ALInboundMessageRuntime {
         return {
             selfPeerId: this.input.selfPeerId,
             toInboxEntry: this.input.toInboxEntry,
-            canForward: this.input.forwardMessage !== undefined,
+            canForward: (msg) =>
+                this.input.forwardMessage !== undefined &&
+                (this.input.canForwardMessage?.(msg) ?? true),
         };
     }
 

--- a/packages/shared/api/group-client-views.ts
+++ b/packages/shared/api/group-client-views.ts
@@ -61,6 +61,25 @@ export function readGroupVersion(snapshot: AnyGroupPresence): number {
     return snapshot.group.snapshotVersion;
 }
 
+/**
+ * The snapshot a parked admission requester may see (plan decision 5.1):
+ * their own pending row and the aggregate facts, never the roster or the
+ * live sessions — the same invite visibility tier their reads get. Returns
+ * the snapshot unchanged for any principal who is not parked pending.
+ */
+export function toPendingMemberGroupSnapshot(
+    snapshot: GroupSnapshot,
+    principalId: string,
+): GroupSnapshot {
+    const member = snapshot.members.find(
+        (candidate) => candidate.principalId === principalId,
+    );
+    if (member?.status !== 'pending') {
+        return snapshot;
+    }
+    return { ...snapshot, members: [member], activeSessions: [] };
+}
+
 export function readGroupStateRevision(snapshot: AnyGroupPresence): number {
     return snapshot.stateRevision;
 }

--- a/packages/shared/api/group-policy-types.ts
+++ b/packages/shared/api/group-policy-types.ts
@@ -19,6 +19,7 @@ export const GROUP_POLICY_REASON_CODES = [
     'group-admission-closed',
     'group-admission-deadline-passed',
     'group-admission-capacity-reached',
+    'group-data-blocked-until-active',
 ] as const;
 
 export type GroupPolicyReasonCode =

--- a/packages/shared/services/WsQueueBoxServerService.ts
+++ b/packages/shared/services/WsQueueBoxServerService.ts
@@ -7,7 +7,7 @@ import {
 import { ResourceEntry } from '../queuebox/ResourceEntry.ts';
 import { ResilienceDto } from '../queuebox/DequeueResourceEntryController.ts';
 import { OnWebSocketServerMessageCallback } from './InboxOutboxContracts.ts';
-import { ALMessage } from '../al-contracts/al-contract.ts';
+import { ALMessage, isRoomScopedALMessage } from '../al-contracts/al-contract.ts';
 import {
     validatePersistedALMessage,
 } from '../al-contracts/al-message-persistence-validation.ts';
@@ -58,6 +58,15 @@ export type WsQueueBoxServerServiceOptions = Readonly<{
     outboundDiagnostics?: ALOutboundRuntimeDiagnosticsSink;
     outboundDeliveryOutcome?: (outcome: WsOutboxDeliveryOutcome) => void;
     deliveryDiagnostics?: WsDeliveryDiagnosticsSink;
+    /**
+     * Whether inbound ALM forwarding relays room-scoped messages (default
+     * true, the standalone service contract). A composition that installs a
+     * topic router with a room authorizer must pass false: the router owns
+     * room-scoped fanout behind its authorization, and relaying here would
+     * deliver messages the authorizer rejects (and double-deliver the ones
+     * it accepts).
+     */
+    forwardsRoomScopedMessages?: boolean;
 }>;
 
 type WsServerPreparedMessage = Readonly<
@@ -96,6 +105,7 @@ export class WsQueueBoxServerService {
     private readonly targetResolver: WsServerTargetResolver;
     private readonly outboundDeliveryOutcome?: (outcome: WsOutboxDeliveryOutcome) => void;
     private readonly deliveryDiagnostics?: WsDeliveryDiagnosticsSink;
+    private readonly forwardsRoomScopedMessages: boolean;
     public readonly inbox: QueueBoxResourceEntryRepository;
     public readonly outbox: QueueBoxResourceEntryRepository;
     public readonly socket: JsonWebSocketServer;
@@ -116,6 +126,7 @@ export class WsQueueBoxServerService {
         this.targetResolver = options.targetResolver ?? {};
         this.outboundDeliveryOutcome = options.outboundDeliveryOutcome;
         this.deliveryDiagnostics = options.deliveryDiagnostics;
+        this.forwardsRoomScopedMessages = options.forwardsRoomScopedMessages ?? true;
 
         this.outboundRuntime = new ALOutboundMessageRuntime<
             WsServerPreparedMessage
@@ -213,6 +224,8 @@ export class WsQueueBoxServerService {
                 forwardMessage: async (msg, fromPeerId, plan) => {
                     await this.forwardIncomingMessage(msg, fromPeerId, plan);
                 },
+                canForwardMessage: (msg) =>
+                    this.forwardsRoomScopedMessages || !isRoomScopedALMessage(msg),
             },
         );
 

--- a/packages/tests/shared-server/group-policy.test.ts
+++ b/packages/tests/shared-server/group-policy.test.ts
@@ -396,6 +396,37 @@ describe('group policy helpers', () => {
         nowEpochMs: NOW,
       }),
     ).toEqual({ allowed: true });
+    // Plan decision 5.4: blocked-until-active gates only before activation,
+    // and an absent value leaves application data ungated.
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({
+          lifecycleState: 'establishing',
+          activeSessions: [session('alice-session', 'alice')],
+        }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+        preActivationAppData: 'blocked-until-active',
+      }),
+    ).toMatchObject(denied('group-data-blocked-until-active'));
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({ activeSessions: [session('alice-session', 'alice')] }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+        preActivationAppData: 'blocked-until-active',
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({
+          lifecycleState: 'establishing',
+          activeSessions: [session('alice-session', 'alice')],
+        }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+      }),
+    ).toEqual({ allowed: true });
     expect(
       canSendRoomMessage({
         snapshot: snapshot({
@@ -568,6 +599,17 @@ describe('group policy helpers', () => {
             nowEpochMs: NOW,
           }),
         ),
+      ),
+      expectCode(
+        canSendRoomMessage({
+          snapshot: snapshot({
+            lifecycleState: 'establishing',
+            activeSessions: [session('alice-session', 'alice')],
+          }),
+          actor: ACTOR,
+          senderSessionId: 'alice-session',
+          preActivationAppData: 'blocked-until-active',
+        }),
       ),
     ]);
 

--- a/packages/tests/shared-server/group-state/mutation/group-admission-mutation.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-admission-mutation.test.ts
@@ -190,6 +190,36 @@ describe('group admission mutation', () => {
     expect(await memberStatus(runtime, 'upsert-room', 'bob')).toBe('pending');
   });
 
+  // An active member re-asserting membership is not joining: admission never
+  // demotes or re-gates an existing membership.
+  it('never re-gates an active member re-upserting themselves', async () => {
+    const runtime = new FakeRuntimeStateRepository();
+    await seedManagedGroup(runtime, 're-upsert-room', {
+      mode: 'manager-approval',
+      untilEpochMs: 5_000,
+    });
+    const service = createService(runtime, 2_000);
+
+    await service.joinGroup(SCOPE, 're-upsert-room', {
+      actorPrincipalId: 'bob',
+      requestId: 'park-bob',
+    });
+    await service.grantGroupAdmission(SCOPE, 're-upsert-room', 'bob', {
+      actorPrincipalId: 'alice',
+      requestId: 'grant-bob',
+    });
+    expect(await memberStatus(runtime, 're-upsert-room', 'bob')).toBe('active');
+
+    // Past the admission window, on a fresh requestId: still a no-op, never a
+    // demotion to pending and never a window denial.
+    await createService(runtime, 9_000).upsertMember(SCOPE, 're-upsert-room', 'bob', {
+      status: 'active',
+      actorPrincipalId: 'bob',
+      requestId: 'reassert-bob',
+    });
+    expect(await memberStatus(runtime, 're-upsert-room', 'bob')).toBe('active');
+  });
+
   it('denies joins outside forming under a closed admission mode', async () => {
     const runtime = new FakeRuntimeStateRepository();
     await seedManagedGroup(runtime, 'closed-room', { mode: 'closed' });

--- a/packages/tests/shared/al-inbound-message-runtime.test.ts
+++ b/packages/tests/shared/al-inbound-message-runtime.test.ts
@@ -87,6 +87,33 @@ describe('ALInboundMessageRuntime', () => {
         expect(forwardedIds).toEqual([seq2.id.msgId, seq1.id.msgId]);
     });
 
+    // The transport capability is reconciled at admission (not at the
+    // forward executor): a disowned message records no forward effect and
+    // its subtree ack collapses to an immediate delivered ack — never a
+    // deferred ack that waits on a subtree that will not exist.
+    it('acks delivered without forwarding when the transport disowns a message', async () => {
+        const { runtime, controlMessages, forwardedIds, dispatchedTexts } = createInboundHarness(
+            undefined,
+            { canForwardMessage: () => false },
+        );
+        const msg = createOrderedMessage(1, 'kept-local', 'all-logical-recipients');
+
+        await runtime.handleIncomingMessage(msg, 'peer-1');
+
+        expect(forwardedIds).toEqual([]);
+        expect(dispatchedTexts).toEqual(['kept-local']);
+        const ackPayloads = controlMessages.flatMap((candidate) => {
+            const parsed = parseALControlMessage(candidate);
+            return parsed?.type === 'ack' ? [parsed.payload] : [];
+        });
+        expect(ackPayloads).toHaveLength(1);
+        expect(ackPayloads[0]).toMatchObject({
+            ackedMsgId: msg.id.msgId,
+            toPeerId: 'peer-1',
+            status: 'delivered',
+        });
+    });
+
     it('retries a stale optimistic write and still releases ordered messages once', async () => {
         vi.useFakeTimers();
 
@@ -602,6 +629,7 @@ function createInboundHarness(
             fromPeerId: string,
             plan: ALMessageHandlingPlan,
         ) => Promise<void>;
+        canForwardMessage: (msg: ALMessage) => boolean;
     }> = {},
 ) {
     const inbox = new InMemoryQueueBox(new Map());
@@ -645,6 +673,7 @@ function createInboundHarness(
         forwardMessage: overrides.forwardMessage ?? (async (msg) => {
             forwardedIds.push(msg.id.msgId);
         }),
+        canForwardMessage: overrides.canForwardMessage,
     });
 
     return {

--- a/packages/tests/shared/group-client-views.test.ts
+++ b/packages/tests/shared/group-client-views.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { toPendingMemberGroupSnapshot } from '@shared/api/group-client-views.ts';
+import { createGroupSnapshotFixture } from '../shared-web/authoritative-group-fixtures.ts';
+import type { GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
+
+const SCOPE = { applicationId: 'app-1', workspaceId: 'workspace-1' };
+
+function snapshotWithPendingParker(): GroupSnapshot {
+    const snapshot = createGroupSnapshotFixture({
+        ...SCOPE,
+        groupId: 'room-1',
+        sessionIds: ['alice-session'],
+    });
+    const parker: GroupMember = {
+        ...snapshot.members[0],
+        principalId: 'parker',
+        status: 'pending',
+        joined: null,
+        left: null,
+        removed: null,
+        banned: null,
+    };
+    return { ...snapshot, members: [...snapshot.members, parker] };
+}
+
+describe('toPendingMemberGroupSnapshot', () => {
+    // A parked requester gets the invite visibility tier: their own row and
+    // the aggregate facts, never the roster or the live sessions.
+    it('redacts the roster and sessions for a parked pending requester', () => {
+        const snapshot = snapshotWithPendingParker();
+
+        const redacted = toPendingMemberGroupSnapshot(snapshot, 'parker');
+
+        expect(redacted.members.map((member) => member.principalId)).toEqual(['parker']);
+        expect(redacted.activeSessions).toEqual([]);
+        expect(redacted.group).toBe(snapshot.group);
+    });
+
+    it('returns the snapshot unchanged for active members and strangers', () => {
+        const snapshot = snapshotWithPendingParker();
+        const activePrincipalId = snapshot.members[0].principalId;
+
+        expect(toPendingMemberGroupSnapshot(snapshot, activePrincipalId)).toBe(snapshot);
+        expect(toPendingMemberGroupSnapshot(snapshot, 'stranger')).toBe(snapshot);
+    });
+});

--- a/packages/tests/shared/ws-server-qos-policy.test.ts
+++ b/packages/tests/shared/ws-server-qos-policy.test.ts
@@ -537,6 +537,39 @@ describe('WsQueueBoxServerService QoS runtime', () => {
             .toBe(true);
     });
 
+    // A composition that installs the topic router owns room-scoped fanout
+    // behind its room authorizer, so it opts the ALM relay out — forwarding
+    // here would deliver messages the authorizer rejects.
+    it('skips room-broadcast forwarding when the composition disowns it', async () => {
+        const socket = createFakeWsServer();
+        const service = new shared.WsQueueBoxServerService(
+            new shared.InMemoryQueueBox(new Map()),
+            new shared.InMemoryQueueBox(new Map()),
+            socket as never,
+            'server-1',
+            {
+                targetResolver: createTargetResolver(),
+                forwardsRoomScopedMessages: false,
+            },
+        );
+        const msg = shared.newALBroadcastMessage(
+            'peer-1',
+            {
+                topicId: 'room.manual.message',
+                resourceId: 'room-broadcast-2',
+                contextId: 'group-1',
+            },
+            'room',
+            'room.manual.message',
+            { text: 'hello room' },
+            { groupRef: groupRef('group-1') },
+        );
+
+        await (service as any).handleIncomingServerMessage(msg, 'conn-1');
+
+        expect(socket.sent).toHaveLength(0);
+    });
+
     it('suppresses duplicate inbound delivery on the server wrapper', async () => {
         const socket = createFakeWsServer();
         const service = new shared.WsQueueBoxServerService(


### PR DESCRIPTION
Slice 5c of the group lifecycle control plane workstream (plan decision 5.4), plus five fixes from
an adversarial multi-agent review of the merged 5b — three of which were live on main.

**The data-policy gate.** `canSendRoomMessage` denies room-scoped application data with
`group-data-blocked-until-active` when the policy declares `blocked-until-active` and the group is
not ACTIVE. The room authorizer resolves the policy value only for non-active groups, so
steady-state room traffic pays no policy read; absent reads as `allowed` (the workstream's
no-policy invariant) and corrupt fails closed. The CRDT live topics are exempt by an explicit
topic-id classification: CRDT authority is the AppInbox append path, the WS topic only fans out
committed updates, and collaborative documents stay alive while a group forms — the exemption is a
named line at the enforcement point, pinned by tests, not an accident of routing.

**The recipe exposed a pre-existing enforcement bypass.** `api-v1-group-data-policy` pinned
"NACKed and not delivered" — and delivery happened anyway: the ALM inbound admission's
`forward-message` effect relayed room-scoped broadcasts to resolved recipients regardless of the
router's room authorizer. Every room-authorizer denial (banned members, stale snapshots, scope
mismatches, the new data policy) was NACK-only theater, and authorized sends were double-delivered
behind client-side msgId dedupe. A log census across full local runs showed the forward path served
nothing else. Room-scoped delivery now belongs exclusively to the router's authorized fanout,
classified by one shared `isRoomScopedALMessage` helper used by both layers. The memory-mode base
profile (22/22) and cluster profile confirm no relay regressions.

**Review fixes on 5b's admission wiring:**
- An already-active member self-re-upserting (`status: 'active'`, fresh requestId — the routine
  reconnect pattern) was pushed through the admission decision: demoted to `pending` under
  manager-approval, or denied after a window closed. Membership re-assertion now bypasses admission
  exactly like `computeJoin`'s active no-op; regression-pinned.
- Governance activation of a pending member skipped the admission-window re-check that grant
  enforces; both now share `assertGroupAdmissionWindowsOpen` (decision 5.2: windows bind on every
  path that lands a member active).
- The sequential mutation read fetched the roster before the CAS-anchoring group entry, so a
  concurrent membership change could pin a stale formation electorate the guard would never catch;
  the roster now reads after the group entry, making 4a's recorded consistency guarantee hold.
- `GROUP_INVITE_ACCEPT` evidence accepts `member-admission-requested` (acceptance shares
  `computeJoin` and can park an uninvited caller on an open-join manager-approval group).
- Owner-approved park-response redaction: a parked join/accept/self-upsert returns the requester's
  own pending row with sessions emptied (`toPendingMemberGroupSnapshot`) — the invite visibility
  tier their reads already get — instead of the full roster and live sessions.

**Validation.** Full `test:unit`, api-v1 Deno suite run unfiltered (**487 passed, 0 failed** — the
earlier "green" runs in this workstream were masked by piping gates through `tail`; the route-census
gap that slipped 5b was independently fixed by #299, onto which this branch is rebased),
`typecheck` incl. the tests ratchet, `check:repo-style:changed` (PASS), local cluster profile with
all nine lifecycle/admission/data recipes passing (`api-v1-group-data-policy` 23/23), memory base
profile 22/22, and `test:api-v1:black-box:postgres:medium-scale`: **PASSED, success=2748
failure=0** — constants, operation matrix, and assertions untouched.

Slice 5 is complete with this PR; the plan refresh marking it delivered (with the 5.x execution
decisions) rides the next session's first commit per the workstream pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)