### PR TITLE
Fix distributed runtime request identities

### DIFF
--- a/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/03-rtc-smoke-2-agent.json
@@ -39,7 +39,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-smoke-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-smoke-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -71,7 +71,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-smoke-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-smoke-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/04-provider-parity-2-agent.json
@@ -99,7 +99,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/provider-parity-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/provider-parity-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -131,7 +131,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/provider-parity-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/provider-parity-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05-rtc-realtime-2-agent-5s.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05a-rtc-realtime-stability-2-agent-5s.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
+++ b/apps/rallar-black-box/manifests/hetzner/05b-rtc-realtime-stability-2-agent-30s.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05c-rtc-realtime-stability-2-agent-30s-10hz.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05d-rtc-realtime-stability-2-agent-30s-15hz.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
+++ b/apps/rallar-black-box/manifests/hetzner/05e-rtc-realtime-stability-2-agent-30s-20hz.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -238,7 +238,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -270,7 +270,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
+++ b/apps/rallar-black-box/manifests/hetzner/06-rtc-realtime-3-agent-15s.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/07-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/08-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/09-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/10-rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/11-rtc-messages-principal-15-agent-30s-20hz-mesh.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/12-rtc-messages-all-peer-15-agent-30s-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/13-rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/hetzner/14-rtc-messages-principal-30-agent-30s-20hz-mesh.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/15-rtc-messages-all-peer-30-agent-30s-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/16-rtc-absence-wait-2-agent.json
@@ -39,7 +39,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/d23699bb-0a36-4076-8fab-10c942115141-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/d23699bb-0a36-4076-8fab-10c942115141-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -71,7 +71,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/595968fc-482e-4ef5-8125-565007433507-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/595968fc-482e-4ef5-8125-565007433507-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/17-group-assertions-2-agent.json
+++ b/apps/rallar-black-box/manifests/hetzner/17-group-assertions-2-agent.json
@@ -39,7 +39,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/c9602657-7db6-48c2-b9dd-fadf8e4f76eb-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/c9602657-7db6-48c2-b9dd-fadf8e4f76eb-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -71,7 +71,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/f026327b-5bb1-4246-9694-cec49a0ca372-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/f026327b-5bb1-4246-9694-cec49a0ca372-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-10-agent-5m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-15-agent-5m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-20-agent-5m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-all-peer-30-agent-5m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-10-agent-5m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-15-agent-5m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-20-agent-5m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-10hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/matrix/rtc-messages-principal-30-agent-5m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
+++ b/apps/rallar-black-box/manifests/hetzner/diagnostic/rtc-realtime-2-agent-20hz-stress.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-realtime-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "hetzner-headless-room",
                 "displayName": "hetzner-headless-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/hetzner-headless-room/members/{auth.clientId}/requests/rtc-realtime-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/01-rtc-messages-principal-50-agent-30s-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
