### PR TITLE
Fix Hetzner API configuration rollout

### DIFF
--- a/apps/api-v1/resources/configuration/defaults-config.json
+++ b/apps/api-v1/resources/configuration/defaults-config.json
@@ -130,6 +130,7 @@
   },
   "ice": {
     "mode": "local",
+    "region": "eu",
     "cacheTtlMs": 300000,
     "rateLimit": {
       "windowMs": 60000,

--- a/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
+++ b/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
@@ -480,14 +480,12 @@ function decodeIce(
             rateLimit
         };
     }
-    for (const path of ['ice.appName', 'ice.region'] as const) {
-        if (decoder.hasValue(path)) {
-            decoder.invariant(
-                path,
-                'local-ice-field',
-                'Local ICE does not accept Metered provider fields.'
-            );
-        }
+    if (decoder.hasValue('ice.appName')) {
+        decoder.invariant(
+            'ice.appName',
+            'local-ice-field',
+            'Local ICE does not accept a Metered provider app name.'
+        );
     }
     if (secrets.meteredApiKey !== undefined) {
         decoder.invariant(

--- a/apps/api-v1/test/configuration/api-v1-configuration-test-fixture.ts
+++ b/apps/api-v1/test/configuration/api-v1-configuration-test-fixture.ts
@@ -136,6 +136,7 @@ export function validConfigurationDefaultsSource(): MutableApiV1ConfigurationSou
         },
         ice: {
             mode: 'local',
+            region: 'eu',
             cacheTtlMs: 300_000,
             rateLimit: {
                 windowMs: 60_000,

--- a/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
+++ b/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
@@ -112,6 +112,34 @@ Deno.test('committed profiles resolve their intended database, delivery, and ICE
     }
 });
 
+Deno.test('Metered ICE uses the mandatory default region when no override is provided', () => {
+    const input = validDecodeApiV1ConfigurationInput();
+    input.environmentSource = {
+        ice: {
+            mode: 'metered',
+            appName: 'rallar-production'
+        }
+    };
+    input.secretsSource = {
+        authenticationCredentialSecret: CONFIGURATION_SECRET_SENTINELS.authenticationCredentialSecret,
+        meteredApiKey: CONFIGURATION_SECRET_SENTINELS.meteredApiKey
+    };
+
+    const configuration = decodeApiV1Configuration(input);
+
+    assert.equal(configuration.ice.mode, 'metered');
+    assert.equal(configuration.ice.region, 'eu');
+});
+
+Deno.test('local ICE ignores Metered region overrides', () => {
+    const input = validDecodeApiV1ConfigurationInput();
+    input.environmentSource = { ice: { region: 'us' } };
+
+    const configuration = decodeApiV1Configuration(input);
+
+    assert.equal(configuration.ice.mode, 'local');
+});
+
 Deno.test('configuration decoder rejects unknown and missing fields at every owned source boundary', () => {
     const cases = [
         {
@@ -136,6 +164,21 @@ Deno.test('configuration decoder rejects unknown and missing fields at every own
                 delete (input.defaultsSource as MutableApiV1ConfigurationSourceObject).group;
             },
             expectedPath: 'group'
+        },
+        {
+            name: 'missing mandatory Metered ICE region',
+            mutate(input: MutableDecodeApiV1ConfigurationInput) {
+                const defaults = input.defaultsSource as MutableApiV1ConfigurationSourceObject;
+                const ice = defaults.ice as MutableApiV1ConfigurationSourceObject;
+                ice.mode = 'metered';
+                ice.appName = 'rallar';
+                delete ice.region;
+                input.secretsSource = {
+                    ...(input.secretsSource as MutableApiV1ConfigurationSourceObject),
+                    meteredApiKey: CONFIGURATION_SECRET_SENTINELS.meteredApiKey
+                };
+            },
+            expectedPath: 'ice.region'
         },
         {
             name: 'unknown profile field',

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -181,7 +181,7 @@ accepted. There are no aliases or transitional readers.
 | `RALLAR_RTC_RTT_REPORTING_DEGREE_LIMIT` | No                                                                         | RTC topology `degreeLimit`, `5` | Positive integer cap for accepted RTC RTT reporting edges per endpoint. Invalid values fall back to the topology degree.   |
 | `METERED_APP_NAME`                      | Required when `RALLAR_ICE_MODE=metered` and `/api/webrtc/ice` is requested | None                            | Metered TURN app name. Used in `https://<app>.metered.live/...`.                                                           |
 | `METERED_API_KEY`                       | Required when `RALLAR_ICE_MODE=metered` and `/api/webrtc/ice` is requested | None                            | Metered TURN API key. Server-only secret.                                                                                  |
-| `METERED_REGION`                        | No                                                                         | Empty string                    | Optional Metered TURN region query parameter.                                                                              |
+| `METERED_REGION`                        | No                                                                         | `eu`                            | Optional override for the mandatory Metered TURN region. Ignored when ICE mode is `local`.                                 |
 
 ### Timing And App Inbox Tuning
 

--- a/packages/tests/hetzner/spa-env-script.test.ts
+++ b/packages/tests/hetzner/spa-env-script.test.ts
@@ -65,7 +65,7 @@ describe('Hetzner SPA public env wiring', () => {
         );
         expect(rolloutScript).toContain('ensure_api_auth_credential_secret');
         expect(rolloutScript).toContain(
-            'update_env_value "/etc/rallar/api-v1.env" "RALLAR_AUTH_CREDENTIAL_SECRET"'
+            'update_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_AUTH_CREDENTIAL_SECRET"'
         );
     });
 
@@ -153,6 +153,53 @@ describe('Hetzner SPA public env wiring', () => {
         expect(result.stderr).not.toContain(authSecret);
     });
 
+    it('writes non-empty optional API overrides and removes them when rollout inputs are blank', async () => {
+        const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'rallar-api-env-'));
+        const apiEnvironmentFile = path.join(temporaryDirectory, 'api-v1.env');
+        const rolloutScript = path.join(
+            repoRoot,
+            'scripts/hetzner/controller/08-rollout-controller.sh'
+        );
+        const optionalOverrides = {
+            RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS: 'operations-admin',
+            RALLAR_RTC_TOPOLOGY_DEGREE_LIMIT: '7',
+            RALLAR_RTC_TOPOLOGY_TREE_MIN_SIZE: '6',
+            RALLAR_RTC_TOPOLOGY_MESH_MIN_SIZE: '24',
+            RALLAR_RTC_TOPOLOGY_MESH_PARAM_K: '3',
+            RALLAR_RTC_TOPOLOGY_RTT_REBUILD_DEBOUNCE_MS: '400'
+        };
+        await writeFile(apiEnvironmentFile, 'PORT=8080\n');
+
+        await execFileAsync('bash', [rolloutScript], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                ...optionalOverrides,
+                RALLAR_ROLLOUT_SCRIPT_SELF_TEST: 'write-api-optional-environment',
+                RALLAR_API_ENV_FILE: apiEnvironmentFile
+            }
+        });
+
+        expect(await readFile(apiEnvironmentFile, 'utf8')).toBe([
+            'PORT=8080',
+            ...Object.entries(optionalOverrides).map(([name, value]) => `${name}=${value}`),
+            ''
+        ].join('\n'));
+
+        await execFileAsync('bash', [rolloutScript], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                ...Object.fromEntries(Object.keys(optionalOverrides).map((name) => [name, ''])),
+                RALLAR_ROLLOUT_SCRIPT_SELF_TEST: 'write-api-optional-environment',
+                RALLAR_API_ENV_FILE: apiEnvironmentFile
+            }
+        });
+
+        expect(await readFile(apiEnvironmentFile, 'utf8')).toBe('PORT=8080\n');
+        expect((await stat(apiEnvironmentFile)).mode & 0o777).toBe(0o600);
+    });
+
     it('serves nested SPA entry points before falling back to the operator index', async () => {
         const helper = await readFile(
             path.join(repoRoot, 'scripts/hetzner/controller/rallar-public-spa-env.sh'),
@@ -163,9 +210,7 @@ describe('Hetzner SPA public env wiring', () => {
     });
 
     it('uses the control-server Deno config for Hetzner cache warming and systemd start', async () => {
-        const controlConfig = JSON.parse(await readFile(controlServerConfigPath, 'utf8')) as {
-            nodeModulesDir?: unknown;
-        };
+        const controlConfig = await readFile(controlServerConfigPath, 'utf8');
         const deployScript = await readFile(
             path.join(repoRoot, 'scripts/hetzner/controller/02-deploy-controller.sh'),
             'utf8'
@@ -175,7 +220,7 @@ describe('Hetzner SPA public env wiring', () => {
             'utf8'
         );
 
-        expect(controlConfig.nodeModulesDir).toBe('auto');
+        expect(controlConfig).toContain('"nodeModulesDir": "auto"');
         for (const script of [deployScript, rolloutScript]) {
             expect(script).toContain(
                 'deno cache --frozen --config "${RALLAR_CHECKOUT_DIR}/apps/rallar-black-box-control-server/deno.json"'

--- a/scripts/hetzner/controller/08-rollout-controller.sh
+++ b/scripts/hetzner/controller/08-rollout-controller.sh
@@ -213,6 +213,42 @@ sanitize_api_environment_file() {
 	rm -f "${tmp_file}"
 }
 
+update_env_value() {
+	local env_file="$1"
+	local key="$2"
+	local value="$3"
+	local tmp_file
+
+	if [[ ! -f "${env_file}" ]]; then
+		echo "Missing ${env_file}. Run 02-deploy-controller.sh first." >&2
+		exit 1
+	fi
+
+	tmp_file="$(mktemp)"
+	awk -v key="${key}" -v value="${value}" '
+    BEGIN { replaced = 0 }
+    $0 ~ "^" key "=" {
+      if (!replaced && value != "") {
+        print key "=" value
+        replaced = 1
+      }
+      next
+    }
+    { print }
+    END {
+      if (!replaced && value != "") {
+        print key "=" value
+      }
+    }
+  ' "${env_file}" >"${tmp_file}"
+	if [[ "$(id -u)" == "0" ]]; then
+		install -m 0600 -o root -g root "${tmp_file}" "${env_file}"
+	else
+		install -m 0600 "${tmp_file}" "${env_file}"
+	fi
+	rm -f "${tmp_file}"
+}
+
 run_rollout_self_test() {
 	case "${RALLAR_ROLLOUT_SCRIPT_SELF_TEST:-}" in
 	checkout-ref)
@@ -235,6 +271,21 @@ run_rollout_self_test() {
 	normalize-api-environment)
 		sanitize_api_environment_file "${RALLAR_API_ENV_FILE}"
 		echo "normalizedApiEnvironment=true"
+		;;
+	write-api-optional-environment)
+		local name
+		local names=(
+			RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS
+			RALLAR_RTC_TOPOLOGY_DEGREE_LIMIT
+			RALLAR_RTC_TOPOLOGY_TREE_MIN_SIZE
+			RALLAR_RTC_TOPOLOGY_MESH_MIN_SIZE
+			RALLAR_RTC_TOPOLOGY_MESH_PARAM_K
+			RALLAR_RTC_TOPOLOGY_RTT_REBUILD_DEBOUNCE_MS
+		)
+		for name in "${names[@]}"; do
+			update_env_value "${RALLAR_API_ENV_FILE}" "${name}" "${!name:-}"
+		done
+		echo "wroteApiOptionalEnvironment=true"
 		;;
 	*)
 		echo "Unknown RALLAR_ROLLOUT_SCRIPT_SELF_TEST: ${RALLAR_ROLLOUT_SCRIPT_SELF_TEST}" >&2
@@ -326,38 +377,6 @@ wait_for_url() {
 	return 1
 }
 
-update_env_value() {
-	local env_file="$1"
-	local key="$2"
-	local value="$3"
-	local tmp_file
-
-	if [[ ! -f "${env_file}" ]]; then
-		echo "Missing ${env_file}. Run 02-deploy-controller.sh first." >&2
-		exit 1
-	fi
-
-	tmp_file="$(mktemp)"
-	awk -v key="${key}" -v value="${key}=${value}" '
-    BEGIN { replaced = 0 }
-    $0 ~ "^" key "=" {
-      if (!replaced) {
-        print value
-        replaced = 1
-      }
-      next
-    }
-    { print }
-    END {
-      if (!replaced) {
-        print value
-      }
-    }
-  ' "${env_file}" >"${tmp_file}"
-	install -m 0600 -o root -g root "${tmp_file}" "${env_file}"
-	rm -f "${tmp_file}"
-}
-
 normalize_api_environment_allowlist() {
 	sanitize_api_environment_file "${RALLAR_API_ENV_FILE}"
 	chown root:root "${RALLAR_API_ENV_FILE}"
@@ -380,7 +399,7 @@ ensure_operator_token_secret() {
 	local secret="${RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET:-}"
 
 	if [[ -z "${secret}" ]]; then
-		secret="$(read_env_value "/etc/rallar/api-v1.env" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET")"
+		secret="$(read_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET")"
 	fi
 	if [[ -z "${secret}" ]]; then
 		secret="$(read_env_value "/etc/rallar/control-server.env" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET")"
@@ -389,9 +408,9 @@ ensure_operator_token_secret() {
 		secret="$(openssl rand -hex 32)"
 	fi
 
-	update_env_value "/etc/rallar/api-v1.env" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET" "${secret}"
-	update_env_value "/etc/rallar/api-v1.env" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS" "${RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS}"
-	update_env_value "/etc/rallar/api-v1.env" "RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS" "${RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS}"
+	update_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET" "${secret}"
+	update_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS" "${RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS}"
+	update_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS" "${RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS}"
 	update_env_value "/etc/rallar/control-server.env" "RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET" "${secret}"
 }
 
@@ -399,7 +418,7 @@ ensure_api_auth_credential_secret() {
 	local secret="${RALLAR_AUTH_CREDENTIAL_SECRET:-}"
 
 	if [[ -z "${secret}" ]]; then
-		secret="$(read_env_value "/etc/rallar/api-v1.env" "RALLAR_AUTH_CREDENTIAL_SECRET")"
+		secret="$(read_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_AUTH_CREDENTIAL_SECRET")"
 	fi
 	if [[ -z "${secret}" ]]; then
 		secret="$(openssl rand -hex 32)"
@@ -409,12 +428,12 @@ ensure_api_auth_credential_secret() {
 		exit 1
 	fi
 
-	update_env_value "/etc/rallar/api-v1.env" "RALLAR_AUTH_CREDENTIAL_SECRET" "${secret}"
+	update_env_value "${RALLAR_API_ENV_FILE}" "RALLAR_AUTH_CREDENTIAL_SECRET" "${secret}"
 }
 
 update_api_cors_origins() {
 	apply_rallar_public_cors_defaults
-	update_env_value "/etc/rallar/api-v1.env" "CORS_ORIGINS" "${RALLAR_API_CORS_ORIGINS}"
+	update_env_value "${RALLAR_API_ENV_FILE}" "CORS_ORIGINS" "${RALLAR_API_CORS_ORIGINS}"
 }
 
 update_api_rtc_topology_env() {


### PR DESCRIPTION
## Goal

Restore Hetzner API rollouts while keeping Metered ICE region mandatory and leaving local ICE behavior independent of region.

## Changes

- Keep `ice.region` mandatory for Metered ICE and provide the default `eu` value.
- Ignore `ice.region` when local ICE mode is selected.
- Remove blank optional API rollout overrides from the generated environment instead of persisting invalid empty values.
- Add configuration and rollout self-test coverage for both behaviors.

## Acceptance

- Metered ICE resolves an explicit or default non-empty region.
- Local ICE remains local even when the shared defaults contain a region.
- Blank operator-client and RTC topology overrides are absent from the API environment.
- Hetzner controller rollout and health checks succeed.

## Validation

- API configuration tests: 18 passed.
- API typecheck passed.
- API full suite: 496 passed.
- API memory black-box suite: 32 passed.
- Focused Hetzner tests: 100 passed in the final verification run.
- Shell syntax, formatting, diff, and touched-file style checks passed.
- The two-agent Hetzner health recipe passed against the PR head, including artifact analysis and diagnostics.
- Public API config, API docs, control health, and SPA smoke checks passed after rollout.

## Risk and rollback

Risk is limited to API configuration decoding and optional environment-file updates. Roll back this commit to restore the prior behavior.

## Follow-up

None.