### PR TITLE
Petition the activation criterion from refinement-deferred RTT work

### DIFF
--- a/packages/shared-server/rallar-system/topology/replay/compute-formation-criterion-command.ts
+++ b/packages/shared-server/rallar-system/topology/replay/compute-formation-criterion-command.ts
@@ -11,6 +11,13 @@ import {
 } from '../../group-state/group-formation-mutation-command.ts';
 import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
 import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
+import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
+
+import type { RtcTopologyExecutionRepository } from '../../repositories/RtcTopologyExecutionRepository.ts';
+import type { GroupTopologyPlanningAuthority } from '../planning/group-topology-planning-authority.ts';
+import type { GroupTopologyPlanningService } from '../planning/group-topology-planning-service.ts';
+import type { PersistedRtcTopologyWork } from './rtc-topology-work-codec.ts';
 
 export interface ComputeFormationCriterionCommandInput {
   readonly group: GroupSnapshot;
@@ -80,4 +87,133 @@ export async function computeFormationCriterionCommand(
         observedRate: readiness.observedRate,
       });
   }
+}
+
+export const DEFAULT_DEFERRED_CRITERION_PETITION_MIN_INTERVAL_MS = 1_000;
+
+export interface FormationCriterionPort {
+  readonly readLifecyclePolicy: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
+  readonly submitCommand: (command: GroupMutationCommand, atEpochMs: number) => Promise<void>;
+}
+
+export interface DeferredCriterionPetitionDependencies {
+  readonly topologyPlanning: Pick<GroupTopologyPlanningService, 'readTopologyPlanningAuthority'>;
+  readonly executionRepository: Pick<RtcTopologyExecutionRepository, 'readTopologyMutation'>;
+  readonly formationCriterion?: FormationCriterionPort;
+  readonly criterionPetitionMinIntervalMs?: number;
+}
+
+type DeferredPetitionRead = Awaited<
+  ReturnType<RtcTopologyExecutionRepository['readTopologyMutation']>
+>;
+
+export interface DeferredCriterionPetitioner {
+  request(work: PersistedRtcTopologyWork, read: DeferredPetitionRead): Promise<void>;
+}
+
+/**
+ * The evidence leg of the activation criterion: observation petitions intent
+ * and the petitioned command re-authorizes through AppInbox with fresh state,
+ * so a stale petition is a replay or a typed rejection, never a wrong
+ * transition.
+ */
+export async function petitionFormationCriterion(
+  dependencies: DeferredCriterionPetitionDependencies,
+  authority: GroupTopologyPlanningAuthority,
+  planned: RallarOverlayTopologySnapshot,
+): Promise<void> {
+  if (!dependencies.formationCriterion) return;
+  const command = await computeFormationCriterionCommand({
+    group: authority.group,
+    planned,
+    rttMeasurements: authority.rttMeasurements,
+    nowEpochMs: authority.nowEpochMs,
+    readLifecyclePolicy: dependencies.formationCriterion.readLifecyclePolicy,
+  });
+  if (command === null) return;
+  await dependencies.formationCriterion.submitCommand(command, authority.nowEpochMs);
+}
+
+/**
+ * Process-local damping for criterion petitions from refinement-deferred RTT
+ * work: a burst petitions at most once per interval per group, so deferred
+ * work items stay cheap while the measurement that crosses the threshold
+ * still activates the group within the interval. Damped requests arm one
+ * trailing timer per group, because the crossing measurement lives at the
+ * burst's tail by construction — leading-edge damping alone would defer the
+ * decisive petition forever. The trailing petition is best-effort and only
+ * warns on failure: the deadline evaluation stays the correctness backstop.
+ * A removed stored plan never petitions — its empty edge set would read as
+ * trivially-complete readiness.
+ */
+export function createDeferredCriterionPetitioner(
+  dependencies: DeferredCriterionPetitionDependencies,
+): DeferredCriterionPetitioner {
+  const minIntervalMs =
+    dependencies.criterionPetitionMinIntervalMs ??
+    DEFAULT_DEFERRED_CRITERION_PETITION_MIN_INTERVAL_MS;
+  const lastPetitionAtByGroupKey = new Map<string, number>();
+  const trailingByGroupKey = new Map<string, PersistedRtcTopologyWork>();
+
+  const petition = async (
+    work: PersistedRtcTopologyWork,
+    planned: RallarOverlayTopologySnapshot,
+  ) => {
+    const authority = await dependencies.topologyPlanning.readTopologyPlanningAuthority({
+      groupRef: work.groupSnapshot.group,
+      requestOptions: fromCanonicalGroupTopologyConfigPatch(work.requestOptions),
+      knownGroup: work.groupSnapshot,
+      snapshotSelection: 'prefer-current',
+    });
+    await petitionFormationCriterion(dependencies, authority, planned);
+  };
+
+  const flushTrailing = async (groupKey: string) => {
+    const work = trailingByGroupKey.get(groupKey);
+    trailingByGroupKey.delete(groupKey);
+    if (!work) return;
+    lastPetitionAtByGroupKey.set(groupKey, Date.now());
+    try {
+      const read = await dependencies.executionRepository.readTopologyMutation(
+        work.groupSnapshot.group,
+        null,
+      );
+      if (read.snapshot !== null && read.snapshot.value.state === 'active') {
+        await petition(work, read.snapshot.value);
+      }
+    } catch (error) {
+      console.warn(
+        `Deferred criterion petition failed for ${groupKey}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
+
+  return {
+    async request(work, read) {
+      if (
+        work.groupSnapshot.group.lifecycleState !== 'establishing' ||
+        read.snapshot === null ||
+        read.snapshot.value.state !== 'active'
+      ) {
+        return;
+      }
+      const groupKey = toWebRtcGroupKey(work.groupSnapshot.group);
+      const nowEpochMs = Date.now();
+      const lastPetitionAt = lastPetitionAtByGroupKey.get(groupKey);
+      if (lastPetitionAt !== undefined && nowEpochMs - lastPetitionAt < minIntervalMs) {
+        const armTrailing = !trailingByGroupKey.has(groupKey);
+        trailingByGroupKey.set(groupKey, work);
+        if (armTrailing) {
+          setTimeout(() => {
+            void flushTrailing(groupKey);
+          }, lastPetitionAt + minIntervalMs - nowEpochMs);
+        }
+        return;
+      }
+      lastPetitionAtByGroupKey.set(groupKey, nowEpochMs);
+      await petition(work, read.snapshot.value);
+    },
+  };
 }

--- a/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/create-rtc-topology-work-handler.ts
@@ -50,11 +50,12 @@ type AcceptedRtcTopologyMutation = Exclude<
   Readonly<{ outcome: 'loaded' | 'retry' }>
 >;
 
-import { computeFormationCriterionCommand } from './compute-formation-criterion-command.ts';
-import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
-import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
-import type { GroupTopologyPlanningAuthority } from '../planning/group-topology-planning-authority.ts';
-import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import {
+  createDeferredCriterionPetitioner,
+  type DeferredCriterionPetitioner,
+  type FormationCriterionPort,
+  petitionFormationCriterion,
+} from './compute-formation-criterion-command.ts';
 
 export interface RtcTopologyDeliveryOptions {
   readonly publisherStreamId: string;
@@ -79,10 +80,12 @@ interface RtcTopologyWorkHandlerOptions {
    * this deployment does not automate formation; groups then activate only by
    * operator command.
    */
-  readonly formationCriterion?: Readonly<{
-    readLifecyclePolicy: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
-    submitCommand: (command: GroupMutationCommand, atEpochMs: number) => Promise<void>;
-  }>;
+  readonly formationCriterion?: FormationCriterionPort;
+  /**
+   * Damping interval for criterion petitions from refinement-deferred RTT
+   * work. Absent means the default; 0 petitions per deferred item.
+   */
+  readonly criterionPetitionMinIntervalMs?: number;
   readonly topologyDelivery?: RtcTopologyDeliveryOptions;
   readonly onInactiveOverlay?: (overlayId: string) => void;
   readonly wakeQueue?: () => void;
@@ -129,6 +132,7 @@ interface ComputeAcceptedRtcTopologyWorkInput {
   readonly attemptCount: number;
   readonly read: RtcTopologyExecutionRead;
   readonly expireAtEpochMs: number;
+  readonly deferredCriterionPetitioner: DeferredCriterionPetitioner;
 }
 
 interface ToTopologyPublicationInput {
@@ -141,18 +145,23 @@ interface ToTopologyPublicationInput {
 export function createRtcTopologyWorkHandler(
   options: RtcTopologyWorkHandlerOptions,
 ): OnMessageCallback {
+  const deferredCriterionPetitioner = createDeferredCriterionPetitioner(options);
   return {
     onMessage: async (message, entry) => {
-      await processRtcTopologyWork(options, message, entry);
+      await processRtcTopologyWork({ options, message, entry, deferredCriterionPetitioner });
     },
   };
 }
 
-async function processRtcTopologyWork(
-  options: RtcTopologyWorkHandlerOptions,
-  message: ALMessage,
-  entry: ResourceEntry,
-): Promise<void> {
+interface ProcessRtcTopologyWorkInput {
+  readonly options: RtcTopologyWorkHandlerOptions;
+  readonly message: ALMessage;
+  readonly entry: ResourceEntry;
+  readonly deferredCriterionPetitioner: DeferredCriterionPetitioner;
+}
+
+async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promise<void> {
+  const { options, message, entry, deferredCriterionPetitioner } = input;
   const workEnvelope = readRtcTopologyWorkEnvelope(message, options.runtime.workType);
   const workId = toRtcTopologyExecutionId(workEnvelope);
   const read = await options.executionRepository.readTopologyMutation(
@@ -170,6 +179,7 @@ async function processRtcTopologyWork(
     attemptCount: entry.dequeueAudit.attempts,
     read,
     expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds,
+    deferredCriterionPetitioner,
   });
   await writeAcceptedRtcTopologyWork(options, entry, accepted);
 }
@@ -202,23 +212,6 @@ async function processLoadedRtcTopologyWork(
   options.wakeReplay?.();
 }
 
-async function petitionFormationCriterion(
-  options: RtcTopologyWorkHandlerOptions,
-  authority: GroupTopologyPlanningAuthority,
-  planned: RallarOverlayTopologySnapshot,
-): Promise<void> {
-  if (!options.formationCriterion) return;
-  const command = await computeFormationCriterionCommand({
-    group: authority.group,
-    planned,
-    rttMeasurements: authority.rttMeasurements,
-    nowEpochMs: authority.nowEpochMs,
-    readLifecyclePolicy: options.formationCriterion.readLifecyclePolicy,
-  });
-  if (command === null) return;
-  await options.formationCriterion.submitCommand(command, authority.nowEpochMs);
-}
-
 async function computeAcceptedRtcTopologyWork(
   input: ComputeAcceptedRtcTopologyWorkInput,
 ): Promise<AcceptedRtcTopologyWork> {
@@ -235,6 +228,12 @@ async function computeAcceptedRtcTopologyWork(
       expireAtEpochMs: input.expireAtEpochMs,
     })
   ) {
+    // The gate defers the replan, never the activation decision: the
+    // measurement that carries an establishing group across its threshold
+    // must still petition the criterion, or activation waits for the next
+    // deadline evaluation. A removed stored plan never petitions — its
+    // empty edge set would read as trivially-complete readiness.
+    await input.deferredCriterionPetitioner.request(work, read);
     return {
       decision: 'skipped-rtt-refinement',
       work,

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-drop-in-social-preset.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-drop-in-social-preset.json
@@ -440,7 +440,7 @@
       },
       "expect": {
         "connection": "wsAlice",
-        "withinMs": 10000,
+        "withinMs": 20000,
         "message": {
           "id": {
             "msgId": "drop-in-live-{runId}"

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
@@ -492,14 +492,14 @@
             "send": {
               "id": {
                 "v": 2,
-                "msgId": "rtt-{i}x{j}-{runId}",
+                "msgId": "rtt-managed-burst-large-{i}x{j}-{runId}",
                 "ts": 0,
                 "senderId": "{client{i}SessionId}",
                 "sessionId": "{client{i}SessionId}"
               },
               "route": {
                 "topicId": "rtt",
-                "resourceId": "rtt-{i}x{j}",
+                "resourceId": "rtt-managed-burst-large-{i}x{j}",
                 "contextId": "1"
               },
               "delivery": {
@@ -606,7 +606,7 @@
               "mode": "open"
             },
             "activation": {
-              "deadlineMs": 45000,
+              "deadlineMs": 600000,
               "maxFormationAttempts": 1
             }
           }
@@ -18598,8 +18598,7 @@
         "body": {
           "lifecycleState": "active",
           "lastFormationOutcome": {
-            "outcome": "activated",
-            "observedRate": 1
+            "outcome": "activated"
           }
         }
       }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
@@ -372,14 +372,14 @@
             "send": {
               "id": {
                 "v": 2,
-                "msgId": "rtt-{i}x{j}-{runId}",
+                "msgId": "rtt-managed-burst-medium-{i}x{j}-{runId}",
                 "ts": 0,
                 "senderId": "{client{i}SessionId}",
                 "sessionId": "{client{i}SessionId}"
               },
               "route": {
                 "topicId": "rtt",
-                "resourceId": "rtt-{i}x{j}",
+                "resourceId": "rtt-managed-burst-medium-{i}x{j}",
                 "contextId": "1"
               },
               "delivery": {
@@ -486,7 +486,7 @@
               "mode": "open"
             },
             "activation": {
-              "deadlineMs": 30000,
+              "deadlineMs": 600000,
               "maxFormationAttempts": 1
             }
           }
@@ -3558,7 +3558,7 @@
         },
         "poll": {
           "maxAttempts": 90,
-          "maxDurationMs": 75000,
+          "maxDurationMs": 60000,
           "backoffMs": 1000,
           "backoffMultiplier": 1
         }
@@ -3568,8 +3568,7 @@
         "body": {
           "lifecycleState": "active",
           "lastFormationOutcome": {
-            "outcome": "activated",
-            "observedRate": 1
+            "outcome": "activated"
           }
         }
       }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
@@ -551,7 +551,7 @@
       },
       "expect": {
         "connection": "wsBob",
-        "withinMs": 10000,
+        "withinMs": 20000,
         "message": {
           "payload": {
             "typeId": "al.control.nack.v1"
@@ -1003,7 +1003,7 @@
       },
       "expect": {
         "connection": "wsCarol",
-        "withinMs": 10000,
+        "withinMs": 20000,
         "message": {
           "id": {
             "msgId": "match-arena-live-{runId}"
@@ -1048,8 +1048,8 @@
           "x-client-id": "{aliceClientId}"
         },
         "poll": {
-          "maxAttempts": 50,
-          "maxDurationMs": 75000,
+          "maxAttempts": 100,
+          "maxDurationMs": 150000,
           "backoffMs": 1500,
           "backoffMultiplier": 1
         }

--- a/packages/tests/shared-server/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rtc-topology-outbox-work.test.ts
@@ -30,6 +30,9 @@ import {
 import { readRtcTopologyWorkEnvelope } from '@shared-server/rallar-system/topology/replay/rtc-topology-work-codec.ts';
 import { createAppInboxTestDatabase } from './app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import type { GroupMutationCommand } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import { createTestGroup } from '../create-test-group.ts';
 
 describe('RTC topology APP_OUTBOX work', () => {
@@ -677,6 +680,107 @@ describe('RTC topology APP_OUTBOX work', () => {
     );
     expect(readTopologyPlanningAuthority).toHaveBeenCalledTimes(2);
     expect(observeRtt).toHaveBeenCalledTimes(3);
+  });
+
+  // The refinement gate defers the replan, never the activation decision:
+  // deferred RTT work for an establishing group still petitions the
+  // criterion, so the measurement that crosses the threshold activates the
+  // group instead of waiting for the deadline evaluation.
+  it('petitions the criterion for an establishing group when the gate defers the replan', async () => {
+    const queue = new InMemoryQueueBox();
+    const runtime = createRtcTopologyOutboxPublisher({
+      outboxQueueReader: new OutboxQueueReader(queue),
+      now: () => 1_000,
+    });
+    const refinement = new RtcRttRefinementService({
+      gate: new RtcRttRefinementGate({
+        minIntervalMs: 0,
+        vivaldiDeltaThresholdMs: Number.MAX_SAFE_INTEGER,
+      }),
+      nowEpochMs: () => 1_000,
+      observeRtt: () => true,
+      readPredictedNodeData: () => predictedNodes(4),
+    });
+    const base = createGroupSnapshot(3);
+    const group: GroupSnapshot = {
+      ...base,
+      group: {
+        ...base.group,
+        lifecycleState: 'establishing',
+        establishmentStartedAtEpochMs: 500,
+      },
+    };
+    const planned = {
+      sourceGroupStateCausalRevision: { groupRevision: 3, presenceRevision: 0 },
+      state: 'active',
+      overlayId: toScopedOverlayId(group.group),
+      groupRef: group.group,
+      name: 'room-1',
+      topology: 'star',
+      activeSessionIds: ['session-a', 'session-b'],
+      nextHopsBySessionId: {
+        'session-a': ['session-b'],
+        'session-b': ['session-a'],
+      },
+      degreeLimit: 5,
+      version: 1,
+      createdByClientId: 'owner',
+      createdAtEpochMs: 1,
+      updatedAtEpochMs: 1,
+    } as const;
+    const runtimeRepository = new FakeRuntimeStateRepository();
+    const snapshots = new RtcTopologySnapshotRepository(runtimeRepository);
+    await expect(snapshots.commitSnapshot({ candidate: planned })).resolves.toMatchObject({
+      status: 'accepted',
+    });
+    const authority = {
+      group,
+      rttMeasurements: [rtt('session-a', 'session-b', 1)],
+      nowEpochMs: 1_000,
+    };
+    const readTopologyPlanningAuthority = vi.fn(async () => authority);
+    const submitCommand = vi.fn(
+      async (_command: GroupMutationCommand, _atEpochMs: number) => {},
+    );
+    const handler = createRtcTopologyWorkHandler({
+      runtime,
+      database: createAppInboxTestDatabase(queue, {
+        replace: async (entry) => entry,
+      }),
+      topologyPlanning: {
+        readTopologyPlanningAuthority,
+        computeTopologyFromAuthority: vi.fn(),
+        observeCommittedTopology: vi.fn(),
+        recordTopologyPublication: vi.fn(),
+        recordTopologyRebuildSkippedFingerprint: vi.fn(),
+      } as never,
+      executionRepository: new RtcTopologyExecutionRepository(runtimeRepository),
+      rttRefinementService: refinement,
+      formationCriterion: {
+        readLifecyclePolicy: async () => ({
+          status: 'present',
+          policy: {
+            ...createDefaultGroupLifecyclePolicy(),
+            activation: {
+              mode: 'threshold',
+              successRate: 1,
+              minimumViableRate: 0,
+              deadlineMs: 0,
+              maxFormationAttempts: 1,
+              strictConfirmation: false,
+            },
+          },
+        }),
+        submitCommand,
+      },
+    });
+
+    const entry = await enqueueAndReserveRtt(queue, runtime, group, 1);
+    await expect(handler.onMessage(JSON.parse(entry.resource), entry)).resolves.toBeUndefined();
+
+    expect(readTopologyPlanningAuthority).toHaveBeenCalledTimes(1);
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    expect(submitCommand.mock.calls[0]?.[1]).toBe(1_000);
   });
 
   it('claims zero-knob RTT work and reuses its canonical observation on retry', async () => {

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -278,10 +278,13 @@ apart from the items under "Deferred, explicitly".
   generic `400 app-inbox-malformed-command`; the issue codes (`strict-confirmation-unsupported`,
   `manager-initiator-without-manager`, …) never reach the response. Deferred at 6a until an
   application needs to distinguish them — the HTTP twin of the WS NACK opacity in decision 6.2.
-- **A threshold edge-trigger on the evidence leg.** The acceptance that moves readiness
-  across a group's threshold could petition the activation criterion directly, bypassing the
-  refinement gate's debounce for that one case, so bursty-evidence groups activate when the
-  threshold is crossed instead of at the next deadline evaluation (decision 6.9).
+- ~~A threshold edge-trigger on the evidence leg.~~ Delivered immediately after the
+  workstream close-out (product-owner selection, 2026-08-20): refinement-deferred RTT work
+  petitions the criterion under process-local per-group damping with a trailing flush, so
+  bursty-evidence groups activate within about a second of crossing the threshold instead
+  of at the next deadline evaluation; the deadline stays the correctness backstop. The
+  managed burst tiers pin it structurally — deadlines at the ten-minute clamp with
+  sub-minute activation polls.
 - **Per-edge confirm-or-fail batch machinery** — the whole activation design. Gated behind
   `strictConfirmation: true`, which v1 rejects. The posture decision (observed convergence as
   default) is recorded product-owner decision 2 and is supported by the Phase 0–4 evidence in

--- a/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
+++ b/playground/rtc-design/2026-08-17-group-lifecycle-control-plane-implementation-plan.md
@@ -226,7 +226,7 @@ Recorded with their alternatives in `2026-08-19-pending-admission-representation
 | 5.11 | **The data gate reads lazily and fails closed.** The room authorizer resolves `preActivationAppData` only when the group is not `active` (active groups pay no policy read); an absent policy is `allowed` (main-parity), a corrupt one is `blocked-until-active`. The CRDT topics (`room.crdt`, `app.crdt`) are exempt: collaborative documents are lobby-phase workspace with their own authorization, not the competitive pre-match traffic the gate exists to hold back. |
 | 5.12 | **Zero planned edges is trivially ready (rate 1)** — planned edges skip self-hops, so a single-member group activates per its criterion without waiting on establishment. The recipes accommodate this: below-floor legs need two presence-connected members, and the approval recipe pins a parked `pending` member surviving two formation-epoch advances before grant binds at the current epoch. |
 
-### Slice 6 — Read surface and scenario matrix
+### Slice 6 — Read surface and scenario matrix — **delivered**
 
 Lifecycle state joins the group snapshot and read APIs beside the readiness derivation, so
 applications and tests read intent and observation side by side. *Largely delivered early: the
@@ -250,8 +250,27 @@ eight partial, one uncovered, with every missing pin named.
 | --- | --- |
 | 6.1 | **Preset-labeled recipes are the organizing principle.** Every recipe exercising lifecycle behaviour names the policy it tests. The formation-burst recipes gain `preset: 'optimistic'` at all three tiers — they *are* the optimistic-baseline scenario, now explicitly — and every preset gets at least one labeled recipe: `managed` already has several; `match` and `drop-in-social` gain composed-behaviour recipes (no recipe sends either today). The compatibility guarantee is pinned once, not per tier: a create that omits `lifecyclePolicy` resolves to exactly the optimistic default (absent ≡ explicit equivalence) — this is the acceptance property's pin. |
 | 6.2 | **The generic WS NACK is the contract.** The room authorizer maps every policy denial to the generic NACK reason; `group-data-blocked-until-active` and the admission codes are typed on the HTTP surface only. Recipes pin the generic NACK over WS and the typed code over HTTP. Surfacing typed codes in the NACK is deferred until an application needs to distinguish them. |
-| 6.3 | **Managed burst variants at N=20 and N=50.** These are runner-process WS clients, not browsers, so the cost is seconds. N=20 makes fractional readiness expressible (~190 planned mesh edges); N=50 exercises the quadratic planned-edge surface (~1,225) where a bookkeeping cliff would hide from 20. Gate placement is decided at implementation from the recipe matrix; the single-server-safe lifecycle recipes also join the memory profile so the fast loop runs them. |
+| 6.3 | **Managed burst variants at N=20 and N=50.** These are runner-process WS clients, not browsers, so the cost is seconds. N=20 makes fractional readiness expressible and N=50 doubles the session count. *Amended per decision 6.10: the planner's k-regular mesh keeps planned edges linear (37 at 20 sessions, 97 at 50) — the original "quadratic surface (~1,225)" rationale was wrong about the planner.* Gate placement is decided at implementation from the recipe matrix; the single-server-safe lifecycle recipes also join the memory profile so the fast loop runs them. |
 | 6.4 | **Delivered as 6a/6b/6c.** 6a: the per-scenario missing pins in existing recipes, the `strict-confirmation` negative, the absent ≡ optimistic equivalence pin, and the weak-pin repairs (the mis-aimed non-manager leg, body-code assertions, the `member-joined` event pin). 6b: preset labeling of the burst recipes plus the managed 20/50 variants and profile wiring. 6c: the `match` and `drop-in-social` composed-preset recipes. |
+
+#### Decisions taken during slice 6 execution (2026-08-20)
+
+The execution findings behind these live in `2026-08-20-scenario-matrix-gap-analysis.md`
+(§ 6b execution findings) and the PR records.
+
+| # | Decision |
+| --- | --- |
+| 6.5 | **Delivered as 6a (PR #305), member event payloads (PR #306), 6b (PR #307), and 6c (PR #308).** #306 was scope added by product-owner decision during 6a: member events name the member they are about — every `member-*` event carries `payload.principalId` of the affected member and `ownership-transferred` carries `fromPrincipalId`/`toPrincipalId`; the actor stays the command issuer. |
+| 6.6 | **Policy-validity rejections stay generic on the wire** (product-owner decision during 6a): the recipes pin `400 app-inbox-malformed-command` plus not-persisted read-backs; typing the HTTP validity surface is the recorded deferred item, the HTTP twin of decision 6.2. |
+| 6.7 | **RTT-report acceptance honours the per-group degree limit** (runtime fix the 6b scale tier exposed): both the durable and in-memory acceptance paths resolve the limit exactly as the read-side planning filter does — the group's effective topology config under the server reporting default, with an explicitly configured `rttReportingDegreeLimit` still winning. Without it, evidence a raised-limit plan needs was never stored and readiness could not converge. |
+| 6.8 | **Profile placement rules, learned the hard way.** Synthetic worst-case load recipes (the managed 20/50 bursts) live only in the opt-in `api-v1-black-box-formation-large` profile: on shared servers one contention-driven terminal mutation failure breaks unrelated recipes asserting the server-global `atomicCompletionFailures` counter. And a recipe may sit in only one of the profiles a single Postgres CI job runs — dual membership replays requestIds against the same servers under one runId and self-conflicts on idempotency. The lifecycle recipes therefore moved from the cluster profile into the memory profiles; profile overlap is zero. |
+| 6.9 | **Two scale-exposed limits recorded, not fixed**: threshold activation under bursty evidence waits for the deadline evaluation because the evidence-leg criterion petition rides the refinement gate's debounce; and an all-pairs RTT burst can exhaust the 20-attempt optimistic retry schedule under 19-writer endpoint contention. Real heartbeat-cadence reporting hits neither. |
+| 6.10 | **Planned mesh edges grow linearly, not quadratically** (`meshParamK` 2 with rendezvous fill — 37 edges at 20 sessions, 97 at 50), correcting the planner assumption in decision 6.3's rationale; the tiers still exercise planning, acceptance, and readiness at 20/50 sessions, and all-pairs *reporting* stays the coverage guarantee. |
+
+With slice 6 delivered, every row of the design document's ten-scenario matrix is closed as
+recipe pins, all four presets carry labeled recipes, and the whole-workstream acceptance
+property is pinned as the absent ≡ optimistic-default equivalence. The workstream is complete
+apart from the items under "Deferred, explicitly".
 
 ## Deferred, explicitly
 
@@ -259,6 +278,10 @@ eight partial, one uncovered, with every missing pin named.
   generic `400 app-inbox-malformed-command`; the issue codes (`strict-confirmation-unsupported`,
   `manager-initiator-without-manager`, …) never reach the response. Deferred at 6a until an
   application needs to distinguish them — the HTTP twin of the WS NACK opacity in decision 6.2.
+- **A threshold edge-trigger on the evidence leg.** The acceptance that moves readiness
+  across a group's threshold could petition the activation criterion directly, bypassing the
+  refinement gate's debounce for that one case, so bursty-evidence groups activate when the
+  threshold is crossed instead of at the next deadline evaluation (decision 6.9).
 - **Per-edge confirm-or-fail batch machinery** — the whole activation design. Gated behind
   `strictConfirmation: true`, which v1 rejects. The posture decision (observed convergence as
   default) is recorded product-owner decision 2 and is supported by the Phase 0–4 evidence in


### PR DESCRIPTION
Stacked on #309 (base: `slice-6-refresh`). Delivers the threshold edge-trigger the
workstream close-out recorded as deferred (product-owner selection): threshold groups now
activate when their evidence crosses the bar, not at the next deadline evaluation.

## The mechanism

The activation criterion has two legs: the formation timer evaluates at the deadline, and
RTT-triggered topology work petitions it on the way through. The refinement gate debounces
that work under burst traffic (30s min-interval per group), and the petition rode the same
gated skip — so the measurement that crossed the threshold usually landed in cooldown and a
fully-ready group sat in ESTABLISHING until its deadline.

Now a refinement-deferred `rtt-refresh` work item still petitions the criterion while its
group is establishing, under process-local per-group damping (default 1s) **with a trailing
timer**: leading-edge damping alone would defer the decisive petition forever, because the
crossing measurement lives at the burst's tail by construction. A removed stored plan never
petitions (its empty edge set would read as trivially-complete readiness), trailing
petitions warn-and-continue on failure, and the deadline evaluation stays the correctness
backstop. The petition machinery lives with `computeFormationCriterionCommand` in the
criterion module; the work handler consumes it through a narrow port.

Measured effect: the managed 20-client tier drops from ~41s (deadline-bound) to ~11s; the
50-client tier activates in ~49s against a 10-minute deadline.

## Recipe pins (and two recipe fixes the work exposed)

- The managed burst tiers now prove the edge-trigger structurally: deadlines at the
  10-minute clamp with 60–90s activation polls — only the evidence leg can pass them. The
  recorded outcome pin drops `observedRate: 1`, since the crossing petition legitimately
  fires anywhere in [successRate, 1].
- **Tier-scoped RTT identities**: both tiers stamped reports `rtt-{i}x{j}-{runId}` with a
  shared runId, so the large tier's first C(20,2)=190 pairs were idempotent replays of the
  medium tier's — capping coverage at 1,035/1,225 forever. The RTT topic is global, not
  group-scoped; ids now carry the tier name. (Found via a petition probe after the failure
  reproduced only in medium-then-large sequences.)
- The composed-preset recipes widen their honest-failure poll (150s — two 20s deadline
  cycles plus durable-timer latency on Postgres overran 75s) and WS delivery windows (20s).

## Verification

- Unit pin: a refinement-deferred item for an establishing group with a stored plan reads
  the authority and submits the activation command (`rtc-topology-outbox-work.test.ts`,
  22/22; the existing sub-threshold-skip pin still holds for non-establishing groups).
- Managed tiers green standalone, in medium-then-large sequence, and repeated on a warm
  server (accumulation guard).
- Memory-mode managed run 32/32; Postgres CI-shape run 32/32 + cluster 5/5 on a fresh
  database; full vitest 884 files / 7,809 tests; full Deno 0 failed; typecheck + ratchet
  PASS; **medium-scale gate 2,748/2,748 PASSED**; changed-style gate PASS (the petition
  module split keeps the work handler under the cognitive-load warn tier without adding a
  21st file to `topology/replay`).
- The plan's deferred-item entry for the edge-trigger is marked delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
