### PR TITLE
Name the affected member in member event payloads

### DIFF
--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
@@ -56,6 +56,7 @@ export interface NewGroupEventInput {
   readonly causalRevision: GroupStateCausalRevision;
   readonly command: GroupMutationCommand;
   readonly facts: GroupMutationFacts;
+  readonly members: readonly GroupMember[];
 }
 
 export function materializedRotateJoinCode(
@@ -86,6 +87,7 @@ export function computeGroupMutationWriteResult(
     causalRevision,
     command,
     facts,
+    members: input.members,
   });
   const summaryOutboxEntries =
     input.presenceSummaryWork === 'none'
@@ -283,6 +285,27 @@ export function newGroupEvent(input: NewGroupEventInput): GroupEvent {
     reason: command.input.reason,
     traceId: command.input.traceId,
     requestId: command.requestId,
-    payload: {},
+    payload: toGroupEventPayload(eventType, input.members),
   };
+}
+
+// The actor is whoever issued the command, so a member event must name the
+// member it is about itself: a manager's grant emits member-joined with the
+// manager as actor and the admitted member only here.
+function toGroupEventPayload(
+  eventType: GroupEventType,
+  members: readonly GroupMember[],
+): GroupEvent['payload'] {
+  if (eventType === 'ownership-transferred') {
+    const nextOwner = members.find((member) => member.role === 'owner');
+    const previousOwner = members.find((member) => member.role !== 'owner');
+    return {
+      ...(previousOwner ? { fromPrincipalId: previousOwner.principalId } : {}),
+      ...(nextOwner ? { toPrincipalId: nextOwner.principalId } : {}),
+    };
+  }
+  if (eventType.startsWith('member-') && members.length === 1) {
+    return { principalId: members[0].principalId };
+  }
+  return {};
 }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
@@ -397,7 +397,10 @@
         "body": [
           {
             "eventType": "member-joined",
-            "requestId": "grant-bob-{runId}"
+            "requestId": "grant-bob-{runId}",
+            "payload": {
+              "principalId": "{bobClientId}"
+            }
           }
         ]
       }

--- a/packages/tests/shared-server/group-state/mutation/group-admission-mutation.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-admission-mutation.test.ts
@@ -127,6 +127,46 @@ describe('group admission mutation', () => {
     expect(await memberStatus(runtime, 'non-manager-room', 'carol')).toBe('pending');
   });
 