+++ b/apps/rallar-black-box/manifests/world-fleet/02-rtc-messages-principal-50-agent-30s-20hz-mesh.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/03-rtc-messages-all-peer-50-agent-30s-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-30s-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-10hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-20hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-all-peer-50-agent-60m-5hz-tree.json
@@ -48,7 +48,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-all-peer-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -80,7 +80,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-all-peer-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
+++ b/apps/rallar-black-box/manifests/world-fleet/diagnostic/rtc-messages-principal-50-agent-60m-20hz-tree.json
@@ -45,7 +45,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -77,7 +77,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }
@@ -297,7 +297,7 @@
             },
             "request": {
               "method": "POST",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/requests/rtc-messages-principal-ensure-group-{runtimeIdentity}",
               "body": {
                 "groupId": "world-fleet-room",
                 "displayName": "world-fleet-room",
@@ -329,7 +329,7 @@
             },
             "request": {
               "method": "PUT",
-              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runId}",
+              "path": "/api/state/apps/rallar-server/workspaces/default/groups/world-fleet-room/members/{auth.clientId}/requests/rtc-messages-principal-ensure-member-{runtimeIdentity}",
               "body": {
                 "status": "active"
               }

--- a/apps/rallar-black-box/src/hetzner/create-hetzner-group-assertions-recipe.ts
+++ b/apps/rallar-black-box/src/hetzner/create-hetzner-group-assertions-recipe.ts
@@ -6,8 +6,8 @@ import type { RallarBlackBoxTestRecipe } from '@shared-test/rallar-bb-test/types
 
 const CONTROL_TOPIC = 'black-box.group-assertions.control';
 const LEAK_PROBE_TOPIC = 'black-box.group-assertions.leak-probe';
-const ENSURE_GROUP_REQUEST_ID = 'c9602657-7db6-48c2-b9dd-fadf8e4f76eb-{runId}';
-const ENSURE_MEMBER_REQUEST_ID = 'f026327b-5bb1-4246-9694-cec49a0ca372-{runId}';
+const ENSURE_GROUP_REQUEST_ID = 'c9602657-7db6-48c2-b9dd-fadf8e4f76eb-{runtimeIdentity}';
+const ENSURE_MEMBER_REQUEST_ID = 'f026327b-5bb1-4246-9694-cec49a0ca372-{runtimeIdentity}';
 
 export const HETZNER_GROUP_ASSERTIONS_RECIPE_ID = 'group-assertions-recipe';
 

--- a/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
+++ b/apps/rallar-black-box/src/hetzner/create-hetzner-rtc-absence-wait-recipe.ts
@@ -3,8 +3,8 @@ import type { RallarBlackBoxTestRecipe } from '@shared-test/rallar-bb-test/types
 
 const CONTROL_TOPIC = 'black-box.absence.control';
 const LEAK_PROBE_TOPIC = 'black-box.absence.leak-probe';
-const ENSURE_GROUP_REQUEST_ID = 'd23699bb-0a36-4076-8fab-10c942115141-{runId}';
-const ENSURE_MEMBER_REQUEST_ID = '595968fc-482e-4ef5-8125-565007433507-{runId}';
+const ENSURE_GROUP_REQUEST_ID = 'd23699bb-0a36-4076-8fab-10c942115141-{runtimeIdentity}';
+const ENSURE_MEMBER_REQUEST_ID = '595968fc-482e-4ef5-8125-565007433507-{runtimeIdentity}';
 
 // The Hetzner isolation contract pins every identity in a manifest to one
 // effective group, so the absence claims stay inside that room: the delivered

--- a/packages/shared-test/rallar-bb-test/browser-adapter.ts
+++ b/packages/shared-test/rallar-bb-test/browser-adapter.ts
@@ -1,5 +1,6 @@
 import type { AuthSession } from '@shared/api/api-config.ts';
 import { readSession } from '@shared/api/auth.ts';
+import { fnv1a64 } from '@shared/queuebox/AppQueueIdentity.ts';
 import {
     toRtcReadyPeerIds,
     waitForRtcConnectReadiness,
@@ -162,12 +163,25 @@ type WebSocketTicketResolution = Readonly<{
 const DEFAULT_WS_OPEN_TIMEOUT_MS = 5_000;
 const DEFAULT_HTTP_BODY_LIMIT = 64_000;
 const WEBSOCKET_OPEN_STATE = 1;
-const AUTH_PLACEHOLDER_PATTERN =
-    /(?:\{auth\.(clientId|username|sessionId|accessToken|wsTicket)\}|%7Bauth\.(clientId|username|sessionId|accessToken|wsTicket)%7D)/gi;
-const CONFIG_PLACEHOLDER_PATTERN = /(?:\{config\.(apiBaseUrl|wsBaseUrl)\}|%7Bconfig\.(apiBaseUrl|wsBaseUrl)%7D)/gi;
-const AUTH_PLACEHOLDER_TEST_PATTERN =
-    /(?:\{auth\.(clientId|username|sessionId|accessToken|wsTicket)\}|%7Bauth\.(clientId|username|sessionId|accessToken|wsTicket)%7D)/i;
-const CONFIG_PLACEHOLDER_TEST_PATTERN = /(?:\{config\.(apiBaseUrl|wsBaseUrl)\}|%7Bconfig\.(apiBaseUrl|wsBaseUrl)%7D)/i;
+const RUNTIME_IDENTITY_BASE36_LENGTH = 13;
+const AUTH_PLACEHOLDER_SOURCE = String.raw`(?:\{auth\.(clientId|username|sessionId|accessToken|wsTicket)\}|` +
+    String.raw`%7Bauth\.(clientId|username|sessionId|accessToken|wsTicket)%7D)`;
+const CONFIG_PLACEHOLDER_SOURCE = String.raw`(?:\{config\.(apiBaseUrl|wsBaseUrl)\}|` +
+    String.raw`%7Bconfig\.(apiBaseUrl|wsBaseUrl)%7D)`;
+const RUNTIME_IDENTITY_PLACEHOLDER_SOURCE = String.raw`(?:\{(runId|agentId|runtimeIdentity)\}|` +
+    String.raw`%7B(runId|agentId|runtimeIdentity)%7D)`;
+const AUTH_PLACEHOLDER_PATTERN = new RegExp(AUTH_PLACEHOLDER_SOURCE, 'gi');
+const CONFIG_PLACEHOLDER_PATTERN = new RegExp(CONFIG_PLACEHOLDER_SOURCE, 'gi');
+const RUNTIME_IDENTITY_PLACEHOLDER_PATTERN = new RegExp(
+    RUNTIME_IDENTITY_PLACEHOLDER_SOURCE,
+    'gi'
+);
+const AUTH_PLACEHOLDER_TEST_PATTERN = new RegExp(AUTH_PLACEHOLDER_SOURCE, 'i');
+const CONFIG_PLACEHOLDER_TEST_PATTERN = new RegExp(CONFIG_PLACEHOLDER_SOURCE, 'i');
+const RUNTIME_IDENTITY_PLACEHOLDER_TEST_PATTERN = new RegExp(
+    RUNTIME_IDENTITY_PLACEHOLDER_SOURCE,
+    'i'
+);
 const WS_TICKET_PLACEHOLDER_TEST_PATTERN = /(?:\{auth\.wsTicket\}|%7Bauth\.wsTicket%7D)/i;
 
 const RTC_FAILURE_STATUSES = new Set([
@@ -189,6 +203,14 @@ type RtcSendFailure = Readonly<{
     code: string;
     message: string;
     details?: unknown;
+}>;
+
+type RtcSendObservationInput = Readonly<{
+    command: Extract<CommandWithId, { kind: 'rtc.send'; }>;
+    diagnostics: object;
+    durationMs: number;
+    ok: boolean;
+    errorCode?: string;
 }>;
 
 const RTC_READY_PEER_IDS_PLACEHOLDER = '{rtc.readyPeerIds}';
@@ -334,24 +356,20 @@ function countDataChannelStatuses(diagnostics: unknown, status: string): number 
 }
 
 function rtcSendObservation(
-    command: Extract<CommandWithId, { kind: 'rtc.send'; }>,
-    diagnostics: unknown,
-    durationMs: number,
-    ok: boolean,
-    errorCode?: string
+    input: RtcSendObservationInput
 ): Readonly<Record<string, unknown>> {
-    const root = asRecord(diagnostics);
+    const root = asRecord(input.diagnostics);
     const message = asRecord(root.message);
     const status = firstDefined(
         toStringValue(root.status),
         toStringValue(message.status)
     );
     return {
-        commandId: command.commandId,
-        kind: command.kind,
-        transport: command.transport,
-        durationMs,
-        ok,
+        commandId: input.command.commandId,
+        kind: input.command.kind,
+        transport: input.command.transport,
+        durationMs: input.durationMs,
+        ok: input.ok,
         status,
         queued: status === 'queued' || status === 'buffered',
         enqueued: status === 'enqueued',
@@ -360,12 +378,12 @@ function rtcSendObservation(
             status === 'rate-limited' ||
             status === 'buffer-full' ||
             status === 'circuit-open',
-        droppedPayloadCount: countDataChannelStatuses(diagnostics, 'dropped'),
+        droppedPayloadCount: countDataChannelStatuses(input.diagnostics, 'dropped'),
         replacedPayloadCount: firstDefined(
             typeof root.replacedPayloadCount === 'number' ? root.replacedPayloadCount : undefined,
             typeof root.replacedCount === 'number' ? root.replacedCount : undefined
         ),
-        errorCode
+        errorCode: input.errorCode
     };
 }
 
@@ -570,20 +588,34 @@ function configWsBaseUrl(config: RallarBlackBoxTestConfig | undefined): string |
     }
 }
 
-function requiresAuthPlaceholder(value: unknown): boolean {
+function runtimeIdentity(config: RallarBlackBoxTestConfig | undefined): string {
+    if (!config?.runId || !config.agentId) {
+        throw new Error(
+            'Cannot resolve recipe placeholder {runtimeIdentity} without ' +
+                'configured runId and agentId.'
+        );
+    }
+
+    return fnv1a64(`${config.runId}\u0000${config.agentId}`)
+        .padStart(RUNTIME_IDENTITY_BASE36_LENGTH, '0');
+}
+
+function requiresCommandPlaceholder(value: unknown): boolean {
     if (typeof value === 'string') {
-        return AUTH_PLACEHOLDER_TEST_PATTERN.test(value) || CONFIG_PLACEHOLDER_TEST_PATTERN.test(value);
+        return AUTH_PLACEHOLDER_TEST_PATTERN.test(value) ||
+            CONFIG_PLACEHOLDER_TEST_PATTERN.test(value) ||
+            RUNTIME_IDENTITY_PLACEHOLDER_TEST_PATTERN.test(value);
     }
 
     if (Array.isArray(value)) {
-        return value.some((item) => requiresAuthPlaceholder(item));
+        return value.some((item) => requiresCommandPlaceholder(item));
     }
 
     if (!value || typeof value !== 'object') {
         return false;
     }
 
-    return Object.values(value).some((item) => requiresAuthPlaceholder(item));
+    return Object.values(value).some((item) => requiresCommandPlaceholder(item));
 }
 
 function requiresAuthSessionPlaceholder(value: unknown): boolean {
@@ -627,44 +659,77 @@ function replaceCommandPlaceholdersInString(
     }>
 ): string {
     return value
-        .replace(CONFIG_PLACEHOLDER_PATTERN, (_match, plainKey: string | undefined, encodedKey: string | undefined) => {
-            const key = plainKey ?? encodedKey;
-            const replacement = key === 'apiBaseUrl'
-                ? configApiBaseUrl(options.config)
-                : configWsBaseUrl(options.config);
-            if (!replacement) {
-                throw new Error(`Cannot resolve recipe placeholder {config.${key}} without configured ${key}.`);
-            }
-
-            return replacement;
-        })
-        .replace(AUTH_PLACEHOLDER_PATTERN, (_match, plainKey: string | undefined, encodedKey: string | undefined) => {
-            const key = plainKey ?? encodedKey;
-            if (key === 'wsTicket') {
-                if (!options.wsTicket?.ticket) {
-                    throw new Error('Cannot resolve recipe placeholder {auth.wsTicket} without a websocket ticket.');
+        .replace(
+            RUNTIME_IDENTITY_PLACEHOLDER_PATTERN,
+            (_match, plainKey: string | undefined, encodedKey: string | undefined) => {
+                const key = plainKey ?? encodedKey;
+                const replacement = key === 'runtimeIdentity'
+                    ? runtimeIdentity(options.config)
+                    : key === 'runId'
+                    ? options.config?.runId
+                    : options.config?.agentId;
+                if (!replacement) {
+                    throw new Error(
+                        `Cannot resolve recipe placeholder {${key}} without configured ${key}.`
+                    );
                 }
 
-                return options.wsTicket.ticket;
+                return replacement;
             }
+        )
+        .replace(
+            CONFIG_PLACEHOLDER_PATTERN,
+            (_match, plainKey: string | undefined, encodedKey: string | undefined) => {
+                const key = plainKey ?? encodedKey;
+                const replacement = key === 'apiBaseUrl'
+                    ? configApiBaseUrl(options.config)
+                    : configWsBaseUrl(options.config);
+                if (!replacement) {
+                    throw new Error(
+                        `Cannot resolve recipe placeholder {config.${key}} ` +
+                            `without configured ${key}.`
+                    );
+                }
 
-            if (!options.session) {
-                throw new Error(`Cannot resolve recipe placeholder {auth.${key}} without a logged-in Rallar session.`);
+                return replacement;
             }
+        )
+        .replace(
+            AUTH_PLACEHOLDER_PATTERN,
+            (_match, plainKey: string | undefined, encodedKey: string | undefined) => {
+                const key = plainKey ?? encodedKey;
+                if (key === 'wsTicket') {
+                    if (!options.wsTicket?.ticket) {
+                        throw new Error(
+                            'Cannot resolve recipe placeholder {auth.wsTicket} ' +
+                                'without a websocket ticket.'
+                        );
+                    }
 
-            switch (key) {
-                case 'clientId':
-                    return options.session.clientId;
-                case 'username':
-                    return options.session.username;
-                case 'sessionId':
-                    return options.wsTicket?.sessionId ?? options.session.sessionId;
-                case 'accessToken':
-                    return options.session.accessToken;
-                default:
-                    return '';
+                    return options.wsTicket.ticket;
+                }
+
+                if (!options.session) {
+                    throw new Error(
+                        `Cannot resolve recipe placeholder {auth.${key}} ` +
+                            'without a logged-in Rallar session.'
+                    );
+                }
+
+                switch (key) {
+                    case 'clientId':
+                        return options.session.clientId;
+                    case 'username':
+                        return options.session.username;
+                    case 'sessionId':
+                        return options.wsTicket?.sessionId ?? options.session.sessionId;
+                    case 'accessToken':
+                        return options.session.accessToken;
+                    default:
+                        return '';
+                }
             }
-        });
+        );
 }
 
 function replaceCommandPlaceholders<T>(
@@ -675,7 +740,7 @@ function replaceCommandPlaceholders<T>(
         wsTicket?: WebSocketTicketResolution;
     }>
 ): T {
-    if (!requiresAuthPlaceholder(value)) {
+    if (!requiresCommandPlaceholder(value)) {
         return value;
     }
 
@@ -1018,7 +1083,12 @@ class BrowserCommandAdapter {
             case 'crdt.health':
                 return await this.executeCrdt(command, context, 'health', 'rallar.bb.crdt.health');
             case 'crdt.wait':
-                return await this.executeCrdt(command, context, 'wait', 'rallar.bb.crdt.wait_matched');
+                return await this.executeCrdt(
+                    command,
+                    context,
+                    'wait',
+                    'rallar.bb.crdt.wait_matched'
+                );
             case 'crdt.undo':
                 return await this.executeCrdt(command, context, 'undo', 'rallar.bb.crdt.undone');
             case 'crdt.redo':
@@ -1026,21 +1096,61 @@ class BrowserCommandAdapter {
             case 'crdt.close':
                 return await this.executeCrdt(command, context, 'close', 'rallar.bb.crdt.closed');
             case 'crdt.destroy':
-                return await this.executeCrdt(command, context, 'destroy', 'rallar.bb.crdt.destroyed');
+                return await this.executeCrdt(
+                    command,
+                    context,
+                    'destroy',
+                    'rallar.bb.crdt.destroyed'
+                );
             case 'director.appoint':
-                return await this.executeDirector(command, context, 'appoint', 'rallar.bb.director.appointed');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'appoint',
+                    'rallar.bb.director.appointed'
+                );
             case 'director.resign':
-                return await this.executeDirector(command, context, 'resign', 'rallar.bb.director.resigned');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'resign',
+                    'rallar.bb.director.resigned'
+                );
             case 'director.status':
-                return await this.executeDirector(command, context, 'status', 'rallar.bb.director.status');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'status',
+                    'rallar.bb.director.status'
+                );
             case 'director.relay.start':
-                return await this.executeDirector(command, context, 'relayStart', 'rallar.bb.director.relay_started');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'relayStart',
+                    'rallar.bb.director.relay_started'
+                );
             case 'director.intent':
-                return await this.executeDirector(command, context, 'intent', 'rallar.bb.director.intent_sent');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'intent',
+                    'rallar.bb.director.intent_sent'
+                );
             case 'director.sync.request':
-                return await this.executeDirector(command, context, 'syncRequest', 'rallar.bb.director.sync_requested');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'syncRequest',
+                    'rallar.bb.director.sync_requested'
+                );
             case 'director.relay.stop':
-                return await this.executeDirector(command, context, 'relayStop', 'rallar.bb.director.relay_stopped');
+                return await this.executeDirector(
+                    command,
+                    context,
+                    'relayStop',
+                    'rallar.bb.director.relay_stopped'
+                );
             case 'health':
                 return await this.health(command, context);
             case 'close':
@@ -1481,9 +1591,13 @@ class BrowserCommandAdapter {
             return {
                 ...resolved,
                 handle: command.commandId,
-                apiBaseUrl: resolved.apiBaseUrl ?? context.config()?.apiBaseUrl ?? configuredRallar.apiBaseUrl,
+                apiBaseUrl: resolved.apiBaseUrl ??
+                    context.config()?.apiBaseUrl ??
+                    configuredRallar.apiBaseUrl,
                 actor: resolved.actor ?? context.config()?.actor,
-                sessionId: resolved.sessionId ?? context.config()?.sessionId ?? configuredRallar.sessionId,
+                sessionId: resolved.sessionId ??
+                    context.config()?.sessionId ??
+                    configuredRallar.sessionId,
                 roomId: resolved.roomId ?? context.config()?.roomId,
                 rallar: {
                     ...configuredRallar,
@@ -1496,9 +1610,13 @@ class BrowserCommandAdapter {
             const configuredRallar = asRecord(context.config()?.rallar);
             return {
                 ...resolved,
-                apiBaseUrl: resolved.apiBaseUrl ?? context.config()?.apiBaseUrl ?? configuredRallar.apiBaseUrl,
+                apiBaseUrl: resolved.apiBaseUrl ??
+                    context.config()?.apiBaseUrl ??
+                    configuredRallar.apiBaseUrl,
                 actor: resolved.actor ?? context.config()?.actor,
-                sessionId: resolved.sessionId ?? context.config()?.sessionId ?? configuredRallar.sessionId,
+                sessionId: resolved.sessionId ??
+                    context.config()?.sessionId ??
+                    configuredRallar.sessionId,
                 roomId: resolved.roomId ?? context.config()?.roomId,
                 rallar: {
                     ...configuredRallar,
@@ -1776,11 +1894,17 @@ class BrowserCommandAdapter {
         }
         const readinessOptions = this.rtcConnectReadinessOptions(command);
         if (readinessOptions) {
-            this.recordRtcReadinessDiagnostic(context, command, 'rallar.bb.rtc.readiness_wait_started', 'info', {
-                minReadyPeers: readinessOptions.minReadyPeers,
-                timeoutMs: readinessOptions.timeoutMs,
-                intervalMs: readinessOptions.intervalMs
-            });
+            this.recordRtcReadinessDiagnostic(
+                context,
+                command,
+                'rallar.bb.rtc.readiness_wait_started',
+                'info',
+                {
+                    minReadyPeers: readinessOptions.minReadyPeers,
+                    timeoutMs: readinessOptions.timeoutMs,
+                    intervalMs: readinessOptions.intervalMs
+                }
+            );
             readiness = await waitForRtcConnectReadiness(
                 this.requireRallarRuntime(),
                 readinessOptions,
@@ -1866,7 +1990,9 @@ class BrowserCommandAdapter {
         );
         let scopedSend: unknown = resolvedSend;
         if (Object.keys(scopedSendFields).length > 0) {
-            scopedSend = resolvedSend && typeof resolvedSend === 'object' && !Array.isArray(resolvedSend)
+            scopedSend = resolvedSend &&
+                    typeof resolvedSend === 'object' &&
+                    !Array.isArray(resolvedSend)
                 ? {
                     ...(resolvedSend as Record<string, unknown>),
                     ...Object.fromEntries(
@@ -1897,13 +2023,13 @@ class BrowserCommandAdapter {
             abort.cleanup();
         }
         const failure = rtcSendFailureFromDiagnostics(diagnostics);
-        const sendObservation = rtcSendObservation(
+        const sendObservation = rtcSendObservation({
             command,
-            diagnostics,
-            Math.max(0, Date.now() - sendStartedAtEpochMs),
-            failure === undefined,
-            failure?.code
-        );
+            diagnostics: asRecord(diagnostics),
+            durationMs: Math.max(0, Date.now() - sendStartedAtEpochMs),
+            ok: failure === undefined,
+            errorCode: failure?.code
+        });
         context.recordEvent({
             kind: 'diagnostic',
             topic: failure ? 'rallar.bb.rtc.send_failed' : 'rallar.bb.rtc.send_completed',
@@ -1965,7 +2091,8 @@ class BrowserCommandAdapter {
         const abort = this.commandAbortSignal(command, context);
         const streamStartedAtEpochMs = Date.now();
         const maxInFlight = toPositiveInteger(command.maxInFlight, 64);
-        const drainTimeoutMs = typeof command.drainTimeoutMs === 'number' && command.drainTimeoutMs >= 0
+        const drainTimeoutMs = typeof command.drainTimeoutMs === 'number' &&
+                command.drainTimeoutMs >= 0
             ? command.drainTimeoutMs
             : 5_000;
         const progressEveryMs = toPositiveInteger(command.progressEveryMs, 1_000);
@@ -2111,8 +2238,14 @@ class BrowserCommandAdapter {
                             scheduledAtEpochMs: activeFrame.scheduledAtEpochMs,
                             startedAtEpochMs: activeFrame.startedAtEpochMs,
                             completedAtEpochMs,
-                            startDriftMs: Math.max(0, activeFrame.startedAtEpochMs - activeFrame.scheduledAtEpochMs),
-                            durationMs: Math.max(0, completedAtEpochMs - activeFrame.startedAtEpochMs),
+                            startDriftMs: Math.max(
+                                0,
+                                activeFrame.startedAtEpochMs - activeFrame.scheduledAtEpochMs
+                            ),
+                            durationMs: Math.max(
+                                0,
+                                completedAtEpochMs - activeFrame.startedAtEpochMs
+                            ),
                             ok: false,
                             status: 'failed',
                             errorCode: error instanceof Error ? error.name : 'RALLAR_BLACK_BOX_RTC_STREAM_SEND_FAILED'
@@ -2145,7 +2278,10 @@ class BrowserCommandAdapter {
                         scheduledAtEpochMs: frame.scheduledAtEpochMs,
                         startedAtEpochMs: frame.startedAtEpochMs,
                         completedAtEpochMs: now,
-                        startDriftMs: Math.max(0, frame.startedAtEpochMs - frame.scheduledAtEpochMs),
+                        startDriftMs: Math.max(
+                            0,
+                            frame.startedAtEpochMs - frame.scheduledAtEpochMs
+                        ),
                         durationMs: Math.max(0, now - frame.startedAtEpochMs),
                         ok: false,
                         status: 'drain-timeout',
@@ -2398,7 +2534,8 @@ class BrowserCommandAdapter {
                 value,
                 error: {
                     code: 'RALLAR_BLACK_BOX_HTTP_STATUS_NOT_ACCEPTED',
-                    message: `http.request received status ${response.status}; accepted status codes: ${accepted}.`,
+                    message: `http.request received status ${response.status}; ` +
+                        `accepted status codes: ${accepted}.`,
                     details: value
                 },
                 nextStatus: 'failed'

--- a/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
+++ b/packages/shared-test/rallar-bb-test/recipe-fixtures.ts
@@ -171,7 +171,8 @@ function rtcConnectReadiness(
 
     return {
         minReadyPeers: Math.max(1, Math.round(options.readyPeerCount)),
-        timeoutMs: typeof options.readyTimeoutMs === 'number' && Number.isFinite(options.readyTimeoutMs)
+        timeoutMs: typeof options.readyTimeoutMs === 'number' &&
+                Number.isFinite(options.readyTimeoutMs)
             ? Math.max(1, Math.round(options.readyTimeoutMs))
             : 5_000,
         intervalMs: 100
@@ -213,10 +214,15 @@ function multicastDeliveryPlan(
     logicalFanoutMessages: number;
 }> {
     const participantCount = normalizePositiveInteger(options.participantCount, 50, 2);
-    const senderCount = Math.min(participantCount, normalizePositiveInteger(options.senderCount, 1, 1));
+    const senderCount = Math.min(
+        participantCount,
+        normalizePositiveInteger(options.senderCount, 1, 1)
+    );
     const rateHz = normalizeRallarBlackBoxRtcRealtimeRateHz(options.rateHz);
     const intervalMs = Math.max(1, Math.round(1_000 / rateHz));
-    const durationSeconds = normalizeRallarBlackBoxRtcRealtimeDurationSeconds(options.durationSeconds);
+    const durationSeconds = normalizeRallarBlackBoxRtcRealtimeDurationSeconds(
+        options.durationSeconds
+    );
     const frameCount = Math.max(1, Math.round(durationSeconds * rateHz));
     const receiverCount = senderCount === participantCount
         ? participantCount
@@ -427,7 +433,7 @@ function ensureGroupRequestId(
     requestPrefix: string,
     operation: 'group' | 'member'
 ): string {
-    return `${requestPrefix}-ensure-${operation}-{runId}`;
+    return `${requestPrefix}-ensure-${operation}-{runtimeIdentity}`;
 }
 
 function createRallarBlackBoxEnsureGroupCommands(
@@ -478,7 +484,8 @@ function createRallarBlackBoxEnsureGroupCommands(
             commandId: `${input.commandPrefix}-ensure-member`,
             timeoutMs: 5_000,
             metadata: {
-                purpose: 'Ensure the logged-in browser client is an active group member before RTC room join.',
+                purpose: 'Ensure the logged-in browser client is an active group member ' +
+                    'before RTC room join.',
                 idempotent: true,
                 group: input.group
             },
@@ -593,48 +600,55 @@ export function createRallarBlackBoxProviderParityLiveRecipe(
         }
     });
     const configureCommand = baseRecipe.commands[0];
-    const scopedCommands = baseRecipe.commands.slice(1).map((command): RallarBlackBoxTestCommand => {
-        if (command.kind === 'rtc.connect') {
-            return {
-                ...command,
-                actor,
-                roomId: group.groupId,
-                applicationId: group.applicationId,
-                workspaceId: group.workspaceId,
-                roomRef,
-                timeoutMs: computeRtcConnectCommandTimeoutMs(options, command.timeoutMs ?? 5_000),
-                rallar: {
-                    ...command.rallar,
-                    apiBaseUrl,
+    const scopedCommands = baseRecipe.commands.slice(1).map(
+        (command): RallarBlackBoxTestCommand => {
+            if (command.kind === 'rtc.connect') {
+                return {
+                    ...command,
+                    actor,
+                    roomId: group.groupId,
                     applicationId: group.applicationId,
                     workspaceId: group.workspaceId,
-                    scope: {
+                    roomRef,
+                    timeoutMs: computeRtcConnectCommandTimeoutMs(
+                        options,
+                        command.timeoutMs ?? 5_000
+                    ),
+                    rallar: {
+                        ...command.rallar,
+                        apiBaseUrl,
                         applicationId: group.applicationId,
-                        workspaceId: group.workspaceId
+                        workspaceId: group.workspaceId,
+                        scope: {
+                            applicationId: group.applicationId,
+                            workspaceId: group.workspaceId
+                        },
+                        roomRef
                     },
-                    roomRef
-                },
-                readiness: rtcConnectReadiness(options)
-            };
+                    readiness: rtcConnectReadiness(options)
+                };
+            }
+            if (command.kind === 'rtc.send') {
+                const send = command.send &&
+                        typeof command.send === 'object' &&
+                        !Array.isArray(command.send)
+                    ? command.send
+                    : {};
+                return {
+                    ...command,
+                    applicationId: group.applicationId,
+                    workspaceId: group.workspaceId,
+                    roomRef,
+                    send: {
+                        ...send,
+                        roomId: group.groupId,
+                        roomRef
+                    }
+                };
+            }
+            return command;
         }
-        if (command.kind === 'rtc.send') {
-            const send = command.send && typeof command.send === 'object' && !Array.isArray(command.send)
-                ? command.send
-                : {};
-            return {
-                ...command,
-                applicationId: group.applicationId,
-                workspaceId: group.workspaceId,
-                roomRef,
-                send: {
-                    ...send,
-                    roomId: group.groupId,
-                    roomRef
-                }
-            };
-        }
-        return command;
-    });
+    );
 
     return {
         ...baseRecipe,
@@ -698,8 +712,8 @@ export function createRallarBlackBoxRtcMessagesPrincipalMulticastRecipes(
         schemaVersion: 1,
         recipeId: RALLAR_BLACK_BOX_RTC_MESSAGES_PRINCIPAL_MULTICAST_SENDER_RECIPE_FIXTURE_ID,
         name: 'RTC messages principal multicast sender',
-        description:
-            `Connect RTC messages and multicast ${receiverPlan.frameCount} principal frames at ${receiverPlan.rateHz} Hz.`,
+        description: 'Connect RTC messages and multicast ' +
+            `${receiverPlan.frameCount} principal frames at ${receiverPlan.rateHz} Hz.`,
         continueOnFailure: false,
         metadata: senderMetadata,
         commands: [
@@ -765,8 +779,8 @@ export function createRallarBlackBoxRtcMessagesPrincipalMulticastRecipes(
         schemaVersion: 1,
         recipeId: RALLAR_BLACK_BOX_RTC_MESSAGES_PRINCIPAL_MULTICAST_RECEIVER_RECIPE_FIXTURE_ID,
         name: 'RTC messages principal multicast receiver',
-        description:
-            `Connect RTC messages, hold for ${receiverPlan.durationSeconds}s, and assert principal multicast delivery.`,
+        description: `Connect RTC messages, hold for ${receiverPlan.durationSeconds}s, ` +
+            'and assert principal multicast delivery.',
         continueOnFailure: false,
         metadata: receiverMetadata,
         commands: [
@@ -841,8 +855,8 @@ export function createRallarBlackBoxRtcMessagesAllPeerMulticastRecipe(
         schemaVersion: 1,
         recipeId: RALLAR_BLACK_BOX_RTC_MESSAGES_ALL_PEER_MULTICAST_RECIPE_FIXTURE_ID,
         name: 'RTC messages all-peer multicast',
-        description:
-            `Connect RTC messages and multicast from every peer at ${plan.rateHz} Hz for ${plan.durationSeconds}s.`,
+        description: 'Connect RTC messages and multicast from every peer at ' +
+            `${plan.rateHz} Hz for ${plan.durationSeconds}s.`,
         continueOnFailure: false,
         metadata,
         commands: [
@@ -939,7 +953,9 @@ export function createRallarBlackBoxRtcMessagesAllPeerMulticastRecipe(
 export function createRallarBlackBoxRtcRealtimeRecipe(
     options: RallarBlackBoxRtcRealtimeRecipeOptions = {}
 ): RallarBlackBoxTestRecipe {
-    const durationSeconds = normalizeRallarBlackBoxRtcRealtimeDurationSeconds(options.durationSeconds);
+    const durationSeconds = normalizeRallarBlackBoxRtcRealtimeDurationSeconds(
+        options.durationSeconds
+    );
     const rateHz = normalizeRallarBlackBoxRtcRealtimeRateHz(options.rateHz);
     const intervalMs = Math.max(1, Math.round(1_000 / rateHz));
     const frameCount = Math.max(1, Math.round(durationSeconds * rateHz));
@@ -949,6 +965,7 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
     const executionMode = options.executionMode ?? 'loop';
     const continueOnStreamSendFailure = options.stream?.continueOnSendFailure ??
         ((options.stream?.maxDroppedFrames ?? 0) > 0 ? true : undefined);
+
     const sendCommand: RallarBlackBoxTestCommand = {
         kind: 'rtc.send',
         commandId: 'rtc-realtime-position',
@@ -992,6 +1009,7 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
             }
         }
     };
+
     const streamCommand: RallarBlackBoxTestCommand = {
         kind: 'rtc.stream',
         commandId: 'rtc-realtime-position-stream',
@@ -1011,6 +1029,7 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
         ...(continueOnStreamSendFailure === undefined
             ? {}
             : { continueOnSendFailure: continueOnStreamSendFailure }),
+
         thresholds: {
             minSendSuccessRatio: options.stream?.minSendSuccessRatio ?? 0.99,
             maxDroppedFrames: options.stream?.maxDroppedFrames ?? 0,
@@ -1055,10 +1074,12 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
             }
         }
     };
+
     return {
         recipeId: RALLAR_BLACK_BOX_RTC_REALTIME_RECIPE_FIXTURE_ID,
         name: 'RTC realtime position stream',
-        description: `Connect RTC and send game-style position updates at ${rateHz} Hz for the configured duration.`,
+        description: 'Connect RTC and send game-style position updates at ' +
+            `${rateHz} Hz for the configured duration.`,
         continueOnFailure: false,
         metadata: {
             profile: 'rtc-realtime',
@@ -1069,6 +1090,7 @@ export function createRallarBlackBoxRtcRealtimeRecipe(
             executionMode,
             group
         },
+
         commands: [
             ...createRallarBlackBoxEnsureGroupCommands({
                 commandPrefix: 'rtc-realtime',
@@ -1258,11 +1280,13 @@ export const RALLAR_BLACK_BOX_RECIPE_FIXTURES: readonly RallarBlackBoxRecipeFixt
     {
         fixtureId: 'composite-evidence',
         label: 'Composite Evidence',
-        description: 'Runs loop, parallel, wait, and assert commands against local browser-agent evidence.',
+        description: 'Runs loop, parallel, wait, and assert commands against local ' +
+            'browser-agent evidence.',
         recipe: {
             recipeId: 'composite-evidence-recipe',
             name: 'Composite evidence recipe',
-            description: 'Validates composite command authoring without requiring live Rallar services.',
+            description: 'Validates composite command authoring without requiring live ' +
+                'Rallar services.',
             continueOnFailure: false,
             metadata: {
                 profile: 'composite',

--- a/packages/tests/rallar-black-box/distributed-recipes.test.ts
+++ b/packages/tests/rallar-black-box/distributed-recipes.test.ts
@@ -434,11 +434,6 @@ describe('distributed recipes helpers', () => {
         const sendCommand = loopCommand?.commands[0] as
             | Extract<typeof recipe.commands[number], { kind: 'rtc.send'; }>
             | undefined;
-        const firstPayload = sendCommand?.send as {
-            roomId?: string;
-            roomRef?: Record<string, unknown>;
-            data?: Record<string, unknown>;
-        } | undefined;
         const preview = distributedRecipeCommandPreview(recipe);
 
         const groupRequestId = createRallarBlackBoxEnsureGroupRequestId({
@@ -488,7 +483,7 @@ describe('distributed recipes helpers', () => {
                 acceptedStatusCodes: [200, 201]
             }
         });
-        expect((connectCommand as { readiness?: unknown; } | undefined)?.readiness).toBeUndefined();
+        expect(connectCommand?.readiness).toBeUndefined();
         expect(loopCommand).toMatchObject({
             kind: 'loop',
             commandId: 'rtc-realtime-position-loop',
@@ -511,20 +506,22 @@ describe('distributed recipes helpers', () => {
             workspaceId: 'live',
             groupId: 'arena-1'
         });
-        expect(firstPayload?.roomId).toBe('arena-1');
-        expect(firstPayload?.data).toMatchObject({
-            topic: 'room.black-box.rtc-realtime.position',
-            actor: '{auth.clientId}',
-            seq: '{loop.index}',
-            rateHz: 20,
-            durationSeconds: 2,
-            totalFrames: 40,
-            tMs: '{loop.elapsedMs}',
-            position: {
-                frame: '{loop.iteration}',
-                x: '{loop.index}',
-                y: 0,
-                z: '{loop.index}'
+        expect(sendCommand?.send).toMatchObject({
+            roomId: 'arena-1',
+            data: {
+                topic: 'room.black-box.rtc-realtime.position',
+                actor: '{auth.clientId}',
+                seq: '{loop.index}',
+                rateHz: 20,
+                durationSeconds: 2,
+                totalFrames: 40,
+                tMs: '{loop.elapsedMs}',
+                position: {
+                    frame: '{loop.iteration}',
+                    x: '{loop.index}',
+                    y: 0,
+                    z: '{loop.index}'
+                }
             }
         });
         expect(recipe.metadata).toMatchObject({
@@ -571,12 +568,14 @@ describe('distributed recipes helpers', () => {
                 }
             }
         });
-        expect((stream?.send as { data?: Record<string, unknown>; } | undefined)?.data).toMatchObject({
-            seq: '{stream.index}',
-            tMs: '{stream.elapsedMs}',
-            position: {
-                frame: '{stream.iteration}',
-                x: '{stream.index}'
+        expect(stream?.send).toMatchObject({
+            data: {
+                seq: '{stream.index}',
+                tMs: '{stream.elapsedMs}',
+                position: {
+                    frame: '{stream.iteration}',
+                    x: '{stream.index}'
+                }
             }
         });
         expect(distributedRecipeCommandPreview(recipe)).toEqual({
@@ -599,7 +598,6 @@ describe('distributed recipes helpers', () => {
         const stream = recipe.commands.find((command) => command.kind === 'rtc.stream') as
             | Extract<typeof recipe.commands[number], { kind: 'rtc.stream'; }>
             | undefined;
-        const sendPayload = stream?.send as { data?: Record<string, unknown>; } | undefined;
 
         expect(recipe.description).toContain('10 Hz');
         expect(stream).toMatchObject({
@@ -621,11 +619,13 @@ describe('distributed recipes helpers', () => {
                 frameCount: 50
             }
         });
-        expect(sendPayload?.data).toMatchObject({
-            rateHz: 10,
-            intervalMs: 100,
-            durationSeconds: 5,
-            totalFrames: 50
+        expect(stream?.send).toMatchObject({
+            data: {
+                rateHz: 10,
+                intervalMs: 100,
+                durationSeconds: 5,
+                totalFrames: 50
+            }
         });
         expect(recipe.metadata).toMatchObject({
             rateHz: 10,
@@ -734,7 +734,7 @@ describe('distributed recipes helpers', () => {
             request: {
                 method: 'POST',
                 path: expect.stringMatching(
-                    /^\/api\/state\/apps\/game-app\/workspaces\/live\/groups\/requests\/[^/]+-\{runId\}$/
+                    /^\/api\/state\/apps\/game-app\/workspaces\/live\/groups\/requests\/[^/]+-\{runtimeIdentity\}$/
                 ),
                 body: {
                     groupId: 'arena-1',
@@ -750,7 +750,7 @@ describe('distributed recipes helpers', () => {
                 path: expect.stringMatching(
                     new RegExp(
                         '^/api/state/apps/game-app/workspaces/live/groups/arena-1/' +
-                            'members/\\{auth\\.clientId\\}/requests/[^/]+-\\{runId\\}$'
+                            'members/\\{auth\\.clientId\\}/requests/[^/]+-\\{runtimeIdentity\\}$'
                     )
                 ),
                 body: {
@@ -1020,7 +1020,7 @@ describe('distributed recipes helpers', () => {
             [
                 'http.request',
                 expect.stringMatching(
-                    /^POST \/api\/state\/apps\/game-app\/workspaces\/live\/groups\/requests\/[^/]+-\{runId\}$/
+                    /^POST \/api\/state\/apps\/game-app\/workspaces\/live\/groups\/requests\/[^/]+-\{runtimeIdentity\}$/
                 )
             ],
             [
@@ -1028,7 +1028,7 @@ describe('distributed recipes helpers', () => {
                 expect.stringMatching(
                     new RegExp(
                         '^PUT /api/state/apps/game-app/workspaces/live/groups/arena-1/' +
-                            'members/\\{auth\\.clientId\\}/requests/[^/]+-\\{runId\\}$'
+                            'members/\\{auth\\.clientId\\}/requests/[^/]+-\\{runtimeIdentity\\}$'
                     )
                 )
             ],
@@ -1077,11 +1077,7 @@ describe('distributed recipes helpers', () => {
             }
         );
 
-        const readinesses = [realtime, smoke, parity].map((recipe) =>
-            (recipe.commands.find((command) => command.kind === 'rtc.connect') as {
-                readiness?: unknown;
-            } | undefined)?.readiness
-        );
+        const readinesses = [realtime, smoke, parity].map((recipe) => recipe.commands.find((command) => command.kind === 'rtc.connect')?.readiness);
 
         expect(readinesses).toEqual([
             { minReadyPeers: 2, timeoutMs: 10_000, intervalMs: 100 },
@@ -1946,8 +1942,22 @@ describe('distributed recipes helpers', () => {
             { agentId: 'agent-c', role: 'observer', recipeIds: ['shared-recipe'] }
         ] as const;
         const commandLinks = [
-            { phase: 'stage', agentId: 'agent-a', commandId: 'sender-a', recipeId: 'sender-recipe', role: 'sender', queuedAtEpochMs: 1_100 },
-            { phase: 'stage', agentId: 'agent-b', commandId: 'receiver-b', recipeId: 'receiver-recipe', role: 'receiver', queuedAtEpochMs: 1_110 },
+            {
+                phase: 'stage',
+                agentId: 'agent-a',
+                commandId: 'sender-a',
+                recipeId: 'sender-recipe',
+                role: 'sender',
+                queuedAtEpochMs: 1_100
+            },
+            {
+                phase: 'stage',
+                agentId: 'agent-b',
+                commandId: 'receiver-b',
+                recipeId: 'receiver-recipe',
+                role: 'receiver',
+                queuedAtEpochMs: 1_110
+            },
             { phase: 'stage', agentId: 'agent-b', commandId: 'shared-b', recipeId: 'shared-recipe', queuedAtEpochMs: 1_120 },
             { phase: 'stage', agentId: 'agent-c', commandId: 'shared-c', recipeId: 'shared-recipe', queuedAtEpochMs: 1_130 }
         ] satisfies ControlDistributedRunSnapshot['commandLinks'];
@@ -3738,42 +3748,55 @@ describe('distributed recipes helpers', () => {
     });
 
     it('treats malformed manifest fields as absent without losing top-level history evidence', () => {
-        const malformedManifestRun: ControlDistributedRunSnapshot = {
-            ...distributedRun,
-            distributedRunId: 'dist-malformed-manifest',
-            manifest: undefined as unknown as ControlDistributedRunSnapshot['manifest']
-        };
-        const malformedFieldsRun: ControlDistributedRunSnapshot = {
-            ...distributedRun,
-            distributedRunId: 'dist-malformed-fields',
-            manifest: {
-                displayName: { text: 'not searchable' },
-                group: {
-                    applicationId: { text: 'not searchable' },
-                    workspaceId: { text: 'not searchable' },
-                    groupId: { text: 'not searchable' }
-                },
-                recipes: { recipeId: 'not-an-array' },
-                metadata: { createdBy: { name: 'not searchable' } }
-            } as unknown as ControlDistributedRunSnapshot['manifest']
-        };
-        const independentSelectionRun: ControlDistributedRunSnapshot = {
-            ...distributedRun,
-            distributedRunId: 'dist-independent-selections',
-            manifest: {
-                ...distributedRun.manifest,
-                recipes: [
-                    null,
-                    { profile: 'regression' },
-                    { recipeId: 'other-recipe', profile: 'smoke' },
-                    {
-                        recipeId: 'malformed-profile',
-                        profile: { text: 'not searchable' },
-                        role: { text: 'not searchable' }
-                    }
-                ]
-            } as unknown as ControlDistributedRunSnapshot['manifest']
-        };
+        const malformedManifestRun = Object.defineProperty(
+            {
+                ...distributedRun,
+                distributedRunId: 'dist-malformed-manifest'
+            },
+            'manifest',
+            { value: undefined }
+        );
+        const malformedFieldsRun = Object.defineProperty(
+            {
+                ...distributedRun,
+                distributedRunId: 'dist-malformed-fields'
+            },
+            'manifest',
+            {
+                value: {
+                    displayName: { text: 'not searchable' },
+                    group: {
+                        applicationId: { text: 'not searchable' },
+                        workspaceId: { text: 'not searchable' },
+                        groupId: { text: 'not searchable' }
+                    },
+                    recipes: { recipeId: 'not-an-array' },
+                    metadata: { createdBy: { name: 'not searchable' } }
+                }
+            }
+        );
+        const independentSelectionRun = Object.defineProperty(
+            {
+                ...distributedRun,
+                distributedRunId: 'dist-independent-selections'
+            },
+            'manifest',
+            {
+                value: {
+                    ...distributedRun.manifest,
+                    recipes: [
+                        null,
+                        { profile: 'regression' },
+                        { recipeId: 'other-recipe', profile: 'smoke' },
+                        {
+                            recipeId: 'malformed-profile',
+                            profile: { text: 'not searchable' },
+                            role: { text: 'not searchable' }
+                        }
+                    ]
+                }
+            }
+        );
 
         expect(
             filterDistributedRuns([

--- a/packages/tests/rallar-black-box/hetzner-recipe-mutation-identity.test.ts
+++ b/packages/tests/rallar-black-box/hetzner-recipe-mutation-identity.test.ts
@@ -37,7 +37,9 @@ describe.each(
                     !requestId.includes('auth.')
             )
         ).toBe(true);
-        expect(firstRequestIds.every((requestId) => requestId?.endsWith('-{runId}'))).toBe(true);
+        expect(firstRequestIds.every(
+            (requestId) => requestId?.endsWith('-{runtimeIdentity}')
+        )).toBe(true);
     });
 });
 

--- a/packages/tests/shared-test/rallar-bb-browser-adapter-auth.test.ts
+++ b/packages/tests/shared-test/rallar-bb-browser-adapter-auth.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { isApiMutationRequestId } from '@shared/api/mutation/api-mutation-request.ts';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createRallarBlackBoxBrowserTestRuntime } from '../../shared-test/rallar-bb-test/browser-adapter.ts';
 import { createRallarBlackBoxRtcRealtimeRecipe } from '../../shared-test/rallar-bb-test/recipe-fixtures.ts';
@@ -86,7 +87,9 @@ describe('rallar-bb browser adapter auth', () => {
 
         expect(result.ok).toBe(true);
         const headers = new Headers(fetchCalls[0].init?.headers);
-        expect(fetchCalls[0].input).toBe('https://api.example.test/api/state/apps/app/workspaces/ws/groups');
+        expect(fetchCalls[0].input).toBe(
+            'https://api.example.test/api/state/apps/app/workspaces/ws/groups'
+        );
         expect(headers.get('authorization')).toBe('Bearer token-1');
         expect(headers.get('x-client-id')).toBe('client-1');
         expect(headers.get('content-type')).toBeNull();
@@ -216,7 +219,9 @@ describe('rallar-bb browser adapter auth', () => {
         expect(authenticateConfigs).toHaveLength(1);
         expect(authenticateConfigs[0]).not.toHaveProperty('roomId');
         expect(connectCalls).toBe(0);
-        expect(fetchCalls[0].input).toBe('https://api.example.test/api/state/apps/app/workspaces/ws/groups');
+        expect(fetchCalls[0].input).toBe(
+            'https://api.example.test/api/state/apps/app/workspaces/ws/groups'
+        );
         expect(headers.get('authorization')).toBe('Bearer token-1');
         expect(headers.get('x-client-id')).toBe('controller-01');
     });
@@ -272,118 +277,122 @@ describe('rallar-bb browser adapter auth', () => {
         expect(connectConfigs).toHaveLength(1);
     });
 
-    it('preserves bootstrap Rallar credentials when recipe configure narrows live scope', async () => {
-        const authenticateConfigs: unknown[] = [];
-        const runtime = createRallarBlackBoxBrowserTestRuntime({
-            fetch: (async () =>
-                new Response(JSON.stringify({ ok: true }), {
-                    status: 201,
-                    headers: {
-                        'content-type': 'application/json'
-                    }
-                })) as typeof fetch,
-            rallarRuntime: {
-                authenticate: async (config) => {
-                    authenticateConfigs.push(config);
-                    const rallar = (config as { rallar?: { username?: string; password?: string; }; }).rallar;
-                    if (!rallar?.username || !rallar.password) {
-                        throw new Error('missing Rallar credentials');
-                    }
-                    storage.setItem(
-                        'auth.session',
-                        JSON.stringify({
-                            clientId: 'controller-01',
-                            accessToken: 'token-1',
-                            username: rallar.username,
-                            sessionId: 'controller-01',
-                            expiresAtEpochMs: Date.now() + 60_000
-                        })
-                    );
-                    return { status: 'authenticated' };
-                },
-                connect: async () => {
-                    throw new Error('full connect must not run for HTTP authentication');
-                },
-                send: async () => ({ sent: true }),
-                refreshRoom: async () => undefined,
-                close: async () => ({ closed: true }),
-                health: async () => ({ connected: true })
-            }
-        });
+    it(
+        'preserves bootstrap Rallar credentials when recipe configure ' +
+            'narrows live scope',
+        async () => {
+            const authenticateConfigs: unknown[] = [];
+            const runtime = createRallarBlackBoxBrowserTestRuntime({
+                fetch: (async () =>
+                    new Response(JSON.stringify({ ok: true }), {
+                        status: 201,
+                        headers: {
+                            'content-type': 'application/json'
+                        }
+                    })) as typeof fetch,
+                rallarRuntime: {
+                    authenticate: async (config) => {
+                        authenticateConfigs.push(config);
+                        const rallar = (config as { rallar?: { username?: string; password?: string; }; }).rallar;
+                        if (!rallar?.username || !rallar.password) {
+                            throw new Error('missing Rallar credentials');
+                        }
+                        storage.setItem(
+                            'auth.session',
+                            JSON.stringify({
+                                clientId: 'controller-01',
+                                accessToken: 'token-1',
+                                username: rallar.username,
+                                sessionId: 'controller-01',
+                                expiresAtEpochMs: Date.now() + 60_000
+                            })
+                        );
+                        return { status: 'authenticated' };
+                    },
+                    connect: async () => {
+                        throw new Error('full connect must not run for HTTP authentication');
+                    },
+                    send: async () => ({ sent: true }),
+                    refreshRoom: async () => undefined,
+                    close: async () => ({ closed: true }),
+                    health: async () => ({ connected: true })
+                }
+            });
 
-        await runtime.execute({
-            kind: 'configure',
-            commandId: 'bootstrap-configure',
-            config: {
-                apiBaseUrl: 'https://api.example.test',
-                actor: 'controller-01',
-                sessionId: 'controller-01',
-                roomId: 'hetzner-headless-room',
+            await runtime.execute({
+                kind: 'configure',
+                commandId: 'bootstrap-configure',
+                config: {
+                    apiBaseUrl: 'https://api.example.test',
+                    actor: 'controller-01',
+                    sessionId: 'controller-01',
+                    roomId: 'hetzner-headless-room',
+                    rallar: {
+                        username: 'rallar',
+                        password: 'secret',
+                        register: 'if-needed'
+                    }
+                }
+            });
+            await runtime.execute({
+                kind: 'configure',
+                commandId: 'recipe-configure-live-scope',
+                config: {
+                    apiBaseUrl: 'https://api.example.test',
+                    actor: 'controller-01',
+                    sessionId: 'controller-01',
+                    roomId: 'hetzner-headless-room',
+                    rallar: {
+                        apiBaseUrl: 'https://api.example.test',
+                        applicationId: 'rallar-server',
+                        workspaceId: 'default',
+                        timeoutMs: 10_000,
+                        logoutOnClose: false,
+                        leaveRoomOnClose: false,
+                        scope: {
+                            applicationId: 'rallar-server',
+                            workspaceId: 'default'
+                        },
+                        roomRef: {
+                            applicationId: 'rallar-server',
+                            workspaceId: 'default',
+                            groupId: 'hetzner-headless-room'
+                        }
+                    }
+                }
+            });
+            const result = await runtime.execute({
+                kind: 'http.request',
+                commandId: 'http-api-auth-after-recipe-configure',
+                request: {
+                    path: '/api/state/apps/rallar-server/workspaces/default/groups',
+                    method: 'POST',
+                    body: {
+                        requestId: 'ensure-group',
+                        groupId: 'hetzner-headless-room'
+                    }
+                },
+                response: {
+                    body: 'json'
+                }
+            });
+
+            expect(result.ok).toBe(true);
+            expect(authenticateConfigs).toHaveLength(1);
+            expect(authenticateConfigs[0]).toMatchObject({
                 rallar: {
                     username: 'rallar',
                     password: 'secret',
-                    register: 'if-needed'
-                }
-            }
-        });
-        await runtime.execute({
-            kind: 'configure',
-            commandId: 'recipe-configure-live-scope',
-            config: {
-                apiBaseUrl: 'https://api.example.test',
-                actor: 'controller-01',
-                sessionId: 'controller-01',
-                roomId: 'hetzner-headless-room',
-                rallar: {
-                    apiBaseUrl: 'https://api.example.test',
+                    register: 'if-needed',
                     applicationId: 'rallar-server',
                     workspaceId: 'default',
                     timeoutMs: 10_000,
                     logoutOnClose: false,
-                    leaveRoomOnClose: false,
-                    scope: {
-                        applicationId: 'rallar-server',
-                        workspaceId: 'default'
-                    },
-                    roomRef: {
-                        applicationId: 'rallar-server',
-                        workspaceId: 'default',
-                        groupId: 'hetzner-headless-room'
-                    }
+                    leaveRoomOnClose: false
                 }
-            }
-        });
-        const result = await runtime.execute({
-            kind: 'http.request',
-            commandId: 'http-api-auth-after-recipe-configure',
-            request: {
-                path: '/api/state/apps/rallar-server/workspaces/default/groups',
-                method: 'POST',
-                body: {
-                    requestId: 'ensure-group',
-                    groupId: 'hetzner-headless-room'
-                }
-            },
-            response: {
-                body: 'json'
-            }
-        });
-
-        expect(result.ok).toBe(true);
-        expect(authenticateConfigs).toHaveLength(1);
-        expect(authenticateConfigs[0]).toMatchObject({
-            rallar: {
-                username: 'rallar',
-                password: 'secret',
-                register: 'if-needed',
-                applicationId: 'rallar-server',
-                workspaceId: 'default',
-                timeoutMs: 10_000,
-                logoutOnClose: false,
-                leaveRoomOnClose: false
-            }
-        });
-    });
+            });
+        }
+    );
 
     it('resolves logged-in auth placeholders in HTTP paths and bodies', async () => {
         storage.setItem(
@@ -449,110 +458,265 @@ describe('rallar-bb browser adapter auth', () => {
         });
     });
 
-    it('authenticates before resolving HTTP auth placeholders without starting full connect', async () => {
+    it(
+        'authenticates before resolving HTTP auth placeholders without ' +
+            'starting full connect',
+        async () => {
+            const fetchCalls: Array<{
+                input: RequestInfo | URL;
+                init?: RequestInit;
+            }> = [];
+            const authenticateConfigs: unknown[] = [];
+            let connectCalls = 0;
+            const runtime = createRallarBlackBoxBrowserTestRuntime({
+                fetch: (async (input, init) => {
+                    fetchCalls.push({ input, init });
+                    return new Response(JSON.stringify({ ok: true }), {
+                        status: 200,
+                        headers: {
+                            'content-type': 'application/json'
+                        }
+                    });
+                }) as typeof fetch,
+                rallarRuntime: {
+                    authenticate: async (config) => {
+                        authenticateConfigs.push(config);
+                        storage.setItem(
+                            'auth.session',
+                            JSON.stringify({
+                                clientId: 'controller-01',
+                                accessToken: 'token-1',
+                                username: 'rallar',
+                                sessionId: 'controller-01',
+                                expiresAtEpochMs: Date.now() + 60_000
+                            })
+                        );
+                        return { status: 'authenticated' };
+                    },
+                    connect: async () => {
+                        connectCalls += 1;
+                        throw new Error('full connect must not run for HTTP authentication');
+                    },
+                    send: async () => ({ sent: true }),
+                    refreshRoom: async () => undefined,
+                    close: async () => ({ closed: true }),
+                    health: async () => ({ connected: true })
+                }
+            });
+
+            await runtime.execute({
+                kind: 'configure',
+                commandId: 'configure-api-auth-placeholders-with-runtime-login',
+                config: {
+                    apiBaseUrl: 'https://api.example.test',
+                    actor: 'controller-01',
+                    sessionId: 'controller-01',
+                    roomId: 'hetzner-headless-room',
+                    transport: 'realtime',
+                    rallar: {
+                        apiBaseUrl: 'https://api.example.test',
+                        username: 'rallar',
+                        password: 'secret',
+                        register: 'if-needed',
+                        transport: 'realtime'
+                    }
+                }
+            });
+            const result = await runtime.execute({
+                kind: 'http.request',
+                commandId: 'http-api-auth-placeholders-with-runtime-login',
+                request: {
+                    path: '/api/state/apps/app/workspaces/ws/groups/bb-group/members/{auth.clientId}',
+                    method: 'PUT',
+                    body: {
+                        requestId: 'ensure-member:{auth.clientId}',
+                        status: 'active'
+                    }
+                },
+                response: {
+                    body: 'json'
+                }
+            });
+
+            expect(result.ok).toBe(true);
+            const headers = new Headers(fetchCalls[0].init?.headers);
+            expect(authenticateConfigs).toEqual([
+                expect.objectContaining({
+                    connection: 'controller-01',
+                    actor: 'controller-01',
+                    rallar: expect.objectContaining({
+                        apiBaseUrl: 'https://api.example.test',
+                        username: 'rallar',
+                        password: 'secret',
+                        register: 'if-needed',
+                        transport: 'realtime',
+                        expectedSessionId: 'controller-01'
+                    })
+                })
+            ]);
+            expect(authenticateConfigs[0]).not.toHaveProperty('roomId');
+            expect(connectCalls).toBe(0);
+            expect(fetchCalls[0].input).toBe(
+                'https://api.example.test/api/state/apps/app/workspaces/ws/groups/bb-group/members/controller-01'
+            );
+            expect(headers.get('authorization')).toBe('Bearer token-1');
+            expect(JSON.parse(String(fetchCalls[0].init?.body))).toEqual({
+                requestId: 'ensure-member:controller-01',
+                status: 'active'
+            });
+        }
+    );
+
+    it('resolves raw and URL-encoded runtime identity placeholders in HTTP requests', async () => {
         const fetchCalls: Array<{
             input: RequestInfo | URL;
             init?: RequestInit;
         }> = [];
-        const authenticateConfigs: unknown[] = [];
-        let connectCalls = 0;
         const runtime = createRallarBlackBoxBrowserTestRuntime({
             fetch: (async (input, init) => {
                 fetchCalls.push({ input, init });
-                return new Response(JSON.stringify({ ok: true }), {
-                    status: 200,
-                    headers: {
-                        'content-type': 'application/json'
-                    }
-                });
-            }) as typeof fetch,
-            rallarRuntime: {
-                authenticate: async (config) => {
-                    authenticateConfigs.push(config);
-                    storage.setItem(
-                        'auth.session',
-                        JSON.stringify({
-                            clientId: 'controller-01',
-                            accessToken: 'token-1',
-                            username: 'rallar',
-                            sessionId: 'controller-01',
-                            expiresAtEpochMs: Date.now() + 60_000
-                        })
-                    );
-                    return { status: 'authenticated' };
-                },
-                connect: async () => {
-                    connectCalls += 1;
-                    throw new Error('full connect must not run for HTTP authentication');
-                },
-                send: async () => ({ sent: true }),
-                refreshRoom: async () => undefined,
-                close: async () => ({ closed: true }),
-                health: async () => ({ connected: true })
-            }
+                return new Response('{}', { status: 200 });
+            }) as typeof fetch
         });
 
         await runtime.execute({
             kind: 'configure',
-            commandId: 'configure-api-auth-placeholders-with-runtime-login',
+            commandId: 'configure-runtime-identity-placeholders',
             config: {
                 apiBaseUrl: 'https://api.example.test',
-                actor: 'controller-01',
-                sessionId: 'controller-01',
-                roomId: 'hetzner-headless-room',
-                transport: 'realtime',
-                rallar: {
-                    apiBaseUrl: 'https://api.example.test',
-                    username: 'rallar',
-                    password: 'secret',
-                    register: 'if-needed',
-                    transport: 'realtime'
-                }
+                runId: 'distributed-run-325',
+                agentId: 'controller-01'
             }
         });
         const result = await runtime.execute({
             kind: 'http.request',
-            commandId: 'http-api-auth-placeholders-with-runtime-login',
+            commandId: 'http-runtime-identity-placeholders',
             request: {
-                path: '/api/state/apps/app/workspaces/ws/groups/bb-group/members/{auth.clientId}',
-                method: 'PUT',
-                body: {
-                    requestId: 'ensure-member:{auth.clientId}',
-                    status: 'active'
-                }
-            },
-            response: {
-                body: 'json'
+                path: '/api/state/requests/ensure-group-{runId}-%7BagentId%7D',
+                method: 'POST'
             }
         });
 
         expect(result.ok).toBe(true);
-        const headers = new Headers(fetchCalls[0].init?.headers);
-        expect(authenticateConfigs).toEqual([
-            expect.objectContaining({
-                connection: 'controller-01',
-                actor: 'controller-01',
-                rallar: expect.objectContaining({
-                    apiBaseUrl: 'https://api.example.test',
-                    username: 'rallar',
-                    password: 'secret',
-                    register: 'if-needed',
-                    transport: 'realtime',
-                    expectedSessionId: 'controller-01'
-                })
-            })
+        expect(fetchCalls.map((call) => call.input)).toEqual([
+            'https://api.example.test/api/state/requests/' +
+            'ensure-group-distributed-run-325-controller-01'
         ]);
-        expect(authenticateConfigs[0]).not.toHaveProperty('roomId');
-        expect(connectCalls).toBe(0);
-        expect(fetchCalls[0].input).toBe(
-            'https://api.example.test/api/state/apps/app/workspaces/ws/groups/bb-group/members/controller-01'
-        );
-        expect(headers.get('authorization')).toBe('Bearer token-1');
-        expect(JSON.parse(String(fetchCalls[0].init?.body))).toEqual({
-            requestId: 'ensure-member:controller-01',
-            status: 'active'
-        });
     });
+
+    it('creates stable bounded identities from long run and agent ids', async () => {
+        const requestIds: string[] = [];
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async (input) => {
+                requestIds.push(new URL(String(input)).pathname.split('/').at(-1) ?? '');
+                return new Response('{}', { status: 200 });
+            }) as typeof fetch
+        });
+        const runId = 'rallar-live-three-browser-live3-1787338266520-7060e2f6c24808';
+
+        for (
+            const [index, agentId] of [
+                'live-realtime-a-live3-1787338266520-7060e2f6c24808',
+                'live-realtime-b-live3-1787338266520-7060e2f6c24808',
+                'live-realtime-a-live3-1787338266520-7060e2f6c24808'
+            ].entries()
+        ) {
+            await runtime.execute({
+                kind: 'configure',
+                commandId: `configure-runtime-identity-${index}`,
+                config: {
+                    apiBaseUrl: 'https://api.example.test',
+                    runId,
+                    agentId
+                }
+            });
+            const result = await runtime.execute({
+                kind: 'http.request',
+                commandId: `request-runtime-identity-${index}`,
+                request: {
+                    path: '/api/state/requests/ensure-group-{runtimeIdentity}',
+                    method: 'POST'
+                }
+            });
+            expect(result.ok).toBe(true);
+        }
+
+        expect(requestIds).toHaveLength(3);
+        expect(requestIds[0]).toBe(requestIds[2]);
+        expect(requestIds[0]).not.toBe(requestIds[1]);
+        expect(requestIds.every(isApiMutationRequestId)).toBe(true);
+    });
+
+    it('pads runtime identities to a fixed width', async () => {
+        const fetchCalls: Array<RequestInfo | URL> = [];
+        const runtime = createRallarBlackBoxBrowserTestRuntime({
+            fetch: (async (input) => {
+                fetchCalls.push(input);
+                return new Response('{}', { status: 200 });
+            }) as typeof fetch
+        });
+
+        await runtime.execute({
+            kind: 'configure',
+            commandId: 'configure-fixed-width-runtime-identity',
+            config: {
+                apiBaseUrl: 'https://api.example.test',
+                runId: 'run',
+                agentId: 'agent-0'
+            }
+        });
+        const result = await runtime.execute({
+            kind: 'http.request',
+            commandId: 'request-fixed-width-runtime-identity',
+            request: {
+                path: '/api/state/requests/ensure-group-{runtimeIdentity}',
+                method: 'POST'
+            }
+        });
+
+        expect(result.ok).toBe(true);
+        expect(fetchCalls.map((call) => new URL(String(call)).pathname)).toEqual([
+            '/api/state/requests/ensure-group-05930sb3l88hy'
+        ]);
+    });
+
+    it(
+        'fails before fetch when a runtime identity placeholder has no ' +
+            'configured value',
+        async () => {
+            let fetchCalls = 0;
+            const runtime = createRallarBlackBoxBrowserTestRuntime({
+                fetch: (async () => {
+                    fetchCalls += 1;
+                    return new Response('{}', { status: 200 });
+                }) as typeof fetch
+            });
+
+            await runtime.execute({
+                kind: 'configure',
+                commandId: 'configure-incomplete-runtime-identity',
+                config: {
+                    apiBaseUrl: 'https://api.example.test',
+                    runId: 'distributed-run-325'
+                }
+            });
+            const result = await runtime.execute({
+                kind: 'http.request',
+                commandId: 'http-incomplete-runtime-identity',
+                request: {
+                    path: '/api/state/requests/ensure-group-{runtimeIdentity}',
+                    method: 'POST'
+                }
+            });
+
+            expect(result.ok).toBe(false);
+            expect(result.error?.message).toBe(
+                'Cannot resolve recipe placeholder {runtimeIdentity} without ' +
+                    'configured runId and agentId.'
+            );
+            expect(fetchCalls).toBe(0);
+        }
+    );
 
     it('runs the RTC realtime recipe setup before browser RTC connect', async () => {
         storage.setItem(
@@ -586,7 +750,12 @@ describe('rallar-bb browser adapter auth', () => {
                     operations.push('RTC connect');
                     return { connected: true };
                 },
-                send: async () => ({ status: 'sent', peerIds: ['bob-session'], results: [], health: [] }),
+                send: async () => ({
+                    status: 'sent',
+                    peerIds: ['bob-session'],
+                    results: [],
+                    health: []
+                }),
                 refreshRoom: async () => undefined,
                 close: async () => ({ closed: true }),
                 health: async () => ({ connected: true })
@@ -606,6 +775,8 @@ describe('rallar-bb browser adapter auth', () => {
             commandId: 'configure-rtc-realtime',
             config: {
                 apiBaseUrl: 'https://api.example.test',
+                runId: 'distributed-run-325',
+                agentId: 'controller-01',
                 actor: 'alice',
                 sessionId: 'session-1',
                 transport: 'realtime',
@@ -629,27 +800,19 @@ describe('rallar-bb browser adapter auth', () => {
 
         expect(runResult.ok).toBe(true);
         expect(operations.slice(0, 3)).toEqual([
-            expect.stringMatching(
-                /^POST \/api\/state\/apps\/rallar-server\/workspaces\/default\/groups\/requests\/[^/]+-%7BrunId%7D$/
-            ),
-            expect.stringMatching(
-                new RegExp(
-                    '^PUT /api/state/apps/rallar-server/workspaces/default/groups/' +
-                        'hetzner-headless-room/members/alice/requests/[^/]+-%7BrunId%7D$'
-                )
-            ),
+            'POST /api/state/apps/rallar-server/workspaces/default/groups/requests/' +
+            'rtc-realtime-ensure-group-2dg71r3s68rqz',
+            'PUT /api/state/apps/rallar-server/workspaces/default/groups/' +
+            'hetzner-headless-room/members/alice/requests/' +
+            'rtc-realtime-ensure-member-2dg71r3s68rqz',
             'RTC connect'
         ]);
         expect(fetchCalls.map((call) => new URL(String(call.input)).pathname)).toEqual([
-            expect.stringMatching(
-                /^\/api\/state\/apps\/rallar-server\/workspaces\/default\/groups\/requests\/[^/]+-%7BrunId%7D$/
-            ),
-            expect.stringMatching(
-                new RegExp(
-                    '^/api/state/apps/rallar-server/workspaces/default/groups/' +
-                        'hetzner-headless-room/members/alice/requests/[^/]+-%7BrunId%7D$'
-                )
-            )
+            '/api/state/apps/rallar-server/workspaces/default/groups/requests/' +
+            'rtc-realtime-ensure-group-2dg71r3s68rqz',
+            '/api/state/apps/rallar-server/workspaces/default/groups/' +
+            'hetzner-headless-room/members/alice/requests/' +
+            'rtc-realtime-ensure-member-2dg71r3s68rqz'
         ]);
         expect(JSON.parse(String(fetchCalls[0].init?.body))).toEqual({
             groupId: 'hetzner-headless-room',
@@ -771,7 +934,9 @@ describe('rallar-bb browser adapter auth', () => {
         expect(fetchCalls[0].input).toMatch(
             /^https:\/\/api\.example\.test\/api\/auth\/ws-ticket\/requests\/[^/]+$/
         );
-        expect(new Headers(fetchCalls[0].init?.headers).get('authorization')).toBe('Bearer token-1');
+        expect(
+            new Headers(fetchCalls[0].init?.headers).get('authorization')
+        ).toBe('Bearer token-1');
         expect(openedSockets).toEqual([
             'wss://api.example.test/api/ws/session-1?ticket=ticket-1'
         ]);


### PR DESCRIPTION
## Goal

Prevent distributed black-box recipes from sending unresolved, colliding, or overlong mutation request IDs.

## Changes

- Resolve raw and URL-encoded run, agent, and composite runtime identity placeholders in browser commands.
- Use a fixed-width per-run/per-agent runtime fingerprint for generated group and member mutation request IDs.
- Regenerate Hetzner and world-fleet manifests and add regression coverage.

## Acceptance

- Distributed group/member setup emits API-valid request IDs without literal placeholders.
- IDs are stable for replay, unique per agent, and bounded to API limits.
- Missing runtime identity inputs fail before fetch.

## Validation

- Focused Vitest regression suite: 5 files, 98 tests passed.
- Shared-test TypeScript check passed.
- Hetzner and world-fleet manifest checks passed: 62 and 8 manifests.
- Rallar Black Box production build passed: 911 modules transformed.
- Changed repository-style gate and repository-structure check passed.
- Full shared-test suite passed before the rebase. Post-rebase, 885 of 887 tests passed; the two unrelated failures require opening a local listener, which this sandbox denied with `listen EPERM`.
- Focused live Playwright checks were not repeated after the formatting-only upstream rebase; prior runs crossed the changed mutation boundary and later failed on unrelated WebSocket/legacy-route behavior.

## Risk and rollback

Risk is limited to browser command placeholder resolution and generated distributed recipes. Reverting the feature commit restores the previous request-ID behavior; no persisted format or migration is involved.

## Follow-up

None.
