### PR TITLE
Measure line width by what the line declares

### DIFF
--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -193,7 +193,10 @@ migration decision above.
 Use the nearest configured formatter. The repository TypeScript baseline is:
 
 - 2-space indentation;
-- 100-character line width;
+- 100-character line width, measured on code. A module specifier is not measured: its length is
+  the path, and a formatter honouring the same width leaves the line intact. A `function` or
+  `interface` declaration header is measured at 140, because its length is the names it
+  declares. Import depth and naming are owned by the layout and type-organization rules;
 - semicolons;
 - single quotes;
 - trailing commas in multiline declarations, calls, objects, arrays, and types;

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,17 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": [
+        "packages/tests/**",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
+      "options": {
+        "printWidth": 140
+      }
+    }
+  ]
 }

--- a/apps/api-v1/scripts/migrate-rtc-persisted-state.ts
+++ b/apps/api-v1/scripts/migrate-rtc-persisted-state.ts
@@ -1,5 +1,4 @@
 import type { PSqlSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
 import { PSqlRuntimeStateRepository }
   from '@shared-server/postgres/runtime-state/PSqlRuntimeStateRepository.ts';
 import {

--- a/apps/api-v1/src/composition/create-api-v1-admin-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-admin-services.ts
@@ -1,16 +1,12 @@
 import type { RallarCrdtAdminReadRepository } from '@shared/crdt/mod.ts';
 import type { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
-// prettier-ignore
 import { PSqlAdminOperationsStatsReader } from '@shared-server/postgres/admin-operations/\
 PSqlAdminOperationsStatsReader.ts';
-// prettier-ignore
 import { PSqlAdminSupportReader } from '@shared-server/postgres/admin-support/\
 PSqlAdminSupportReader.ts';
 import type { PSqlSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
 import { AdminOperationsService } from '@shared-server/rallar-system/admin-operations/\
 AdminOperationsService.ts';
-// prettier-ignore
 import {
   AdminSupportService,
   type AdminSupportTopologyManagement,
@@ -19,13 +15,10 @@ AdminSupportService.ts';
 import type {
   ClientStateService,
 } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-// prettier-ignore
 import type { RallarGroupFormationMetricsRecorder } from '@shared-server/rallar-system/\
 formation-metrics.ts';
-// prettier-ignore
 import type { GroupStateService } from '@shared-server/rallar-system/services/\
 group-state-service.ts';
-// prettier-ignore
 import { SpaStatisticsService } from '@shared-server/rallar-system/spa-statistics/\
 SpaStatisticsService.ts';
 import type { RallarTimingSink } from '@shared-server/rallar-system/services/timing.ts';

--- a/apps/api-v1/src/composition/create-api-v1-system-installers.ts
+++ b/apps/api-v1/src/composition/create-api-v1-system-installers.ts
@@ -21,7 +21,6 @@ import {
   type InitRallarSystemWsTopicsOptions,
 } from '@shared-server/rallar-system/ws-system-topics.ts';
 
-// prettier-ignore
 import { createCrdtWsMutationIngress } from '@shared-server/rallar-system/crdt/inbox/\
 create-crdt-ws-mutation-ingress.ts';
 

--- a/apps/api-v1/src/composition/create-api-v1-topology-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-topology-services.ts
@@ -12,10 +12,8 @@ import type {
 import type {
   GroupFormationRttMutationSink,
 } from '@shared-server/rallar-system/formation-metrics.ts';
-// prettier-ignore
 import { GroupStateRepository } from '@shared-server/rallar-system/repositories/\
 GroupStateRepository.ts';
-// prettier-ignore
 import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/repositories/\
 RtcTopologySnapshotRepository.ts';
 import {
@@ -24,23 +22,19 @@ import {
 } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
 import { sendStateSyncMessage } from '@shared-server/rallar-system/state-sync-routing.ts';
 import type { RallarTimingSink } from '@shared-server/rallar-system/services/timing.ts';
-// prettier-ignore
 import { GroupTopologyConfigRepository } from '@shared-server/rallar-system/topology/config/\
 persistence/group-topology-config-repository.ts';
-// prettier-ignore
 import { GroupTopologyManagementService } from '@shared-server/rallar-system/topology/\
 group-topology-management-service.ts';
 import type {
   RtcRttAppInboxDependencies,
 } from '@shared-server/rallar-system/rtc-topology/inbox/rtc-rtt-app-inbox-contracts.ts';
-// prettier-ignore
 import { RtcRttRepository } from '@shared-server/rallar-system/rtc-topology/persistence/\
 rtc-rtt-repository.ts';
 import {
   RtcRttRefinementGate,
   type RtcRttRefinementGateConfig,
 } from '@shared-server/rallar-system/rtc-topology/topic/rtc-rtt-refinement-gate.ts';
-// prettier-ignore
 import { RtcRttRefinementService } from '@shared-server/rallar-system/rtc-topology/topic/\
 rtc-rtt-refinement-service.ts';
 

--- a/apps/api-v1/src/composition/create-default-rallar-server.ts
+++ b/apps/api-v1/src/composition/create-default-rallar-server.ts
@@ -3,7 +3,6 @@ import type { Hono } from 'jsr:@hono/hono@4.11.9';
 import { defaultRepositoryManager } from '@shared/cache/defaultRepositoryManager.ts';
 import type { RallarCrdtDocumentTypePolicy } from '@shared/crdt/mod.ts';
 import { PSqlAppDataRepository } from '@shared-server/postgres/app-data/PSqlAppDataRepository.ts';
-// prettier-ignore
 import { PSqlCrdtLogRepository } from '@shared-server/rallar-system/crdt/persistence/\
 psql-crdt-log-repository.ts';
 import type { PSqlSql } from '@shared-server/postgres/PostgresSqlClient.ts';
@@ -11,7 +10,6 @@ import {
   createAuthUserRepository,
   createRuntimeStateRepository,
 } from '@shared-server/postgres/rallar-system/createStateRepositories.ts';
-// prettier-ignore
 import type { RallarServerApplication } from '@shared-server/rallar-facade/\
 RallarServerApplication.ts';
 import type { RallarServerWsFacadeOptions } from '@shared-server/rallar-facade/ws-topic-router.ts';

--- a/apps/api-v1/src/crdt/create-api-crdt-inbox-service.ts
+++ b/apps/api-v1/src/crdt/create-api-crdt-inbox-service.ts
@@ -1,18 +1,13 @@
 import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { PSqlSql, PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
 import { PSqlCrdtMutationRepository } from '@shared-server/rallar-system/crdt/persistence/\
 psql-crdt-mutation-repository.ts';
-// prettier-ignore
 import type { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/\
 ResourceInboxRepository.ts';
-// prettier-ignore
 import type { ResourceInboxResultsRepository } from '@shared-server/postgres/resource-inbox/\
 ResourceInboxResultsRepository.ts';
-// prettier-ignore
 import { AppCrdtInboxService } from '@shared-server/rallar-system/crdt/inbox/\
 app-crdt-inbox-service.ts';
-// prettier-ignore
 import type { AppInboxServiceOptions } from '@shared-server/rallar-system/services/\
 AppInboxService.ts';
 import type * as Crdt from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';

--- a/apps/api-v1/src/routes/graph-topology-routes.ts
+++ b/apps/api-v1/src/routes/graph-topology-routes.ts
@@ -7,12 +7,10 @@ import type {
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
-// prettier-ignore
 import {
   computeGroupFormationReadiness,
 } from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
 import type { GroupFormationView } from '@shared/api/group-lifecycle/group-formation-view.ts';
-// prettier-ignore
 import type {
   GroupLifecyclePolicyRead,
 } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';

--- a/apps/api-v1/src/routes/group-formation-view-read.ts
+++ b/apps/api-v1/src/routes/group-formation-view-read.ts
@@ -1,20 +1,16 @@
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
-// prettier-ignore
 import {
   computeGroupFormationReadiness,
 } from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
 import type { GroupFormationView } from '@shared/api/group-lifecycle/group-formation-view.ts';
-// prettier-ignore
 import {
   createDefaultGroupLifecyclePolicy,
 } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
-// prettier-ignore
 import {
   resolveGroupLifecycleManagers,
   toGroupLifecycleElectionKey,
 } from '@shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts';
-// prettier-ignore
 import type {
   GroupLifecyclePolicyRead,
 } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';

--- a/apps/api-v1/src/services/create-api-admin-mutation-gateway.ts
+++ b/apps/api-v1/src/services/create-api-admin-mutation-gateway.ts
@@ -2,10 +2,8 @@ import type { AuthSession } from '@shared/api/api-config.ts';
 import type {
   AdminOperationsMutationGateway,
 } from '@shared-server/rallar-system/admin-operations/admin-operations-mutation-gateway.ts';
-// prettier-ignore
 import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/\
 auth-session-repository.ts';
-// prettier-ignore
 import type { AppAdminInboxService } from '@shared-server/rallar-system/services/\
 AppAdminInboxService.ts';
 import { AppInboxType } from '@shared-server/rallar-system/services/app-inbox-contracts.ts';

--- a/apps/api-v1/test/routes/admin-operations-routes.test.ts
+++ b/apps/api-v1/test/routes/admin-operations-routes.test.ts
@@ -4,7 +4,6 @@ import { Hono } from 'jsr:@hono/hono@4.11.9';
 
 import type { AuthSession } from '@shared/api/api-config.ts';
 import { Either } from '@shared/resilience/Either.ts';
-// prettier-ignore
 import { toUnavailableAppInboxFailure } from '@shared-server/rallar-system/services/\
 app-inbox-failure.ts';
 

--- a/packages/shared-graph/graph/vivaldi.ts
+++ b/packages/shared-graph/graph/vivaldi.ts
@@ -1,148 +1,139 @@
 import { UndirectedGraph } from 'graphology';
-// prettier-ignore
 import {
-    compareVertexIds,
-    type EdgeProp,
-    type GraphProp,
-    type VertexProp,
-    VertexState,
-    VertexType,
+  compareVertexIds,
+  type EdgeProp,
+  type GraphProp,
+  type VertexProp,
+  VertexState,
+  VertexType,
 } from '../graph-props.ts';
 import {
-    computePredictedRttMs,
-    DEFAULT_VIVALDI_CONFIG,
-    type VivaldiConfig,
-    type VivaldiNodeData,
+  computePredictedRttMs,
+  DEFAULT_VIVALDI_CONFIG,
+  type VivaldiConfig,
+  type VivaldiNodeData,
 } from './vivaldi-core.ts';
 import { selectDegreeCappedEdges } from './select-degree-capped-edges.ts';
 
 export {
-    Coordinates,
-    DEFAULT_VIVALDI_CONFIG,
-    predictedRttMs,
-    VivaldiNode,
+  Coordinates,
+  DEFAULT_VIVALDI_CONFIG,
+  predictedRttMs,
+  VivaldiNode,
 } from './vivaldi-core.ts';
 
-export type {
-    VivaldiConfig,
-    VivaldiNodeData,
-} from './vivaldi-core.ts';
+export type { VivaldiConfig, VivaldiNodeData } from './vivaldi-core.ts';
 
 export function upsertPredictedVertex(
-    graph: UndirectedGraph<VertexProp, EdgeProp, GraphProp>,
-    vertexId: string,
-    graphProp: GraphProp,
+  graph: UndirectedGraph<VertexProp, EdgeProp, GraphProp>,
+  vertexId: string,
+  graphProp: GraphProp,
 ): void {
-    if (graph.hasNode(vertexId)) {
-        return;
-    }
+  if (graph.hasNode(vertexId)) {
+    return;
+  }
 
-    const vertex: VertexProp = {
-        id: vertexId,
-        type: VertexType.CLIENT,
-        state: VertexState.MEMBER,
-        degreeLimit: graphProp.degreeLimitMember,
-    };
+  const vertex: VertexProp = {
+    id: vertexId,
+    type: VertexType.CLIENT,
+    state: VertexState.MEMBER,
+    degreeLimit: graphProp.degreeLimitMember,
+  };
 
-    graph.addNode(vertexId, vertex);
+  graph.addNode(vertexId, vertex);
 }
 
 export function upsertPredictedEdge(
-    graph: UndirectedGraph<VertexProp, EdgeProp, GraphProp>,
-    fromId: string,
-    toId: string,
-    weight: number,
+  graph: UndirectedGraph<VertexProp, EdgeProp, GraphProp>,
+  fromId: string,
+  toId: string,
+  weight: number,
 ): void {
-    const edgeProp: EdgeProp = {
-        from: fromId,
-        to: toId,
-        weight,
-    };
+  const edgeProp: EdgeProp = {
+    from: fromId,
+    to: toId,
+    weight,
+  };
 
-    if (graph.hasEdge(fromId, toId)) {
-        const edgeKey = graph.edge(fromId, toId);
-        if (edgeKey !== undefined) {
-            graph.replaceEdgeAttributes(edgeKey, edgeProp);
-        }
-        return;
+  if (graph.hasEdge(fromId, toId)) {
+    const edgeKey = graph.edge(fromId, toId);
+    if (edgeKey !== undefined) {
+      graph.replaceEdgeAttributes(edgeKey, edgeProp);
     }
+    return;
+  }
 
-    graph.addEdge(fromId, toId, edgeProp);
+  graph.addEdge(fromId, toId, edgeProp);
 }
 
 export function createPredictedGraph(
-    nodeDataById: ReadonlyMap<string, VivaldiNodeData>,
-    graphProp: GraphProp,
-    cfg?: Partial<VivaldiConfig>,
+  nodeDataById: ReadonlyMap<string, VivaldiNodeData>,
+  graphProp: GraphProp,
+  cfg?: Partial<VivaldiConfig>,
 ): UndirectedGraph<VertexProp, EdgeProp, GraphProp> {
-    const graph = new UndirectedGraph<VertexProp, EdgeProp, GraphProp>();
-    graph.replaceAttributes(graphProp);
+  const graph = new UndirectedGraph<VertexProp, EdgeProp, GraphProp>();
+  graph.replaceAttributes(graphProp);
 
-    const nodes = [...nodeDataById.values()];
+  const nodes = [...nodeDataById.values()];
 
-    for (const node of nodes) {
-        upsertPredictedVertex(graph, node.id, graphProp);
+  for (const node of nodes) {
+    upsertPredictedVertex(graph, node.id, graphProp);
+  }
+
+  const mergedCfg = { ...DEFAULT_VIVALDI_CONFIG, ...cfg };
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const source = nodes[i];
+      const target = nodes[j];
+      const weight = computePredictedRttMs(source, target, mergedCfg);
+      upsertPredictedEdge(graph, source.id, target.id, weight);
     }
+  }
 
-    const mergedCfg = { ...DEFAULT_VIVALDI_CONFIG, ...cfg };
-    for (let i = 0; i < nodes.length; i++) {
-        for (let j = i + 1; j < nodes.length; j++) {
-            const source = nodes[i];
-            const target = nodes[j];
-            const weight = computePredictedRttMs(source, target, mergedCfg);
-            upsertPredictedEdge(graph, source.id, target.id, weight);
-        }
-    }
-
-    return graph;
+  return graph;
 }
 
 export function createDegreeCappedPredictedGraph(
-    nodeDataById: ReadonlyMap<string, VivaldiNodeData>,
-    graphProp: GraphProp,
-    options: Readonly<{ degreeLimit: number }> & Partial<VivaldiConfig>,
+  nodeDataById: ReadonlyMap<string, VivaldiNodeData>,
+  graphProp: GraphProp,
+  options: Readonly<{ degreeLimit: number }> & Partial<VivaldiConfig>,
 ): UndirectedGraph<VertexProp, EdgeProp, GraphProp> {
-    const graph = new UndirectedGraph<VertexProp, EdgeProp, GraphProp>();
-    graph.replaceAttributes(graphProp);
+  const graph = new UndirectedGraph<VertexProp, EdgeProp, GraphProp>();
+  graph.replaceAttributes(graphProp);
 
-    // Canonical id order, never map-insertion order: the same member set has to
-    // produce the same graph on every server, and equal predicted weights are
-    // common enough (co-located or collinear coordinates) that the tie-break
-    // decides real edges. Sorting here also lets the selection tie-break on
-    // node indices instead of comparing ids per candidate.
-    //
-    // compareVertexIds and not localeCompare: collation depends on the runtime's
-    // default locale and ICU data, so servers configured differently could order
-    // the same ids differently, which is exactly the divergence this ordering
-    // exists to remove.
-    const nodes = [...nodeDataById.values()].sort((left, right) =>
-        compareVertexIds(left.id, right.id)
-    );
-    const degreeLimit = Number.isInteger(options.degreeLimit) &&
-            options.degreeLimit > 0
-        ? options.degreeLimit
-        : graphProp.degreeLimitMember;
+  // Canonical id order, never map-insertion order: the same member set has to
+  // produce the same graph on every server, and equal predicted weights are
+  // common enough (co-located or collinear coordinates) that the tie-break
+  // decides real edges. Sorting here also lets the selection tie-break on
+  // node indices instead of comparing ids per candidate.
+  //
+  // compareVertexIds and not localeCompare: collation depends on the runtime's
+  // default locale and ICU data, so servers configured differently could order
+  // the same ids differently, which is exactly the divergence this ordering
+  // exists to remove.
+  const nodes = [...nodeDataById.values()].sort((left, right) =>
+    compareVertexIds(left.id, right.id),
+  );
+  const degreeLimit =
+    Number.isInteger(options.degreeLimit) && options.degreeLimit > 0
+      ? options.degreeLimit
+      : graphProp.degreeLimitMember;
 
-    for (const node of nodes) {
-        upsertPredictedVertex(graph, node.id, graphProp);
-    }
+  for (const node of nodes) {
+    upsertPredictedVertex(graph, node.id, graphProp);
+  }
 
-    const mergedCfg = { ...DEFAULT_VIVALDI_CONFIG, ...options };
-    const selected = selectDegreeCappedEdges({
-        nodeCount: nodes.length,
-        degreeLimit,
-        computeWeight: (sourceIndex, targetIndex) =>
-            computePredictedRttMs(nodes[sourceIndex], nodes[targetIndex], mergedCfg),
-    });
+  const mergedCfg = { ...DEFAULT_VIVALDI_CONFIG, ...options };
+  const selected = selectDegreeCappedEdges({
+    nodeCount: nodes.length,
+    degreeLimit,
+    computeWeight: (sourceIndex, targetIndex) =>
+      computePredictedRttMs(nodes[sourceIndex], nodes[targetIndex], mergedCfg),
+  });
 
-    for (const edge of selected) {
-        upsertPredictedEdge(
-            graph,
-            nodes[edge.sourceIndex].id,
-            nodes[edge.targetIndex].id,
-            edge.weight,
-        );
-    }
+  for (const edge of selected) {
+    upsertPredictedEdge(graph, nodes[edge.sourceIndex].id, nodes[edge.targetIndex].id, edge.weight);
+  }
 
-    return graph;
+  return graph;
 }

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-artifact-reader.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-artifact-reader.ts
@@ -6,10 +6,7 @@ import type {
   RtcBaselineJson,
   RtcBaselineResult,
 } from '../contracts/rtc-baseline-contracts.ts';
-// prettier-ignore
-import {
-  validateRtcBaselineStoredArtifact,
-} from '../contracts/rtc-baseline-artifact-validation.ts';
+import { validateRtcBaselineStoredArtifact } from '../contracts/rtc-baseline-artifact-validation.ts';
 import { decodeRtcBaselineFailureOutcome } from '../acceptance/rtc-baseline-failure-accounting.ts';
 import {
   classifyRtcBaselineArtifactPath,

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-comparison.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-comparison.ts
@@ -10,10 +10,7 @@ import {
   evaluateRtcBaselineWorkloadRepeatOutcome,
   rtcBaselineTriggeredWorkloads,
 } from './rtc-baseline-statistics.ts';
-// prettier-ignore
-import type {
-  RtcBaselineFinalizedArtifactVerifier,
-} from './rtc-baseline-finalized-verification.ts';
+import type { RtcBaselineFinalizedArtifactVerifier } from './rtc-baseline-finalized-verification.ts';
 
 function failed(path: string, code: string, message: string): RtcBaselineResult<never> {
   return { ok: false, issues: [{ path, code, message }] };

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-evidence.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-evidence.ts
@@ -27,9 +27,7 @@ import type {
   RtcBaselineMetricSummary,
 } from './rtc-baseline-statistics.ts';
 import { summarizeRtcBaselineMetricPartitions } from './rtc-baseline-statistics.ts';
-// prettier-ignore
-import { computeRtcBaselineExpectedSampleIdentities } from
-  '../catalog/rtc-baseline-workload-manifest.ts';
+import { computeRtcBaselineExpectedSampleIdentities } from '../catalog/rtc-baseline-workload-manifest.ts';
 import {
   projectRtcBaselineArtifactOutcomes,
   type RtcBaselineArtifactProjection,

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-reader.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-reader.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  createRtcBaselineExternalAttemptReader,
-} from '../catalog/rtc-baseline-workload-manifest.ts';
+import { createRtcBaselineExternalAttemptReader } from '../catalog/rtc-baseline-workload-manifest.ts';
 import type {
   RtcBaselineAttemptLocatorDto,
   RtcBaselineResult,
@@ -20,17 +17,10 @@ import {
   createRtcBaselineFinalizedArtifactVerifier,
   type RtcBaselineFinalizedArtifactVerifier,
 } from './rtc-baseline-finalized-verification.ts';
-// prettier-ignore
 import { createRtcBaselineFinalizedComparisonReader } from './rtc-baseline-finalized-comparison.ts';
-// prettier-ignore
-import type {
-  RtcBaselineFinalizedReaderDependencies,
-} from './rtc-baseline-finalized-artifact-reader.ts';
+import type { RtcBaselineFinalizedReaderDependencies } from './rtc-baseline-finalized-artifact-reader.ts';
 
-// prettier-ignore
-export type {
-  RtcBaselineFinalizedReaderDependencies,
-} from './rtc-baseline-finalized-artifact-reader.ts';
+export type { RtcBaselineFinalizedReaderDependencies } from './rtc-baseline-finalized-artifact-reader.ts';
 export type { RtcBaselineFinalizedArtifactValidation } from './rtc-baseline-evidence-layout.ts';
 export type {
   RtcBaselinePairedComparison,

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-verification.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-finalized-verification.ts
@@ -1,6 +1,4 @@
-// prettier-ignore
-import { computeRtcBaselineExpectedSampleIdentities } from
-  '../catalog/rtc-baseline-workload-manifest.ts';
+import { computeRtcBaselineExpectedSampleIdentities } from '../catalog/rtc-baseline-workload-manifest.ts';
 import type { RtcBaselineResult } from '../contracts/rtc-baseline-contracts.ts';
 import {
   validateRtcBaselineArtifactReconciliation,
@@ -28,10 +26,7 @@ import {
   type RtcBaselineFinalizedReaderDependencies,
   type RtcBaselineReadFinalizedArtifacts,
 } from './rtc-baseline-finalized-artifact-reader.ts';
-// prettier-ignore
-import {
-  validateRtcBaselineArtifactOutcomeReconciliation,
-} from './rtc-baseline-artifact-projection.ts';
+import { validateRtcBaselineArtifactOutcomeReconciliation } from './rtc-baseline-artifact-projection.ts';
 
 export interface RtcBaselineFinalizedArtifactVerifier {
   readVerifiedArtifacts(

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-acceptance.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-acceptance.ts
@@ -1,6 +1,4 @@
-// prettier-ignore
-import { createRtcBaselineEvidenceAcceptance } from
-  '../acceptance/rtc-baseline-evidence-acceptance.ts';
+import { createRtcBaselineEvidenceAcceptance } from '../acceptance/rtc-baseline-evidence-acceptance.ts';
 import {
   RTC_BASELINE_ACCEPTED_ARTIFACT_DIRECTORIES,
   resolveRtcBaselineAcceptedArtifactPath,

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-evidence.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-evidence.ts
@@ -12,9 +12,7 @@ import {
   type RtcBaselineResult,
 } from '../contracts/rtc-baseline-contracts.ts';
 import { requireRtcBaselineDecodedType } from '../contracts/rtc-baseline-decoding.ts';
-// prettier-ignore
-import { validateRtcBaselineReconciliation } from
-  '../contracts/rtc-baseline-artifact-validation.ts';
+import { validateRtcBaselineReconciliation } from '../contracts/rtc-baseline-artifact-validation.ts';
 import {
   createRtcBaselineFileStore,
   type RtcBaselineFileStore,

--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-envelope.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-envelope.ts
@@ -10,9 +10,7 @@ import type {
   RtcBaselineWorkloadId,
 } from '../contracts/rtc-baseline-contracts.ts';
 import { decodeRtcBaselineCaptureRequest } from '../contracts/rtc-baseline-decoding.ts';
-// prettier-ignore
-import type { RtcBaselineEvidenceAcceptance } from
-  '../acceptance/rtc-baseline-evidence-acceptance.ts';
+import type { RtcBaselineEvidenceAcceptance } from '../acceptance/rtc-baseline-evidence-acceptance.ts';
 import type { RtcBaselineFinalizedEvidence } from '../evidence/rtc-baseline-finalized-evidence.ts';
 import type { RtcBaselineFinalizedReader } from '../evidence/rtc-baseline-finalized-reader.ts';
 import { validateRtcBaselineCaptureRequest } from '../contracts/rtc-baseline-validation.ts';

--- a/packages/shared-rtc-bench/diagnostics/rtt-traffic/configure-rtc-rtt-traffic-cache-repositories.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtt-traffic/configure-rtc-rtt-traffic-cache-repositories.ts
@@ -1,7 +1,5 @@
 import { configureOverlayRepository } from '@shared/repository/overlays-repository.ts';
-// prettier-ignore
-import { initialiseRallarServerCacheRepositories } from
-  '@shared-server/rallar-system/cache-repositories.ts';
+import { initialiseRallarServerCacheRepositories } from '@shared-server/rallar-system/cache-repositories.ts';
 
 const MINUTE_MS = 60_000;
 

--- a/packages/shared-rtc-bench/diagnostics/rtt-traffic/rtc-topology-rtt-traffic-metrics.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtt-traffic/rtc-topology-rtt-traffic-metrics.ts
@@ -10,16 +10,10 @@ import {
 } from '@shared/mod.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
-// prettier-ignore
-import * as clientStateSnapshotsRepository from
-  '@shared/repository/client-state-snapshots-repository.ts';
+import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import { initRallarSystemWsTopics } from '@shared-server/rallar-system/ws-system-topics.ts';
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { configureRtcRttTrafficCacheRepositories } from
-  './configure-rtc-rtt-traffic-cache-repositories.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { configureRtcRttTrafficCacheRepositories } from './configure-rtc-rtt-traffic-cache-repositories.ts';
 
 type Args = Readonly<{
   sessions: number;
@@ -211,7 +205,7 @@ function createGroupSnapshot(groupId: string, memberSessionIds: readonly string[
       formationAttemptCount: 0,
       lastFormationOutcome: null,
       establishmentStartedAtEpochMs: null,
-        formationElectorate: [],
+      formationElectorate: [],
     },
     members: memberSessionIds.map((sessionId) => ({
       applicationId,

--- a/packages/shared-rtc-bench/topology-delivery/run-rtc-topology-delivery-log-workloads.ts
+++ b/packages/shared-rtc-bench/topology-delivery/run-rtc-topology-delivery-log-workloads.ts
@@ -1,13 +1,9 @@
-// prettier-ignore
-import { PSqlRtcTopologyDeliveryRepository } from
-  '@shared-server/postgres/rtc-topology/p-sql-rtc-topology-delivery-repository.ts';
+import { PSqlRtcTopologyDeliveryRepository } from '@shared-server/postgres/rtc-topology/p-sql-rtc-topology-delivery-repository.ts';
 import type {
   RtcTopologyDeliveryAppendInput,
   RtcTopologyDeliveryAppendResult,
 } from '@shared-server/rallar-system/topology/replay/rtc-topology-delivery-contracts.ts';
-// prettier-ignore
-import { isRtcTopologyDeliveryRetryableConflict } from
-  '@shared-server/rallar-system/topology/replay/rtc-topology-delivery-validation.ts';
+import { isRtcTopologyDeliveryRetryableConflict } from '@shared-server/rallar-system/topology/replay/rtc-topology-delivery-validation.ts';
 import {
   type BenchmarkSql,
   RTC_TOPOLOGY_DELIVERY_LOG_BENCHMARK_POLICY,

--- a/packages/shared-rtc-bench/topology-replay/replay-drain-operation-counts.ts
+++ b/packages/shared-rtc-bench/topology-replay/replay-drain-operation-counts.ts
@@ -1,8 +1,6 @@
 import { dirname } from 'node:path';
 
-// prettier-ignore
-import type { RtcTopologyDeliveryLogEntry } from
-  '@shared-server/rallar-system/topology/replay/rtc-topology-delivery-contracts.ts';
+import type { RtcTopologyDeliveryLogEntry } from '@shared-server/rallar-system/topology/replay/rtc-topology-delivery-contracts.ts';
 import type {
   RtcTopologyReplayConsumerInput,
   RtcTopologyReplayCursorCasInput,
@@ -48,9 +46,7 @@ export interface RtcTopologyReplayDrainOperationArtifact {
   readonly workloads: Readonly<Record<WorkloadName, RtcTopologyReplayDrainOperationCounts>>;
 }
 
-// prettier-ignore
-export async function runRtcTopologyReplayDrainOperationWorkloads(
-): Promise<RtcTopologyReplayDrainOperationArtifact> {
+export async function runRtcTopologyReplayDrainOperationWorkloads(): Promise<RtcTopologyReplayDrainOperationArtifact> {
   const workloads = {
     caughtUp: await runWorkload({ entryCount: 0, outcome: 'delivered' }),
     entries100: await runWorkload({ entryCount: 100, outcome: 'delivered' }),

--- a/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-close-retention-bench.ts
+++ b/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-close-retention-bench.ts
@@ -11,9 +11,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcDataChannelCloseRetentionInput {
   readonly queueDepth: number;

--- a/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-drain-bench.ts
+++ b/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-drain-bench.ts
@@ -10,9 +10,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 export type RtcDataChannelDrainDepth = 32 | 1000 | 5000;
 const frozenDepthByValue: Readonly<Record<string, RtcDataChannelDrainDepth>> = {

--- a/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-error-reference-bench.ts
+++ b/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-error-reference-bench.ts
@@ -11,9 +11,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcDataChannelErrorReferenceAcceptedArguments {
   readonly mode: 'accepted';

--- a/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-replace-key-bench.ts
+++ b/packages/shared-rtc-bench/workloads/data-channel/rtc-data-channel-replace-key-bench.ts
@@ -10,9 +10,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcDataChannelReplaceKeyInput {
   readonly queueDepth: number;

--- a/packages/shared-rtc-bench/workloads/topology/rtc-room-graph-rtt-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-room-graph-rtt-bench.ts
@@ -1,10 +1,6 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { createDeterministicRtcTopologyGroupSnapshot } from
-  './create-deterministic-rtc-topology-group-snapshot.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { createDeterministicRtcTopologyGroupSnapshot } from './create-deterministic-rtc-topology-group-snapshot.ts';
 
 import {
   rtcBaselineIssue,
@@ -17,9 +13,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 export type RtcRoomGraphRttMode = 'sparse' | 'complete';
 interface RtcRoomGraphRttInput {

--- a/packages/shared-rtc-bench/workloads/topology/rtc-rtt-repository-filter-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-rtt-repository-filter-bench.ts
@@ -1,17 +1,9 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
-// prettier-ignore
-import { validateRtcRttMeasurement }
-  from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
-// prettier-ignore
-import { RtcRttRepository }
-  from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-repository.ts';
-// prettier-ignore
-import { RTC_RTT_LATEST_NAMESPACE }
-  from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-runtime-namespaces.ts';
+import { validateRtcRttMeasurement } from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
+import { RtcRttRepository } from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-repository.ts';
+import { RTC_RTT_LATEST_NAMESPACE } from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-runtime-namespaces.ts';
 
-// prettier-ignore
-import { SyntheticRtcRttRuntimeStateRepository } from
-  './synthetic-rtc-rtt-runtime-state-repository.ts';
+import { SyntheticRtcRttRuntimeStateRepository } from './synthetic-rtc-rtt-runtime-state-repository.ts';
 
 import {
   rtcBaselineIssue,
@@ -23,9 +15,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 export interface RtcRttRepositoryFilterInput {
   readonly roomSessions: number;

--- a/packages/shared-rtc-bench/workloads/topology/rtc-topology-inactive-churn-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-topology-inactive-churn-bench.ts
@@ -1,10 +1,6 @@
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { createDeterministicRtcTopologyGroupSnapshot } from
-  './create-deterministic-rtc-topology-group-snapshot.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { createDeterministicRtcTopologyGroupSnapshot } from './create-deterministic-rtc-topology-group-snapshot.ts';
 
 import {
   rtcBaselineIssue,
@@ -17,9 +13,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 export type RtcTopologyInactiveChurnMode = 'retain' | 'cleanup';
 interface RtcTopologyInactiveChurnInput {

--- a/packages/shared-rtc-bench/workloads/topology/rtc-topology-mesh-no-rtt-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-topology-mesh-no-rtt-bench.ts
@@ -1,9 +1,5 @@
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { createDeterministicRtcTopologyGroupSnapshot } from
-  './create-deterministic-rtc-topology-group-snapshot.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { createDeterministicRtcTopologyGroupSnapshot } from './create-deterministic-rtc-topology-group-snapshot.ts';
 
 import {
   rtcBaselineIssue,
@@ -16,9 +12,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcTopologyMeshInput {
   readonly sessions: number;

--- a/packages/shared-rtc-bench/workloads/topology/rtc-topology-star-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-topology-star-bench.ts
@@ -1,9 +1,5 @@
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { createDeterministicRtcTopologyGroupSnapshot } from
-  './create-deterministic-rtc-topology-group-snapshot.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { createDeterministicRtcTopologyGroupSnapshot } from './create-deterministic-rtc-topology-group-snapshot.ts';
 
 import {
   rtcBaselineIssue,
@@ -16,9 +12,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcTopologyStarInput {
   readonly sessions: number;

--- a/packages/shared-rtc-bench/workloads/topology/rtc-topology-tree-no-rtt-bench.ts
+++ b/packages/shared-rtc-bench/workloads/topology/rtc-topology-tree-no-rtt-bench.ts
@@ -1,9 +1,5 @@
-// prettier-ignore
-import { RallarRtcTopologyService } from
-  '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { createDeterministicRtcTopologyGroupSnapshot } from
-  './create-deterministic-rtc-topology-group-snapshot.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { createDeterministicRtcTopologyGroupSnapshot } from './create-deterministic-rtc-topology-group-snapshot.ts';
 
 import {
   rtcBaselineIssue,
@@ -16,9 +12,7 @@ import {
   parseRtcBaselineOneTokenOptions,
 } from '../../baseline/command/rtc-baseline-cli-options.ts';
 import { validateRtcBaselineId } from '../../baseline/contracts/rtc-baseline-validation.ts';
-// prettier-ignore
-import { runRtcBaselineAcceptedWorkerSamples } from
-  '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
+import { runRtcBaselineAcceptedWorkerSamples } from '../../baseline/acceptance/rtc-baseline-failure-accounting.ts';
 
 interface RtcTopologyTreeInput {
   readonly sessions: number;

--- a/packages/shared-server/mod.ts
+++ b/packages/shared-server/mod.ts
@@ -16,12 +16,8 @@ export { hashAuthSecret } from './rallar-system/auth/credentials/hash-auth-secre
 export * from './rallar-system/auth/persistence/auth-user-repository.ts';
 export * from './rallar-system/client-state/persistence/client-state-repository.ts';
 export * from './rallar-system/repositories/GroupStateRepository.ts';
-// prettier-ignore
-export { GroupTopologyConfigRepository }
-  from './rallar-system/topology/config/persistence/group-topology-config-repository.ts';
-// prettier-ignore
-export { GroupTopologyConfigRepositoryInvariantCorruptionError }
-  from './rallar-system/topology/config/persistence/group-topology-config-repository-contracts.ts';
+export { GroupTopologyConfigRepository } from './rallar-system/topology/config/persistence/group-topology-config-repository.ts';
+export { GroupTopologyConfigRepositoryInvariantCorruptionError } from './rallar-system/topology/config/persistence/group-topology-config-repository-contracts.ts';
 export type {
   GroupTopologyConfigCommitResult,
   GroupTopologyConfigDeleteResult,
@@ -50,10 +46,7 @@ export * from './rallar-system/repositories/RtcTopologyExecutionRepository.ts';
 export * from './rallar-system/repositories/StateEventStore.ts';
 export * from './rallar-system/pubsub/QueueBoxPubSubBridge.ts';
 export * from './rallar-system/pubsub/RtcTopologyClusterTransport.ts';
-// prettier-ignore
-export {
-  ClientMutationRejectedError,
-} from './rallar-system/client-state/client-state-validation-primitives.ts';
+export { ClientMutationRejectedError } from './rallar-system/client-state/client-state-validation-primitives.ts';
 export {
   toClientMutationIssuedSessionAuthority,
   toClientMutationSystemAuthority,
@@ -67,24 +60,15 @@ export {
   toUpsertInstanceCommandInput,
   toUpsertPrincipalCommandInput,
 } from './rallar-system/client-state/mutation/client-mutation-command.ts';
-// prettier-ignore
-export {
-  ClientMutationIdempotencyConflictError,
-} from './rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts';
+export { ClientMutationIdempotencyConflictError } from './rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts';
 export { createClientStateService } from './rallar-system/client-state/client-state-service.ts';
 export {
   requiresClientWrite,
   toClientMutationReceipt,
   toClientStateWritten,
 } from './rallar-system/client-state/client-state-service-contracts.ts';
-// prettier-ignore
-export type {
-  ClientMutationPersistedFacts,
-} from './rallar-system/client-state/mutation/client-mutation-command.ts';
-// prettier-ignore
-export type {
-  ClientMutationReceipt,
-} from './rallar-system/client-state/mutation/client-mutation-contracts.ts';
+export type { ClientMutationPersistedFacts } from './rallar-system/client-state/mutation/client-mutation-command.ts';
+export type { ClientMutationReceipt } from './rallar-system/client-state/mutation/client-mutation-contracts.ts';
 export type {
   ClientMutationWritten,
   ClientStateService,
@@ -110,10 +94,7 @@ export {
   AUTH_STATE_APP_INBOX_TOPIC,
   toAuthAppInboxType,
 } from './rallar-system/auth/inbox/auth-app-inbox-routing.ts';
-// prettier-ignore
-export {
-  AppClientInboxService,
-} from './rallar-system/client-state/inbox/app-client-inbox-service.ts';
+export { AppClientInboxService } from './rallar-system/client-state/inbox/app-client-inbox-service.ts';
 export type {
   ClientAuthorisedWsSessionConnectAppInboxPayload,
   ClientAuthorisedWsSessionDisconnectAppInboxPayload,

--- a/packages/shared-server/postgres/rallar-system/createStateRepositories.ts
+++ b/packages/shared-server/postgres/rallar-system/createStateRepositories.ts
@@ -1,117 +1,111 @@
 import { AuthSessionRepository } from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
 import { AuthUserRepository } from '@shared-server/rallar-system/repositories/AuthUserRepository.ts';
 import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-// prettier-ignore
-import {
-    GroupStateRepository,
-} from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
+import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import type {
-    ClientStateEventStore,
-    GroupStateEventStore,
+  ClientStateEventStore,
+  GroupStateEventStore,
 } from '@shared-server/rallar-system/repositories/StateEventStore.ts';
 import type { RuntimeStateRepositoryLike } from '@shared-server/runtime-state/RuntimeStateRepository.ts';
 import type { PSqlSql } from '../PostgresSqlClient.ts';
 import { PSqlRuntimeStateRepository } from '../runtime-state/PSqlRuntimeStateRepository.ts';
 import {
-    PSqlClientStateEventRepository,
-    PSqlGroupStateEventRepository,
+  PSqlClientStateEventRepository,
+  PSqlGroupStateEventRepository,
 } from './PSqlStateEventRepository.ts';
 
-export function createRuntimeStateRepository(
-    sql: PSqlSql,
-): PSqlRuntimeStateRepository {
-    return new PSqlRuntimeStateRepository(sql);
+export function createRuntimeStateRepository(sql: PSqlSql): PSqlRuntimeStateRepository {
+  return new PSqlRuntimeStateRepository(sql);
 }
 
 export function createClientStateRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): ClientStateRepository {
-    const runtimeRepository = toRuntimeStateRepository(input);
-    return new ClientStateRepository(runtimeRepository, {
-        events: maybeCreateClientStateEventRepository(input),
-    });
+  const runtimeRepository = toRuntimeStateRepository(input);
+  return new ClientStateRepository(runtimeRepository, {
+    events: maybeCreateClientStateEventRepository(input),
+  });
 }
 
 export function createAuthSessionRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): AuthSessionRepository {
-    return new AuthSessionRepository(toRuntimeStateRepository(input));
+  return new AuthSessionRepository(toRuntimeStateRepository(input));
 }
 
 export function createAuthUserRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): AuthUserRepository {
-    return new AuthUserRepository(toRuntimeStateRepository(input));
+  return new AuthUserRepository(toRuntimeStateRepository(input));
 }
 
 export function createGroupStateRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): GroupStateRepository {
-    const runtimeRepository = toRuntimeStateRepository(input);
-    return new GroupStateRepository(runtimeRepository, {
-        events: maybeCreateGroupStateEventRepository(input),
-    });
+  const runtimeRepository = toRuntimeStateRepository(input);
+  return new GroupStateRepository(runtimeRepository, {
+    events: maybeCreateGroupStateEventRepository(input),
+  });
 }
 
 export function createClientStateEventRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): ClientStateEventStore {
-    return new PSqlClientStateEventRepository(toSql(input));
+  return new PSqlClientStateEventRepository(toSql(input));
 }
 
 export function createGroupStateEventRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): GroupStateEventStore {
-    return new PSqlGroupStateEventRepository(toSql(input));
+  return new PSqlGroupStateEventRepository(toSql(input));
 }
 
-function toRuntimeStateRepository(input: RuntimeStateRepositoryLike | PSqlSql): RuntimeStateRepositoryLike {
-    if (isRuntimeStateRepositoryLike(input)) {
-        return input;
-    }
+function toRuntimeStateRepository(
+  input: RuntimeStateRepositoryLike | PSqlSql,
+): RuntimeStateRepositoryLike {
+  if (isRuntimeStateRepositoryLike(input)) {
+    return input;
+  }
 
-    return createRuntimeStateRepository(input);
+  return createRuntimeStateRepository(input);
 }
 
 function toSql(input: RuntimeStateRepositoryLike | PSqlSql): PSqlSql {
-    if (input instanceof PSqlRuntimeStateRepository) {
-        return input.sql;
-    }
+  if (input instanceof PSqlRuntimeStateRepository) {
+    return input.sql;
+  }
 
-    if (!isRuntimeStateRepositoryLike(input)) {
-        return input;
-    }
+  if (!isRuntimeStateRepositoryLike(input)) {
+    return input;
+  }
 
-    throw new Error(
-        'A SQL-backed state event repository requires PSqlSql or PSqlRuntimeStateRepository',
-    );
+  throw new Error(
+    'A SQL-backed state event repository requires PSqlSql or PSqlRuntimeStateRepository',
+  );
 }
 
 function maybeCreateClientStateEventRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): ClientStateEventStore | undefined {
-    return canCreateSqlStateEventRepository(input)
-        ? createClientStateEventRepository(input)
-        : undefined;
+  return canCreateSqlStateEventRepository(input)
+    ? createClientStateEventRepository(input)
+    : undefined;
 }
 
 function maybeCreateGroupStateEventRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): GroupStateEventStore | undefined {
-    return canCreateSqlStateEventRepository(input)
-        ? createGroupStateEventRepository(input)
-        : undefined;
+  return canCreateSqlStateEventRepository(input)
+    ? createGroupStateEventRepository(input)
+    : undefined;
 }
 
-function canCreateSqlStateEventRepository(
-    input: RuntimeStateRepositoryLike | PSqlSql,
-): boolean {
-    return input instanceof PSqlRuntimeStateRepository ||
-        !isRuntimeStateRepositoryLike(input);
+function canCreateSqlStateEventRepository(input: RuntimeStateRepositoryLike | PSqlSql): boolean {
+  return input instanceof PSqlRuntimeStateRepository || !isRuntimeStateRepositoryLike(input);
 }
 
 function isRuntimeStateRepositoryLike(
-    input: RuntimeStateRepositoryLike | PSqlSql,
+  input: RuntimeStateRepositoryLike | PSqlSql,
 ): input is RuntimeStateRepositoryLike {
-    return typeof (input as RuntimeStateRepositoryLike).findEntry === 'function';
+  return typeof (input as RuntimeStateRepositoryLike).findEntry === 'function';
 }

--- a/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
@@ -10,14 +10,8 @@ import { Either } from '@shared/resilience/Either.ts';
 import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import type { PSqlSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import type {
-  ResourceInboxRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
-// prettier-ignore
-import type {
-  ResourceInboxResultsRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import type { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
+import type { ResourceInboxResultsRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
 import type { AuthMutationService } from '../auth-mutation-service.ts';
 import type { AuthCredentialIssuer } from '../credentials/auth-credential-issuer.ts';
 import { hashAuthSecret } from '../credentials/hash-auth-secret.ts';

--- a/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import type {
-  AppInboxMutationTransactionWriter,
-} from '@shared-server/rallar-system/services/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/services/app-inbox-transaction-writer.ts';
 
 import type { AuthCredentialIssuer } from '../credentials/auth-credential-issuer.ts';
 import type { AuthMutationService } from '../auth-mutation-service.ts';

--- a/packages/shared-server/rallar-system/auth/mutation/validate/auth-mutation-validation.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/validate/auth-mutation-validation.ts
@@ -1,11 +1,5 @@
-// prettier-ignore
-import type {
-  RuntimeStateEntryValue,
-} from '../../../../runtime-state/RuntimeStateJsonStore.ts';
-// prettier-ignore
-import {
-  validateRuntimeStateExpiredAuthority,
-} from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
+import type { RuntimeStateEntryValue } from '../../../../runtime-state/RuntimeStateJsonStore.ts';
+import { validateRuntimeStateExpiredAuthority } from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
 import type { PersistedAuthSession } from '../../persistence/auth-persistence-contracts.ts';
 import { authSessionKey, authTokenDigestKey } from '../../persistence/auth-storage-keys.ts';
 import type {

--- a/packages/shared-server/rallar-system/auth/mutation/validate/validate-auth-agent-ticket-mutation.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/validate/validate-auth-agent-ticket-mutation.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  validateRuntimeStateExpiredAuthority,
-} from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
+import { validateRuntimeStateExpiredAuthority } from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
 import { authTicketDigestKey } from '../../persistence/auth-storage-keys.ts';
 import type {
   AuthMutationCommand,

--- a/packages/shared-server/rallar-system/auth/mutation/validate/validate-auth-ticket-mutation.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/validate/validate-auth-ticket-mutation.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  validateRuntimeStateExpiredAuthority,
-} from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
+import { validateRuntimeStateExpiredAuthority } from '../../../../runtime-state/RuntimeStateExpiredEntry.ts';
 import { authTicketDigestKey } from '../../persistence/auth-storage-keys.ts';
 import type {
   AuthMutationCommand,

--- a/packages/shared-server/rallar-system/auth/mutation/write/write-auth-mutation.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/write/write-auth-mutation.ts
@@ -1,12 +1,6 @@
 import type { PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '@shared-server/postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  requireConditionalWrite,
-} from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
+import { PSqlRuntimeStateRepository } from '@shared-server/postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { requireConditionalWrite } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import { AuthSessionRepository } from '../../persistence/auth-session-repository.ts';
 import { AuthUserRepository } from '../../persistence/auth-user-repository.ts';
 import type { AuthMutationComputed, AuthMutationResult } from '../auth-mutation-contracts.ts';

--- a/packages/shared-server/rallar-system/auth/mutation/write/write-auth-session.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/write/write-auth-session.ts
@@ -1,12 +1,6 @@
 import type { PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
-// prettier-ignore
-import {
-  requireConditionalWrite,
-} from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
+import { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
+import { requireConditionalWrite } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import type { AuthSessionRepository } from '../../persistence/auth-session-repository.ts';
 import { requireIssueSessionLifecycle } from '../../sessions/require-issue-session-lifecycle.ts';
 import type {

--- a/packages/shared-server/rallar-system/auth/mutation/write/write-auth-ticket-mutation.ts
+++ b/packages/shared-server/rallar-system/auth/mutation/write/write-auth-ticket-mutation.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  requireConditionalWrite,
-} from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
+import { requireConditionalWrite } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import type { AuthSessionRepository } from '../../persistence/auth-session-repository.ts';
 import { requireAuthTicket } from '../validate/auth-mutation-validation.ts';
 import type { AuthMutationComputed, AuthMutationRead } from '../auth-mutation-contracts.ts';

--- a/packages/shared-server/rallar-system/client-state/client-state-service-contracts.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service-contracts.ts
@@ -9,19 +9,13 @@ import type {
 } from '@shared/api/client-types.ts';
 import type { StateEventPage } from '@shared/api/state-event-types.ts';
 import { Either } from '@shared/resilience/Either.ts';
-// prettier-ignore
-import type {
-  RuntimeStateOptimisticTransactionalRepositoryLike,
-} from '../../runtime-state/RuntimeStateRepository.ts';
+import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../runtime-state/RuntimeStateRepository.ts';
 import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
 import type { ClientSessionExpiryCandidate } from '../repositories/session-expiry.ts';
 import type { ClientStateEventStore } from '../repositories/StateEventStore.ts';
 import type { PersistedAuthSession } from '../auth/persistence/auth-persistence-contracts.ts';
 import type { StateEventListQuery } from '../state-event-listing.ts';
-// prettier-ignore
-import {
-  assertNeverClientMutationComputed,
-} from './mutation/compute/compute-client-mutation-result.ts';
+import { assertNeverClientMutationComputed } from './mutation/compute/compute-client-mutation-result.ts';
 import type {
   ClientMutationCommand,
   ClientMutationComputed,
@@ -29,10 +23,7 @@ import type {
   ClientMutationRead,
   ClientMutationReceipt,
 } from './mutation/client-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  WsSessionGenerationLifecycleService,
-} from '../services/ws-session-generation-lifecycle.ts';
+import type { WsSessionGenerationLifecycleService } from '../services/ws-session-generation-lifecycle.ts';
 
 export type RegisterAuthorisedWsClientInput = Readonly<{
   applicationId?: string;

--- a/packages/shared-server/rallar-system/client-state/client-state-service.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service.ts
@@ -14,10 +14,7 @@ import {
   type ClientStateServiceDependencies,
 } from './client-state-service-contracts.ts';
 import { createTimedClientStateService } from './client-state-service-timing.ts';
-// prettier-ignore
-import {
-  createWsSessionGenerationLifecycleService,
-} from '../services/ws-session-generation-lifecycle.ts';
+import { createWsSessionGenerationLifecycleService } from '../services/ws-session-generation-lifecycle.ts';
 
 export function createClientStateService(
   dependencies: ClientStateServiceDependencies,

--- a/packages/shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts
@@ -5,10 +5,7 @@ import {
 } from '@shared/api/state-types.ts';
 import type { IssuedAuthSession } from '../../repositories/AuthSessionRepository.ts';
 import type { RegisterAuthorisedWsClientInput } from '../client-state-service-contracts.ts';
-// prettier-ignore
-import {
-  toClientMutationIssuedSessionAuthority,
-} from '../mutation/client-mutation-authority.ts';
+import { toClientMutationIssuedSessionAuthority } from '../mutation/client-mutation-authority.ts';
 import type { AppInboxEnqueueInput } from '../../services/AppInboxService.ts';
 import { AppInboxType } from '../../services/AppInboxService.ts';
 import type {

--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -1,10 +1,7 @@
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import type { PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
 import type { AppInboxMessageContext } from '../../services/app-inbox-contracts.ts';
-// prettier-ignore
-import type {
-  AppInboxMutationTransactionWriter,
-} from '../../services/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '../../services/app-inbox-transaction-writer.ts';
 import {
   type WsSessionGenerationFacts,
   type WsSessionGenerationLifecycleComputed,
@@ -22,10 +19,7 @@ import type {
   ClientMutationCommandInput,
   ClientMutationComputed,
 } from '../mutation/client-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateClientMutationAuthorityPolicy,
-} from '../mutation/result-validation/validate-client-mutation-authority-policy.ts';
+import { validateClientMutationAuthorityPolicy } from '../mutation/result-validation/validate-client-mutation-authority-policy.ts';
 import {
   type ClientStateMutationService,
   type ClientStateService,

--- a/packages/shared-server/rallar-system/client-state/mutation/client-mutation-command.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/client-mutation-command.ts
@@ -20,10 +20,7 @@ import type {
   ClientMutationCommandInput,
   ClientMutationFacts,
 } from './client-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateClientMutationCommand,
-} from './command-validation/validate-client-mutation-command.ts';
+import { validateClientMutationCommand } from './command-validation/validate-client-mutation-command.ts';
 
 export type ClientMutationPersistedFacts = Omit<ClientMutationFacts, 'commandHash'>;
 

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-read.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-read.ts
@@ -18,10 +18,7 @@ import {
 } from '../../client-state-validation-primitives.ts';
 import { sameClientPrincipalRef } from '../../client-state-semantic-equality.ts';
 import type { ClientMutationCommand, ClientMutationRead } from '../client-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateClientExpiredSessionAuthority,
-} from '../validate-client-expired-session-authority.ts';
+import { validateClientExpiredSessionAuthority } from '../validate-client-expired-session-authority.ts';
 
 export function validateClientMutationRead(
   command: ClientMutationCommand,

--- a/packages/shared-server/rallar-system/client-state/mutation/validate-client-expired-session-authority.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/validate-client-expired-session-authority.ts
@@ -1,8 +1,5 @@
 import type { ClientPrincipalRef } from '@shared/api/client-types.ts';
-// prettier-ignore
-import {
-  validateRuntimeStateExpiredAuthority,
-} from '@shared-server/runtime-state/RuntimeStateExpiredEntry.ts';
+import { validateRuntimeStateExpiredAuthority } from '@shared-server/runtime-state/RuntimeStateExpiredEntry.ts';
 import type { RuntimeStateEntry } from '@shared-server/runtime-state/RuntimeStateRepository.ts';
 import { clientStateSessionStorageKey } from '../persistence/client-state-storage-keys.ts';
 

--- a/packages/shared-server/rallar-system/client-state/mutation/write/write-client-mutation.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/write/write-client-mutation.ts
@@ -1,12 +1,6 @@
-// prettier-ignore
-import {
-  requireConditionalWrite,
-} from '../../../../runtime-state/optimistic-runtime-state-write.ts';
+import { requireConditionalWrite } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { PSqlTransactionSql } from '../../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '../../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxRepository } from '../../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import { ClientStateRepository } from '../../persistence/client-state-repository.ts';
 import type {
   ClientMutationComputedWrite,

--- a/packages/shared-server/rallar-system/client-state/persistence/assemble-client-state-snapshot.ts
+++ b/packages/shared-server/rallar-system/client-state/persistence/assemble-client-state-snapshot.ts
@@ -13,10 +13,7 @@ import {
   compareClientStateSessionStorageKeys,
   clientStatePrincipalStorageKey,
 } from './client-state-storage-keys.ts';
-// prettier-ignore
-import {
-  ClientStateRepositoryInvariantCorruptionError,
-} from './client-state-persistence-contracts.ts';
+import { ClientStateRepositoryInvariantCorruptionError } from './client-state-persistence-contracts.ts';
 
 export type ClientStateSnapshotAssemblyInput = Readonly<{
   principal: ClientPrincipal;

--- a/packages/shared-server/rallar-system/client-state/persistence/client-state-repository.ts
+++ b/packages/shared-server/rallar-system/client-state/persistence/client-state-repository.ts
@@ -9,18 +9,9 @@ import type {
 } from '@shared/api/client-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
-// prettier-ignore
-import type {
-  PSqlTransactionSql,
-} from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  PSqlClientStateEventRepository,
-} from '../../../postgres/rallar-system/PSqlStateEventRepository.ts';
+import type { PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
+import { PSqlRuntimeStateRepository } from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { PSqlClientStateEventRepository } from '../../../postgres/rallar-system/PSqlStateEventRepository.ts';
 import type {
   RuntimeStateConditionalDeleteResult,
   RuntimeStateConditionalWriteResult,
@@ -58,10 +49,7 @@ export type {
   ClientPrincipalSnapshotRead,
   ClientStateRepositoryOptions,
 } from './client-state-persistence-contracts.ts';
-// prettier-ignore
-export {
-  ClientStateRepositoryInvariantCorruptionError,
-} from './client-state-persistence-contracts.ts';
+export { ClientStateRepositoryInvariantCorruptionError } from './client-state-persistence-contracts.ts';
 
 export function createTransactionBoundClientStateRepository(
   transaction: PSqlTransactionSql,

--- a/packages/shared-server/rallar-system/client-state/persistence/validate-persisted-client-state.ts
+++ b/packages/shared-server/rallar-system/client-state/persistence/validate-persisted-client-state.ts
@@ -14,10 +14,7 @@ import {
   validateClientPrincipal,
   validateClientSession,
 } from '../client-state-contract-validation.ts';
-// prettier-ignore
-import {
-  validateClientMutationIdempotencyRecordValue,
-} from '../client-mutation-receipt-validation.ts';
+import { validateClientMutationIdempotencyRecordValue } from '../client-mutation-receipt-validation.ts';
 import { rejectClientMutation } from '../client-state-validation-primitives.ts';
 import { sameClientPrincipalRef } from '../client-state-semantic-equality.ts';
 import type { ClientMutationIdempotencyRecord } from './client-state-persistence-contracts.ts';

--- a/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
+++ b/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
@@ -5,10 +5,8 @@ import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
 
 import type { PSqlSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
 import type { ResourceInboxRepository } from '../../../postgres/resource-inbox/\
 ResourceInboxRepository.ts';
-// prettier-ignore
 import type { ResourceInboxResultsRepository } from '../../../postgres/resource-inbox/\
 ResourceInboxResultsRepository.ts';
 import type { AppInboxFailure } from '../../services/app-inbox-failure.ts';

--- a/packages/shared-server/rallar-system/crdt/persistence/psql-crdt-mutation-repository.ts
+++ b/packages/shared-server/rallar-system/crdt/persistence/psql-crdt-mutation-repository.ts
@@ -9,7 +9,6 @@ import {
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import type { PSqlSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
 import { ResourceInboxRepository } from '../../../postgres/resource-inbox/\
 ResourceInboxRepository.ts';
 import {

--- a/packages/shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts
+++ b/packages/shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts
@@ -34,11 +34,7 @@ import {
   type RallarCrdtServerTrustedMetadata,
   type RallarCrdtServerWsTopicInstaller,
 } from './rallar-crdt-server-contracts.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  validateRallarCrdtServerLiveEnvelope,
-} from './validate-rallar-crdt-server-live-envelope.ts';
+import { validateRallarCrdtServerLiveEnvelope } from './validate-rallar-crdt-server-live-envelope.ts';
 
 interface RallarCrdtEnvelopeByKind {
   readonly update: RallarCrdtUpdateEnvelope;

--- a/packages/shared-server/rallar-system/group-policy.ts
+++ b/packages/shared-server/rallar-system/group-policy.ts
@@ -10,19 +10,12 @@ import type {
   GroupPolicyResult,
 } from '@shared/api/group-policy-types.ts';
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
 import {
   resolveGroupLifecycleManagers,
   toGroupLifecycleElectionKey,
 } from '@shared/api/group-lifecycle/resolve-group-lifecycle-managers.ts';
-// prettier-ignore
-import type {
-    GroupLifecycleTransition,
-} from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
-// prettier-ignore
-import {
-    computeGroupLifecycleTransition,
-} from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
+import type { GroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
+import { computeGroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 
 export type GroupPolicyActor = Readonly<{
   principalId?: string;

--- a/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
@@ -1,12 +1,8 @@
 import { Temporal } from '@js-temporal/polyfill';
 
 import type { Group, GroupRef } from '@shared/api/group-types.ts';
-// prettier-ignore
-import {
-  computeFormationRetryBackoffMs,
-} from '@shared/api/group-lifecycle/evaluate-group-activation-criterion.ts';
+import { computeFormationRetryBackoffMs } from '@shared/api/group-lifecycle/evaluate-group-activation-criterion.ts';
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
 import type {
   GroupLifecycleTransitionOperation,
   GroupMutationCommand,
@@ -18,11 +14,7 @@ import { fnv1a64 } from '@shared/queuebox/AppQueueIdentity.ts';
 import { AppOutboxType } from '../services/AppOutboxService.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
-// prettier-ignore
-import {
-  toAppQueueCreatedBy,
-  toAppQueueKey,
-} from '../services/app-inbox-queue-key.ts';
+import { toAppQueueCreatedBy, toAppQueueKey } from '../services/app-inbox-queue-key.ts';
 import { groupStateGroupStorageKey } from './persistence/group-state-storage-keys.ts';
 
 export const APP_OUTBOX_FORMATION_TIMER_TOPIC = 'app-outbox.formation-timer';

--- a/packages/shared-server/rallar-system/group-state/group-mutation-authority.ts
+++ b/packages/shared-server/rallar-system/group-state/group-mutation-authority.ts
@@ -18,10 +18,7 @@ import {
   type GroupMutationCommand,
   type GroupMutationFacts,
 } from './mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateGroupMutationCommand,
-} from './mutation/command-validation/validate-group-mutation-command.ts';
+import { validateGroupMutationCommand } from './mutation/command-validation/validate-group-mutation-command.ts';
 import { hashMutationCommand, type JsonWireValue } from '../services/mutation-command-identity.ts';
 import {
   toAggregateMutationCommand,

--- a/packages/shared-server/rallar-system/group-state/group-mutation-command.ts
+++ b/packages/shared-server/rallar-system/group-state/group-mutation-command.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  toNormalizedGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
+import { toNormalizedGroupLifecyclePolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import {
   DEFAULT_RALLAR_GROUP_DIRECTOR_HEARTBEAT_TTL_MS,
   normalizeRallarGroupDirectorHeartbeatTtlMs,

--- a/packages/shared-server/rallar-system/group-state/group-state-service-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/group-state-service-contracts.ts
@@ -30,10 +30,7 @@ import type { StateEventPage } from '@shared/api/state-event-types.ts';
 import type { Either } from '@shared/resilience/Either.ts';
 
 import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import type {
-  RuntimeStateOptimisticTransactionalRepositoryLike,
-} from '../../runtime-state/RuntimeStateRepository.ts';
+import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../runtime-state/RuntimeStateRepository.ts';
 import type { AuthSessionRepository } from '../repositories/AuthSessionRepository.ts';
 import type { PersistedAuthSession } from '../auth/persistence/auth-persistence-contracts.ts';
 import type { IssuedAuthSession } from '../auth/persistence/auth-session-types.ts';
@@ -50,10 +47,7 @@ import type {
 } from './mutation/group-mutation-contracts.ts';
 import type { GroupSessionCleanupInput } from './presence/group-session-cleanup.ts';
 import type { RallarTimingSink } from '../services/timing.ts';
-// prettier-ignore
-import type {
-  WsSessionGenerationLifecycleService,
-} from '../services/ws-session-generation-lifecycle.ts';
+import type { WsSessionGenerationLifecycleService } from '../services/ws-session-generation-lifecycle.ts';
 
 export type GroupWritten = Readonly<{
   snapshot: GroupSnapshot;

--- a/packages/shared-server/rallar-system/group-state/group-state-service.ts
+++ b/packages/shared-server/rallar-system/group-state/group-state-service.ts
@@ -4,17 +4,11 @@ import type {
 } from './mutation/group-mutation-contracts.ts';
 import { computeGroupMutation } from './mutation/orchestration/compute-group-mutation.ts';
 import { validateGroupMutation } from './mutation/state-validation/validate-group-mutation.ts';
-// prettier-ignore
-import {
-  validateGroupMutationCommand,
-} from './mutation/command-validation/validate-group-mutation-command.ts';
+import { validateGroupMutationCommand } from './mutation/command-validation/validate-group-mutation-command.ts';
 import { GroupStateRepository } from './persistence/group-state-repository.ts';
 import { readGroupMutation } from './mutation/read/read-group-mutation.ts';
 import { writeGroupMutation } from './mutation/write/write-group-mutation.ts';
-// prettier-ignore
-import {
-  createWsSessionGenerationLifecycleService,
-} from '../services/ws-session-generation-lifecycle.ts';
+import { createWsSessionGenerationLifecycleService } from '../services/ws-session-generation-lifecycle.ts';
 import { readGroupSessionCleanupCandidates } from './presence/group-session-cleanup.ts';
 import { hashMutationCommand, type JsonWireValue } from '../services/mutation-command-identity.ts';
 import { sha256CanonicalJson } from './mutation/group-state-crypto.ts';
@@ -42,11 +36,7 @@ export class GroupMutationIdempotencyConflictError extends Error {
   readonly existingCommandHash: string;
   readonly receivedCommandHash: string;
 
-  constructor(
-    commandId: string,
-    existingCommandHash: string,
-    receivedCommandHash: string,
-  ) {
+  constructor(commandId: string, existingCommandHash: string, receivedCommandHash: string) {
     super(`Group mutation command differs for request ${commandId}`);
     this.commandId = commandId;
     this.existingCommandHash = existingCommandHash;

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
@@ -1,21 +1,15 @@
-// prettier-ignore
-import { createTransactionBoundGroupStateRepository } from
-  '../persistence/group-state-repository.ts';
+import { createTransactionBoundGroupStateRepository } from '../persistence/group-state-repository.ts';
 import {
   type InactiveGroupPresenceResult,
   processGroupPresenceConnect,
 } from '../presence/group-presence-service.ts';
 import type { AppInboxMessageContext } from '../../services/AppInboxService.ts';
-// prettier-ignore
-import type { AppInboxMutationTransactionWriter } from
-  '../../services/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '../../services/app-inbox-transaction-writer.ts';
 import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
-// prettier-ignore
 import type {
   WsSessionGenerationLifecycleComputed,
   WsSessionGenerationLifecycleService,
-} from
-  '../../services/ws-session-generation-lifecycle.ts';
+} from '../../services/ws-session-generation-lifecycle.ts';
 import { GroupMutationAuthorizationError } from '../group-mutation-authority.ts';
 import type {
   GroupMutationPreparation,
@@ -23,7 +17,6 @@ import type {
   GroupStateMutationService,
   GroupStateService,
 } from '../group-state-service-contracts.ts';
-// prettier-ignore
 import type {
   GroupFormationGroupMutationSink,
   GroupFormationMutationOutcome,

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-aggregate-mutation.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  validateGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
+import { validateGroupLifecyclePolicy } from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
 import {
   createRallarGroupDirectorAppointment,
   mergeRallarGroupDirectorMetadata,

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-lifecycle-transition.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-lifecycle-transition.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  createDefaultGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import {
   computeGroupLifecycleTransition,
   type GroupLifecycleTransition,
@@ -13,10 +10,7 @@ import {
   GroupPolicyDeniedError,
 } from '../../../group-policy.ts';
 import { GroupMutationRejectedError } from '../group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  computeFormationTimerEntries,
-} from '../../formation-timer-outbox-entry.ts';
+import { computeFormationTimerEntries } from '../../formation-timer-outbox-entry.ts';
 import type {
   GroupLifecycleTransitionOperation,
   GroupMutationCommand,

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -19,14 +19,8 @@ import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { GroupPolicyCapacityConfig } from '../../group-policy.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
 import type { RuntimeStateEntry } from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import type {
-  InitialGroupPresenceSummaryCandidate,
-} from '../presence/group-initial-presence-summary.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicyRead,
-} from '../persistence/group-lifecycle-policy-repository.ts';
+import type { InitialGroupPresenceSummaryCandidate } from '../presence/group-initial-presence-summary.ts';
+import type { GroupLifecyclePolicyRead } from '../persistence/group-lifecycle-policy-repository.ts';
 
 type NullableActorInput = Readonly<{
   actorPrincipalId: string | null;

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
@@ -9,10 +9,7 @@ import type {
 } from '@shared/api/group-types.ts';
 import { toGroupSnapshotStateRevision } from '@shared/api/group-client-views.ts';
 import type { MutationActor } from '@shared/api/mutation-actor.ts';
-// prettier-ignore
-import {
-  computeGroupPresenceSummaryEntry,
-} from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
+import { computeGroupPresenceSummaryEntry } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
 
 import type {
@@ -27,10 +24,7 @@ import type {
   PresenceGuardCandidate,
 } from './group-mutation-contracts.ts';
 import { GroupMutationRejectedError } from './group-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  InitialGroupPresenceSummaryCandidate,
-} from '../presence/group-initial-presence-summary.ts';
+import type { InitialGroupPresenceSummaryCandidate } from '../presence/group-initial-presence-summary.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 const DEFAULT_GROUP_JOIN_CODE_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
@@ -132,7 +126,7 @@ export function computeGroupMutationWriteResult(
     idempotency: toGroupMutationIdempotency(command, facts, receipt),
     outboxEntries,
     lifecyclePolicy:
-      command.operation === 'createGroup' ? command.input.lifecyclePolicy ?? null : null,
+      command.operation === 'createGroup' ? (command.input.lifecyclePolicy ?? null) : null,
   };
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-admission-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/membership/compute-group-admission-mutation.ts
@@ -1,16 +1,7 @@
 import type { GroupMember } from '@shared/api/group-types.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
-import {
-  computeGroupAdmissionDecision,
-} from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
-// prettier-ignore
-import {
-  createDefaultGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import { computeGroupAdmissionDecision } from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import {
   canActivateGroupMember,
   canDecideGroupAdmission,

--- a/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts
@@ -5,10 +5,7 @@ import type {
   GroupMutationIdempotencyProbe,
   GroupMutationRead,
 } from '../group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateGroupMutationCommand,
-} from '../command-validation/validate-group-mutation-command.ts';
+import { validateGroupMutationCommand } from '../command-validation/validate-group-mutation-command.ts';
 import { validateGroupMutationRead } from '../state-validation/validate-group-mutation-read.ts';
 import {
   computeCreate,
@@ -16,10 +13,7 @@ import {
   computeRotateJoinCode,
   computeUpdate,
 } from '../aggregate/compute-group-aggregate-mutation.ts';
-// prettier-ignore
-import {
-  computeLifecycleTransition,
-} from '../aggregate/compute-lifecycle-transition.ts';
+import { computeLifecycleTransition } from '../aggregate/compute-lifecycle-transition.ts';
 import {
   computeGovernedMember,
   computeInvite,

--- a/packages/shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts
@@ -1,11 +1,7 @@
 import { readRallarGroupDirectorAppointment } from '@shared/api/group-director.ts';
 import { GroupStateRepository } from '../../persistence/group-state-repository.ts';
-// prettier-ignore
-import type {
-  GroupStateMutationExactReadResult,
-} from '../../persistence/read-exact-group-state-mutation.ts';
+import type { GroupStateMutationExactReadResult } from '../../persistence/read-exact-group-state-mutation.ts';
 import type { GroupMutationCommand, GroupMutationRead } from '../group-mutation-contracts.ts';
-// prettier-ignore
 import {
   isGroupAdmissionDecisionOperation,
   isGroupAdmissionPolicyReadOperation,

--- a/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation-write.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/result-validation/validate-computed-group-mutation-write.ts
@@ -1,8 +1,5 @@
 import type { MutationActor } from '@shared/api/mutation-actor.ts';
-// prettier-ignore
-import {
-  computeGroupPresenceSummaryEntry,
-} from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
+import { computeGroupPresenceSummaryEntry } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
 import { jsonEquals } from '@shared/repository/state-utils.ts';
 
 import type {
@@ -15,10 +12,7 @@ import {
   resolveGroupMutationTargetPrincipalId,
   resolveGroupMutationTargetSessionId,
 } from '../orchestration/resolve-group-mutation-target-identity.ts';
-// prettier-ignore
-import {
-  isPureLeaseRenewalHeartbeat,
-} from '../presence/compute-group-presence-mutation.ts';
+import { isPureLeaseRenewalHeartbeat } from '../presence/compute-group-presence-mutation.ts';
 import {
   validateGroupMutationIdempotencyRecord,
   validateMutationReceipt,
@@ -32,10 +26,7 @@ import {
   validatePresenceSession,
   validatePresenceSummaryValue,
 } from '../../persistence/validate-persisted-group-presence.ts';
-// prettier-ignore
-import {
-  validateInitialGroupPresenceSummaryCandidate,
-} from '../../presence/group-initial-presence-summary.ts';
+import { validateInitialGroupPresenceSummaryCandidate } from '../../presence/group-initial-presence-summary.ts';
 import {
   assertExactKeys,
   assertRequiredKeys,
@@ -43,17 +34,10 @@ import {
   requireOneOf,
 } from '../../group-state-validation-primitives.ts';
 import { validateGroupEvent } from '../../../persisted-group-event.ts';
-// prettier-ignore
-import {
-  createDefaultGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { Group } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-// prettier-ignore
-import {
-  computeFormationTimerEntries,
-} from '../../formation-timer-outbox-entry.ts';
-// prettier-ignore
+import { computeFormationTimerEntries } from '../../formation-timer-outbox-entry.ts';
 import {
   isGroupLifecycleTransitionOperation,
   type GroupLifecycleTransitionOperation,

--- a/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation-read.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation-read.ts
@@ -10,12 +10,8 @@ import {
   groupStatePresenceSessionStorageKey,
   groupStatePresenceSummaryStorageKey,
 } from '../../persistence/group-state-storage-keys.ts';
-// prettier-ignore
-import {
-  validateGroupExpiredStateAuthority,
-} from '../../presence/group-expired-state-authority.ts';
+import { validateGroupExpiredStateAuthority } from '../../presence/group-expired-state-authority.ts';
 import type { GroupMutationCommand, GroupMutationRead } from '../group-mutation-contracts.ts';
-// prettier-ignore
 import {
   isGroupAdmissionDecisionOperation,
   isGroupAdmissionPolicyReadOperation,
@@ -25,10 +21,7 @@ import {
   resolveGroupMutationReadIdentities,
   type GroupMutationReadIdentities,
 } from '../read/resolve-group-mutation-read-identities.ts';
-// prettier-ignore
-import {
-  validateGroupMutationIdempotencyRecord,
-} from '../result-validation/validate-group-mutation-result.ts';
+import { validateGroupMutationIdempotencyRecord } from '../result-validation/validate-group-mutation-result.ts';
 import {
   requireOneOf,
   assertExactKeys,

--- a/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/state-validation/validate-group-mutation.ts
@@ -6,10 +6,7 @@ import type {
   GroupMutationFacts,
   GroupMutationRead,
 } from '../group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateGroupMutationCommand,
-} from '../command-validation/validate-group-mutation-command.ts';
+import { validateGroupMutationCommand } from '../command-validation/validate-group-mutation-command.ts';
 import { validateGroupMutationRead } from './validate-group-mutation-read.ts';
 import {
   computeGroupMutation,

--- a/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import {
-  GroupLifecyclePolicyRepository,
-} from '../../persistence/group-lifecycle-policy-repository.ts';
+import { GroupLifecyclePolicyRepository } from '../../persistence/group-lifecycle-policy-repository.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
 import {
@@ -29,19 +26,10 @@ import {
   groupStateUpdatePresenceDescriptor,
   groupStateUpdatePresenceSummaryDescriptor,
 } from '../../persistence/group-state-write-descriptors.ts';
-// prettier-ignore
-import {
-  createTransactionBoundGroupStateRepository,
-} from '../../persistence/group-state-repository.ts';
+import { createTransactionBoundGroupStateRepository } from '../../persistence/group-state-repository.ts';
 import type { PSqlTransactionSql } from '../../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '../../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '../../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import { PSqlRuntimeStateRepository } from '../../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { ResourceInboxRepository } from '../../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import type {
   GroupMutationComputedWrite,
   GroupMutationReceipt,

--- a/packages/shared-server/rallar-system/group-state/persistence/group-aggregate-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-aggregate-repository.ts
@@ -10,15 +10,9 @@ import {
   RuntimeStateJsonStore,
   type RuntimeStateEntryValue,
 } from '../../../runtime-state/RuntimeStateJsonStore.ts';
-// prettier-ignore
-import type {
-  RuntimeStateGuardedBatchUpdate,
-} from '../../../runtime-state/RuntimeStateGuardedBatch.ts';
+import type { RuntimeStateGuardedBatchUpdate } from '../../../runtime-state/RuntimeStateGuardedBatch.ts';
 import type { GroupMutationIdempotencyRecord } from '../mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateGroupMutationIdempotencyRecord,
-} from '../mutation/result-validation/validate-group-mutation-result.ts';
+import { validateGroupMutationIdempotencyRecord } from '../mutation/result-validation/validate-group-mutation-result.ts';
 import { validatePersistedGroupEvent } from '../../persisted-group-event.ts';
 import type { GroupStateEventStore } from '../../repositories/StateEventStore.ts';
 import { filterStateEventsForList, type StateEventListQuery } from '../../state-event-listing.ts';
@@ -43,10 +37,7 @@ import { validatePersistedGroup } from './validate-persisted-group.ts';
 export class GroupAggregateRepository extends RuntimeStateJsonStore {
   private readonly events: GroupStateEventStore;
 
-  constructor(
-    repository: RuntimeStateRepositoryLike,
-    events: GroupStateEventStore,
-  ) {
+  constructor(repository: RuntimeStateRepositoryLike, events: GroupStateEventStore) {
     super(repository);
     this.events = events;
   }

--- a/packages/shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts
@@ -1,8 +1,5 @@
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
-import {
-  validateGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
+import { validateGroupLifecyclePolicy } from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 
 import { RuntimeStateJsonStore } from '../../../runtime-state/RuntimeStateJsonStore.ts';
@@ -57,19 +54,18 @@ export class GroupLifecyclePolicyRepository extends RuntimeStateJsonStore {
     return validateGroupLifecyclePolicy(stored.policy).fold<GroupLifecyclePolicyRead>(
       (issues) => ({
         status: 'corrupt',
-        reason: 'stored policy is no longer coherent: ' +
-          issues.map((issue) => issue.code).join(', '),
+        reason:
+          'stored policy is no longer coherent: ' + issues.map((issue) => issue.code).join(', '),
       }),
       (policy) => ({ status: 'present', policy }),
     );
   }
 
   async writePolicy(ref: GroupRef, policy: GroupLifecyclePolicy): Promise<void> {
-    await this.putValue(
-      GROUP_LIFECYCLE_POLICIES_NAMESPACE,
-      groupStateGroupStorageKey(ref),
-      { groupRef: ref, policy } satisfies StoredGroupLifecyclePolicy,
-    );
+    await this.putValue(GROUP_LIFECYCLE_POLICIES_NAMESPACE, groupStateGroupStorageKey(ref), {
+      groupRef: ref,
+      policy,
+    } satisfies StoredGroupLifecyclePolicy);
   }
 }
 

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
@@ -10,14 +10,8 @@ import type {
 import type { StateEventPage } from '@shared/api/state-event-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import type { PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  PSqlGroupStateEventRepository,
-} from '../../../postgres/rallar-system/PSqlStateEventRepository.ts';
+import { PSqlRuntimeStateRepository } from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { PSqlGroupStateEventRepository } from '../../../postgres/rallar-system/PSqlStateEventRepository.ts';
 import type {
   RuntimeStateConditionalDeleteResult,
   RuntimeStateConditionalWriteResult,
@@ -43,7 +37,6 @@ export function createTransactionBoundGroupStateRepository(
   });
 }
 
-// prettier-ignore
 import {
   GroupLifecyclePolicyRepository,
   type GroupLifecyclePolicyRead,

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-write-descriptors.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-write-descriptors.ts
@@ -22,10 +22,7 @@ import {
   groupStatePresenceSessionStorageKey,
 } from './group-state-storage-keys.ts';
 import { type GroupMutationIdempotencyRecord } from '../mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  validateGroupMutationIdempotencyRecord,
-} from '../mutation/result-validation/validate-group-mutation-result.ts';
+import { validateGroupMutationIdempotencyRecord } from '../mutation/result-validation/validate-group-mutation-result.ts';
 import {
   validatePersistedGroup,
   validatePersistedGroupMember,

--- a/packages/shared-server/rallar-system/group-state/persistence/read-group-state-authority.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/read-group-state-authority.ts
@@ -8,10 +8,7 @@ import {
   isRuntimeStateReadBatchRepositoryLike,
   type RuntimeStateReadBatchSelector,
 } from '../../../runtime-state/RuntimeStateReadBatch.ts';
-// prettier-ignore
-import {
-  resolveRuntimeStateReadBatchLiveValues,
-} from '../../../runtime-state/RuntimeStateReadBatchLiveValues.ts';
+import { resolveRuntimeStateReadBatchLiveValues } from '../../../runtime-state/RuntimeStateReadBatchLiveValues.ts';
 import { groupStateGroupStorageKey } from './group-state-storage-keys.ts';
 import {
   GROUPS_NAMESPACE,

--- a/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/compute-group-presence-summary.ts
@@ -13,14 +13,8 @@ import {
   groupStateGroupStorageKey,
   groupStatePresenceSummaryStorageKey,
 } from '../persistence/group-state-storage-keys.ts';
-// prettier-ignore
-import {
-  validateRuntimeEntryValue,
-} from '../mutation/state-validation/validate-group-mutation-read.ts';
-// prettier-ignore
-import {
-  presenceAdmissionIdentity,
-} from '../mutation/presence/compute-group-presence-admission.ts';
+import { validateRuntimeEntryValue } from '../mutation/state-validation/validate-group-mutation-read.ts';
+import { presenceAdmissionIdentity } from '../mutation/presence/compute-group-presence-admission.ts';
 import { validateStoredGroup } from '../persistence/validate-persisted-group.ts';
 import { validatePresenceSummaryValue } from '../persistence/validate-persisted-group-presence.ts';
 import {
@@ -29,10 +23,7 @@ import {
   requireJsonSafe,
   requirePositiveSafeInteger,
 } from '../group-state-validation-primitives.ts';
-// prettier-ignore
-import {
-  validateGroupPresenceSummaryReadCollections,
-} from './validate-group-presence-summary-read-collections.ts';
+import { validateGroupPresenceSummaryReadCollections } from './validate-group-presence-summary-read-collections.ts';
 
 export type GroupPresenceSummaryRead = Readonly<{
   group: RuntimeStateEntryValue<Group>;

--- a/packages/shared-server/rallar-system/group-state/presence/group-expired-state-authority.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-expired-state-authority.ts
@@ -1,9 +1,6 @@
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RuntimeStateEntry } from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  validateRuntimeStateExpiredAuthority,
-} from '../../../runtime-state/RuntimeStateExpiredEntry.ts';
+import { validateRuntimeStateExpiredAuthority } from '../../../runtime-state/RuntimeStateExpiredEntry.ts';
 import {
   groupStateGroupStorageKey,
   groupStatePresenceSessionStorageKey,

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -15,10 +15,7 @@ import type {
   WsSessionGenerationLifecycleService,
   WsSessionHighWaterIdentity,
 } from '../../services/ws-session-generation-lifecycle.ts';
-// prettier-ignore
-import type {
-  GroupPresenceSessionCleanupAppInboxPayload,
-} from './group-presence-session-cleanup-app-inbox-payload.ts';
+import type { GroupPresenceSessionCleanupAppInboxPayload } from './group-presence-session-cleanup-app-inbox-payload.ts';
 
 type WriteMutation = <Result>(
   write: (transaction: PSqlTransactionSql) => Promise<Result>,

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import type {
-  ClientAuthorisedWsSessionConnectAppInboxPayload,
-} from '../../client-state/inbox/app-client-inbox-contracts.ts';
+import type { ClientAuthorisedWsSessionConnectAppInboxPayload } from '../../client-state/inbox/app-client-inbox-contracts.ts';
 
 export interface GroupPresenceSessionCleanupAppInboxPayload {
   readonly connection: ClientAuthorisedWsSessionConnectAppInboxPayload;

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts
@@ -10,27 +10,15 @@ import type {
 } from '@shared/api/group-types.ts';
 import type { GroupStateDeltaEnvelope } from '@shared/api/group-state-delta.ts';
 import { jsonEquals } from '@shared/repository/state-utils.ts';
-// prettier-ignore
-import type {
-  GroupPresenceSummaryWorkData,
-} from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
-// prettier-ignore
-import {
-  toCanonicalGroupTopologyConfigPatch,
-} from '@shared/api/group-topology-config-canonical.ts';
+import type { GroupPresenceSummaryWorkData } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
 import { requireConditionalWrite } from '../../../runtime-state/optimistic-runtime-state-write.ts';
-// prettier-ignore
-import type {
-  RuntimeStateOptimisticTransactionalRepositoryLike,
-} from '../../../runtime-state/RuntimeStateRepository.ts';
+import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../../runtime-state/RuntimeStateRepository.ts';
 import type { PSqlSql, PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
 import { runInTransaction } from '../../../postgres/run-in-transaction.ts';
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxRepository } from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import {
   createTransactionBoundGroupStateRepository,
   GroupStateRepository,
@@ -56,7 +44,6 @@ import {
   CoalescedAppOutboxWorkService,
   type ComputedCoalescedAppOutboxWork,
 } from '../../services/CoalescedAppOutboxWorkService.ts';
-// prettier-ignore
 import {
   computeCoalescedRtcTopologyGroupRevisionWork,
   toRtcTopologyCoalescedGroupRevisionResourceId,
@@ -64,14 +51,8 @@ import {
 import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '../../services/rtc-topology-outbox-entry.ts';
 import { toAppQueueKey } from '../../services/app-inbox-queue-key.ts';
 import { groupStateGroupStorageKey } from '../persistence/group-state-storage-keys.ts';
-// prettier-ignore
-import type {
-  GroupFormationPresenceSummarySink,
-} from '../../formation-metrics.ts';
-// prettier-ignore
-import {
-  decodeCanonicalGroupPresenceSummaryWork,
-} from './decode-canonical-group-presence-summary-work.ts';
+import type { GroupFormationPresenceSummarySink } from '../../formation-metrics.ts';
+import { decodeCanonicalGroupPresenceSummaryWork } from './decode-canonical-group-presence-summary-work.ts';
 
 export type GroupPresenceSummaryTopologyIntent =
   | Readonly<{

--- a/packages/shared-server/rallar-system/group-state/presence/validate-group-presence-summary-read-collections.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/validate-group-presence-summary-read-collections.ts
@@ -1,9 +1,6 @@
 import type { GroupPresenceSession, GroupRef } from '@shared/api/group-types.ts';
 
-// prettier-ignore
-import {
-  validateRuntimeEntryValue,
-} from '../mutation/state-validation/validate-group-mutation-read.ts';
+import { validateRuntimeEntryValue } from '../mutation/state-validation/validate-group-mutation-read.ts';
 import {
   groupStateMemberStorageKey,
   groupStatePresenceAdmissionStorageKey,

--- a/packages/shared-server/rallar-system/group-state/snapshot/validate-persisted-group-snapshot.ts
+++ b/packages/shared-server/rallar-system/group-state/snapshot/validate-persisted-group-snapshot.ts
@@ -5,10 +5,7 @@ import {
   validatePersistedGroup,
   validatePersistedGroupMember,
 } from '../persistence/validate-persisted-group.ts';
-// prettier-ignore
-import {
-  validatePersistedGroupPresenceSession,
-} from '../persistence/validate-persisted-group-presence.ts';
+import { validatePersistedGroupPresenceSession } from '../persistence/validate-persisted-group-presence.ts';
 
 type PersistedSnapshotRecord = Record<string, unknown>;
 

--- a/packages/shared-server/rallar-system/rtc-topology/inbox/rtc-rtt-app-inbox-authority.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/inbox/rtc-rtt-app-inbox-authority.ts
@@ -3,10 +3,7 @@ import type { GroupStateService } from '../../group-state/group-state-service-co
 import { validateRtcRttMeasurement } from '../persistence/rtc-rtt-persistence-validation.ts';
 import { toRtcRttMutationReceiptId } from '../mutation/rtc-rtt-mutation-identifiers.ts';
 import { hashCanonicalCommand } from '../../services/canonical-command-hash.ts';
-// prettier-ignore
-import {
-  createTopologyMutationAuthorityProof,
-} from '../../topology/inbox/topology-mutation-authority-proof.ts';
+import { createTopologyMutationAuthorityProof } from '../../topology/inbox/topology-mutation-authority-proof.ts';
 import type { AppInboxEnqueueInput } from '../../services/AppInboxService.ts';
 import { AppInboxType } from '../../services/AppInboxService.ts';
 import {

--- a/packages/shared-server/rallar-system/rtc-topology/inbox/rtc-rtt-app-inbox-contracts.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/inbox/rtc-rtt-app-inbox-contracts.ts
@@ -3,14 +3,8 @@ import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
 import type { RtcRttRepository } from '../persistence/rtc-rtt-repository.ts';
-// prettier-ignore
-import type {
-  GroupFormationRttMutationSink,
-} from '../../formation-metrics.ts';
-// prettier-ignore
-import type {
-  TopologyMutationAuthorityProof,
-} from '../../topology/inbox/topology-mutation-authority-proof.ts';
+import type { GroupFormationRttMutationSink } from '../../formation-metrics.ts';
+import type { TopologyMutationAuthorityProof } from '../../topology/inbox/topology-mutation-authority-proof.ts';
 
 export type RtcRttAppInboxCommand = Readonly<{
   actor: Readonly<{ principalId: string; sessionId: string }>;

--- a/packages/shared-server/rallar-system/rtc-topology/mutation/validate-rtc-rtt-write-candidate.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/mutation/validate-rtc-rtt-write-candidate.ts
@@ -1,8 +1,6 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
-// prettier-ignore
-import * as snapshotValidation
-    from '../../group-state/snapshot/validate-persisted-group-snapshot.ts';
+import * as snapshotValidation from '../../group-state/snapshot/validate-persisted-group-snapshot.ts';
 import {
   compareRtcTopologyIdentifiers,
   toCanonicalRtcTopologyGroupIdentity,

--- a/packages/shared-server/rallar-system/rtc-topology/mutation/write-rtc-rtt-mutation.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/mutation/write-rtc-rtt-mutation.ts
@@ -1,20 +1,12 @@
-// prettier-ignore
-import { toCanonicalGroupTopologyConfigPatch }
-    from '@shared/api/group-topology-config-canonical.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import { PSqlRuntimeStateRepository }
-    from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import { RuntimeStateWriteConflictError }
-    from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { PSqlRuntimeStateRepository } from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 
 import { RtcRttRepository } from '../persistence/rtc-rtt-repository.ts';
 import { RTC_RTT_MUTATION_RETENTION_MS } from '../persistence/rtc-rtt-persistence-validation.ts';
 import { validateRtcRttWriteCandidate } from './validate-rtc-rtt-write-candidate.ts';
-// prettier-ignore
-import { writeRtcTopologyOutbox }
-    from '../../services/rtc-topology-outbox-entry.ts';
+import { writeRtcTopologyOutbox } from '../../services/rtc-topology-outbox-entry.ts';
 import type { RtcRttMutationComputed } from './rtc-rtt-mutation-contracts.ts';
 
 export async function writeRtcRttMutation(

--- a/packages/shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-receipt-cleanup.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-receipt-cleanup.ts
@@ -1,13 +1,7 @@
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
-// prettier-ignore
-import type { RuntimeStateOptimisticTransactionalRepositoryLike }
-    from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import { isRuntimeStateOptimisticTransactionalRepositoryLike }
-    from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import { RuntimeStateWriteConflictError }
-    from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../../runtime-state/RuntimeStateRepository.ts';
+import { isRuntimeStateOptimisticTransactionalRepositoryLike } from '../../../runtime-state/RuntimeStateRepository.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import { RtcTopologyRepositoryInvariantCorruptionError } from '../../rtc-topology-errors.ts';
 import { compareRtcTopologyIdentifiers } from '../../rtc-topology-identifiers.ts';
 import type { RtcRttMutationReceipt } from './rtc-rtt-persistence-contracts.ts';

--- a/packages/shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-repository.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-repository.ts
@@ -8,9 +8,7 @@ import type {
   RuntimeStateEntryPageOptions,
   RuntimeStateRepositoryLike,
 } from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import { RuntimeStateWriteConflictError }
-    from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { RtcRttMutationLifecycleFacts } from '../mutation/rtc-rtt-mutation-contracts.ts';
 import type {
   RtcRttEndpointAdmission,

--- a/packages/shared-server/rallar-system/rtc-topology/policy/read-rtc-rtt-expired-authority.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/policy/read-rtc-rtt-expired-authority.ts
@@ -2,9 +2,7 @@ import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/RuntimeStateJsonStore.ts';
 import type { RuntimeStateEntry } from '../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import { validateRuntimeStateExpiredAuthority }
-    from '../../../runtime-state/RuntimeStateExpiredEntry.ts';
+import { validateRuntimeStateExpiredAuthority } from '../../../runtime-state/RuntimeStateExpiredEntry.ts';
 import {
   compareRtcTopologyIdentifiers,
   toCanonicalRtcTopologyGroupIdentity,
@@ -13,9 +11,7 @@ import {
   toRtcRttEndpointAdmissionStorageKey,
   toRtcRttMeasurementStorageKey,
 } from '../persistence/rtc-rtt-storage-keys.ts';
-// prettier-ignore
-import type { RtcRttEndpointAdmission }
-    from '../persistence/rtc-rtt-persistence-contracts.ts';
+import type { RtcRttEndpointAdmission } from '../persistence/rtc-rtt-persistence-contracts.ts';
 
 export interface RtcRttExpiredAuthority {
   readonly admissionByEndpoint: ReadonlyMap<

--- a/packages/shared-server/rallar-system/rtc-topology/topic/init-rtc-rtt-topic.ts
+++ b/packages/shared-server/rallar-system/rtc-topology/topic/init-rtc-rtt-topic.ts
@@ -4,9 +4,7 @@ import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-// prettier-ignore
-import * as groupStateSnapshotsRepository
-  from '@shared/repository/group-state-snapshots-repository.ts';
+import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
 import * as rttRepository from '@shared/repository/rtt-repository.ts';
 import type { WsQueueBoxServerService } from '@shared/services/WsQueueBoxServerService.ts';
 import type { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
@@ -18,9 +16,7 @@ import type { RtcRttRefinementGate } from './rtc-rtt-refinement-gate.ts';
 
 import type { RtcTopologyRuntimeState } from '../../ws-rtc-topology-runtime.ts';
 import type { RtcTopologyWorkPublisher } from '../../services/RtcTopologyOutboxWork.ts';
-// prettier-ignore
-import type { GroupTopologyGroupSnapshotReader }
-  from '../../topology/group-topology-management-service.ts';
+import type { GroupTopologyGroupSnapshotReader } from '../../topology/group-topology-management-service.ts';
 import type { RallarRtcTopologyService } from '../../services/rallar-rtc-topology-service.ts';
 import {
   evaluateRtcRttMeasurement,

--- a/packages/shared-server/rallar-system/services/AppAdminInboxService.ts
+++ b/packages/shared-server/rallar-system/services/AppAdminInboxService.ts
@@ -5,19 +5,11 @@ import {
 } from '@shared/api/admin-operations-types.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { Either } from '@shared/resilience/Either.ts';
-// prettier-ignore
-import {
-  TryWithExhaustedError,
-  TryWithPolicy,
-  tryWithPolicy,
-} from '@shared/resilience/TryWith.ts';
+import { TryWithExhaustedError, TryWithPolicy, tryWithPolicy } from '@shared/resilience/TryWith.ts';
 import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { PSqlSql } from '../../postgres/PostgresSqlClient.ts';
 import { ResourceInboxRepository } from '../../postgres/resource-inbox/ResourceInboxRepository.ts';
-// prettier-ignore
-import {
-  ResourceInboxResultsRepository,
-} from '../../postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import { ResourceInboxResultsRepository } from '../../postgres/resource-inbox/ResourceInboxResultsRepository.ts';
 import {
   type AdminPruneAppData,
   type AdminPruneCommand,

--- a/packages/shared-server/rallar-system/services/AppGroupInboxService.ts
+++ b/packages/shared-server/rallar-system/services/AppGroupInboxService.ts
@@ -5,51 +5,31 @@ import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import type { PSqlSql } from '../../postgres/PostgresSqlClient.ts';
 import { ResourceInboxRepository } from '../../postgres/resource-inbox/ResourceInboxRepository.ts';
-// prettier-ignore
-import {
-  ResourceInboxResultsRepository,
-} from '../../postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import { ResourceInboxResultsRepository } from '../../postgres/resource-inbox/ResourceInboxResultsRepository.ts';
 import { GroupMutationAuthorizationError } from '../group-state/group-mutation-authority.ts';
 import type { GroupStateService } from '../group-state/group-state-service-contracts.ts';
-// prettier-ignore
-import type {
-  GroupFormationGroupMutationSink,
-} from '../formation-metrics.ts';
+import type { GroupFormationGroupMutationSink } from '../formation-metrics.ts';
 import { GroupStateInboxHandler } from '../group-state/inbox/group-state-inbox-handler.ts';
-// prettier-ignore
-import { toGroupMutationDescriptor } from
-  '../group-state/inbox/to-group-mutation-descriptor.ts';
+import { toGroupMutationDescriptor } from '../group-state/inbox/to-group-mutation-descriptor.ts';
 import {
   GROUP_MUTATION_INBOX_TYPES,
   isAuthenticatedGroupMutationEnqueue,
 } from '../group-state/inbox/group-state-inbox-contracts.ts';
-// prettier-ignore
-import type {
-  GroupPresenceSessionCleanupAppInboxPayload,
-} from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
+import type { GroupPresenceSessionCleanupAppInboxPayload } from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
 import {
   processGroupSessionCleanup,
   toExpiredPresenceEnqueue,
   toGroupSessionCleanupEnqueue,
 } from '../group-state/presence/group-presence-service.ts';
-// prettier-ignore
-import type {
-  GroupMutationCommand,
-} from '../group-state/mutation/group-mutation-contracts.ts';
+import type { GroupMutationCommand } from '../group-state/mutation/group-mutation-contracts.ts';
 import type { IssuedAuthSession } from '../auth/persistence/auth-session-types.ts';
-// prettier-ignore
-import type {
-  RtcRttAppInboxDependencies,
-} from '../rtc-topology/inbox/rtc-rtt-app-inbox-contracts.ts';
+import type { RtcRttAppInboxDependencies } from '../rtc-topology/inbox/rtc-rtt-app-inbox-contracts.ts';
 import { RtcRttAppInboxHandler } from '../rtc-topology/inbox/rtc-rtt-app-inbox-handler.ts';
 import {
   TopologyAppInboxHandler,
   type TopologyAppInboxMutationOwners,
 } from '../topology/inbox/topology-app-inbox-handler.ts';
-// prettier-ignore
-import type {
-  GroupTopologyManagementService,
-} from '../topology/group-topology-management-service.ts';
+import type { GroupTopologyManagementService } from '../topology/group-topology-management-service.ts';
 import {
   type AppInboxEnqueueInput,
   type AppInboxFailure,
@@ -91,10 +71,7 @@ export {
   type GroupUpdateAppInboxPayload,
 } from '../group-state/inbox/group-state-inbox-contracts.ts';
 
-// prettier-ignore
-export type {
-  GroupPresenceSessionCleanupAppInboxPayload,
-} from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
+export type { GroupPresenceSessionCleanupAppInboxPayload } from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
 
 export type {
   CreateTopologyAppInboxCommandInput,

--- a/packages/shared-server/rallar-system/services/RtcTopologyOutboxWork.ts
+++ b/packages/shared-server/rallar-system/services/RtcTopologyOutboxWork.ts
@@ -1,11 +1,7 @@
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
-// prettier-ignore
-import type { CanonicalGroupTopologyConfigPatch }
-    from '@shared/api/graph-topology-management-types.ts';
-// prettier-ignore
-import { toCanonicalGroupTopologyConfigPatch }
-    from '@shared/api/group-topology-config-canonical.ts';
+import type { CanonicalGroupTopologyConfigPatch } from '@shared/api/graph-topology-management-types.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { readGroupStateRevision } from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';

--- a/packages/shared-server/rallar-system/services/app-group-ws-session-lifecycle.ts
+++ b/packages/shared-server/rallar-system/services/app-group-ws-session-lifecycle.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-export type {
-  GroupPresenceSessionCleanupAppInboxPayload,
-} from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
+export type { GroupPresenceSessionCleanupAppInboxPayload } from '../group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
 export {
   processGroupPresenceConnect,
   processGroupSessionCleanup,

--- a/packages/shared-server/rallar-system/services/app-inbox-command-wire.ts
+++ b/packages/shared-server/rallar-system/services/app-inbox-command-wire.ts
@@ -1,9 +1,7 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { readCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
-// prettier-ignore
-import { validateRtcRttMeasurement }
-  from '../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
+import { validateRtcRttMeasurement } from '../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
 import { hashCanonicalCommand } from './canonical-command-hash.ts';
 import {
   serializeCanonicalMutationCommand,

--- a/packages/shared-server/rallar-system/services/client-expired-state-authority.ts
+++ b/packages/shared-server/rallar-system/services/client-expired-state-authority.ts
@@ -1,4 +1,1 @@
-// prettier-ignore
-export {
-  validateClientExpiredSessionAuthority,
-} from '../client-state/mutation/validate-client-expired-session-authority.ts';
+export { validateClientExpiredSessionAuthority } from '../client-state/mutation/validate-client-expired-session-authority.ts';

--- a/packages/shared-server/rallar-system/services/client-state-mutations.ts
+++ b/packages/shared-server/rallar-system/services/client-state-mutations.ts
@@ -18,26 +18,11 @@ export type {
   ClientMutationReceipt,
 } from '../client-state/persistence/client-state-persistence-contracts.ts';
 export { ClientMutationRejectedError } from '../client-state/client-state-validation-primitives.ts';
-// prettier-ignore
-export {
-  validateClientMutationCommand,
-} from '../client-state/mutation/command-validation/validate-client-mutation-command.ts';
-// prettier-ignore
-export {
-  validateClientMutationRequest,
-} from '../client-state/mutation/command-validation/validate-client-mutation-request.ts';
-// prettier-ignore
-export {
-  computeClientMutation,
-} from '../client-state/mutation/compute/compute-client-mutation.ts';
-// prettier-ignore
-export {
-  assertNeverClientMutationComputed,
-} from '../client-state/mutation/compute/compute-client-mutation-result.ts';
-// prettier-ignore
-export {
-  validateClientMutationAuthorityPolicy,
-} from '../client-state/mutation/result-validation/validate-client-mutation-authority-policy.ts';
+export { validateClientMutationCommand } from '../client-state/mutation/command-validation/validate-client-mutation-command.ts';
+export { validateClientMutationRequest } from '../client-state/mutation/command-validation/validate-client-mutation-request.ts';
+export { computeClientMutation } from '../client-state/mutation/compute/compute-client-mutation.ts';
+export { assertNeverClientMutationComputed } from '../client-state/mutation/compute/compute-client-mutation-result.ts';
+export { validateClientMutationAuthorityPolicy } from '../client-state/mutation/result-validation/validate-client-mutation-authority-policy.ts';
 export {
   ClientMutationIdempotencyConflictError,
   validateClientMutation,

--- a/packages/shared-server/rallar-system/services/client-state-service.ts
+++ b/packages/shared-server/rallar-system/services/client-state-service.ts
@@ -1,5 +1,4 @@
 export { createClientStateService } from '../client-state/client-state-service.ts';
-// prettier-ignore
 export { ClientMutationIdempotencyConflictError } from '../client-state/mutation/result-validation/validate-client-mutation.ts';
 export { ClientMutationRejectedError } from '../client-state/client-state-validation-primitives.ts';
 export {
@@ -20,10 +19,7 @@ export {
   toClientMutationReceipt,
   toClientStateWritten,
 } from '../client-state/client-state-service-contracts.ts';
-// prettier-ignore
-export type {
-  ClientMutationPersistedFacts,
-} from '../client-state/mutation/client-mutation-command.ts';
+export type { ClientMutationPersistedFacts } from '../client-state/mutation/client-mutation-command.ts';
 export type { ClientMutationReceipt } from '../client-state/mutation/client-mutation-contracts.ts';
 export type {
   ClientMutationWritten,

--- a/packages/shared-server/rallar-system/services/group-state-mutations.ts
+++ b/packages/shared-server/rallar-system/services/group-state-mutations.ts
@@ -44,10 +44,7 @@ export {
   validatePersistedGroupPresenceSession,
   validatePersistedGroupPresenceSummary,
 } from '../group-state/persistence/validate-persisted-group-presence.ts';
-// prettier-ignore
-export {
-  validateGroupMutationIdempotencyRecord,
-} from '../group-state/mutation/result-validation/validate-group-mutation-result.ts';
+export { validateGroupMutationIdempotencyRecord } from '../group-state/mutation/result-validation/validate-group-mutation-result.ts';
 export {
   compareGroupCausalRevision,
   computeGroupPresenceSummary,

--- a/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
+++ b/packages/shared-server/rallar-system/services/rallar-rtc-topology-service.ts
@@ -51,15 +51,9 @@ export interface RtcTopologyKindHysteresisWidths {
   readonly treeExitWidth: number;
 }
 
-// prettier-ignore
-export {
-  planRallarRtcTopologySnapshot,
-} from '../topology/planning/plan-rallar-rtc-topology-snapshot.ts';
+export { planRallarRtcTopologySnapshot } from '../topology/planning/plan-rallar-rtc-topology-snapshot.ts';
 
-// prettier-ignore
-export type {
-  RallarRtcTopologyRttQueueResult,
-} from '../topology/runtime/rtc-topology-rtt-rebuild-scheduler.ts';
+export type { RallarRtcTopologyRttQueueResult } from '../topology/runtime/rtc-topology-rtt-rebuild-scheduler.ts';
 
 const DEFAULT_RTT_REBUILD_DEBOUNCE_MS = 250;
 

--- a/packages/shared-server/rallar-system/services/rtc-topology-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/services/rtc-topology-outbox-entry.ts
@@ -13,12 +13,8 @@ import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry
 
 import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
 import { ResourceInboxRepository } from '../../postgres/resource-inbox/ResourceInboxRepository.ts';
-// prettier-ignore
-import { validateRtcRttMeasurement }
-  from '../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
-// prettier-ignore
-import { toRtcRttMutationReceiptId }
-  from '../rtc-topology/mutation/rtc-rtt-mutation-identifiers.ts';
+import { validateRtcRttMeasurement } from '../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
+import { toRtcRttMutationReceiptId } from '../rtc-topology/mutation/rtc-rtt-mutation-identifiers.ts';
 import { AppOutboxType } from './AppOutboxService.ts';
 import { toAppQueueCreatedBy, toAppQueueKey } from './app-inbox-queue-key.ts';
 

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts
@@ -8,14 +8,8 @@ import {
   validateTopologyConfigMutationIdempotency,
 } from './mutation/topology-config-mutation-idempotency.ts';
 import { validateTopologyConfigMutation } from './mutation/validate-topology-config-mutation.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigGenerationReadiness,
-} from './maintenance/group-topology-config-generation-readiness.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigRepository,
-} from './persistence/group-topology-config-repository.ts';
+import type { GroupTopologyConfigGenerationReadiness } from './maintenance/group-topology-config-generation-readiness.ts';
+import type { GroupTopologyConfigRepository } from './persistence/group-topology-config-repository.ts';
 import type { GroupStateRepository } from '../../group-state/persistence/group-state-repository.ts';
 
 export interface GroupTopologyConfigMutationServiceDependencies {

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
@@ -9,10 +9,7 @@ import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
 import type { GroupTopologyGroupSnapshotReader } from '../group-topology-management-contracts.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigGenerationReadiness,
-} from './maintenance/group-topology-config-generation-readiness.ts';
+import type { GroupTopologyConfigGenerationReadiness } from './maintenance/group-topology-config-generation-readiness.ts';
 import {
   resolveGroupTopologyConfig,
   type GroupTopologyServerOptions,

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config.ts
@@ -7,10 +7,7 @@ import type {
   StoredGroupTopologyConfig,
   StoredGroupTopologyOverride,
 } from '@shared/api/graph-topology-management-types.ts';
-// prettier-ignore
-import type {
-  RallarRtcTopologyServiceOptions,
-} from '../../services/rallar-rtc-topology-service.ts';
+import type { RallarRtcTopologyServiceOptions } from '../../services/rallar-rtc-topology-service.ts';
 
 export const DEFAULT_GROUP_TOPOLOGY_OVERRIDE_TTL_MS = 15 * 60 * 1000;
 export const MAX_GROUP_TOPOLOGY_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/shared-server/rallar-system/topology/config/maintenance/backfill-group-topology-config-generations.ts
+++ b/packages/shared-server/rallar-system/topology/config/maintenance/backfill-group-topology-config-generations.ts
@@ -6,9 +6,7 @@ import {
   RuntimeStateWriteConflictError,
   waitForRuntimeStateWriteRetry,
 } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
-// prettier-ignore
-import type { GroupTopologyConfigGenerationSource }
-  from '../persistence/group-topology-config-repository-contracts.ts';
+import type { GroupTopologyConfigGenerationSource } from '../persistence/group-topology-config-repository-contracts.ts';
 import { GroupTopologyConfigRepository } from '../persistence/group-topology-config-repository.ts';
 
 export interface GroupTopologyConfigGenerationBackfillResult {

--- a/packages/shared-server/rallar-system/topology/config/maintenance/group-topology-config-generation-readiness.ts
+++ b/packages/shared-server/rallar-system/topology/config/maintenance/group-topology-config-generation-readiness.ts
@@ -2,10 +2,7 @@ import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 
 import { GroupTopologyConfigRepository } from '../persistence/group-topology-config-repository.ts';
-// prettier-ignore
-import {
-  backfillGroupTopologyConfigGenerationsForRef,
-} from './backfill-group-topology-config-generations.ts';
+import { backfillGroupTopologyConfigGenerationsForRef } from './backfill-group-topology-config-generations.ts';
 
 export class GroupTopologyConfigGenerationReadiness {
   private readonly readinessByGroupKey = new Map<string, Promise<void>>();

--- a/packages/shared-server/rallar-system/topology/config/maintenance/migrate-legacy-group-topology-config-keys.ts
+++ b/packages/shared-server/rallar-system/topology/config/maintenance/migrate-legacy-group-topology-config-keys.ts
@@ -9,16 +9,10 @@ import {
   isRuntimeStateTransactionalRepositoryLike,
   type RuntimeStateOptimisticTransactionalRepositoryLike,
 } from '../../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import type { GroupTopologyConfigGenerationTarget }
-  from '../mutation/group-topology-config-mutation-contracts.ts';
-// prettier-ignore
-import type { GroupTopologyConfigLegacyKeyMigrationSource }
-  from '../persistence/group-topology-config-repository-contracts.ts';
+import type { GroupTopologyConfigGenerationTarget } from '../mutation/group-topology-config-mutation-contracts.ts';
+import type { GroupTopologyConfigLegacyKeyMigrationSource } from '../persistence/group-topology-config-repository-contracts.ts';
 import { GroupTopologyConfigRepository } from '../persistence/group-topology-config-repository.ts';
-// prettier-ignore
-import { groupTopologyConfigSourceNamespace }
-  from '../persistence/group-topology-config-runtime-namespaces.ts';
+import { groupTopologyConfigSourceNamespace } from '../persistence/group-topology-config-runtime-namespaces.ts';
 
 interface GroupTopologyConfigLegacyKeyMigrationOptions {
   readonly oldWritersStopped: true;

--- a/packages/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts
@@ -7,9 +7,7 @@ import type {
 } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RuntimeStateEntryValue } from '../../../../runtime-state/RuntimeStateJsonStore.ts';
-// prettier-ignore
-import type * as persistence
-  from '../../../group-state/persistence/group-state-persistence-contracts.ts';
+import type * as persistence from '../../../group-state/persistence/group-state-persistence-contracts.ts';
 import type { GroupTopologyServerOptions } from '../group-topology-config.ts';
 import type { ComputedRtcTopologyOutbox } from '../../../services/rtc-topology-outbox-entry.ts';
 

--- a/packages/shared-server/rallar-system/topology/config/mutation/read-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/read-topology-config-mutation.ts
@@ -1,12 +1,6 @@
-// prettier-ignore
-import type { GroupStateRepository }
-  from '../../../group-state/persistence/group-state-repository.ts';
-// prettier-ignore
-import type { GroupTopologyConfigRepository }
-  from '../persistence/group-topology-config-repository.ts';
-// prettier-ignore
-import { RuntimeStateWriteConflictError }
-  from '../../../../runtime-state/optimistic-runtime-state-write.ts';
+import type { GroupStateRepository } from '../../../group-state/persistence/group-state-repository.ts';
+import type { GroupTopologyConfigRepository } from '../persistence/group-topology-config-repository.ts';
+import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import type {
   GroupTopologyConfigMutationCommand,
   GroupTopologyConfigMutationRead,

--- a/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-idempotency.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-idempotency.ts
@@ -8,10 +8,7 @@ import {
   requireTopologyConfigRequestId,
   validateTopologyConfigIdempotencyInput,
 } from './validate-topology-config-mutation-input.ts';
-// prettier-ignore
-import {
-  validateGroupTopologyConfigMutationRecord,
-} from './validate-topology-config-records.ts';
+import { validateGroupTopologyConfigMutationRecord } from './validate-topology-config-records.ts';
 
 export interface ValidateTopologyConfigMutationIdempotencyInput {
   readonly command: GroupTopologyConfigMutationCommand;

--- a/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
@@ -3,10 +3,7 @@ import type {
   GroupTopologyConfigMutationReceipt,
 } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
-// prettier-ignore
-import {
-  toCanonicalGroupTopologyConfigPatch,
-} from '@shared/api/group-topology-config-canonical.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { RuntimeStateEntryValue } from '../../../../runtime-state/RuntimeStateJsonStore.ts';
 import { toRtcTopologyEntryResourceId } from '../../../services/rtc-topology-outbox-entry.ts';
 import type {

--- a/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation.ts
@@ -5,10 +5,7 @@ import type {
   TopologyConfigMutationInput,
 } from './group-topology-config-mutation-contracts.ts';
 import { requireTopologyConfigRequestId } from './validate-topology-config-mutation-input.ts';
-// prettier-ignore
-import {
-  validateGroupTopologyConfigMutationRecord,
-} from './validate-topology-config-records.ts';
+import { validateGroupTopologyConfigMutationRecord } from './validate-topology-config-records.ts';
 
 export interface ValidateTopologyConfigMutationInput extends TopologyConfigMutationInput {
   readonly computed: GroupTopologyConfigMutationComputed;

--- a/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-receipt.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-receipt.ts
@@ -1,4 +1,3 @@
-// prettier-ignore
 import type {
   GroupTopologyConfigAcceptedCausalRevision,
   GroupTopologyConfigMutationReceipt,

--- a/packages/shared-server/rallar-system/topology/config/mutation/write-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/write-topology-config-mutation.ts
@@ -1,12 +1,6 @@
 import type { PSqlTransactionSql } from '../../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '../../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  RuntimeStateWriteConflictError,
-} from '../../../../runtime-state/optimistic-runtime-state-write.ts';
+import { PSqlRuntimeStateRepository } from '../../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import { GroupStateRepository } from '../../../group-state/persistence/group-state-repository.ts';
 import { writeRtcTopologyOutbox } from '../../../services/rtc-topology-outbox-entry.ts';
 import { GroupTopologyConfigRepository } from '../persistence/group-topology-config-repository.ts';

--- a/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-repository-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-repository-contracts.ts
@@ -5,9 +5,7 @@ import type {
 import type { GroupRef } from '@shared/api/group-types.ts';
 
 import type { RuntimeStateEntry } from '../../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import type { GroupTopologyConfigGenerationTarget }
-  from '../mutation/group-topology-config-mutation-contracts.ts';
+import type { GroupTopologyConfigGenerationTarget } from '../mutation/group-topology-config-mutation-contracts.ts';
 
 export type GroupTopologyConfigCommitResult =
   Readonly<{ status: 'accepted'; storageRevision: number }> | Readonly<{ status: 'conflict' }>;
@@ -27,9 +25,7 @@ export interface GroupTopologyConfigGenerationSourceEntry {
   readonly value: StoredGroupTopologyConfig | StoredGroupTopologyOverride;
 }
 
-// prettier-ignore
-export interface GroupTopologyConfigLegacyKeyMigrationSource
-  extends GroupTopologyConfigGenerationSourceEntry {
+export interface GroupTopologyConfigLegacyKeyMigrationSource extends GroupTopologyConfigGenerationSourceEntry {
   readonly canonicalKey: string;
 }
 
@@ -44,10 +40,7 @@ export class GroupTopologyConfigRepositoryInvariantCorruptionError extends Error
 
   readonly storageKey: string;
 
-  constructor(
-    storageKey: string,
-    message: string,
-  ) {
+  constructor(storageKey: string, message: string) {
     super(`${message}: ${storageKey}`);
     this.storageKey = storageKey;
     this.name = 'GroupTopologyConfigRepositoryInvariantCorruptionError';

--- a/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-runtime-namespaces.ts
+++ b/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-runtime-namespaces.ts
@@ -1,6 +1,4 @@
-// prettier-ignore
-import type { GroupTopologyConfigGenerationTarget }
-  from '../mutation/group-topology-config-mutation-contracts.ts';
+import type { GroupTopologyConfigGenerationTarget } from '../mutation/group-topology-config-mutation-contracts.ts';
 
 export const GROUP_TOPOLOGY_CONFIG_NAMESPACE = 'group-topology:config';
 export const GROUP_TOPOLOGY_OVERRIDE_NAMESPACE = 'group-topology:override';

--- a/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-source-repository.ts
+++ b/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-source-repository.ts
@@ -7,9 +7,7 @@ import type {
   RuntimeStateEntryPageOptions,
   RuntimeStateRepositoryLike,
 } from '../../../../runtime-state/RuntimeStateRepository.ts';
-// prettier-ignore
-import type { GroupTopologyConfigGenerationTarget }
-  from '../mutation/group-topology-config-mutation-contracts.ts';
+import type { GroupTopologyConfigGenerationTarget } from '../mutation/group-topology-config-mutation-contracts.ts';
 import {
   decodeCanonicalGroupTopologyGenerationSourceEntry,
   decodeGroupTopologyLegacyKeyMigrationEntry,

--- a/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-storage-keys.ts
+++ b/packages/shared-server/rallar-system/topology/config/persistence/group-topology-config-storage-keys.ts
@@ -6,12 +6,8 @@ import {
   groupStateGroupStorageKey,
   groupStateIdempotencyStorageKey,
 } from '../../../group-state/persistence/group-state-storage-keys.ts';
-// prettier-ignore
-import type { GroupTopologyConfigGenerationTarget }
-  from '../mutation/group-topology-config-mutation-contracts.ts';
-// prettier-ignore
-import { toGroupTopologyConfigRepositoryCorruption }
-  from './group-topology-config-repository-contracts.ts';
+import type { GroupTopologyConfigGenerationTarget } from '../mutation/group-topology-config-mutation-contracts.ts';
+import { toGroupTopologyConfigRepositoryCorruption } from './group-topology-config-repository-contracts.ts';
 
 interface GroupTopologyChildStorageKey {
   readonly groupRef: GroupRef;

--- a/packages/shared-server/rallar-system/topology/config/persistence/read-exact-group-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/persistence/read-exact-group-topology-config-mutation.ts
@@ -14,9 +14,7 @@ import {
   type RuntimeStateReadBatchSelector,
   validateRuntimeStateReadBatchResult,
 } from '../../../../runtime-state/RuntimeStateReadBatch.ts';
-// prettier-ignore
-import { resolveRuntimeStateReadBatchLiveValues }
-  from '../../../../runtime-state/RuntimeStateReadBatchLiveValues.ts';
+import { resolveRuntimeStateReadBatchLiveValues } from '../../../../runtime-state/RuntimeStateReadBatchLiveValues.ts';
 import type {
   GroupTopologyConfigGeneration,
   GroupTopologyConfigGenerationTarget,

--- a/packages/shared-server/rallar-system/topology/group-topology-management-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/group-topology-management-contracts.ts
@@ -9,21 +9,13 @@ import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 
 import type { GroupStateRepository } from '../group-state/persistence/group-state-repository.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigRepository,
-} from './config/persistence/group-topology-config-repository.ts';
+import type { GroupTopologyConfigRepository } from './config/persistence/group-topology-config-repository.ts';
 import type { RtcRttRepository } from '../rtc-topology/persistence/rtc-rtt-repository.ts';
-// prettier-ignore
-import type {
-  RtcTopologySnapshotRepository,
-} from '../repositories/RtcTopologySnapshotRepository.ts';
+import type { RtcTopologySnapshotRepository } from '../repositories/RtcTopologySnapshotRepository.ts';
 import type { RallarRtcTopologyService } from '../services/rallar-rtc-topology-service.ts';
 import type { RallarTimingSink } from '../services/timing.ts';
 import type { GroupTopologyServerOptions } from './config/group-topology-config.ts';
-// prettier-ignore
-import type * as mutationContracts
-  from './config/mutation/group-topology-config-mutation-contracts.ts';
+import type * as mutationContracts from './config/mutation/group-topology-config-mutation-contracts.ts';
 
 export type GroupTopologyPublisher = (
   message: ALMessage,

--- a/packages/shared-server/rallar-system/topology/group-topology-management-service.ts
+++ b/packages/shared-server/rallar-system/topology/group-topology-management-service.ts
@@ -10,22 +10,14 @@ import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology
 import * as processRttRepository from '@shared/repository/rtt-repository.ts';
 
 import type { PSqlTransactionSql } from '../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  GroupTopologyConfigMutationService,
-} from './config/group-topology-config-mutation-service.ts';
+import { GroupTopologyConfigMutationService } from './config/group-topology-config-mutation-service.ts';
 import type {
   GroupTopologyConfigMutationAttemptRead,
   GroupTopologyConfigMutationPreparation,
 } from './config/group-topology-config-mutation-service.ts';
 import { GroupTopologyConfigQueryService } from './config/group-topology-config-query-service.ts';
-// prettier-ignore
-import {
-  GroupTopologyConfigGenerationReadiness,
-} from './config/maintenance/group-topology-config-generation-readiness.ts';
-// prettier-ignore
-import type * as mutationContracts
-  from './config/mutation/group-topology-config-mutation-contracts.ts';
+import { GroupTopologyConfigGenerationReadiness } from './config/maintenance/group-topology-config-generation-readiness.ts';
+import type * as mutationContracts from './config/mutation/group-topology-config-mutation-contracts.ts';
 import {
   toTopologyConfigMutationResult,
   type GroupTopologyConfigMutationExecution,
@@ -42,10 +34,7 @@ import type {
   ReconfigureGroupTopologyInput,
   ReconcileGroupTopologyResult,
 } from './group-topology-management-contracts.ts';
-// prettier-ignore
-import type {
-  GroupTopologyPlanningAuthority,
-} from './planning/group-topology-planning-authority.ts';
+import type { GroupTopologyPlanningAuthority } from './planning/group-topology-planning-authority.ts';
 import {
   GroupTopologyPlanningService,
   type GroupTopologyPlanningServiceDependencies,
@@ -55,19 +44,13 @@ import type {
   GroupTopologyReconfigureComputed,
   GroupTopologyReconfigureRead,
 } from './reconfigure/group-topology-reconfigure-contracts.ts';
-// prettier-ignore
-import {
-  GroupTopologyReconfigureMutation,
-} from './reconfigure/group-topology-reconfigure-mutation.ts';
+import { GroupTopologyReconfigureMutation } from './reconfigure/group-topology-reconfigure-mutation.ts';
 
 export * from './group-topology-errors.ts';
 export type * from './group-topology-management-contracts.ts';
 export type * from './planning/group-topology-planning-authority.ts';
 export type * from './reconfigure/group-topology-reconfigure-contracts.ts';
-// prettier-ignore
-export type {
-  GroupTopologyConfigMutationExecution,
-} from './config/mutation/to-topology-config-mutation-result.ts';
+export type { GroupTopologyConfigMutationExecution } from './config/mutation/to-topology-config-mutation-result.ts';
 export { writeTopologyConfigMutation } from './config/mutation/write-topology-config-mutation.ts';
 export {
   createRtcOverlayTopologyBroadcastMessage,

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
@@ -8,10 +8,7 @@ import type { GroupTopologyConfigPatch } from '@shared/api/graph-topology-manage
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import { GroupMutationAuthorizationError } from '../../group-state/group-mutation-authority.ts';
 import { hashCanonicalCommand } from '../../services/canonical-command-hash.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigMutationCommand,
-} from '../config/mutation/group-topology-config-mutation-contracts.ts';
+import type { GroupTopologyConfigMutationCommand } from '../config/mutation/group-topology-config-mutation-contracts.ts';
 import type { AppInboxEnqueueInput } from '../../services/AppInboxService.ts';
 import { AppInboxType } from '../../services/AppInboxService.ts';
 import type {

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-contracts.ts
@@ -1,14 +1,8 @@
 import type { GroupRef } from '@shared/api/group-types.ts';
-// prettier-ignore
-import type {
-  CanonicalGroupTopologyConfigPatch,
-} from '@shared/api/graph-topology-management-types.ts';
+import type { CanonicalGroupTopologyConfigPatch } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupTopologyConfigPatch } from '@shared/api/graph-topology-management-types.ts';
 
-// prettier-ignore
-import type {
-  TopologyMutationAuthorityProof,
-} from './topology-mutation-authority-proof.ts';
+import type { TopologyMutationAuthorityProof } from './topology-mutation-authority-proof.ts';
 
 export type TopologyAppInboxOperation =
   | 'putConfig'

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -1,36 +1,18 @@
-// prettier-ignore
-import {
-  fromCanonicalGroupTopologyConfigPatch,
-} from '@shared/api/group-topology-config-canonical.ts';
+import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { GroupStateService } from '../../group-state/group-state-service-contracts.ts';
-// prettier-ignore
-import type {
-  AppInboxMutationTransactionWriter,
-} from '../../services/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '../../services/app-inbox-transaction-writer.ts';
 import type {
   AppInboxEnqueueInput,
   AppInboxMessageContext,
 } from '../../services/AppInboxService.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigMutationService,
-} from '../config/group-topology-config-mutation-service.ts';
-// prettier-ignore
-import {
-  toTopologyConfigMutationResult,
-} from '../config/mutation/to-topology-config-mutation-result.ts';
+import type { GroupTopologyConfigMutationService } from '../config/group-topology-config-mutation-service.ts';
+import { toTopologyConfigMutationResult } from '../config/mutation/to-topology-config-mutation-result.ts';
 import { writeTopologyConfigMutation } from '../config/mutation/write-topology-config-mutation.ts';
 import { GroupTopologyConfigIdempotencyConflictError } from '../group-topology-errors.ts';
-// prettier-ignore
-import type {
-  GroupTopologyReconfigureCommand,
-} from '../reconfigure/group-topology-reconfigure-contracts.ts';
-// prettier-ignore
-import type {
-  GroupTopologyReconfigureMutation,
-} from '../reconfigure/group-topology-reconfigure-mutation.ts';
+import type { GroupTopologyReconfigureCommand } from '../reconfigure/group-topology-reconfigure-contracts.ts';
+import type { GroupTopologyReconfigureMutation } from '../reconfigure/group-topology-reconfigure-mutation.ts';
 import {
   createAuthenticatedTopologyEnqueue,
   readTopologyAppInboxAuthority,

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
@@ -5,10 +5,7 @@ import type {
 } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 
-// prettier-ignore
-import type {
-  RtcTopologyKindHysteresisWidths,
-} from '../../services/rallar-rtc-topology-service.ts';
+import type { RtcTopologyKindHysteresisWidths } from '../../services/rallar-rtc-topology-service.ts';
 
 export type GroupTopologyPlanningSnapshotSelection = 'prefer-current' | 'preserve-known-revision';
 

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -18,9 +18,7 @@ import {
   type RallarRtcTopologyUpdateResult,
   type RtcTopologyPlanningIntent,
 } from '../../services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import { filterRtcRttMeasurementsForGroup }
-  from '../../rtc-topology/policy/rtc-rtt-measurement-policy.ts';
+import { filterRtcRttMeasurementsForGroup } from '../../rtc-topology/policy/rtc-rtt-measurement-policy.ts';
 import { GroupTopologyValidationError } from '../group-topology-errors.ts';
 import type {
   GroupTopologyGroupSnapshotReader,
@@ -28,19 +26,13 @@ import type {
   ReconfigureGroupTopologyInput,
   ReconcileGroupTopologyResult,
 } from '../group-topology-management-contracts.ts';
-// prettier-ignore
-import type {
-  GroupTopologyConfigQueryService,
-} from '../config/group-topology-config-query-service.ts';
+import type { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
 import type { GroupTopologyServerOptions } from '../config/group-topology-config.ts';
 import type {
   GroupTopologyPlanningAuthority,
   ReadGroupTopologyPlanningAuthorityInput,
 } from './group-topology-planning-authority.ts';
-// prettier-ignore
-import {
-  createRtcOverlayTopologyBroadcastMessage,
-} from './materialize-rtc-overlay-topology-broadcast-message.ts';
+import { createRtcOverlayTopologyBroadcastMessage } from './materialize-rtc-overlay-topology-broadcast-message.ts';
 import {
   isGroupTopologyPlannableAt,
   selectGroupTopologyPlanningSnapshot,

--- a/packages/shared-server/rallar-system/topology/planning/materialize-rtc-overlay-topology-broadcast-message.ts
+++ b/packages/shared-server/rallar-system/topology/planning/materialize-rtc-overlay-topology-broadcast-message.ts
@@ -3,10 +3,7 @@ import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 
-// prettier-ignore
-import {
-  DEFAULT_RTC_TOPOLOGY_PUBLICATION_RETENTION_MS,
-} from '../../repositories/RtcTopologyPublicationRepository.ts';
+import { DEFAULT_RTC_TOPOLOGY_PUBLICATION_RETENTION_MS } from '../../repositories/RtcTopologyPublicationRepository.ts';
 import { toRtcTopologyPublicationMessageId } from '../../rtc-topology-identifiers.ts';
 
 export interface RtcOverlayTopologyMessageFacts {

--- a/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
+++ b/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
@@ -3,21 +3,12 @@ import {
   readGroupCausalRevision,
 } from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
-// prettier-ignore
-import {
-  GroupStateSnapshotIncomparableError,
-} from '@shared/repository/group-state-snapshots-repository.ts';
-// prettier-ignore
-import {
-  isTuplePreservingGroupLivenessReduction,
-} from '@shared/repository/group-state-snapshot-revision.ts';
+import { GroupStateSnapshotIncomparableError } from '@shared/repository/group-state-snapshots-repository.ts';
+import { isTuplePreservingGroupLivenessReduction } from '@shared/repository/group-state-snapshot-revision.ts';
 import { StateSnapshotRevisionConflictError } from '@shared/repository/state-snapshot-revision.ts';
 
 import { rtcTopologySemanticEqual } from '../../rtc-topology-semantic-equality.ts';
-// prettier-ignore
-import type {
-  GroupTopologyPlanningSnapshotSelection,
-} from './group-topology-planning-authority.ts';
+import type { GroupTopologyPlanningSnapshotSelection } from './group-topology-planning-authority.ts';
 
 export function isGroupTopologyActiveAt(
   snapshot: GroupSnapshot,

--- a/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-contracts.ts
@@ -1,14 +1,9 @@
 import type { GroupTopologyConfigPatch } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 
-// prettier-ignore
-import type * as persistence
-  from '../../group-state/persistence/group-state-persistence-contracts.ts';
+import type * as persistence from '../../group-state/persistence/group-state-persistence-contracts.ts';
 import type { ComputedRtcTopologyOutbox } from '../../services/rtc-topology-outbox-entry.ts';
-// prettier-ignore
-import type {
-  GroupTopologyPlanningAuthority,
-} from '../planning/group-topology-planning-authority.ts';
+import type { GroupTopologyPlanningAuthority } from '../planning/group-topology-planning-authority.ts';
 
 export interface GroupTopologyReconfigureCommand {
   readonly groupRef: GroupRef;

--- a/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts
@@ -1,19 +1,10 @@
 import { compareGroupCausalRevision } from '@shared/api/group-client-views.ts';
 import { readGroupCausalRevision } from '@shared/api/group-client-views.ts';
-// prettier-ignore
-import {
-  toCanonicalGroupTopologyConfigPatch,
-} from '@shared/api/group-topology-config-canonical.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 
 import type { PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import {
-  PSqlRuntimeStateRepository,
-} from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
-// prettier-ignore
-import {
-  RuntimeStateWriteConflictError,
-} from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { PSqlRuntimeStateRepository } from '../../../postgres/runtime-state/PSqlRuntimeStateRepository.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import {
   canMutateActiveGroup,
   canUpdateGroupSnapshot,
@@ -21,7 +12,6 @@ import {
 } from '../../group-policy.ts';
 import { GroupStateRepository } from '../../group-state/persistence/group-state-repository.ts';
 import { writeRtcTopologyOutbox } from '../../services/rtc-topology-outbox-entry.ts';
-// prettier-ignore
 import type {
   GroupTopologyPlanningAuthority,
   ReadGroupTopologyPlanningAuthorityInput,

--- a/packages/shared-server/rallar-system/topology/replay/compute-formation-criterion-command.ts
+++ b/packages/shared-server/rallar-system/topology/replay/compute-formation-criterion-command.ts
@@ -1,29 +1,16 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
-// prettier-ignore
-import {
-  computeGroupFormationReadiness,
-} from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
-// prettier-ignore
-import {
-  evaluateGroupActivationCriterion,
-} from '@shared/api/group-lifecycle/evaluate-group-activation-criterion.ts';
-// prettier-ignore
-import {
-  createDefaultGroupLifecyclePolicy,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { computeGroupFormationReadiness } from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
+import { evaluateGroupActivationCriterion } from '@shared/api/group-lifecycle/evaluate-group-activation-criterion.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
-// prettier-ignore
 import {
   toFailFormationCommand,
   toFormationActivateCommand,
 } from '../../group-state/group-formation-mutation-command.ts';
 import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicyRead,
-} from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
 
 export interface ComputeFormationCriterionCommandInput {
   readonly group: GroupSnapshot;
@@ -53,9 +40,8 @@ export async function computeFormationCriterionCommand(
   if (policyRead.status === 'corrupt') {
     return null;
   }
-  const policy = policyRead.status === 'present'
-    ? policyRead.policy
-    : createDefaultGroupLifecyclePolicy();
+  const policy =
+    policyRead.status === 'present' ? policyRead.policy : createDefaultGroupLifecyclePolicy();
   const readiness = computeGroupFormationReadiness({
     planned: input.planned,
     rttMeasurements: input.rttMeasurements,

--- a/packages/shared-server/rallar-system/topology/replay/create-formation-timer-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/create-formation-timer-work-handler.ts
@@ -3,25 +3,15 @@ import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
-// prettier-ignore
-import {
-  toFormationRetryEstablishCommand,
-} from '../../group-state/group-formation-mutation-command.ts';
-// prettier-ignore
+import { toFormationRetryEstablishCommand } from '../../group-state/group-formation-mutation-command.ts';
 import {
   decodeFormationTimerWork,
   type GroupFormationTimerWork,
 } from '../../group-state/formation-timer-outbox-entry.ts';
 import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicyRead,
-} from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
 import type { GroupTopologyPlanningService } from '../planning/group-topology-planning-service.ts';
-// prettier-ignore
-import {
-  computeFormationCriterionCommand,
-} from './compute-formation-criterion-command.ts';
+import { computeFormationCriterionCommand } from './compute-formation-criterion-command.ts';
 
 interface OnMessageCallback {
   onMessage(message: ALMessage, entry: ResourceEntry): Promise<void>;

--- a/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
@@ -1,28 +1,20 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
-// prettier-ignore
-import { fromCanonicalGroupTopologyConfigPatch }
-  from '@shared/api/group-topology-config-canonical.ts';
+import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/InboxOutboxContracts.ts';
 
 import type { PSqlSql, PSqlTransactionSql } from '../../../postgres/PostgresSqlClient.ts';
-// prettier-ignore
-import { ResourceInboxRepository }
-  from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxRepository } from '../../../postgres/resource-inbox/ResourceInboxRepository.ts';
 import { runInTransaction } from '../../../postgres/run-in-transaction.ts';
-// prettier-ignore
-import { RuntimeStateWriteConflictError }
-  from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import {
   hashRtcTopologyExecutionCommand,
   type RtcTopologyPublication,
   toRtcTopologyPublicationId,
 } from '../../repositories/RtcTopologyPublicationRepository.ts';
-// prettier-ignore
-import type { RtcTopologyExecutionRepository }
-  from '../../repositories/RtcTopologyExecutionRepository.ts';
+import type { RtcTopologyExecutionRepository } from '../../repositories/RtcTopologyExecutionRepository.ts';
 import { finishRtcTopologyReservation, finishRtcTopologyWork } from './finish-rtc-topology-work.ts';
 import type { RtcTopologyDeliveryAppendPort } from './rtc-topology-delivery-append-port.ts';
 import { RtcTopologyDeliveryLeaseLostError } from './rtc-topology-delivery-stream-service.ts';
@@ -43,9 +35,7 @@ import {
 } from '../../services/rtc-topology-mutations.ts';
 import { writeRtcTopologyPublicationOutbox } from '../../services/rtc-topology-ws-outbox-entry.ts';
 import type { RtcTopologyWorkRuntime } from '../../services/RtcTopologyOutboxWork.ts';
-// prettier-ignore
-import type { RtcRttRefinementService }
-  from '../../rtc-topology/topic/rtc-rtt-refinement-service.ts';
+import type { RtcRttRefinementService } from '../../rtc-topology/topic/rtc-rtt-refinement-service.ts';
 import { isChangeGatedGroupRevisionWork } from './rtc-topology-coalesced-group-revision-work.ts';
 import { computeAuthorityTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
 import {
@@ -60,22 +50,10 @@ type AcceptedRtcTopologyMutation = Exclude<
   Readonly<{ outcome: 'loaded' | 'retry' }>
 >;
 
-// prettier-ignore
-import {
-  computeFormationCriterionCommand,
-} from './compute-formation-criterion-command.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicyRead,
-} from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
-// prettier-ignore
-import type {
-  GroupMutationCommand,
-} from '../../group-state/mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  GroupTopologyPlanningAuthority,
-} from '../planning/group-topology-planning-authority.ts';
+import { computeFormationCriterionCommand } from './compute-formation-criterion-command.ts';
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
+import type { GroupTopologyPlanningAuthority } from '../planning/group-topology-planning-authority.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
 export interface RtcTopologyDeliveryOptions {

--- a/packages/shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts
+++ b/packages/shared-server/rallar-system/topology/replay/rtc-topology-input-fingerprint.ts
@@ -4,14 +4,8 @@ import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
 import { compareRtcTopologyIdentifiers } from '../../rtc-topology-identifiers.ts';
-// prettier-ignore
-import type {
-  RtcTopologyKindHysteresisWidths,
-} from '../../services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import type {
-  GroupTopologyPlanningAuthority,
-} from '../planning/group-topology-planning-authority.ts';
+import type { RtcTopologyKindHysteresisWidths } from '../../services/rallar-rtc-topology-service.ts';
+import type { GroupTopologyPlanningAuthority } from '../planning/group-topology-planning-authority.ts';
 import { groupStateGroupStorageKey } from '../../group-state-storage-keys.ts';
 import { sha256CanonicalJson } from '../../group-state/mutation/group-state-crypto.ts';
 import { RuntimeStateJsonStore } from '../../../runtime-state/RuntimeStateJsonStore.ts';

--- a/packages/shared-server/rallar-system/topology/replay/rtc-topology-work-codec.ts
+++ b/packages/shared-server/rallar-system/topology/replay/rtc-topology-work-codec.ts
@@ -1,15 +1,9 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
-// prettier-ignore
-import { validateRtcRttMeasurement }
-  from '../../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
+import { validateRtcRttMeasurement } from '../../rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
 import { validateAuthoritativeGroupSnapshot } from '@shared/api/authoritative-state-validation.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
-// prettier-ignore
-import { readCanonicalGroupTopologyConfigPatch }
-  from '@shared/api/group-topology-config-canonical.ts';
-// prettier-ignore
-import type { CanonicalGroupTopologyConfigPatch }
-  from '@shared/api/graph-topology-management-types.ts';
+import { readCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import type { CanonicalGroupTopologyConfigPatch } from '@shared/api/graph-topology-management-types.ts';
 import { readGroupStateRevision } from '@shared/api/group-client-views.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 

--- a/packages/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts
@@ -1,7 +1,4 @@
-// prettier-ignore
-import type {
-  EvolvePlannedTopologyFullRebuildReason,
-} from '../planning/evolve-planned-topology.ts';
+import type { EvolvePlannedTopologyFullRebuildReason } from '../planning/evolve-planned-topology.ts';
 
 export interface RallarRtcTopologyMetrics {
   readonly topologyUpdateCount: number;

--- a/packages/shared-server/rallar-system/ws-rtc-topology-runtime.ts
+++ b/packages/shared-server/rallar-system/ws-rtc-topology-runtime.ts
@@ -1,7 +1,5 @@
 import type { GroupStateRepository } from './group-state/persistence/group-state-repository.ts';
-// prettier-ignore
-import type { GroupTopologyConfigRepository }
-  from './topology/config/persistence/group-topology-config-repository.ts';
+import type { GroupTopologyConfigRepository } from './topology/config/persistence/group-topology-config-repository.ts';
 import type { RtcRttRepository } from './rtc-topology/persistence/rtc-rtt-repository.ts';
 import type { RtcTopologySnapshotRepository } from './repositories/RtcTopologySnapshotRepository.ts';
 

--- a/packages/shared-server/rallar-system/ws-system-topics.ts
+++ b/packages/shared-server/rallar-system/ws-system-topics.ts
@@ -39,18 +39,9 @@ import {
 } from './rtc-topology/topic/init-rtc-rtt-topic.ts';
 import type { RtcRttRefinementGate } from './rtc-topology/topic/rtc-rtt-refinement-gate.ts';
 import type { RtcRttRefinementService } from './rtc-topology/topic/rtc-rtt-refinement-service.ts';
-// prettier-ignore
-import type {
-  GroupLifecyclePolicyRead,
-} from './group-state/persistence/group-lifecycle-policy-repository.ts';
-// prettier-ignore
-import type {
-  GroupMutationCommand,
-} from './group-state/mutation/group-mutation-contracts.ts';
-// prettier-ignore
-import {
-  createFormationTimerWorkHandler,
-} from './topology/replay/create-formation-timer-work-handler.ts';
+import type { GroupLifecyclePolicyRead } from './group-state/persistence/group-lifecycle-policy-repository.ts';
+import type { GroupMutationCommand } from './group-state/mutation/group-mutation-contracts.ts';
+import { createFormationTimerWorkHandler } from './topology/replay/create-formation-timer-work-handler.ts';
 import { AppOutboxType } from './services/AppOutboxService.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
@@ -120,8 +111,8 @@ export function initRallarSystemWsTopics(
   const rtcTopologyRuntimeState = rtcTopologyPersistence.repositories;
   const rtcTopologyFlushTimers = new Map<string, RtcTopologyFlushTimer>();
   let globalGraphRttRecomputeTimer: ReturnType<typeof setTimeout> | undefined;
-  const globalGraphRecomputeLimit = options.globalGraphRecomputeLimit ??
-    DEFAULT_GLOBAL_GRAPH_RECOMPUTE_LIMIT;
+  const globalGraphRecomputeLimit =
+    options.globalGraphRecomputeLimit ?? DEFAULT_GLOBAL_GRAPH_RECOMPUTE_LIMIT;
   const globalGraphRecomputeLimiter = toRateLimiter(
     globalGraphRecomputeLimit.windowMs,
     globalGraphRecomputeLimit.maxPerWindow,

--- a/packages/shared-test/black-box-runner/api-v1-black-box-run.mts
+++ b/packages/shared-test/black-box-runner/api-v1-black-box-run.mts
@@ -26,10 +26,7 @@ import {
   withManagedApiServerPlans,
 } from './managed-api/with-managed-api-server-plans.mts';
 // Prettier would collapse this import beyond the repository's 100-column review limit.
-// prettier-ignore
-import {
-  runApiV1RtcTopologyReplayProof,
-} from './topology-replay/api-v1-rtc-topology-replay-proof.mts';
+import { runApiV1RtcTopologyReplayProof } from './topology-replay/api-v1-rtc-topology-replay-proof.mts';
 
 export {
   managedApiDiagnosticSecrets,

--- a/packages/shared-test/black-box-runner/api-v1-state-write-evidence.ts
+++ b/packages/shared-test/black-box-runner/api-v1-state-write-evidence.ts
@@ -9,10 +9,7 @@ export {
   type OverdueRecoveryEvidence,
   type ParsedInboxRow,
 } from './state-write-evidence/api-v1-state-write-evidence-contracts.ts';
-// prettier-ignore
-export {
-  collectApiV1StateWriteEvidence,
-} from './state-write-evidence/api-v1-state-write-evidence-source.ts';
+export { collectApiV1StateWriteEvidence } from './state-write-evidence/api-v1-state-write-evidence-source.ts';
 export {
   collectApiV1StateWriteEvidenceFromSql,
   type ApiV1StateWriteEvidenceSqlSpec,

--- a/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-command-codecs.ts
+++ b/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-command-codecs.ts
@@ -1,16 +1,8 @@
-// prettier-ignore
-import { decodeAdminPruneCommand }
-  from '@shared-server/rallar-system/admin-operations/admin-prune-work-codec.ts';
-// prettier-ignore
-import { validateRtcRttMeasurement }
-  from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
+import { decodeAdminPruneCommand } from '@shared-server/rallar-system/admin-operations/admin-prune-work-codec.ts';
+import { validateRtcRttMeasurement } from '@shared-server/rallar-system/rtc-topology/persistence/rtc-rtt-persistence-validation.ts';
 import { AppInboxType } from '@shared-server/rallar-system/services/app-inbox-contracts.ts';
-// prettier-ignore
-import { decodeAuthMutationCommand }
-  from '@shared-server/rallar-system/auth/mutation/decode-auth-mutation-command.ts';
-// prettier-ignore
-import { decodeCrdtMutationCommand }
-  from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import { decodeAuthMutationCommand } from '@shared-server/rallar-system/auth/mutation/decode-auth-mutation-command.ts';
+import { decodeCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
 
 export interface ExactStandaloneCommandIdsInput {
   readonly type: AppInboxType;

--- a/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-receipt-evidence.ts
+++ b/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-receipt-evidence.ts
@@ -7,12 +7,8 @@ import * as GroupState from '@shared-server/rallar-system/repositories/GroupStat
 import { GroupTopologyConfigRepository } from '@shared-server/mod.ts';
 import * as ClientMutations from '@shared-server/rallar-system/services/client-state-mutations.ts';
 import * as GroupMutations from '@shared-server/rallar-system/services/group-state-mutations.ts';
-// prettier-ignore
-import * as TopologyMutation
-  from '@shared-server/rallar-system/topology/config/mutation/topology-config-mutation-boundary.ts';
-// prettier-ignore
-import * as AppInboxCommandIdentity
-  from '@shared-server/rallar-system/services/app-inbox-command-identity.ts';
+import * as TopologyMutation from '@shared-server/rallar-system/topology/config/mutation/topology-config-mutation-boundary.ts';
+import * as AppInboxCommandIdentity from '@shared-server/rallar-system/services/app-inbox-command-identity.ts';
 import { AppInboxType } from '@shared-server/rallar-system/services/app-inbox-contracts.ts';
 
 import type { ApiV1StateWriteEvidenceQuery } from './api-v1-state-write-evidence-contracts.ts';

--- a/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-result-evidence.ts
+++ b/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-result-evidence.ts
@@ -1,18 +1,12 @@
 import { decodeAuthMutationResult } from '@shared-server/mod.ts';
-// prettier-ignore
-import * as CrdtResult
-  from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
-// prettier-ignore
-import { readPersistedAppInboxFailure }
-  from '@shared-server/rallar-system/services/app-inbox-failure.ts';
+import * as CrdtResult from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { readPersistedAppInboxFailure } from '@shared-server/rallar-system/services/app-inbox-failure.ts';
 
 import {
   type PublicResultReceiptIdentity,
   publicResultIdentityMatches,
 } from './api-v1-state-write-group-causal-evidence.ts';
-// prettier-ignore
-import { validateTopologyMutationResultPayload }
-  from './validate-topology-mutation-result-payload.ts';
+import { validateTopologyMutationResultPayload } from './validate-topology-mutation-result-payload.ts';
 
 interface ResultEvidence {
   readonly valid: boolean;

--- a/packages/shared-web/browser/rtc-diagnostics/rallar-rtc-diagnostics-contracts.ts
+++ b/packages/shared-web/browser/rtc-diagnostics/rallar-rtc-diagnostics-contracts.ts
@@ -1,109 +1,106 @@
 import type { RallarOverlayAdoptionDiagnostics } from '@shared/repository/overlays-repository.ts';
-// prettier-ignore
-import type {
-  WebRtcPeerConnectionAttemptBudgetDiagnostics,
-} from '@shared/services/WebRtcConnectionService.ts';
+import type { WebRtcPeerConnectionAttemptBudgetDiagnostics } from '@shared/services/WebRtcConnectionService.ts';
 import type { WebRtcGroupManagerDiagnostics } from '@shared/services/WebRtcGroupManager.ts';
 import type { RtcDataChannelHealth } from '@shared/webrtc/QRtcDataChannel.ts';
 import type { QRtcPeerConnectionDiagnostics } from '@shared/webrtc/QRtcPeerConnection.ts';
 
 export type RallarRtcPeerConnectionStatus = Readonly<{
-    state?: string;
-    connectionState?: string;
-    iceConnectionState?: string;
-    iceGatheringState?: string;
-    signalingState?: string;
-    hasLocalDescription: boolean;
-    hasRemoteDescription: boolean;
-    canTrickleIceCandidates?: boolean | null;
-    reconnectAttempts: number;
-    reconnecting: boolean;
-    disconnectPending: boolean;
-    makingOffer: boolean;
-    ignoreOffer: boolean;
-    iceCandidateQueueSize: number;
-    localStreamId?: string;
-    remoteStreamIds: readonly string[];
+  state?: string;
+  connectionState?: string;
+  iceConnectionState?: string;
+  iceGatheringState?: string;
+  signalingState?: string;
+  hasLocalDescription: boolean;
+  hasRemoteDescription: boolean;
+  canTrickleIceCandidates?: boolean | null;
+  reconnectAttempts: number;
+  reconnecting: boolean;
+  disconnectPending: boolean;
+  makingOffer: boolean;
+  ignoreOffer: boolean;
+  iceCandidateQueueSize: number;
+  localStreamId?: string;
+  remoteStreamIds: readonly string[];
 }>;
 
 export type RallarRtcLaneStatus = Readonly<{
-    peerId: string;
-    laneId: string;
-    channel?: RtcDataChannelHealth;
-    isOpen: boolean;
-    isReconnectable: boolean;
+  peerId: string;
+  laneId: string;
+  channel?: RtcDataChannelHealth;
+  isOpen: boolean;
+  isReconnectable: boolean;
 }>;
 
 export type RallarRtcPeerStatus = Readonly<{
-    peerId: string;
-    connection: RallarRtcPeerConnectionStatus;
-    lanes: readonly RallarRtcLaneStatus[];
-    isActive: boolean;
-    hasNoReconnectableLanes: boolean;
-    isRoutable: boolean;
-    readyLaneIds: readonly string[];
+  peerId: string;
+  connection: RallarRtcPeerConnectionStatus;
+  lanes: readonly RallarRtcLaneStatus[];
+  isActive: boolean;
+  hasNoReconnectableLanes: boolean;
+  isRoutable: boolean;
+  readyLaneIds: readonly string[];
 }>;
 
 export type RallarRtcStatus = Readonly<{
-    sessionId?: string;
-    laneId: string;
-    knownPeerIds: readonly string[];
-    activePeerIds: readonly string[];
-    peerIdsWithNoReconnectableLanes: readonly string[];
-    readyPeerIds: readonly string[];
-    peers: readonly RallarRtcPeerStatus[];
+  sessionId?: string;
+  laneId: string;
+  knownPeerIds: readonly string[];
+  activePeerIds: readonly string[];
+  peerIdsWithNoReconnectableLanes: readonly string[];
+  readyPeerIds: readonly string[];
+  peers: readonly RallarRtcPeerStatus[];
 }>;
 
 export type RallarRtcDiagnosticsOptions = Readonly<{
-    peerIds?: readonly string[];
-    laneIds?: readonly string[];
+  peerIds?: readonly string[];
+  laneIds?: readonly string[];
 }>;
 
 export type RallarRtcCandidateDiagnostics = Readonly<{
-    id?: string;
-    candidateType?: string;
-    protocol?: string;
-    address?: string;
-    ip?: string;
-    port?: number;
-    relayProtocol?: string;
-    networkType?: string;
-    url?: string;
+  id?: string;
+  candidateType?: string;
+  protocol?: string;
+  address?: string;
+  ip?: string;
+  port?: number;
+  relayProtocol?: string;
+  networkType?: string;
+  url?: string;
 }>;
 
 export type RallarRtcCandidatePairDiagnostics = Readonly<{
-    id?: string;
-    state?: string;
-    nominated?: boolean;
-    selected?: boolean;
-    currentRoundTripTime?: number;
-    availableOutgoingBitrate?: number;
-    bytesSent?: number;
-    bytesReceived?: number;
-    local?: RallarRtcCandidateDiagnostics;
-    remote?: RallarRtcCandidateDiagnostics;
-    usesRelay: boolean;
+  id?: string;
+  state?: string;
+  nominated?: boolean;
+  selected?: boolean;
+  currentRoundTripTime?: number;
+  availableOutgoingBitrate?: number;
+  bytesSent?: number;
+  bytesReceived?: number;
+  local?: RallarRtcCandidateDiagnostics;
+  remote?: RallarRtcCandidateDiagnostics;
+  usesRelay: boolean;
 }>;
 
 export type RallarRtcPeerDiagnostics = Readonly<{
-    peerId: string;
-    connection: RallarRtcPeerConnectionStatus;
-    connectionDiagnostics?: QRtcPeerConnectionDiagnostics;
-    lanes: readonly RallarRtcLaneStatus[];
-    selectedCandidatePair?: RallarRtcCandidatePairDiagnostics;
-    usesRelay: boolean;
-    statsAvailable: boolean;
-    statsError?: string;
+  peerId: string;
+  connection: RallarRtcPeerConnectionStatus;
+  connectionDiagnostics?: QRtcPeerConnectionDiagnostics;
+  lanes: readonly RallarRtcLaneStatus[];
+  selectedCandidatePair?: RallarRtcCandidatePairDiagnostics;
+  usesRelay: boolean;
+  statsAvailable: boolean;
+  statsError?: string;
 }>;
 
 export type RallarRtcDiagnostics = Readonly<{
-    sessionId?: string;
-    generatedAtEpochMs: number;
-    peerCount: number;
-    connectedPeerCount: number;
-    relayPeerCount: number;
-    peers: readonly RallarRtcPeerDiagnostics[];
-    groupManager?: WebRtcGroupManagerDiagnostics;
-    overlayAdoption?: RallarOverlayAdoptionDiagnostics;
-    connectionAttemptBudget?: WebRtcPeerConnectionAttemptBudgetDiagnostics;
+  sessionId?: string;
+  generatedAtEpochMs: number;
+  peerCount: number;
+  connectedPeerCount: number;
+  relayPeerCount: number;
+  peers: readonly RallarRtcPeerDiagnostics[];
+  groupManager?: WebRtcGroupManagerDiagnostics;
+  overlayAdoption?: RallarOverlayAdoptionDiagnostics;
+  connectionAttemptBudget?: WebRtcPeerConnectionAttemptBudgetDiagnostics;
 }>;

--- a/packages/tests/repo/repo-style-check.test.ts
+++ b/packages/tests/repo/repo-style-check.test.ts
@@ -3,10 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  estimateCyclomaticComplexity,
-  extractRouteHandlerRanges,
-} from '../../../scripts/repo-style-check/factory-route-rules.mjs';
+import { estimateCyclomaticComplexity, extractRouteHandlerRanges } from '../../../scripts/repo-style-check/factory-route-rules.mjs';
 import { isTestRunnerConfigFile } from '../../../scripts/repo-style-check/repository-scan.mjs';
 
 const repoRoot = process.cwd();
@@ -33,9 +30,7 @@ describe('repo style checker', () => {
       ].join('\n'),
     });
 
-    expect(runChecker(fixtureRoot)).toContain(
-      'Command model CreateThingCommand contains optional fields',
-    );
+    expect(runChecker(fixtureRoot)).toContain('Command model CreateThingCommand contains optional fields');
   });
 
   it('keeps plain-object type guidance disabled unless explicitly requested', () => {
@@ -116,12 +111,7 @@ describe('repo style checker', () => {
         '  const runtimeShaped: number;',
         '}',
       ].join('\n'),
-      'ambient-vocabulary.d.ts': [
-        'export type AccountDto = Account;',
-        'export enum AccountStatus {',
-        '  Pending,',
-        '}',
-      ].join('\n'),
+      'ambient-vocabulary.d.ts': ['export type AccountDto = Account;', 'export enum AccountStatus {', '  Pending,', '}'].join('\n'),
     });
 
     expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
@@ -129,9 +119,7 @@ describe('repo style checker', () => {
 
   it('warns for TypeScript enum declarations', () => {
     const fixtureRoot = createFixture({
-      'account-status.ts': ['export enum AccountStatus {', '  Pending,', '  Complete,', '}'].join(
-        '\n',
-      ),
+      'account-status.ts': ['export enum AccountStatus {', '  Pending,', '  Complete,', '}'].join('\n'),
     });
 
     const result = runChecker(fixtureRoot);
@@ -141,38 +129,24 @@ describe('repo style checker', () => {
 
   it('keeps output-contract naming disabled unless explicitly requested', () => {
     const fixtureRoot = createFixture({
-      'computed.ts': ['function computeThing() {', '  return { first: 1, second: 2 };', '}'].join(
-        '\n',
-      ),
+      'computed.ts': ['function computeThing() {', '  return { first: 1, second: 2 };', '}'].join('\n'),
     });
 
     expect(runChecker(fixtureRoot)).not.toContain('without an explicit output contract');
-    expect(runChecker(fixtureRoot, '--output-contracts')).toContain(
-      'without an explicit output contract',
-    );
+    expect(runChecker(fixtureRoot, '--output-contracts')).toContain('without an explicit output contract');
   });
 
   it('does not require TypeScript output contracts in JavaScript modules', () => {
     const fixtureRoot = createFixture({
-      'computed.mjs': [
-        'export function computeThing() {',
-        '  return { first: 1, second: 2 };',
-        '}',
-      ].join('\n'),
+      'computed.mjs': ['export function computeThing() {', '  return { first: 1, second: 2 };', '}'].join('\n'),
     });
 
-    expect(runChecker(fixtureRoot, '--output-contracts')).not.toContain(
-      'without an explicit output contract',
-    );
+    expect(runChecker(fixtureRoot, '--output-contracts')).not.toContain('without an explicit output contract');
   });
 
   it('warns for an inline object return type when output checks are requested', () => {
     const fixtureRoot = createFixture({
-      'computed.ts': [
-        'function computeThing(): { first: number; second: number } {',
-        '  return { first: 1, second: 2 };',
-        '}',
-      ].join('\n'),
+      'computed.ts': ['function computeThing(): { first: number; second: number } {', '  return { first: 1, second: 2 };', '}'].join('\n'),
     });
 
     expect(runChecker(fixtureRoot, '--output-contracts')).toContain('Function computeThing');
@@ -233,10 +207,7 @@ describe('repo style checker', () => {
   });
 
   it('excludes generated declaration files from production warnings', () => {
-    const generatedLines = Array.from(
-      { length: 450 },
-      (_, index) => `export interface Generated${index} { readonly value: string; }`,
-    );
+    const generatedLines = Array.from({ length: 450 }, (_, index) => `export interface Generated${index} { readonly value: string; }`);
     const fixtureRoot = createFixture({
       'schema.generated.d.ts': generatedLines.join('\n'),
     });
@@ -247,7 +218,7 @@ describe('repo style checker', () => {
   // Tests are in scope for the standard, so the full checker reports them. Enforcement is staged
   // separately in the changed-range gate; this checker is warning-only either way.
   it('reports test and mock paths alongside production', () => {
-    const longLine = `const value = '${'x'.repeat(110)}';`;
+    const longLine = `const value = '${'x'.repeat(150)}';`;
     const fixtureRoot = createFixture({
       'tests/example.ts': longLine,
       'mocks/example.ts': longLine,
@@ -273,23 +244,14 @@ describe('repo style checker', () => {
   it('counts test sources in layout directory counts but never generated ones', () => {
     const fixtureRoot = createFixture({
       ...Object.fromEntries(
-        Array.from({ length: 20 }, (_, index) => [
-          `auth-command-${index}.ts`,
-          `export const authCommand${index} = ${index};`,
-        ]),
+        Array.from({ length: 20 }, (_, index) => [`auth-command-${index}.ts`, `export const authCommand${index} = ${index};`]),
       ),
       'schema.generated.ts': 'export const generatedSchema = true;',
       ...Object.fromEntries(
-        Array.from({ length: 21 }, (_, index) => [
-          `tests/test-command-${index}.ts`,
-          `export const testCommand${index} = ${index};`,
-        ]),
+        Array.from({ length: 21 }, (_, index) => [`tests/test-command-${index}.ts`, `export const testCommand${index} = ${index};`]),
       ),
       ...Object.fromEntries(
-        Array.from({ length: 21 }, (_, index) => [
-          `mocks/mock-command-${index}.ts`,
-          `export const mockCommand${index} = ${index};`,
-        ]),
+        Array.from({ length: 21 }, (_, index) => [`mocks/mock-command-${index}.ts`, `export const mockCommand${index} = ${index};`]),
       ),
       ...Object.fromEntries(
         Array.from({ length: 21 }, (_, index) => [
@@ -319,9 +281,7 @@ describe('repo style checker', () => {
     });
 
     expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
-    expect(readFileSync(path.join(repoRoot, 'docs/repo-human-style-guide.md'), 'utf8')).toMatch(
-      /test-runner\s+configuration files/,
-    );
+    expect(readFileSync(path.join(repoRoot, 'docs/repo-human-style-guide.md'), 'utf8')).toMatch(/test-runner\s+configuration files/);
   });
 
   it('classifies test-runner configuration filenames without regex backtracking', () => {
@@ -351,9 +311,7 @@ describe('repo style checker', () => {
       ].join('\n'),
     });
 
-    expect(runChecker(fixtureRoot)).toContain(
-      'Prefer required factory input and createDefaultServer()',
-    );
+    expect(runChecker(fixtureRoot)).toContain('Prefer required factory input and createDefaultServer()');
   });
 
   it('warns for hidden factory defaults regardless of the input type suffix', () => {
@@ -373,15 +331,11 @@ describe('repo style checker', () => {
       ].join('\n'),
     });
 
-    expect(runChecker(fixtureRoot)).toContain(
-      'Prefer required factory input and createDefaultServer()',
-    );
+    expect(runChecker(fixtureRoot)).toContain('Prefer required factory input and createDefaultServer()');
   });
 
   it('keeps the checker implementation free of self-reported style findings', () => {
-    expect(runChecker(path.join(repoRoot, 'scripts/repo-style-check'))).toContain(
-      'PASS (no issues found in this run)',
-    );
+    expect(runChecker(path.join(repoRoot, 'scripts/repo-style-check'))).toContain('PASS (no issues found in this run)');
   });
 
   it('reports conservative layout warnings by default and isolates them on request', () => {
@@ -389,9 +343,7 @@ describe('repo style checker', () => {
       ...Object.fromEntries(
         Array.from({ length: 21 }, (_, index) => [
           `auth-command-${index}.ts`,
-          index === 0
-            ? `export const authCommand${index} = '${'x'.repeat(110)}';`
-            : `export const authCommand${index} = ${index};`,
+          index === 0 ? `export const authCommand${index} = '${'x'.repeat(110)}';` : `export const authCommand${index} = ${index};`,
         ]),
       ),
     });
@@ -442,10 +394,7 @@ describe('repo style checker', () => {
   it('caps displayed warnings while preserving full finding and affected-item counts', () => {
     const files = {
       ...Object.fromEntries(
-        Array.from({ length: 205 }, (_, index) => [
-          `feature-${index}/long-line.ts`,
-          `const value${index} = '${'x'.repeat(110)}';`,
-        ]),
+        Array.from({ length: 205 }, (_, index) => [`feature-${index}/long-line.ts`, `const value${index} = '${'x'.repeat(110)}';`]),
       ),
       'BadOne.ts': 'export const badOne = true;',
       'BadTwo.ts': 'export const badTwo = true;',
@@ -467,9 +416,7 @@ describe('repo style checker', () => {
     expect(executeChecker(fixtureRoot).status).toBe(0);
     const strictResult = executeChecker(fixtureRoot, '--strict');
     expect(strictResult.status).toBe(1);
-    expect(`${strictResult.stdout}${strictResult.stderr}`).toContain(
-      'strict mode is not available',
-    );
+    expect(`${strictResult.stdout}${strictResult.stderr}`).toContain('strict mode is not available');
   });
 });
 

--- a/packages/tests/repo/repo-style-structural-lineage-fixtures.ts
+++ b/packages/tests/repo/repo-style-structural-lineage-fixtures.ts
@@ -48,17 +48,11 @@ export function createSplitFixture(input: CreateSplitFixtureInput): SplitFixture
   commitAll(root, 'base');
   const mergeBase = readGit(root, ['rev-parse', 'HEAD']).trim();
   const sourceBlob = readBlob(root, mergeBase, sourcePath);
-  const targetPaths =
-    input.targetPaths ??
-    input.targetFindings.map((_, index) => `apps/example/target-${letter(index)}.ts`);
+  const targetPaths = input.targetPaths ?? input.targetFindings.map((_, index) => `apps/example/target-${letter(index)}.ts`);
   writeFixture(
     root,
     sourcePath,
-    targetPaths
-      .map(
-        (targetPath) => `export * from './${path.basename(targetPath, path.extname(targetPath))}';`,
-      )
-      .join('\n'),
+    targetPaths.map((targetPath) => `export * from './${path.basename(targetPath, path.extname(targetPath))}';`).join('\n'),
   );
   targetPaths.forEach((targetPath, index) => {
     writeFixture(root, targetPath, input.targetFindings[index]?.join('') ?? '');
@@ -86,11 +80,7 @@ export function writeLineageManifest(root: string, lineages: readonly unknown[])
   writeLineageManifestAt(root, 'plans/repo-style-lineages/example.json', lineages);
 }
 
-export function writeLineageManifestAt(
-  root: string,
-  relativePath: string,
-  lineages: readonly unknown[],
-): void {
+export function writeLineageManifestAt(root: string, relativePath: string, lineages: readonly unknown[]): void {
   writeFixture(root, relativePath, `${JSON.stringify({ version: 1, lineages }, null, 2)}\n`);
 }
 
@@ -177,14 +167,10 @@ export function readBlob(root: string, revision: string, relativePath: string): 
 
 export function runChangedChecker(input: RunChangedCheckerInput) {
   const targetReference = input.targetReference ?? 'HEAD';
-  return spawnSync(
-    process.execPath,
-    [...(input.nodeArguments ?? []), checkerPath, input.mergeBase, targetReference],
-    {
-      cwd: input.root,
-      encoding: 'utf8',
-    },
-  );
+  return spawnSync(process.execPath, [...(input.nodeArguments ?? []), checkerPath, input.mergeBase, targetReference], {
+    cwd: input.root,
+    encoding: 'utf8',
+  });
 }
 
 export function runGit(root: string, args: readonly string[]): void {
@@ -203,10 +189,7 @@ export function overlongSource(label: string, extraLength = 0): string {
 }
 
 export function unknownSource(prefix: string, count: number): string {
-  return Array.from(
-    { length: count },
-    (_, index) => `const ${prefix}${index}: unknown = ${index};`,
-  ).join('\n');
+  return Array.from({ length: count }, (_, index) => `const ${prefix}${index}: unknown = ${index};`).join('\n');
 }
 
 function letter(index: number): string {

--- a/packages/tests/repo/repo-style-structural-lineage.test.ts
+++ b/packages/tests/repo/repo-style-structural-lineage.test.ts
@@ -1,10 +1,4 @@
-// prettier-ignore
-import {
-  afterEach,
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   cleanupStructuralLineageFixtures,
@@ -103,9 +97,7 @@ describe('changed repository style structural lineage', () => {
       baseFindings: [overlongSource('alpha')],
       targetFindings: [[overlongSource('bravo')]],
     });
-    writeLineageManifestAt(fixture.root, 'plans/repo-style-lineages/nested/example.json', [
-      lineage(fixture),
-    ]);
+    writeLineageManifestAt(fixture.root, 'plans/repo-style-lineages/nested/example.json', [lineage(fixture)]);
 
     const worktreeResult = runChangedChecker({
       root: fixture.root,
@@ -256,8 +248,7 @@ describe('changed repository style structural lineage', () => {
     },
     {
       name: 'missing target',
-      mutate: (fixture: SplitFixture) =>
-        lineage(fixture, { targets: ['apps/example/missing-target.ts'] }),
+      mutate: (fixture: SplitFixture) => lineage(fixture, { targets: ['apps/example/missing-target.ts'] }),
       diagnostic: 'target does not exist',
     },
     {
@@ -270,14 +261,12 @@ describe('changed repository style structural lineage', () => {
     },
     {
       name: 'malformed path',
-      mutate: (fixture: SplitFixture) =>
-        lineage(fixture, { targets: ['apps/example/../outside.ts'] }),
+      mutate: (fixture: SplitFixture) => lineage(fixture, { targets: ['apps/example/../outside.ts'] }),
       diagnostic: 'target path must be a normalized repository-relative path',
     },
     {
       name: 'non-production path',
-      mutate: (fixture: SplitFixture) =>
-        lineage(fixture, { targets: ['packages/tests/example.ts'] }),
+      mutate: (fixture: SplitFixture) => lineage(fixture, { targets: ['packages/tests/example.ts'] }),
       diagnostic: 'target path must name production code',
     },
   ])('fails closed for a $name', ({ mutate, diagnostic }) => {
@@ -370,16 +359,8 @@ describe('changed repository style structural lineage', () => {
       baseFindings: [overlongSource('base')],
       targetFindings: [[overlongSource('target')]],
     });
-    writeFixture(
-      fixture.root,
-      'plans/repo-style-lineages/zeta.json',
-      '{"version":1,"lineages":"not-an-array"}\n',
-    );
-    writeFixture(
-      fixture.root,
-      'plans/repo-style-lineages/alpha.json',
-      '{"version":2,"lineages":[]}\n',
-    );
+    writeFixture(fixture.root, 'plans/repo-style-lineages/zeta.json', '{"version":1,"lineages":"not-an-array"}\n');
+    writeFixture(fixture.root, 'plans/repo-style-lineages/alpha.json', '{"version":2,"lineages":[]}\n');
     commitAll(fixture.root, 'add malformed manifests');
 
     const first = runChangedChecker({ root: fixture.root, mergeBase: fixture.mergeBase });

--- a/packages/tests/repo/repo-style-test-calibration.test.ts
+++ b/packages/tests/repo/repo-style-test-calibration.test.ts
@@ -10,23 +10,48 @@ import {
   isTestSourceFile,
   resolveFileLineBackstop,
   testEnforcedRuleIds,
+  scanProductionSources,
 } from '../../../scripts/repo-style-check/repository-scan.mjs';
 
 const repoRoot = process.cwd();
 
 function readStyleAuthority(): string {
-  return readFileSync(
-    path.join(repoRoot, '.agents/skills/rallar-code-writing/references/repo-code-style.md'),
-    'utf8',
-  );
+  return readFileSync(path.join(repoRoot, '.agents/skills/rallar-code-writing/references/repo-code-style.md'), 'utf8');
 }
 
 function readScanner(): string {
-  return readFileSync(
-    path.join(repoRoot, 'scripts/repo-style-check/repository-scan.mjs'),
-    'utf8',
-  );
+  return readFileSync(path.join(repoRoot, 'scripts/repo-style-check/repository-scan.mjs'), 'utf8');
 }
+
+describe('line width by line kind', () => {
+  const scan = (file: string, raw: string) =>
+    scanProductionSources({
+      repoRoot: process.cwd(),
+      sources: [{ file: path.join(process.cwd(), file), raw }],
+      options: {},
+    }).findings.filter((entry) => entry.ruleId === 'line.width');
+
+  const pad = (count: number) => 'A'.repeat(count);
+
+  it('measures code at 100', () => {
+    expect(scan('packages/shared/probe.ts', `const value = '${pad(95)}';\n`)).toHaveLength(1);
+    expect(scan('packages/shared/probe.ts', `const value = '${pad(60)}';\n`)).toHaveLength(0);
+  });
+
+  it('does not measure a module specifier at all', () => {
+    const long = `import type { Probe } from './${pad(180)}.ts';\n`;
+
+    expect(scan('packages/shared/probe.ts', long)).toHaveLength(0);
+  });
+
+  it('measures a function or interface declaration header at 140', () => {
+    const under = `export interface Probe${pad(60)} { readonly a: string }\n`;
+    const over = `export interface Probe${pad(140)} { readonly a: string }\n`;
+
+    expect(scan('packages/shared/probe.ts', under)).toHaveLength(0);
+    expect(scan('packages/shared/probe.ts', over)).toHaveLength(1);
+  });
+});
 
 describe('repo style test calibration', () => {
   it('gives test files the wider navigation backstop the test corpus was measured against', () => {
@@ -47,11 +72,7 @@ describe('repo style test calibration', () => {
   it('blocks only the staged rules when the changed file is a test', () => {
     const testFile = 'packages/tests/shared/queue.test.ts';
 
-    expect([...testEnforcedRuleIds].toSorted()).toEqual([
-      'boundary.unknown',
-      'construction.forward-capture',
-      'line.width',
-    ]);
+    expect([...testEnforcedRuleIds].toSorted()).toEqual(['boundary.unknown', 'construction.forward-capture', 'line.width']);
     expect(isTestEnforcedFinding(testFile, 'line.width')).toBe(true);
     expect(isTestEnforcedFinding(testFile, 'boundary.unknown')).toBe(true);
     expect(isTestEnforcedFinding(testFile, 'file.cognitive-load')).toBe(false);
@@ -90,10 +111,7 @@ describe('repo style test calibration', () => {
   });
 
   it('resolves conventional role qualifiers before reading a filename stem', () => {
-    const layoutRules = readFileSync(
-      path.join(repoRoot, 'scripts/repo-style-check/layout-rules.mjs'),
-      'utf8',
-    );
+    const layoutRules = readFileSync(path.join(repoRoot, 'scripts/repo-style-check/layout-rules.mjs'), 'utf8');
 
     expect(layoutRules).toContain('fileRoleQualifierPattern');
     expect(layoutRules).toContain('.replace(fileRoleQualifierPattern');

--- a/packages/tests/repo/validation-evidence/branch-release-result.test.ts
+++ b/packages/tests/repo/validation-evidence/branch-release-result.test.ts
@@ -8,26 +8,23 @@ describe('Branch Release Gate result', () => {
   it.each([
     ['governance', 'cancelled', 'cancelled', 'skipped', 'cancelled'],
     ['release', 'success', 'success', 'cancelled', 'cancelled'],
-  ])('reports a cancelled %s run as cancelled, not as a failure', (
-    _name,
-    governanceResult,
-    selectionResult,
-    releaseResult,
-    publicationResult,
-  ) => {
-    const issues = validateBranchReleaseConclusion({
-      governanceResult,
-      selectionResult,
-      reuse: '',
-      releaseResult,
-      publicationResult,
-    });
+  ])(
+    'reports a cancelled %s run as cancelled, not as a failure',
+    (_name, governanceResult, selectionResult, releaseResult, publicationResult) => {
+      const issues = validateBranchReleaseConclusion({
+        governanceResult,
+        selectionResult,
+        reuse: '',
+        releaseResult,
+        publicationResult,
+      });
 
-    expect(issues).toHaveLength(1);
-    expect(issues[0]).toContain('run cancelled before it could conclude');
-    expect(issues[0]).toContain('a superseding run decides this branch');
-    expect(issues[0]).not.toContain('reuse decision must be true or false');
-  });
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('run cancelled before it could conclude');
+      expect(issues[0]).toContain('a superseding run decides this branch');
+      expect(issues[0]).not.toContain('reuse decision must be true or false');
+    },
+  );
 
   it.each([
     ['fresh validation', 'false', 'success', 'success'],

--- a/packages/tests/repo/validation-evidence/branch-release-result.test.ts
+++ b/packages/tests/repo/validation-evidence/branch-release-result.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, it } from 'vitest';
 import { validateBranchReleaseConclusion } from '../../../../scripts/validation-evidence/branch-release-result.mjs';
 
 describe('Branch Release Gate result', () => {
+  // A superseded run cancels its jobs, leaving their outputs empty. The conclusion must name that
+  // rather than reporting the chain of derived failures an empty reuse decision would produce.
+  it.each([
+    ['governance', 'cancelled', 'cancelled', 'skipped', 'cancelled'],
+    ['release', 'success', 'success', 'cancelled', 'cancelled'],
+  ])('reports a cancelled %s run as cancelled, not as a failure', (
+    _name,
+    governanceResult,
+    selectionResult,
+    releaseResult,
+    publicationResult,
+  ) => {
+    const issues = validateBranchReleaseConclusion({
+      governanceResult,
+      selectionResult,
+      reuse: '',
+      releaseResult,
+      publicationResult,
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain('run cancelled before it could conclude');
+    expect(issues[0]).toContain('a superseding run decides this branch');
+    expect(issues[0]).not.toContain('reuse decision must be true or false');
+  });
+
   it.each([
     ['fresh validation', 'false', 'success', 'success'],
     ['same-PR content reuse', 'true', 'skipped', 'skipped'],

--- a/packages/tests/shared-server/admin-operations-service.test.ts
+++ b/packages/tests/shared-server/admin-operations-service.test.ts
@@ -9,10 +9,7 @@ import type {
 import type { RallarCrdtDocumentRef } from '@shared/crdt/mod.ts';
 import type { AdminOperationsMutationGateway } from '@shared-server/rallar-system/admin-operations/admin-operations-mutation-gateway.ts';
 import { AdminOperationsService } from '@shared-server/rallar-system/admin-operations/AdminOperationsService.ts';
-// prettier-ignore
-import {
-  emptyGroupFormationMetrics,
-} from '@shared-server/rallar-system/formation-metrics.ts';
+import { emptyGroupFormationMetrics } from '@shared-server/rallar-system/formation-metrics.ts';
 import type { RallarTimingEvent } from '@shared-server/rallar-system/services/timing.ts';
 
 const NOW_EPOCH_MS = 1_700_000_000_000;
@@ -272,16 +269,18 @@ describe('AdminOperationsService', () => {
       request: { document: CRDT_DOCUMENT },
     });
 
-    expect(calls).toEqual([{
-      document: CRDT_DOCUMENT,
-      options: {
-        reason: 'api-v1-admin-operations-debug-export',
-        redaction: {
-          payloadsRedacted: true,
-          reason: 'api-v1-admin-operations-redaction',
+    expect(calls).toEqual([
+      {
+        document: CRDT_DOCUMENT,
+        options: {
+          reason: 'api-v1-admin-operations-debug-export',
+          redaction: {
+            payloadsRedacted: true,
+            reason: 'api-v1-admin-operations-redaction',
+          },
         },
       },
-    }]);
+    ]);
     expect(result).toMatchObject({
       document: CRDT_DOCUMENT,
       redaction: { payloadsRedacted: true },
@@ -289,9 +288,7 @@ describe('AdminOperationsService', () => {
   });
 });
 
-function createService(
-  overrides: Partial<ConstructorParameters<typeof AdminOperationsService>[0]> = {},
-): AdminOperationsService {
+function createService(overrides: Partial<ConstructorParameters<typeof AdminOperationsService>[0]> = {}): AdminOperationsService {
   return new AdminOperationsService({
     now: () => NOW_EPOCH_MS,
     serverId: 'test-server',
@@ -310,9 +307,7 @@ function createService(
   });
 }
 
-function createMutationGateway(
-  overrides: Partial<AdminOperationsMutationGateway> = {},
-): AdminOperationsMutationGateway {
+function createMutationGateway(overrides: Partial<AdminOperationsMutationGateway> = {}): AdminOperationsMutationGateway {
   const completed = () => Promise.resolve({ status: 'completed', changed: false });
   return {
     recomputeTopology: completed,

--- a/packages/tests/shared-server/admin-prune-retry-lifetime.test.ts
+++ b/packages/tests/shared-server/admin-prune-retry-lifetime.test.ts
@@ -1,10 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_RESOURCE_INBOX_RETRY_HORIZON_MS,
@@ -16,21 +11,12 @@ import {
   type AdminPruneExpiredRepository,
   type AdminPrunePageRead,
 } from '@shared-server/rallar-system/admin-operations/AdminPruneExpiredWork.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import type {
-  ReservedAdminPrunePageWork,
-} from '@shared-server/rallar-system/admin-operations/admin-prune-work-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createAdminPruneAggregate,
-} from '@shared-server/rallar-system/admin-operations/admin-prune-progress.ts';
+import type { ReservedAdminPrunePageWork } from '@shared-server/rallar-system/admin-operations/admin-prune-work-codec.ts';
+import { createAdminPruneAggregate } from '@shared-server/rallar-system/admin-operations/admin-prune-progress.ts';
 import type { PSqlSql, PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
 
 const NOW = 1_700_000_000_000;
-const RETRY_LIFETIME =
-  DEFAULT_RESOURCE_INBOX_RETRY_HORIZON_MS + RESOURCE_INBOX_RETRY_PROCESSING_MARGIN_MS;
+const RETRY_LIFETIME = DEFAULT_RESOURCE_INBOX_RETRY_HORIZON_MS + RESOURCE_INBOX_RETRY_PROCESSING_MARGIN_MS;
 
 describe('admin prune retry lifetime', () => {
   it('gives every successor and pending result a complete 20-attempt retry horizon', () => {
@@ -65,9 +51,7 @@ describe('admin prune retry lifetime', () => {
     const computed = service.compute(command, read);
 
     expect(computed.next?.expireAtEpochMs).toBe(NOW + RETRY_LIFETIME);
-    expect(Number(computed.aggregateSuccessor.audit.expiryTs.epochMilliseconds)).toBe(
-      NOW + RETRY_LIFETIME,
-    );
+    expect(Number(computed.aggregateSuccessor.audit.expiryTs.epochMilliseconds)).toBe(NOW + RETRY_LIFETIME);
   });
 });
 
@@ -106,10 +90,7 @@ function createReservation(): ResourceEntry {
 
 function createDatabase(): PSqlSql {
   const database: PSqlSql = Object.assign(
-    <T>(
-      _stringsOrValues: TemplateStringsArray | readonly unknown[],
-      ..._values: unknown[]
-    ): Promise<T> =>
+    <T>(_stringsOrValues: TemplateStringsArray | readonly unknown[], ..._values: unknown[]): Promise<T> =>
       Promise.reject(new Error('Unexpected SQL execution in admin prune compute test')),
     {
       begin: <T>(_run: (sql: PSqlTransactionSql) => Promise<T>): Promise<T> =>

--- a/packages/tests/shared-server/authoritative-mutation-read-compute-validate-write.test.ts
+++ b/packages/tests/shared-server/authoritative-mutation-read-compute-validate-write.test.ts
@@ -1,16 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { findMutationBoundaryViolations } from './mutation-boundary-analysis.ts';
 import { readFunctionBody, readMethodBody } from './authoritative-mutation-source-analysis.ts';
-// prettier-ignore
-import { authoritativeMutationRuntimeSourcePaths }
-  from './authoritative-mutation-runtime-source-inventory.ts';
+import { authoritativeMutationRuntimeSourcePaths } from './authoritative-mutation-runtime-source-inventory.ts';
 
 // Retain permanently as cross-domain semantic phase-order evidence.
 const read = (file: string): string => readFileSync(file, 'utf8');
@@ -37,16 +30,13 @@ const sharedValidationPrimitiveNames = [
   'nullablePositiveSafeInteger',
 ] as const;
 const forbiddenPersistenceOwnerImport = new RegExp(
-  String.raw`from ['"](?:\.\.\/)+` +
-    String.raw`(?:mutation|services|inbox|repositories\/GroupStateRepository)(?:\/|\.ts)`,
+  String.raw`from ['"](?:\.\.\/)+` + String.raw`(?:mutation|services|inbox|repositories\/GroupStateRepository)(?:\/|\.ts)`,
 );
 
 const sources = {
   appAdmin: read(`${serviceRoot}/AppAdminInboxService.ts`),
   authHandler: read(`${authRoot}/inbox/auth-inbox-handler.ts`),
-  appClient: read(
-    'packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts',
-  ),
+  appClient: read('packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts'),
   appCrdt: read('packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts'),
   crdtAdminMutations: read('apps/api-v1/src/crdt/create-crdt-admin-mutations.ts'),
   appGroup: read(`${serviceRoot}/AppGroupInboxService.ts`),
@@ -54,9 +44,7 @@ const sources = {
   rtcHandler: read(`${rtcInboxRoot}/rtc-rtt-app-inbox-handler.ts`),
   groupHandler: read(`${groupStateRoot}/inbox/group-state-inbox-handler.ts`),
   groupService: read(`${groupStateRoot}/group-state-service.ts`),
-  client: read(
-    'packages/shared-server/rallar-system/client-state/mutation/write/write-client-mutation.ts',
-  ),
+  client: read('packages/shared-server/rallar-system/client-state/mutation/write/write-client-mutation.ts'),
   group: read(`${groupStateRoot}/mutation/write/write-group-mutation.ts`),
   topologyConfig: read(`${topologyRoot}/config/mutation/write-topology-config-mutation.ts`),
   topologyReconfigure: read(`${topologyRoot}/reconfigure/group-topology-reconfigure-mutation.ts`),
@@ -99,30 +87,18 @@ it('keeps group-state service and inbox ownership in the target modules', () => 
 });
 
 it('keeps persistence validators below mutation and stateful owners', () => {
-  for (const file of [
-    `${persistenceRoot}/validate-persisted-group.ts`,
-    `${persistenceRoot}/validate-persisted-group-presence.ts`,
-  ]) {
+  for (const file of [`${persistenceRoot}/validate-persisted-group.ts`, `${persistenceRoot}/validate-persisted-group-presence.ts`]) {
     const source = read(file);
     expect(source, file).not.toMatch(forbiddenPersistenceOwnerImport);
   }
 });
 
 it('keeps one implementation of each shared group-state validation primitive', () => {
-  const validatorPaths = [
-    `${persistenceRoot}/validate-persisted-group.ts`,
-    `${persistenceRoot}/validate-persisted-group-presence.ts`,
-  ];
-  const ownerSources = [validationPrimitivesPath, oldValidationPath, ...validatorPaths]
-    .filter(existsSync)
-    .map(read)
-    .join('\n');
+  const validatorPaths = [`${persistenceRoot}/validate-persisted-group.ts`, `${persistenceRoot}/validate-persisted-group-presence.ts`];
+  const ownerSources = [validationPrimitivesPath, oldValidationPath, ...validatorPaths].filter(existsSync).map(read).join('\n');
 
   for (const name of sharedValidationPrimitiveNames) {
-    expect(
-      ownerSources.match(new RegExp(`function\\s+${name}\\s*\\(`, 'g')) ?? [],
-      name,
-    ).toHaveLength(1);
+    expect(ownerSources.match(new RegExp(`function\\s+${name}\\s*\\(`, 'g')) ?? [], name).toHaveLength(1);
   }
 });
 
@@ -130,10 +106,7 @@ it('keeps shared validation primitives in the feature root', () => {
   expect(existsSync(validationPrimitivesPath), validationPrimitivesPath).toBe(true);
   expect(existsSync(oldValidationPath), oldValidationPath).toBe(false);
 
-  for (const file of [
-    `${persistenceRoot}/validate-persisted-group.ts`,
-    `${persistenceRoot}/validate-persisted-group-presence.ts`,
-  ]) {
+  for (const file of [`${persistenceRoot}/validate-persisted-group.ts`, `${persistenceRoot}/validate-persisted-group-presence.ts`]) {
     expect(read(file), file).toContain("from '../group-state-validation-primitives.ts'");
   }
 });
@@ -167,12 +140,7 @@ it.each([
     name: 'admin AppInbox',
     source: sources.appAdmin,
     owner: 'processCommand',
-    calls: [
-      'this.read(command)',
-      'this.compute(command, read)',
-      'this.validate(command, read, computed)',
-      'this.writeMutation(context',
-    ],
+    calls: ['this.read(command)', 'this.compute(command, read)', 'this.validate(command, read, computed)', 'this.writeMutation(context'],
   },
   {
     name: 'client AppInbox',
@@ -224,12 +192,7 @@ it.each([
     name: 'RTC RTT AppInbox',
     source: sources.rtcHandler,
     owner: 'processMutation',
-    calls: [
-      'readRtcRttMutation(',
-      'computeRtcRttMutation(',
-      'validateRtcRttMutation(',
-      'this.commitMutation(',
-    ],
+    calls: ['readRtcRttMutation(', 'computeRtcRttMutation(', 'validateRtcRttMutation(', 'this.commitMutation('],
   },
 ])('$name keeps one visible read/compute/validate/write path', ({ source, owner, calls }) => {
   const body = readMethodBody(source, owner);
@@ -309,12 +272,7 @@ it('fences explicit reconfigure authority before inserting APP_OUTBOX', () => {
 
 it('writes RTT admission, measurement, receipt, and direct APP_OUTBOX rows atomically', () => {
   const seam = readFunctionBody(sources.rtt, 'writeRtcRttMutation');
-  expectInOrder(seam, [
-    'commitEndpointAdmission(',
-    'commitMeasurement(',
-    'insertMutationReceipt(',
-    'writeRtcTopologyOutbox(transaction,',
-  ]);
+  expectInOrder(seam, ['commitEndpointAdmission(', 'commitMeasurement(', 'insertMutationReceipt(', 'writeRtcTopologyOutbox(transaction,']);
   expect(seam).not.toContain('insertRecomputeIntent');
   expect(seam).not.toContain('StateMutation' + 'Outbox');
 });
@@ -341,13 +299,7 @@ it('keeps all topology and RTT computed effects direct and mandatory', () => {
 });
 
 it('does not reintroduce intermediate state-mutation intents on Task 7 paths', () => {
-  for (const source of [
-    sources.appGroup,
-    sources.topologyConfig,
-    sources.topologyReconfigure,
-    sources.rtt,
-    sources.topologyWorker,
-  ]) {
+  for (const source of [sources.appGroup, sources.topologyConfig, sources.topologyReconfigure, sources.rtt, sources.topologyWorker]) {
     expect(source).not.toContain('StateMutation' + 'OutboxWork');
   }
   expect(sources.topologyConfig).not.toContain('StateMutation' + 'OutboxRepository');

--- a/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
@@ -6,37 +6,17 @@ import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-import {
-  AuthSessionRepository,
-  type IssuedAuthSession,
-} from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
-// prettier-ignore
-import {
-  AppClientInboxService,
-} from
-'@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
-// prettier-ignore
-import {
-  toAuthorisedWsClientConnectEnqueue,
-} from
-'@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
-// prettier-ignore
-import {
-  createClientStateService,
-} from
-'@shared-server/rallar-system/client-state/client-state-service.ts';
-// prettier-ignore
+import { AuthSessionRepository, type IssuedAuthSession } from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
+import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
+import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import type {
   ClientMutationWritten,
   ClientStateWritten,
-} from
-'@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+} from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
-import {
-  TestResourceInbox,
-  TestResourceInboxResults,
-} from '../auth/auth-app-inbox-test-runtime.ts';
+import { TestResourceInbox, TestResourceInboxResults } from '../auth/auth-app-inbox-test-runtime.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 
 const SERVICE_ID = 'server-12345678';
@@ -67,9 +47,7 @@ it('rejects authorised websocket disconnect after durable auth revocation', asyn
       userAgent: 'Browser',
     },
   } as const;
-  const connected = await processAppInboxMethod(reader, () =>
-    service.processAuthorisedWsClientConnect(connectInput),
-  );
+  const connected = await processAppInboxMethod(reader, () => service.processAuthorisedWsClientConnect(connectInput));
   vi.mocked(publisher.publishClientSnapshot).mockClear();
   vi.mocked(publisher.publishClientEvent).mockClear();
   await authSessions.deleteSession(authSession);
@@ -192,61 +170,53 @@ it('processes authorised websocket connects independently per state scope', asyn
   });
 });
 
-it(
-  [
-    'disconnects authorised websocket sessions from their connected state scope',
-    'while auth exists',
-  ].join(' '),
-  async () => {
-    const queue = new TestResourceInbox();
-    const reader = new InboxQueueReader(queue);
-    const results = new TestResourceInboxResults();
-    const publisher = createPublisher();
-    const authSession = issuedSession('admin', 'admin-ws-session');
-    const runtimeRepository = new FakeRuntimeStateRepository();
-    await new AuthSessionRepository(runtimeRepository).putSession(authSession);
-    const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
-    const service = createAuthorisedWsService({
-      database,
-      queue,
-      reader,
-      results,
-      runtimeRepository,
-    });
+it(['disconnects authorised websocket sessions from their connected state scope', 'while auth exists'].join(' '), async () => {
+  const queue = new TestResourceInbox();
+  const reader = new InboxQueueReader(queue);
+  const results = new TestResourceInboxResults();
+  const publisher = createPublisher();
+  const authSession = issuedSession('admin', 'admin-ws-session');
+  const runtimeRepository = new FakeRuntimeStateRepository();
+  await new AuthSessionRepository(runtimeRepository).putSession(authSession);
+  const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
+  const service = createAuthorisedWsService({
+    database,
+    queue,
+    reader,
+    results,
+    runtimeRepository,
+  });
 
-    const connectInput = {
-      authSession,
-      generationId: 'generation-scoped',
-      input: {
-        applicationId: 'ar-eye-hunter',
-        workspaceId: 'default',
-        expiresAtEpochMs: Date.now() + 60_000,
-      },
-    } as const;
-    await processAppInboxMethod(reader, () =>
-      service.processAuthorisedWsClientConnect(connectInput),
-    );
-    const disconnected = await processAppInboxMethod(reader, () =>
-      service.processAuthorisedWsClientDisconnect({
-        connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
-        disconnectedAtEpochMs: Date.now(),
-        reason: 'socket-closed',
-      }),
-    );
-
-    expect(requireRightSnapshot(disconnected).principal).toMatchObject({
+  const connectInput = {
+    authSession,
+    generationId: 'generation-scoped',
+    input: {
       applicationId: 'ar-eye-hunter',
       workspaceId: 'default',
-      principalId: 'admin',
-    });
-    expect(requireRightSnapshot(disconnected).activeSessions).toHaveLength(0);
-    expect(requireRightWritten(disconnected).event).toMatchObject({
-      applicationId: 'ar-eye-hunter',
-      workspaceId: 'default',
-      eventType: 'session-disconnected',
-    });
-  },
-);
+      expiresAtEpochMs: Date.now() + 60_000,
+    },
+  } as const;
+  await processAppInboxMethod(reader, () => service.processAuthorisedWsClientConnect(connectInput));
+  const disconnected = await processAppInboxMethod(reader, () =>
+    service.processAuthorisedWsClientDisconnect({
+      connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
+      disconnectedAtEpochMs: Date.now(),
+      reason: 'socket-closed',
+    }),
+  );
+
+  expect(requireRightSnapshot(disconnected).principal).toMatchObject({
+    applicationId: 'ar-eye-hunter',
+    workspaceId: 'default',
+    principalId: 'admin',
+  });
+  expect(requireRightSnapshot(disconnected).activeSessions).toHaveLength(0);
+  expect(requireRightWritten(disconnected).event).toMatchObject({
+    applicationId: 'ar-eye-hunter',
+    workspaceId: 'default',
+    eventType: 'session-disconnected',
+  });
+});
 
 interface CreateAuthorisedWsServiceInput {
   readonly database: ReturnType<typeof createAppInboxTestDatabase>;
@@ -287,8 +257,7 @@ function requireRightWritten(result: Either<string, ClientStateWritten>): Client
 }
 
 function requireClientMutationWritten(written: ClientStateWritten): ClientMutationWritten {
-  const result = written.result as
-    ClientStateWritten['result'] | { left?: string; right?: ClientMutationWritten };
+  const result = written.result as ClientStateWritten['result'] | { left?: string; right?: ClientMutationWritten };
   if ('fold' in result && typeof result.fold === 'function') {
     return result.fold(
       (error) => {
@@ -315,10 +284,7 @@ function issuedSession(clientId: string, sessionId: string): IssuedAuthSession {
   };
 }
 
-async function processAppInboxMethod<R>(
-  reader: InboxQueueReader,
-  run: () => Promise<R>,
-): Promise<R> {
+async function processAppInboxMethod<R>(reader: InboxQueueReader, run: () => Promise<R>): Promise<R> {
   const resultPromise = run();
   await new Promise((resolve) => setTimeout(resolve, 0));
   await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
@@ -334,11 +300,5 @@ function createPublisher() {
 
 function createResilience(): ResilienceDto {
   const duration = Temporal.Duration.from({ seconds: 10 });
-  return ResilienceDto.toResilienceDto(
-    new CircuitBreakerPolicy(10, duration, duration, duration),
-    1,
-    10,
-    1,
-    1,
-  );
+  return ResilienceDto.toResilienceDto(new CircuitBreakerPolicy(10, duration, duration, duration), 1, 10, 1, 1);
 }

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry-fixtures.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry-fixtures.ts
@@ -7,10 +7,7 @@ import {
   type ResourceEntry,
   toKeyAsString,
 } from '@shared/queuebox/ResourceEntry.ts';
-// prettier-ignore
-import {
-  AuthSessionRepository,
-} from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
+import { AuthSessionRepository } from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
 
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 
@@ -45,16 +42,12 @@ export class ClientExpiryTestResourceInboxResults {
   }
 }
 
-export async function readClientExpiryTestEntries(
-  queue: ClientExpiryTestResourceInbox,
-): Promise<ResourceEntry[]> {
+export async function readClientExpiryTestEntries(queue: ClientExpiryTestResourceInbox): Promise<ResourceEntry[]> {
   const entries = await Promise.all((await queue.getAllKeys()).map((key) => queue.getItem(key)));
   return entries.filter((entry): entry is ResourceEntry => entry !== undefined);
 }
 
-export function listActiveClientExpiryTestEntries(
-  entries: readonly ResourceEntry[],
-): ResourceEntry[] {
+export function listActiveClientExpiryTestEntries(entries: readonly ResourceEntry[]): ResourceEntry[] {
   return entries.filter((entry) => NOT_COMPLETED_RETRYABLE_STATUSES.has(entry.status));
 }
 

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
@@ -3,22 +3,13 @@ import { expect, it, vi } from 'vitest';
 import type { ClientPrincipalRef } from '@shared/api/client-types.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-// prettier-ignore
-import {
-  ClientStateRepository,
-} from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
+import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
 import {
   type ClientStateService,
   type ClientStateWritten,
 } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-// prettier-ignore
-import {
-  createClientStateService,
-} from '@shared-server/rallar-system/client-state/client-state-service.ts';
-// prettier-ignore
-import {
-  AppClientInboxService,
-} from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
+import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
 import {
   type ClientExpiredSessionsAppInboxPayload,
   type ClientSessionConnectAppInboxPayload,
@@ -45,48 +36,35 @@ interface SeedClientExpirySessionInput {
   readonly runtimeRepository: FakeRuntimeStateRepository;
 }
 
-// prettier-ignore
-it(
-  'processes expired client sessions through the inbox and publishes written mutations',
-  async () => {
-    const queue = new ClientExpiryTestResourceInbox();
-    const reader = new InboxQueueReader(queue);
-    const results = new ClientExpiryTestResourceInboxResults();
-    const runtimeRepository = new FakeRuntimeStateRepository();
-    const publisher = createPublisher();
-    const expiresAtEpochMs = Date.now() - 1_000;
-    const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
-    const clientStateService = createClientStateService({
-      runtimeRepository,
-      formationDamping: 'damped',
-      createClientStateEventStore: () => database.clientEventStore,
-      serviceId: 'server-12345678',
-    });
-    const service = new AppClientInboxService(
-      reader,
-      queue as never,
-      results as never,
-      database,
-      clientStateService,
-      'server-12345678',
-    );
-    await seedClientExpirySession(service, reader, { expiresAtEpochMs, runtimeRepository });
+it('processes expired client sessions through the inbox and publishes written mutations', async () => {
+  const queue = new ClientExpiryTestResourceInbox();
+  const reader = new InboxQueueReader(queue);
+  const results = new ClientExpiryTestResourceInboxResults();
+  const runtimeRepository = new FakeRuntimeStateRepository();
+  const publisher = createPublisher();
+  const expiresAtEpochMs = Date.now() - 1_000;
+  const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
+  const clientStateService = createClientStateService({
+    runtimeRepository,
+    formationDamping: 'damped',
+    createClientStateEventStore: () => database.clientEventStore,
+    serviceId: 'server-12345678',
+  });
+  const service = new AppClientInboxService(reader, queue as never, results as never, database, clientStateService, 'server-12345678');
+  await seedClientExpirySession(service, reader, { expiresAtEpochMs, runtimeRepository });
 
-    const expired = await processClientInbox(reader, () =>
-      service.processExpiredSessions(expiresAtEpochMs + 1),
-    );
+  const expired = await processClientInbox(reader, () => service.processExpiredSessions(expiresAtEpochMs + 1));
 
-    expect(expired.right).toHaveLength(1);
-    expect(expired.right?.[0].result.right?.event).toMatchObject({
-      eventType: 'session-expired',
-      reason: 'expired',
-      sessionId: 'alice-session',
-    });
-    expect(expired.right?.[0].result.right?.snapshot.activeSessions).toEqual([]);
-    expect(publisher.publishClientSnapshot).not.toHaveBeenCalled();
-    expect(publisher.publishClientEvent).not.toHaveBeenCalled();
-  },
-);
+  expect(expired.right).toHaveLength(1);
+  expect(expired.right?.[0].result.right?.event).toMatchObject({
+    eventType: 'session-expired',
+    reason: 'expired',
+    sessionId: 'alice-session',
+  });
+  expect(expired.right?.[0].result.right?.snapshot.activeSessions).toEqual([]);
+  expect(publisher.publishClientSnapshot).not.toHaveBeenCalled();
+  expect(publisher.publishClientEvent).not.toHaveBeenCalled();
+});
 
 it('keeps at most one active waiting client expiry entry across timestamps', async () => {
   const queue = new ClientExpiryTestResourceInbox();
@@ -110,9 +88,7 @@ it('keeps at most one active waiting client expiry entry across timestamps', asy
 
   expect(listActiveClientExpiryTestEntries(entries)).toHaveLength(1);
   expect(entries[0].key.resourceId).toBe('expire-client-sessions');
-  expect(
-    readClientExpiryTestEnqueueData<ClientExpiredSessionsAppInboxPayload>(entries[0]).atEpochMs,
-  ).toBe(60_000);
+  expect(readClientExpiryTestEnqueueData<ClientExpiredSessionsAppInboxPayload>(entries[0]).atEpochMs).toBe(60_000);
 
   await dequeueClientInbox(reader);
 
@@ -182,10 +158,7 @@ it('expires stale sessions once and leaves publication to the app inbox', async 
     disconnectReason: 'expired',
     disconnectedAtEpochMs: expiresAtEpochMs,
   });
-  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual([
-    'session-connected',
-    'session-expired',
-  ]);
+  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual(['session-connected', 'session-expired']);
   expect(publisher.publishClientSnapshot).not.toHaveBeenCalled();
   expect(publisher.publishClientEvent).not.toHaveBeenCalled();
 });
@@ -201,19 +174,13 @@ it('does not rewrite an expired session when a late disconnect cleanup arrives',
   const principalRef = toClientPrincipalRef('alice');
 
   await service.expireExpiredSessions(now);
-  const lateDisconnect = await service.disconnectSession(
-    SCOPE,
-    principalRef.principalId,
-    'alice-browser',
-    'session-1',
-    {
-      generationId: 'generation-session-1',
-      reason: 'socket-closed',
-      actorPrincipalId: 'alice',
-      actorSessionId: 'session-1',
-      requestId: 'late-disconnect-after-expiry',
-    },
-  );
+  const lateDisconnect = await service.disconnectSession(SCOPE, principalRef.principalId, 'alice-browser', 'session-1', {
+    generationId: 'generation-session-1',
+    reason: 'socket-closed',
+    actorPrincipalId: 'alice',
+    actorSessionId: 'session-1',
+    requestId: 'late-disconnect-after-expiry',
+  });
 
   expect(lateDisconnect.result.right?.event).toBeNull();
   const repository = new ClientStateRepository(runtimeRepository);
@@ -228,10 +195,7 @@ it('does not rewrite an expired session when a late disconnect cleanup arrives',
     disconnectReason: 'expired',
     disconnectedAtEpochMs: expiresAtEpochMs,
   });
-  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual([
-    'session-connected',
-    'session-expired',
-  ]);
+  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual(['session-connected', 'session-expired']);
   expect(runtimeRepository.locks).toEqual([]);
 });
 
@@ -245,21 +209,15 @@ it('ignores a late heartbeat from an expired connection generation', async () =>
   const principalRef = toClientPrincipalRef('alice');
 
   await service.expireExpiredSessions(now);
-  const lateHeartbeat = await service.heartbeatSession(
-    SCOPE,
-    principalRef.principalId,
-    'alice-browser',
-    'session-1',
-    {
-      generationId: 'generation-session-1',
-      presenceState: 'online',
-      actorPrincipalId: 'alice',
-      actorSessionId: 'session-1',
-      lastHeartbeatAtEpochMs: now + 1,
-      expiresAtEpochMs: now + 60_000,
-      requestId: 'late-heartbeat-after-expiry',
-    },
-  );
+  const lateHeartbeat = await service.heartbeatSession(SCOPE, principalRef.principalId, 'alice-browser', 'session-1', {
+    generationId: 'generation-session-1',
+    presenceState: 'online',
+    actorPrincipalId: 'alice',
+    actorSessionId: 'session-1',
+    lastHeartbeatAtEpochMs: now + 1,
+    expiresAtEpochMs: now + 60_000,
+    requestId: 'late-heartbeat-after-expiry',
+  });
 
   expect(lateHeartbeat.result.right?.event).toBeNull();
   expect(lateHeartbeat.result.right?.snapshot.activeSessions).toHaveLength(0);
@@ -272,10 +230,7 @@ it('ignores a late heartbeat from an expired connection generation', async () =>
       sessionId: 'session-1',
     }),
   ).toMatchObject({ status: 'expired', disconnectReason: 'expired' });
-  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual([
-    'session-connected',
-    'session-expired',
-  ]);
+  expect((await repository.listEvents(principalRef)).map((event) => event.eventType)).toEqual(['session-connected', 'session-expired']);
 });
 
 async function seedClientExpirySession(
@@ -283,15 +238,8 @@ async function seedClientExpirySession(
   reader: InboxQueueReader,
   input: SeedClientExpirySessionInput,
 ): Promise<void> {
-  const authority = await createClientExpiryTestIssuedAuthority(
-    input.runtimeRepository,
-    'alice',
-    'alice-session',
-  );
-  const seeded = service.processAuthenticatedEntryUntilCompletion<
-    ClientSessionConnectAppInboxPayload,
-    ClientStateWritten
-  >(
+  const authority = await createClientExpiryTestIssuedAuthority(input.runtimeRepository, 'alice', 'alice-session');
+  const seeded = service.processAuthenticatedEntryUntilCompletion<ClientSessionConnectAppInboxPayload, ClientStateWritten>(
     {
       type: AppInboxType.CLIENT_SESSION_CONNECT,
       resourceId: 'seed-client-expiry-session',
@@ -331,10 +279,7 @@ async function dequeueClientInbox(reader: InboxQueueReader): Promise<void> {
   await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
 }
 
-async function waitForQueueEntryCount(
-  queue: ClientExpiryTestResourceInbox,
-  count: number,
-): Promise<void> {
+async function waitForQueueEntryCount(queue: ClientExpiryTestResourceInbox, count: number): Promise<void> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     if ((await readClientExpiryTestEntries(queue)).length >= count) {
       return;
@@ -365,27 +310,18 @@ function createClientStateServiceStub(overrides: Partial<ClientStateService>): C
   };
 }
 
-async function seedConnectedSession(
-  runtimeRepository: FakeRuntimeStateRepository,
-  expiresAtEpochMs: number,
-): Promise<void> {
+async function seedConnectedSession(runtimeRepository: FakeRuntimeStateRepository, expiresAtEpochMs: number): Promise<void> {
   const now = Math.max(2_000, expiresAtEpochMs - 1_000);
-  await createClientStatePhaseTestDriver(runtimeRepository, () => now).connectSession(
-    SCOPE,
-    'alice',
-    'alice-browser',
-    'session-1',
-    {
-      generationId: 'generation-session-1',
-      presenceState: 'online',
-      actorPrincipalId: 'alice',
-      actorSessionId: 'session-1',
-      connectedAtEpochMs: 2_000,
-      lastHeartbeatAtEpochMs: expiresAtEpochMs - 1_000,
-      expiresAtEpochMs,
-      requestId: 'seed-session-1',
-    },
-  );
+  await createClientStatePhaseTestDriver(runtimeRepository, () => now).connectSession(SCOPE, 'alice', 'alice-browser', 'session-1', {
+    generationId: 'generation-session-1',
+    presenceState: 'online',
+    actorPrincipalId: 'alice',
+    actorSessionId: 'session-1',
+    connectedAtEpochMs: 2_000,
+    lastHeartbeatAtEpochMs: expiresAtEpochMs - 1_000,
+    expiresAtEpochMs,
+    requestId: 'seed-session-1',
+  });
 }
 
 function toClientPrincipalRef(principalId: string): ClientPrincipalRef {

--- a/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
@@ -5,35 +5,20 @@ import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
 import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
-import {
-  EntityStatus,
-  isExpiredResourceEntry,
-  type Key,
-  type ResourceEntry,
-  toKeyAsString,
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, isExpiredResourceEntry, type Key, type ResourceEntry, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
 import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-import {
-  AuthSessionRepository,
-  type IssuedAuthSession,
-} from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
+import { AuthSessionRepository, type IssuedAuthSession } from '@shared-server/rallar-system/repositories/AuthSessionRepository.ts';
 import { InMemoryClientStateEventStore } from '@shared-server/rallar-system/repositories/StateEventStore.ts';
-import {
-  AppClientInboxService,
-  AppInboxType,
-} from '@shared-server/rallar-system/services/AppClientInboxService.ts';
+import { AppClientInboxService, AppInboxType } from '@shared-server/rallar-system/services/AppClientInboxService.ts';
 import {
   type ClientMutationWritten,
   type ClientStateService,
   type ClientStateWritten,
   createClientStateService,
 } from '@shared-server/rallar-system/services/client-state-service.ts';
-// prettier-ignore
-import {
-  createWsSessionGenerationLifecycleService,
-} from '@shared-server/rallar-system/services/ws-session-generation-lifecycle.ts';
+import { createWsSessionGenerationLifecycleService } from '@shared-server/rallar-system/services/ws-session-generation-lifecycle.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
@@ -58,9 +43,7 @@ export function requireRightSnapshot(result: Either<string, ClientStateWritten>)
   return requireClientStateWrittenSnapshot(result.right);
 }
 
-export function requireRightWritten(
-  result: Either<string, ClientStateWritten>,
-): ClientMutationWritten {
+export function requireRightWritten(result: Either<string, ClientStateWritten>): ClientMutationWritten {
   if (!result.right) {
     throw new Error(result.left ?? 'Expected client app-inbox right result');
   }
@@ -133,10 +116,7 @@ export async function processAppInbox<V, R>(
     data: V;
   },
 ): Promise<Either<string, R>> {
-  const resultPromise = service.processAuthenticatedEntryUntilCompletion<V, R>(
-    input,
-    toTestIssuedAuthority(service, input),
-  );
+  const resultPromise = service.processAuthenticatedEntryUntilCompletion<V, R>(input, toTestIssuedAuthority(service, input));
   await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
 
   return await resultPromise;
@@ -149,16 +129,9 @@ function toTestIssuedAuthority<V>(
     data: V;
   }>,
 ): IssuedAuthSession {
-  const data =
-    typeof input.data === 'object' && input.data !== null
-      ? Object.fromEntries(Object.entries(input.data))
-      : {};
-  const request =
-    typeof data.request === 'object' && data.request !== null
-      ? Object.fromEntries(Object.entries(data.request))
-      : {};
-  const principalId =
-    typeof data.principalId === 'string' ? data.principalId : (input.senderId ?? 'alice');
+  const data = typeof input.data === 'object' && input.data !== null ? Object.fromEntries(Object.entries(input.data)) : {};
+  const request = typeof data.request === 'object' && data.request !== null ? Object.fromEntries(Object.entries(data.request)) : {};
+  const principalId = typeof data.principalId === 'string' ? data.principalId : (input.senderId ?? 'alice');
   const sessionId =
     typeof data.sessionId === 'string'
       ? data.sessionId
@@ -191,10 +164,7 @@ export async function processAuthenticatedClientMutation<V, R = ClientStateWritt
   authority: IssuedAuthSession,
 ): Promise<Either<string, R>> {
   const authenticated = service as unknown as Readonly<{
-    processAuthenticatedEntryUntilCompletion<V, R = V>(
-      enqueue: typeof input,
-      authority: IssuedAuthSession,
-    ): Promise<Either<string, R>>;
+    processAuthenticatedEntryUntilCompletion<V, R = V>(enqueue: typeof input, authority: IssuedAuthSession): Promise<Either<string, R>>;
   }>;
   return await authenticated.processAuthenticatedEntryUntilCompletion<V, R>(input, authority);
 }
@@ -211,10 +181,7 @@ export function issuedSession(clientId: string, sessionId: string): IssuedAuthSe
   };
 }
 
-async function waitForQueueEntryStatus(
-  queue: InMemoryQueueBox,
-  status: EntityStatus,
-): Promise<void> {
+async function waitForQueueEntryStatus(queue: InMemoryQueueBox, status: EntityStatus): Promise<void> {
   for (let i = 0; i < 20; i += 1) {
     if ((await readEntries(queue)).some((entry) => entry.status === status)) {
       return;
@@ -232,13 +199,9 @@ export async function readEntries(queue: InMemoryQueueBox): Promise<ResourceEntr
   return entries.filter((entry): entry is ResourceEntry => entry !== undefined);
 }
 
-export function createClientStateServiceStub(
-  overrides: Partial<ClientStateService>,
-): ClientStateService {
+export function createClientStateServiceStub(overrides: Partial<ClientStateService>): ClientStateService {
   return {
-    sessionGenerationLifecycle: createWsSessionGenerationLifecycleService(
-      new FakeRuntimeStateRepository(),
-    ),
+    sessionGenerationLifecycle: createWsSessionGenerationLifecycleService(new FakeRuntimeStateRepository()),
     formationDamping: 'damped',
     listSnapshots: vi.fn(),
     readSnapshot: vi.fn(),
@@ -301,11 +264,5 @@ export function createPublisher() {
 
 export function createResilience(): ResilienceDto {
   const duration = Temporal.Duration.from({ seconds: 10 });
-  return ResilienceDto.toResilienceDto(
-    new CircuitBreakerPolicy(10, duration, duration, duration),
-    1,
-    10,
-    1,
-    1,
-  );
+  return ResilienceDto.toResilienceDto(new CircuitBreakerPolicy(10, duration, duration, duration), 1, 10, 1, 1);
 }

--- a/packages/tests/shared-server/client-state/client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-transaction-boundary-fixture.ts
@@ -3,47 +3,23 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
-import {
-  EntityStatus,
-  NEVER_EXPIRE_TS,
-  type ResourceEntry,
-  toKeyAsString,
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, NEVER_EXPIRE_TS, type ResourceEntry, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
 import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-// prettier-ignore
-import type {
-  AppInboxMessageContext,
-} from '@shared-server/rallar-system/services/AppInboxService.ts';
+import type { AppInboxMessageContext } from '@shared-server/rallar-system/services/AppInboxService.ts';
 import { AppInboxType } from '@shared-server/rallar-system/services/AppInboxService.ts';
-// prettier-ignore
-import {
-  AppInboxTransactionWriter,
-} from '@shared-server/rallar-system/services/app-inbox-transaction-writer.ts';
-// prettier-ignore
-import {
-  ClientStateInboxHandler,
-} from '@shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts';
-// prettier-ignore
-import {
-  toClientMutationIssuedSessionAuthority,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-authority.ts';
-// prettier-ignore
-import {
-  toUpsertPrincipalCommandInput,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
+import { AppInboxTransactionWriter } from '@shared-server/rallar-system/services/app-inbox-transaction-writer.ts';
+import { ClientStateInboxHandler } from '@shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts';
+import { toClientMutationIssuedSessionAuthority } from '@shared-server/rallar-system/client-state/mutation/client-mutation-authority.ts';
+import { toUpsertPrincipalCommandInput } from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
 
-// prettier-ignore
-import type {
-  ClientMutationComputed,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
+import type { ClientMutationComputed } from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 
 const SCOPE = { applicationId: 'ar-eye-hunter', workspaceId: 'default' } as const;
 const EXPECTED_DURABLE_JSON =
-  '{"status":"ok","result":{"right":{"snapshot":{"snapshotVersion":4,"stateRevision":3},' +
-  '"event":{"eventId":"event-4"}}}}';
+  '{"status":"ok","result":{"right":{"snapshot":{"snapshotVersion":4,"stateRevision":3},' + '"event":{"eventId":"event-4"}}}}';
 
 interface HandlerHarness {
   readonly actions: string[];
@@ -54,9 +30,7 @@ interface HandlerHarness {
   readonly results: TestResourceInboxResults;
 }
 
-export async function createHandlerHarness(
-  options: Readonly<{ failTransaction?: boolean }> = {},
-): Promise<HandlerHarness> {
+export async function createHandlerHarness(options: Readonly<{ failTransaction?: boolean }> = {}): Promise<HandlerHarness> {
   const actions: string[] = [];
   const observedSnapshots: object[] = [];
   const committedSnapshot = { snapshotVersion: 4, stateRevision: 3 };

--- a/packages/tests/shared-server/client-state/client-state-public-compatibility.test.ts
+++ b/packages/tests/shared-server/client-state/client-state-public-compatibility.test.ts
@@ -1,21 +1,10 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import * as sharedServer from '@shared-server/mod.ts';
-// prettier-ignore
-import * as compatibilityInbox from
-  '@shared-server/rallar-system/services/AppClientInboxService.ts';
-// prettier-ignore
-import * as compatibilityService from
-  '@shared-server/rallar-system/services/client-state-service.ts';
-// prettier-ignore
-import {
-  ClientMutationIdempotencyConflictError,
-} from
-'@shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts';
-// prettier-ignore
-import {
-  ClientMutationRejectedError,
-} from '@shared-server/rallar-system/client-state/client-state-validation-primitives.ts';
+import * as compatibilityInbox from '@shared-server/rallar-system/services/AppClientInboxService.ts';
+import * as compatibilityService from '@shared-server/rallar-system/services/client-state-service.ts';
+import { ClientMutationIdempotencyConflictError } from '@shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts';
+import { ClientMutationRejectedError } from '@shared-server/rallar-system/client-state/client-state-validation-primitives.ts';
 import {
   toClientMutationIssuedSessionAuthority,
   toClientMutationSystemAuthority,
@@ -29,19 +18,13 @@ import {
   toUpsertInstanceCommandInput,
   toUpsertPrincipalCommandInput,
 } from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
-// prettier-ignore
-import {
-  createClientStateService,
-} from '@shared-server/rallar-system/client-state/client-state-service.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import {
   requiresClientWrite,
   toClientMutationReceipt,
   toClientStateWritten,
 } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-// prettier-ignore
-import {
-  AppClientInboxService,
-} from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
+import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
 import type * as PublicSharedServer from '@shared-server/mod.ts';
 import type {
   ClientAuthorisedWsSessionConnectAppInboxPayload,
@@ -53,14 +36,8 @@ import type {
   ClientSessionDisconnectAppInboxPayload,
   ClientSessionHeartbeatAppInboxPayload,
 } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-contracts.ts';
-// prettier-ignore
-import type {
-  ClientMutationPersistedFacts,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
-// prettier-ignore
-import type {
-  ClientMutationReceipt,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
+import type { ClientMutationPersistedFacts } from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
+import type { ClientMutationReceipt } from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
 import type {
   ClientMutationWritten,
   ClientStateService,
@@ -70,19 +47,10 @@ import type {
 } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
 
 describe('shared-server client-state public API contract', () => {
-  it(
-    'keeps every predecessor runtime export as an identical canonical binding',
-    assertPredecessorRuntimeExports,
-  );
-  it(
-    'keeps public, canonical, and compatibility runtime exports identical',
-    assertPublicCanonicalCompatibilityRuntimeIdentity,
-  );
+  it('keeps every predecessor runtime export as an identical canonical binding', assertPredecessorRuntimeExports);
+  it('keeps public, canonical, and compatibility runtime exports identical', assertPublicCanonicalCompatibilityRuntimeIdentity);
   it('does not leak internal client-state construction or handler bindings', assertNoInternalLeaks);
-  it(
-    'keeps predecessor public types equal to their canonical and compatibility contracts',
-    assertPredecessorPublicTypeIdentity,
-  );
+  it('keeps predecessor public types equal to their canonical and compatibility contracts', assertPredecessorPublicTypeIdentity);
 });
 
 // @ts-expect-error Public callers must not receive the handler-only mutation capability.
@@ -98,13 +66,9 @@ type PublicClientStateInboxHandlerDependencies =
 type PublicClientStateInboxAfterCommitResult = PublicSharedServer.ClientStateInboxAfterCommitResult;
 
 function assertPredecessorRuntimeExports(): void {
-  expect(sharedServer.ClientMutationIdempotencyConflictError).toBe(
-    ClientMutationIdempotencyConflictError,
-  );
+  expect(sharedServer.ClientMutationIdempotencyConflictError).toBe(ClientMutationIdempotencyConflictError);
   expect(sharedServer.ClientMutationRejectedError).toBe(ClientMutationRejectedError);
-  expect(sharedServer.toClientMutationIssuedSessionAuthority).toBe(
-    toClientMutationIssuedSessionAuthority,
-  );
+  expect(sharedServer.toClientMutationIssuedSessionAuthority).toBe(toClientMutationIssuedSessionAuthority);
   expect(sharedServer.toClientMutationSystemAuthority).toBe(toClientMutationSystemAuthority);
   expect(sharedServer.toClientMutationCommand).toBe(toClientMutationCommand);
   expect(sharedServer.toConnectCommandInput).toBe(toConnectCommandInput);
@@ -123,64 +87,36 @@ function assertPredecessorRuntimeExports(): void {
 function assertPublicCanonicalCompatibilityRuntimeIdentity(): void {
   expect(sharedServer.createClientStateService).toBe(compatibilityService.createClientStateService);
   expect(sharedServer.AppClientInboxService).toBe(compatibilityInbox.AppClientInboxService);
-  expect(sharedServer.ClientMutationRejectedError).toBe(
-    compatibilityService.ClientMutationRejectedError,
-  );
-  expect(sharedServer.ClientMutationIdempotencyConflictError).toBe(
-    compatibilityService.ClientMutationIdempotencyConflictError,
-  );
+  expect(sharedServer.ClientMutationRejectedError).toBe(compatibilityService.ClientMutationRejectedError);
+  expect(sharedServer.ClientMutationIdempotencyConflictError).toBe(compatibilityService.ClientMutationIdempotencyConflictError);
   expect(sharedServer.toClientMutationCommand).toBe(compatibilityService.toClientMutationCommand);
-  expect(sharedServer.toClientMutationIssuedSessionAuthority).toBe(
-    compatibilityService.toClientMutationIssuedSessionAuthority,
-  );
+  expect(sharedServer.toClientMutationIssuedSessionAuthority).toBe(compatibilityService.toClientMutationIssuedSessionAuthority);
 }
 
 function assertNoInternalLeaks(): void {
-  for (const internalExport of [
-    'CLIENT_STATE_INBOX_REGISTRATION_TYPES',
-    'createTimedClientStateService',
-    'ClientStateInboxHandler',
-  ]) {
+  for (const internalExport of ['CLIENT_STATE_INBOX_REGISTRATION_TYPES', 'createTimedClientStateService', 'ClientStateInboxHandler']) {
     expect(Object.hasOwn(sharedServer, internalExport), internalExport).toBe(false);
   }
 }
 
 function assertPredecessorPublicTypeIdentity(): void {
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientMutationPersistedFacts>()
-    .toEqualTypeOf<ClientMutationPersistedFacts>();
+  expectTypeOf<PublicSharedServer.ClientMutationPersistedFacts>().toEqualTypeOf<ClientMutationPersistedFacts>();
   expectTypeOf<PublicSharedServer.ClientMutationReceipt>().toEqualTypeOf<ClientMutationReceipt>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.RegisterAuthorisedWsClientInput>()
-    .toEqualTypeOf<RegisterAuthorisedWsClientInput>();
+  expectTypeOf<PublicSharedServer.RegisterAuthorisedWsClientInput>().toEqualTypeOf<RegisterAuthorisedWsClientInput>();
   expectTypeOf<PublicSharedServer.ClientMutationWritten>().toEqualTypeOf<ClientMutationWritten>();
   expectTypeOf<PublicSharedServer.ClientStateWritten>().toEqualTypeOf<ClientStateWritten>();
   expectTypeOf<PublicSharedServer.ClientStateService>().toEqualTypeOf<ClientStateService>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientStateServiceDependencies>()
-    .toEqualTypeOf<ClientStateServiceDependencies>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientPrincipalUpsertAppInboxPayload>()
-    .toEqualTypeOf<ClientPrincipalUpsertAppInboxPayload>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientInstanceUpsertAppInboxPayload>()
-    .toEqualTypeOf<ClientInstanceUpsertAppInboxPayload>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientSessionConnectAppInboxPayload>()
-    .toEqualTypeOf<ClientSessionConnectAppInboxPayload>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientSessionHeartbeatAppInboxPayload>()
-    .toEqualTypeOf<ClientSessionHeartbeatAppInboxPayload>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientSessionDisconnectAppInboxPayload>()
-    .toEqualTypeOf<ClientSessionDisconnectAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientStateServiceDependencies>().toEqualTypeOf<ClientStateServiceDependencies>();
+  expectTypeOf<PublicSharedServer.ClientPrincipalUpsertAppInboxPayload>().toEqualTypeOf<ClientPrincipalUpsertAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientInstanceUpsertAppInboxPayload>().toEqualTypeOf<ClientInstanceUpsertAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientSessionConnectAppInboxPayload>().toEqualTypeOf<ClientSessionConnectAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientSessionHeartbeatAppInboxPayload>().toEqualTypeOf<ClientSessionHeartbeatAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientSessionDisconnectAppInboxPayload>().toEqualTypeOf<ClientSessionDisconnectAppInboxPayload>();
   // prettier-ignore
   expectTypeOf<PublicSharedServer.ClientAuthorisedWsSessionConnectAppInboxPayload>()
     .toEqualTypeOf<ClientAuthorisedWsSessionConnectAppInboxPayload>();
   // prettier-ignore
   expectTypeOf<PublicSharedServer.ClientAuthorisedWsSessionDisconnectAppInboxPayload>()
     .toEqualTypeOf<ClientAuthorisedWsSessionDisconnectAppInboxPayload>();
-  // prettier-ignore
-  expectTypeOf<PublicSharedServer.ClientExpiredSessionsAppInboxPayload>()
-    .toEqualTypeOf<ClientExpiredSessionsAppInboxPayload>();
+  expectTypeOf<PublicSharedServer.ClientExpiredSessionsAppInboxPayload>().toEqualTypeOf<ClientExpiredSessionsAppInboxPayload>();
 }

--- a/packages/tests/shared-server/client-state/client-state-service-timing.test.ts
+++ b/packages/tests/shared-server/client-state/client-state-service-timing.test.ts
@@ -2,25 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
 import type { RallarTimingEvent } from '@shared-server/rallar-system/services/timing.ts';
-// prettier-ignore
-import {
-  createTimedClientStateService,
-} from '@shared-server/rallar-system/client-state/client-state-service-timing.ts';
+import { createTimedClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-timing.ts';
 
-// prettier-ignore
-import type {
-  ClientMutationCommand,
-} from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
-// prettier-ignore
-import type {
-  ClientStateService,
-} from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+import type { ClientMutationCommand } from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
+import type { ClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
 
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-  CLIENT_MUTATION_SERVICE_SCOPE,
-  createPublisher as createServicePublisher,
-} from './client-state-service-test-fixtures.ts';
+import { CLIENT_MUTATION_SERVICE_SCOPE, createPublisher as createServicePublisher } from './client-state-service-test-fixtures.ts';
 import { createLegacyClientStateTestDriver as createClientStateService } from './client-state-test-runtime.ts';
 
 describe('client-state service timing', () => {
@@ -37,9 +25,7 @@ describe('client-state service timing', () => {
 
     await expect(timed.read(TIMED_COMMAND)).resolves.toBe(fixture.readResult);
     expect(timed.compute(TIMED_COMMAND, fixture.readResult as never)).toBe(fixture.computedResult);
-    expect(() =>
-      timed.validate(TIMED_COMMAND, fixture.readResult as never, fixture.computedResult as never),
-    ).not.toThrow();
+    expect(() => timed.validate(TIMED_COMMAND, fixture.readResult as never, fixture.computedResult as never)).not.toThrow();
     await expect(timed.write(TIMED_TRANSACTION, TIMED_COMPUTED)).rejects.toBe(fixture.writeFailure);
 
     expect(fixture.calls).toEqual([
@@ -52,14 +38,12 @@ describe('client-state service timing', () => {
       'write',
       'event:mutation.write:error',
     ]);
-    expect(fixture.events.map((event) => [event.operation, event.serviceId, event.status])).toEqual(
-      [
-        ['mutation.read', 'client-timing-service', 'ok'],
-        ['mutation.compute', 'client-timing-service', 'ok'],
-        ['mutation.validate', 'client-timing-service', 'ok'],
-        ['mutation.write', 'client-timing-service', 'error'],
-      ],
-    );
+    expect(fixture.events.map((event) => [event.operation, event.serviceId, event.status])).toEqual([
+      ['mutation.read', 'client-timing-service', 'ok'],
+      ['mutation.compute', 'client-timing-service', 'ok'],
+      ['mutation.validate', 'client-timing-service', 'ok'],
+      ['mutation.write', 'client-timing-service', 'error'],
+    ]);
     expect(fixture.events.at(-1)?.error?.message).toBe(fixture.writeFailure.message);
   });
 });

--- a/packages/tests/shared-server/client-state/client-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/client-state/client-state-snapshot-read-through-cache.test.ts
@@ -1,33 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type {
-  AuditStamp,
-  ClientInstance,
-  ClientPrincipal,
-  ClientSession,
-  ClientSnapshot,
-} from '@shared/api/client-types.ts';
+import type { AuditStamp, ClientInstance, ClientPrincipal, ClientSession, ClientSnapshot } from '@shared/api/client-types.ts';
 import {
   findClientStateSnapshotByRef,
   findClientStateSnapshotByPrincipalId,
   toClientStateSnapshotRepositoryKey as toSharedClientStateSnapshotRepositoryKey,
 } from '@shared/repository/client-state-snapshots-repository.ts';
-// prettier-ignore
-import {
-  toClientStateSnapshotRepositoryKey as toPackageClientStateSnapshotRepositoryKey,
-} from '@shared-server/mod.ts';
-// prettier-ignore
-import { ClientStateRepository } from
-  '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-// prettier-ignore
+import { toClientStateSnapshotRepositoryKey as toPackageClientStateSnapshotRepositoryKey } from '@shared-server/mod.ts';
+import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
 import {
   createClientStateSnapshotReadThroughCache,
   toClientStateSnapshotRepositoryKey,
-} from
-  '@shared-server/rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts';
-// prettier-ignore
-import {
-  toClientStateSnapshotRepositoryKey as toLegacyClientStateSnapshotRepositoryKey,
-} from '@shared-server/rallar-system/services/client-state-snapshot-read-through-cache.ts';
+} from '@shared-server/rallar-system/client-state/snapshot/client-state-snapshot-read-through-cache.ts';
+import { toClientStateSnapshotRepositoryKey as toLegacyClientStateSnapshotRepositoryKey } from '@shared-server/rallar-system/services/client-state-snapshot-read-through-cache.ts';
 import { configureTestCacheRepositories } from '../../cache-repository-config.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 
@@ -54,8 +38,7 @@ describe('ClientStateSnapshotReadThroughCache', () => {
     expect(toPackageClientStateSnapshotRepositoryKey).toBe(toClientStateSnapshotRepositoryKey);
     expect(toLegacyClientStateSnapshotRepositoryKey).toBe(toClientStateSnapshotRepositoryKey);
     expect(toClientStateSnapshotRepositoryKey).not.toBe(toSharedClientStateSnapshotRepositoryKey);
-    const expectedKey =
-      '["client-state-snapshot","app-1",["present","workspace-a"],"alice"]';
+    const expectedKey = '["client-state-snapshot","app-1",["present","workspace-a"],"alice"]';
     expect(toClientStateSnapshotRepositoryKey(ref)).toBe(expectedKey);
     expect(toSharedClientStateSnapshotRepositoryKey(ref)).toBe(expectedKey);
   });
@@ -245,13 +228,9 @@ describe('ClientStateSnapshotReadThroughCache', () => {
     ).toThrow('Client snapshot revision conflict');
     expect(readThroughCache.peek(base.principal)).toEqual(revisionTwo);
   });
-
 });
 
-async function putClientSnapshot(
-  repository: ClientStateRepository,
-  snapshot: ClientSnapshot,
-): Promise<void> {
+async function putClientSnapshot(repository: ClientStateRepository, snapshot: ClientSnapshot): Promise<void> {
   const principalEntry = await repository.findPrincipalEntry(snapshot.principal);
   const principalResult = principalEntry
     ? await repository.updatePrincipal(snapshot.principal, principalEntry.entry.revision)
@@ -260,17 +239,13 @@ async function putClientSnapshot(
   const instances = await Promise.all(
     snapshot.instances.map(async (instance) => {
       const entry = await repository.findInstanceEntry(instance);
-      return entry
-        ? await repository.updateInstance(instance, entry.entry.revision)
-        : await repository.insertInstance(instance);
+      return entry ? await repository.updateInstance(instance, entry.entry.revision) : await repository.insertInstance(instance);
     }),
   );
   const sessions = await Promise.all(
     snapshot.activeSessions.map(async (session) => {
       const entry = await repository.findSessionEntry(session);
-      return entry
-        ? await repository.updateSession(session, entry.entry.revision)
-        : await repository.insertSession(session);
+      return entry ? await repository.updateSession(session, entry.entry.revision) : await repository.insertSession(session);
     }),
   );
   expect(instances.every((result) => result.status === 'applied')).toBe(true);
@@ -339,10 +314,7 @@ function createClientInstance(input: CreateClientSnapshotFixtureInput): ClientIn
   };
 }
 
-function createClientSession(
-  input: CreateClientSnapshotFixtureInput,
-  clientInstanceId: string,
-): ClientSession {
+function createClientSession(input: CreateClientSnapshotFixtureInput, clientInstanceId: string): ClientSession {
   const { applicationId, workspaceId, principalId, snapshotVersion } = input;
 
   return {

--- a/packages/tests/shared-server/crdt/crdt-public-compatibility.test.ts
+++ b/packages/tests/shared-server/crdt/crdt-public-compatibility.test.ts
@@ -1,24 +1,12 @@
-// prettier-ignore
-import {
-  expect,
-  expectTypeOf,
-  it,
-} from 'vitest';
+import { expect, expectTypeOf, it } from 'vitest';
 
-import type {
-  RallarCrdtAdminReadRepository,
-  RallarCrdtValidationResult,
-} from '@shared/crdt/mod.ts';
+import type { RallarCrdtAdminReadRepository, RallarCrdtValidationResult } from '@shared/crdt/mod.ts';
 import * as sharedServer from '@shared-server/mod.ts';
 import {
   InMemoryRallarCrdtLogRepository,
   type InMemoryRallarCrdtLogRepositoryOptions,
 } from '@shared-server/rallar-system/crdt/persistence/in-memory-crdt-log-repository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  installRallarCrdtWsTopics,
-} from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
+import { installRallarCrdtWsTopics } from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
 import {
   RALLAR_CRDT_SERVER_DEFAULT_MAX_SYNC_BYTES,
   RALLAR_CRDT_SERVER_DEFAULT_MAX_UPDATE_BYTES,
@@ -50,15 +38,9 @@ it('keeps the package CRDT log repository on its canonical owner', () => {
 it('keeps public CRDT runtime values on their canonical owners', () => {
   expect(sharedServer.InMemoryRallarCrdtLogRepository).toBe(InMemoryRallarCrdtLogRepository);
   expect(sharedServer.installRallarCrdtWsTopics).toBe(installRallarCrdtWsTopics);
-  expect(sharedServer.validateRallarCrdtServerLiveEnvelope).toBe(
-    validateRallarCrdtServerLiveEnvelope,
-  );
-  expect(sharedServer.RALLAR_CRDT_SERVER_DEFAULT_MAX_UPDATE_BYTES).toBe(
-    RALLAR_CRDT_SERVER_DEFAULT_MAX_UPDATE_BYTES,
-  );
-  expect(sharedServer.RALLAR_CRDT_SERVER_DEFAULT_MAX_SYNC_BYTES).toBe(
-    RALLAR_CRDT_SERVER_DEFAULT_MAX_SYNC_BYTES,
-  );
+  expect(sharedServer.validateRallarCrdtServerLiveEnvelope).toBe(validateRallarCrdtServerLiveEnvelope);
+  expect(sharedServer.RALLAR_CRDT_SERVER_DEFAULT_MAX_UPDATE_BYTES).toBe(RALLAR_CRDT_SERVER_DEFAULT_MAX_UPDATE_BYTES);
+  expect(sharedServer.RALLAR_CRDT_SERVER_DEFAULT_MAX_SYNC_BYTES).toBe(RALLAR_CRDT_SERVER_DEFAULT_MAX_SYNC_BYTES);
 });
 
 it('keeps the public live-envelope validator on its named-input package contract', () => {
@@ -77,87 +59,31 @@ it('keeps the public live-envelope validator on its named-input package contract
 });
 
 // Prettier's 120-column output exceeds the repository's 100-character review limit.
-// prettier-ignore
 it('keeps every public CRDT server and in-memory repository type on the package root', () => {
-  expectTypeOf<
-    sharedServer.RallarCrdtServerEnvelopeKind
-  >().toEqualTypeOf<
-    RallarCrdtServerEnvelopeKind
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerTopicScope
-  >().toEqualTypeOf<
-    RallarCrdtServerTopicScope
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerTrustedMetadata
-  >().toEqualTypeOf<
-    RallarCrdtServerTrustedMetadata
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerAcceptedEnvelope
-  >().toEqualTypeOf<
-    RallarCrdtServerAcceptedEnvelope
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerMutationIngress
-  >().toEqualTypeOf<
-    RallarCrdtServerMutationIngress
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerDocumentAuthorizationInput
-  >().toEqualTypeOf<
-    RallarCrdtServerDocumentAuthorizationInput
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerTopicBridgeOptions
-  >().toEqualTypeOf<
-    RallarCrdtServerTopicBridgeOptions
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerPrincipalFanoutInput
-  >().toEqualTypeOf<
-    RallarCrdtServerPrincipalFanoutInput
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerTopicBridge
-  >().toEqualTypeOf<
-    RallarCrdtServerTopicBridge
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerWsTopicInstaller
-  >().toEqualTypeOf<
-    RallarCrdtServerWsTopicInstaller
-  >();
-  expectTypeOf<
-    sharedServer.RallarCrdtServerLiveValidationContext
-  >().toEqualTypeOf<
-    RallarCrdtServerLiveValidationContext
-  >();
-  expectTypeOf<
-    sharedServer.ValidateRallarCrdtServerLiveEnvelopeInput
-  >().toEqualTypeOf<
-    ValidateRallarCrdtServerLiveEnvelopeInput
-  >();
-  expectTypeOf<
-    sharedServer.InMemoryRallarCrdtLogRepositoryOptions
-  >().toEqualTypeOf<
-    InMemoryRallarCrdtLogRepositoryOptions
-  >();
+  expectTypeOf<sharedServer.RallarCrdtServerEnvelopeKind>().toEqualTypeOf<RallarCrdtServerEnvelopeKind>();
+  expectTypeOf<sharedServer.RallarCrdtServerTopicScope>().toEqualTypeOf<RallarCrdtServerTopicScope>();
+  expectTypeOf<sharedServer.RallarCrdtServerTrustedMetadata>().toEqualTypeOf<RallarCrdtServerTrustedMetadata>();
+  expectTypeOf<sharedServer.RallarCrdtServerAcceptedEnvelope>().toEqualTypeOf<RallarCrdtServerAcceptedEnvelope>();
+  expectTypeOf<sharedServer.RallarCrdtServerMutationIngress>().toEqualTypeOf<RallarCrdtServerMutationIngress>();
+  expectTypeOf<sharedServer.RallarCrdtServerDocumentAuthorizationInput>().toEqualTypeOf<RallarCrdtServerDocumentAuthorizationInput>();
+  expectTypeOf<sharedServer.RallarCrdtServerTopicBridgeOptions>().toEqualTypeOf<RallarCrdtServerTopicBridgeOptions>();
+  expectTypeOf<sharedServer.RallarCrdtServerPrincipalFanoutInput>().toEqualTypeOf<RallarCrdtServerPrincipalFanoutInput>();
+  expectTypeOf<sharedServer.RallarCrdtServerTopicBridge>().toEqualTypeOf<RallarCrdtServerTopicBridge>();
+  expectTypeOf<sharedServer.RallarCrdtServerWsTopicInstaller>().toEqualTypeOf<RallarCrdtServerWsTopicInstaller>();
+  expectTypeOf<sharedServer.RallarCrdtServerLiveValidationContext>().toEqualTypeOf<RallarCrdtServerLiveValidationContext>();
+  expectTypeOf<sharedServer.ValidateRallarCrdtServerLiveEnvelopeInput>().toEqualTypeOf<ValidateRallarCrdtServerLiveEnvelopeInput>();
+  expectTypeOf<sharedServer.InMemoryRallarCrdtLogRepositoryOptions>().toEqualTypeOf<InMemoryRallarCrdtLogRepositoryOptions>();
 });
 
-it(
-  'limits the concrete PostgreSQL repository to supported read and ' + 'administration operations',
-  () => {
-    expectTypeOf<PSqlCrdtLogRepository>().toExtend<RallarCrdtAdminReadRepository>();
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('append');
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('appendBatch');
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('writeSnapshot');
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('updateDocumentLifecycle');
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('restoreBackupBundle');
-    expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('rebuildProjection');
-  },
-);
+it('limits the concrete PostgreSQL repository to supported read and ' + 'administration operations', () => {
+  expectTypeOf<PSqlCrdtLogRepository>().toExtend<RallarCrdtAdminReadRepository>();
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('append');
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('appendBatch');
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('writeSnapshot');
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('updateDocumentLifecycle');
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('restoreBackupBundle');
+  expectTypeOf<PSqlCrdtLogRepository>().not.toHaveProperty('rebuildProjection');
+});
 
 it('limits concrete PostgreSQL repository options to the values the owner reads', () => {
   expectTypeOf<keyof PSqlCrdtLogRepositoryOptions>().toEqualTypeOf<'now' | 'policies' | 'audit'>();

--- a/packages/tests/shared-server/crdt/inbox/app-crdt-inbox-service.test.ts
+++ b/packages/tests/shared-server/crdt/inbox/app-crdt-inbox-service.test.ts
@@ -1,17 +1,8 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { AppInboxType } from '@shared-server/rallar-system/services/AppInboxService.ts';
-// prettier-ignore
-import type { AppCrdtInboxService }
-  from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
-// prettier-ignore
-import { CRDT_MUTATION_INBOX_TYPES }
-  from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';
+import type { AppCrdtInboxService } from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
+import { CRDT_MUTATION_INBOX_TYPES } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';
 import {
   createCrdtMutationCommand,
   decodeCrdtMutationCommand,
@@ -38,8 +29,7 @@ const DOCUMENT: RallarCrdtDocumentRef = {
 
 describe('CRDT AppInbox mutation contracts', () => {
   it('does not expose mutable audit sink registration', () => {
-    const hasMutableAuditSetter: 'setAuditSink' extends keyof AppCrdtInboxService ? true : false =
-      false;
+    const hasMutableAuditSetter: 'setAuditSink' extends keyof AppCrdtInboxService ? true : false = false;
 
     expect(hasMutableAuditSetter).toBe(false);
   });

--- a/packages/tests/shared-server/crdt/inbox/crdt-app-inbox-ingress.test.ts
+++ b/packages/tests/shared-server/crdt/inbox/crdt-app-inbox-ingress.test.ts
@@ -1,10 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import {
@@ -18,26 +12,10 @@ import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInbo
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { PSqlSql, PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxResultsRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  AppCrdtInboxService,
-} from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationService,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
+import { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxResultsRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import { AppCrdtInboxService } from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
+import { createCrdtMutationService } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -54,11 +32,9 @@ describe('CRDT production AppInbox ingress', () => {
     const service = appCrdt(reader);
     const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     try {
-      await expect(
-        service.createAndEnqueueAppend(
-          input({ updateEnvelope: update('update-1'), receivedAtEpochMs: 1_000 }),
-        ),
-      ).rejects.toThrow('injected durable enqueue failure');
+      await expect(service.createAndEnqueueAppend(input({ updateEnvelope: update('update-1'), receivedAtEpochMs: 1_000 }))).rejects.toThrow(
+        'injected durable enqueue failure',
+      );
     } finally {
       error.mockRestore();
     }
@@ -69,9 +45,7 @@ describe('CRDT production AppInbox ingress', () => {
     const service = appCrdt(reader);
     const semantic = update('stable-update');
 
-    await service.createAndEnqueueAppend(
-      input({ updateEnvelope: semantic, receivedAtEpochMs: 1_000 }),
-    );
+    await service.createAndEnqueueAppend(input({ updateEnvelope: semantic, receivedAtEpochMs: 1_000 }));
     await vi.waitFor(() => expect(reader.messages).toHaveLength(1));
 
     const command = JSON.parse(reader.messages[0]!.payload.resource).data;
@@ -80,38 +54,35 @@ describe('CRDT production AppInbox ingress', () => {
     expect(command.capturedAtEpochMs).not.toBe(semantic.createdAtEpochMs);
   });
 
-  it(
-    'gives reconnect delivery a new AppInbox identity while retaining ' + 'update replay identity',
-    async () => {
-      const reader = new CapturingInboxReader(false);
-      const service = appCrdt(reader);
-      const semantic = update('reconnect-update');
+  it('gives reconnect delivery a new AppInbox identity while retaining ' + 'update replay identity', async () => {
+    const reader = new CapturingInboxReader(false);
+    const service = appCrdt(reader);
+    const semantic = update('reconnect-update');
 
-      await service.createAndEnqueueAppend(
-        input({
-          updateEnvelope: semantic,
-          receivedAtEpochMs: 1_000,
-          sessionId: 'session-1',
-          deliveryId: 'delivery-1',
-        }),
-      );
-      await service.createAndEnqueueAppend(
-        input({
-          updateEnvelope: semantic,
-          receivedAtEpochMs: 2_000,
-          sessionId: 'session-2',
-          deliveryId: 'delivery-2',
-        }),
-      );
-      await vi.waitFor(() => expect(reader.messages).toHaveLength(2));
+    await service.createAndEnqueueAppend(
+      input({
+        updateEnvelope: semantic,
+        receivedAtEpochMs: 1_000,
+        sessionId: 'session-1',
+        deliveryId: 'delivery-1',
+      }),
+    );
+    await service.createAndEnqueueAppend(
+      input({
+        updateEnvelope: semantic,
+        receivedAtEpochMs: 2_000,
+        sessionId: 'session-2',
+        deliveryId: 'delivery-2',
+      }),
+    );
+    await vi.waitFor(() => expect(reader.messages).toHaveLength(2));
 
-      const commands = reader.messages.map((message) => JSON.parse(message.payload.resource).data);
-      expect(commands[0].update.updateId).toBe(commands[1].update.updateId);
-      expect(commands[0].commandId).toBe(commands[1].commandId);
-      expect(commands[0].deliveryId).not.toBe(commands[1].deliveryId);
-      expect(commands[0].actor.sessionId).not.toBe(commands[1].actor.sessionId);
-    },
-  );
+    const commands = reader.messages.map((message) => JSON.parse(message.payload.resource).data);
+    expect(commands[0].update.updateId).toBe(commands[1].update.updateId);
+    expect(commands[0].commandId).toBe(commands[1].commandId);
+    expect(commands[0].deliveryId).not.toBe(commands[1].deliveryId);
+    expect(commands[0].actor.sessionId).not.toBe(commands[1].actor.sessionId);
+  });
 });
 
 class CapturingInboxReader extends InboxQueueReader {
@@ -160,10 +131,8 @@ function appCrdt(inbox: InboxQueueReader): AppCrdtInboxService {
 
 function createUnusedDatabase(): PSqlSql {
   const database: PSqlSql = Object.assign(
-    <T>(
-      _stringsOrValues: TemplateStringsArray | readonly unknown[],
-      ..._values: unknown[]
-    ): Promise<T> => Promise.reject(new Error('Unexpected SQL execution in ingress unit test')),
+    <T>(_stringsOrValues: TemplateStringsArray | readonly unknown[], ..._values: unknown[]): Promise<T> =>
+      Promise.reject(new Error('Unexpected SQL execution in ingress unit test')),
     {
       begin: <T>(_run: (sql: PSqlTransactionSql) => Promise<T>): Promise<T> =>
         Promise.reject(new Error('Unexpected transaction in ingress unit test')),
@@ -180,12 +149,7 @@ interface CrdtInboxInput {
 }
 
 function input(input: CrdtInboxInput) {
-  const {
-    updateEnvelope,
-    receivedAtEpochMs,
-    sessionId = 'session-1',
-    deliveryId = `delivery-${receivedAtEpochMs}`,
-  } = input;
+  const { updateEnvelope, receivedAtEpochMs, sessionId = 'session-1', deliveryId = `delivery-${receivedAtEpochMs}` } = input;
   return {
     update: updateEnvelope,
     deliveryId,

--- a/packages/tests/shared-server/crdt/inbox/crdt-audit-delivery.test.ts
+++ b/packages/tests/shared-server/crdt/inbox/crdt-audit-delivery.test.ts
@@ -1,54 +1,20 @@
 import { Temporal } from '@js-temporal/polyfill';
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import {
-  newALRoute,
-  newALUntargetedMessage,
-  type ALMessage,
-} from '@shared/al-contracts/al-contract.ts';
+import { newALRoute, newALUntargetedMessage, type ALMessage } from '@shared/al-contracts/al-contract.ts';
 import type { RallarCrdtAuditEvent, RallarCrdtAuditSink } from '@shared/crdt/mod.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { OnMessageCallback } from '@shared/services/InboxOutboxContracts.ts';
 import { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  AppCrdtInboxService,
-} from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  registerCrdtAuditDelivery,
-} from '@shared-server/rallar-system/crdt/inbox/register-crdt-audit-delivery.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import type {
-  CrdtMutationService,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
+import { AppCrdtInboxService } from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
+import { registerCrdtAuditDelivery } from '@shared-server/rallar-system/crdt/inbox/register-crdt-audit-delivery.ts';
+import type { CrdtMutationService } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
 import type { PSqlSql, PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxResultsRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  CRDT_AUDIT_APP_OUTBOX_TYPE,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
+import { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxResultsRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import { CRDT_AUDIT_APP_OUTBOX_TYPE } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
 
 const EVENT: RallarCrdtAuditEvent = {
   kind: 'erase',
@@ -90,18 +56,12 @@ describe('CRDT audit delivery', () => {
     const malformedJson = createAuditMessage(EVENT);
     Reflect.set(malformedJson.payload, 'resource', '{');
 
-    await expect(handler.onMessage(wrongContentType, createResourceEntry())).rejects.toThrow(
-      'CRDT audit outbox content type is invalid',
+    await expect(handler.onMessage(wrongContentType, createResourceEntry())).rejects.toThrow('CRDT audit outbox content type is invalid');
+    await expect(handler.onMessage(malformedJson, createResourceEntry())).rejects.toBeInstanceOf(SyntaxError);
+    await expect(handler.onMessage(createAuditMessage({ ...EVENT, kind: 'append' }), createResourceEntry())).rejects.toThrow(
+      'CRDT audit outbox event is invalid',
     );
-    await expect(handler.onMessage(malformedJson, createResourceEntry())).rejects.toBeInstanceOf(
-      SyntaxError,
-    );
-    await expect(
-      handler.onMessage(createAuditMessage({ ...EVENT, kind: 'append' }), createResourceEntry()),
-    ).rejects.toThrow('CRDT audit outbox event is invalid');
-    await expect(handler.onMessage(createAuditMessage(EVENT), createResourceEntry())).rejects.toBe(
-      sinkFailure,
-    );
+    await expect(handler.onMessage(createAuditMessage(EVENT), createResourceEntry())).rejects.toBe(sinkFailure);
     expect(record).toHaveBeenCalledOnce();
     expect(record).toHaveBeenCalledWith(EVENT);
   });
@@ -147,10 +107,7 @@ function createInbox(input: CreateInboxInput): AppCrdtInboxService {
 
 function createUnusedDatabase(): PSqlSql {
   const database: PSqlSql = Object.assign(
-    <T>(
-      _stringsOrValues: TemplateStringsArray | readonly unknown[],
-      ..._values: unknown[]
-    ): Promise<T> =>
+    <T>(_stringsOrValues: TemplateStringsArray | readonly unknown[], ..._values: unknown[]): Promise<T> =>
       Promise.reject(new Error('Unexpected SQL execution in audit registration test')),
     {
       begin: <T>(_run: (sql: PSqlTransactionSql) => Promise<T>): Promise<T> =>
@@ -195,12 +152,7 @@ class RecordingOutboxQueueReader extends OutboxQueueReader {
 }
 
 function createAuditMessage(event: unknown): ALMessage {
-  return newALUntargetedMessage(
-    'server-1',
-    newALRoute('crdt.audit', 'document-1', 'audit-1'),
-    CRDT_AUDIT_APP_OUTBOX_TYPE,
-    event,
-  );
+  return newALUntargetedMessage('server-1', newALRoute('crdt.audit', 'document-1', 'audit-1'), CRDT_AUDIT_APP_OUTBOX_TYPE, event);
 }
 
 function createResourceEntry(): ResourceEntry {

--- a/packages/tests/shared-server/crdt/mutation/crdt-append-result-invariants.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-append-result-invariants.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   RALLAR_CRDT_OPERATION_VERSION,
@@ -21,47 +16,15 @@ import {
 } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  AppCrdtInboxService,
-} from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
+import { AppCrdtInboxService } from '@shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts';
 import type { PSqlSql, PSqlTransactionSql } from '@shared-server/postgres/PostgresSqlClient.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  ResourceInboxResultsRepository,
-} from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationService,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationCommand,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  decodeCrdtMutationResult,
-} from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  computeCrdtMutation,
-} from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  appendRejectionReason,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-append-rejection.ts';
+import { ResourceInboxRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxRepository.ts';
+import { ResourceInboxResultsRepository } from '@shared-server/postgres/resource-inbox/ResourceInboxResultsRepository.ts';
+import { createCrdtMutationService } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
+import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import { decodeCrdtMutationResult } from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { computeCrdtMutation } from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
+import { appendRejectionReason } from '@shared-server/rallar-system/crdt/mutation/crdt-append-rejection.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -73,29 +36,24 @@ const DOCUMENT: RallarCrdtDocumentRef = {
 };
 
 describe('CRDT append and administration result invariants', () => {
-  it(
-    'keeps semantic append identity stable while delivery identity and ' + 'retry lifetime vary',
-    async () => {
-      const capturedAtEpochMs = 1_000;
-      const service = appCrdt();
-      const command = await service.createAndEnqueueAppend({
-        update: update('semantic-update'),
-        deliveryId: 'transport-delivery-1',
-        actor: actor(),
-        responseAudience: audience('principal'),
-        capturedAtEpochMs,
-        expireAtEpochMs: capturedAtEpochMs + 60_000,
-      });
+  it('keeps semantic append identity stable while delivery identity and ' + 'retry lifetime vary', async () => {
+    const capturedAtEpochMs = 1_000;
+    const service = appCrdt();
+    const command = await service.createAndEnqueueAppend({
+      update: update('semantic-update'),
+      deliveryId: 'transport-delivery-1',
+      actor: actor(),
+      responseAudience: audience('principal'),
+      capturedAtEpochMs,
+      expireAtEpochMs: capturedAtEpochMs + 60_000,
+    });
 
-      expect(command.commandId).toBe('semantic-update');
-      expect(command).toMatchObject({ deliveryId: 'transport-delivery-1' });
-      expect(command.expireAtEpochMs).toBe(
-        capturedAtEpochMs +
-          DEFAULT_RESOURCE_INBOX_RETRY_HORIZON_MS +
-          RESOURCE_INBOX_RETRY_PROCESSING_MARGIN_MS,
-      );
-    },
-  );
+    expect(command.commandId).toBe('semantic-update');
+    expect(command).toMatchObject({ deliveryId: 'transport-delivery-1' });
+    expect(command.expireAtEpochMs).toBe(
+      capturedAtEpochMs + DEFAULT_RESOURCE_INBOX_RETRY_HORIZON_MS + RESOURCE_INBOX_RETRY_PROCESSING_MARGIN_MS,
+    );
+  });
 
   it('allows replay only for append producers', async () => {
     const command = await lifecycleCommand();
@@ -306,10 +264,7 @@ function appCrdt(): AppCrdtInboxService {
 
 function createUnusedDatabase(): PSqlSql {
   const database: PSqlSql = Object.assign(
-    <T>(
-      _stringsOrValues: TemplateStringsArray | readonly unknown[],
-      ..._values: unknown[]
-    ): Promise<T> =>
+    <T>(_stringsOrValues: TemplateStringsArray | readonly unknown[], ..._values: unknown[]): Promise<T> =>
       Promise.reject(new Error('Unexpected SQL execution in mutation invariant test')),
     {
       begin: <T>(_run: (sql: PSqlTransactionSql) => Promise<T>): Promise<T> =>

--- a/packages/tests/shared-server/crdt/mutation/crdt-command-and-outbox-invariants.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-command-and-outbox-invariants.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   RALLAR_CRDT_OPERATION_VERSION,
@@ -21,16 +16,8 @@ import {
   type CrdtMutationRead,
   type CrdtMutationRepository,
 } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationCommand,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationService,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
+import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import { createCrdtMutationService } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -88,9 +75,7 @@ describe('CRDT command and outbox invariants', () => {
     await expect(appendCommand(invalidUpdate)).rejects.toThrow(/update|field/i);
     const accepted = compute(await appendCommand(update('wire')), read());
     const wire = outboxMessage(accepted, 'reply');
-    expect(Object.keys(wire).sort()).toEqual(
-      ['audit', 'constraints', 'id', 'payload', 'route', 'targets'].sort(),
-    );
+    expect(Object.keys(wire).sort()).toEqual(['audit', 'constraints', 'id', 'payload', 'route', 'targets'].sort());
     expect(Object.keys(wire.payload).sort()).toEqual(['contentType', 'resource', 'typeId'].sort());
   });
 
@@ -298,11 +283,7 @@ function update(updateId: string): RallarCrdtUpdateEnvelope {
   };
 }
 
-function snapshotFor(
-  document: RallarCrdtDocumentRef,
-  snapshotId: string,
-  value: unknown,
-): RallarCrdtSnapshotEnvelope {
+function snapshotFor(document: RallarCrdtDocumentRef, snapshotId: string, value: unknown): RallarCrdtSnapshotEnvelope {
   return {
     protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
     document,
@@ -338,9 +319,7 @@ function metadata(overrides: Partial<RallarCrdtDocumentMetadata> = {}): RallarCr
 }
 
 function outboxMessage(computed: CrdtMutationComputed, effect: string) {
-  const entry = computed.outboxEntries.find((candidate) =>
-    candidate.key.resourceId.endsWith(`:${effect}`),
-  );
+  const entry = computed.outboxEntries.find((candidate) => candidate.key.resourceId.endsWith(`:${effect}`));
   if (!entry) {
     throw new Error(`Missing ${effect} outbox entry`);
   }

--- a/packages/tests/shared-server/crdt/mutation/crdt-exact-codecs.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-exact-codecs.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   createRallarCrdtDebugBundle,
@@ -18,16 +13,9 @@ import {
   createCrdtMutationCommand,
   decodeCrdtMutationCommand,
 } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// prettier-ignore
-import { decodeCrdtMutationResult }
-  from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
-// prettier-ignore
-import { decodeExactDebugBundle }
-  from '@shared-server/rallar-system/crdt/mutation/decode-exact-debug-bundle.ts';
-import {
-  decodeCrdtAuditEvent,
-  decodeExactSnapshotEnvelope,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-value-codec.ts';
+import { decodeCrdtMutationResult } from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { decodeExactDebugBundle } from '@shared-server/rallar-system/crdt/mutation/decode-exact-debug-bundle.ts';
+import { decodeCrdtAuditEvent, decodeExactSnapshotEnvelope } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-value-codec.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -39,26 +27,20 @@ const DOCUMENT: RallarCrdtDocumentRef = {
 };
 
 describe('CRDT mutation exact nested codecs', () => {
-  it(
-    'decodes scalar audit metadata and rejects nested metadata ' +
-      'without rewriting base input errors',
-    () => {
-      const event = {
-        kind: 'erase',
-        atEpochMs: 2_000,
-        documentKey: toRallarCrdtDocumentKey(DOCUMENT),
-        principalId: 'principal-1',
-        reason: 'privacy',
-        metadata: { mode: 'destroy-document', attempts: 2, verified: true },
-      } as const;
+  it('decodes scalar audit metadata and rejects nested metadata ' + 'without rewriting base input errors', () => {
+    const event = {
+      kind: 'erase',
+      atEpochMs: 2_000,
+      documentKey: toRallarCrdtDocumentKey(DOCUMENT),
+      principalId: 'principal-1',
+      reason: 'privacy',
+      metadata: { mode: 'destroy-document', attempts: 2, verified: true },
+    } as const;
 
-      expect(decodeCrdtAuditEvent(event)).toEqual(event);
-      expect(() =>
-        decodeCrdtAuditEvent({ ...event, metadata: { mode: { nested: true } } }),
-      ).toThrow('CRDT audit outbox event is invalid');
-      expect(() => decodeCrdtAuditEvent(null)).toThrow('CRDT admin request must be an object');
-    },
-  );
+    expect(decodeCrdtAuditEvent(event)).toEqual(event);
+    expect(() => decodeCrdtAuditEvent({ ...event, metadata: { mode: { nested: true } } })).toThrow('CRDT audit outbox event is invalid');
+    expect(() => decodeCrdtAuditEvent(null)).toThrow('CRDT admin request must be an object');
+  });
 
   it('rejects extra fields in authoritative update payload batches', async () => {
     const payload = {
@@ -93,39 +75,36 @@ describe('CRDT mutation exact nested codecs', () => {
     ).rejects.toThrow(/payload|batch|fields|exact/i);
   });
 
-  it(
-    'checks compact fields before the canonical command hash ' + 'without rewriting raw snapshots',
-    () => {
-      const command = compactCommand();
-      const mismatchedReason = {
-        ...command,
-        snapshot: {
-          ...command.snapshot,
-          metadata: { ...command.snapshot.metadata, reason: 'other' },
-        },
-      };
-      expect(() => decodeCrdtMutationCommand(withCommandHash(mismatchedReason))).toThrow(
-        'CRDT compact snapshot reason differs from command reason',
-      );
+  it('checks compact fields before the canonical command hash ' + 'without rewriting raw snapshots', () => {
+    const command = compactCommand();
+    const mismatchedReason = {
+      ...command,
+      snapshot: {
+        ...command.snapshot,
+        metadata: { ...command.snapshot.metadata, reason: 'other' },
+      },
+    };
+    expect(() => decodeCrdtMutationCommand(withCommandHash(mismatchedReason))).toThrow(
+      'CRDT compact snapshot reason differs from command reason',
+    );
 
-      expect(() =>
-        decodeCrdtMutationCommand({ ...command, snapshotId: '', commandHash: 'bad-hash' }),
-      ).toThrow('snapshotId must be a non-empty string');
+    expect(() => decodeCrdtMutationCommand({ ...command, snapshotId: '', commandHash: 'bad-hash' })).toThrow(
+      'snapshotId must be a non-empty string',
+    );
 
-      expect(() =>
-        decodeCrdtMutationCommand(
-          withCommandHash({
-            ...command,
-            reason: '',
-            snapshot: {
-              ...command.snapshot,
-              metadata: { ...command.snapshot.metadata, updateCount: -1 },
-            },
-          }),
-        ),
-      ).toThrow('metadata updateCount must be a non-negative safe integer');
-    },
-  );
+    expect(() =>
+      decodeCrdtMutationCommand(
+        withCommandHash({
+          ...command,
+          reason: '',
+          snapshot: {
+            ...command.snapshot,
+            metadata: { ...command.snapshot.metadata, updateCount: -1 },
+          },
+        }),
+      ),
+    ).toThrow('metadata updateCount must be a non-negative safe integer');
+  });
 
   it('rejects extra fields in authoritative erase debug bundles', () => {
     const bundle = JSON.parse(

--- a/packages/tests/shared-server/crdt/mutation/crdt-mutation-safety-invariants.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-mutation-safety-invariants.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   hashRallarCrdtUpdateEnvelope,
@@ -12,26 +7,10 @@ import {
   type RallarCrdtDocumentRef,
   type RallarCrdtUpdateEnvelope,
 } from '@shared/crdt/mod.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationCommand,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  decodeCrdtMutationResult,
-} from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  computeCrdtMutation,
-} from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  toCrdtAuditOutbox,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
+import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import { decodeCrdtMutationResult } from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { computeCrdtMutation } from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
+import { toCrdtAuditOutbox } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',

--- a/packages/tests/shared-server/crdt/mutation/crdt-mutation-service.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-mutation-service.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   RALLAR_CRDT_OPERATION_VERSION,
@@ -23,21 +18,9 @@ import {
   type CrdtMutationRead,
   type CrdtMutationRepository,
 } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationCommand,
-} from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  createCrdtMutationService,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  decodeCrdtMutationResult,
-} from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import { createCrdtMutationService } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts';
+import { decodeCrdtMutationResult } from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -94,20 +77,10 @@ describe('CRDT mutation service', () => {
       createWriter: () => repository,
       serviceId: 'server-1',
     });
-    await applyCrdtMutation(
-      service,
-      repository,
-      await createAppendCommand('append-first', 'update-1'),
-    );
+    await applyCrdtMutation(service, repository, await createAppendCommand('append-first', 'update-1'));
 
-    const replay = await computeCrdtMutation(
-      service,
-      await createAppendCommand('append-replay', 'update-1'),
-    );
-    const collision = await computeCrdtMutation(
-      service,
-      await createAppendCommand('append-collision', 'update-1', 'different'),
-    );
+    const replay = await computeCrdtMutation(service, await createAppendCommand('append-replay', 'update-1'));
+    const collision = await computeCrdtMutation(service, await createAppendCommand('append-collision', 'update-1', 'different'));
 
     expect(replay.outcome).toBe('replay');
     expect(collision).toMatchObject({
@@ -128,9 +101,7 @@ describe('CRDT mutation service', () => {
     const first = await computeCrdtMutation(service, command);
     repository.failNextConflict = true;
 
-    await expect(service.write(repository.transaction, first)).rejects.toBeInstanceOf(
-      CrdtMutationConflictError,
-    );
+    await expect(service.write(repository.transaction, first)).rejects.toBeInstanceOf(CrdtMutationConflictError);
     repository.metadata = createMetadata({
       lifecycle: 'archived',
       documentRevision: 1,
@@ -224,12 +195,8 @@ describe('CRDT mutation service', () => {
     const commandMismatch = { ...computed, command: { ...command } };
     const readMismatch = { ...computed, read: { ...read } };
 
-    expect(service.validate({ command, read, computed: commandMismatch })).toMatchObject([
-      { code: 'computed-identity-differs' },
-    ]);
-    expect(service.validate({ command, read, computed: readMismatch })).toMatchObject([
-      { code: 'computed-identity-differs' },
-    ]);
+    expect(service.validate({ command, read, computed: commandMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
+    expect(service.validate({ command, read, computed: readMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
   });
 
   it('returns all ordered validation issues for a malformed compact accepted result', async () => {
@@ -267,9 +234,7 @@ describe('CRDT mutation service', () => {
     });
 
     expect(() => service.validate({ command, read, computed: malformed })).not.toThrow();
-    expect(
-      service.validate({ command, read, computed: malformed }).map((issue) => issue.code),
-    ).toEqual([
+    expect(service.validate({ command, read, computed: malformed }).map((issue) => issue.code)).toEqual([
       'computed-identity-differs',
       'computed-predecessor-differs',
       'compact-reason-differs',
@@ -335,9 +300,7 @@ function createUpdate(updateId: string, title: string): RallarCrdtUpdateEnvelope
   };
 }
 
-function createMetadata(
-  overrides: Partial<RallarCrdtDocumentMetadata> = {},
-): RallarCrdtDocumentMetadata {
+function createMetadata(overrides: Partial<RallarCrdtDocumentMetadata> = {}): RallarCrdtDocumentMetadata {
   return {
     document: DOCUMENT,
     documentKey: toRallarCrdtDocumentKey(DOCUMENT),
@@ -414,10 +377,8 @@ class MemoryCrdtMutationRepository implements CrdtMutationRepository {
 
 function createUnusedTransaction(): PSqlTransactionSql {
   const transaction: PSqlTransactionSql = Object.assign(
-    <T>(
-      _stringsOrValues: TemplateStringsArray | readonly unknown[],
-      ..._values: unknown[]
-    ): Promise<T> => Promise.reject(new Error('Unexpected SQL execution in mutation unit test')),
+    <T>(_stringsOrValues: TemplateStringsArray | readonly unknown[], ..._values: unknown[]): Promise<T> =>
+      Promise.reject(new Error('Unexpected SQL execution in mutation unit test')),
     {
       begin: <T>(_run: (sql: PSqlTransactionSql) => Promise<T>): Promise<T> =>
         Promise.reject(new Error('Unexpected nested transaction in mutation unit test')),

--- a/packages/tests/shared-server/crdt/mutation/crdt-persisted-contract-invariants.test.ts
+++ b/packages/tests/shared-server/crdt/mutation/crdt-persisted-contract-invariants.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   hashRallarCrdtJson,
@@ -15,19 +10,12 @@ import {
   type RallarCrdtUpdateEnvelope,
   toRallarCrdtDocumentKey,
 } from '@shared/crdt/mod.ts';
-import {
-  DEFAULT_RESOURCE_INBOX_RETRY_POLICY,
-  retryAfterAttempt,
-} from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
+import { DEFAULT_RESOURCE_INBOX_RETRY_POLICY, retryAfterAttempt } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
 import { WsQueueBoxServerService } from '@shared/services/WsQueueBoxServerService.ts';
 import { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 import { RallarServerWsFacade } from '@shared-server/rallar-facade/ws-topic-router.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  installRallarCrdtWsTopics,
-} from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
+import { installRallarCrdtWsTopics } from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
 import {
   type DocumentRow,
   type SnapshotRow,
@@ -40,21 +28,9 @@ import {
   createCrdtMutationCommand,
   decodeCrdtMutationCommand,
 } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  decodeCrdtMutationResult,
-} from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  computeCrdtMutation,
-} from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  toCrdtAuditOutbox,
-} from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
+import { decodeCrdtMutationResult } from '@shared-server/rallar-system/crdt/mutation/decode-crdt-mutation-result.ts';
+import { computeCrdtMutation } from '@shared-server/rallar-system/crdt/mutation/compute-crdt-mutation.ts';
+import { toCrdtAuditOutbox } from '@shared-server/rallar-system/crdt/mutation/create-crdt-mutation-outbox.ts';
 
 const DOCUMENT: RallarCrdtDocumentRef = {
   applicationId: 'app-1',
@@ -239,19 +215,12 @@ describe('CRDT persisted mutation contract invariants', () => {
       }
     }
 
-    expect(Number(entry.audit.expiryTs.epochMilliseconds)).toBeGreaterThanOrEqual(
-      finalRetryAtEpochMs + 60_000,
-    );
+    expect(Number(entry.audit.expiryTs.epochMilliseconds)).toBeGreaterThanOrEqual(finalRetryAtEpochMs + 60_000);
   });
 
   it('never configures update topics for live-only fanout without mutation ingress', () => {
     const socket = new JsonWebSocketServer();
-    const service = new WsQueueBoxServerService(
-      new InMemoryQueueBox(),
-      new InMemoryQueueBox(),
-      socket,
-      'server-1',
-    );
+    const service = new WsQueueBoxServerService(new InMemoryQueueBox(), new InMemoryQueueBox(), socket, 'server-1');
     const bridge = installRallarCrdtWsTopics(new RallarServerWsFacade(service));
 
     expect(

--- a/packages/tests/shared-server/crdt/persistence/in-memory-crdt-log-repository.test.ts
+++ b/packages/tests/shared-server/crdt/persistence/in-memory-crdt-log-repository.test.ts
@@ -1,10 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   createRallarCrdtAppendRequestEnvelope,
@@ -31,11 +25,7 @@ import {
   toRallarCrdtDocumentKey,
   verifyRallarCrdtDebugBundle,
 } from '@shared/mod.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  InMemoryRallarCrdtLogRepository,
-} from '@shared-server/rallar-system/crdt/persistence/in-memory-crdt-log-repository.ts';
+import { InMemoryRallarCrdtLogRepository } from '@shared-server/rallar-system/crdt/persistence/in-memory-crdt-log-repository.ts';
 
 const roomRef = {
   applicationId: 'rallar-test',
@@ -119,9 +109,7 @@ describe('InMemoryRallarCrdtLogRepository', () => {
       serverId: 'server-a',
       authorizationScope: 'room',
     });
-    expect(duplicate.status === 'duplicate' && duplicate.append).toEqual(
-      accepted.status === 'accepted' && accepted.append,
-    );
+    expect(duplicate.status === 'duplicate' && duplicate.append).toEqual(accepted.status === 'accepted' && accepted.append);
   });
 
   it('stores encrypted updates durably without plaintext and restores them', async () => {
@@ -153,9 +141,7 @@ describe('InMemoryRallarCrdtLogRepository', () => {
     expect(isRallarCrdtEncryptedOperationBatch(encrypted.payload)).toBe(true);
     expect(JSON.stringify(backup)).not.toContain('Sensitive durable title');
     expect(restoredRecord?.update.payload).toEqual(encrypted.payload);
-    expect(
-      (await decryptRallarCrdtUpdateEnvelope(restoredRecord!.update, keyring)).payload.operations,
-    ).toEqual([
+    expect((await decryptRallarCrdtUpdateEnvelope(restoredRecord!.update, keyring)).payload.operations).toEqual([
       {
         kind: 'register.set',
         path: ['title'],
@@ -219,29 +205,26 @@ describe('InMemoryRallarCrdtLogRepository', () => {
     expect(clock.callCount()).toBe(1);
   });
 
-  it(
-    'does not read a creation clock while rejecting an existing ' + 'mismatched duplicate',
-    async () => {
-      const clock = createRecordingClock(2_000);
-      const repository = new InMemoryRallarCrdtLogRepository({
-        now: clock.now,
-      });
-      await repository.append(toAppendInput(createUpdateEnvelope('clock-rejected-1')));
-      clock.reset();
-      clock.throwOnCall(2);
+  it('does not read a creation clock while rejecting an existing ' + 'mismatched duplicate', async () => {
+    const clock = createRecordingClock(2_000);
+    const repository = new InMemoryRallarCrdtLogRepository({
+      now: clock.now,
+    });
+    await repository.append(toAppendInput(createUpdateEnvelope('clock-rejected-1')));
+    clock.reset();
+    clock.throwOnCall(2);
 
-      const rejected = await repository.append(
-        toAppendInput(
-          createUpdateEnvelope('clock-rejected-1', {
-            payload: batchWithTitle('Mismatched duplicate'),
-          }),
-        ),
-      );
+    const rejected = await repository.append(
+      toAppendInput(
+        createUpdateEnvelope('clock-rejected-1', {
+          payload: batchWithTitle('Mismatched duplicate'),
+        }),
+      ),
+    );
 
-      expect(rejected.status === 'rejected' && rejected.code).toBe('duplicate-hash-mismatch');
-      expect(clock.callCount()).toBe(1);
-    },
-  );
+    expect(rejected.status === 'rejected' && rejected.code).toBe('duplicate-hash-mismatch');
+    expect(clock.callCount()).toBe(1);
+  });
 
   it('serves catch-up pages by append sequence and cursor', async () => {
     const repository = new InMemoryRallarCrdtLogRepository({
@@ -261,10 +244,7 @@ describe('InMemoryRallarCrdtLogRepository', () => {
       limit: 2,
     });
 
-    expect(firstPage.records.map((record) => record.update.updateId)).toEqual([
-      'update-1',
-      'update-2',
-    ]);
+    expect(firstPage.records.map((record) => record.update.updateId)).toEqual(['update-1', 'update-2']);
     expect(firstPage).toMatchObject({
       firstSequence: 1,
       lastSequence: 2,
@@ -332,43 +312,37 @@ describe('InMemoryRallarCrdtLogRepository', () => {
     expect(clock.callCount()).toBe(0);
   });
 
-  it(
-    'does not read the clock for an existing lifecycle change with an ' + 'explicit timestamp',
-    async () => {
-      const clock = createRecordingClock(2_000);
-      const repository = new InMemoryRallarCrdtLogRepository({ now: clock.now });
-      await repository.append(toAppendInput(createUpdateEnvelope('lifecycle-clock-1')));
-      clock.reset();
-      clock.throwOnCall(1);
+  it('does not read the clock for an existing lifecycle change with an ' + 'explicit timestamp', async () => {
+    const clock = createRecordingClock(2_000);
+    const repository = new InMemoryRallarCrdtLogRepository({ now: clock.now });
+    await repository.append(toAppendInput(createUpdateEnvelope('lifecycle-clock-1')));
+    clock.reset();
+    clock.throwOnCall(1);
 
-      const metadata = await repository.updateDocumentLifecycle({
-        document: documentRef,
-        lifecycle: 'archived',
-        changedAtEpochMs: 3_000,
-      });
+    const metadata = await repository.updateDocumentLifecycle({
+      document: documentRef,
+      lifecycle: 'archived',
+      changedAtEpochMs: 3_000,
+    });
 
-      expect(metadata.updatedAtEpochMs).toBe(3_000);
-      expect(clock.callCount()).toBe(0);
-    },
-  );
+    expect(metadata.updatedAtEpochMs).toBe(3_000);
+    expect(clock.callCount()).toBe(0);
+  });
 
-  it(
-    'does not read the clock for an existing debug export with an ' + 'explicit timestamp',
-    async () => {
-      const clock = createRecordingClock(2_000);
-      const repository = new InMemoryRallarCrdtLogRepository({ now: clock.now });
-      await repository.append(toAppendInput(createUpdateEnvelope('debug-clock-1')));
-      clock.reset();
-      clock.throwOnCall(1);
+  it('does not read the clock for an existing debug export with an ' + 'explicit timestamp', async () => {
+    const clock = createRecordingClock(2_000);
+    const repository = new InMemoryRallarCrdtLogRepository({ now: clock.now });
+    await repository.append(toAppendInput(createUpdateEnvelope('debug-clock-1')));
+    clock.reset();
+    clock.throwOnCall(1);
 
-      const bundle = await repository.exportDebugBundle(documentRef, {
-        exportedAtEpochMs: 4_000,
-      });
+    const bundle = await repository.exportDebugBundle(documentRef, {
+      exportedAtEpochMs: 4_000,
+    });
 
-      expect(bundle.exportedAtEpochMs).toBe(4_000);
-      expect(clock.callCount()).toBe(0);
-    },
-  );
+    expect(bundle.exportedAtEpochMs).toBe(4_000);
+    expect(clock.callCount()).toBe(0);
+  });
 
   it('rejects appends after a document is archived', async () => {
     const lifecycleHook = vi.fn();
@@ -451,9 +425,7 @@ describe('InMemoryRallarCrdtLogRepository', () => {
       },
     });
 
-    expect((await repository.append(toAppendInput(createUpdateEnvelope('update-1')))).status).toBe(
-      'accepted',
-    );
+    expect((await repository.append(toAppendInput(createUpdateEnvelope('update-1')))).status).toBe('accepted');
     const rateLimited = await repository.append(toAppendInput(createUpdateEnvelope('update-2')));
     expect(rateLimited.status === 'rejected' && rateLimited.code).toBe('rate-limited');
 
@@ -486,75 +458,72 @@ describe('InMemoryRallarCrdtLogRepository', () => {
     expect(rejected.status === 'rejected' && rejected.code).toBe('quota-exceeded');
   });
 
-  it(
-    'lists admin status, exports debug bundles, restores backups, and ' + 'rebuilds projections',
-    async () => {
-      const rebuildHook = vi.fn();
-      const audit = new InMemoryRallarCrdtAuditSink();
-      const repository = new InMemoryRallarCrdtLogRepository({
-        now: fixedNow(2_000),
-        audit,
-        hooks: {
-          rebuild: rebuildHook,
-        },
-      });
-      await repository.append(toAppendInput(createUpdateEnvelope('update-1')));
+  it('lists admin status, exports debug bundles, restores backups, and ' + 'rebuilds projections', async () => {
+    const rebuildHook = vi.fn();
+    const audit = new InMemoryRallarCrdtAuditSink();
+    const repository = new InMemoryRallarCrdtLogRepository({
+      now: fixedNow(2_000),
+      audit,
+      hooks: {
+        rebuild: rebuildHook,
+      },
+    });
+    await repository.append(toAppendInput(createUpdateEnvelope('update-1')));
 
-      const list = await repository.listDocuments({
-        documentType: 'checklist',
-      });
-      const debugBundle = await repository.exportDebugBundle(documentRef, {
-        reason: 'test-export',
-      });
-      const backup = await repository.exportBackupBundle(documentRef);
-      const rebuildReport = await repository.rebuildProjection(documentRef, 'checklist-summary');
-      await repository.writeSnapshot({
-        snapshot: {
-          protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
-          document: documentRef,
-          snapshotId: 'snapshot-compact-1',
-          schemaVersion: 1,
-          createdAtEpochMs: 3_000,
-          maxLamport: 1,
-          includedUpdateIds: ['update-1'],
-          value: {
-            title: 'Title update-1',
-          },
-          metadata: {
-            updateCount: 1,
-          },
+    const list = await repository.listDocuments({
+      documentType: 'checklist',
+    });
+    const debugBundle = await repository.exportDebugBundle(documentRef, {
+      reason: 'test-export',
+    });
+    const backup = await repository.exportBackupBundle(documentRef);
+    const rebuildReport = await repository.rebuildProjection(documentRef, 'checklist-summary');
+    await repository.writeSnapshot({
+      snapshot: {
+        protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
+        document: documentRef,
+        snapshotId: 'snapshot-compact-1',
+        schemaVersion: 1,
+        createdAtEpochMs: 3_000,
+        maxLamport: 1,
+        includedUpdateIds: ['update-1'],
+        value: {
+          title: 'Title update-1',
         },
-        appendSequence: 1,
-        reason: 'non-destructive-compaction',
-      });
-      const restored = new InMemoryRallarCrdtLogRepository({
-        now: fixedNow(4_000),
-        audit,
-      });
+        metadata: {
+          updateCount: 1,
+        },
+      },
+      appendSequence: 1,
+      reason: 'non-destructive-compaction',
+    });
+    const restored = new InMemoryRallarCrdtLogRepository({
+      now: fixedNow(4_000),
+      audit,
+    });
 
-      expect(list.documents).toHaveLength(1);
-      expect(debugBundle.integrity.updateCount).toBe(1);
-      expect(backup?.integrity.updateCount).toBe(1);
-      expect(rebuildReport.valid).toBe(true);
-      expect(rebuildHook).toHaveBeenCalledWith(documentRef);
-      expect(
-        await restored.restoreBackupBundle(backup!, {
-          overwrite: true,
-        }),
-      ).toMatchObject({
-        restoredUpdateCount: 1,
-        firstAppendSequence: 1,
-        lastAppendSequence: 1,
-      });
-      expect((await restored.listAfter({ document: documentRef })).records).toHaveLength(1);
-      expect(audit.count('append')).toBe(1);
-      expect(audit.count('export')).toBeGreaterThanOrEqual(2);
-      expect(audit.count('backup')).toBeGreaterThanOrEqual(1);
-      expect(audit.count('compact')).toBe(1);
-      expect(audit.count('restore')).toBe(1);
-      expect(audit.count('rebuild')).toBe(1);
-    },
-  );
+    expect(list.documents).toHaveLength(1);
+    expect(debugBundle.integrity.updateCount).toBe(1);
+    expect(backup?.integrity.updateCount).toBe(1);
+    expect(rebuildReport.valid).toBe(true);
+    expect(rebuildHook).toHaveBeenCalledWith(documentRef);
+    expect(
+      await restored.restoreBackupBundle(backup!, {
+        overwrite: true,
+      }),
+    ).toMatchObject({
+      restoredUpdateCount: 1,
+      firstAppendSequence: 1,
+      lastAppendSequence: 1,
+    });
+    expect((await restored.listAfter({ document: documentRef })).records).toHaveLength(1);
+    expect(audit.count('append')).toBe(1);
+    expect(audit.count('export')).toBeGreaterThanOrEqual(2);
+    expect(audit.count('backup')).toBeGreaterThanOrEqual(1);
+    expect(audit.count('compact')).toBe(1);
+    expect(audit.count('restore')).toBe(1);
+    expect(audit.count('rebuild')).toBe(1);
+  });
 
   it('rejects a valid cross-document backup without changing either document', async () => {
     const source = new InMemoryRallarCrdtLogRepository({ now: fixedNow(2_000) });
@@ -646,17 +615,12 @@ describe('InMemoryRallarCrdtLogRepository', () => {
             }
           : sourceBackup!.metadata,
       snapshot:
-        testCase.change === 'snapshot-document'
-          ? { ...sourceBackup!.snapshot!, document: otherDocumentRef }
-          : sourceBackup!.snapshot,
+        testCase.change === 'snapshot-document' ? { ...sourceBackup!.snapshot!, document: otherDocumentRef } : sourceBackup!.snapshot,
       records: [
         {
           ...record,
           document: testCase.change === 'record-document' ? otherDocumentRef : record.document,
-          documentKey:
-            testCase.change === 'record-key'
-              ? toRallarCrdtDocumentKey(otherDocumentRef)
-              : record.documentKey,
+          documentKey: testCase.change === 'record-key' ? toRallarCrdtDocumentKey(otherDocumentRef) : record.documentKey,
         },
       ],
     });
@@ -671,47 +635,44 @@ describe('InMemoryRallarCrdtLogRepository', () => {
     expect(await target.listAfter({ document: otherDocumentRef })).toMatchObject({ records: [] });
   });
 
-  it(
-    'pages larger update logs and verifies integrity digests without ' + 'unbounded payloads',
-    async () => {
-      const repository = new InMemoryRallarCrdtLogRepository({
-        now: fixedNow(2_000),
+  it('pages larger update logs and verifies integrity digests without ' + 'unbounded payloads', async () => {
+    const repository = new InMemoryRallarCrdtLogRepository({
+      now: fixedNow(2_000),
+    });
+    for (let index = 1; index <= 25; index += 1) {
+      await repository.append(toAppendInput(createUpdateEnvelope(`large-${index}`)));
+    }
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    do {
+      const page = await repository.listAfter({
+        document: documentRef,
+        afterCursor: cursor,
+        limit: 7,
       });
-      for (let index = 1; index <= 25; index += 1) {
-        await repository.append(toAppendInput(createUpdateEnvelope(`large-${index}`)));
+      pageCount += 1;
+      seen.push(...page.records.map((record) => record.update.updateId));
+      cursor = page.nextCursor;
+      if (!page.hasMore) {
+        break;
       }
+    } while (cursor);
 
-      const seen: string[] = [];
-      let cursor: string | undefined;
-      let pageCount = 0;
-      do {
-        const page = await repository.listAfter({
-          document: documentRef,
-          afterCursor: cursor,
-          limit: 7,
-        });
-        pageCount += 1;
-        seen.push(...page.records.map((record) => record.update.updateId));
-        cursor = page.nextCursor;
-        if (!page.hasMore) {
-          break;
-        }
-      } while (cursor);
+    const integrity = await repository.verifyIntegrity(documentRef);
 
-      const integrity = await repository.verifyIntegrity(documentRef);
-
-      expect(pageCount).toBe(4);
-      expect(seen).toHaveLength(25);
-      expect(seen[0]).toBe('large-1');
-      expect(seen.at(-1)).toBe('large-25');
-      expect(integrity).toMatchObject({
-        valid: true,
-        checkedUpdateCount: 25,
-        sequenceGaps: [],
-      });
-      expect(integrity.bundleHash).toMatch(/^crdt-fnv1a32:/);
-    },
-  );
+    expect(pageCount).toBe(4);
+    expect(seen).toHaveLength(25);
+    expect(seen[0]).toBe('large-1');
+    expect(seen.at(-1)).toBe('large-25');
+    expect(integrity).toMatchObject({
+      valid: true,
+      checkedUpdateCount: 25,
+      sequenceGaps: [],
+    });
+    expect(integrity.bundleHash).toMatch(/^crdt-fnv1a32:/);
+  });
 });
 
 function toAppendInput(update: RallarCrdtUpdateEnvelope) {
@@ -726,10 +687,7 @@ function toAppendInput(update: RallarCrdtUpdateEnvelope) {
     },
   };
 }
-function createUpdateEnvelope(
-  updateId: string,
-  overrides: Partial<RallarCrdtUpdateEnvelope> = {},
-): RallarCrdtUpdateEnvelope {
+function createUpdateEnvelope(updateId: string, overrides: Partial<RallarCrdtUpdateEnvelope> = {}): RallarCrdtUpdateEnvelope {
   return {
     protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
     document: documentRef,

--- a/packages/tests/shared-server/crdt/realtime/crdt-principal-fanout-cold-cache.test.ts
+++ b/packages/tests/shared-server/crdt/realtime/crdt-principal-fanout-cold-cache.test.ts
@@ -1,9 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   type AuditStamp,
   type ClientInstance,
@@ -23,33 +18,20 @@ import {
 import { InMemoryQueueBox } from '@shared/queuebox/InMemoryQueueBox.ts';
 import { ConnectionContext, JsonWebSocketServer } from '@shared/mod.ts';
 import { WsQueueBoxServerService } from '@shared/services/WsQueueBoxServerService.ts';
-// prettier-ignore
-import {
-  ClientStateRepository,
-} from '@shared-server/rallar-system/repositories/\
+import { ClientStateRepository } from '@shared-server/rallar-system/repositories/\
 ClientStateRepository.ts';
-// prettier-ignore
-import {
-  createClientStateSnapshotReadThroughCache,
-} from '@shared-server/rallar-system/services/\
+import { createClientStateSnapshotReadThroughCache } from '@shared-server/rallar-system/services/\
 client-state-snapshot-read-through-cache.ts';
-// prettier-ignore
-import {
-  createWsServerTargetResolver,
-} from '@shared-server/rallar-system/middleware/\
+import { createWsServerTargetResolver } from '@shared-server/rallar-system/middleware/\
 RallarMiddleware.ts';
 
-// prettier-ignore
-import {
-  findCurrentClientSnapshot,
-} from '../../../../../apps/api-v1/src/crdt/\
+import { findCurrentClientSnapshot } from '../../../../../apps/api-v1/src/crdt/\
 create-api-crdt-document-authorizer.ts';
 import { FakeRuntimeStateRepository } from '../../fake-runtime-state-repository.ts';
 import { configureTestCacheRepositories } from '../../../cache-repository-config.ts';
 
 const NOW = Date.now();
-const COLD_CACHE_FANOUT_BEHAVIOR =
-  'fails closed while cold, then expands omitted-workspace ' + 'principal to all current sessions';
+const COLD_CACHE_FANOUT_BEHAVIOR = 'fails closed while cold, then expands omitted-workspace ' + 'principal to all current sessions';
 
 describe('CRDT principal fanout from a cold cache', () => {
   it(COLD_CACHE_FANOUT_BEHAVIOR, async () => {
@@ -135,10 +117,7 @@ function principalMessage() {
   );
 }
 
-async function putSnapshot(
-  repository: ClientStateRepository,
-  snapshot: ClientSnapshot,
-): Promise<void> {
+async function putSnapshot(repository: ClientStateRepository, snapshot: ClientSnapshot): Promise<void> {
   await repository.insertPrincipal(snapshot.principal);
   for (const instance of snapshot.instances) {
     await repository.insertInstance(instance);

--- a/packages/tests/shared-server/crdt/realtime/rallar-crdt-server.test.ts
+++ b/packages/tests/shared-server/crdt/realtime/rallar-crdt-server.test.ts
@@ -1,10 +1,4 @@
-// prettier-ignore
-import {
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   AL_CONTROL_NACK_TYPE_ID,
@@ -29,16 +23,8 @@ import {
   type WsServerTargetResolver,
 } from '@shared/mod.ts';
 import { RallarServerWsFacade } from '@shared-server/rallar-facade/ws-topic-router.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  InMemoryRallarCrdtLogRepository,
-} from '@shared-server/rallar-system/crdt/persistence/in-memory-crdt-log-repository.ts';
-// Prettier's single-line form exceeds the repository's 100-character review limit.
-// prettier-ignore
-import {
-  installRallarCrdtWsTopics,
-} from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
+import { InMemoryRallarCrdtLogRepository } from '@shared-server/rallar-system/crdt/persistence/in-memory-crdt-log-repository.ts';
+import { installRallarCrdtWsTopics } from '@shared-server/rallar-system/crdt/realtime/install-rallar-crdt-ws-topics.ts';
 
 const roomRef = {
   applicationId: 'rallar-test',
@@ -218,43 +204,40 @@ describe('installRallarCrdtWsTopics', () => {
     }
   });
 
-  it(
-    'rejects unsupported principal live fanout even when app CRDT ' + 'documents are enabled',
-    async () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      try {
-        const { facade, socket } = createFacade();
-        installRallarCrdtWsTopics(facade, {
-          allowAppDocuments: true,
-        });
-        const update = createUpdateEnvelope({
-          document: {
-            applicationId: 'rallar-test',
-            workspaceId: 'main',
-            scope: 'principal',
-            documentType: 'checklist',
-            documentId: 'principal-doc',
-            principalId: 'principal-1',
-          },
-        });
-        const message = newALBroadcastMessage(
-          'peer-1',
-          newALRoute(RALLAR_CRDT_APP_TOPIC_ID, 'rallar-test', update.updateId),
-          'all',
-          RALLAR_CRDT_UPDATE_TYPE_ID,
-          update,
-        );
+  it('rejects unsupported principal live fanout even when app CRDT ' + 'documents are enabled', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const { facade, socket } = createFacade();
+      installRallarCrdtWsTopics(facade, {
+        allowAppDocuments: true,
+      });
+      const update = createUpdateEnvelope({
+        document: {
+          applicationId: 'rallar-test',
+          workspaceId: 'main',
+          scope: 'principal',
+          documentType: 'checklist',
+          documentId: 'principal-doc',
+          principalId: 'principal-1',
+        },
+      });
+      const message = newALBroadcastMessage(
+        'peer-1',
+        newALRoute(RALLAR_CRDT_APP_TOPIC_ID, 'rallar-test', update.updateId),
+        'all',
+        RALLAR_CRDT_UPDATE_TYPE_ID,
+        update,
+      );
 
-        await facade.handle(message);
+      await facade.handle(message);
 
-        expect(socket.sent).toHaveLength(1);
-        expect(socket.sent[0].connectionId).toBe('conn-1');
-        expect(socket.sent[0].data.payload.typeId).toBe(AL_CONTROL_NACK_TYPE_ID);
-      } finally {
-        warn.mockRestore();
-      }
-    },
-  );
+      expect(socket.sent).toHaveLength(1);
+      expect(socket.sent[0].connectionId).toBe('conn-1');
+      expect(socket.sent[0].data.payload.typeId).toBe(AL_CONTROL_NACK_TYPE_ID);
+    } finally {
+      warn.mockRestore();
+    }
+  });
 
   it('rejects oversized CRDT updates', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -331,48 +314,43 @@ describe('installRallarCrdtWsTopics', () => {
     }
   });
 
-  it(
-    'hands accepted updates to durable mutation ingress without direct append ' + 'or fanout',
-    async () => {
-      const { facade, socket } = createFacade({
-        authorizeRoomMessage: () => true,
-      });
-      const logRepository = new InMemoryRallarCrdtLogRepository({
-        now: () => 2_000,
-        serverId: 'server-1',
-      });
-      const accepted: unknown[] = [];
-      installRallarCrdtWsTopics(facade, {
-        logRepository,
-        mutationIngress: {
-          enqueueUpdate: (entry) => {
-            accepted.push(entry);
-            return Promise.resolve();
-          },
+  it('hands accepted updates to durable mutation ingress without direct append ' + 'or fanout', async () => {
+    const { facade, socket } = createFacade({
+      authorizeRoomMessage: () => true,
+    });
+    const logRepository = new InMemoryRallarCrdtLogRepository({
+      now: () => 2_000,
+      serverId: 'server-1',
+    });
+    const accepted: unknown[] = [];
+    installRallarCrdtWsTopics(facade, {
+      logRepository,
+      mutationIngress: {
+        enqueueUpdate: (entry) => {
+          accepted.push(entry);
+          return Promise.resolve();
         },
-      });
-      const update = createUpdateEnvelope();
-      const message = newALBroadcastMessage(
-        'peer-1',
-        newALRoute(RALLAR_CRDT_ROOM_TOPIC_ID, 'room-1', update.updateId),
-        'room',
-        RALLAR_CRDT_UPDATE_TYPE_ID,
-        update,
-        {
-          groupRef: roomRef,
-        },
-      );
+      },
+    });
+    const update = createUpdateEnvelope();
+    const message = newALBroadcastMessage(
+      'peer-1',
+      newALRoute(RALLAR_CRDT_ROOM_TOPIC_ID, 'room-1', update.updateId),
+      'room',
+      RALLAR_CRDT_UPDATE_TYPE_ID,
+      update,
+      {
+        groupRef: roomRef,
+      },
+    );
 
-      await facade.handle(message);
+    await facade.handle(message);
 
-      expect(accepted).toHaveLength(1);
-      expect(accepted[0]).toMatchObject({ kind: 'update', envelope: update });
-      expect(socket.sent).toHaveLength(0);
-      expect(
-        (await logRepository.readDocumentMetadata(roomDocumentRef))?.updateCount,
-      ).toBeUndefined();
-    },
-  );
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0]).toMatchObject({ kind: 'update', envelope: update });
+    expect(socket.sent).toHaveLength(0);
+    expect((await logRepository.readDocumentMetadata(roomDocumentRef))?.updateCount).toBeUndefined();
+  });
 
   it('responds to durable WS catch-up requests from the append log', async () => {
     const { facade, socket } = createFacade({
@@ -434,13 +412,9 @@ describe('installRallarCrdtWsTopics', () => {
 
     await facade.handle(message);
 
-    const responseMessage = socket.sent.find(
-      (entry) => entry.data.payload.typeId === RALLAR_CRDT_CATCH_UP_RESPONSE_TYPE_ID,
-    );
+    const responseMessage = socket.sent.find((entry) => entry.data.payload.typeId === RALLAR_CRDT_CATCH_UP_RESPONSE_TYPE_ID);
     expect(responseMessage?.connectionId).toBe('conn-1');
-    const response = JSON.parse(
-      responseMessage?.data.payload.resource ?? '{}',
-    ) as RallarCrdtCatchUpResponseEnvelope;
+    const response = JSON.parse(responseMessage?.data.payload.resource ?? '{}') as RallarCrdtCatchUpResponseEnvelope;
     expect(response.requestId).toBe('catch-up-1');
     expect(response.page.records.map((record) => record.update.updateId)).toEqual(['update-2']);
     expect(response.page.lastSequence).toBe(2);
@@ -479,9 +453,7 @@ describe('installRallarCrdtWsTopics', () => {
     expect(accepted).toHaveLength(1);
     expect(accepted[0]).toMatchObject({ kind: 'update', envelope: update });
     expect(socket.sent).toHaveLength(0);
-    expect(
-      (await logRepository.readDocumentMetadata(principalDocumentRef))?.updateCount,
-    ).toBeUndefined();
+    expect((await logRepository.readDocumentMetadata(principalDocumentRef))?.updateCount).toBeUndefined();
   });
 
   it('does not run lifecycle rejection or fanout before AppInbox processing', async () => {
@@ -584,9 +556,7 @@ function createTargetResolver(): WsServerTargetResolver {
   };
 }
 
-function createUpdateEnvelope(
-  overrides: Partial<RallarCrdtUpdateEnvelope> = {},
-): RallarCrdtUpdateEnvelope {
+function createUpdateEnvelope(overrides: Partial<RallarCrdtUpdateEnvelope> = {}): RallarCrdtUpdateEnvelope {
   return {
     protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
     document: roomDocumentRef,

--- a/packages/tests/shared-server/formation-metrics.test.ts
+++ b/packages/tests/shared-server/formation-metrics.test.ts
@@ -6,10 +6,7 @@ import {
   emptyGroupFormationMetrics,
   toGroupFormationOperationKind,
 } from '@shared-server/rallar-system/formation-metrics.ts';
-// prettier-ignore
-import {
-  APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
-} from '@shared-server/rallar-system/services/rtc-topology-outbox-entry.ts';
+import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '@shared-server/rallar-system/services/rtc-topology-outbox-entry.ts';
 
 describe('group formation metrics recorder', () => {
   it('maps group mutation operations onto formation operation kinds', () => {

--- a/packages/tests/shared-server/group-create-lifecycle-policy.test.ts
+++ b/packages/tests/shared-server/group-create-lifecycle-policy.test.ts
@@ -1,84 +1,73 @@
 import { describe, expect, it } from 'vitest';
 import type { CreateGroupRequest } from '@shared/api/state-types.ts';
-// prettier-ignore
-import {
-    resolveGroupLifecyclePolicyPreset,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
-// prettier-ignore
-import {
-    toAggregateMutationCommand,
-} from '@shared-server/rallar-system/group-state/group-mutation-command.ts';
-// prettier-ignore
-import {
-    validateGroupMutationCommand,
-} from '@shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toAggregateMutationCommand } from '@shared-server/rallar-system/group-state/group-mutation-command.ts';
+import { validateGroupMutationCommand } from '@shared-server/rallar-system/group-state/mutation/command-validation/validate-group-mutation-command.ts';
 
 const SCOPE = { applicationId: 'app-1', workspaceId: 'ws-1' } as const;
 
 function toCreateCommand(lifecyclePolicy?: CreateGroupRequest['lifecyclePolicy']) {
-    const request: CreateGroupRequest = {
-        groupId: 'group-1',
-        displayName: 'Group One',
-        kind: 'room',
-        createdByPrincipalId: 'owner-1',
-        actorPrincipalId: 'owner-1',
-        ...(lifecyclePolicy === undefined ? {} : { lifecyclePolicy }),
-    } as CreateGroupRequest;
+  const request: CreateGroupRequest = {
+    groupId: 'group-1',
+    displayName: 'Group One',
+    kind: 'room',
+    createdByPrincipalId: 'owner-1',
+    actorPrincipalId: 'owner-1',
+    ...(lifecyclePolicy === undefined ? {} : { lifecyclePolicy }),
+  } as CreateGroupRequest;
 
-    const command = toAggregateMutationCommand(
-        {
-            operation: 'createGroup',
-            scope: SCOPE,
-            groupId: 'group-1',
-            request,
-        } as never,
-        () => 'command-1',
-    );
-    if (command.operation !== 'createGroup') {
-        throw new Error('Expected a createGroup command');
-    }
+  const command = toAggregateMutationCommand(
+    {
+      operation: 'createGroup',
+      scope: SCOPE,
+      groupId: 'group-1',
+      request,
+    } as never,
+    () => 'command-1',
+  );
+  if (command.operation !== 'createGroup') {
+    throw new Error('Expected a createGroup command');
+  }
 
-    return command;
+  return command;
 }
 
 describe('createGroup lifecycle policy input', () => {
-    // The load-bearing property, asserted on the wire shape rather than on
-    // behaviour: a create that does not mention a policy must produce exactly
-    // the command it produces today, because the event id is derived from it.
-    it('leaves the command untouched when no policy is supplied', () => {
-        const command = toCreateCommand();
+  // The load-bearing property, asserted on the wire shape rather than on
+  // behaviour: a create that does not mention a policy must produce exactly
+  // the command it produces today, because the event id is derived from it.
+  it('leaves the command untouched when no policy is supplied', () => {
+    const command = toCreateCommand();
 
-        expect('lifecyclePolicy' in command.input).toBe(false);
-        expect(() => validateGroupMutationCommand(command)).not.toThrow();
+    expect('lifecyclePolicy' in command.input).toBe(false);
+    expect(() => validateGroupMutationCommand(command)).not.toThrow();
+  });
+
+  it('normalizes a supplied preset into a complete policy', () => {
+    const command = toCreateCommand({ preset: 'managed' });
+
+    expect(command.input.lifecyclePolicy).toEqual(resolveGroupLifecyclePolicyPreset('managed'));
+  });
+
+  it('layers sparse overrides over the preset', () => {
+    const command = toCreateCommand({
+      preset: 'managed',
+      admission: { mode: 'closed' },
     });
 
-    it('normalizes a supplied preset into a complete policy', () => {
-        const command = toCreateCommand({ preset: 'managed' });
+    expect(command.input.lifecyclePolicy?.admission.mode).toBe('closed');
+    expect(command.input.lifecyclePolicy?.formation).toBe('phased');
+  });
 
-        expect(command.input.lifecyclePolicy).toEqual(
-            resolveGroupLifecyclePolicyPreset('managed'),
-        );
-    });
+  it('clamps an out-of-range knob rather than rejecting it', () => {
+    const command = toCreateCommand({ activation: { successRate: 4 } });
 
-    it('layers sparse overrides over the preset', () => {
-        const command = toCreateCommand({
-            preset: 'managed',
-            admission: { mode: 'closed' },
-        });
+    expect(command.input.lifecyclePolicy?.activation.successRate).toBe(1);
+  });
 
-        expect(command.input.lifecyclePolicy?.admission.mode).toBe('closed');
-        expect(command.input.lifecyclePolicy?.formation).toBe('phased');
-    });
+  it('accepts a normalized policy through the structural validator', () => {
+    const command = toCreateCommand({ preset: 'match' });
 
-    it('clamps an out-of-range knob rather than rejecting it', () => {
-        const command = toCreateCommand({ activation: { successRate: 4 } });
-
-        expect(command.input.lifecyclePolicy?.activation.successRate).toBe(1);
-    });
-
-    it('accepts a normalized policy through the structural validator', () => {
-        const command = toCreateCommand({ preset: 'match' });
-
-        expect(() => validateGroupMutationCommand(command)).not.toThrow();
-    });
+    expect(() => validateGroupMutationCommand(command)).not.toThrow();
+  });
 });

--- a/packages/tests/shared-server/group-lifecycle-policy-repository.test.ts
+++ b/packages/tests/shared-server/group-lifecycle-policy-repository.test.ts
@@ -1,133 +1,123 @@
 import { describe, expect, it } from 'vitest';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
-// prettier-ignore
 import {
-    createDefaultGroupLifecyclePolicy,
-    resolveGroupLifecyclePolicyPreset,
+  createDefaultGroupLifecyclePolicy,
+  resolveGroupLifecyclePolicyPreset,
 } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
-// prettier-ignore
 import {
-    GROUP_LIFECYCLE_POLICIES_NAMESPACE,
-    GroupLifecyclePolicyRepository,
+  GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+  GroupLifecyclePolicyRepository,
 } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
-// prettier-ignore
-import {
-    groupStateGroupStorageKey,
-} from '@shared-server/rallar-system/group-state/persistence/group-state-storage-keys.ts';
+import { groupStateGroupStorageKey } from '@shared-server/rallar-system/group-state/persistence/group-state-storage-keys.ts';
 import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
 
 const GROUP: GroupRef = {
-    applicationId: 'app-1',
-    workspaceId: 'ws-1',
-    groupId: 'group-1',
+  applicationId: 'app-1',
+  workspaceId: 'ws-1',
+  groupId: 'group-1',
 };
 
 function createRepository(): GroupLifecyclePolicyRepository {
-    return new GroupLifecyclePolicyRepository(new FakeRuntimeStateRepository());
+  return new GroupLifecyclePolicyRepository(new FakeRuntimeStateRepository());
 }
 
-async function storeRaw(
-    repository: GroupLifecyclePolicyRepository,
-    ref: GroupRef,
-    value: unknown,
-): Promise<void> {
-    await repository.runtimeRepository.upsert(
-        GROUP_LIFECYCLE_POLICIES_NAMESPACE,
-        groupStateGroupStorageKey(ref),
-        JSON.stringify(value),
-        NEVER_EXPIRE_AT_TIMESTAMP,
-    );
+async function storeRaw(repository: GroupLifecyclePolicyRepository, ref: GroupRef, value: unknown): Promise<void> {
+  await repository.runtimeRepository.upsert(
+    GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+    groupStateGroupStorageKey(ref),
+    JSON.stringify(value),
+    NEVER_EXPIRE_AT_TIMESTAMP,
+  );
 }
 
 describe('GroupLifecyclePolicyRepository', () => {
-    // Absent is the common case and has to stay cheap and unambiguous: every
-    // group that exists today has no stored policy.
-    it('reads an unwritten group as absent', async () => {
-        expect(await createRepository().readPolicy(GROUP)).toEqual({ status: 'absent' });
+  // Absent is the common case and has to stay cheap and unambiguous: every
+  // group that exists today has no stored policy.
+  it('reads an unwritten group as absent', async () => {
+    expect(await createRepository().readPolicy(GROUP)).toEqual({ status: 'absent' });
+  });
+
+  it('round-trips a stored policy', async () => {
+    const repository = createRepository();
+    const policy = resolveGroupLifecyclePolicyPreset('managed');
+
+    await repository.writePolicy(GROUP, policy);
+
+    expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy });
+  });
+
+  it('keeps policies of different groups apart', async () => {
+    const repository = createRepository();
+    const other: GroupRef = { ...GROUP, groupId: 'group-2' };
+
+    await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
+
+    expect(await repository.readPolicy(other)).toEqual({ status: 'absent' });
+  });
+
+  // A row written under one group's key that carries another group's identity
+  // is corruption, not an absent policy. Reporting it as absent would let a
+  // closed group read as open.
+  it('reports a foreign identity as corrupt rather than absent', async () => {
+    const repository = createRepository();
+
+    await storeRaw(repository, GROUP, {
+      groupRef: { ...GROUP, groupId: 'someone-else' },
+      policy: createDefaultGroupLifecyclePolicy(),
     });
 
-    it('round-trips a stored policy', async () => {
-        const repository = createRepository();
-        const policy = resolveGroupLifecyclePolicyPreset('managed');
+    const read = await repository.readPolicy(GROUP);
 
-        await repository.writePolicy(GROUP, policy);
+    expect(read.status).toBe('corrupt');
+  });
 
-        expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy });
-    });
+  it.each([
+    { label: 'a non-object policy', policy: 'not-a-policy' },
+    { label: 'a null policy', policy: null },
+  ])('reports $label as corrupt', async ({ policy }) => {
+    const repository = createRepository();
 
-    it('keeps policies of different groups apart', async () => {
-        const repository = createRepository();
-        const other: GroupRef = { ...GROUP, groupId: 'group-2' };
+    await storeRaw(repository, GROUP, { groupRef: GROUP, policy });
 
-        await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
+    expect((await repository.readPolicy(GROUP)).status).toBe('corrupt');
+  });
 
-        expect(await repository.readPolicy(other)).toEqual({ status: 'absent' });
-    });
+  // A policy stored under rules it no longer satisfies is reported rather
+  // than served. The enforcement point decides what to do; storage does not
+  // quietly substitute a permissive default.
+  it('reports a stored policy that no longer validates as corrupt', async () => {
+    const repository = createRepository();
+    const incoherent = {
+      ...createDefaultGroupLifecyclePolicy(),
+      manager: {
+        selection: 'none',
+        assignedPrincipalIds: [],
+        count: 1,
+        succession: 'none',
+      },
+      establishment: {
+        transports: 'rtc-and-ws',
+        initiator: 'manager',
+        maxConcurrentEdgeSetups: 8,
+      },
+    };
 
-    // A row written under one group's key that carries another group's identity
-    // is corruption, not an absent policy. Reporting it as absent would let a
-    // closed group read as open.
-    it('reports a foreign identity as corrupt rather than absent', async () => {
-        const repository = createRepository();
+    await storeRaw(repository, GROUP, { groupRef: GROUP, policy: incoherent });
 
-        await storeRaw(repository, GROUP, {
-            groupRef: { ...GROUP, groupId: 'someone-else' },
-            policy: createDefaultGroupLifecyclePolicy(),
-        });
+    const read = await repository.readPolicy(GROUP);
 
-        const read = await repository.readPolicy(GROUP);
+    expect(read.status).toBe('corrupt');
+    expect(read.status === 'corrupt' && read.reason).toContain('manager-initiator-without-manager');
+  });
 
-        expect(read.status).toBe('corrupt');
-    });
+  it('overwrites a previously stored policy', async () => {
+    const repository = createRepository();
+    const replacement = resolveGroupLifecyclePolicyPreset('drop-in-social');
 
-    it.each([
-        { label: 'a non-object policy', policy: 'not-a-policy' },
-        { label: 'a null policy', policy: null },
-    ])('reports $label as corrupt', async ({ policy }) => {
-        const repository = createRepository();
+    await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
+    await repository.writePolicy(GROUP, replacement);
 
-        await storeRaw(repository, GROUP, { groupRef: GROUP, policy });
-
-        expect((await repository.readPolicy(GROUP)).status).toBe('corrupt');
-    });
-
-    // A policy stored under rules it no longer satisfies is reported rather
-    // than served. The enforcement point decides what to do; storage does not
-    // quietly substitute a permissive default.
-    it('reports a stored policy that no longer validates as corrupt', async () => {
-        const repository = createRepository();
-        const incoherent = {
-            ...createDefaultGroupLifecyclePolicy(),
-            manager: {
-                selection: 'none',
-                assignedPrincipalIds: [],
-                count: 1,
-                succession: 'none',
-            },
-            establishment: {
-                transports: 'rtc-and-ws',
-                initiator: 'manager',
-                maxConcurrentEdgeSetups: 8,
-            },
-        };
-
-        await storeRaw(repository, GROUP, { groupRef: GROUP, policy: incoherent });
-
-        const read = await repository.readPolicy(GROUP);
-
-        expect(read.status).toBe('corrupt');
-        expect(read.status === 'corrupt' && read.reason)
-            .toContain('manager-initiator-without-manager');
-    });
-
-    it('overwrites a previously stored policy', async () => {
-        const repository = createRepository();
-        const replacement = resolveGroupLifecyclePolicyPreset('drop-in-social');
-
-        await repository.writePolicy(GROUP, resolveGroupLifecyclePolicyPreset('match'));
-        await repository.writePolicy(GROUP, replacement);
-
-        expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy: replacement });
-    });
+    expect(await repository.readPolicy(GROUP)).toEqual({ status: 'present', policy: replacement });
+  });
 });

--- a/packages/tests/shared-server/group-policy.test.ts
+++ b/packages/tests/shared-server/group-policy.test.ts
@@ -1,713 +1,834 @@
-import {describe, expect, it} from 'vitest';
-import type {
-    AuditStamp,
-    Group,
-    GroupMember,
-    GroupPresenceSession,
-    GroupSnapshot,
-} from '@shared/api/group-types.ts';
+import { describe, expect, it } from 'vitest';
+import type { AuditStamp, Group, GroupMember, GroupPresenceSession, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { GroupPolicyReasonCode } from '@shared/api/group-policy-types.ts';
-import {GROUP_POLICY_REASON_CODES} from '@shared/api/group-policy-types.ts';
+import { GROUP_POLICY_REASON_CODES } from '@shared/api/group-policy-types.ts';
 import {
-    canActivateGroupMember,
-    canChangeGroupLifecycle,
-    canCommandGroupLifecycleTransition,
-    canConnectGroupPresenceSession,
-    canGovernGroupMember,
-    canJoinGroup,
-    canMutateActiveGroup,
-    canReadGroupSnapshot,
-    canSendRoomMessage,
-    canUpdateGroupSnapshot,
-    type GroupPolicyActor,
-    readGroupVisibility,
-    shouldPlanGroupPurge,
+  canActivateGroupMember,
+  canChangeGroupLifecycle,
+  canCommandGroupLifecycleTransition,
+  canConnectGroupPresenceSession,
+  canGovernGroupMember,
+  canJoinGroup,
+  canMutateActiveGroup,
+  canReadGroupSnapshot,
+  canSendRoomMessage,
+  canUpdateGroupSnapshot,
+  type GroupPolicyActor,
+  readGroupVisibility,
+  shouldPlanGroupPurge,
 } from '@shared-server/rallar-system/group-policy.ts';
 import { createTestGroup } from '../create-test-group.ts';
-// prettier-ignore
-import {
-    resolveGroupLifecyclePolicyPreset,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
-// prettier-ignore
-import {
-    computeGroupAdmissionDecision,
-} from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { computeGroupAdmissionDecision } from '@shared/api/group-lifecycle/compute-group-admission-decision.ts';
 
 const NOW = 1_000;
 const ACTOR: GroupPolicyActor = {
-    principalId: 'alice',
-    sessionId: 'alice-session',
+  principalId: 'alice',
+  sessionId: 'alice-session',
 };
 
 describe('group policy helpers', () => {
-    it('evaluates join policy from group lifecycle, join mode, member status, and capacity inputs', () => {
-        expect(canJoinGroup({snapshot: snapshot(), actor: actor('carol')}))
-            .toEqual({allowed: true});
-        expect(canJoinGroup({
-            snapshot: snapshot({joinMode: 'invite-only'}),
-            actor: actor('carol'),
-        })).toMatchObject(denied('group-invite-required'));
-        expect(canJoinGroup({
-            snapshot: snapshot({
-                joinMode: 'invite-only',
-                members: [member('carol', {status: 'invited', invitationExpiresAtEpochMs: NOW - 1})],
-            }),
-            actor: actor('carol'),
+  it('evaluates join policy from group lifecycle, join mode, member status, and capacity inputs', () => {
+    expect(canJoinGroup({ snapshot: snapshot(), actor: actor('carol') })).toEqual({
+      allowed: true,
+    });
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ joinMode: 'invite-only' }),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('group-invite-required'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({
+          joinMode: 'invite-only',
+          members: [member('carol', { status: 'invited', invitationExpiresAtEpochMs: NOW - 1 })],
+        }),
+        actor: actor('carol'),
+        nowEpochMs: NOW,
+      }),
+    ).toMatchObject(denied('group-invite-expired'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({
+          joinMode: 'invite-only',
+          members: [member('carol', { status: 'invited', invitationExpiresAtEpochMs: NOW + 1 })],
+        }),
+        actor: actor('carol'),
+        nowEpochMs: NOW,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ joinMode: 'code' }),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('group-code-required'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ joinMode: 'code' }),
+        actor: actor('carol'),
+        joinCode: 'wrong',
+        expectedJoinCode: 'right',
+      }),
+    ).toMatchObject(denied('group-code-invalid'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({
+          members: [member('alice'), member('carol', { status: 'removed' })],
+        }),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('member-removed'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({
+          members: [member('alice'), member('carol', { status: 'banned' })],
+        }),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('member-banned'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({
+          maxMembers: 1,
+          members: [member('alice')],
+        }),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('group-full'));
+  });
+
+  it('evaluates presence policy from active membership, lifecycle, and session caps', () => {
+    expect(
+      canConnectGroupPresenceSession({
+        snapshot: snapshot({ activeSessions: [session('alice-session', 'alice')] }),
+        actor: ACTOR,
+        sessionId: 'alice-session',
+        nowEpochMs: NOW,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canConnectGroupPresenceSession({
+        snapshot: snapshot({ status: 'archived' }),
+        actor: ACTOR,
+        sessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('group-archived'));
+    expect(
+      canConnectGroupPresenceSession({
+        snapshot: snapshot({ status: 'deleted' }),
+        actor: ACTOR,
+        sessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('group-deleted'));
+    expect(
+      canConnectGroupPresenceSession({
+        snapshot: snapshot({
+          members: [member('alice', { status: 'left' })],
+        }),
+        actor: ACTOR,
+        sessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('member-not-active'));
+    expect(
+      canConnectGroupPresenceSession({
+        snapshot: snapshot({
+          maxSessionsPerMember: 1,
+          activeSessions: [session('alice-session-1', 'alice')],
+        }),
+        actor: ACTOR,
+        sessionId: 'alice-session-2',
+        nowEpochMs: NOW,
+      }),
+    ).toMatchObject(denied('member-session-limit-reached'));
+  });
+
+  it('evaluates active-member capacity without applying admission mode', () => {
+    expect(
+      canActivateGroupMember({
+        snapshot: snapshot({
+          joinMode: 'invite-only',
+          maxMembers: 2,
+          members: [member('alice'), member('bob', { status: 'invited' })],
+        }),
+        targetPrincipalId: 'carol',
+        nowEpochMs: NOW,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canActivateGroupMember({
+        snapshot: snapshot({
+          joinMode: 'invite-only',
+          maxMembers: 1,
+          members: [member('alice')],
+        }),
+        targetPrincipalId: 'carol',
+        nowEpochMs: NOW,
+      }),
+    ).toMatchObject(denied('group-full'));
+  });
+
+  it('evaluates lifecycle-only mutation policy without admission or capacity checks', () => {
+    expect(canMutateActiveGroup({ group: snapshot({ maxMembers: 1 }).group })).toEqual({
+      allowed: true,
+    });
+    expect(
+      canMutateActiveGroup({
+        group: snapshot({ expiresAtEpochMs: NOW - 1 }).group,
+        nowEpochMs: NOW,
+      }),
+    ).toMatchObject(denied('group-not-active'));
+    expect(canMutateActiveGroup({ group: snapshot({ status: 'archived' }).group })).toMatchObject(denied('group-archived'));
+    expect(canMutateActiveGroup({ group: snapshot({ status: 'deleted' }).group })).toMatchObject(denied('group-deleted'));
+  });
+
+  it('plans purge eligibility from purgeAfterEpochMs without mutating state', () => {
+    expect(
+      shouldPlanGroupPurge({
+        group: snapshot({ purgeAfterEpochMs: NOW - 1 }).group,
+        nowEpochMs: NOW,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPlanGroupPurge({
+        group: snapshot({ purgeAfterEpochMs: NOW + 1 }).group,
+        nowEpochMs: NOW,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPlanGroupPurge({
+        group: snapshot().group,
+        nowEpochMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('classifies read visibility for full state, invite metadata, directory metadata, and hidden groups', () => {
+    expect(readGroupVisibility({ snapshot: snapshot(), actor: ACTOR })).toBe('full');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({
+          members: [member('alice', { status: 'invited' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toBe('invite');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({
+          members: [member('alice', { status: 'pending' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toBe('invite');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({ joinMode: 'open' }),
+        actor: actor('carol'),
+      }),
+    ).toBe('directory');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({ joinMode: 'invite-only' }),
+        actor: actor('carol'),
+      }),
+    ).toBe('none');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({ members: [member('alice', { status: 'removed' })] }),
+        actor: ACTOR,
+      }),
+    ).toBe('none');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({ members: [member('alice', { status: 'banned' })] }),
+        actor: ACTOR,
+      }),
+    ).toBe('none');
+    expect(
+      readGroupVisibility({
+        snapshot: snapshot({ status: 'deleted' }),
+        actor: ACTOR,
+      }),
+    ).toBe('none');
+  });
+
+  it('evaluates full snapshot reads for active, invited, non-member, removed, banned, and deleted cases', () => {
+    expect(canReadGroupSnapshot({ snapshot: snapshot(), actor: ACTOR })).toEqual({ allowed: true });
+    expect(
+      canReadGroupSnapshot({
+        snapshot: snapshot({
+          members: [member('alice', { status: 'invited' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('group-policy-denied'));
+    expect(
+      canReadGroupSnapshot({
+        snapshot: snapshot(),
+        actor: actor('carol'),
+      }),
+    ).toMatchObject(denied('group-policy-denied'));
+    expect(
+      canReadGroupSnapshot({
+        snapshot: snapshot({ members: [member('alice', { status: 'removed' })] }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('member-removed'));
+    expect(
+      canReadGroupSnapshot({
+        snapshot: snapshot({ members: [member('alice', { status: 'banned' })] }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('member-banned'));
+    expect(
+      canReadGroupSnapshot({
+        snapshot: snapshot({ status: 'deleted' }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('group-deleted'));
+  });
+
+  it('evaluates lifecycle changes for owner/admin/member actors', () => {
+    expect(
+      canChangeGroupLifecycle({
+        snapshot: snapshot(),
+        actor: ACTOR,
+        targetStatus: 'archived',
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canChangeGroupLifecycle({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'member' })],
+        }),
+        actor: ACTOR,
+        targetStatus: 'archived',
+      }),
+    ).toMatchObject(denied('forbidden-role'));
+  });
+
+  it('evaluates group update policy for active owners/admins only', () => {
+    expect(
+      canUpdateGroupSnapshot({
+        snapshot: snapshot(),
+        actor: ACTOR,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canUpdateGroupSnapshot({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'admin' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canUpdateGroupSnapshot({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'member' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('forbidden-role'));
+    expect(
+      canUpdateGroupSnapshot({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'owner', status: 'left' })],
+        }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('member-not-active'));
+    expect(
+      canUpdateGroupSnapshot({
+        snapshot: snapshot({ status: 'archived' }),
+        actor: ACTOR,
+      }),
+    ).toMatchObject(denied('group-archived'));
+  });
+
+  it('evaluates governance actions and protects the last owner', () => {
+    expect(
+      canGovernGroupMember({
+        snapshot: snapshot(),
+        actor: ACTOR,
+        targetPrincipalId: 'bob',
+        action: 'ban',
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canGovernGroupMember({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'admin' }), member('bob', { role: 'owner' })],
+        }),
+        actor: ACTOR,
+        targetPrincipalId: 'bob',
+        action: 'remove',
+      }),
+    ).toMatchObject(denied('forbidden-role'));
+    expect(
+      canGovernGroupMember({
+        snapshot: snapshot({
+          members: [member('alice', { role: 'admin' }), member('bob')],
+        }),
+        actor: ACTOR,
+        targetPrincipalId: 'bob',
+        action: 'transfer-ownership',
+      }),
+    ).toMatchObject(denied('forbidden-role'));
+    expect(
+      canGovernGroupMember({
+        snapshot: snapshot(),
+        actor: ACTOR,
+        targetPrincipalId: 'alice',
+        action: 'demote',
+      }),
+    ).toMatchObject(denied('last-owner'));
+  });
+
+  it('evaluates room message sends for stale snapshots, live sessions, lifecycle, and member status', () => {
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({ activeSessions: [session('alice-session', 'alice')] }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+        nowEpochMs: NOW,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({
+          snapshotVersion: 1,
+          activeSessions: [session('alice-session', 'alice')],
+        }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+        minSnapshotVersion: 2,
+      }),
+    ).toMatchObject(denied('group-policy-denied'));
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({
+          status: 'archived',
+          activeSessions: [session('alice-session', 'alice')],
+        }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('group-archived'));
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({ activeSessions: [] }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('member-not-active'));
+    expect(
+      canSendRoomMessage({
+        snapshot: snapshot({
+          members: [member('alice', { status: 'banned' })],
+          activeSessions: [session('alice-session', 'alice')],
+        }),
+        actor: ACTOR,
+        senderSessionId: 'alice-session',
+      }),
+    ).toMatchObject(denied('member-banned'));
+  });
+
+  it('covers every initial policy reason code with pure helper scenarios', () => {
+    const coveredCodes = new Set<GroupPolicyReasonCode>([
+      expectCode(canReadGroupSnapshot({ snapshot: snapshot(), actor: actor('carol') })),
+      expectCode(canJoinGroup({ snapshot: snapshot({ joinMode: 'invite-only' }), actor: actor('carol') })),
+      expectCode(canJoinGroup({ snapshot: snapshot({ joinMode: 'code' }), actor: actor('carol') })),
+      expectCode(
+        canJoinGroup({
+          snapshot: snapshot({ joinMode: 'code' }),
+          actor: actor('carol'),
+          joinCode: 'wrong',
+          expectedJoinCode: 'right',
+        }),
+      ),
+      expectCode(
+        canJoinGroup({
+          snapshot: snapshot({
+            joinMode: 'invite-only',
+            members: [member('carol', { status: 'invited', invitationExpiresAtEpochMs: NOW - 1 })],
+          }),
+          actor: actor('carol'),
+          nowEpochMs: NOW,
+        }),
+      ),
+      expectCode(canJoinGroup({ snapshot: snapshot({ status: 'archived' }), actor: actor('carol') })),
+      expectCode(canJoinGroup({ snapshot: snapshot({ status: 'deleted' }), actor: actor('carol') })),
+      expectCode(
+        canJoinGroup({
+          snapshot: snapshot({ expiresAtEpochMs: NOW - 1 }),
+          actor: actor('carol'),
+          nowEpochMs: NOW,
+        }),
+      ),
+      expectCode(canJoinGroup({ snapshot: snapshot({ maxMembers: 1 }), actor: actor('carol') })),
+      expectCode(
+        canConnectGroupPresenceSession({
+          snapshot: snapshot({
+            maxSessionsPerMember: 1,
+            activeSessions: [session('alice-session-1', 'alice')],
+          }),
+          actor: ACTOR,
+          sessionId: 'alice-session-2',
+          nowEpochMs: NOW,
+        }),
+      ),
+      expectCode(
+        canConnectGroupPresenceSession({
+          snapshot: snapshot({ members: [member('alice', { status: 'left' })] }),
+          actor: ACTOR,
+          sessionId: 'alice-session',
+        }),
+      ),
+      expectCode(
+        canJoinGroup({
+          snapshot: snapshot({
+            members: [member('alice'), member('carol', { status: 'removed' })],
+          }),
+          actor: actor('carol'),
+        }),
+      ),
+      expectCode(
+        canJoinGroup({
+          snapshot: snapshot({ members: [member('alice'), member('carol', { status: 'banned' })] }),
+          actor: actor('carol'),
+        }),
+      ),
+      expectCode(
+        canChangeGroupLifecycle({
+          snapshot: snapshot({ members: [member('alice', { role: 'member' })] }),
+          actor: ACTOR,
+          targetStatus: 'archived',
+        }),
+      ),
+      expectCode(
+        canGovernGroupMember({
+          snapshot: snapshot(),
+          actor: ACTOR,
+          targetPrincipalId: 'alice',
+          action: 'demote',
+        }),
+      ),
+      expectCode(
+        canCommandGroupLifecycleTransition({
+          snapshot: snapshot({ lifecycleState: 'active' }),
+          actor: ACTOR,
+          policy: resolveGroupLifecyclePolicyPreset('optimistic'),
+          transition: 'start-establishment',
+          activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
+        }),
+      ),
+      expectCode(
+        canCommandGroupLifecycleTransition({
+          // An empty electorate resolves zero managers, covering the
+          // lifecycle-manager-unavailable reason code.
+          snapshot: snapshot({ lifecycleState: 'forming', formationElectorate: [] }),
+          actor: ACTOR,
+          policy: resolveGroupLifecyclePolicyPreset('match'),
+          transition: 'start-establishment',
+          activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
+        }),
+      ),
+      expectCode(
+        toAdmissionResult(
+          computeGroupAdmissionDecision({
+            admission: { mode: 'closed', untilEpochMs: null, untilMemberCount: null },
+            lifecycleState: 'active',
+            activeMemberCount: 1,
+            invited: false,
             nowEpochMs: NOW,
-        })).toMatchObject(denied('group-invite-expired'));
-        expect(canJoinGroup({
-            snapshot: snapshot({
-                joinMode: 'invite-only',
-                members: [member('carol', {status: 'invited', invitationExpiresAtEpochMs: NOW + 1})],
-            }),
-            actor: actor('carol'),
+          }),
+        ),
+      ),
+      expectCode(
+        toAdmissionResult(
+          computeGroupAdmissionDecision({
+            admission: { mode: 'open', untilEpochMs: NOW, untilMemberCount: null },
+            lifecycleState: 'forming',
+            activeMemberCount: 1,
+            invited: false,
             nowEpochMs: NOW,
-        })).toEqual({allowed: true});
-        expect(canJoinGroup({
-            snapshot: snapshot({joinMode: 'code'}),
-            actor: actor('carol'),
-        })).toMatchObject(denied('group-code-required'));
-        expect(canJoinGroup({
-            snapshot: snapshot({joinMode: 'code'}),
-            actor: actor('carol'),
-            joinCode: 'wrong',
-            expectedJoinCode: 'right',
-        })).toMatchObject(denied('group-code-invalid'));
-        expect(canJoinGroup({
-            snapshot: snapshot({
-                members: [
-                    member('alice'),
-                    member('carol', {status: 'removed'}),
-                ],
-            }),
-            actor: actor('carol'),
-        })).toMatchObject(denied('member-removed'));
-        expect(canJoinGroup({
-            snapshot: snapshot({
-                members: [
-                    member('alice'),
-                    member('carol', {status: 'banned'}),
-                ],
-            }),
-            actor: actor('carol'),
-        })).toMatchObject(denied('member-banned'));
-        expect(canJoinGroup({
-            snapshot: snapshot({
-                maxMembers: 1,
-                members: [member('alice')],
-            }),
-            actor: actor('carol'),
-        })).toMatchObject(denied('group-full'));
-    });
-
-    it('evaluates presence policy from active membership, lifecycle, and session caps', () => {
-        expect(canConnectGroupPresenceSession({
-            snapshot: snapshot({activeSessions: [session('alice-session', 'alice')]}),
-            actor: ACTOR,
-            sessionId: 'alice-session',
+          }),
+        ),
+      ),
+      expectCode(
+        toAdmissionResult(
+          computeGroupAdmissionDecision({
+            admission: { mode: 'open', untilEpochMs: null, untilMemberCount: 1 },
+            lifecycleState: 'forming',
+            activeMemberCount: 1,
+            invited: false,
             nowEpochMs: NOW,
-        })).toEqual({allowed: true});
-        expect(canConnectGroupPresenceSession({
-            snapshot: snapshot({status: 'archived'}),
-            actor: ACTOR,
-            sessionId: 'alice-session',
-        })).toMatchObject(denied('group-archived'));
-        expect(canConnectGroupPresenceSession({
-            snapshot: snapshot({status: 'deleted'}),
-            actor: ACTOR,
-            sessionId: 'alice-session',
-        })).toMatchObject(denied('group-deleted'));
-        expect(canConnectGroupPresenceSession({
-            snapshot: snapshot({
-                members: [member('alice', {status: 'left'})],
-            }),
-            actor: ACTOR,
-            sessionId: 'alice-session',
-        })).toMatchObject(denied('member-not-active'));
-        expect(canConnectGroupPresenceSession({
-            snapshot: snapshot({
-                maxSessionsPerMember: 1,
-                activeSessions: [session('alice-session-1', 'alice')],
-            }),
-            actor: ACTOR,
-            sessionId: 'alice-session-2',
-            nowEpochMs: NOW,
-        })).toMatchObject(denied('member-session-limit-reached'));
-    });
+          }),
+        ),
+      ),
+    ]);
 
-    it('evaluates active-member capacity without applying admission mode', () => {
-        expect(canActivateGroupMember({
-            snapshot: snapshot({
-                joinMode: 'invite-only',
-                maxMembers: 2,
-                members: [
-                    member('alice'),
-                    member('bob', {status: 'invited'}),
-                ],
-            }),
-            targetPrincipalId: 'carol',
-            nowEpochMs: NOW,
-        })).toEqual({allowed: true});
-        expect(canActivateGroupMember({
-            snapshot: snapshot({
-                joinMode: 'invite-only',
-                maxMembers: 1,
-                members: [member('alice')],
-            }),
-            targetPrincipalId: 'carol',
-            nowEpochMs: NOW,
-        })).toMatchObject(denied('group-full'));
-    });
+    expect([...GROUP_POLICY_REASON_CODES].filter((code) => !coveredCodes.has(code))).toEqual([]);
+  });
 
-    it('evaluates lifecycle-only mutation policy without admission or capacity checks', () => {
-        expect(canMutateActiveGroup({group: snapshot({maxMembers: 1}).group}))
-            .toEqual({allowed: true});
-        expect(canMutateActiveGroup({
-            group: snapshot({expiresAtEpochMs: NOW - 1}).group,
-            nowEpochMs: NOW,
-        })).toMatchObject(denied('group-not-active'));
-        expect(canMutateActiveGroup({group: snapshot({status: 'archived'}).group}))
-            .toMatchObject(denied('group-archived'));
-        expect(canMutateActiveGroup({group: snapshot({status: 'deleted'}).group}))
-            .toMatchObject(denied('group-deleted'));
-    });
+  it('applies the configured default member cap only when the stored cap is null', () => {
+    const capacity = { defaultMaxMembers: 256 };
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ activeMemberCount: 256 }),
+        actor: actor('carol'),
+        capacity,
+      }),
+    ).toMatchObject(denied('group-full'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ activeMemberCount: 255 }),
+        actor: actor('carol'),
+        capacity,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canActivateGroupMember({
+        snapshot: snapshot({ activeMemberCount: 256 }),
+        targetPrincipalId: 'carol',
+        nowEpochMs: NOW,
+        capacity,
+      }),
+    ).toMatchObject(denied('group-full'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ activeMemberCount: 256 }),
+        actor: ACTOR,
+        capacity,
+      }),
+    ).toEqual({ allowed: true });
+  });
 
-    it('plans purge eligibility from purgeAfterEpochMs without mutating state', () => {
-        expect(shouldPlanGroupPurge({
-            group: snapshot({purgeAfterEpochMs: NOW - 1}).group,
-            nowEpochMs: NOW,
-        })).toBe(true);
-        expect(shouldPlanGroupPurge({
-            group: snapshot({purgeAfterEpochMs: NOW + 1}).group,
-            nowEpochMs: NOW,
-        })).toBe(false);
-        expect(shouldPlanGroupPurge({
-            group: snapshot().group,
-            nowEpochMs: NOW,
-        })).toBe(false);
-    });
+  it('keeps null-cap groups uncapped when the default member cap is disabled or absent', () => {
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ activeMemberCount: 100_000 }),
+        actor: actor('carol'),
+        capacity: { defaultMaxMembers: null },
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ activeMemberCount: 100_000 }),
+        actor: actor('carol'),
+      }),
+    ).toEqual({ allowed: true });
+  });
 
-    it('classifies read visibility for full state, invite metadata, directory metadata, and hidden groups', () => {
-        expect(readGroupVisibility({snapshot: snapshot(), actor: ACTOR}))
-            .toBe('full');
-        expect(readGroupVisibility({
-            snapshot: snapshot({
-                members: [member('alice', {status: 'invited'})],
-            }),
-            actor: ACTOR,
-        })).toBe('invite');
-        expect(readGroupVisibility({
-            snapshot: snapshot({
-                members: [member('alice', {status: 'pending'})],
-            }),
-            actor: ACTOR,
-        })).toBe('invite');
-        expect(readGroupVisibility({
-            snapshot: snapshot({joinMode: 'open'}),
-            actor: actor('carol'),
-        })).toBe('directory');
-        expect(readGroupVisibility({
-            snapshot: snapshot({joinMode: 'invite-only'}),
-            actor: actor('carol'),
-        })).toBe('none');
-        expect(readGroupVisibility({
-            snapshot: snapshot({members: [member('alice', {status: 'removed'})]}),
-            actor: ACTOR,
-        })).toBe('none');
-        expect(readGroupVisibility({
-            snapshot: snapshot({members: [member('alice', {status: 'banned'})]}),
-            actor: ACTOR,
-        })).toBe('none');
-        expect(readGroupVisibility({
-            snapshot: snapshot({status: 'deleted'}),
-            actor: ACTOR,
-        })).toBe('none');
-    });
-
-    it('evaluates full snapshot reads for active, invited, non-member, removed, banned, and deleted cases', () => {
-        expect(canReadGroupSnapshot({snapshot: snapshot(), actor: ACTOR}))
-            .toEqual({allowed: true});
-        expect(canReadGroupSnapshot({
-            snapshot: snapshot({
-                members: [member('alice', {status: 'invited'})],
-            }),
-            actor: ACTOR,
-        })).toMatchObject(denied('group-policy-denied'));
-        expect(canReadGroupSnapshot({
-            snapshot: snapshot(),
-            actor: actor('carol'),
-        })).toMatchObject(denied('group-policy-denied'));
-        expect(canReadGroupSnapshot({
-            snapshot: snapshot({members: [member('alice', {status: 'removed'})]}),
-            actor: ACTOR,
-        })).toMatchObject(denied('member-removed'));
-        expect(canReadGroupSnapshot({
-            snapshot: snapshot({members: [member('alice', {status: 'banned'})]}),
-            actor: ACTOR,
-        })).toMatchObject(denied('member-banned'));
-        expect(canReadGroupSnapshot({
-            snapshot: snapshot({status: 'deleted'}),
-            actor: ACTOR,
-        })).toMatchObject(denied('group-deleted'));
-    });
-
-    it('evaluates lifecycle changes for owner/admin/member actors', () => {
-        expect(canChangeGroupLifecycle({
-            snapshot: snapshot(),
-            actor: ACTOR,
-            targetStatus: 'archived',
-        })).toEqual({allowed: true});
-        expect(canChangeGroupLifecycle({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'member'})],
-            }),
-            actor: ACTOR,
-            targetStatus: 'archived',
-        })).toMatchObject(denied('forbidden-role'));
-    });
-
-    it('evaluates group update policy for active owners/admins only', () => {
-        expect(canUpdateGroupSnapshot({
-            snapshot: snapshot(),
-            actor: ACTOR,
-        })).toEqual({allowed: true});
-        expect(canUpdateGroupSnapshot({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'admin'})],
-            }),
-            actor: ACTOR,
-        })).toEqual({allowed: true});
-        expect(canUpdateGroupSnapshot({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'member'})],
-            }),
-            actor: ACTOR,
-        })).toMatchObject(denied('forbidden-role'));
-        expect(canUpdateGroupSnapshot({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'owner', status: 'left'})],
-            }),
-            actor: ACTOR,
-        })).toMatchObject(denied('member-not-active'));
-        expect(canUpdateGroupSnapshot({
-            snapshot: snapshot({status: 'archived'}),
-            actor: ACTOR,
-        })).toMatchObject(denied('group-archived'));
-    });
-
-    it('evaluates governance actions and protects the last owner', () => {
-        expect(canGovernGroupMember({
-            snapshot: snapshot(),
-            actor: ACTOR,
-            targetPrincipalId: 'bob',
-            action: 'ban',
-        })).toEqual({allowed: true});
-        expect(canGovernGroupMember({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'admin'}), member('bob', {role: 'owner'})],
-            }),
-            actor: ACTOR,
-            targetPrincipalId: 'bob',
-            action: 'remove',
-        })).toMatchObject(denied('forbidden-role'));
-        expect(canGovernGroupMember({
-            snapshot: snapshot({
-                members: [member('alice', {role: 'admin'}), member('bob')],
-            }),
-            actor: ACTOR,
-            targetPrincipalId: 'bob',
-            action: 'transfer-ownership',
-        })).toMatchObject(denied('forbidden-role'));
-        expect(canGovernGroupMember({
-            snapshot: snapshot(),
-            actor: ACTOR,
-            targetPrincipalId: 'alice',
-            action: 'demote',
-        })).toMatchObject(denied('last-owner'));
-    });
-
-    it('evaluates room message sends for stale snapshots, live sessions, lifecycle, and member status', () => {
-        expect(canSendRoomMessage({
-            snapshot: snapshot({activeSessions: [session('alice-session', 'alice')]}),
-            actor: ACTOR,
-            senderSessionId: 'alice-session',
-            nowEpochMs: NOW,
-        })).toEqual({allowed: true});
-        expect(canSendRoomMessage({
-            snapshot: snapshot({
-                snapshotVersion: 1,
-                activeSessions: [session('alice-session', 'alice')],
-            }),
-            actor: ACTOR,
-            senderSessionId: 'alice-session',
-            minSnapshotVersion: 2,
-        })).toMatchObject(denied('group-policy-denied'));
-        expect(canSendRoomMessage({
-            snapshot: snapshot({
-                status: 'archived',
-                activeSessions: [session('alice-session', 'alice')],
-            }),
-            actor: ACTOR,
-            senderSessionId: 'alice-session',
-        })).toMatchObject(denied('group-archived'));
-        expect(canSendRoomMessage({
-            snapshot: snapshot({activeSessions: []}),
-            actor: ACTOR,
-            senderSessionId: 'alice-session',
-        })).toMatchObject(denied('member-not-active'));
-        expect(canSendRoomMessage({
-            snapshot: snapshot({
-                members: [member('alice', {status: 'banned'})],
-                activeSessions: [session('alice-session', 'alice')],
-            }),
-            actor: ACTOR,
-            senderSessionId: 'alice-session',
-        })).toMatchObject(denied('member-banned'));
-    });
-
-    it('covers every initial policy reason code with pure helper scenarios', () => {
-        const coveredCodes = new Set<GroupPolicyReasonCode>([
-            expectCode(canReadGroupSnapshot({snapshot: snapshot(), actor: actor('carol')})),
-            expectCode(
-                canJoinGroup({snapshot: snapshot({joinMode: 'invite-only'}), actor: actor('carol')}),
-            ),
-            expectCode(canJoinGroup({snapshot: snapshot({joinMode: 'code'}), actor: actor('carol')})),
-            expectCode(canJoinGroup({
-                snapshot: snapshot({joinMode: 'code'}),
-                actor: actor('carol'),
-                joinCode: 'wrong',
-                expectedJoinCode: 'right',
-            })),
-            expectCode(canJoinGroup({
-                snapshot: snapshot({
-                    joinMode: 'invite-only',
-                    members: [member('carol', {status: 'invited', invitationExpiresAtEpochMs: NOW - 1})],
-                }),
-                actor: actor('carol'),
-                nowEpochMs: NOW,
-            })),
-            expectCode(
-                canJoinGroup({snapshot: snapshot({status: 'archived'}), actor: actor('carol')}),
-            ),
-            expectCode(
-                canJoinGroup({snapshot: snapshot({status: 'deleted'}), actor: actor('carol')}),
-            ),
-            expectCode(canJoinGroup({
-                snapshot: snapshot({expiresAtEpochMs: NOW - 1}),
-                actor: actor('carol'),
-                nowEpochMs: NOW,
-            })),
-            expectCode(canJoinGroup({snapshot: snapshot({maxMembers: 1}), actor: actor('carol')})),
-            expectCode(canConnectGroupPresenceSession({
-                snapshot: snapshot({
-                    maxSessionsPerMember: 1,
-                    activeSessions: [session('alice-session-1', 'alice')],
-                }),
-                actor: ACTOR,
-                sessionId: 'alice-session-2',
-                nowEpochMs: NOW,
-            })),
-            expectCode(canConnectGroupPresenceSession({
-                snapshot: snapshot({members: [member('alice', {status: 'left'})]}),
-                actor: ACTOR,
-                sessionId: 'alice-session',
-            })),
-            expectCode(canJoinGroup({
-                snapshot: snapshot({members: [member('alice'), member('carol', {status: 'removed'})]}),
-                actor: actor('carol'),
-            })),
-            expectCode(canJoinGroup({
-                snapshot: snapshot({members: [member('alice'), member('carol', {status: 'banned'})]}),
-                actor: actor('carol'),
-            })),
-            expectCode(canChangeGroupLifecycle({
-                snapshot: snapshot({members: [member('alice', {role: 'member'})]}),
-                actor: ACTOR,
-                targetStatus: 'archived',
-            })),
-            expectCode(canGovernGroupMember({
-                snapshot: snapshot(),
-                actor: ACTOR,
-                targetPrincipalId: 'alice',
-                action: 'demote',
-            })),
-            expectCode(canCommandGroupLifecycleTransition({
-                snapshot: snapshot({lifecycleState: 'active'}),
-                actor: ACTOR,
-                policy: resolveGroupLifecyclePolicyPreset('optimistic'),
-                transition: 'start-establishment',
-                activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
-            })),
-            expectCode(canCommandGroupLifecycleTransition({
-                // An empty electorate resolves zero managers, covering the
-                // lifecycle-manager-unavailable reason code.
-                snapshot: snapshot({lifecycleState: 'forming', formationElectorate: []}),
-                actor: ACTOR,
-                policy: resolveGroupLifecyclePolicyPreset('match'),
-                transition: 'start-establishment',
-                activeMemberPrincipalIds: [ACTOR.principalId ?? ''],
-            })),
-            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
-                admission: {mode: 'closed', untilEpochMs: null, untilMemberCount: null},
-                lifecycleState: 'active',
-                activeMemberCount: 1,
-                invited: false,
-                nowEpochMs: NOW,
-            }))),
-            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
-                admission: {mode: 'open', untilEpochMs: NOW, untilMemberCount: null},
-                lifecycleState: 'forming',
-                activeMemberCount: 1,
-                invited: false,
-                nowEpochMs: NOW,
-            }))),
-            expectCode(toAdmissionResult(computeGroupAdmissionDecision({
-                admission: {mode: 'open', untilEpochMs: null, untilMemberCount: 1},
-                lifecycleState: 'forming',
-                activeMemberCount: 1,
-                invited: false,
-                nowEpochMs: NOW,
-            }))),
-        ]);
-
-        expect([...GROUP_POLICY_REASON_CODES].filter((code) => !coveredCodes.has(code)))
-            .toEqual([]);
-    });
-
-    it('applies the configured default member cap only when the stored cap is null', () => {
-        const capacity = {defaultMaxMembers: 256};
-        expect(canJoinGroup({
-            snapshot: snapshot({activeMemberCount: 256}),
-            actor: actor('carol'),
-            capacity,
-        })).toMatchObject(denied('group-full'));
-        expect(canJoinGroup({
-            snapshot: snapshot({activeMemberCount: 255}),
-            actor: actor('carol'),
-            capacity,
-        })).toEqual({allowed: true});
-        expect(canActivateGroupMember({
-            snapshot: snapshot({activeMemberCount: 256}),
-            targetPrincipalId: 'carol',
-            nowEpochMs: NOW,
-            capacity,
-        })).toMatchObject(denied('group-full'));
-        expect(canJoinGroup({
-            snapshot: snapshot({activeMemberCount: 256}),
-            actor: ACTOR,
-            capacity,
-        })).toEqual({allowed: true});
-    });
-
-    it('keeps null-cap groups uncapped when the default member cap is disabled or absent', () => {
-        expect(canJoinGroup({
-            snapshot: snapshot({activeMemberCount: 100_000}),
-            actor: actor('carol'),
-            capacity: {defaultMaxMembers: null},
-        })).toEqual({allowed: true});
-        expect(canJoinGroup({
-            snapshot: snapshot({activeMemberCount: 100_000}),
-            actor: actor('carol'),
-        })).toEqual({allowed: true});
-    });
-
-    it('lets an explicit stored member cap win over the configured default', () => {
-        expect(canJoinGroup({
-            snapshot: snapshot({maxMembers: 1, activeMemberCount: 1}),
-            actor: actor('carol'),
-            capacity: {defaultMaxMembers: 256},
-        })).toMatchObject(denied('group-full'));
-        expect(canJoinGroup({
-            snapshot: snapshot({maxMembers: 500, activeMemberCount: 256}),
-            actor: actor('carol'),
-            capacity: {defaultMaxMembers: 256},
-        })).toEqual({allowed: true});
-    });
+  it('lets an explicit stored member cap win over the configured default', () => {
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ maxMembers: 1, activeMemberCount: 1 }),
+        actor: actor('carol'),
+        capacity: { defaultMaxMembers: 256 },
+      }),
+    ).toMatchObject(denied('group-full'));
+    expect(
+      canJoinGroup({
+        snapshot: snapshot({ maxMembers: 500, activeMemberCount: 256 }),
+        actor: actor('carol'),
+        capacity: { defaultMaxMembers: 256 },
+      }),
+    ).toEqual({ allowed: true });
+  });
 });
 
 function denied(code: GroupPolicyReasonCode) {
-    return {
-        allowed: false,
-        code,
-    };
+  return {
+    allowed: false,
+    code,
+  };
 }
 
-function toAdmissionResult(
-    decision: ReturnType<typeof computeGroupAdmissionDecision>,
-): ReturnType<typeof canJoinGroup> {
-    return decision.kind === 'deny' ? decision.denial : {allowed: true};
+function toAdmissionResult(decision: ReturnType<typeof computeGroupAdmissionDecision>): ReturnType<typeof canJoinGroup> {
+  return decision.kind === 'deny' ? decision.denial : { allowed: true };
 }
 
 function expectCode(result: ReturnType<typeof canJoinGroup>): GroupPolicyReasonCode {
-    expect(result.allowed).toBe(false);
-    if (result.allowed) {
-        throw new Error('Expected denied group policy result.');
-    }
-    return result.code;
+  expect(result.allowed).toBe(false);
+  if (result.allowed) {
+    throw new Error('Expected denied group policy result.');
+  }
+  return result.code;
 }
 
 function actor(principalId: string): GroupPolicyActor {
-    return {
-        principalId,
-        sessionId: `${principalId}-session`,
-    };
+  return {
+    principalId,
+    sessionId: `${principalId}-session`,
+  };
 }
 
 function snapshot(
-    options:
-    & Partial<Group>
-        & Readonly<{
-        members?: readonly GroupMember[];
-        activeSessions?: readonly GroupPresenceSession[];
+  options: Partial<Group> &
+    Readonly<{
+      members?: readonly GroupMember[];
+      activeSessions?: readonly GroupPresenceSession[];
     }> = {},
 ): GroupSnapshot {
-    const members = options.members ?? [member('alice', {role: 'owner'})];
-    const activeSessions = options.activeSessions ?? [];
-    const common = createTestGroup({
-        applicationId: 'app-1',
-        workspaceId: 'workspace-1',
-        groupId: 'room-1',
-        slug: options.slug ?? null,
-        displayName: options.displayName ?? 'Room 1',
-        description: options.description ?? null,
-        kind: options.kind ?? 'room',
-        joinMode: options.joinMode ?? 'open',
-        maxMembers: options.maxMembers ?? null,
-        maxSessionsPerMember: options.maxSessionsPerMember ?? null,
-        metadata: options.metadata ?? {},
-        snapshotVersion: options.snapshotVersion ?? 1,
-        metadataVersion: options.metadataVersion ?? 1,
-        rosterVersion: options.rosterVersion ?? 1,
-        presenceVersion: options.presenceVersion ?? 1,
-        created: options.created ?? audit(1),
-        updated: options.updated ?? audit(1),
-        expiresAtEpochMs: options.expiresAtEpochMs ?? null,
-        emptySinceEpochMs: options.emptySinceEpochMs ?? null,
-        purgeAfterEpochMs: options.purgeAfterEpochMs ?? null,
-        activeMemberCount: options.activeMemberCount ??
-            members.filter((entry) => entry.status === 'active').length,
-        ownerPrincipalId: options.ownerPrincipalId ?? members.find((entry) =>
-            entry.status === 'active' && entry.role === 'owner'
-        )?.principalId ?? 'alice',
-        ...(options.lifecycleState === undefined ? {} : {lifecycleState: options.lifecycleState}),
-        ...(options.formationElectorate === undefined
-            ? {}
-            : {formationElectorate: options.formationElectorate}),
-    });
-    const group: Group = options.status === 'archived'
-        ? {
-            ...common,
-            status: 'archived',
-            archived: options.archived ?? audit(1),
-            deleted: null,
+  const members = options.members ?? [member('alice', { role: 'owner' })];
+  const activeSessions = options.activeSessions ?? [];
+  const common = createTestGroup({
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId: 'room-1',
+    slug: options.slug ?? null,
+    displayName: options.displayName ?? 'Room 1',
+    description: options.description ?? null,
+    kind: options.kind ?? 'room',
+    joinMode: options.joinMode ?? 'open',
+    maxMembers: options.maxMembers ?? null,
+    maxSessionsPerMember: options.maxSessionsPerMember ?? null,
+    metadata: options.metadata ?? {},
+    snapshotVersion: options.snapshotVersion ?? 1,
+    metadataVersion: options.metadataVersion ?? 1,
+    rosterVersion: options.rosterVersion ?? 1,
+    presenceVersion: options.presenceVersion ?? 1,
+    created: options.created ?? audit(1),
+    updated: options.updated ?? audit(1),
+    expiresAtEpochMs: options.expiresAtEpochMs ?? null,
+    emptySinceEpochMs: options.emptySinceEpochMs ?? null,
+    purgeAfterEpochMs: options.purgeAfterEpochMs ?? null,
+    activeMemberCount: options.activeMemberCount ?? members.filter((entry) => entry.status === 'active').length,
+    ownerPrincipalId:
+      options.ownerPrincipalId ?? members.find((entry) => entry.status === 'active' && entry.role === 'owner')?.principalId ?? 'alice',
+    ...(options.lifecycleState === undefined ? {} : { lifecycleState: options.lifecycleState }),
+    ...(options.formationElectorate === undefined ? {} : { formationElectorate: options.formationElectorate }),
+  });
+  const group: Group =
+    options.status === 'archived'
+      ? {
+          ...common,
+          status: 'archived',
+          archived: options.archived ?? audit(1),
+          deleted: null,
         }
-        : options.status === 'deleted'
+      : options.status === 'deleted'
         ? {
             ...common,
             status: 'deleted',
             archived: options.archived ?? null,
             deleted: options.deleted ?? audit(1),
-        }
+          }
         : {
             ...common,
             status: 'active',
             archived: null,
             deleted: null,
-        };
+          };
 
-    return {
-        stateRevision: 1,
-        causalRevision: {groupRevision: 1, presenceRevision: 1},
-        group,
-        members,
-        activeSessions,
-        memberCount: members.filter((entry) => entry.status === 'active').length,
-        onlineMemberCount: new Set(activeSessions.map((entry) => entry.principalId)).size,
-    };
+  return {
+    stateRevision: 1,
+    causalRevision: { groupRevision: 1, presenceRevision: 1 },
+    group,
+    members,
+    activeSessions,
+    memberCount: members.filter((entry) => entry.status === 'active').length,
+    onlineMemberCount: new Set(activeSessions.map((entry) => entry.principalId)).size,
+  };
 }
 
-function member(
-    principalId: string,
-    options: Partial<GroupMember> = {},
-): GroupMember {
-    const common = {
-        applicationId: 'app-1',
-        workspaceId: 'workspace-1',
-        groupId: 'room-1',
-        principalId,
-        role: options.role ?? 'member',
-        joined: options.joined ?? audit(1),
-        updated: options.updated ?? audit(1),
-        invitedByPrincipalId: options.invitedByPrincipalId ?? null,
-        invitationExpiresAtEpochMs: options.invitationExpiresAtEpochMs ?? null,
-    };
-    if (options.status === 'left') {
-        return {...common, status: 'left', left: options.left ?? audit(1), removed: null, banned: null};
-    }
-    if (options.status === 'removed') {
-        return {...common, status: 'removed', left: null, removed: options.removed ?? audit(1), banned: null};
-    }
-    if (options.status === 'banned') {
-        return {...common, status: 'banned', left: null, removed: null, banned: options.banned ?? audit(1)};
-    }
-    if (options.status === 'invited' || options.status === 'pending') {
-        return {
-            ...common,
-            status: options.status,
-            joined: null,
-            left: null,
-            removed: null,
-            banned: null,
-        };
-    }
+function member(principalId: string, options: Partial<GroupMember> = {}): GroupMember {
+  const common = {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId: 'room-1',
+    principalId,
+    role: options.role ?? 'member',
+    joined: options.joined ?? audit(1),
+    updated: options.updated ?? audit(1),
+    invitedByPrincipalId: options.invitedByPrincipalId ?? null,
+    invitationExpiresAtEpochMs: options.invitationExpiresAtEpochMs ?? null,
+  };
+  if (options.status === 'left') {
     return {
-        ...common,
-        status: 'active',
-        left: null,
-        removed: null,
-        banned: null,
+      ...common,
+      status: 'left',
+      left: options.left ?? audit(1),
+      removed: null,
+      banned: null,
     };
+  }
+  if (options.status === 'removed') {
+    return {
+      ...common,
+      status: 'removed',
+      left: null,
+      removed: options.removed ?? audit(1),
+      banned: null,
+    };
+  }
+  if (options.status === 'banned') {
+    return {
+      ...common,
+      status: 'banned',
+      left: null,
+      removed: null,
+      banned: options.banned ?? audit(1),
+    };
+  }
+  if (options.status === 'invited' || options.status === 'pending') {
+    return {
+      ...common,
+      status: options.status,
+      joined: null,
+      left: null,
+      removed: null,
+      banned: null,
+    };
+  }
+  return {
+    ...common,
+    status: 'active',
+    left: null,
+    removed: null,
+    banned: null,
+  };
 }
 
-function session(
-    sessionId: string,
-    principalId: string,
-    options: Partial<GroupPresenceSession> = {},
-): GroupPresenceSession {
-    const common = {
-        applicationId: 'app-1',
-        workspaceId: 'workspace-1',
-        groupId: 'room-1',
-        sessionId,
-        principalId,
-        generationId: options.generationId ?? `${sessionId}-generation`,
-        generationVersion: options.generationVersion ?? 1,
-        connectedAtEpochMs: options.connectedAtEpochMs ?? 1,
-        lastHeartbeatAtEpochMs: options.lastHeartbeatAtEpochMs ?? NOW,
-        expiresAtEpochMs: options.expiresAtEpochMs ?? NOW + 1_000,
-    };
-    if (options.status === 'disconnected') {
-        return {
-            ...common,
-            status: 'disconnected',
-            disconnectedAtEpochMs: options.disconnectedAtEpochMs ?? NOW,
-            disconnectReason: options.disconnectReason ?? 'disconnected',
-        };
-    }
+function session(sessionId: string, principalId: string, options: Partial<GroupPresenceSession> = {}): GroupPresenceSession {
+  const common = {
+    applicationId: 'app-1',
+    workspaceId: 'workspace-1',
+    groupId: 'room-1',
+    sessionId,
+    principalId,
+    generationId: options.generationId ?? `${sessionId}-generation`,
+    generationVersion: options.generationVersion ?? 1,
+    connectedAtEpochMs: options.connectedAtEpochMs ?? 1,
+    lastHeartbeatAtEpochMs: options.lastHeartbeatAtEpochMs ?? NOW,
+    expiresAtEpochMs: options.expiresAtEpochMs ?? NOW + 1_000,
+  };
+  if (options.status === 'disconnected') {
     return {
-        ...common,
-        status: 'active',
-        disconnectedAtEpochMs: null,
-        disconnectReason: null,
+      ...common,
+      status: 'disconnected',
+      disconnectedAtEpochMs: options.disconnectedAtEpochMs ?? NOW,
+      disconnectReason: options.disconnectReason ?? 'disconnected',
     };
+  }
+  return {
+    ...common,
+    status: 'active',
+    disconnectedAtEpochMs: null,
+    disconnectReason: null,
+  };
 }
 
 function audit(atEpochMs: number): AuditStamp {
-    return {
-        atEpochMs,
-        actor: {kind: 'service', serviceId: 'test'},
-        reason: null,
-        traceId: null,
-        requestId: null,
-    };
+  return {
+    atEpochMs,
+    actor: { kind: 'service', serviceId: 'test' },
+    reason: null,
+    traceId: null,
+    requestId: null,
+  };
 }

--- a/packages/tests/shared-server/group-state/group-lifecycle-command-policy.test.ts
+++ b/packages/tests/shared-server/group-state/group-lifecycle-command-policy.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import {
-  canCommandGroupLifecycleTransition,
-} from '@shared-server/rallar-system/group-policy.ts';
-// prettier-ignore
-import {
-  resolveGroupLifecyclePolicyPreset,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { canCommandGroupLifecycleTransition } from '@shared-server/rallar-system/group-policy.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { Group, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
@@ -69,16 +63,11 @@ function command(commandCase: CommandCase) {
     transition: commandCase.transition ?? 'start-establishment',
     activeMemberPrincipalIds:
       commandCase.activeMemberPrincipalIds ??
-      commandCase.members
-        .filter((candidate) => candidate.status === 'active')
-        .map((candidate) => candidate.principalId),
+      commandCase.members.filter((candidate) => candidate.status === 'active').map((candidate) => candidate.principalId),
   });
 }
 
-function withManager(
-  policy: GroupLifecyclePolicy,
-  manager: Partial<GroupLifecyclePolicy['manager']>,
-): GroupLifecyclePolicy {
+function withManager(policy: GroupLifecyclePolicy, manager: Partial<GroupLifecyclePolicy['manager']>): GroupLifecyclePolicy {
   return { ...policy, manager: { ...policy.manager, ...manager } };
 }
 
@@ -111,12 +100,11 @@ describe('canCommandGroupLifecycleTransition', () => {
   it('resolves the manager to the creator under managed', () => {
     const members = [member('alice', 'owner'), member('bob', 'admin')];
     const forming: Partial<Group> = { lifecycleState: 'forming', ownerPrincipalId: 'alice' };
-    expect(
-      command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MANAGED }),
-    ).toEqual({ allowed: true });
-    expect(
-      command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MANAGED }),
-    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
+    expect(command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MANAGED })).toEqual({ allowed: true });
+    expect(command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MANAGED })).toMatchObject({
+      allowed: false,
+      code: 'forbidden-role',
+    });
   });
 
   it('honours assigned order and count: only the first count are managers', () => {
@@ -130,9 +118,10 @@ describe('canCommandGroupLifecycleTransition', () => {
     expect(command({ overrides: forming, members, actorPrincipalId: 'bob', policy })).toEqual({
       allowed: true,
     });
-    expect(
-      command({ overrides: forming, members, actorPrincipalId: 'carol', policy }),
-    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
+    expect(command({ overrides: forming, members, actorPrincipalId: 'carol', policy })).toMatchObject({
+      allowed: false,
+      code: 'forbidden-role',
+    });
   });
 
   it('passes manager duty to the next assigned member when the first departs', () => {
@@ -156,12 +145,11 @@ describe('canCommandGroupLifecycleTransition', () => {
     // Epoch 0 pins the creator alone, so the sole electable manager is alice.
     const members = [member('alice', 'owner'), member('bob', 'member')];
     const forming: Partial<Group> = { lifecycleState: 'forming', formationElectorate: ['alice'] };
-    expect(
-      command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MATCH }),
-    ).toEqual({ allowed: true });
-    expect(
-      command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MATCH }),
-    ).toMatchObject({ allowed: false, code: 'forbidden-role' });
+    expect(command({ overrides: forming, members, actorPrincipalId: 'alice', policy: MATCH })).toEqual({ allowed: true });
+    expect(command({ overrides: forming, members, actorPrincipalId: 'bob', policy: MATCH })).toMatchObject({
+      allowed: false,
+      code: 'forbidden-role',
+    });
   });
 
   it('keeps the zero-manager fallback typed when nothing resolves', () => {

--- a/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
+++ b/packages/tests/shared-server/group-state/group-lifecycle-safety-baseline.test.ts
@@ -2,35 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import type { AuditStamp, Group, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
-import {
-  computeGroupMutation,
-} from '@shared-server/rallar-system/services/group-state-mutations.ts';
+import { computeGroupMutation } from '@shared-server/rallar-system/services/group-state-mutations.ts';
 import type {
   GroupMutationCommand,
   GroupMutationFacts,
   GroupMutationRead,
 } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
-import {
-  canConnectGroupPresenceSession,
-  canGovernGroupMember,
-  canJoinGroup,
-} from '@shared-server/rallar-system/group-policy.ts';
+import { canConnectGroupPresenceSession, canGovernGroupMember, canJoinGroup } from '@shared-server/rallar-system/group-policy.ts';
 import { createTestGroup } from '../../create-test-group.ts';
 
-import {
-  groupMemberStorageKey,
-  groupRef,
-  groupStorageKey,
-  storedEntry,
-} from './mutation/group-mutation-test-runtime.ts';
+import { groupMemberStorageKey, groupRef, groupStorageKey, storedEntry } from './mutation/group-mutation-test-runtime.ts';
 
-const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = [
-  'forming',
-  'establishing',
-  'active',
-  'reconfiguring',
-];
+const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = ['forming', 'establishing', 'active', 'reconfiguring'];
 
 /**
  * The safety-baseline invariant of the lifecycle plan: phases gate
@@ -41,31 +24,37 @@ const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = [
 describe('group lifecycle safety baseline', () => {
   it('admits joins in every lifecycle state', () => {
     for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
-      expect(canJoinGroup({
-        snapshot: snapshotIn(lifecycleState),
-        actor: { principalId: 'carol' },
-      })).toEqual({ allowed: true });
+      expect(
+        canJoinGroup({
+          snapshot: snapshotIn(lifecycleState),
+          actor: { principalId: 'carol' },
+        }),
+      ).toEqual({ allowed: true });
     }
   });
 
   it('admits presence sessions for active members in every lifecycle state', () => {
     for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
-      expect(canConnectGroupPresenceSession({
-        snapshot: snapshotIn(lifecycleState),
-        actor: { principalId: 'alice' },
-        sessionId: 'alice-session',
-      })).toEqual({ allowed: true });
+      expect(
+        canConnectGroupPresenceSession({
+          snapshot: snapshotIn(lifecycleState),
+          actor: { principalId: 'alice' },
+          sessionId: 'alice-session',
+        }),
+      ).toEqual({ allowed: true });
     }
   });
 
   it('lets owners govern members in every lifecycle state', () => {
     for (const lifecycleState of EVERY_LIFECYCLE_STATE) {
-      expect(canGovernGroupMember({
-        snapshot: snapshotIn(lifecycleState),
-        actor: { principalId: 'alice' },
-        targetPrincipalId: 'bob',
-        action: 'invite',
-      })).toEqual({ allowed: true });
+      expect(
+        canGovernGroupMember({
+          snapshot: snapshotIn(lifecycleState),
+          actor: { principalId: 'alice' },
+          targetPrincipalId: 'bob',
+          action: 'invite',
+        }),
+      ).toEqual({ allowed: true });
     }
   });
 
@@ -172,10 +161,7 @@ function joinRead(lifecycleState: GroupLifecycleState): GroupMutationRead {
   } as GroupMutationRead;
 }
 
-function memberRead(
-  lifecycleState: GroupLifecycleState,
-  principalId: string,
-): GroupMutationRead {
+function memberRead(lifecycleState: GroupLifecycleState, principalId: string): GroupMutationRead {
   const stored = baseRead(lifecycleState);
   return {
     ...stored,

--- a/packages/tests/shared-server/group-state/group-state-test-mutation-executor.ts
+++ b/packages/tests/shared-server/group-state/group-state-test-mutation-executor.ts
@@ -1,10 +1,7 @@
 import { Either } from '@shared/resilience/Either.ts';
 import type { GroupEvent } from '@shared/api/group-types.ts';
 import { GroupStateRepository } from '@shared-server/rallar-system/repositories/GroupStateRepository.ts';
-import {
-  hashMutationCommand,
-  type JsonWireValue,
-} from '@shared-server/rallar-system/services/mutation-command-identity.ts';
+import { hashMutationCommand, type JsonWireValue } from '@shared-server/rallar-system/services/mutation-command-identity.ts';
 import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '@shared-server/runtime-state/RuntimeStateRepository.ts';
 import {
   isRuntimeStateGuardedBatchRepositoryLike,
@@ -25,10 +22,7 @@ import {
   type toSessionCleanupCommand,
 } from '@shared-server/rallar-system/services/group-state-service.ts';
 import { materializeGroupStateGuardedBatch } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
-// prettier-ignore
-import {
-  GroupLifecyclePolicyRepository,
-} from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
+import { GroupLifecyclePolicyRepository } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
 import type {
   GroupMutationComputed,
   GroupMutationComputedWrite,
@@ -46,8 +40,7 @@ type GroupStateTestMutationExecutorDependencies = Readonly<{
   sleep?: (delayMs: number) => Promise<void>;
 }>;
 
-type GroupStateTestMaintenanceCommand =
-  ReturnType<typeof toExpiryCommand> | ReturnType<typeof toSessionCleanupCommand>;
+type GroupStateTestMaintenanceCommand = ReturnType<typeof toExpiryCommand> | ReturnType<typeof toSessionCleanupCommand>;
 
 export class GroupStateTestMutationExecutor {
   private readonly dependencies: GroupStateTestMutationExecutorDependencies;
@@ -56,11 +49,7 @@ export class GroupStateTestMutationExecutor {
     this.dependencies = dependencies;
   }
 
-  async executeAuthenticated(
-    descriptor: GroupMutationDescriptor,
-    authority: AuthSession,
-    receiptOnly: boolean,
-  ): Promise<unknown> {
+  async executeAuthenticated(descriptor: GroupMutationDescriptor, authority: AuthSession, receiptOnly: boolean): Promise<unknown> {
     const prepared = await this.dependencies.durableService.prepareMutation(descriptor, authority);
     let computed: GroupMutationComputed | undefined;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
@@ -94,10 +83,9 @@ export class GroupStateTestMutationExecutor {
     const commandHash = await hashMutationCommand(command as JsonWireValue);
     let computed: GroupMutationComputed | undefined;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
-      const read =
-        await import('@shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts').then(
-          ({ readGroupMutation }) => readGroupMutation(this.repository(), command),
-        );
+      const read = await import('@shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts').then(
+        ({ readGroupMutation }) => readGroupMutation(this.repository(), command),
+      );
       const facts: GroupMutationFacts = {
         nowEpochMs: atEpochMs,
         expireAtEpochMs: TEST_OUTBOX_EXPIRE_AT_EPOCH_MS,
@@ -111,8 +99,7 @@ export class GroupStateTestMutationExecutor {
         formationDamping: 'legacy',
         authenticatedAuthority: null,
       };
-      const mutation =
-        await import('@shared-server/rallar-system/services/group-state-mutations.ts');
+      const mutation = await import('@shared-server/rallar-system/services/group-state-mutations.ts');
       computed = mutation.computeGroupMutation({ command, read, facts });
       mutation.validateGroupMutation({ command, read, facts, computed });
       if (computed.outcome === 'idempotency-conflict') {
@@ -172,10 +159,7 @@ export class GroupStateTestMutationExecutor {
         await writeConditionalMutation(repository, computed);
       }
       if (computed.lifecyclePolicy !== null) {
-        await new GroupLifecyclePolicyRepository(transaction).writePolicy(
-          computed.receipt.aggregateRef,
-          computed.lifecyclePolicy,
-        );
+        await new GroupLifecyclePolicyRepository(transaction).writePolicy(computed.receipt.aggregateRef, computed.lifecyclePolicy);
       }
       await repository.appendEvent(computed.event);
     });
@@ -188,57 +172,33 @@ export class GroupStateTestMutationExecutor {
     await this.dependencies.sleep?.(attempt === 1 ? 2 : 8);
   }
 
-  private async receiptEvent(
-    repository: GroupStateRepository,
-    receipt: GroupMutationReceipt,
-  ): Promise<GroupEvent | null> {
+  private async receiptEvent(repository: GroupStateRepository, receipt: GroupMutationReceipt): Promise<GroupEvent | null> {
     if (receipt.eventId === null) return null;
-    return (
-      (await repository.listEvents(receipt.aggregateRef)).find(
-        (event) => event.eventId === receipt.eventId,
-      ) ?? null
-    );
+    return (await repository.listEvents(receipt.aggregateRef)).find((event) => event.eventId === receipt.eventId) ?? null;
   }
 
-  private repository(
-    runtimeRepository = this.dependencies.runtimeRepository,
-  ): GroupStateRepository {
+  private repository(runtimeRepository = this.dependencies.runtimeRepository): GroupStateRepository {
     return new GroupStateRepository(runtimeRepository, {
       events: this.dependencies.createGroupStateEventStore?.(runtimeRepository),
     });
   }
 }
 
-async function writeGuardedBatch(
-  transaction: RuntimeStateGuardedBatchRepositoryLike,
-  computed: GroupMutationComputedWrite,
-): Promise<void> {
+async function writeGuardedBatch(transaction: RuntimeStateGuardedBatchRepositoryLike, computed: GroupMutationComputedWrite): Promise<void> {
   const materialized = materializeGroupStateGuardedBatch(computed);
-  const result = validateRuntimeStateGuardedBatchResult(
-    materialized.batch,
-    await transaction.executeGuardedBatch(materialized.batch),
-  );
-  if (
-    result.guard.status === 'conflict' ||
-    result.effects.some((effect) => effect.status !== 'applied')
-  ) {
+  const result = validateRuntimeStateGuardedBatchResult(materialized.batch, await transaction.executeGuardedBatch(materialized.batch));
+  if (result.guard.status === 'conflict' || result.effects.some((effect) => effect.status !== 'applied')) {
     throw new RuntimeStateWriteConflictError();
   }
 }
 
-async function writeConditionalMutation(
-  repository: GroupStateRepository,
-  computed: GroupMutationComputedWrite,
-): Promise<void> {
+async function writeConditionalMutation(repository: GroupStateRepository, computed: GroupMutationComputedWrite): Promise<void> {
   await writeConditionalGuard(repository, computed);
   if (computed.presenceAdmission) {
     requireConditionalWrite(
       computed.presenceAdmission.operation === 'insert'
         ? await repository.insertPresenceAdmission(computed.presenceAdmission.value)
-        : await repository.updatePresenceAdmission(
-            computed.presenceAdmission.value,
-            computed.presenceAdmission.expectedRevision,
-          ),
+        : await repository.updatePresenceAdmission(computed.presenceAdmission.value, computed.presenceAdmission.expectedRevision),
     );
   }
   for (const member of computed.members) await repository.putMember(member);
@@ -261,10 +221,7 @@ async function writeConditionalMutation(
   }
 }
 
-async function writeConditionalGuard(
-  repository: GroupStateRepository,
-  computed: GroupMutationComputedWrite,
-): Promise<void> {
+async function writeConditionalGuard(repository: GroupStateRepository, computed: GroupMutationComputedWrite): Promise<void> {
   if (computed.guard.kind === 'group') {
     requireConditionalWrite(
       computed.guard.operation === 'insert'

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
@@ -1,18 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import type { AppInboxEnqueueInput } from
-  '@shared-server/rallar-system/services/AppGroupInboxService.ts';
-// prettier-ignore
-import { AppInboxType } from
-  '@shared-server/rallar-system/services/AppGroupInboxService.ts';
-// prettier-ignore
-import { toGroupMutationDescriptor } from
-  '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
+import type { AppInboxEnqueueInput } from '@shared-server/rallar-system/services/AppGroupInboxService.ts';
+import { AppInboxType } from '@shared-server/rallar-system/services/AppGroupInboxService.ts';
+import { toGroupMutationDescriptor } from '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
 import type { AuthenticatedGroupMutationEnqueue } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
-// prettier-ignore
-import type { GroupMutationDescriptor } from
-  '@shared-server/rallar-system/services/group-state-service.ts';
+import type { GroupMutationDescriptor } from '@shared-server/rallar-system/services/group-state-service.ts';
 import { SCOPE } from './group-state-inbox-test-runtime.ts';
 
 const groupId = 'descriptor-room';
@@ -21,10 +13,7 @@ const actor = { actorPrincipalId: 'owner', actorSessionId: 'owner-session' };
 describe('AppGroupInboxService authenticated mutation descriptors', () => {
   it('maps every authenticated GROUP_* AppInbox variant to one exact descriptor', () => {
     for (const testCase of descriptorCases) {
-      expect(
-        toGroupMutationDescriptor(testCase.enqueue as AuthenticatedGroupMutationEnqueue),
-        testCase.name,
-      ).toEqual(testCase.descriptor);
+      expect(toGroupMutationDescriptor(testCase.enqueue as AuthenticatedGroupMutationEnqueue), testCase.name).toEqual(testCase.descriptor);
     }
   });
 
@@ -117,13 +106,10 @@ const descriptorCases: readonly DescriptorCase[] = [
     'appointDirector',
     { ...actor, requestId: 'appoint-director' },
   ),
-  descriptorCase(
-    'join',
-    AppInboxType.GROUP_JOIN,
-    { scope: SCOPE, groupId, request: { ...actor, requestId: 'join' } },
-    'joinGroup',
-    { ...actor, requestId: 'join' },
-  ),
+  descriptorCase('join', AppInboxType.GROUP_JOIN, { scope: SCOPE, groupId, request: { ...actor, requestId: 'join' } }, 'joinGroup', {
+    ...actor,
+    requestId: 'join',
+  }),
   descriptorCase(
     'invite-create',
     AppInboxType.GROUP_INVITE_CREATE,

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -1,15 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
-// prettier-ignore
-import {
-  GroupStateInboxHandler,
-} from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
+import { GroupStateInboxHandler } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
 
-// prettier-ignore
-import {
-  createGroupStateTransactionBoundaryHarness,
-} from './group-state-transaction-boundary-fixture.ts';
+import { createGroupStateTransactionBoundaryHarness } from './group-state-transaction-boundary-fixture.ts';
 
 const EXPECTED_CREATE_GROUP_DURABLE_JSON =
   '{"status":"created","result":{"right":{"snapshot":' +
@@ -64,9 +58,7 @@ describe('group-state AppInbox transaction result boundary', () => {
     const rawDurableResult = JSON.parse(persisted!.resource) as Record<string, unknown>;
     expect(Object.keys(rawDurableResult)).toEqual(['status', 'result']);
     expect(Object.keys(rawDurableResult.result as Record<string, unknown>)).toEqual(['right']);
-    expect(
-      Object.keys((rawDurableResult.result as { right: Record<string, unknown> }).right),
-    ).toEqual(['snapshot', 'event']);
+    expect(Object.keys((rawDurableResult.result as { right: Record<string, unknown> }).right)).toEqual(['snapshot', 'event']);
     expect(rawDurableResult).toEqual(created);
     expect(harness.transactionWriter.read(harness.context)).toEqual({
       state: 'transaction-finalized',
@@ -85,9 +77,7 @@ describe('group-state AppInbox transaction result boundary', () => {
     expect(harness.formationMutationEvents).toEqual([]);
     await harness.handler.processGroupStateMutation(harness.context);
 
-    expect(harness.formationMutationEvents).toEqual([
-      { operation: 'createGroup', outcome: 'write' },
-    ]);
+    expect(harness.formationMutationEvents).toEqual([{ operation: 'createGroup', outcome: 'write' }]);
   });
 
   it('persists an inactive presence result once without active mutation effects', async () => {
@@ -142,9 +132,7 @@ describe('group-state AppInbox transaction result boundary', () => {
       wakeQueue: () => actions.push('wake'),
     });
     const result = await handler.processGroupStateMutation(inactiveConnectContext());
-    expect(JSON.stringify(result)).toBe(
-      '{"status":"inactive","sessionId":"inactive-session","generationId":"inactive-generation"}',
-    );
+    expect(JSON.stringify(result)).toBe('{"status":"inactive","sessionId":"inactive-session","generationId":"inactive-generation"}');
     expect(actions).toEqual(['inactive-transaction']);
     expect(writeMutation).toHaveBeenCalledOnce();
     expect(writeMutationWithAfterCommitResult).not.toHaveBeenCalled();
@@ -158,8 +146,7 @@ describe('group-state AppInbox transaction result boundary', () => {
     vi.doMock('@shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts', () => ({
       readGroupStateInboxResult: readResult,
     }));
-    const { actions, handler, observed, writeMutationWithAfterCommitResult } =
-      await createCommittedSnapshotObservationFixture();
+    const { actions, handler, observed, writeMutationWithAfterCommitResult } = await createCommittedSnapshotObservationFixture();
 
     await expect(
       handler.processGroupStateMutation({
@@ -191,27 +178,18 @@ describe('group-state AppInbox transaction result boundary', () => {
       result: { right: { value: 0, omitted: null } },
     } as const;
 
-    const returned = await harness.transactionWriter.writeMutation(
-      harness.context,
-      async () => durableResult,
-    );
+    const returned = await harness.transactionWriter.writeMutation(harness.context, async () => durableResult);
     const persisted = await harness.results.findByKey(harness.context.entry.key);
 
     expect(returned).toBe(durableResult);
-    expect(persisted?.resource).toBe(
-      '{"status":"legacy-compatible","result":{"right":{"value":0,"omitted":null}}}',
-    );
-    expect(Object.keys(JSON.parse(persisted!.resource) as Record<string, unknown>)).toEqual([
-      'status',
-      'result',
-    ]);
+    expect(persisted?.resource).toBe('{"status":"legacy-compatible","result":{"right":{"value":0,"omitted":null}}}');
+    expect(Object.keys(JSON.parse(persisted!.resource) as Record<string, unknown>)).toEqual(['status', 'result']);
     expect(harness.transactionWriter.read(harness.context)).toEqual({
       state: 'transaction-finalized',
       status: EntityStatus.COMPLETED,
       result: durableResult,
     });
   });
-
 });
 
 interface CommittedSnapshotFixture {

--- a/packages/tests/shared-server/group-state/mutation/group-lifecycle-mutation.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-lifecycle-mutation.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AuditStamp, Group } from '@shared/api/group-types.ts';
-// prettier-ignore
-import {
-  resolveGroupLifecyclePolicyPreset,
-} from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
-// prettier-ignore
-import {
-  computeGroupMutation,
-} from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
 import type {
   GroupMutationCommand,
   GroupMutationFacts,
@@ -17,12 +11,7 @@ import type {
 import { GroupPolicyDeniedError } from '@shared-server/rallar-system/group-policy.ts';
 import { createTestGroup } from '../../../create-test-group.ts';
 
-import {
-  groupMemberStorageKey,
-  groupRef,
-  groupStorageKey,
-  storedEntry,
-} from './group-mutation-test-runtime.ts';
+import { groupMemberStorageKey, groupRef, groupStorageKey, storedEntry } from './group-mutation-test-runtime.ts';
 
 describe('group lifecycle transition computation', () => {
   it('starts establishment from forming and advances the formation epoch', () => {
@@ -116,10 +105,7 @@ describe('group lifecycle transition computation', () => {
   it('rejects on a corrupt stored policy instead of failing open', () => {
     const computed = computeGroupMutation({
       command: transitionCommand('startGroupEstablishment'),
-      read: transitionRead(
-        { lifecycleState: 'forming', formationEpoch: 0 },
-        { policyStatus: 'corrupt' },
-      ),
+      read: transitionRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policyStatus: 'corrupt' }),
       facts: transitionFacts(),
     });
     expect(computed.outcome).toBe('rejected');
@@ -194,10 +180,7 @@ describe('group lifecycle transition computation', () => {
     // optimistic is any-member initiated, so a plain member may command.
     const computed = computeGroupMutation({
       command: transitionCommand('startGroupEstablishment'),
-      read: transitionRead(
-        { lifecycleState: 'forming', formationEpoch: 0 },
-        { policyStatus: 'absent' },
-      ),
+      read: transitionRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policyStatus: 'absent' }),
       facts: transitionFacts(),
     });
     expect(computed.outcome).toBe('write');
@@ -223,9 +206,7 @@ function transitionCommand(
   } as GroupMutationCommand;
 }
 
-function criterionRead(
-  groupOverrides: Partial<Group>,
-): GroupMutationRead {
+function criterionRead(groupOverrides: Partial<Group>): GroupMutationRead {
   return {
     ...transitionRead(groupOverrides),
     actorMember: null,
@@ -266,10 +247,7 @@ interface TransitionReadOptions {
   readonly actorPrincipalId?: string;
 }
 
-function transitionRead(
-  groupOverrides: Partial<Group>,
-  options: TransitionReadOptions = {},
-): GroupMutationRead {
+function transitionRead(groupOverrides: Partial<Group>, options: TransitionReadOptions = {}): GroupMutationRead {
   const actorPrincipalId = options.actorPrincipalId ?? 'alice';
   const audit = lifecycleAuditStamp(1_000, actorPrincipalId);
   const group = createTestGroup({ ...groupRef('pure-room'), ...groupOverrides });
@@ -287,16 +265,15 @@ function transitionRead(
     updated: audit,
   };
   const policyStatus = options.policyStatus ?? 'absent';
-  const lifecyclePolicy = policyStatus === 'corrupt'
-    ? { status: 'corrupt' as const, reason: 'stored policy is not an object' }
-    : policyStatus === 'absent'
-      ? { status: 'absent' as const }
-      : {
-        status: 'present' as const,
-        policy: resolveGroupLifecyclePolicyPreset(
-          policyStatus === 'managed' ? 'managed' : 'optimistic',
-        ),
-      };
+  const lifecyclePolicy =
+    policyStatus === 'corrupt'
+      ? { status: 'corrupt' as const, reason: 'stored policy is not an object' }
+      : policyStatus === 'absent'
+        ? { status: 'absent' as const }
+        : {
+            status: 'present' as const,
+            policy: resolveGroupLifecyclePolicyPreset(policyStatus === 'managed' ? 'managed' : 'optimistic'),
+          };
   return {
     idempotency: null,
     group: storedEntry(groupStorageKey(), group),

--- a/packages/tests/shared-server/group-state/presence/group-presence-connect-decision.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-connect-decision.test.ts
@@ -8,10 +8,7 @@ import type {
   GroupStateMutationCommand,
   GroupStateMutationService,
 } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
-// prettier-ignore
-import {
-  processGroupPresenceConnect,
-} from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
+import { processGroupPresenceConnect } from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
 import type {
   WsSessionGenerationLifecycleComputed,
   WsSessionGenerationLifecycleRead,
@@ -32,47 +29,42 @@ describe('group presence connect decision', () => {
       sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle,
     });
 
-    expect(JSON.stringify(outcome)).toBe(
-      '{"status":"inactive","sessionId":"session-1","generationId":"generation-1"}',
-    );
+    expect(JSON.stringify(outcome)).toBe('{"status":"inactive","sessionId":"session-1","generationId":"generation-1"}');
     expect(phases).toEqual(['lifecycle-read', 'lifecycle-closed-check']);
   });
 
-  it(
-    'returns the exact computed mutation and lifecycle guard ' + 'for the handler to commit',
-    async () => {
-      const phases: string[] = [];
-      const dependencies = createDecisionDependencies({
-        phases,
-        closedAtObservation: false,
-      });
+  it('returns the exact computed mutation and lifecycle guard ' + 'for the handler to commit', async () => {
+    const phases: string[] = [];
+    const dependencies = createDecisionDependencies({
+      phases,
+      closedAtObservation: false,
+    });
 
-      const outcome = await processGroupPresenceConnect({
-        command: dependencies.command,
-        mutationService: dependencies.mutationService,
-        sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle,
-      });
+    const outcome = await processGroupPresenceConnect({
+      command: dependencies.command,
+      mutationService: dependencies.mutationService,
+      sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle,
+    });
 
-      expect(outcome).toEqual({
-        status: 'ready-to-commit',
-        computed: dependencies.computed,
-        lifecycleGuard: dependencies.lifecycleGuard,
-      });
-      if (outcome.status !== 'ready-to-commit') {
-        throw new Error('Expected a ready-to-commit presence decision');
-      }
-      expect(outcome.computed).toBe(dependencies.computed);
-      expect(outcome.lifecycleGuard).toBe(dependencies.lifecycleGuard);
-      expect(phases).toEqual([
-        'lifecycle-read',
-        'lifecycle-closed-check',
-        'mutation-read',
-        'mutation-compute',
-        'mutation-validate',
-        'lifecycle-compute-guard',
-      ]);
-    },
-  );
+    expect(outcome).toEqual({
+      status: 'ready-to-commit',
+      computed: dependencies.computed,
+      lifecycleGuard: dependencies.lifecycleGuard,
+    });
+    if (outcome.status !== 'ready-to-commit') {
+      throw new Error('Expected a ready-to-commit presence decision');
+    }
+    expect(outcome.computed).toBe(dependencies.computed);
+    expect(outcome.lifecycleGuard).toBe(dependencies.lifecycleGuard);
+    expect(phases).toEqual([
+      'lifecycle-read',
+      'lifecycle-closed-check',
+      'mutation-read',
+      'mutation-compute',
+      'mutation-validate',
+      'lifecycle-compute-guard',
+    ]);
+  });
 });
 
 interface CreateDecisionDependenciesInput {
@@ -111,10 +103,7 @@ function createDecisionDependencies(input: CreateDecisionDependenciesInput): Dec
   };
 }
 
-function createMutationServiceFixture(
-  command: GroupStateMutationCommand,
-  phases: string[],
-): MutationServiceFixture {
+function createMutationServiceFixture(command: GroupStateMutationCommand, phases: string[]): MutationServiceFixture {
   const read = {} as GroupMutationRead;
   const computed = {
     outcome: 'no-op',
@@ -145,9 +134,7 @@ function createMutationServiceFixture(
   return { computed, service };
 }
 
-function createLifecycleServiceFixture(
-  input: CreateDecisionDependenciesInput,
-): LifecycleServiceFixture {
+function createLifecycleServiceFixture(input: CreateDecisionDependenciesInput): LifecycleServiceFixture {
   const lifecycleRead = lifecycleReadFixture();
   const lifecycleGuard = lifecycleGuardFixture(lifecycleRead);
   const service: WsSessionGenerationLifecycleService = {
@@ -202,9 +189,7 @@ function lifecycleReadFixture(): WsSessionGenerationLifecycleRead {
   };
 }
 
-function lifecycleGuardFixture(
-  lifecycleRead: WsSessionGenerationLifecycleRead,
-): WsSessionGenerationLifecycleComputed {
+function lifecycleGuardFixture(lifecycleRead: WsSessionGenerationLifecycleRead): WsSessionGenerationLifecycleComputed {
   return {
     outcome: 'insert',
     key: lifecycleRead.key,

--- a/packages/tests/shared-server/group-state/presence/group-presence-summary-formation-metrics.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-summary-formation-metrics.test.ts
@@ -2,25 +2,13 @@ import { Temporal } from '@js-temporal/polyfill';
 import { describe, expect, it, vi } from 'vitest';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
-import {
-  computeGroupPresenceSummaryEntry,
-  type GroupPresenceSummaryWorkData,
-} from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
+import { computeGroupPresenceSummaryEntry, type GroupPresenceSummaryWorkData } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-// prettier-ignore
-import {
-  GroupPresenceSummaryWork,
-} from '@shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts';
-// prettier-ignore
-import {
-  APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
-} from '@shared-server/rallar-system/services/rtc-topology-outbox-entry.ts';
+import { GroupPresenceSummaryWork } from '@shared-server/rallar-system/group-state/presence/group-presence-summary-work.ts';
+import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '@shared-server/rallar-system/services/rtc-topology-outbox-entry.ts';
 import { createAppInboxTestDatabase } from '../../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../../fake-runtime-state-repository.ts';
-import {
-  TestResourceInbox,
-  TestResourceInboxResults,
-} from '../inbox/group-state-inbox-resource-fixtures.ts';
+import { TestResourceInbox, TestResourceInboxResults } from '../inbox/group-state-inbox-resource-fixtures.ts';
 
 const BASE_EPOCH_MS = Date.now();
 
@@ -73,10 +61,7 @@ describe('GroupPresenceSummaryWork formation metrics', () => {
 
   it('records no summary expansion metric when the transaction fails', async () => {
     const { message, entry } = createCanonicalReservation();
-    const database = createAppInboxTestDatabase(
-      new TestResourceInbox(),
-      new TestResourceInboxResults(),
-    );
+    const database = createAppInboxTestDatabase(new TestResourceInbox(), new TestResourceInboxResults());
     const formationMetrics = vi.fn();
     const worker = new GroupPresenceSummaryWork({
       topologyIntent: { damping: 'legacy' },
@@ -88,15 +73,11 @@ describe('GroupPresenceSummaryWork formation metrics', () => {
       formationMetrics,
     });
     vi.spyOn(worker, 'read').mockResolvedValue({} as never);
-    vi.spyOn(worker, 'compute').mockReturnValue(
-      createComputedWorkWithDownstreamTopics([AppTopics.groupStateEvent]),
-    );
+    vi.spyOn(worker, 'compute').mockReturnValue(createComputedWorkWithDownstreamTopics([AppTopics.groupStateEvent]));
     vi.spyOn(worker, 'validate').mockReturnValue(undefined);
     vi.spyOn(worker, 'write').mockResolvedValue(undefined);
 
-    await expect(worker.processReservedEntry(message, entry)).rejects.toThrow(
-      'Presence-summary reservation changed before commit',
-    );
+    await expect(worker.processReservedEntry(message, entry)).rejects.toThrow('Presence-summary reservation changed before commit');
     expect(formationMetrics).not.toHaveBeenCalled();
   });
 });

--- a/packages/tests/shared-server/rallar-system/group-topology-capability-source-style-snapshot.ts
+++ b/packages/tests/shared-server/rallar-system/group-topology-capability-source-style-snapshot.ts
@@ -7,13 +7,10 @@ export const groupTopologyCapabilityBaseTree = '7fdefc3d98f875298c95a65d716de88a
 export const predecessorGroupTopologyTestRoot = 'packages/tests/shared-server/topology';
 export const mirroredGroupTopologyTestRoot = 'packages/tests/shared-server/rallar-system/topology';
 export const groupTopologyPlanningSnapshotPath =
-  'packages/shared-server/rallar-system/topology/planning/' +
-  'select-group-topology-planning-snapshot.ts';
-export const rtcTopologyWorkHandlerPath =
-  'packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts';
+  'packages/shared-server/rallar-system/topology/planning/' + 'select-group-topology-planning-snapshot.ts';
+export const rtcTopologyWorkHandlerPath = 'packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts';
 
-export const groupTopologySourceStyleSnapshotOwner =
-  'rallar-group-topology-server-structure child through PR D';
+export const groupTopologySourceStyleSnapshotOwner = 'rallar-group-topology-server-structure child through PR D';
 export const groupTopologySourceStyleSnapshotRemovalCondition =
   'The later evidence ledger decides removal after all rows have human dispositions and ' +
   'permanent semantic and size checks own the loss risks.';
@@ -28,6 +25,22 @@ export function countSourceMatches(sources: readonly string[], expression: RegEx
 
 export function maximumSourceLineWidth(source: string): number {
   return Math.max(...source.split(/\r?\n/u).map((line) => line.length));
+}
+
+export function maximumEnforcedLineWidth(source: string): number {
+  return Math.max(
+    ...source
+      .split(/\r?\n/u)
+      .filter((line) => !isModuleSpecifierLine(line))
+      .map((line) => line.length),
+  );
+}
+
+function isModuleSpecifierLine(line: string): boolean {
+  return (
+    /^\s*(?:import|export)\b[^'"`]*from\s*['"`][^'"`]+['"`];?\s*$/u.test(line) ||
+    /^\s*(?:import|export)\s*['"`][^'"`]+['"`];?\s*$/u.test(line)
+  );
 }
 
 export function sourceLineCount(source: string): number {

--- a/packages/tests/shared-server/rallar-system/rtc-topology/rtc-rtt-refinement-gate.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-topology/rtc-rtt-refinement-gate.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-// prettier-ignore
-import {
-    RtcRttRefinementGate,
-} from '@shared-server/rallar-system/rtc-topology/topic/rtc-rtt-refinement-gate.ts';
+import { RtcRttRefinementGate } from '@shared-server/rallar-system/rtc-topology/topic/rtc-rtt-refinement-gate.ts';
 
 describe('rtc rtt refinement gate', () => {
   it('accumulates sub-threshold movement without refining, then refines once', () => {
@@ -71,11 +68,6 @@ describe('rtc rtt refinement gate', () => {
   });
 });
 
-function claim(
-  gate: RtcRttRefinementGate,
-  groupKey: string,
-  predictedDeltaMs: number,
-  nowEpochMs: number,
-): boolean {
+function claim(gate: RtcRttRefinementGate, groupKey: string, predictedDeltaMs: number, nowEpochMs: number): boolean {
   return gate.claimRefinement({ groupKey, predictedDeltaMs, nowEpochMs });
 }

--- a/packages/tests/shared-server/rallar-system/rtc-topology/rtc-rtt-topic.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-topology/rtc-rtt-topic.test.ts
@@ -15,17 +15,10 @@ import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
 import { latestRttById } from '@shared/repository/rtt-repository.ts';
-import {
-  initRallarSystemWsTopics,
-  type InitRallarSystemWsTopicsOptions,
-} from '@shared-server/rallar-system/ws-system-topics.ts';
+import { initRallarSystemWsTopics, type InitRallarSystemWsTopicsOptions } from '@shared-server/rallar-system/ws-system-topics.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
 import { GroupTopologyManagementService } from '@shared-server/rallar-system/topology/group-topology-management-service.ts';
-// prettier-ignore
-import type {
-  GroupTopologyGroupSnapshotReader,
-} from
-'@shared-server/rallar-system/topology/group-topology-management-contracts.ts';
+import type { GroupTopologyGroupSnapshotReader } from '@shared-server/rallar-system/topology/group-topology-management-contracts.ts';
 import { RtcTopologyExecutionRepository } from '@shared-server/rallar-system/repositories/RtcTopologyExecutionRepository.ts';
 import * as vivaldiService from '@shared-graph/vivaldi-service.ts';
 import { configureTestCacheRepositories } from '../../../cache-repository-config.ts';
@@ -124,20 +117,12 @@ describe('RTC RTT websocket topic', () => {
 
   it('rejects RTT measurements outside the reporting edge policy', async () => {
     configureTestCacheRepositories();
-    const { sockets, topologyService } = createRttHarness(
-      ['session-a', 'session-b', 'session-c', 'session-d'],
-      {
-        rtcTopologyOptions: {
-          rttReportingDegreeLimit: 1,
-        },
+    const { sockets, topologyService } = createRttHarness(['session-a', 'session-b', 'session-c', 'session-d'], {
+      rtcTopologyOptions: {
+        rttReportingDegreeLimit: 1,
       },
-    );
-    const group = createGroupSnapshot('room-1', [
-      'session-a',
-      'session-b',
-      'session-c',
-      'session-d',
-    ]);
+    });
+    const group = createGroupSnapshot('room-1', ['session-a', 'session-b', 'session-c', 'session-d']);
     groupStateSnapshotsRepository.setGroupStateSnapshot(group);
     topologyService.updateGroupTopology(group);
 
@@ -291,24 +276,13 @@ describe('RTC RTT websocket topic', () => {
       configureTestCacheRepositories();
 
       const server = new JsonWebSocketServer();
-      const sockets = createSockets([
-        'session-a',
-        'session-b',
-        'session-c',
-        'session-d',
-        'session-e',
-      ]);
+      const sockets = createSockets(['session-a', 'session-b', 'session-c', 'session-d', 'session-e']);
 
       for (const [sessionId, socket] of sockets) {
         server.addConnection(new ConnectionContext(sessionId, socket as never));
       }
 
-      const service = new WsQueueBoxServerService(
-        new InMemoryQueueBox(new Map()),
-        new InMemoryQueueBox(new Map()),
-        server,
-        'server-1',
-      );
+      const service = new WsQueueBoxServerService(new InMemoryQueueBox(new Map()), new InMemoryQueueBox(new Map()), server, 'server-1');
       initRallarSystemWsTopics(service, {
         rtcTopologyOptions: {
           rttRebuildDebounceMs: 100,
@@ -316,9 +290,7 @@ describe('RTC RTT websocket topic', () => {
       });
 
       const group = createGroupSnapshot('room-1', [...sockets.keys()]);
-      clientStateSnapshotsRepository.setClientStateSnapshots(
-        [...sockets.keys()].map(createClientSnapshot),
-      );
+      clientStateSnapshotsRepository.setClientStateSnapshots([...sockets.keys()].map(createClientSnapshot));
       const senderSocket = sockets.get('session-a')!;
 
       await senderSocket.dispatchMessage(
@@ -377,13 +349,7 @@ describe('RTC RTT websocket topic', () => {
       configureTestCacheRepositories();
 
       const server = new JsonWebSocketServer();
-      const sockets = createSockets([
-        'session-a',
-        'session-b',
-        'session-c',
-        'session-d',
-        'session-e',
-      ]);
+      const sockets = createSockets(['session-a', 'session-b', 'session-c', 'session-d', 'session-e']);
 
       for (const [sessionId, socket] of sockets) {
         server.addConnection(new ConnectionContext(sessionId, socket as never));
@@ -393,12 +359,7 @@ describe('RTC RTT websocket topic', () => {
       const runtimeRepository = new FakeRuntimeStateRepository();
       const outboxQueueReader = new OutboxQueueReader(appOutboxQueue);
       const wake = vi.fn();
-      const service = new WsQueueBoxServerService(
-        new InMemoryQueueBox(new Map()),
-        new InMemoryQueueBox(new Map()),
-        server,
-        'server-1',
-      );
+      const service = new WsQueueBoxServerService(new InMemoryQueueBox(new Map()), new InMemoryQueueBox(new Map()), server, 'server-1');
       const group = createGroupSnapshot('room-1', [...sockets.keys()]);
       const findGroupSnapshotByRef = vi.fn(() => Promise.resolve(group));
       initRallarSystemWsTopics(service, {
@@ -414,9 +375,7 @@ describe('RTC RTT websocket topic', () => {
         },
       });
 
-      clientStateSnapshotsRepository.setClientStateSnapshots(
-        [...sockets.keys()].map(createClientSnapshot),
-      );
+      clientStateSnapshotsRepository.setClientStateSnapshots([...sockets.keys()].map(createClientSnapshot));
       const senderSocket = sockets.get('session-a')!;
 
       await senderSocket.dispatchMessage(
@@ -547,18 +506,11 @@ function createRttHarness(
     server.addConnection(new ConnectionContext(sessionId, socket as never));
   }
 
-  const service = new WsQueueBoxServerService(
-    new InMemoryQueueBox(new Map()),
-    new InMemoryQueueBox(new Map()),
-    server,
-    'server-1',
-  );
+  const service = new WsQueueBoxServerService(new InMemoryQueueBox(new Map()), new InMemoryQueueBox(new Map()), server, 'server-1');
   const topologyService = new RallarRtcTopologyService(options.rtcTopologyOptions);
   initRallarSystemWsTopics(service, {
     rtcTopologyService: topologyService,
-    ...(options.runtimeRepository
-      ? { rtcTopologyRuntimeState: { repository: options.runtimeRepository } }
-      : {}),
+    ...(options.runtimeRepository ? { rtcTopologyRuntimeState: { repository: options.runtimeRepository } } : {}),
     enqueueRtcRttMutation: options.enqueueRtcRttMutation,
   });
 
@@ -590,9 +542,7 @@ async function dispatchRtt(
 }
 
 function countSentTopologyMessages(sockets: ReadonlyMap<string, FakeSocket>): number {
-  return [...sockets.values()]
-    .flatMap((socket) => socket.sent)
-    .filter((sent) => sent.payload.typeId === AppTopics.overlayTopology).length;
+  return [...sockets.values()].flatMap((socket) => socket.sent).filter((sent) => sent.payload.typeId === AppTopics.overlayTopology).length;
 }
 
 function createTopologyExecutionDependencies(runtimeRepository: FakeRuntimeStateRepository) {
@@ -613,13 +563,9 @@ function createTopologyManagement(
 }
 
 function createUnusedDatabase(): PSqlSql {
-  return Object.assign(
-    (..._values: readonly unknown[]) =>
-      Promise.reject(new Error('Unexpected SQL execution in WS routing unit test')),
-    {
-      begin: () => Promise.reject(new Error('Unexpected transaction in WS routing unit test')),
-    },
-  );
+  return Object.assign((..._values: readonly unknown[]) => Promise.reject(new Error('Unexpected SQL execution in WS routing unit test')), {
+    begin: () => Promise.reject(new Error('Unexpected transaction in WS routing unit test')),
+  });
 }
 
 function createCentralRttMeasurements(

--- a/packages/tests/shared-server/rallar-system/topology/group-topology-capability-source-style-snapshot.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/group-topology-capability-source-style-snapshot.test.ts
@@ -9,6 +9,7 @@ import {
   groupTopologyPlanningSnapshotPath,
   groupTopologySourceStyleSnapshotOwner,
   groupTopologySourceStyleSnapshotRemovalCondition,
+  maximumEnforcedLineWidth,
   maximumSourceLineWidth,
   mirroredGroupTopologyTestRoot,
   predecessorGroupTopologyTestRoot,
@@ -110,7 +111,7 @@ describe('group topology capability source and style snapshot', () => {
 
   it('resolves the retained PR C line-width finding without changing its owner', () => {
     expect(
-      maximumSourceLineWidth(readWorkspaceFile(groupTopologyPlanningSnapshotPath)),
+      maximumEnforcedLineWidth(readWorkspaceFile(groupTopologyPlanningSnapshotPath)),
     ).toBeLessThanOrEqual(100);
   });
 });

--- a/packages/tests/shared-server/rallar-system/topology/planning/canonical-topology-planning-input.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/canonical-topology-planning-input.test.ts
@@ -1,55 +1,49 @@
 import { describe, expect, it } from 'vitest';
-// prettier-ignore
 import {
-    computeCanonicalTopologyPairWeight,
-    toCanonicalTopologySessionIds,
+  computeCanonicalTopologyPairWeight,
+  toCanonicalTopologySessionIds,
 } from '@shared-server/rallar-system/topology/planning/canonical-topology-planning-input.ts';
 
 describe('canonical topology planning input', () => {
-    it('sorts and dedupes session ids by exact code-unit order', () => {
-        expect(
-            toCanonicalTopologySessionIds(['b', 'a', 'b', 'Z', 'á', 'é']),
-        ).toEqual(['Z', 'a', 'á', 'b', 'é']);
-    });
+  it('sorts and dedupes session ids by exact code-unit order', () => {
+    expect(toCanonicalTopologySessionIds(['b', 'a', 'b', 'Z', 'á', 'é'])).toEqual(['Z', 'a', 'á', 'b', 'é']);
+  });
 
-    it('returns identical canonical order for every permutation', () => {
-        const sessionIds = ['s-3', 's-1', 's-10', 's-2', 'S-1'];
-        const canonical = toCanonicalTopologySessionIds(sessionIds);
-        expect(toCanonicalTopologySessionIds([...sessionIds].reverse())).toEqual(canonical);
-        expect(toCanonicalTopologySessionIds([...sessionIds].sort())).toEqual(canonical);
-    });
+  it('returns identical canonical order for every permutation', () => {
+    const sessionIds = ['s-3', 's-1', 's-10', 's-2', 'S-1'];
+    const canonical = toCanonicalTopologySessionIds(sessionIds);
+    expect(toCanonicalTopologySessionIds([...sessionIds].reverse())).toEqual(canonical);
+    expect(toCanonicalTopologySessionIds([...sessionIds].sort())).toEqual(canonical);
+  });
 
-    it('derives symmetric, bounded, pair-stable weights', () => {
-        const weight = computeCanonicalTopologyPairWeight('session-a', 'session-b');
-        expect(computeCanonicalTopologyPairWeight('session-b', 'session-a')).toBe(weight);
+  it('derives symmetric, bounded, pair-stable weights', () => {
+    const weight = computeCanonicalTopologyPairWeight('session-a', 'session-b');
+    expect(computeCanonicalTopologyPairWeight('session-b', 'session-a')).toBe(weight);
+    expect(weight).toBeGreaterThanOrEqual(1);
+    expect(weight).toBeLessThan(32);
+    expect(computeCanonicalTopologyPairWeight('session-a', 'session-b')).toBe(weight);
+  });
+
+  it('keeps every pair weight >= 1 across many pairs (the mirror distance sentinel)', () => {
+    for (let left = 0; left < 40; left++) {
+      for (let right = left + 1; right < 40; right++) {
+        const weight = computeCanonicalTopologyPairWeight(`session-${left}`, `session-${right}`);
         expect(weight).toBeGreaterThanOrEqual(1);
         expect(weight).toBeLessThan(32);
-        expect(computeCanonicalTopologyPairWeight('session-a', 'session-b')).toBe(weight);
-    });
+      }
+    }
+  });
 
-    it('keeps every pair weight >= 1 across many pairs (the mirror distance sentinel)', () => {
-        for (let left = 0; left < 40; left++) {
-            for (let right = left + 1; right < 40; right++) {
-                const weight = computeCanonicalTopologyPairWeight(
-                    `session-${left}`,
-                    `session-${right}`,
-                );
-                expect(weight).toBeGreaterThanOrEqual(1);
-                expect(weight).toBeLessThan(32);
-            }
-        }
-    });
+  it('does not shift a pair weight when unrelated members change', () => {
+    const before = computeCanonicalTopologyPairWeight('session-a', 'session-b');
+    // Positional weights shifted on every membership change; canonical pair
+    // weights are a function of the unordered pair identity alone.
+    expect(computeCanonicalTopologyPairWeight('session-a', 'session-b')).toBe(before);
+  });
 
-    it('does not shift a pair weight when unrelated members change', () => {
-        const before = computeCanonicalTopologyPairWeight('session-a', 'session-b');
-        // Positional weights shifted on every membership change; canonical pair
-        // weights are a function of the unordered pair identity alone.
-        expect(computeCanonicalTopologyPairWeight('session-a', 'session-b')).toBe(before);
-    });
-
-    it('distinguishes delimiter-colliding pair identities', () => {
-        const collidingLeft = computeCanonicalTopologyPairWeight('a', 'b:c');
-        const collidingRight = computeCanonicalTopologyPairWeight('a:b', 'c');
-        expect(collidingLeft).not.toBe(collidingRight);
-    });
+  it('distinguishes delimiter-colliding pair identities', () => {
+    const collidingLeft = computeCanonicalTopologyPairWeight('a', 'b:c');
+    const collidingRight = computeCanonicalTopologyPairWeight('a:b', 'c');
+    expect(collidingLeft).not.toBe(collidingRight);
+  });
 });

--- a/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-no-rtt.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-no-rtt.test.ts
@@ -1,27 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { validateGroupTopologyNextHops } from '@shared-graph/group-topology-validation.ts';
-// prettier-ignore
-import {
-  RallarRtcTopologyService,
-} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import {
-  toCanonicalTopologySessionIds,
-} from '@shared-server/rallar-system/topology/planning/canonical-topology-planning-input.ts';
-// prettier-ignore
-import {
-  computeNoRttTopologyNextHops,
-} from '@shared-server/rallar-system/topology/planning/compute-no-rtt-topology-next-hops.ts';
-// prettier-ignore
-import {
-  computeNoRttTreeNextHops,
-} from '@shared-server/rallar-system/topology/planning/compute-no-rtt-tree-next-hops.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { toCanonicalTopologySessionIds } from '@shared-server/rallar-system/topology/planning/canonical-topology-planning-input.ts';
+import { computeNoRttTopologyNextHops } from '@shared-server/rallar-system/topology/planning/compute-no-rtt-topology-next-hops.ts';
+import { computeNoRttTreeNextHops } from '@shared-server/rallar-system/topology/planning/compute-no-rtt-tree-next-hops.ts';
 
-import {
-  createRtcTopologyGroupSnapshot,
-  createRtcTopologyMemberIds,
-} from '../rtc-topology-test-fixtures.ts';
+import { createRtcTopologyGroupSnapshot, createRtcTopologyMemberIds } from '../rtc-topology-test-fixtures.ts';
 
 describe('RTC topology planning without RTT measurements', () => {
   it('does not build a weighted room graph for star topology', () => {
@@ -37,15 +22,7 @@ describe('RTC topology planning without RTT measurements', () => {
 
     expect(createRoomGraph).not.toHaveBeenCalled();
     expect(result.snapshot.topology).toBe('star');
-    expect(result.snapshot.nextHopsBySessionId['peer-1']).toEqual([
-      'peer-2',
-      'peer-3',
-      'peer-4',
-      'peer-5',
-      'peer-6',
-      'peer-7',
-      'peer-8',
-    ]);
+    expect(result.snapshot.nextHopsBySessionId['peer-1']).toEqual(['peer-2', 'peer-3', 'peer-4', 'peer-5', 'peer-6', 'peer-7', 'peer-8']);
   });
 
   it('does not build a weighted room graph for no-RTT mesh topology', () => {
@@ -67,9 +44,7 @@ describe('RTC topology planning without RTT measurements', () => {
 
     expect(createRoomGraph).not.toHaveBeenCalled();
     expect(result.snapshot.topology).toBe('mesh');
-    expect(result.snapshot.nextHopsBySessionId).toEqual(
-      graphPathResult.snapshot.nextHopsBySessionId,
-    );
+    expect(result.snapshot.nextHopsBySessionId).toEqual(graphPathResult.snapshot.nextHopsBySessionId);
     const validation = validateGroupTopologyNextHops({
       activeSessionIds: new Set(result.snapshot.activeSessionIds),
       nextHopsBySessionId: result.snapshot.nextHopsBySessionId,
@@ -83,43 +58,35 @@ describe('RTC topology planning without RTT measurements', () => {
     [8, 3],
     [10, 5],
     [15, 4],
-  ] as const)(
-    'does not build a weighted room graph for no-RTT %s-member tree topology with degree %s',
-    (memberCount, degreeLimit) => {
-      const group = createRtcTopologyGroupSnapshot(
-        'room-1',
-        createRtcTopologyMemberIds(memberCount),
-      );
-      const service = new RallarRtcTopologyService({
-        now: () => 100,
-        degreeLimit,
-        meshMinSize: 999,
-      });
-      const graphPathService = new RallarRtcTopologyService({
-        now: () => 100,
-        degreeLimit,
-        meshMinSize: 999,
-      });
-      const createRoomGraph = vi.spyOn(service, 'createRoomGraph');
+  ] as const)('does not build a weighted room graph for no-RTT %s-member tree topology with degree %s', (memberCount, degreeLimit) => {
+    const group = createRtcTopologyGroupSnapshot('room-1', createRtcTopologyMemberIds(memberCount));
+    const service = new RallarRtcTopologyService({
+      now: () => 100,
+      degreeLimit,
+      meshMinSize: 999,
+    });
+    const graphPathService = new RallarRtcTopologyService({
+      now: () => 100,
+      degreeLimit,
+      meshMinSize: 999,
+    });
+    const createRoomGraph = vi.spyOn(service, 'createRoomGraph');
 
-      const result = service.updateGroupTopology(group);
-      const graphPathResult = graphPathService.updateGroupTopology(group, [
-        {
-          sessionIdFrom: 'outside-a',
-          sessionIdTo: 'outside-b',
-          rttMs: 1,
-          createdAtEpochMs: 1,
-          version: 1,
-        },
-      ]);
+    const result = service.updateGroupTopology(group);
+    const graphPathResult = graphPathService.updateGroupTopology(group, [
+      {
+        sessionIdFrom: 'outside-a',
+        sessionIdTo: 'outside-b',
+        rttMs: 1,
+        createdAtEpochMs: 1,
+        version: 1,
+      },
+    ]);
 
-      expect(createRoomGraph).not.toHaveBeenCalled();
-      expect(result.snapshot.topology).toBe('tree');
-      expect(result.snapshot.nextHopsBySessionId).toEqual(
-        graphPathResult.snapshot.nextHopsBySessionId,
-      );
-    },
-  );
+    expect(createRoomGraph).not.toHaveBeenCalled();
+    expect(result.snapshot.topology).toBe('tree');
+    expect(result.snapshot.nextHopsBySessionId).toEqual(graphPathResult.snapshot.nextHopsBySessionId);
+  });
 
   it.each([
     [5, 'tree'],
@@ -155,18 +122,8 @@ describe('RTC topology planning without RTT measurements', () => {
   });
 
   it('computes deterministic tree next hops from canonicalized shuffled input', () => {
-    const canonicalTreeSessionIds = toCanonicalTopologySessionIds([
-      'peer-4',
-      'peer-2',
-      'peer-3',
-      'peer-1',
-    ]);
-    const shuffledCanonicalTreeSessionIds = toCanonicalTopologySessionIds([
-      'peer-3',
-      'peer-1',
-      'peer-4',
-      'peer-2',
-    ]);
+    const canonicalTreeSessionIds = toCanonicalTopologySessionIds(['peer-4', 'peer-2', 'peer-3', 'peer-1']);
+    const shuffledCanonicalTreeSessionIds = toCanonicalTopologySessionIds(['peer-3', 'peer-1', 'peer-4', 'peer-2']);
     expect(
       computeNoRttTopologyNextHops({
         topology: 'tree',

--- a/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-planning.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-planning.test.ts
@@ -1,22 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { validateGroupTopologyNextHops } from '@shared-graph/group-topology-validation.ts';
-// prettier-ignore
-import {
-  RallarRtcTopologyService,
-} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import {
-  RtcTopologyMetrics,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
-// prettier-ignore
-import {
-  planRallarRtcTopologySnapshot,
-} from '@shared-server/rallar-system/topology/planning/plan-rallar-rtc-topology-snapshot.ts';
-// prettier-ignore
-import {
-  RtcTopologyPlanner,
-} from '@shared-server/rallar-system/topology/planning/rtc-topology-planner.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { RtcTopologyMetrics } from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
+import { planRallarRtcTopologySnapshot } from '@shared-server/rallar-system/topology/planning/plan-rallar-rtc-topology-snapshot.ts';
+import { RtcTopologyPlanner } from '@shared-server/rallar-system/topology/planning/rtc-topology-planner.ts';
 
 import {
   createCentralRtcTopologyRttMeasurements,
@@ -26,10 +14,7 @@ import {
 
 describe('RTC topology planning options and revisions', () => {
   it('plans a star topology through the dedicated planning owner', () => {
-    const planner = new RtcTopologyPlanner(
-      { topologyKind: 'star' },
-      { metrics: new RtcTopologyMetrics(), durationNowMs: () => 0 },
-    );
+    const planner = new RtcTopologyPlanner({ topologyKind: 'star' }, { metrics: new RtcTopologyMetrics(), durationNowMs: () => 0 });
 
     const result = planner.plan({
       group: createRtcTopologyGroupSnapshot('planner-owner', createRtcTopologyMemberIds(3)),
@@ -44,10 +29,7 @@ describe('RTC topology planning options and revisions', () => {
 
   it('owns no-RTT tree, weighted tree, and per-update topology decisions', () => {
     const metrics = new RtcTopologyMetrics();
-    const planner = new RtcTopologyPlanner(
-      { topologyKind: 'tree', degreeLimit: 5 },
-      { metrics, durationNowMs: () => 0 },
-    );
+    const planner = new RtcTopologyPlanner({ topologyKind: 'tree', degreeLimit: 5 }, { metrics, durationNowMs: () => 0 });
     const group = createRtcTopologyGroupSnapshot('planner-owner', createRtcTopologyMemberIds(5));
 
     const noRtt = planner.plan({
@@ -59,10 +41,7 @@ describe('RTC topology planning options and revisions', () => {
     });
     const weighted = planner.plan({
       group,
-      rttMeasurements: createCentralRtcTopologyRttMeasurements(
-        createRtcTopologyMemberIds(5),
-        'peer-1',
-      ),
+      rttMeasurements: createCentralRtcTopologyRttMeasurements(createRtcTopologyMemberIds(5), 'peer-1'),
       previous: noRtt.snapshot,
       updateOptions: { topologyOptions: { topologyKind: 'mesh', degreeLimit: 2 } },
       nowEpochMs: 200,
@@ -94,10 +73,7 @@ describe('RTC topology planning options and revisions', () => {
       nowEpochMs: 100,
     });
     const incrementallyPlanned = planner.plan({
-      group: createRtcTopologyGroupSnapshot('planner-incremental', [
-        ...memberSessionIds,
-        'peer-21',
-      ]),
+      group: createRtcTopologyGroupSnapshot('planner-incremental', [...memberSessionIds, 'peer-21']),
       rttMeasurements: [],
       previous: formed.snapshot,
       updateOptions: { planningIntent: 'membership-delta' },
@@ -122,10 +98,7 @@ describe('RTC topology planning options and revisions', () => {
     });
 
     const hysteresisMetrics = new RtcTopologyMetrics();
-    const hysteresisPlanner = new RtcTopologyPlanner(
-      {},
-      { metrics: hysteresisMetrics, durationNowMs: () => 0 },
-    );
+    const hysteresisPlanner = new RtcTopologyPlanner({}, { metrics: hysteresisMetrics, durationNowMs: () => 0 });
     const meshMembers = createRtcTopologyMemberIds(16);
     const meshPlan = hysteresisPlanner.plan({
       group: createRtcTopologyGroupSnapshot('planner-hysteresis', meshMembers),
@@ -191,15 +164,7 @@ describe('RTC topology planning options and revisions', () => {
     });
 
     expect(result.snapshot.topology).toBe('star');
-    expect(result.snapshot.nextHopsBySessionId['peer-1']).toEqual([
-      'peer-2',
-      'peer-3',
-      'peer-4',
-      'peer-5',
-      'peer-6',
-      'peer-7',
-      'peer-8',
-    ]);
+    expect(result.snapshot.nextHopsBySessionId['peer-1']).toEqual(['peer-2', 'peer-3', 'peer-4', 'peer-5', 'peer-6', 'peer-7', 'peer-8']);
   });
 
   it('honors request topology kind override for tree topology', () => {
@@ -256,21 +221,15 @@ describe('RTC topology planning options and revisions', () => {
   it('keeps default threshold behavior when no per-update topology options are passed', () => {
     const service = new RallarRtcTopologyService({ now: () => 100 });
 
-    expect(
-      service.updateGroupTopology(
-        createRtcTopologyGroupSnapshot('small-room', createRtcTopologyMemberIds(4)),
-      ).snapshot.topology,
-    ).toBe('star');
-    expect(
-      service.updateGroupTopology(
-        createRtcTopologyGroupSnapshot('tree-room', createRtcTopologyMemberIds(5)),
-      ).snapshot.topology,
-    ).toBe('tree');
-    expect(
-      service.updateGroupTopology(
-        createRtcTopologyGroupSnapshot('mesh-room', createRtcTopologyMemberIds(16)),
-      ).snapshot.topology,
-    ).toBe('mesh');
+    expect(service.updateGroupTopology(createRtcTopologyGroupSnapshot('small-room', createRtcTopologyMemberIds(4))).snapshot.topology).toBe(
+      'star',
+    );
+    expect(service.updateGroupTopology(createRtcTopologyGroupSnapshot('tree-room', createRtcTopologyMemberIds(5))).snapshot.topology).toBe(
+      'tree',
+    );
+    expect(service.updateGroupTopology(createRtcTopologyGroupSnapshot('mesh-room', createRtcTopologyMemberIds(16))).snapshot.topology).toBe(
+      'mesh',
+    );
   });
 
   it('retains the graph version while advancing an unchanged group revision', () => {
@@ -301,10 +260,7 @@ describe('RTC topology planning options and revisions', () => {
     const service = new RallarRtcTopologyService({ now: () => 100 });
 
     const first = service.updateGroupTopology(group);
-    const second = service.updateGroupTopology(
-      group,
-      createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-    );
+    const second = service.updateGroupTopology(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'));
 
     expect(first.changed).toBe(true);
     expect(second.changed).toBe(true);
@@ -320,11 +276,9 @@ describe('RTC topology planning options and revisions', () => {
     const secondWorker = new RallarRtcTopologyService({ now: () => 200 });
 
     const first = firstWorker.updateGroupTopology(group);
-    const second = secondWorker.updateGroupTopology(
-      group,
-      createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-      { previous: first.snapshot },
-    );
+    const second = secondWorker.updateGroupTopology(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'), {
+      previous: first.snapshot,
+    });
 
     expect(second.changed).toBe(true);
     expect(second.previous).toBe(first.snapshot);

--- a/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-room-graph.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-room-graph.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import {
-  RallarRtcTopologyService,
-} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import {
-  computeCanonicalTopologyPairWeight,
-} from '@shared-server/rallar-system/topology/planning/canonical-topology-planning-input.ts';
-// prettier-ignore
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { computeCanonicalTopologyPairWeight } from '@shared-server/rallar-system/topology/planning/canonical-topology-planning-input.ts';
 import {
   createRtcRoomGraph,
   materializeSparseRtcRoomGraphFallback,
@@ -48,11 +41,7 @@ describe('RTC topology weighted room graph planning', () => {
       ['peer-1', 'peer-3'],
       ['peer-2', 'peer-3'],
     ]);
-    expect(
-      graph
-        .edges()
-        .map((edge) => [graph.extremities(edge), graph.getEdgeAttribute(edge, 'weight')]),
-    ).toEqual([
+    expect(graph.edges().map((edge) => [graph.extremities(edge), graph.getEdgeAttribute(edge, 'weight')])).toEqual([
       [['peer-1', 'peer-2'], computeCanonicalTopologyPairWeight('peer-1', 'peer-2')],
       [['peer-1', 'peer-3'], computeCanonicalTopologyPairWeight('peer-1', 'peer-3')],
       [['peer-2', 'peer-3'], computeCanonicalTopologyPairWeight('peer-2', 'peer-3')],
@@ -143,11 +132,7 @@ describe('RTC topology weighted room graph planning', () => {
     });
 
     const graph = expectReadyRoomGraph(result);
-    expect(
-      graph
-        .edges()
-        .map((edge) => [graph.extremities(edge), graph.getEdgeAttribute(edge, 'weight')]),
-    ).toEqual([
+    expect(graph.edges().map((edge) => [graph.extremities(edge), graph.getEdgeAttribute(edge, 'weight')])).toEqual([
       [['peer-1', 'peer-2'], 5],
       [['peer-2', 'peer-3'], 7],
       [['peer-1', 'peer-3'], computeCanonicalTopologyPairWeight('peer-1', 'peer-3')],
@@ -161,9 +146,7 @@ describe('RTC topology weighted room graph planning', () => {
     const fallbackGraph = service.createRoomGraph(group);
     const fallbackEdge = fallbackGraph.edge('peer-1', 'peer-3');
     expect(fallbackEdge).toBeDefined();
-    expect(fallbackGraph.getEdgeAttribute(fallbackEdge!, 'weight')).toBe(
-      computeCanonicalTopologyPairWeight('peer-1', 'peer-3'),
-    );
+    expect(fallbackGraph.getEdgeAttribute(fallbackEdge!, 'weight')).toBe(computeCanonicalTopologyPairWeight('peer-1', 'peer-3'));
     expect(fallbackGraph.getEdgeAttribute(fallbackEdge!, 'weight')).toBeGreaterThanOrEqual(1);
     expect(fallbackGraph.getEdgeAttribute(fallbackEdge!, 'weight')).toBeLessThan(32);
 
@@ -386,11 +369,7 @@ describe('RTC topology weighted room graph planning', () => {
   });
 });
 
-function edgeWeight(
-  graph: ReturnType<RallarRtcTopologyService['createRoomGraph']>,
-  from: string,
-  to: string,
-): number | undefined {
+function edgeWeight(graph: ReturnType<RallarRtcTopologyService['createRoomGraph']>, from: string, to: string): number | undefined {
   const edge = graph.edge(from, to);
   return edge === undefined ? undefined : graph.getEdgeAttribute(edge, 'weight');
 }

--- a/packages/tests/shared-server/rallar-system/topology/planning/topology-kind-hysteresis.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/topology-kind-hysteresis.test.ts
@@ -1,121 +1,102 @@
 import { describe, expect, it } from 'vitest';
-// prettier-ignore
-import {
-    resolveTopologyKindWithHysteresis,
-} from '@shared-server/rallar-system/topology/planning/topology-kind-hysteresis.ts';
+import { resolveTopologyKindWithHysteresis } from '@shared-server/rallar-system/topology/planning/topology-kind-hysteresis.ts';
 
 const DEFAULTS = {
-    treeMinSize: 5,
-    meshMinSize: 16,
-    meshExitWidth: 4,
-    treeExitWidth: 0,
+  treeMinSize: 5,
+  meshMinSize: 16,
+  meshExitWidth: 4,
+  treeExitWidth: 0,
 };
 
 describe('topology kind hysteresis', () => {
-    it('selects entry kinds without a previous kind', () => {
-        expect(resolve(4, undefined)).toBe('star');
-        expect(resolve(5, undefined)).toBe('tree');
-        expect(resolve(15, undefined)).toBe('tree');
-        expect(resolve(16, undefined)).toBe('mesh');
-    });
+  it('selects entry kinds without a previous kind', () => {
+    expect(resolve(4, undefined)).toBe('star');
+    expect(resolve(5, undefined)).toBe('tree');
+    expect(resolve(15, undefined)).toBe('tree');
+    expect(resolve(16, undefined)).toBe('mesh');
+  });
 
-    it('upgrades immediately at the entry thresholds', () => {
-        expect(resolve(16, 'tree')).toBe('mesh');
-        expect(resolve(5, 'star')).toBe('tree');
-    });
+  it('upgrades immediately at the entry thresholds', () => {
+    expect(resolve(16, 'tree')).toBe('mesh');
+    expect(resolve(5, 'star')).toBe('tree');
+  });
 
-    it('holds mesh across the band and exits below it', () => {
-        expect(resolve(15, 'mesh')).toBe('mesh');
-        expect(resolve(12, 'mesh')).toBe('mesh');
-        expect(resolve(11, 'mesh')).toBe('tree');
-    });
+  it('holds mesh across the band and exits below it', () => {
+    expect(resolve(15, 'mesh')).toBe('mesh');
+    expect(resolve(12, 'mesh')).toBe('mesh');
+    expect(resolve(11, 'mesh')).toBe('tree');
+  });
 
-    it('does not oscillate across the boundary under a size flap', () => {
-        let kind: 'star' | 'tree' | 'mesh' = 'tree';
-        const kinds: string[] = [];
-        for (const size of [15, 16, 15, 16, 15, 14, 13, 12, 11, 12, 15, 16]) {
-            kind = resolve(size, kind);
-            kinds.push(kind);
-        }
-        // One upgrade at 16, held through the 12..15 band, one downgrade at 11,
-        // one re-upgrade at 16 — not a flip per step.
-        expect(kinds).toEqual([
-            'tree',
-            'mesh',
-            'mesh',
-            'mesh',
-            'mesh',
-            'mesh',
-            'mesh',
-            'mesh',
-            'tree',
-            'tree',
-            'tree',
-            'mesh',
-        ]);
-    });
+  it('does not oscillate across the boundary under a size flap', () => {
+    let kind: 'star' | 'tree' | 'mesh' = 'tree';
+    const kinds: string[] = [];
+    for (const size of [15, 16, 15, 16, 15, 14, 13, 12, 11, 12, 15, 16]) {
+      kind = resolve(size, kind);
+      kinds.push(kind);
+    }
+    // One upgrade at 16, held through the 12..15 band, one downgrade at 11,
+    // one re-upgrade at 16 — not a flip per step.
+    expect(kinds).toEqual(['tree', 'mesh', 'mesh', 'mesh', 'mesh', 'mesh', 'mesh', 'mesh', 'tree', 'tree', 'tree', 'mesh']);
+  });
 
-    it('keeps the mesh exit at or above treeMinSize when the band is wide', () => {
-        expect(
-            resolveTopologyKindWithHysteresis({
-                activeSize: 6,
-                treeMinSize: 5,
-                meshMinSize: 8,
-                meshExitWidth: 50,
-                treeExitWidth: 0,
-                previousKind: 'mesh',
-            }),
-        ).toBe('mesh');
-        expect(
-            resolveTopologyKindWithHysteresis({
-                activeSize: 4,
-                treeMinSize: 5,
-                meshMinSize: 8,
-                meshExitWidth: 50,
-                treeExitWidth: 0,
-                previousKind: 'mesh',
-            }),
-        ).toBe('star');
-    });
+  it('keeps the mesh exit at or above treeMinSize when the band is wide', () => {
+    expect(
+      resolveTopologyKindWithHysteresis({
+        activeSize: 6,
+        treeMinSize: 5,
+        meshMinSize: 8,
+        meshExitWidth: 50,
+        treeExitWidth: 0,
+        previousKind: 'mesh',
+      }),
+    ).toBe('mesh');
+    expect(
+      resolveTopologyKindWithHysteresis({
+        activeSize: 4,
+        treeMinSize: 5,
+        meshMinSize: 8,
+        meshExitWidth: 50,
+        treeExitWidth: 0,
+        previousKind: 'mesh',
+      }),
+    ).toBe('star');
+  });
 
-    it('applies the tree exit band only against star downgrades', () => {
-        expect(
-            resolveTopologyKindWithHysteresis({
-                ...DEFAULTS,
-                activeSize: 4,
-                treeExitWidth: 1,
-                previousKind: 'tree',
-            }),
-        ).toBe('tree');
-        expect(
-            resolveTopologyKindWithHysteresis({
-                ...DEFAULTS,
-                activeSize: 3,
-                treeExitWidth: 1,
-                previousKind: 'tree',
-            }),
-        ).toBe('star');
-    });
+  it('applies the tree exit band only against star downgrades', () => {
+    expect(
+      resolveTopologyKindWithHysteresis({
+        ...DEFAULTS,
+        activeSize: 4,
+        treeExitWidth: 1,
+        previousKind: 'tree',
+      }),
+    ).toBe('tree');
+    expect(
+      resolveTopologyKindWithHysteresis({
+        ...DEFAULTS,
+        activeSize: 3,
+        treeExitWidth: 1,
+        previousKind: 'tree',
+      }),
+    ).toBe('star');
+  });
 
-    it('never returns tree for sizes below two under any band', () => {
-        expect(
-            resolveTopologyKindWithHysteresis({
-                ...DEFAULTS,
-                activeSize: 1,
-                treeExitWidth: 50,
-                previousKind: 'tree',
-            }),
-        ).toBe('star');
-    });
+  it('never returns tree for sizes below two under any band', () => {
+    expect(
+      resolveTopologyKindWithHysteresis({
+        ...DEFAULTS,
+        activeSize: 1,
+        treeExitWidth: 50,
+        previousKind: 'tree',
+      }),
+    ).toBe('star');
+  });
 });
 
-function resolve(
-    activeSize: number,
-    previousKind: 'star' | 'tree' | 'mesh' | undefined,
-): 'star' | 'tree' | 'mesh' {
-    return resolveTopologyKindWithHysteresis({
-        ...DEFAULTS,
-        activeSize,
-        previousKind,
-    });
+function resolve(activeSize: number, previousKind: 'star' | 'tree' | 'mesh' | undefined): 'star' | 'tree' | 'mesh' {
+  return resolveTopologyKindWithHysteresis({
+    ...DEFAULTS,
+    activeSize,
+    previousKind,
+  });
 }

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import {
-  RtcTopologyMetrics,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
+import { RtcTopologyMetrics } from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
 
 describe('RtcTopologyMetrics', () => {
   it('records every metric category and resets recorded values', () => {

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-rtt-rebuild-scheduler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-rtt-rebuild-scheduler.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import {
-  RtcTopologyMetrics,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
-// prettier-ignore
-import {
-  RtcTopologyRttRebuildScheduler,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-rtt-rebuild-scheduler.ts';
+import { RtcTopologyMetrics } from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
+import { RtcTopologyRttRebuildScheduler } from '@shared-server/rallar-system/topology/runtime/rtc-topology-rtt-rebuild-scheduler.ts';
 
 describe('RtcTopologyRttRebuildScheduler', () => {
   it('makes work without a snapshot immediately due', () => {
@@ -118,9 +112,7 @@ describe('RtcTopologyRttRebuildScheduler', () => {
       debounceMs: 50,
       metrics,
     });
-    expect(() =>
-      unavailableClockScheduler.queue({ overlayId: 'overlay-3', hasSnapshot: false }),
-    ).toThrow('clock unavailable');
+    expect(() => unavailableClockScheduler.queue({ overlayId: 'overlay-3', hasSnapshot: false })).toThrow('clock unavailable');
     expect(metrics.read(0, scheduler.size)).toMatchObject({
       rttQueueRequestCount: 0,
       rttFlushAttemptCount: 0,
@@ -136,10 +128,7 @@ function createMutableClock(now: number): MutableClock {
   return { now };
 }
 
-function createScheduler(
-  clock: MutableClock,
-  metrics: RtcTopologyMetrics,
-): RtcTopologyRttRebuildScheduler {
+function createScheduler(clock: MutableClock, metrics: RtcTopologyMetrics): RtcTopologyRttRebuildScheduler {
   return new RtcTopologyRttRebuildScheduler({
     nowEpochMs: () => clock.now,
     debounceMs: 50,

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-runtime-integration.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-runtime-integration.test.ts
@@ -1,18 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
-// prettier-ignore
-import {
-  RallarRtcTopologyService,
-} from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
-// prettier-ignore
-import {
-  RtcTopologyPlanner,
-} from '@shared-server/rallar-system/topology/planning/rtc-topology-planner.ts';
-// prettier-ignore
-import {
-  RtcTopologyMetrics,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/services/rallar-rtc-topology-service.ts';
+import { RtcTopologyPlanner } from '@shared-server/rallar-system/topology/planning/rtc-topology-planner.ts';
+import { RtcTopologyMetrics } from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
 
 import {
   createCentralRtcTopologyRttMeasurements,
@@ -49,26 +40,13 @@ describe('RTC topology process runtime integration', () => {
     expect(queued.newlyQueued).toBe(true);
     expect(queued.immediate).toBe(false);
     expect(queued.delayMs).toBe(50);
-    expect(
-      service.flushDueRttTopologyUpdate(
-        group,
-        createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-      ),
-    ).toBeUndefined();
+    expect(service.flushDueRttTopologyUpdate(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'))).toBeUndefined();
 
     now = 1_049;
-    expect(
-      service.flushDueRttTopologyUpdate(
-        group,
-        createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-      ),
-    ).toBeUndefined();
+    expect(service.flushDueRttTopologyUpdate(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'))).toBeUndefined();
 
     now = 1_050;
-    const second = service.flushDueRttTopologyUpdate(
-      group,
-      createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-    );
+    const second = service.flushDueRttTopologyUpdate(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'));
 
     expect(second?.changed).toBe(true);
     expect(second?.snapshot.version).toBe(first.snapshot.version + 1);
@@ -138,8 +116,7 @@ describe('RTC topology process runtime integration', () => {
     {
       name: 'plan reads active sessions before scope and retains its attempt',
       metric: 'topologyUpdateCount' as const,
-      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) =>
-        service.planGroupTopologyAt(group, [], {}, 100),
+      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) => service.planGroupTopologyAt(group, [], {}, 100),
       createGroup: createGroupWithThrowingSessionsAndScope,
       expectedError: 'group sessions unavailable',
       expectedClockReads: 0,
@@ -147,8 +124,7 @@ describe('RTC topology process runtime integration', () => {
     {
       name: 'queue retains its request before scope translation fails',
       metric: 'rttQueueRequestCount' as const,
-      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) =>
-        service.queueRttTopologyUpdate(group),
+      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) => service.queueRttTopologyUpdate(group),
       createGroup: createGroupWithThrowingScope,
       expectedError: 'group scope unavailable',
       expectedClockReads: 0,
@@ -156,8 +132,7 @@ describe('RTC topology process runtime integration', () => {
     {
       name: 'claim retains its attempt before scope translation fails',
       metric: 'rttFlushAttemptCount' as const,
-      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) =>
-        service.claimDueRttTopologyUpdate(group.group),
+      invoke: (service: RallarRtcTopologyService, group: GroupSnapshot) => service.claimDueRttTopologyUpdate(group.group),
       createGroup: createGroupWithThrowingNestedScope,
       expectedError: 'group scope unavailable',
       expectedClockReads: 0,
@@ -205,9 +180,7 @@ describe('RTC topology process runtime integration', () => {
     const group = createGroupWithThrowingActiveSessionRead(3);
     const service = new RallarRtcTopologyService({ now: () => 100 });
 
-    expect(() => planWeightedTopology(service, group, memberSessionIds)).toThrow(
-      'group sessions unavailable',
-    );
+    expect(() => planWeightedTopology(service, group, memberSessionIds)).toThrow('group sessions unavailable');
     expect(service.readMetrics()).toMatchObject({
       topologyUpdateCount: 1,
       updatesWithRttMeasurementCount: 1,
@@ -228,9 +201,7 @@ describe('RTC topology process runtime integration', () => {
     });
     const service = new RallarRtcTopologyService({ now: () => 100 });
 
-    expect(() => planWeightedTopology(service, group, memberSessionIds)).toThrow(
-      'group display name unavailable',
-    );
+    expect(() => planWeightedTopology(service, group, memberSessionIds)).toThrow('group display name unavailable');
     expect(service.readMetrics()).toMatchObject({
       weightedPlanCount: 1,
       topologyChangedCount: 0,
@@ -321,18 +292,10 @@ describe('RTC topology process runtime integration', () => {
 
     expect(queued.newlyQueued).toBe(true);
     expect(coalesced.newlyQueued).toBe(false);
-    expect(
-      service.flushDueRttTopologyUpdate(
-        group,
-        createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-      ),
-    ).toBeUndefined();
+    expect(service.flushDueRttTopologyUpdate(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'))).toBeUndefined();
 
     now = 1_050;
-    const second = service.flushDueRttTopologyUpdate(
-      group,
-      createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-    );
+    const second = service.flushDueRttTopologyUpdate(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'));
     expect(second?.changed).toBe(true);
     service.recordTopologyPublishResult(second?.changed ?? false);
 
@@ -405,9 +368,9 @@ describe('RTC topology process runtime integration', () => {
     const current = service.updateGroupTopology(group).snapshot;
     service.queueRttTopologyUpdate(group);
 
-    expect(() =>
-      service.observeCommittedTopologySnapshot({ ...current, name: 'Conflicting room' }),
-    ).toThrowError(new Error(`RTC topology process-cache revision conflict: ${current.overlayId}`));
+    expect(() => service.observeCommittedTopologySnapshot({ ...current, name: 'Conflicting room' })).toThrowError(
+      new Error(`RTC topology process-cache revision conflict: ${current.overlayId}`),
+    );
     expect(service.readRttTopologyUpdateDelayMs(group)).toBe(50);
 
     expect(
@@ -548,15 +511,6 @@ function createSparseRtcTopologyRttMeasurements() {
   ];
 }
 
-function planWeightedTopology(
-  service: RallarRtcTopologyService,
-  group: GroupSnapshot,
-  memberSessionIds: readonly string[],
-): void {
-  service.planGroupTopologyAt(
-    group,
-    createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'),
-    {},
-    100,
-  );
+function planWeightedTopology(service: RallarRtcTopologyService, group: GroupSnapshot, memberSessionIds: readonly string[]): void {
+  service.planGroupTopologyAt(group, createCentralRtcTopologyRttMeasurements(memberSessionIds, 'peer-1'), {}, 100);
 }

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-snapshot-registry.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-snapshot-registry.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
-// prettier-ignore
-import {
-  RtcTopologySnapshotRegistry,
-} from '@shared-server/rallar-system/topology/runtime/rtc-topology-snapshot-registry.ts';
+import { RtcTopologySnapshotRegistry } from '@shared-server/rallar-system/topology/runtime/rtc-topology-snapshot-registry.ts';
 
 describe('RtcTopologySnapshotRegistry', () => {
   it('accepts first and causally dominating observations', () => {
@@ -53,9 +50,7 @@ describe('RtcTopologySnapshotRegistry', () => {
 
     registry.observe(current);
 
-    expect(() => registry.observe(conflicting)).toThrowError(
-      new Error(`RTC topology process-cache causal conflict: ${current.overlayId}`),
-    );
+    expect(() => registry.observe(conflicting)).toThrowError(new Error(`RTC topology process-cache causal conflict: ${current.overlayId}`));
   });
 
   it('owns only snapshot lookup and removal state', () => {

--- a/packages/tests/shared-server/state-write-performance-topology-reasons.test.ts
+++ b/packages/tests/shared-server/state-write-performance-topology-reasons.test.ts
@@ -4,10 +4,7 @@ import {
   GROUP_TOPOLOGY_CONFLICT_REASON,
   GROUP_TOPOLOGY_CONFLICT_REASON_SCHEMA,
 } from '../../../scripts/perf/pool-group-topology-state-write-position-balanced-results.mjs';
-// prettier-ignore
-import type {
-  StateWriteBenchmarkRegressionReason,
-} from '../../../scripts/perf/state-write/api-v1-state-write-benchmark-artifact.ts';
+import type { StateWriteBenchmarkRegressionReason } from '../../../scripts/perf/state-write/api-v1-state-write-benchmark-artifact.ts';
 
 const APPROVED_PR_C_BASE_COMMIT = '39ad65b499c4bf944acfe48446ad1c334d97d37d';
 const CANDIDATE_COMMIT = '74a62eb22583216e8c6651de069209d7e1a8ca67';
@@ -17,16 +14,14 @@ const CANDIDATE_IDENTITY = { commit: CANDIDATE_COMMIT, tree: CANDIDATE_TREE } as
 describe('API-v1 state-write topology regression reasons', { timeout: 30_000 }, () => {
   it('binds precommitted topology conflict reasons before measurement', async () => {
     const bench = await import('../../../scripts/perf/api-v1-state-write-concurrency-bench.ts');
-    const artifactOwner =
-      await import('../../../scripts/perf/state-write/api-v1-state-write-benchmark-artifact.ts');
+    const artifactOwner = await import('../../../scripts/perf/state-write/api-v1-state-write-benchmark-artifact.ts');
     const input = createConflictReasonInput();
-    const parseReasons = (text: string | undefined) =>
-      bench.parseGroupTopologyRegressionReasons(text, CANDIDATE_IDENTITY);
+    const parseReasons = (text: string | undefined) => bench.parseGroupTopologyRegressionReasons(text, CANDIDATE_IDENTITY);
     expect(parseReasons(undefined)).toEqual([]);
     expect(parseReasons(JSON.stringify(input))).toEqual(input.reasons);
-    expect(
-      bench.parseBenchmarkOptions(['--regression-reasons-file=tmp/perf/topology-reasons.json']),
-    ).toMatchObject({ regressionReasonsFile: 'tmp/perf/topology-reasons.json' });
+    expect(bench.parseBenchmarkOptions(['--regression-reasons-file=tmp/perf/topology-reasons.json'])).toMatchObject({
+      regressionReasonsFile: 'tmp/perf/topology-reasons.json',
+    });
     const createArtifact = (regressionReasons: readonly StateWriteBenchmarkRegressionReason[]) =>
       artifactOwner.createStateWriteBenchmarkArtifact({
         generatedAt: '2026-08-09T00:00:00.000Z',
@@ -35,27 +30,17 @@ describe('API-v1 state-write topology regression reasons', { timeout: 30_000 }, 
         regressionReasons,
         workloads: [{ name: 'sentinel-workload' }],
       });
-    expect(createArtifact(parseReasons(JSON.stringify(input))).regressionReasons).toEqual(
-      input.reasons,
-    );
+    expect(createArtifact(parseReasons(JSON.stringify(input))).regressionReasons).toEqual(input.reasons);
     expect(createArtifact([])).toMatchObject({ regressionReasons: [] });
     expect(createArtifact([])).not.toHaveProperty('features');
     const artifactBytes = new TextEncoder().encode(
-      `${JSON.stringify(
-        createArtifact([
-          { workload: 'shared', metric: 'sql.statements', reason: 'precommitted reason' },
-        ]),
-        null,
-        2,
-      )}\n`,
+      `${JSON.stringify(createArtifact([{ workload: 'shared', metric: 'sql.statements', reason: 'precommitted reason' }]), null, 2)}\n`,
     );
     const artifactDigest = await crypto.subtle.digest('SHA-256', artifactBytes);
-    expect(toHex(artifactDigest)).toBe(
-      '36b2810baac9613e69c4152eb60e66e548bea94636aead2e5b3b35fd1f1b55e3',
+    expect(toHex(artifactDigest)).toBe('36b2810baac9613e69c4152eb60e66e548bea94636aead2e5b3b35fd1f1b55e3');
+    expect(() => bench.parseBenchmarkOptions(['--regression-reasons-file=tmp/perf/../topology-reasons.json'])).toThrow(
+      /must remain under tmp\/perf/,
     );
-    expect(() =>
-      bench.parseBenchmarkOptions(['--regression-reasons-file=tmp/perf/../topology-reasons.json']),
-    ).toThrow(/must remain under tmp\/perf/);
     for (const mutate of conflictReasonFailures()) {
       const malformed = structuredClone(input);
       mutate(malformed);
@@ -65,31 +50,20 @@ describe('API-v1 state-write topology regression reasons', { timeout: 30_000 }, 
 
   it('selects RTC durable-append reasons without contaminating other captures', async () => {
     const bench = await import('../../../scripts/perf/api-v1-state-write-concurrency-bench.ts');
-    const rtcOptions = bench.parseBenchmarkOptions([
-      '--regression-reason-profile=rtc-topology-durable-append',
-    ]);
+    const rtcOptions = bench.parseBenchmarkOptions(['--regression-reason-profile=rtc-topology-durable-append']);
     expect(rtcOptions).toMatchObject({
       regressionReasonProfile: 'rtc-topology-durable-append',
     });
-    expect(
-      bench.selectStateWriteRegressionReasons(rtcOptions.regressionReasonProfile, []),
-    ).toHaveLength(12);
+    expect(bench.selectStateWriteRegressionReasons(rtcOptions.regressionReasonProfile, [])).toHaveLength(12);
 
     const ordinaryOptions = bench.parseBenchmarkOptions([]);
-    expect(
-      bench.selectStateWriteRegressionReasons(ordinaryOptions.regressionReasonProfile, []),
-    ).toEqual([]);
+    expect(bench.selectStateWriteRegressionReasons(ordinaryOptions.regressionReasonProfile, [])).toEqual([]);
 
-    const groupTopologyOptions = bench.parseBenchmarkOptions([
-      '--regression-reasons-file=tmp/perf/topology-reasons.json',
-    ]);
+    const groupTopologyOptions = bench.parseBenchmarkOptions(['--regression-reasons-file=tmp/perf/topology-reasons.json']);
     const groupTopologyReasons = createConflictReasonInput().reasons;
-    expect(
-      bench.selectStateWriteRegressionReasons(
-        groupTopologyOptions.regressionReasonProfile,
-        groupTopologyReasons,
-      ),
-    ).toEqual(groupTopologyReasons);
+    expect(bench.selectStateWriteRegressionReasons(groupTopologyOptions.regressionReasonProfile, groupTopologyReasons)).toEqual(
+      groupTopologyReasons,
+    );
 
     expect(() =>
       bench.parseBenchmarkOptions([
@@ -104,12 +78,7 @@ describe('API-v1 state-write topology regression reasons', { timeout: 30_000 }, 
 });
 
 function createConflictReasonInput(): any {
-  const metrics = [
-    'sql.statements',
-    'sql.rowsRead',
-    'sql.serializedResultBytes',
-    'postgres.transactionDurationMs',
-  ];
+  const metrics = ['sql.statements', 'sql.rowsRead', 'sql.serializedResultBytes', 'postgres.transactionDurationMs'];
   return {
     schemaVersion: GROUP_TOPOLOGY_CONFLICT_REASON_SCHEMA,
     baseCommit: APPROVED_PR_C_BASE_COMMIT,

--- a/packages/tests/shared-server/ws-server-room-broadcast-delta-audience.test.ts
+++ b/packages/tests/shared-server/ws-server-room-broadcast-delta-audience.test.ts
@@ -3,10 +3,7 @@ import { newALBroadcastMessage, newALEventRoute } from '@shared/al-contracts/al-
 import { AppTopics } from '@shared/api/api-config.ts';
 import type { GroupStateDeltaEnvelope } from '@shared/api/group-state-delta.ts';
 import { validateGroupStateDeltaEnvelope } from '@shared/api/group-state-delta.ts';
-// prettier-ignore
-import {
-  createWsServerTargetResolver,
-} from '@shared-server/rallar-system/middleware/ws-server-target-resolver.ts';
+import { createWsServerTargetResolver } from '@shared-server/rallar-system/middleware/ws-server-target-resolver.ts';
 import {
   createDeltaEnvelopeFixture,
   createDeltaEnvelopeFixtureGroupSnapshot,
@@ -25,11 +22,7 @@ const JOINING = { principalId: 'joining', sessionId: 'joining-session', role: 'm
 // process-local snapshot names that session yet.
 describe('room-scope broadcast delivery of group-state delta envelopes', () => {
   it('delivers to the persisted audience without consulting a group snapshot', () => {
-    const server = createDeltaEnvelopeFixtureWebSocketServer([
-      'alice-session',
-      'joining-session',
-      'stranger-session',
-    ]);
+    const server = createDeltaEnvelopeFixtureWebSocketServer(['alice-session', 'joining-session', 'stranger-session']);
     const findGroupSnapshotByRef = vi.fn(() => createDeltaEnvelopeFixtureGroupSnapshot([ALICE]));
     const resolver = createWsServerTargetResolver(server, {
       findGroupSnapshotByRef,
@@ -41,10 +34,7 @@ describe('room-scope broadcast delivery of group-state delta envelopes', () => {
     });
     expect(() => validateGroupStateDeltaEnvelope(envelope)).not.toThrow();
 
-    const recipients = resolver.resolveBroadcastRecipients?.(
-      'room',
-      toRoomEnvelopeMessage(envelope),
-    );
+    const recipients = resolver.resolveBroadcastRecipients?.('room', toRoomEnvelopeMessage(envelope));
 
     expect(readFixtureConnectionIds(recipients)).toEqual(['alice-session', 'joining-session']);
     expect(findGroupSnapshotByRef).not.toHaveBeenCalled();
@@ -103,11 +93,7 @@ describe('room-scope broadcast delivery of group-state delta envelopes', () => {
       'room',
       newALBroadcastMessage(
         'rallar-server',
-        newALEventRoute(
-          AppTopics.groupStateSnapshot,
-          DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId,
-          'snapshot-1',
-        ),
+        newALEventRoute(AppTopics.groupStateSnapshot, DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId, 'snapshot-1'),
         'room',
         AppTopics.groupStateSnapshot,
         createDeltaEnvelopeFixtureGroupSnapshot([ALICE, JOINING]),
@@ -134,11 +120,7 @@ describe('room-scope broadcast delivery of group-state delta envelopes', () => {
       'room',
       newALBroadcastMessage(
         'rallar-server',
-        newALEventRoute(
-          AppTopics.groupStateEvent,
-          DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId,
-          'event-foreign',
-        ),
+        newALEventRoute(AppTopics.groupStateEvent, DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId, 'event-foreign'),
         'room',
         AppTopics.groupStateEvent,
         foreignEnvelope,
@@ -153,11 +135,7 @@ describe('room-scope broadcast delivery of group-state delta envelopes', () => {
 function toRoomEnvelopeMessage(envelope: GroupStateDeltaEnvelope) {
   return newALBroadcastMessage(
     'rallar-server',
-    newALEventRoute(
-      AppTopics.groupStateEvent,
-      DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId,
-      envelope.event.eventId,
-    ),
+    newALEventRoute(AppTopics.groupStateEvent, DELTA_ENVELOPE_FIXTURE_GROUP_REF.groupId, envelope.event.eventId),
     'room',
     AppTopics.groupStateEvent,
     envelope,

--- a/packages/tests/shared/group-activation-criterion.test.ts
+++ b/packages/tests/shared/group-activation-criterion.test.ts
@@ -1,124 +1,146 @@
 import { describe, expect, it } from 'vitest';
 
 import type { GroupActivationCriterion } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
 import {
-    computeFormationRetryBackoffMs,
-    DEFAULT_FORMATION_RETRY_BACKOFF_MS,
-    evaluateGroupActivationCriterion,
-    MAX_FORMATION_RETRY_BACKOFF_MS,
+  computeFormationRetryBackoffMs,
+  DEFAULT_FORMATION_RETRY_BACKOFF_MS,
+  evaluateGroupActivationCriterion,
+  MAX_FORMATION_RETRY_BACKOFF_MS,
 } from '@shared/api/group-lifecycle/evaluate-group-activation-criterion.ts';
 
 const NOW = 1_000_000;
 const STARTED = NOW - 25_000;
 
 function criterion(overrides: Partial<GroupActivationCriterion>): GroupActivationCriterion {
-    return {
-        mode: 'threshold-or-deadline',
-        successRate: 0.95,
-        minimumViableRate: 0.5,
-        deadlineMs: 20_000,
-        maxFormationAttempts: 3,
-        strictConfirmation: false,
-        ...overrides,
-    };
+  return {
+    mode: 'threshold-or-deadline',
+    successRate: 0.95,
+    minimumViableRate: 0.5,
+    deadlineMs: 20_000,
+    maxFormationAttempts: 3,
+    strictConfirmation: false,
+    ...overrides,
+  };
 }
 
-function evaluate(input: Readonly<{
+function evaluate(
+  input: Readonly<{
     activation: GroupActivationCriterion;
     observedRate: number;
     establishmentStartedAtEpochMs?: number | null;
     formationAttemptCount?: number;
     nowEpochMs?: number;
-}>) {
-    return evaluateGroupActivationCriterion({
-        establishmentStartedAtEpochMs: STARTED,
-        formationAttemptCount: 0,
-        nowEpochMs: NOW,
-        ...input,
-    });
+  }>,
+) {
+  return evaluateGroupActivationCriterion({
+    establishmentStartedAtEpochMs: STARTED,
+    formationAttemptCount: 0,
+    nowEpochMs: NOW,
+    ...input,
+  });
 }
 
 describe('evaluateGroupActivationCriterion', () => {
-    it('always waits in manual mode', () => {
-        expect(evaluate({
-            activation: criterion({ mode: 'manual', successRate: 0 }),
-            observedRate: 1,
-        })).toEqual({ decision: 'wait' });
-    });
+  it('always waits in manual mode', () => {
+    expect(
+      evaluate({
+        activation: criterion({ mode: 'manual', successRate: 0 }),
+        observedRate: 1,
+      }),
+    ).toEqual({ decision: 'wait' });
+  });
 
-    it('activates on threshold regardless of the deadline', () => {
-        for (const mode of ['threshold', 'threshold-or-deadline'] as const) {
-            expect(evaluate({
-                activation: criterion({ mode }),
-                observedRate: 0.95,
-                nowEpochMs: STARTED + 1,
-            })).toEqual({ decision: 'activate' });
-        }
-    });
+  it('activates on threshold regardless of the deadline', () => {
+    for (const mode of ['threshold', 'threshold-or-deadline'] as const) {
+      expect(
+        evaluate({
+          activation: criterion({ mode }),
+          observedRate: 0.95,
+          nowEpochMs: STARTED + 1,
+        }),
+      ).toEqual({ decision: 'activate' });
+    }
+  });
 
-    it('waits below threshold before the deadline', () => {
-        expect(evaluate({
-            activation: criterion({}),
-            observedRate: 0.9,
-            nowEpochMs: STARTED + 10_000,
-        })).toEqual({ decision: 'wait' });
-    });
+  it('waits below threshold before the deadline', () => {
+    expect(
+      evaluate({
+        activation: criterion({}),
+        observedRate: 0.9,
+        nowEpochMs: STARTED + 10_000,
+      }),
+    ).toEqual({ decision: 'wait' });
+  });
 
-    it('waits in pure threshold mode forever below the rate', () => {
-        expect(evaluate({
-            activation: criterion({ mode: 'threshold' }),
-            observedRate: 0.9,
-            nowEpochMs: STARTED + 1_000_000,
-        })).toEqual({ decision: 'wait' });
-    });
+  it('waits in pure threshold mode forever below the rate', () => {
+    expect(
+      evaluate({
+        activation: criterion({ mode: 'threshold' }),
+        observedRate: 0.9,
+        nowEpochMs: STARTED + 1_000_000,
+      }),
+    ).toEqual({ decision: 'wait' });
+  });
 
-    it('decides the three bands at the deadline', () => {
-        expect(evaluate({ activation: criterion({}), observedRate: 0.95 }))
-            .toEqual({ decision: 'activate' });
-        expect(evaluate({ activation: criterion({}), observedRate: 0.7 }))
-            .toEqual({ decision: 'activate-degraded' });
-        expect(evaluate({ activation: criterion({}), observedRate: 0.4 }))
-            .toEqual({ decision: 'below-floor', retryAllowed: true });
+  it('decides the three bands at the deadline', () => {
+    expect(evaluate({ activation: criterion({}), observedRate: 0.95 })).toEqual({
+      decision: 'activate',
     });
+    expect(evaluate({ activation: criterion({}), observedRate: 0.7 })).toEqual({
+      decision: 'activate-degraded',
+    });
+    expect(evaluate({ activation: criterion({}), observedRate: 0.4 })).toEqual({
+      decision: 'below-floor',
+      retryAllowed: true,
+    });
+  });
 
-    it('treats floor equal to success rate as all-or-nothing', () => {
-        const allOrNothing = criterion({ successRate: 1, minimumViableRate: 1, mode: 'deadline' });
-        expect(evaluate({ activation: allOrNothing, observedRate: 1 }))
-            .toEqual({ decision: 'activate' });
-        expect(evaluate({ activation: allOrNothing, observedRate: 0.94 }))
-            .toEqual({ decision: 'below-floor', retryAllowed: true });
+  it('treats floor equal to success rate as all-or-nothing', () => {
+    const allOrNothing = criterion({ successRate: 1, minimumViableRate: 1, mode: 'deadline' });
+    expect(evaluate({ activation: allOrNothing, observedRate: 1 })).toEqual({
+      decision: 'activate',
     });
+    expect(evaluate({ activation: allOrNothing, observedRate: 0.94 })).toEqual({
+      decision: 'below-floor',
+      retryAllowed: true,
+    });
+  });
 
-    it('stops allowing retries at maxFormationAttempts', () => {
-        expect(evaluate({
-            activation: criterion({}),
-            observedRate: 0,
-            formationAttemptCount: 2,
-        })).toEqual({ decision: 'below-floor', retryAllowed: false });
-    });
+  it('stops allowing retries at maxFormationAttempts', () => {
+    expect(
+      evaluate({
+        activation: criterion({}),
+        observedRate: 0,
+        formationAttemptCount: 2,
+      }),
+    ).toEqual({ decision: 'below-floor', retryAllowed: false });
+  });
 
-    it('waits without a deadline anchor even past any plausible deadline', () => {
-        expect(evaluate({
-            activation: criterion({ mode: 'deadline' }),
-            observedRate: 0,
-            establishmentStartedAtEpochMs: null,
-        })).toEqual({ decision: 'wait' });
-    });
+  it('waits without a deadline anchor even past any plausible deadline', () => {
+    expect(
+      evaluate({
+        activation: criterion({ mode: 'deadline' }),
+        observedRate: 0,
+        establishmentStartedAtEpochMs: null,
+      }),
+    ).toEqual({ decision: 'wait' });
+  });
 
-    it('never auto-activates on threshold in pure deadline mode', () => {
-        expect(evaluate({
-            activation: criterion({ mode: 'deadline' }),
-            observedRate: 1,
-            nowEpochMs: STARTED + 1,
-        })).toEqual({ decision: 'wait' });
-    });
+  it('never auto-activates on threshold in pure deadline mode', () => {
+    expect(
+      evaluate({
+        activation: criterion({ mode: 'deadline' }),
+        observedRate: 1,
+        nowEpochMs: STARTED + 1,
+      }),
+    ).toEqual({ decision: 'wait' });
+  });
 });
 
 describe('computeFormationRetryBackoffMs', () => {
-    it('escalates linearly with the attempt count and caps', () => {
-        expect(computeFormationRetryBackoffMs(1)).toBe(DEFAULT_FORMATION_RETRY_BACKOFF_MS);
-        expect(computeFormationRetryBackoffMs(3)).toBe(3 * DEFAULT_FORMATION_RETRY_BACKOFF_MS);
-        expect(computeFormationRetryBackoffMs(100)).toBe(MAX_FORMATION_RETRY_BACKOFF_MS);
-    });
+  it('escalates linearly with the attempt count and caps', () => {
+    expect(computeFormationRetryBackoffMs(1)).toBe(DEFAULT_FORMATION_RETRY_BACKOFF_MS);
+    expect(computeFormationRetryBackoffMs(3)).toBe(3 * DEFAULT_FORMATION_RETRY_BACKOFF_MS);
+    expect(computeFormationRetryBackoffMs(100)).toBe(MAX_FORMATION_RETRY_BACKOFF_MS);
+  });
 });

--- a/packages/tests/shared/group-formation-readiness.test.ts
+++ b/packages/tests/shared/group-formation-readiness.test.ts
@@ -2,126 +2,115 @@ import { describe, expect, it } from 'vitest';
 
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
-// prettier-ignore
 import {
-    computeGroupFormationReadiness,
-    DEFAULT_FORMATION_EVIDENCE_FRESHNESS_MS,
+  computeGroupFormationReadiness,
+  DEFAULT_FORMATION_EVIDENCE_FRESHNESS_MS,
 } from '@shared/api/group-lifecycle/compute-group-formation-readiness.ts';
 
 const NOW = 1_000_000;
 
 describe('computeGroupFormationReadiness', () => {
-    it('counts undirected planned edges once regardless of hop direction', () => {
-        // a-b appears in both directions, a-c in one: two planned edges.
-        const readiness = computeGroupFormationReadiness({
-            planned: planned({ a: ['b', 'c'], b: ['a'], c: [] }),
-            rttMeasurements: [],
-            nowEpochMs: NOW,
-        });
-        expect(readiness).toEqual({
-            plannedEdgeCount: 2,
-            observedEdgeCount: 0,
-            observedRate: 0,
-        });
+  it('counts undirected planned edges once regardless of hop direction', () => {
+    // a-b appears in both directions, a-c in one: two planned edges.
+    const readiness = computeGroupFormationReadiness({
+      planned: planned({ a: ['b', 'c'], b: ['a'], c: [] }),
+      rttMeasurements: [],
+      nowEpochMs: NOW,
     });
+    expect(readiness).toEqual({
+      plannedEdgeCount: 2,
+      observedEdgeCount: 0,
+      observedRate: 0,
+    });
+  });
 
-    it('counts evidence in either direction toward the same edge', () => {
-        const readiness = computeGroupFormationReadiness({
-            planned: planned({ a: ['b', 'c'], b: [], c: [] }),
-            rttMeasurements: [
-                measurement('b', 'a', NOW - 10),
-                measurement('a', 'b', NOW - 20),
-            ],
-            nowEpochMs: NOW,
-        });
-        expect(readiness).toEqual({
-            plannedEdgeCount: 2,
-            observedEdgeCount: 1,
-            observedRate: 0.5,
-        });
+  it('counts evidence in either direction toward the same edge', () => {
+    const readiness = computeGroupFormationReadiness({
+      planned: planned({ a: ['b', 'c'], b: [], c: [] }),
+      rttMeasurements: [measurement('b', 'a', NOW - 10), measurement('a', 'b', NOW - 20)],
+      nowEpochMs: NOW,
     });
+    expect(readiness).toEqual({
+      plannedEdgeCount: 2,
+      observedEdgeCount: 1,
+      observedRate: 0.5,
+    });
+  });
 
-    it('ignores stale evidence beyond the freshness window', () => {
-        const readiness = computeGroupFormationReadiness({
-            planned: planned({ a: ['b'] }),
-            rttMeasurements: [
-                measurement('a', 'b', NOW - DEFAULT_FORMATION_EVIDENCE_FRESHNESS_MS - 1),
-            ],
-            nowEpochMs: NOW,
-        });
-        expect(readiness.observedEdgeCount).toBe(0);
+  it('ignores stale evidence beyond the freshness window', () => {
+    const readiness = computeGroupFormationReadiness({
+      planned: planned({ a: ['b'] }),
+      rttMeasurements: [measurement('a', 'b', NOW - DEFAULT_FORMATION_EVIDENCE_FRESHNESS_MS - 1)],
+      nowEpochMs: NOW,
     });
+    expect(readiness.observedEdgeCount).toBe(0);
+  });
 
-    it('honours an explicit freshness window', () => {
-        const readiness = computeGroupFormationReadiness({
-            planned: planned({ a: ['b'] }),
-            rttMeasurements: [measurement('a', 'b', NOW - 5_000)],
-            nowEpochMs: NOW,
-            evidenceFreshnessMs: 4_000,
-        });
-        expect(readiness.observedEdgeCount).toBe(0);
+  it('honours an explicit freshness window', () => {
+    const readiness = computeGroupFormationReadiness({
+      planned: planned({ a: ['b'] }),
+      rttMeasurements: [measurement('a', 'b', NOW - 5_000)],
+      nowEpochMs: NOW,
+      evidenceFreshnessMs: 4_000,
     });
+    expect(readiness.observedEdgeCount).toBe(0);
+  });
 
-    it('ignores evidence for unplanned edges and self-loops', () => {
-        const readiness = computeGroupFormationReadiness({
-            planned: planned({ a: ['b', 'a'] }),
-            rttMeasurements: [
-                measurement('a', 'z', NOW - 10),
-                measurement('a', 'b', NOW - 10),
-            ],
-            nowEpochMs: NOW,
-        });
-        expect(readiness).toEqual({
-            plannedEdgeCount: 1,
-            observedEdgeCount: 1,
-            observedRate: 1,
-        });
+  it('ignores evidence for unplanned edges and self-loops', () => {
+    const readiness = computeGroupFormationReadiness({
+      planned: planned({ a: ['b', 'a'] }),
+      rttMeasurements: [measurement('a', 'z', NOW - 10), measurement('a', 'b', NOW - 10)],
+      nowEpochMs: NOW,
     });
+    expect(readiness).toEqual({
+      plannedEdgeCount: 1,
+      observedEdgeCount: 1,
+      observedRate: 1,
+    });
+  });
 
-    it('treats an edgeless or removed plan as trivially ready', () => {
-        expect(
-            computeGroupFormationReadiness({
-                planned: planned({}),
-                rttMeasurements: [],
-                nowEpochMs: NOW,
-            }).observedRate,
-        ).toBe(1);
-        expect(
-            computeGroupFormationReadiness({
-                planned: { ...planned({ a: ['b'] }), state: 'removed' },
-                rttMeasurements: [measurement('a', 'b', NOW - 1)],
-                nowEpochMs: NOW,
-            }),
-        ).toEqual({ plannedEdgeCount: 0, observedEdgeCount: 0, observedRate: 1 });
-    });
+  it('treats an edgeless or removed plan as trivially ready', () => {
+    expect(
+      computeGroupFormationReadiness({
+        planned: planned({}),
+        rttMeasurements: [],
+        nowEpochMs: NOW,
+      }).observedRate,
+    ).toBe(1);
+    expect(
+      computeGroupFormationReadiness({
+        planned: { ...planned({ a: ['b'] }), state: 'removed' },
+        rttMeasurements: [measurement('a', 'b', NOW - 1)],
+        nowEpochMs: NOW,
+      }),
+    ).toEqual({ plannedEdgeCount: 0, observedEdgeCount: 0, observedRate: 1 });
+  });
 });
 
-function planned(
-    nextHopsBySessionId: Readonly<Record<string, readonly string[]>>,
-): RallarOverlayTopologySnapshot {
-    return {
-        sourceGroupStateCausalRevision: { groupRevision: 1, presenceRevision: 0 },
-        state: 'active',
-        overlayId: 'overlay-1',
-        groupRef: { applicationId: 'app-1', workspaceId: 'workspace-1', groupId: 'room-1' },
-        name: 'Room 1',
-        topology: 'mesh',
-        activeSessionIds: Object.keys(nextHopsBySessionId),
-        nextHopsBySessionId,
-        degreeLimit: 8,
-        version: 1,
-        createdByClientId: 'server',
-        createdAtEpochMs: NOW - 100,
-        updatedAtEpochMs: NOW - 100,
-    };
+function planned(nextHopsBySessionId: Readonly<Record<string, readonly string[]>>): RallarOverlayTopologySnapshot {
+  return {
+    sourceGroupStateCausalRevision: { groupRevision: 1, presenceRevision: 0 },
+    state: 'active',
+    overlayId: 'overlay-1',
+    groupRef: { applicationId: 'app-1', workspaceId: 'workspace-1', groupId: 'room-1' },
+    name: 'Room 1',
+    topology: 'mesh',
+    activeSessionIds: Object.keys(nextHopsBySessionId),
+    nextHopsBySessionId,
+    degreeLimit: 8,
+    version: 1,
+    createdByClientId: 'server',
+    createdAtEpochMs: NOW - 100,
+    updatedAtEpochMs: NOW - 100,
+  };
 }
 
 function measurement(from: string, to: string, createdAtEpochMs: number): RttMeasurementInfo {
-    return {
-        sessionIdFrom: from,
-        sessionIdTo: to,
-        rttMs: 20,
-        createdAtEpochMs,
-        version: 1,
-    };
+  return {
+    sessionIdFrom: from,
+    sessionIdTo: to,
+    rttMs: 20,
+    createdAtEpochMs,
+    version: 1,
+  };
 }

--- a/packages/tests/shared/group-lifecycle-managers.test.ts
+++ b/packages/tests/shared/group-lifecycle-managers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import type { GroupManagerPolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-// prettier-ignore
 import {
   resolveGroupLifecycleManagers,
   type ResolveGroupLifecycleManagersInput,
@@ -20,9 +19,7 @@ function managerPolicy(overrides: Partial<GroupManagerPolicy> = {}): GroupManage
   };
 }
 
-function resolutionInput(
-  overrides: Partial<ResolveGroupLifecycleManagersInput> = {},
-): ResolveGroupLifecycleManagersInput {
+function resolutionInput(overrides: Partial<ResolveGroupLifecycleManagersInput> = {}): ResolveGroupLifecycleManagersInput {
   return {
     manager: managerPolicy(),
     ownerPrincipalId: 'owner',
@@ -54,9 +51,7 @@ describe('group lifecycle manager resolution', () => {
   it('resolves the creator while active and leaves a hole without succession', () => {
     const input = resolutionInput({ manager: managerPolicy({ selection: 'creator' }) });
     expect(resolveGroupLifecycleManagers(input)).toEqual(['owner']);
-    expect(
-      resolveGroupLifecycleManagers({ ...input, activePrincipalIds: new Set(['bob']) }),
-    ).toEqual([]);
+    expect(resolveGroupLifecycleManagers({ ...input, activePrincipalIds: new Set(['bob']) })).toEqual([]);
   });
 
   it('continues the creator into the election ranking under next-by-selection', () => {
@@ -68,20 +63,16 @@ describe('group lifecycle manager resolution', () => {
         activePrincipalIds: new Set(['bob', 'carol', 'dave']),
       }),
     );
-    const successor = expectedElectionOrder(electorate, 1).filter(
-      (principalId) => principalId !== 'owner',
-    )[0];
+    const successor = expectedElectionOrder(electorate, 1).filter((principalId) => principalId !== 'owner')[0];
     expect(managers).toEqual([successor]);
   });
 
   it('keeps assigned order and lets succession decide whether holes fill', () => {
     const manager = managerPolicy({ selection: 'assigned', assignedPrincipalIds: ['a', 'b', 'c'] });
     const active = new Set(['b', 'c']);
-    expect(
-      resolveGroupLifecycleManagers(
-        resolutionInput({ manager: { ...manager, count: 2 }, activePrincipalIds: active }),
-      ),
-    ).toEqual(['b']);
+    expect(resolveGroupLifecycleManagers(resolutionInput({ manager: { ...manager, count: 2 }, activePrincipalIds: active }))).toEqual([
+      'b',
+    ]);
     expect(
       resolveGroupLifecycleManagers(
         resolutionInput({
@@ -145,9 +136,7 @@ describe('group lifecycle manager resolution', () => {
       activePrincipalIds: new Set(electorate),
     });
     expect(resolveGroupLifecycleManagers(input)).toEqual(expectedElectionOrder(electorate, 1));
-    expect(resolveGroupLifecycleManagers({ ...input, formationEpoch: 2 })).toEqual(
-      expectedElectionOrder(electorate, 2),
-    );
+    expect(resolveGroupLifecycleManagers({ ...input, formationEpoch: 2 })).toEqual(expectedElectionOrder(electorate, 2));
   });
 
   it('ranks elected-by-rank by the supplied source and resolves nobody without one', () => {

--- a/packages/tests/shared/group-lifecycle-transitions.test.ts
+++ b/packages/tests/shared/group-lifecycle-transitions.test.ts
@@ -1,83 +1,68 @@
 import { describe, expect, it } from 'vitest';
 
-// prettier-ignore
-import {
-    computeGroupLifecycleTransition,
-    type GroupLifecycleTransition,
-} from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
+import { computeGroupLifecycleTransition, type GroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 
-const STATES: readonly GroupLifecycleState[] = [
-    'forming',
-    'establishing',
-    'active',
-    'reconfiguring',
-];
+const STATES: readonly GroupLifecycleState[] = ['forming', 'establishing', 'active', 'reconfiguring'];
 
 // The complete machine: every cell is either the one allowed target or denied.
 const ALLOWED_CELLS: ReadonlyArray<{
-    transition: GroupLifecycleTransition;
-    from: GroupLifecycleState;
-    to: GroupLifecycleState;
+  transition: GroupLifecycleTransition;
+  from: GroupLifecycleState;
+  to: GroupLifecycleState;
 }> = [
-    { transition: 'start-establishment', from: 'forming', to: 'establishing' },
-    { transition: 'activate', from: 'establishing', to: 'active' },
-    { transition: 'activate', from: 'reconfiguring', to: 'active' },
-    { transition: 'reopen-establishment', from: 'active', to: 'reconfiguring' },
+  { transition: 'start-establishment', from: 'forming', to: 'establishing' },
+  { transition: 'activate', from: 'establishing', to: 'active' },
+  { transition: 'activate', from: 'reconfiguring', to: 'active' },
+  { transition: 'reopen-establishment', from: 'active', to: 'reconfiguring' },
 ];
 
 describe('computeGroupLifecycleTransition', () => {
-    it('accepts exactly the four legal cells and advances the epoch on each', () => {
-        for (const cell of ALLOWED_CELLS) {
-            const outcome = computeGroupLifecycleTransition({
-                transition: cell.transition,
-                lifecycleState: cell.from,
-                formationEpoch: 6,
-            });
-            expect(outcome).toEqual({
-                allowed: true,
-                nextState: cell.to,
-                nextFormationEpoch: 7,
-            });
-        }
-    });
+  it('accepts exactly the four legal cells and advances the epoch on each', () => {
+    for (const cell of ALLOWED_CELLS) {
+      const outcome = computeGroupLifecycleTransition({
+        transition: cell.transition,
+        lifecycleState: cell.from,
+        formationEpoch: 6,
+      });
+      expect(outcome).toEqual({
+        allowed: true,
+        nextState: cell.to,
+        nextFormationEpoch: 7,
+      });
+    }
+  });
 
-    it('denies every other cell as lifecycle-transition-invalid', () => {
-        const transitions: readonly GroupLifecycleTransition[] = [
-            'start-establishment',
-            'activate',
-            'reopen-establishment',
-        ];
-        let denied = 0;
-        for (const transition of transitions) {
-            for (const from of STATES) {
-                if (ALLOWED_CELLS.some(
-                    (cell) => cell.transition === transition && cell.from === from,
-                )) continue;
-                const outcome = computeGroupLifecycleTransition({
-                    transition,
-                    lifecycleState: from,
-                    formationEpoch: 3,
-                });
-                expect(outcome).toMatchObject({
-                    allowed: false,
-                    code: 'lifecycle-transition-invalid',
-                });
-                denied += 1;
-            }
-        }
-        expect(denied).toBe(8);
-    });
-
-    it('reports the offending transition and state in the denial details', () => {
+  it('denies every other cell as lifecycle-transition-invalid', () => {
+    const transitions: readonly GroupLifecycleTransition[] = ['start-establishment', 'activate', 'reopen-establishment'];
+    let denied = 0;
+    for (const transition of transitions) {
+      for (const from of STATES) {
+        if (ALLOWED_CELLS.some((cell) => cell.transition === transition && cell.from === from)) continue;
         const outcome = computeGroupLifecycleTransition({
-            transition: 'activate',
-            lifecycleState: 'forming',
-            formationEpoch: 0,
+          transition,
+          lifecycleState: from,
+          formationEpoch: 3,
         });
         expect(outcome).toMatchObject({
-            allowed: false,
-            details: { transition: 'activate', lifecycleState: 'forming' },
+          allowed: false,
+          code: 'lifecycle-transition-invalid',
         });
+        denied += 1;
+      }
+    }
+    expect(denied).toBe(8);
+  });
+
+  it('reports the offending transition and state in the denial details', () => {
+    const outcome = computeGroupLifecycleTransition({
+      transition: 'activate',
+      lifecycleState: 'forming',
+      formationEpoch: 0,
     });
+    expect(outcome).toMatchObject({
+      allowed: false,
+      details: { transition: 'activate', lifecycleState: 'forming' },
+    });
+  });
 });

--- a/scripts/distributed-validation-risk.mjs
+++ b/scripts/distributed-validation-risk.mjs
@@ -3,18 +3,9 @@
 import { appendFileSync } from 'node:fs';
 import path from 'node:path';
 
-// prettier-ignore
-import {
-  classifyDistributedValidationRisk,
-} from './distributed-validation-risk/distributed-validation-risk.mjs';
-// prettier-ignore
-import {
-  validateDistributedValidationResult,
-} from './distributed-validation-risk/distributed-validation-result.mjs';
-// prettier-ignore
-import {
-  readChangedPathRecords,
-} from './distributed-validation-risk/read-distributed-validation-input.mjs';
+import { classifyDistributedValidationRisk } from './distributed-validation-risk/distributed-validation-risk.mjs';
+import { validateDistributedValidationResult } from './distributed-validation-risk/distributed-validation-result.mjs';
+import { readChangedPathRecords } from './distributed-validation-risk/read-distributed-validation-input.mjs';
 
 await runDistributedValidationRiskCommand(process.argv.slice(2));
 

--- a/scripts/governance-decisions.mjs
+++ b/scripts/governance-decisions.mjs
@@ -4,12 +4,8 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 import { toCanonicalJson } from './governance-decisions/canonical-json.mjs';
-// prettier-ignore
-import { verifyGovernanceDecisionCommit } from
-  './governance-decisions/governance-decision-commit-verification.mjs';
-// prettier-ignore
-import { decodeGovernanceDecisionCommand } from
-  './governance-decisions/governance-decision-command.mjs';
+import { verifyGovernanceDecisionCommit } from './governance-decisions/governance-decision-commit-verification.mjs';
+import { decodeGovernanceDecisionCommand } from './governance-decisions/governance-decision-command.mjs';
 import {
   createGovernanceDecisionReceipt,
   serializeGovernanceDecisionReceipt,
@@ -18,12 +14,8 @@ import {
   trustedGovernanceAppSlug,
   verifyPublishedGovernanceDecisionCommit,
 } from './governance-decisions/governance-decision-remote-verification.mjs';
-// prettier-ignore
-import { decodeGovernanceDecisionRequest } from
-  './governance-decisions/governance-decision-request.mjs';
-// prettier-ignore
-import { computeGovernanceDecisionTransition } from
-  './governance-decisions/governance-decision-transition.mjs';
+import { decodeGovernanceDecisionRequest } from './governance-decisions/governance-decision-request.mjs';
+import { computeGovernanceDecisionTransition } from './governance-decisions/governance-decision-transition.mjs';
 import { createGitHubGovernanceApi } from './governance-decisions/github-governance-api.mjs';
 import {
   authenticateGitHubAdministrator,

--- a/scripts/governance-decisions/governance-decision-receipt-index.mjs
+++ b/scripts/governance-decisions/governance-decision-receipt-index.mjs
@@ -3,14 +3,10 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { readChangedPathsBetweenRevisions } from '../repository-changes/read-git-changes.mjs';
 import { verifyGovernanceDecisionCommit } from './governance-decision-commit-verification.mjs';
 import { decodeGovernanceDecisionReceipt } from './governance-decision-receipt.mjs';
-// prettier-ignore
-import { verifyHistoricalGovernanceDecisionCommit } from
-  './governance-decision-remote-verification.mjs';
+import { verifyHistoricalGovernanceDecisionCommit } from './governance-decision-remote-verification.mjs';
 import { readGitRepositorySnapshot } from './git-repository-snapshot.mjs';
 import { createGitHubGovernanceApi } from './github-governance-api.mjs';
-// prettier-ignore
-import { verifyGovernanceDecisionAdmission } from
-  './governance-decision-admission-verification.mjs';
+import { verifyGovernanceDecisionAdmission } from './governance-decision-admission-verification.mjs';
 
 const receiptPathPattern = /^governance\/decisions\/([0-9a-f]{64})\.json$/u;
 const gitObjectIdPattern = /^[0-9a-f]{40}$/u;

--- a/scripts/perf/state-write/api-v1-state-write-regression-reasons.ts
+++ b/scripts/perf/state-write/api-v1-state-write-regression-reasons.ts
@@ -1,6 +1,4 @@
-// prettier-ignore
-import type { StateWriteBenchmarkRegressionReason } from
-  './api-v1-state-write-benchmark-artifact.ts';
+import type { StateWriteBenchmarkRegressionReason } from './api-v1-state-write-benchmark-artifact.ts';
 
 const DURABLE_APPEND_RESOURCE_REASON =
   'Atomic RTC topology publication now executes one durable per-process stream ' +

--- a/scripts/plan-adaptation/plan-governance-receipt.mjs
+++ b/scripts/plan-adaptation/plan-governance-receipt.mjs
@@ -1,12 +1,8 @@
 import { execFileSync } from 'node:child_process';
 
-// prettier-ignore
-import { verifyGovernanceDecisionCommit } from
-  '../governance-decisions/governance-decision-commit-verification.mjs';
+import { verifyGovernanceDecisionCommit } from '../governance-decisions/governance-decision-commit-verification.mjs';
 import { createGitHubGovernanceApi } from '../governance-decisions/github-governance-api.mjs';
-// prettier-ignore
-import { verifyGovernanceDecisionAdmission } from
-  '../governance-decisions/governance-decision-admission-verification.mjs';
+import { verifyGovernanceDecisionAdmission } from '../governance-decisions/governance-decision-admission-verification.mjs';
 import { readGitRepositorySnapshot } from '../governance-decisions/git-repository-snapshot.mjs';
 import { readChangedPathsBetweenRevisions } from '../repository-changes/read-git-changes.mjs';
 import { parseAdaptivePlanRecord } from './adaptive-plan-record.mjs';

--- a/scripts/pull-request-delivery.mjs
+++ b/scripts/pull-request-delivery.mjs
@@ -121,10 +121,8 @@ function readActionDetail(action, pullRequest) {
     case 'STOP_CLOSED':
       return 'Blocker: The pull request is closed without merge.';
     case 'DONE':
-      // prettier-ignore
       return (
-        'Terminal: GitHub reports this pull request merged; ' +
-        'no governance action is permitted.'
+        'Terminal: GitHub reports this pull request merged; ' + 'no governance action is permitted.'
       );
     case 'STOP_WRONG_BASE':
       return 'Blocker: The pull request does not target the repository default branch.';

--- a/scripts/repo-style-check/repository-scan.mjs
+++ b/scripts/repo-style-check/repository-scan.mjs
@@ -90,6 +90,8 @@ const limits = {
   // production number carries, so a cohesive suite is not split to satisfy a production shape.
   testFileLineCount: 1500,
   lineWidth: 100,
+  declarationWidth: 140,
+  testLineWidth: 140,
   handlerLineCount: 30,
   handlerComplexity: 8,
   factoryBlockLineCount: 45,
@@ -202,6 +204,23 @@ function isAmbientDeclarationFile(file) {
   return /\.d\.[cm]?ts$/u.test(file.toLowerCase());
 }
 
+const specifierOnlyPattern = /^\s*(?:import|export)\s*['"`][^'"`]+['"`];?\s*$/u;
+const specifierFromPattern = /^\s*(?:import|export)\b[^'"`]*from\s*['"`][^'"`]+['"`];?\s*$/u;
+
+function isModuleSpecifierLine(text) {
+  return specifierFromPattern.test(text) || specifierOnlyPattern.test(text);
+}
+
+const declarationHeaderPattern =
+  /^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?(?:function|interface)\b/u;
+
+function resolveLineWidth(text, file) {
+  if (isNonProductionPath(file)) {
+    return limits.testLineWidth;
+  }
+  return declarationHeaderPattern.test(text) ? limits.declarationWidth : limits.lineWidth;
+}
+
 function addFileMeasurementFindings(findings, sourceText) {
   const { lines } = sourceText;
   const navigationLength = resolveNavigationFileLength(sourceText);
@@ -219,12 +238,13 @@ function addFileMeasurementFindings(findings, sourceText) {
 
   const longLines = lines
     .map((text, index) => ({ line: index + 1, text }))
-    .filter((line) => line.text.length > limits.lineWidth);
+    .filter((line) => !isModuleSpecifierLine(line.text))
+    .filter((line) => line.text.length > resolveLineWidth(line.text, sourceText.file));
   for (const line of longLines.slice(0, 8)) {
     findings.push(
       finding(
         'line.width',
-        `Line ${line.line} exceeds ${limits.lineWidth} chars ` +
+        `Line ${line.line} exceeds ${resolveLineWidth(line.text, sourceText.file)} chars ` +
           `(actual ${line.text.length}). Prefer wrapped, traceable formatting.`,
       ),
     );
@@ -381,9 +401,7 @@ export function isTestSourceFile(file) {
   if (isTestRunnerConfigFile(base)) {
     return false;
   }
-  if (
-    parts.some((part) => part === 'node_modules' || generatedPathPartPattern.test(part))
-  ) {
+  if (parts.some((part) => part === 'node_modules' || generatedPathPartPattern.test(part))) {
     return false;
   }
   return !(

--- a/scripts/validation-evidence.mjs
+++ b/scripts/validation-evidence.mjs
@@ -138,7 +138,9 @@ function readOptions(arguments_) {
   for (let index = 0; index < arguments_.length; index += 2) {
     const name = arguments_[index];
     const value = arguments_[index + 1];
-    if (!name.startsWith('--') || value === '' || options.has(name)) {
+    // An empty value is data, not a malformed argument: GitHub Actions yields '' for the output
+    // of a job that never ran. Let it through so the validators can report the real cause.
+    if (!name.startsWith('--') || value === undefined || options.has(name)) {
       throw new Error(`invalid option: ${name}`);
     }
     options.set(name, value);

--- a/scripts/validation-evidence/branch-release-result.mjs
+++ b/scripts/validation-evidence/branch-release-result.mjs
@@ -5,6 +5,23 @@ export function validateBranchReleaseConclusion({
   releaseResult,
   publicationResult,
 }) {
+  // A cancelled upstream job leaves its result and every output it feeds empty, so the checks
+  // below would report a chain of derived failures instead of the one fact that matters.
+  // A superseding run decides the branch; this one has nothing to conclude.
+  const cancelledJobs = [
+    ['Governance Gate', governanceResult],
+    ['validation-evidence selection', selectionResult],
+    ['broad Release Gate', releaseResult],
+    ['validation-evidence publication', publicationResult],
+  ].filter(([, result]) => result === 'cancelled');
+  if (cancelledJobs.length > 0) {
+    return [
+      `run cancelled before it could conclude (${cancelledJobs
+        .map(([name]) => name)
+        .join(', ')}); a superseding run decides this branch`,
+    ];
+  }
+
   const issues = [];
   if (governanceResult !== 'success') {
     issues.push('Governance Gate did not succeed');


### PR DESCRIPTION
Two changes: a cancelled-run reporting fix, and a line-width rule that measures by line kind. They share a branch because the second is what makes 495 formatter workarounds removable.

## Line width by kind

| Line kind | Measured at |
| --- | --- |
| Code | **100** (unchanged) |
| Module specifier (`import`/`export … from '…'`) | **not measured** |
| `function` / `interface` declaration header | **140** |
| Anything in a test path | **140** |

**Specifiers can't be wrapped** — their length is the path, and a formatter honouring the same width leaves them intact. Measured across the repo: 1,549 specifier lines exceed 100, the longest is 197, and 663 of the 818 under `packages/tests` were *already* alias-prefixed, so no further alias would shorten them. Import depth is a real signal, but the layout rules own it.

**Declaration headers** are measured at 140 because their length is the names they declare. The two offenders that forced this were public exports whose names cannot change without a breaking change. Naming is owned by the type-organization rules.

**`.prettierrc.json` now gives test files `printWidth: 140`**, matching the checker. The two tools were pulling in opposite directions; now the formatter reformats toward the limit the checker applies.

## 495 `// prettier-ignore` comments removed

They existed to hand-break imports across two lines so they fit under 100 — a shape the formatter undoes, and that reads worse than the line it avoided. Removing them and running the formatter leaves **4**, in 3 files:

- Two `expectTypeOf` assertions whose **two-link chain the formatter will not break at any width** (Prettier's member-chain heuristic needs ~3 links) and whose type names appear twice on the line.
- Two files whose hand-broken import blocks shifted 40–60 lines when joined, invalidating their structure-coupling registry entries. Left untouched rather than performing registry surgery for a formatting change.

The 38 comments explaining the workaround go with them.

**The formatter was not run across the rest of the test tree.** At 140 it would have reformatted 1,045 files and buried this change; those migrate as they are touched.

## On what Prettier can do here

Worth recording, since it came up: **Prettier has no custom-rule API.** Its options are a fixed set; plugins define printers for new languages, not new formatting rules for TypeScript. It can never break a long string literal (so a long `it('…')` name is unfixable by any setting), and it won't break a two-link member chain. The one lever that helps is `overrides` — per-glob `printWidth` — which is what this PR uses for test files.

## Cancelled runs no longer report as failures

A superseded Branch Release Gate failed with `invalid option: --reuse`, naming neither the cancellation nor the real problem. Two defects:

- The option reader treated an empty value as malformed. An empty value is *data* — GitHub Actions yields `''` for the output of a job that never ran.
- With that fixed, the conclusion would have reported three derived symptoms of one cancelled run and none of the cause. It now recognises cancelled jobs first and returns a single issue naming them.

Verified against the exact invocation from the run that failed.

## Verification

`typecheck` exit 0 · `test:repo-governance` 361 passed · `check:repo-style:changed` PASS · `check-test-structure-coupling --changed` PASS (all 10 candidates classified, registry current).

`test:unit` reports 3 failures — **all pre-existing on `origin/main`**, confirmed by running them on a clean checkout. `mutation-route-owner-analysis` expects 54 entrypoints where #297 made 56, and `group-lifecycle-safety-baseline` fails on a join write. Main is currently red independently of this branch.

Three governance tests were updated rather than deleted: the checker fixture now uses a line that exceeds the test width, and the capability source snapshot has separate readers for raw width (pinning a base commit) and enforced width (asserting a current file carries no finding), so a rule change cannot move a historical snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)