+  it('names the affected member in member event payloads', async () => {
+    const runtime = new FakeRuntimeStateRepository();
+    await seedManagedGroup(runtime, 'event-payload-room');
+    const service = createService(runtime, 2_000);
+
+    await service.joinGroup(SCOPE, 'event-payload-room', {
+      actorPrincipalId: 'bob',
+      requestId: 'park-bob-events',
+    });
+    await service.grantGroupAdmission(SCOPE, 'event-payload-room', 'bob', {
+      actorPrincipalId: 'alice',
+      requestId: 'grant-bob-events',
+    });
+    await service.transferGroupOwnership(SCOPE, 'event-payload-room', {
+      newOwnerPrincipalId: 'bob',
+      actorPrincipalId: 'alice',
+      requestId: 'transfer-to-bob-events',
+    });
+
+    const events = await new GroupStateRepository(runtime).listEvents(
+      groupRef('event-payload-room'),
+    );
+    const byRequestId = (requestId: string) =>
+      events.find((event) => event.requestId === requestId);
+    expect(byRequestId('park-bob-events')).toMatchObject({
+      eventType: 'member-admission-requested',
+      payload: { principalId: 'bob' },
+    });
+    // The actor is the manager who granted; the payload names who joined.
+    expect(byRequestId('grant-bob-events')).toMatchObject({
+      eventType: 'member-joined',
+      actor: { principalId: 'alice' },
+      payload: { principalId: 'bob' },
+    });
+    expect(byRequestId('transfer-to-bob-events')).toMatchObject({
+      eventType: 'ownership-transferred',
+      payload: { fromPrincipalId: 'alice', toPrincipalId: 'bob' },
+    });
+  });
+
   it('re-checks the admission window at grant time, not at parking time', async () => {
     const runtime = new FakeRuntimeStateRepository();
     await seedManagedGroup(runtime, 'window-room', {

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -235,8 +235,11 @@ aggregate has carried the lifecycle fields in every group response since slice 2
 `strict-confirmation` negative recipe.* The design document's ten named
 scenarios land as black-box recipes at the 6/20/50 tiers where scale matters.
 
-`strict-confirmation` becomes a negative test in v1: setting `strictConfirmation: true` returns the
-typed unsupported rejection.
+`strict-confirmation` becomes a negative test in v1: setting `strictConfirmation: true` is rejected
+at creation and nothing persists. *Amended during 6a (decision with the product owner, 2026-08-20):
+the rejection on the wire is the generic `400 app-inbox-malformed-command` — the typed issue code
+exists only at the validation layer. The recipes pin the generic contract; typing the HTTP surface
+is an explicit deferred item below.*
 
 #### Decisions taken during slice 6 planning (2026-08-20)
 
@@ -252,6 +255,10 @@ eight partial, one uncovered, with every missing pin named.
 
 ## Deferred, explicitly
 
+- **Typed policy-validity rejections over HTTP.** Every incoherent-policy create returns the
+  generic `400 app-inbox-malformed-command`; the issue codes (`strict-confirmation-unsupported`,
+  `manager-initiator-without-manager`, …) never reach the response. Deferred at 6a until an
+  application needs to distinguish them — the HTTP twin of the WS NACK opacity in decision 6.2.
 - **Per-edge confirm-or-fail batch machinery** — the whole activation design. Gated behind
   `strictConfirmation: true`, which v1 rejects. The posture decision (observed convergence as
   default) is recorded product-owner decision 2 and is supported by the Phase 0–4 evidence in


### PR DESCRIPTION
Stacked on #305 (base: `slice-6-scenario-matrix`). Implements the product-owner decision from
the 6a observability findings: member events must name the member they are about.

## What changed

- `newGroupEvent` derives the event payload from the mutated member rows
  (`toGroupEventPayload` in `group-mutation-result.ts`): every `member-*` event carries
  `payload.principalId` of the affected member, and `ownership-transferred` carries
  `fromPrincipalId`/`toPrincipalId`. The actor stays the command issuer — a manager's grant
  emits `member-joined` with the manager as actor and the admitted member in the payload.
  All other events (group, session, lifecycle) keep an empty payload. No contract-shape
  change: `GroupEvent.payload` was already an open record, so this is purely additive for
  readers.
- Unit pin in `group-admission-mutation.test.ts`: park, grant, and transfer events name the
  affected member (park names bob, grant has actor alice + payload bob, transfer names
  alice→bob).
- The `grantEmitsMemberJoined` black-box pin now asserts `payload.principalId` end to end.
- Plan amendment (decided 2026-08-20): the slice-6 `strict-confirmation` wording now records
  that the on-wire rejection is the generic `400 app-inbox-malformed-command`, and typing the
  HTTP validity surface is an explicit deferred item.

## Verification

- Typecheck + tests-typecheck ratchet: PASS.
- Focused mutation/event suites: 28/28.
- Full vitest: 884 files / 7,807 tests passed. Full Deno: 0 failed.
- Black-box: extended approval recipe 30/30 against a fresh local server; full
  `api-v1-black-box-cluster` on Postgres via the managed runner: 12/12.
- **Medium-scale gate** (mutation-path change): `api-v1-state-medium-scale-churn`
  2,748/2,748 steps, PASSED.
- Changed-style gate: PASS (a first run flagged `boundary.unknown` on a
  `Record<string, unknown>` return annotation; the helper now returns
  `GroupEvent['payload']`, which is the honest type anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
