### PR TITLE
Fix auth inbox test synchronization and recipe failure contract

### DIFF
--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-presence.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-presence.json
@@ -157,6 +157,8 @@
       "expect": {
         "status": 409,
         "body": {
+          "type": "api-mutation-failure",
+          "version": "canonical.v2",
           "code": "group-already-exists",
           "status": 409
         }

--- a/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
+++ b/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
@@ -1,26 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
+import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
+import { hashAuthSecret } from '@shared-server/rallar-system/auth/credentials/hash-auth-secret.ts';
+import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
+import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import { createGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
+import { GroupStateInboxService } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
+import type { JsonWireObject, JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import { createTestClientStateRepository, createTestGroupStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-import { describe, expect, it } from 'vitest';
 
-import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
-
-import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-
-import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
-import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
-import { GroupStateInboxService, type GroupCreateAppInboxPayload } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
-import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
-
-import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
-
-import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
-
-import { hashAuthSecret } from '@shared-server/rallar-system/auth/credentials/hash-auth-secret.ts';
-import { createGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
-import type { JsonWireObject, JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import { createAppInboxTestDatabase } from './app-inbox-test-database.ts';
-import { createResilience, readEntries, TestResourceInbox, TestResourceInboxResults, waitForQueuedEntry } from './auth/auth-app-inbox-test-runtime.ts';
+import {
+    createAuthInboxTestResilience,
+    readEntries,
+    TestResourceInbox,
+    TestResourceInboxResults,
+    waitForAuthInboxEntry
+} from './auth/auth-app-inbox-test-runtime.ts';
 import { createClientStatePhaseTestDriver, failNextClientStateTestOutboxWrite } from './client-state/client-state-test-runtime.ts';
 import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
 
@@ -172,12 +172,18 @@ describe('AppInbox expired row replacement', () => {
                 normalizedUsername: 'alice'
             }
         });
-        await waitForQueuedEntry(queue);
-        await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience(1));
+        await waitForAuthInboxEntry(queue);
+        await reader.dequeueInbox(
+            InboxQueueReader.INBOX_DEQUEUE_TYPES,
+            createAuthInboxTestResilience(1)
+        );
         const [afterFirstDequeue] = await readEntries(queue);
         if (afterFirstDequeue?.status === EntityStatus.RETRY) {
             await new Promise((resolve) => setTimeout(resolve, 2));
-            await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+            await reader.dequeueInbox(
+                InboxQueueReader.INBOX_DEQUEUE_TYPES,
+                createAuthInboxTestResilience()
+            );
         }
         await expect(pending).resolves.toMatchObject({
             right: { sessionId, accessToken }
@@ -268,12 +274,15 @@ describe('AppInbox expired row replacement', () => {
                     },
                     owner
                 );
-                await waitForQueuedEntry(queue, minimumEntries);
+                await waitForAuthInboxEntry(queue, minimumEntries);
                 return { pending };
             };
 
             const seeded = await create('seed-group', 'Old room');
-            await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+            await reader.dequeueInbox(
+                InboxQueueReader.INBOX_DEQUEUE_TYPES,
+                createAuthInboxTestResilience()
+            );
             await expect(seeded.pending).resolves.toMatchObject({
                 right: { status: 'created' }
             });
@@ -322,13 +331,19 @@ describe('AppInbox expired row replacement', () => {
                 }
             };
             const replacement = await create('replace-group', 'New room');
-            await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience(1));
+            await reader.dequeueInbox(
+                InboxQueueReader.INBOX_DEQUEUE_TYPES,
+                createAuthInboxTestResilience(1)
+            );
             const afterFirst = (await readEntries(queue)).find(
                 (entry) => entry.status === EntityStatus.RETRY || entry.dequeueAudit.attempts > 1
             );
             if (afterFirst?.status === EntityStatus.RETRY) {
                 await new Promise((resolve) => setTimeout(resolve, 2));
-                await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+                await reader.dequeueInbox(
+                    InboxQueueReader.INBOX_DEQUEUE_TYPES,
+                    createAuthInboxTestResilience()
+                );
             }
             await expect(replacement.pending).resolves.toMatchObject({
                 right: { status: 'created' }

--- a/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
+++ b/packages/tests/shared-server/app-inbox-expired-row-replacement.test.ts
@@ -13,14 +13,8 @@ import { createTestClientStateRepository, createTestGroupStateRepository } from 
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience, TestResourceInbox, TestResourceInboxResults } from './app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from './app-inbox-test-database.ts';
-import {
-    createAuthInboxTestResilience,
-    readEntries,
-    TestResourceInbox,
-    TestResourceInboxResults,
-    waitForAuthInboxEntry
-} from './auth/auth-app-inbox-test-runtime.ts';
 import { createClientStatePhaseTestDriver, failNextClientStateTestOutboxWrite } from './client-state/client-state-test-runtime.ts';
 import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
 
@@ -172,17 +166,17 @@ describe('AppInbox expired row replacement', () => {
                 normalizedUsername: 'alice'
             }
         });
-        await waitForAuthInboxEntry(queue);
+        await queue.waitForEntryCount();
         await reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience(1)
+            createAppInboxTestResilience(1)
         );
-        const [afterFirstDequeue] = await readEntries(queue);
+        const [afterFirstDequeue] = await queue.readEntries();
         if (afterFirstDequeue?.status === EntityStatus.RETRY) {
             await new Promise((resolve) => setTimeout(resolve, 2));
             await reader.dequeueInbox(
                 InboxQueueReader.INBOX_DEQUEUE_TYPES,
-                createAuthInboxTestResilience()
+                createAppInboxTestResilience()
             );
         }
         await expect(pending).resolves.toMatchObject({
@@ -196,7 +190,7 @@ describe('AppInbox expired row replacement', () => {
         expect(after[1][0]?.revision).toBe(1);
         expect(rollbackCount).toBe(1);
         expect(rollbackPreservedExpiredIndexes).toBe(true);
-        expect((await readEntries(queue))[0]).toMatchObject({
+        expect((await queue.readEntries())[0]).toMatchObject({
             status: EntityStatus.COMPLETED,
             dequeueAudit: { attempts: 2 }
         });
@@ -274,14 +268,14 @@ describe('AppInbox expired row replacement', () => {
                     },
                     owner
                 );
-                await waitForAuthInboxEntry(queue, minimumEntries);
+                await queue.waitForEntryCount(minimumEntries);
                 return { pending };
             };
 
             const seeded = await create('seed-group', 'Old room');
             await reader.dequeueInbox(
                 InboxQueueReader.INBOX_DEQUEUE_TYPES,
-                createAuthInboxTestResilience()
+                createAppInboxTestResilience()
             );
             await expect(seeded.pending).resolves.toMatchObject({
                 right: { status: 'created' }
@@ -333,16 +327,16 @@ describe('AppInbox expired row replacement', () => {
             const replacement = await create('replace-group', 'New room');
             await reader.dequeueInbox(
                 InboxQueueReader.INBOX_DEQUEUE_TYPES,
-                createAuthInboxTestResilience(1)
+                createAppInboxTestResilience(1)
             );
-            const afterFirst = (await readEntries(queue)).find(
+            const afterFirst = (await queue.readEntries()).find(
                 (entry) => entry.status === EntityStatus.RETRY || entry.dequeueAudit.attempts > 1
             );
             if (afterFirst?.status === EntityStatus.RETRY) {
                 await new Promise((resolve) => setTimeout(resolve, 2));
                 await reader.dequeueInbox(
                     InboxQueueReader.INBOX_DEQUEUE_TYPES,
-                    createAuthInboxTestResilience()
+                    createAppInboxTestResilience()
                 );
             }
             await expect(replacement.pending).resolves.toMatchObject({
@@ -395,7 +389,7 @@ describe('AppInbox expired row replacement', () => {
             expect(database.groupEventStore.events).toHaveLength(2);
             expect(database.outboxEntries.size).toBe(2);
             expect(
-                (await readEntries(queue)).some(
+                (await queue.readEntries()).some(
                     (entry) => entry.status === EntityStatus.COMPLETED && entry.dequeueAudit.attempts === 2
                 )
             ).toBe(true);

--- a/packages/tests/shared-server/app-inbox-queue-entry-test-helpers.ts
+++ b/packages/tests/shared-server/app-inbox-queue-entry-test-helpers.ts
@@ -5,7 +5,7 @@ import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-c
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
-import { createAuthInboxTestResilience, readEntries, type TestResourceInbox } from './auth/auth-app-inbox-test-runtime.ts';
+import { createAppInboxTestResilience, type TestResourceInbox } from './app-inbox-resource-fixtures.ts';
 
 const DELAYED_UNTIL_EPOCH_MS = 1_800_001_000_000;
 
@@ -29,7 +29,7 @@ export function groupPresenceFacts(
 export async function processNext(reader: InboxQueueReader): Promise<void> {
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
 }
 
@@ -62,7 +62,7 @@ export async function requireQueuedType(
     queue: TestResourceInbox,
     type: AppInboxType
 ): Promise<ResourceEntry> {
-    const entry = (await readEntries(queue)).find((candidate) => readType(candidate) === type);
+    const entry = (await queue.readEntries()).find((candidate) => readType(candidate) === type);
     if (!entry) {
         throw new Error(`Expected queued AppInbox type ${type}`);
     }
@@ -74,7 +74,7 @@ export async function waitForQueuedType(
     type: AppInboxType
 ): Promise<ResourceEntry> {
     return await vi.waitFor(async () => {
-        const entry = (await readEntries(queue)).find((candidate) => readType(candidate) === type && candidate.status === EntityStatus.NEW);
+        const entry = (await queue.readEntries()).find((candidate) => readType(candidate) === type && candidate.status === EntityStatus.NEW);
         if (entry) {
             return entry;
         }
@@ -85,7 +85,7 @@ export async function waitForQueuedType(
 export async function queuedTypes(
     queue: TestResourceInbox
 ): Promise<readonly AppInboxType[]> {
-    return (await readEntries(queue)).map(readType);
+    return (await queue.readEntries()).map(readType);
 }
 
 function readType(entry: ResourceEntry): AppInboxType {

--- a/packages/tests/shared-server/app-inbox-queue-entry-test-helpers.ts
+++ b/packages/tests/shared-server/app-inbox-queue-entry-test-helpers.ts
@@ -1,9 +1,11 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { vi } from 'vitest';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-import { createResilience, readEntries, type TestResourceInbox } from './auth/auth-app-inbox-test-runtime.ts';
+
+import { createAuthInboxTestResilience, readEntries, type TestResourceInbox } from './auth/auth-app-inbox-test-runtime.ts';
 
 const DELAYED_UNTIL_EPOCH_MS = 1_800_001_000_000;
 
@@ -25,7 +27,10 @@ export function groupPresenceFacts(
 }
 
 export async function processNext(reader: InboxQueueReader): Promise<void> {
-    await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+    await reader.dequeueInbox(
+        InboxQueueReader.INBOX_DEQUEUE_TYPES,
+        createAuthInboxTestResilience()
+    );
 }
 
 export async function delayEntry(
@@ -68,14 +73,13 @@ export async function waitForQueuedType(
     queue: TestResourceInbox,
     type: AppInboxType
 ): Promise<ResourceEntry> {
-    for (let attempt = 0; attempt < 50; attempt += 1) {
+    return await vi.waitFor(async () => {
         const entry = (await readEntries(queue)).find((candidate) => readType(candidate) === type && candidate.status === EntityStatus.NEW);
         if (entry) {
             return entry;
         }
-        await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    throw new Error(`Expected queued AppInbox type ${type}`);
+        throw new Error(`Expected queued AppInbox type ${type}`);
+    }, { timeout: 2_000 });
 }
 
 export async function queuedTypes(

--- a/packages/tests/shared-server/app-inbox-resource-fixtures.ts
+++ b/packages/tests/shared-server/app-inbox-resource-fixtures.ts
@@ -1,0 +1,175 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
+import { InMemoryQueueBox } from '@shared/queuebox/in-memory-queue-box.ts';
+import { EntityStatus, isExpiredResourceEntry, toKeyAsString, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
+
+const RESOURCE_INBOX_ENTRY_EVENT = 'resource-inbox-entry';
+const RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS = 2_000;
+
+export class TestResourceInbox extends InMemoryQueueBox {
+    private readonly materializations = new Map<string, Promise<ResourceEntry>>();
+    private readonly entryEvents = new EventTarget();
+    private nextMaterializationGate: Promise<void> | undefined;
+
+    delayNextMaterializationUntil(gate: Promise<void>): void {
+        this.nextMaterializationGate = gate;
+    }
+
+    async waitForEntryCount(
+        minimumEntries = 1,
+        timeoutMs = RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS
+    ): Promise<void> {
+        const waitAbort = new AbortController();
+        const timeout = rejectResourceInboxEntryWaitAfter(
+            waitAbort.signal,
+            timeoutMs,
+            minimumEntries
+        );
+        try {
+            while (true) {
+                const entryWritten = new Promise<void>((resolve) => {
+                    this.entryEvents.addEventListener(
+                        RESOURCE_INBOX_ENTRY_EVENT,
+                        () => resolve(),
+                        { once: true, signal: waitAbort.signal }
+                    );
+                });
+                if ((await this.getAllKeys()).length >= minimumEntries) {
+                    return;
+                }
+                await Promise.race([entryWritten, timeout]);
+            }
+        }
+        finally {
+            waitAbort.abort();
+        }
+    }
+
+    async isEntryWithStatus(key: Key, statuses: EntityStatus[]): Promise<boolean> {
+        const entry = await this.getItem(key);
+        return entry !== undefined && statuses.includes(entry.status);
+    }
+
+    override async enqueueIfAbsent(entry: ResourceEntry): Promise<ResourceEntry> {
+        const enqueued = await super.enqueueIfAbsent(entry);
+        this.entryEvents.dispatchEvent(new Event(RESOURCE_INBOX_ENTRY_EVENT));
+        return enqueued;
+    }
+
+    async findAllByTopicAndResourceId(
+        topicId: string,
+        resourceId: string
+    ): Promise<readonly ResourceEntry[]> {
+        return (await this.readEntries()).filter(
+            (entry) =>
+                !isExpiredResourceEntry(entry) &&
+                entry.key.topicId === topicId &&
+                entry.key.resourceId === resourceId
+        );
+    }
+
+    async readEntries(): Promise<ResourceEntry[]> {
+        const entries = await Promise.all(
+            (await this.getAllKeys()).map((key) => this.getItem(key))
+        );
+        return entries.filter((entry): entry is ResourceEntry => entry !== undefined);
+    }
+
+    async writeMaterializedIfAbsentOrReplaceExpired(
+        placeholder: ResourceEntry,
+        materialize: () => Promise<ResourceEntry>
+    ): Promise<ResourceEntry> {
+        const key = toKeyAsString(placeholder.key);
+        const active = this.materializations.get(key);
+        if (active !== undefined) {
+            return await active;
+        }
+
+        const pending = this.materializeEntry(placeholder, materialize);
+        this.materializations.set(key, pending);
+        try {
+            return await pending;
+        }
+        finally {
+            this.materializations.delete(key);
+        }
+    }
+
+    private async materializeEntry(
+        placeholder: ResourceEntry,
+        materialize: () => Promise<ResourceEntry>
+    ): Promise<ResourceEntry> {
+        const existing = await this.getItem(placeholder.key);
+        if (existing !== undefined && !isExpiredResourceEntry(existing)) {
+            return existing;
+        }
+        const gate = this.nextMaterializationGate;
+        this.nextMaterializationGate = undefined;
+        if (gate !== undefined) {
+            await gate;
+        }
+        const materialized = await materialize();
+        const entry = { ...placeholder, resource: materialized.resource };
+        return await this.enqueueIfAbsent(entry);
+    }
+}
+
+export class TestResourceInboxResults {
+    private readonly data = new Map<string, ResourceEntry>();
+
+    async replace(entry: ResourceEntry): Promise<ResourceEntry> {
+        this.data.set(toKeyAsString(entry.key), entry);
+        return entry;
+    }
+
+    async findByKey(key: Key): Promise<ResourceEntry | undefined> {
+        const entry = this.data.get(toKeyAsString(key));
+        return entry === undefined || isExpiredResourceEntry(entry) ? undefined : entry;
+    }
+
+    allEntries(): ResourceEntry[] {
+        return [...this.data.values()];
+    }
+}
+
+export function createAppInboxTestResilience(firstRetryDelayMs?: number): ResilienceDto {
+    const duration = Temporal.Duration.from({ seconds: 10 });
+    const resilienceArguments = [
+        new CircuitBreakerPolicy(10, duration, duration, duration),
+        1,
+        10,
+        1,
+        1
+    ] as const;
+    if (firstRetryDelayMs === undefined) {
+        return ResilienceDto.toResilienceDto(...resilienceArguments);
+    }
+    return ResilienceDto.toResilienceDto(...resilienceArguments, 10, {
+        maxAttempts: 20,
+        delaysAfterAttemptMs: [firstRetryDelayMs],
+        maxDelayMs: firstRetryDelayMs,
+        jitterRatio: 0,
+        staleDueThresholdMs: 30_000
+    });
+}
+
+function rejectResourceInboxEntryWaitAfter(
+    abortSignal: AbortSignal,
+    timeoutMs: number,
+    minimumEntries: number
+): Promise<never> {
+    return new Promise((_, reject) => {
+        const timeout = setTimeout(
+            () =>
+                reject(
+                    new Error(
+                        `ResourceInbox test queue did not reach ${minimumEntries} entries`
+                    )
+                ),
+            timeoutMs
+        );
+        abortSignal.addEventListener('abort', () => clearTimeout(timeout), { once: true });
+    });
+}

--- a/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
+++ b/packages/tests/shared-server/app-inbox-ws-close-test-harness.ts
@@ -1,24 +1,19 @@
+import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
+import type { ClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
+import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
+import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
+import type { GroupStateService } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
+import { createGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
+import { GroupStateInboxService } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
+import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { createTestClientStateRepository, createTestGroupStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
-import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
-
-import { type IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
-
-import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-
-import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
-
-import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
-
-import { type ClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
-import { type GroupStateService } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
-import { createGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
-import { GroupStateInboxService } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
+import { TestResourceInbox, TestResourceInboxResults } from './app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from './app-inbox-test-database.ts';
-import { TestResourceInbox, TestResourceInboxResults } from './auth/auth-app-inbox-test-runtime.ts';
 import { FakeRuntimeStateRepository } from './fake-runtime-state-repository.ts';
 
 // Anchor the seed clock to the real processing clock. The AppInbox stamps and
@@ -161,21 +156,19 @@ export function pauseNextLifecycleRead(
 ): Readonly<{ reached: Promise<void>; resume(): void; }> {
     const lifecycle = state.sessionGenerationLifecycle;
     const originalRead = lifecycle.read.bind(lifecycle);
-    let release!: () => void;
-    let announce!: () => void;
-    const reached = new Promise<void>((resolve) => (announce = resolve));
-    const resumed = new Promise<void>((resolve) => (release = resolve));
+    const reached = Promise.withResolvers<void>();
+    const resumed = Promise.withResolvers<void>();
     let pause = true;
     lifecycle.read = async (identity) => {
         const read = await originalRead(identity);
         if (pause) {
             pause = false;
-            announce();
-            await resumed;
+            reached.resolve();
+            await resumed.promise;
         }
         return read;
     };
-    return { reached, resume: release };
+    return { reached: reached.promise, resume: resumed.resolve };
 }
 
 function issuedSession(clientId: string, sessionId: string): IssuedAuthSession {

--- a/packages/tests/shared-server/auth/auth-app-inbox-test-runtime.ts
+++ b/packages/tests/shared-server/auth/auth-app-inbox-test-runtime.ts
@@ -1,18 +1,16 @@
 import { Temporal } from '@js-temporal/polyfill';
+
+import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
+import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
+import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
+import type { AuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
+import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
 import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/in-memory-queue-box.ts';
 import { EntityStatus, isExpiredResourceEntry, toKeyAsString, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import type { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-
-import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
-
-import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
-import type { AuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
-
-import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
-import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
 
 import type { AppInboxTestDatabase, AppInboxTestDatabaseOptions } from '../app-inbox-test-database-contracts.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
@@ -39,24 +37,64 @@ interface CreateAuthInboxTestRuntimeInput {
     readonly nowEpochMs?: () => number;
 }
 
-interface RunAuthInboxCommandInput<Result, P extends Promise<Either<AppInboxFailure, Result>>> {
-    readonly pending: P;
-    readonly queue: InMemoryQueueBox;
+interface RunAuthInboxCommandInput<Result> {
+    readonly pending: Promise<Either<AppInboxFailure, Result>>;
+    readonly queue: TestResourceInbox;
     readonly reader: InboxQueueReader;
     readonly minimumEntries?: number;
 }
 
+const RESOURCE_INBOX_ENTRY_EVENT = 'resource-inbox-entry';
+const RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS = 2_000;
+
 export class TestResourceInbox extends InMemoryQueueBox {
     private readonly materializations = new Map<string, Promise<ResourceEntry>>();
+    private readonly entryEvents = new EventTarget();
     private nextMaterializationGate: Promise<void> | undefined;
 
     delayNextMaterializationUntil(gate: Promise<void>): void {
         this.nextMaterializationGate = gate;
     }
 
+    async waitForEntryCount(
+        minimumEntries: number,
+        timeoutMs = RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS
+    ): Promise<void> {
+        const waitAbort = new AbortController();
+        const timeout = rejectResourceInboxEntryWaitAfter(
+            waitAbort.signal,
+            timeoutMs,
+            minimumEntries
+        );
+        try {
+            while (true) {
+                const entryWritten = new Promise<void>((resolve) => {
+                    this.entryEvents.addEventListener(
+                        RESOURCE_INBOX_ENTRY_EVENT,
+                        () => resolve(),
+                        { once: true, signal: waitAbort.signal }
+                    );
+                });
+                if ((await this.getAllKeys()).length >= minimumEntries) {
+                    return;
+                }
+                await Promise.race([entryWritten, timeout]);
+            }
+        }
+        finally {
+            waitAbort.abort();
+        }
+    }
+
     async isEntryWithStatus(key: Key, statuses: EntityStatus[]): Promise<boolean> {
         const entry = await this.getItem(key);
         return entry !== undefined && statuses.includes(entry.status);
+    }
+
+    override async enqueueIfAbsent(entry: ResourceEntry): Promise<ResourceEntry> {
+        const enqueued = await super.enqueueIfAbsent(entry);
+        this.entryEvents.dispatchEvent(new Event(RESOURCE_INBOX_ENTRY_EVENT));
+        return enqueued;
     }
 
     async findAllByTopicAndResourceId(
@@ -175,11 +213,17 @@ export function createAuthInboxTestRuntime({
 
 export function createAuthInboxTestResilience(firstRetryDelayMs?: number): ResilienceDto {
     const duration = Temporal.Duration.from({ seconds: 10 });
-    const args = [new CircuitBreakerPolicy(10, duration, duration, duration), 1, 10, 1, 1] as const;
+    const resilienceArguments = [
+        new CircuitBreakerPolicy(10, duration, duration, duration),
+        1,
+        10,
+        1,
+        1
+    ] as const;
     if (firstRetryDelayMs === undefined) {
-        return ResilienceDto.toResilienceDto(...args);
+        return ResilienceDto.toResilienceDto(...resilienceArguments);
     }
-    return ResilienceDto.toResilienceDto(...args, 10, {
+    return ResilienceDto.toResilienceDto(...resilienceArguments, 10, {
         maxAttempts: 20,
         delaysAfterAttemptMs: [firstRetryDelayMs],
         maxDelayMs: firstRetryDelayMs,
@@ -194,24 +238,18 @@ export async function readEntries(queue: InMemoryQueueBox): Promise<ResourceEntr
 }
 
 export async function waitForAuthInboxEntry(
-    queue: InMemoryQueueBox,
+    queue: TestResourceInbox,
     minimumEntries = 1
 ): Promise<void> {
-    for (let attempt = 0; attempt < 50; attempt += 1) {
-        if ((await queue.getAllKeys()).length >= minimumEntries) {
-            return;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1));
-    }
-    throw new Error('Auth AppInbox test entry was not enqueued');
+    await queue.waitForEntryCount(minimumEntries);
 }
 
-export async function runAuthInboxCommand<Result, P extends Promise<Either<AppInboxFailure, Result>>>({
+export async function runAuthInboxCommand<Result>({
     pending,
     queue,
     reader,
     minimumEntries = 1
-}: RunAuthInboxCommandInput<Result, P>): Promise<Awaited<P>> {
+}: RunAuthInboxCommandInput<Result>): Promise<Either<AppInboxFailure, Result>> {
     await waitForAuthInboxEntry(queue, minimumEntries);
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
@@ -220,6 +258,21 @@ export async function runAuthInboxCommand<Result, P extends Promise<Either<AppIn
     return await pending;
 }
 
-export const createResilience = createAuthInboxTestResilience;
-export const waitForQueuedEntry = waitForAuthInboxEntry;
-export const runAuthCommand = runAuthInboxCommand;
+function rejectResourceInboxEntryWaitAfter(
+    abortSignal: AbortSignal,
+    timeoutMs: number,
+    minimumEntries: number
+): Promise<never> {
+    return new Promise((_, reject) => {
+        const timeout = setTimeout(
+            () =>
+                reject(
+                    new Error(
+                        `ResourceInbox test queue did not reach ${minimumEntries} entries`
+                    )
+                ),
+            timeoutMs
+        );
+        abortSignal.addEventListener('abort', () => clearTimeout(timeout), { once: true });
+    });
+}

--- a/packages/tests/shared-server/auth/auth-app-inbox-test-runtime.ts
+++ b/packages/tests/shared-server/auth/auth-app-inbox-test-runtime.ts
@@ -1,17 +1,12 @@
-import { Temporal } from '@js-temporal/polyfill';
-
 import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
 import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
 import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
 import type { AuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
 import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
-import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
-import { InMemoryQueueBox } from '@shared/queuebox/in-memory-queue-box.ts';
-import { EntityStatus, isExpiredResourceEntry, toKeyAsString, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import type { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience, TestResourceInbox, TestResourceInboxResults } from '../app-inbox-resource-fixtures.ts';
 import type { AppInboxTestDatabase, AppInboxTestDatabaseOptions } from '../app-inbox-test-database-contracts.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import type { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
@@ -42,128 +37,6 @@ interface RunAuthInboxCommandInput<Result> {
     readonly queue: TestResourceInbox;
     readonly reader: InboxQueueReader;
     readonly minimumEntries?: number;
-}
-
-const RESOURCE_INBOX_ENTRY_EVENT = 'resource-inbox-entry';
-const RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS = 2_000;
-
-export class TestResourceInbox extends InMemoryQueueBox {
-    private readonly materializations = new Map<string, Promise<ResourceEntry>>();
-    private readonly entryEvents = new EventTarget();
-    private nextMaterializationGate: Promise<void> | undefined;
-
-    delayNextMaterializationUntil(gate: Promise<void>): void {
-        this.nextMaterializationGate = gate;
-    }
-
-    async waitForEntryCount(
-        minimumEntries: number,
-        timeoutMs = RESOURCE_INBOX_ENTRY_WAIT_TIMEOUT_MS
-    ): Promise<void> {
-        const waitAbort = new AbortController();
-        const timeout = rejectResourceInboxEntryWaitAfter(
-            waitAbort.signal,
-            timeoutMs,
-            minimumEntries
-        );
-        try {
-            while (true) {
-                const entryWritten = new Promise<void>((resolve) => {
-                    this.entryEvents.addEventListener(
-                        RESOURCE_INBOX_ENTRY_EVENT,
-                        () => resolve(),
-                        { once: true, signal: waitAbort.signal }
-                    );
-                });
-                if ((await this.getAllKeys()).length >= minimumEntries) {
-                    return;
-                }
-                await Promise.race([entryWritten, timeout]);
-            }
-        }
-        finally {
-            waitAbort.abort();
-        }
-    }
-
-    async isEntryWithStatus(key: Key, statuses: EntityStatus[]): Promise<boolean> {
-        const entry = await this.getItem(key);
-        return entry !== undefined && statuses.includes(entry.status);
-    }
-
-    override async enqueueIfAbsent(entry: ResourceEntry): Promise<ResourceEntry> {
-        const enqueued = await super.enqueueIfAbsent(entry);
-        this.entryEvents.dispatchEvent(new Event(RESOURCE_INBOX_ENTRY_EVENT));
-        return enqueued;
-    }
-
-    async findAllByTopicAndResourceId(
-        topicId: string,
-        resourceId: string
-    ): Promise<readonly ResourceEntry[]> {
-        return (await readEntries(this)).filter(
-            (entry) =>
-                !isExpiredResourceEntry(entry) &&
-                entry.key.topicId === topicId &&
-                entry.key.resourceId === resourceId
-        );
-    }
-
-    async writeMaterializedIfAbsentOrReplaceExpired(
-        placeholder: ResourceEntry,
-        materialize: () => Promise<ResourceEntry>
-    ): Promise<ResourceEntry> {
-        const key = toKeyAsString(placeholder.key);
-        const active = this.materializations.get(key);
-        if (active) {
-            return await active;
-        }
-
-        const pending = this.materializeEntry(placeholder, materialize);
-        this.materializations.set(key, pending);
-        try {
-            return await pending;
-        }
-        finally {
-            this.materializations.delete(key);
-        }
-    }
-
-    private async materializeEntry(
-        placeholder: ResourceEntry,
-        materialize: () => Promise<ResourceEntry>
-    ): Promise<ResourceEntry> {
-        const existing = await this.getItem(placeholder.key);
-        if (existing) {
-            return existing;
-        }
-        const gate = this.nextMaterializationGate;
-        this.nextMaterializationGate = undefined;
-        await gate;
-        const materialized = await materialize();
-        const entry = { ...placeholder, resource: materialized.resource };
-        return await this.enqueueIfAbsent(entry);
-    }
-}
-
-export class TestResourceInboxResults {
-    private readonly data = new Map<string, ResourceEntry>();
-
-    replace(entry: ResourceEntry): Promise<ResourceEntry> {
-        this.data.set(toKeyAsString(entry.key), entry);
-        return Promise.resolve(entry);
-    }
-
-    findByKey(key: Key): Promise<ResourceEntry | undefined> {
-        const entry = this.data.get(toKeyAsString(key));
-        return Promise.resolve(
-            entry === undefined || isExpiredResourceEntry(entry) ? undefined : entry
-        );
-    }
-
-    allEntries(): ResourceEntry[] {
-        return [...this.data.values()];
-    }
 }
 
 export function createAuthInboxTestHarness(
@@ -211,68 +84,16 @@ export function createAuthInboxTestRuntime({
     return { queue, results, reader, service, credentialIssuer, database };
 }
 
-export function createAuthInboxTestResilience(firstRetryDelayMs?: number): ResilienceDto {
-    const duration = Temporal.Duration.from({ seconds: 10 });
-    const resilienceArguments = [
-        new CircuitBreakerPolicy(10, duration, duration, duration),
-        1,
-        10,
-        1,
-        1
-    ] as const;
-    if (firstRetryDelayMs === undefined) {
-        return ResilienceDto.toResilienceDto(...resilienceArguments);
-    }
-    return ResilienceDto.toResilienceDto(...resilienceArguments, 10, {
-        maxAttempts: 20,
-        delaysAfterAttemptMs: [firstRetryDelayMs],
-        maxDelayMs: firstRetryDelayMs,
-        jitterRatio: 0,
-        staleDueThresholdMs: 30_000
-    });
-}
-
-export async function readEntries(queue: InMemoryQueueBox): Promise<ResourceEntry[]> {
-    const entries = await Promise.all((await queue.getAllKeys()).map((key) => queue.getItem(key)));
-    return entries.filter((entry): entry is ResourceEntry => entry !== undefined);
-}
-
-export async function waitForAuthInboxEntry(
-    queue: TestResourceInbox,
-    minimumEntries = 1
-): Promise<void> {
-    await queue.waitForEntryCount(minimumEntries);
-}
-
 export async function runAuthInboxCommand<Result>({
     pending,
     queue,
     reader,
     minimumEntries = 1
 }: RunAuthInboxCommandInput<Result>): Promise<Either<AppInboxFailure, Result>> {
-    await waitForAuthInboxEntry(queue, minimumEntries);
+    await queue.waitForEntryCount(minimumEntries);
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
     return await pending;
-}
-
-function rejectResourceInboxEntryWaitAfter(
-    abortSignal: AbortSignal,
-    timeoutMs: number,
-    minimumEntries: number
-): Promise<never> {
-    return new Promise((_, reject) => {
-        const timeout = setTimeout(
-            () =>
-                reject(
-                    new Error(
-                        `ResourceInbox test queue did not reach ${minimumEntries} entries`
-                    )
-                ),
-            timeoutMs
-        );
-        abortSignal.addEventListener('abort', () => clearTimeout(timeout), { once: true });
-    });
 }

--- a/packages/tests/shared-server/auth/auth-http-idempotency-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-http-idempotency-security.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
@@ -11,10 +12,15 @@ import {
     createAuthInboxTestResilience,
     createAuthInboxTestRuntime,
     readEntries,
-    runAuthCommand,
+    runAuthInboxCommand,
     waitForAuthInboxEntry,
     type AuthInboxTestRuntime
 } from './auth-app-inbox-test-runtime.ts';
+
+interface AuthHttpIdempotencyRuntime {
+    readonly auth: AuthInboxTestRuntime;
+    readonly repository: AuthSessionRepository;
+}
 
 const SHARED_REQUEST_ID = 'SharedLogoutRequest_0123456789abcdefghijklmnopqrstuv';
 
@@ -23,7 +29,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
         const runtime = createRuntime();
         const session = await putSession(runtime, 'client:a', 'session:a');
 
-        await runAuthCommand({
+        await runAuthInboxCommand({
             pending: runtime.auth.service.logoutSession({
                 requestId: SHARED_REQUEST_ID,
                 session
@@ -257,7 +263,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
     it('replays a consumed agent ticket only with its original credential proof', async () => {
         const runtime = createRuntime();
         const authority = await putSession(runtime, 'operator-client', 'operator-session');
-        const issued = await runAuthCommand({
+        const issued = await runAuthInboxCommand({
             pending: runtime.auth.service.issueAgentSessionTickets({
                 requestId: 'AgentTicketIssueRequest_0123',
                 session: authority,
@@ -275,7 +281,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
             requestId: 'AgentTicketConsumeRequest_0123456789abcdefghijklmnop',
             ticket
         };
-        const consumed = await runAuthCommand({
+        const consumed = await runAuthInboxCommand({
             pending: runtime.auth.service.consumeAgentSessionTicket(consumeInput),
             queue: runtime.auth.queue,
             reader: runtime.auth.reader,
@@ -289,10 +295,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
     });
 });
 
-function createRuntime(): Readonly<{
-    auth: AuthInboxTestRuntime;
-    repository: AuthSessionRepository;
-}> {
+function createRuntime(): AuthHttpIdempotencyRuntime {
     const runtimeRepository = new FakeRuntimeStateRepository();
     return {
         auth: createAuthInboxTestRuntime({
@@ -305,10 +308,10 @@ function createRuntime(): Readonly<{
 }
 
 async function putSession(
-    runtime: ReturnType<typeof createRuntime>,
+    runtime: AuthHttpIdempotencyRuntime,
     clientId: string,
     sessionId: string
-) {
+): Promise<IssuedAuthSession> {
     const issuedAtEpochMs = Date.now();
     const session = {
         clientId,
@@ -324,10 +327,10 @@ async function putSession(
 
 async function logout(
     auth: AuthInboxTestRuntime,
-    session: Awaited<ReturnType<typeof putSession>>,
+    session: IssuedAuthSession,
     minimumEntries: number
 ): Promise<void> {
-    const result = await runAuthCommand({
+    const result = await runAuthInboxCommand({
         pending: auth.service.logoutSession({
             requestId: SHARED_REQUEST_ID,
             session

--- a/packages/tests/shared-server/auth/auth-http-idempotency-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-http-idempotency-security.test.ts
@@ -7,15 +7,9 @@ import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persis
 import { toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience } from '../app-inbox-resource-fixtures.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-    createAuthInboxTestResilience,
-    createAuthInboxTestRuntime,
-    readEntries,
-    runAuthInboxCommand,
-    waitForAuthInboxEntry,
-    type AuthInboxTestRuntime
-} from './auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestRuntime, runAuthInboxCommand, type AuthInboxTestRuntime } from './auth-app-inbox-test-runtime.ts';
 
 interface AuthHttpIdempotencyRuntime {
     readonly auth: AuthInboxTestRuntime;
@@ -38,7 +32,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
             reader: runtime.auth.reader
         });
 
-        const [entry] = await readEntries(runtime.auth.queue);
+        const [entry] = await runtime.auth.queue.readEntries();
         expect(entry.key).toEqual(toAppQueueKey({
             topicId: AppInboxType.AUTH_SESSION_LOGOUT,
             resourceId: SHARED_REQUEST_ID,
@@ -96,16 +90,16 @@ describe('auth HTTP AppInbox idempotency security', () => {
             ttlMs: 60_000
         });
 
-        await waitForAuthInboxEntry(runtime.auth.queue);
+        await runtime.auth.queue.waitForEntryCount();
         await runtime.auth.reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience()
+            createAppInboxTestResilience()
         );
         const [firstResult, secondResult] = await Promise.all([first, second]);
 
         expect(secondResult.left).toBeUndefined();
         expect(firstResult.right).toEqual(secondResult.right);
-        expect(await readEntries(runtime.auth.queue)).toHaveLength(1);
+        expect(await runtime.auth.queue.readEntries()).toHaveLength(1);
         expect(runtime.auth.results.allEntries()).toHaveLength(1);
     });
 
@@ -148,14 +142,14 @@ describe('auth HTTP AppInbox idempotency security', () => {
 
         const first = auth.service.issueSession(input);
         const second = auth.service.issueSession(input);
-        await waitForAuthInboxEntry(auth.queue);
+        await auth.queue.waitForEntryCount();
 
         expect(sampledTimes).toEqual([]);
         expect(issuedAccessTokenSessionIds).toEqual([]);
 
         await auth.reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience()
+            createAppInboxTestResilience()
         );
         const [firstResult, secondResult] = await Promise.all([first, second]);
 
@@ -195,8 +189,8 @@ describe('auth HTTP AppInbox idempotency security', () => {
             },
             ttlMs: 60_000
         });
-        await waitForAuthInboxEntry(auth.queue);
-        const [queued] = await readEntries(auth.queue);
+        await auth.queue.waitForEntryCount();
+        const [queued] = await auth.queue.readEntries();
         expect(sampledTimes).toEqual([]);
         expect(queued.resource).not.toContain('capturedAtEpochMs');
         expect(queued.resource).not.toContain('sessionId');
@@ -205,7 +199,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
         currentTime = 9_000;
         await auth.reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience()
+            createAppInboxTestResilience()
         );
         const result = await pending;
 
@@ -235,8 +229,8 @@ describe('auth HTTP AppInbox idempotency security', () => {
             }
         };
         const pending = auth.service.registerUser(input);
-        await waitForAuthInboxEntry(auth.queue);
-        const [queued] = await readEntries(auth.queue);
+        await auth.queue.waitForEntryCount();
+        const [queued] = await auth.queue.readEntries();
 
         expect(sampledTimes).toEqual([]);
         expect(queued.resource).not.toContain(input.request.password);
@@ -247,7 +241,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
         currentTime = 9_000;
         await auth.reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience()
+            createAppInboxTestResilience()
         );
         const result = await pending;
 
@@ -291,7 +285,7 @@ describe('auth HTTP AppInbox idempotency security', () => {
         const replayed = await runtime.auth.service.consumeAgentSessionTicket(consumeInput);
 
         expect(replayed.right).toEqual(consumed.right);
-        expect(await readEntries(runtime.auth.queue)).toHaveLength(2);
+        expect(await runtime.auth.queue.readEntries()).toHaveLength(2);
     });
 });
 

--- a/packages/tests/shared-server/auth/auth-inbox-registration-and-routing.test.ts
+++ b/packages/tests/shared-server/auth/auth-inbox-registration-and-routing.test.ts
@@ -7,16 +7,10 @@ import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience, TestResourceInbox, TestResourceInboxResults } from '../app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-    createAuthInboxTestResilience,
-    createAuthInboxTestRuntime,
-    TestResourceInbox,
-    TestResourceInboxResults,
-    waitForAuthInboxEntry,
-    type AuthInboxTestRuntime
-} from './auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestRuntime, type AuthInboxTestRuntime } from './auth-app-inbox-test-runtime.ts';
 
 const AUTH_INBOX_TYPES = [
     'AUTH_USER_REGISTER',
@@ -74,12 +68,12 @@ describe('AppAuthInboxService registration', () => {
                 expiresAtEpochMs: 2_000
             }
         });
-        await waitForAuthInboxEntry(queue);
+        await queue.waitForEntryCount();
         expect(readCommandKinds).toEqual([]);
 
         await reader.dequeueInbox(
             InboxQueueReader.INBOX_DEQUEUE_TYPES,
-            createAuthInboxTestResilience()
+            createAppInboxTestResilience()
         );
         await expect(pending).resolves.toMatchObject({ right: { loggedOut: true } });
         expect(readCommandKinds).toEqual(['logout-session']);

--- a/packages/tests/shared-server/auth/auth-inbox-registration-and-routing.test.ts
+++ b/packages/tests/shared-server/auth/auth-inbox-registration-and-routing.test.ts
@@ -1,25 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
+import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
+import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-
-import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
-
-import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
-
-import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 import {
+    createAuthInboxTestResilience,
     createAuthInboxTestRuntime,
-    createResilience,
     TestResourceInbox,
     TestResourceInboxResults,
-    waitForQueuedEntry,
+    waitForAuthInboxEntry,
     type AuthInboxTestRuntime
 } from './auth-app-inbox-test-runtime.ts';
+
 const AUTH_INBOX_TYPES = [
     'AUTH_USER_REGISTER',
     'AUTH_SESSION_ISSUE',
@@ -76,10 +74,13 @@ describe('AppAuthInboxService registration', () => {
                 expiresAtEpochMs: 2_000
             }
         });
-        await waitForQueuedEntry(queue);
+        await waitForAuthInboxEntry(queue);
         expect(readCommandKinds).toEqual([]);
 
-        await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+        await reader.dequeueInbox(
+            InboxQueueReader.INBOX_DEQUEUE_TYPES,
+            createAuthInboxTestResilience()
+        );
         await expect(pending).resolves.toMatchObject({ right: { loggedOut: true } });
         expect(readCommandKinds).toEqual(['logout-session']);
     });

--- a/packages/tests/shared-server/auth/auth-persistence-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-persistence-security.test.ts
@@ -167,14 +167,12 @@ async function runCurrentOperation<Result>(
     return await pending;
 }
 
-it('does not scan or accept explicit predecessor rows after the current', async () => {
+it('rejects explicit predecessor rows after the current storage cutover', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2027-01-01T00:00:00.000Z'));
     try {
         const runtime = new FakeRuntimeStateRepository();
         const repository = new AuthSessionRepository(runtime);
-        const page = vi.spyOn(runtime, 'findEntriesByPrefixPage');
-        const findEntry = vi.spyOn(runtime, 'findEntry');
         const expiresAtEpochMs = Date.now() + 60_000;
         const token = 'current-predecessor-token';
         await runtime.upsert(
@@ -216,11 +214,6 @@ it('does not scan or accept explicit predecessor rows after the current', async 
         await expect(
             repository.consumeAgentSessionTicket('predecessor-agent-ticket')
         ).resolves.toBeUndefined();
-        expect(page).not.toHaveBeenCalled();
-        expect(findEntry).not.toHaveBeenCalledWith(
-            'auth-sessions:by-token',
-            `token=${encodeURIComponent(token)}`
-        );
     }
     finally {
         vi.useRealTimers();

--- a/packages/tests/shared-server/auth/auth-persistence-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-persistence-security.test.ts
@@ -8,9 +8,9 @@ import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persist
 import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience, TestResourceInbox, TestResourceInboxResults } from '../app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import { createAuthInboxTestResilience, TestResourceInbox, TestResourceInboxResults, waitForAuthInboxEntry } from './auth-app-inbox-test-runtime.ts';
 
 it('fails closed without consuming corrupt digest-key ticket rows', async () => {
     const cases = [
@@ -159,10 +159,10 @@ async function runCurrentOperation<Result>(
         }
     );
     const pending = operation(service);
-    await waitForAuthInboxEntry(queue);
+    await queue.waitForEntryCount();
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
     return await pending;
 }

--- a/packages/tests/shared-server/auth/auth-persistence-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-persistence-security.test.ts
@@ -1,19 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-
 import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
-
 import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
 import { hashAuthSecret } from '@shared-server/rallar-system/auth/credentials/hash-auth-secret.ts';
-
 import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
-
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
+import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import { createResilience, TestResourceInbox, TestResourceInboxResults, waitForQueuedEntry } from './auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestResilience, TestResourceInbox, TestResourceInboxResults, waitForAuthInboxEntry } from './auth-app-inbox-test-runtime.ts';
+
 it('fails closed without consuming corrupt digest-key ticket rows', async () => {
     const cases = [
         {
@@ -126,7 +124,7 @@ async function expectCurrentConsumeOutcomes(): Promise<void> {
     ).resolves.toMatchObject({ left: { status: 404 } });
 }
 
-function createCurrentSession(capturedAtEpochMs: number) {
+function createCurrentSession(capturedAtEpochMs: number): IssuedAuthSession {
     return {
         clientId: 'current-client',
         accessToken: 'current-access-token',
@@ -161,8 +159,11 @@ async function runCurrentOperation<Result>(
         }
     );
     const pending = operation(service);
-    await waitForQueuedEntry(queue);
-    await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+    await waitForAuthInboxEntry(queue);
+    await reader.dequeueInbox(
+        InboxQueueReader.INBOX_DEQUEUE_TYPES,
+        createAuthInboxTestResilience()
+    );
     return await pending;
 }
 

--- a/packages/tests/shared-server/auth/auth-public-command-routing.test.ts
+++ b/packages/tests/shared-server/auth/auth-public-command-routing.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest';
+import { expect, it, vi } from 'vitest';
 
 import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
 import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
@@ -7,31 +7,17 @@ import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app
 import type { IssueAuthWsTicketCommand } from '@shared-server/rallar-system/auth/mutation/auth-mutation-contracts.ts';
 import { captureAuthMutationFacts } from '@shared-server/rallar-system/auth/mutation/read/capture-auth-mutation-facts.ts';
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { TestResourceInbox, TestResourceInboxResults } from '../app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-    createAuthInboxTestRuntime,
-    readEntries,
-    runAuthInboxCommand,
-    TestResourceInbox,
-    TestResourceInboxResults,
-    type AuthInboxTestRuntime
-} from './auth-app-inbox-test-runtime.ts';
-
-interface RoutedSession {
-    readonly clientId: string;
-    readonly username: string;
-    readonly sessionId: string;
-    readonly accessToken: string;
-    readonly issuedAtEpochMs: number;
-    readonly expiresAtEpochMs: number;
-}
+import { createAuthInboxTestRuntime, runAuthInboxCommand, type AuthInboxTestRuntime } from './auth-app-inbox-test-runtime.ts';
 
 interface ConsumeExpiredTicketsInput {
     readonly auth: AuthInboxTestRuntime;
-    readonly session: RoutedSession;
+    readonly session: IssuedAuthSession;
     readonly wsTicket: string;
     readonly agentTickets: readonly string[];
 }
@@ -39,10 +25,10 @@ interface ConsumeExpiredTicketsInput {
 interface LogoutRoutedSessionInput {
     readonly auth: AuthInboxTestRuntime;
     readonly runtimeRepository: FakeRuntimeStateRepository;
-    readonly session: RoutedSession;
+    readonly session: IssuedAuthSession;
 }
 
-const DELAYED_AUTH_MATERIALIZATION_MS = 100;
+const LEGACY_AUTH_INBOX_POLLING_DEADLINE_MS = 50;
 
 it(
     'routes registration, ticket issuance, agent batches, and logout through durable commands',
@@ -55,9 +41,52 @@ it('waits for delayed auth intent materialization before dequeuing', async () =>
         serviceId: 'delayed-auth-test-service',
         credentialSecret: 'delayed-auth-secret-0123456789abcdef'
     });
-    auth.queue.delayNextMaterializationUntil(
-        new Promise((resolve) => setTimeout(resolve, DELAYED_AUTH_MATERIALIZATION_MS))
-    );
+    const materialization = Promise.withResolvers<void>();
+    auth.queue.delayNextMaterializationUntil(materialization.promise);
+    vi.useFakeTimers();
+    try {
+        let settled = false;
+        const registration = registerRoutedUser(auth);
+        void registration.then(
+            () => {
+                settled = true;
+            },
+            () => {
+                settled = true;
+            }
+        );
+
+        await vi.advanceTimersByTimeAsync(LEGACY_AUTH_INBOX_POLLING_DEADLINE_MS);
+        expect(settled).toBe(false);
+
+        materialization.resolve();
+        expect(await registration).toBeDefined();
+    }
+    finally {
+        materialization.resolve();
+        vi.useRealTimers();
+    }
+});
+
+it('cleans up a timed-out queue wait before later command processing', async () => {
+    const auth = createAuthInboxTestRuntime({
+        runtimeRepository: new FakeRuntimeStateRepository(),
+        serviceId: 'timed-out-wait-auth-test-service',
+        credentialSecret: 'timed-out-wait-auth-secret-0123456789abcdef'
+    });
+    vi.useFakeTimers();
+    try {
+        const timedOut = auth.queue.waitForEntryCount(1, 10);
+        const timeoutExpectation = expect(timedOut).rejects.toThrow(
+            'ResourceInbox test queue did not reach 1 entries'
+        );
+        await vi.advanceTimersByTimeAsync(10);
+
+        await timeoutExpectation;
+    }
+    finally {
+        vi.useRealTimers();
+    }
 
     expect(await registerRoutedUser(auth)).toBeDefined();
 });
@@ -109,7 +138,7 @@ async function issueRoutedSession(
     auth: AuthInboxTestRuntime,
     now: number,
     clientId: string
-): Promise<RoutedSession> {
+): Promise<IssuedAuthSession> {
     const login = await runAuthInboxCommand({
         pending: auth.service.issueSession({
             requestId: 'session-request',
@@ -136,7 +165,7 @@ async function issueRoutedSession(
 
 async function issueRoutedWebSocketTicket(
     auth: AuthInboxTestRuntime,
-    session: RoutedSession
+    session: IssuedAuthSession
 ): Promise<string> {
     const wsTicket = await runAuthInboxCommand({
         pending: auth.service.issueWebSocketTicket({
@@ -172,7 +201,7 @@ async function issueRoutedWebSocketTicket(
 
 async function issueRoutedAgentTickets(
     auth: AuthInboxTestRuntime,
-    session: RoutedSession
+    session: IssuedAuthSession
 ): Promise<readonly string[]> {
     const agentTickets = await runAuthInboxCommand({
         pending: auth.service.issueAgentSessionTickets({
@@ -269,7 +298,7 @@ async function expectNoPlaintextCredentials(
     plaintext: readonly string[]
 ): Promise<void> {
     const durableResources = [
-        ...(await readEntries(auth.queue)).map((entry) => entry.resource),
+        ...(await auth.queue.readEntries()).map((entry) => entry.resource),
         ...auth.results.allEntries().map((entry) => entry.resource)
     ].join('\n');
     for (const credential of plaintext) {

--- a/packages/tests/shared-server/auth/auth-public-command-routing.test.ts
+++ b/packages/tests/shared-server/auth/auth-public-command-routing.test.ts
@@ -1,34 +1,24 @@
-import { describe, expect, it } from 'vitest';
-
-import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
+import { expect, it } from 'vitest';
 
 import { createAuthMutationService } from '@shared-server/rallar-system/auth/auth-mutation-service.ts';
-
 import { createHmacAuthCredentialIssuer } from '@shared-server/rallar-system/auth/credentials/auth-credential-issuer.ts';
 import { hashAuthSecret } from '@shared-server/rallar-system/auth/credentials/hash-auth-secret.ts';
-
 import { AppAuthInboxService } from '@shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts';
-
 import type { IssueAuthWsTicketCommand } from '@shared-server/rallar-system/auth/mutation/auth-mutation-contracts.ts';
-
 import { captureAuthMutationFacts } from '@shared-server/rallar-system/auth/mutation/read/capture-auth-mutation-facts.ts';
-
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 import {
     createAuthInboxTestRuntime,
     readEntries,
-    runAuthCommand,
+    runAuthInboxCommand,
     TestResourceInbox,
     TestResourceInboxResults,
     type AuthInboxTestRuntime
 } from './auth-app-inbox-test-runtime.ts';
-it(
-    'routes registration, ticket issuance, agent batches, and logout through durable commands',
-    routesEveryPublicMutationThroughDurableCommands
-);
 
 interface RoutedSession {
     readonly clientId: string;
@@ -38,6 +28,39 @@ interface RoutedSession {
     readonly issuedAtEpochMs: number;
     readonly expiresAtEpochMs: number;
 }
+
+interface ConsumeExpiredTicketsInput {
+    readonly auth: AuthInboxTestRuntime;
+    readonly session: RoutedSession;
+    readonly wsTicket: string;
+    readonly agentTickets: readonly string[];
+}
+
+interface LogoutRoutedSessionInput {
+    readonly auth: AuthInboxTestRuntime;
+    readonly runtimeRepository: FakeRuntimeStateRepository;
+    readonly session: RoutedSession;
+}
+
+const DELAYED_AUTH_MATERIALIZATION_MS = 100;
+
+it(
+    'routes registration, ticket issuance, agent batches, and logout through durable commands',
+    routesEveryPublicMutationThroughDurableCommands
+);
+
+it('waits for delayed auth intent materialization before dequeuing', async () => {
+    const auth = createAuthInboxTestRuntime({
+        runtimeRepository: new FakeRuntimeStateRepository(),
+        serviceId: 'delayed-auth-test-service',
+        credentialSecret: 'delayed-auth-secret-0123456789abcdef'
+    });
+    auth.queue.delayNextMaterializationUntil(
+        new Promise((resolve) => setTimeout(resolve, DELAYED_AUTH_MATERIALIZATION_MS))
+    );
+
+    expect(await registerRoutedUser(auth)).toBeDefined();
+});
 
 async function routesEveryPublicMutationThroughDurableCommands(): Promise<void> {
     const runtimeRepository = new FakeRuntimeStateRepository();
@@ -52,11 +75,11 @@ async function routesEveryPublicMutationThroughDurableCommands(): Promise<void> 
     const now = clock.now;
     const clientId = await registerRoutedUser(auth);
     const session = await issueRoutedSession(auth, now, clientId);
-    const wsTicket = await issueRoutedWebSocketTicket(auth, now, session);
-    const agentTickets = await issueRoutedAgentTickets(auth, now, session);
+    const wsTicket = await issueRoutedWebSocketTicket(auth, session);
+    const agentTickets = await issueRoutedAgentTickets(auth, session);
     clock.now = now + 30_001;
-    await consumeExpiredRoutedTickets({ auth, now, session, wsTicket, agentTickets });
-    await logoutRoutedSession({ auth, runtimeRepository, now, session });
+    await consumeExpiredRoutedTickets({ auth, session, wsTicket, agentTickets });
+    await logoutRoutedSession({ auth, runtimeRepository, session });
     await expectNoPlaintextCredentials(auth, [
         session.accessToken,
         wsTicket,
@@ -66,7 +89,7 @@ async function routesEveryPublicMutationThroughDurableCommands(): Promise<void> 
 }
 
 async function registerRoutedUser(auth: AuthInboxTestRuntime): Promise<string> {
-    const registered = await runAuthCommand({
+    const registered = await runAuthInboxCommand({
         pending: auth.service.registerUser({
             requestId: 'register-request',
             request: {
@@ -87,7 +110,7 @@ async function issueRoutedSession(
     now: number,
     clientId: string
 ): Promise<RoutedSession> {
-    const login = await runAuthCommand({
+    const login = await runAuthInboxCommand({
         pending: auth.service.issueSession({
             requestId: 'session-request',
             clientId,
@@ -113,10 +136,9 @@ async function issueRoutedSession(
 
 async function issueRoutedWebSocketTicket(
     auth: AuthInboxTestRuntime,
-    now: number,
     session: RoutedSession
 ): Promise<string> {
-    const wsTicket = await runAuthCommand({
+    const wsTicket = await runAuthInboxCommand({
         pending: auth.service.issueWebSocketTicket({
             requestId: 'ws-issue-request',
             session,
@@ -150,10 +172,9 @@ async function issueRoutedWebSocketTicket(
 
 async function issueRoutedAgentTickets(
     auth: AuthInboxTestRuntime,
-    now: number,
     session: RoutedSession
 ): Promise<readonly string[]> {
-    const agentTickets = await runAuthCommand({
+    const agentTickets = await runAuthInboxCommand({
         pending: auth.service.issueAgentSessionTickets({
             requestId: 'agent-issue-request',
             session,
@@ -191,22 +212,13 @@ async function issueRoutedAgentTickets(
     return agentTickets.right!.tickets.map((ticket) => ticket.ticket);
 }
 
-interface ConsumeExpiredTicketsInput {
-    readonly auth: AuthInboxTestRuntime;
-    readonly now: number;
-    readonly session: RoutedSession;
-    readonly wsTicket: string;
-    readonly agentTickets: readonly string[];
-}
-
 async function consumeExpiredRoutedTickets({
     auth,
-    now,
     session,
     wsTicket,
     agentTickets
 }: ConsumeExpiredTicketsInput): Promise<void> {
-    const expiredWs = await runAuthCommand({
+    const expiredWs = await runAuthInboxCommand({
         pending: auth.service.consumeWebSocketTicket({
             requestId: 'ws-expired-consume',
             expectedSessionId: session.sessionId,
@@ -217,7 +229,7 @@ async function consumeExpiredRoutedTickets({
         minimumEntries: 5
     });
     expect(expiredWs.left?.status).toBe(410);
-    const expiredAgent = await runAuthCommand({
+    const expiredAgent = await runAuthInboxCommand({
         pending: auth.service.consumeAgentSessionTicket({
             requestId: 'agent-expired-consume',
             ticket: agentTickets[0]
@@ -229,20 +241,12 @@ async function consumeExpiredRoutedTickets({
     expect(expiredAgent.left?.status).toBe(410);
 }
 
-interface LogoutRoutedSessionInput {
-    readonly auth: AuthInboxTestRuntime;
-    readonly runtimeRepository: FakeRuntimeStateRepository;
-    readonly now: number;
-    readonly session: RoutedSession;
-}
-
 async function logoutRoutedSession({
     auth,
     runtimeRepository,
-    now,
     session
 }: LogoutRoutedSessionInput): Promise<void> {
-    const logout = await runAuthCommand({
+    const logout = await runAuthInboxCommand({
         pending: auth.service.logoutSession({
             requestId: 'logout-request',
             session
@@ -301,7 +305,7 @@ it('rechecks the parent session before issuing agent credentials', async () => {
     );
     const now = Date.now();
 
-    const issued = await runAuthCommand({
+    const issued = await runAuthInboxCommand({
         pending: service.issueAgentSessionTickets({
             requestId: 'agent-without-authority',
             session: {

--- a/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
+++ b/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
@@ -9,14 +9,9 @@ import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persist
 import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience } from '../app-inbox-resource-fixtures.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-    createAuthInboxTestResilience,
-    createAuthInboxTestRuntime,
-    runAuthInboxCommand,
-    waitForAuthInboxEntry,
-    type AuthInboxTestRuntime
-} from './auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestRuntime, runAuthInboxCommand, type AuthInboxTestRuntime } from './auth-app-inbox-test-runtime.ts';
 
 interface ConsumeRaceTicketTwiceInput {
     readonly auth: AuthInboxTestRuntime;
@@ -121,7 +116,7 @@ async function expectSingleRegistrationWinner(
             request
         })
     ];
-    await waitForAuthInboxEntry(auth.queue, 2);
+    await auth.queue.waitForEntryCount(2);
     await dequeue(auth);
     await dequeue(auth);
     const registrationResults = await Promise.all(registrations);
@@ -194,7 +189,7 @@ async function consumeRaceTicketTwice({
             ticket
         })
     ];
-    await waitForAuthInboxEntry(auth.queue, 6);
+    await auth.queue.waitForEntryCount(6);
     await dequeue(auth);
     await dequeue(auth);
     return await Promise.all(consumes);
@@ -203,6 +198,6 @@ async function consumeRaceTicketTwice({
 async function dequeue(auth: AuthInboxTestRuntime): Promise<void> {
     await auth.reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
 }

--- a/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
+++ b/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
@@ -6,16 +6,24 @@ import { hashAuthSecret } from '@shared-server/rallar-system/auth/credentials/ha
 import type { ConsumeAuthWsTicketCommand } from '@shared-server/rallar-system/auth/mutation/auth-mutation-contracts.ts';
 import { captureAuthMutationFacts } from '@shared-server/rallar-system/auth/mutation/read/capture-auth-mutation-facts.ts';
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 import {
     createAuthInboxTestResilience,
     createAuthInboxTestRuntime,
-    runAuthCommand,
-    waitForQueuedEntry,
+    runAuthInboxCommand,
+    waitForAuthInboxEntry,
     type AuthInboxTestRuntime
 } from './auth-app-inbox-test-runtime.ts';
+
+interface ConsumeRaceTicketTwiceInput {
+    readonly auth: AuthInboxTestRuntime;
+    readonly sessionId: string;
+    readonly ticket: string;
+}
+
 it('rejects a corrupted websocket ticket before deleting it', async () => {
     const runtime = new FakeRuntimeStateRepository();
     const sessions = new AuthSessionRepository(runtime);
@@ -84,10 +92,9 @@ async function selectsSingleConcurrentWinner(): Promise<void> {
     const now = Date.now();
     const clientId = await expectSingleRegistrationWinner(auth);
     const session = await issueRaceSession(auth, now, clientId);
-    const ticket = await issueRaceTicket(auth, now, session);
+    const ticket = await issueRaceTicket(auth, session);
     const consumeResults = await consumeRaceTicketTwice({
         auth,
-        now,
         sessionId: session.sessionId,
         ticket
     });
@@ -114,22 +121,26 @@ async function expectSingleRegistrationWinner(
             request
         })
     ];
-    await waitForQueuedEntry(auth.queue, 2);
+    await waitForAuthInboxEntry(auth.queue, 2);
     await dequeue(auth);
     await dequeue(auth);
     const registrationResults = await Promise.all(registrations);
     expect(registrationResults.filter((result) => result.right !== undefined)).toHaveLength(1);
     expect(registrationResults.filter((result) => result.left?.status === 409)).toHaveLength(1);
-    return registrationResults.find((result) => result.right)?.right!.clientId ?? '';
+    const winner = registrationResults.find((result) => result.right !== undefined)?.right;
+    if (winner === undefined) {
+        throw new Error('Expected one successful auth registration');
+    }
+    return winner.clientId;
 }
 
 async function issueRaceSession(
     auth: AuthInboxTestRuntime,
     now: number,
     clientId: string
-) {
+): Promise<IssuedAuthSession> {
     const issuedAtEpochMs = now + 1;
-    const login = await runAuthCommand({
+    const login = await runAuthInboxCommand({
         pending: auth.service.issueSession({
             requestId: 'ticket-race-session',
             clientId,
@@ -151,10 +162,9 @@ async function issueRaceSession(
 
 async function issueRaceTicket(
     auth: AuthInboxTestRuntime,
-    now: number,
-    session: Awaited<ReturnType<typeof issueRaceSession>>
+    session: IssuedAuthSession
 ): Promise<string> {
-    const issuedTicket = await runAuthCommand({
+    const issuedTicket = await runAuthInboxCommand({
         pending: auth.service.issueWebSocketTicket({
             requestId: 'ticket-race-issue',
             session,
@@ -167,16 +177,8 @@ async function issueRaceTicket(
     return issuedTicket.right!.ticket;
 }
 
-interface ConsumeRaceTicketTwiceInput {
-    readonly auth: AuthInboxTestRuntime;
-    readonly now: number;
-    readonly sessionId: string;
-    readonly ticket: string;
-}
-
 async function consumeRaceTicketTwice({
     auth,
-    now,
     sessionId,
     ticket
 }: ConsumeRaceTicketTwiceInput) {
@@ -192,7 +194,7 @@ async function consumeRaceTicketTwice({
             ticket
         })
     ];
-    await waitForQueuedEntry(auth.queue, 6);
+    await waitForAuthInboxEntry(auth.queue, 6);
     await dequeue(auth);
     await dequeue(auth);
     return await Promise.all(consumes);

--- a/packages/tests/shared-server/auth/auth-transaction-boundary.test.ts
+++ b/packages/tests/shared-server/auth/auth-transaction-boundary.test.ts
@@ -1,20 +1,16 @@
+import { Temporal } from '@js-temporal/polyfill';
 import { expect, it, vi } from 'vitest';
 
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
 import { AuthUserRepository, type AuthUser } from '@shared-server/rallar-system/auth/persistence/auth-user-repository.ts';
-import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience } from '../app-inbox-resource-fixtures.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
-import {
-    createAuthInboxTestResilience,
-    createAuthInboxTestRuntime,
-    readEntries,
-    waitForAuthInboxEntry,
-    type AuthInboxTestRuntime
-} from './auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestRuntime, type AuthInboxTestRuntime } from './auth-app-inbox-test-runtime.ts';
 
-const serviceId = 'auth-test-service';
+const SERVICE_ID = 'auth-test-service';
 
 it(
     'commits issued session, durable result, and completion in one AppInbox transaction',
@@ -36,7 +32,7 @@ async function commitsIssuedSessionAndResultAtomically(): Promise<void> {
     const credentialSecret = 'test-auth-secret-0123456789abcdef-extra';
     const fixture = createAuthInboxTestRuntime({
         runtimeRepository,
-        serviceId,
+        serviceId: SERVICE_ID,
         credentialSecret
     });
     const pending = fixture.service.issueSession({
@@ -50,7 +46,7 @@ async function commitsIssuedSessionAndResultAtomically(): Promise<void> {
         },
         ttlMs: 60_000
     });
-    await waitForAuthInboxEntry(fixture.queue);
+    await fixture.queue.waitForEntryCount();
     await dequeue(fixture);
     const result = await pending;
 
@@ -75,7 +71,7 @@ async function expectDurableIssueResult({
     accessToken,
     credentialSecret
 }: DurableIssueResultExpectation): Promise<void> {
-    const entries = await readEntries(fixture.queue);
+    const entries = await fixture.queue.readEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0].status).toBe(EntityStatus.COMPLETED);
     expect(entries[0].resource).not.toContain(accessToken);
@@ -90,7 +86,7 @@ async function deniesSessionWhenUserIsDisabledAfterEnqueue(): Promise<void> {
     const runtimeRepository = new FakeRuntimeStateRepository();
     const fixture = createAuthInboxTestRuntime({
         runtimeRepository,
-        serviceId,
+        serviceId: SERVICE_ID,
         credentialSecret: 'disabled-user-secret-0123456789abcdef'
     });
     const user = createRegisteredUser('client-disabled', 'disabled-user');
@@ -103,7 +99,7 @@ async function deniesSessionWhenUserIsDisabledAfterEnqueue(): Promise<void> {
         ttlMs: 60_000,
         authority: registeredUserAuthority(user)
     });
-    await waitForAuthInboxEntry(fixture.queue);
+    await fixture.queue.waitForEntryCount();
     await users.putUser({ ...user, status: 'disabled', updatedAtEpochMs: 1_001 });
     await dequeue(fixture);
 
@@ -133,20 +129,26 @@ async function rereadsUserPolicyAfterRetryConflict(): Promise<void> {
         authority: registeredUserAuthority(fixture.user)
     });
 
-    await releaseConflictForRetry(fixture);
+    const releasedForRetry = await releaseConflictForRetry(fixture);
     await fixture.users.putUser({
         ...fixture.user,
         status: 'disabled',
         updatedAtEpochMs: 1_001
     });
-    await new Promise((resolve) => setTimeout(resolve, 110));
+    await fixture.auth.queue.enqueue({
+        ...releasedForRetry,
+        dequeueAudit: {
+            ...releasedForRetry.dequeueAudit,
+            nextTs: Temporal.Now.instant().subtract({ milliseconds: 1 })
+        }
+    });
     await dequeue(fixture.auth);
 
     const result = await pending;
     expect(result.left).toMatchObject({ status: 403 });
     expect(fixture.conflict.injected).toBe(true);
     expect(fixture.conflict.rollbackCount).toBe(1);
-    expect(policyReadCalls(userRead.mock.calls)).toHaveLength(4);
+    expect(countPolicyReadCalls(userRead.mock.calls)).toBe(4);
     await expectFailedRetry(fixture);
 }
 
@@ -173,28 +175,29 @@ async function createRetryFixture(): Promise<RetryFixture> {
     };
     const auth = createAuthInboxTestRuntime({
         runtimeRepository,
-        serviceId,
+        serviceId: SERVICE_ID,
         credentialSecret: 'retry-disabled-secret-0123456789abcdef',
         databaseOptions: { onTransactionRollback: () => void (conflict.rollbackCount += 1) }
     });
     return { runtimeRepository, auth, users, user, conflict };
 }
 
-async function releaseConflictForRetry(fixture: RetryFixture): Promise<void> {
-    await waitForAuthInboxEntry(fixture.auth.queue);
+async function releaseConflictForRetry(fixture: RetryFixture): Promise<ResourceEntry> {
+    await fixture.auth.queue.waitForEntryCount();
     await fixture.auth.reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience(100)
+        createAppInboxTestResilience(100)
     );
-    const [releasedForRetry] = await readEntries(fixture.auth.queue);
+    const [releasedForRetry] = await fixture.auth.queue.readEntries();
     expect(releasedForRetry).toMatchObject({
         status: EntityStatus.RETRY,
         dequeueAudit: { attempts: 1 }
     });
+    return releasedForRetry;
 }
 
 async function expectFailedRetry(fixture: RetryFixture): Promise<void> {
-    const [failed] = await readEntries(fixture.auth.queue);
+    const [failed] = await fixture.auth.queue.readEntries();
     expect(failed).toMatchObject({
         status: EntityStatus.FAILED,
         dequeueAudit: { attempts: 2 }
@@ -240,10 +243,12 @@ function registeredUserAuthority(user: AuthUser) {
     };
 }
 
-function policyReadCalls(calls: readonly (readonly unknown[])[]): readonly unknown[] {
+function countPolicyReadCalls(
+    calls: readonly (readonly [namespace: string, key: string])[]
+): number {
     return calls.filter(
         ([namespace]) => namespace === 'auth-users:by-username' || namespace === 'auth-users:by-client-id'
-    );
+    ).length;
 }
 
 function sessionStorageKeys(runtimeRepository: FakeRuntimeStateRepository): readonly string[] {
@@ -255,6 +260,6 @@ function sessionStorageKeys(runtimeRepository: FakeRuntimeStateRepository): read
 async function dequeue(fixture: AuthInboxTestRuntime): Promise<void> {
     await fixture.reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
 }

--- a/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
@@ -278,8 +278,9 @@ async function processAppInboxMethod<Result>(
     reader: InboxQueueReader,
     run: () => Promise<Result>
 ): Promise<Result> {
+    const minimumEntries = (await queue.getAllKeys()).length + 1;
     const resultPromise = run();
-    await queue.waitForEntryCount();
+    await queue.waitForEntryCount(minimumEntries);
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
         createAppInboxTestResilience()

--- a/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
@@ -1,27 +1,19 @@
-import { Temporal } from '@js-temporal/polyfill';
 import { expect, it, vi } from 'vitest';
 
+import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
-import { type IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
+import type { ClientMutationWritten, ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
+import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
+import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import type { AuthorisedWsClientMutationResult } from '@shared-server/rallar-system/client-state/inbox/client-state-inbox-result-codec.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
-import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
-import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
-import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
-import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
-
-import type { AuthorisedWsClientMutationResult } from '@shared-server/rallar-system/client-state/inbox/client-state-inbox-result-codec.ts';
-
-import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
-
-import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
-
-import type { ClientMutationWritten, ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-
+import { createAppInboxTestResilience, TestResourceInbox, TestResourceInboxResults } from '../app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
-import { TestResourceInbox, TestResourceInboxResults } from '../auth/auth-app-inbox-test-runtime.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 
 const SERVICE_ID = 'server-12345678';
@@ -51,9 +43,9 @@ it('rejects authorised websocket disconnect after durable auth revocation', asyn
             userAgent: 'Browser'
         }
     } as const;
-    const connected = await processAppInboxMethod(reader, () => service.processAuthorisedWsClientConnect(connectInput));
+    const connected = await processAppInboxMethod(queue, reader, () => service.processAuthorisedWsClientConnect(connectInput));
     await authSessions.deleteSession(authSession);
-    const disconnected = await processAppInboxMethod(reader, () =>
+    const disconnected = await processAppInboxMethod(queue, reader, () =>
         service.processAuthorisedWsClientDisconnect({
             connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
             disconnectedAtEpochMs: Date.now(),
@@ -89,7 +81,7 @@ it('processes authorised websocket connects in the requested state scope', async
         runtimeRepository
     });
 
-    const connected = await processAppInboxMethod(reader, () =>
+    const connected = await processAppInboxMethod(queue, reader, () =>
         service.processAuthorisedWsClientConnect({
             authSession,
             generationId: 'generation-admin',
@@ -139,7 +131,7 @@ it('processes authorised websocket connects independently per state scope', asyn
         runtimeRepository
     });
 
-    const defaultConnect = await processAppInboxMethod(reader, () =>
+    const defaultConnect = await processAppInboxMethod(queue, reader, () =>
         service.processAuthorisedWsClientConnect({
             authSession,
             generationId: 'generation-default',
@@ -148,7 +140,7 @@ it('processes authorised websocket connects independently per state scope', asyn
                 workspaceId: 'default'
             }
         }));
-    const scopedConnect = await processAppInboxMethod(reader, () =>
+    const scopedConnect = await processAppInboxMethod(queue, reader, () =>
         service.processAuthorisedWsClientConnect({
             authSession,
             generationId: 'generation-scoped',
@@ -198,8 +190,8 @@ it(
                 expiresAtEpochMs: Date.now() + 60_000
             }
         } as const;
-        await processAppInboxMethod(reader, () => service.processAuthorisedWsClientConnect(connectInput));
-        const disconnected = await processAppInboxMethod(reader, () =>
+        await processAppInboxMethod(queue, reader, () => service.processAuthorisedWsClientConnect(connectInput));
+        const disconnected = await processAppInboxMethod(queue, reader, () =>
             service.processAuthorisedWsClientDisconnect({
                 connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
                 disconnectedAtEpochMs: Date.now(),
@@ -281,23 +273,16 @@ function issuedSession(clientId: string, sessionId: string): IssuedAuthSession {
     };
 }
 
-async function processAppInboxMethod<R>(
+async function processAppInboxMethod<Result>(
+    queue: TestResourceInbox,
     reader: InboxQueueReader,
-    run: () => Promise<R>
-): Promise<R> {
+    run: () => Promise<Result>
+): Promise<Result> {
     const resultPromise = run();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
-    return await resultPromise;
-}
-
-function createResilience(): ResilienceDto {
-    const duration = Temporal.Duration.from({ seconds: 10 });
-    return ResilienceDto.toResilienceDto(
-        new CircuitBreakerPolicy(10, duration, duration, duration),
-        1,
-        10,
-        1,
-        1
+    await queue.waitForEntryCount();
+    await reader.dequeueInbox(
+        InboxQueueReader.INBOX_DEQUEUE_TYPES,
+        createAppInboxTestResilience()
     );
+    return await resultPromise;
 }

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
@@ -13,8 +13,8 @@ import type { ClientPrincipalRef } from '@shared/api/client-types.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
+import { createAppInboxTestResilience } from '../app-inbox-resource-fixtures.ts';
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
-import { createAuthInboxTestResilience } from '../auth/auth-app-inbox-test-runtime.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 import {
     ClientExpiryTestResourceInbox,
@@ -340,7 +340,7 @@ async function processClientInbox<R>(
 async function dequeueClientInbox(reader: InboxQueueReader): Promise<void> {
     await reader.dequeueInbox(
         InboxQueueReader.INBOX_DEQUEUE_TYPES,
-        createAuthInboxTestResilience()
+        createAppInboxTestResilience()
     );
 }
 

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
@@ -1,26 +1,20 @@
-import { createTestClientStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
-import { expect, it } from 'vitest';
-
-import type { ClientPrincipalRef } from '@shared/api/client-types.ts';
-import type { StateScope } from '@shared/api/state-types.ts';
-import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
-
-import { ClientStateRepository } from '@shared-server/rallar-system/client-state/persistence/client-state-repository.ts';
-
-import type { ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-
-import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
+import { expect, it, vi } from 'vitest';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import {
     type ClientExpiredSessionsAppInboxPayload,
     type ClientSessionConnectAppInboxPayload
 } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-contracts.ts';
 import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
 import { toAuthenticatedClientMutationContextId } from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
+import { createTestClientStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
+import type { ClientPrincipalRef } from '@shared/api/client-types.ts';
+import type { StateScope } from '@shared/api/state-types.ts';
+import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import { createAppInboxTestDatabase } from '../app-inbox-test-database.ts';
-import { createResilience } from '../auth/auth-app-inbox-test-runtime.ts';
+import { createAuthInboxTestResilience } from '../auth/auth-app-inbox-test-runtime.ts';
 import { FakeRuntimeStateRepository } from '../fake-runtime-state-repository.ts';
 import {
     ClientExpiryTestResourceInbox,
@@ -69,6 +63,7 @@ it(
         await seedClientExpirySession(service, reader, { expiresAtEpochMs, runtimeRepository });
 
         const expired = await processClientInbox(
+            queue,
             reader,
             () => service.processExpiredSessions(expiresAtEpochMs + 1)
         );
@@ -330,28 +325,32 @@ async function seedClientExpirySession(
     await seeded;
 }
 
-async function processClientInbox<R>(reader: InboxQueueReader, run: () => Promise<R>): Promise<R> {
+async function processClientInbox<R>(
+    queue: ClientExpiryTestResourceInbox,
+    reader: InboxQueueReader,
+    run: () => Promise<R>
+): Promise<R> {
+    const minimumEntries = (await readClientExpiryTestEntries(queue)).length + 1;
     const pending = run();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitForQueueEntryCount(queue, minimumEntries);
     await dequeueClientInbox(reader);
     return await pending;
 }
 
 async function dequeueClientInbox(reader: InboxQueueReader): Promise<void> {
-    await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+    await reader.dequeueInbox(
+        InboxQueueReader.INBOX_DEQUEUE_TYPES,
+        createAuthInboxTestResilience()
+    );
 }
 
 async function waitForQueueEntryCount(
     queue: ClientExpiryTestResourceInbox,
     count: number
 ): Promise<void> {
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-        if ((await readClientExpiryTestEntries(queue)).length >= count) {
-            return;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-    throw new Error(`Expected at least ${count} app inbox entries`);
+    await vi.waitFor(async () => {
+        expect((await readClientExpiryTestEntries(queue)).length).toBeGreaterThanOrEqual(count);
+    }, { timeout: 2_000 });
 }
 
 async function seedConnectedSession(


### PR DESCRIPTION
## Goal

Eliminate the scheduler-sensitive auth AppInbox false failure and restore the API-v1 group-presence recipe to the canonical mutation-failure contract.

## Changes

- Move the reusable in-memory ResourceInbox queue, result repository, entry inspection, bounded notification wait, and resilience policy to AppInbox-owned test support.
- Keep the auth test runtime focused on auth service composition and durable-command processing.
- Replace the fixed 50-iteration polling window with queue-write notification and a bounded two-second timeout whose listeners and timer are cleaned up on every exit.
- Add deterministic fake-time coverage at the former 50 ms deadline plus direct timeout-and-reuse coverage.
- Make adjacent touched test helpers wait for the next queue entry relative to a captured baseline and remove wall-clock sleeps from retry and client-state command processing.
- Remove rename-only auth test-runtime aliases and use canonical `IssuedAuthSession` and AppInbox fixture names directly.
- Add `type: api-mutation-failure` and `version: canonical.v2` to the duplicate group-create recipe expectation while preserving `group-already-exists` and status 409.
- Remove two auth-persistence spy assertions that pinned internal lookup topology while retaining the three public predecessor-row rejection outcomes.
- Structural disposition: move generic queue lifecycle support to the AppInbox owner; auth-specific command composition remains in the auth runtime. Repository structure validation accepts this shape.
- Reviewed and remediated every changed human-authored file in full; support files modified by remediation entered closure recursively; independent untouched code remained outside closure.

## Acceptance

- Delayed auth intent materialization remains pending past the former polling deadline and completes after the queue write.
- A timed-out wait cleans up correctly and the same queue processes a later command.
- Reused queues wait for the newly started command rather than an already completed entry.
- The API-v1 recipe identity cutover reports no noncanonical failure expectation for group presence.
- Explicit predecessor auth rows remain rejected through all three public repository operations without constraining internal lookup calls.
- Existing auth, retry, expiry, client-state, and WebSocket-close consumers retain their behavior.

**Test design evidence**

- Behavior protected and observation boundary: auth commands wait for a durable queue entry at the in-memory queue write boundary before dequeuing; the recipe assertion checks the externally observable canonical JSON failure envelope; auth persistence cutover coverage observes public repository results.
- Retained interaction assertions (registry reference and rationale): None.
- Coupled or redundant tests removed or replaced: rename-only helper aliases and polling/sleep-based synchronization were replaced by direct queue conditions; two internal lookup-invocation assertions were removed because the public predecessor-row outcomes cover the same contract.

## Validation

Passed on `8bfe238c24fd67a4e4bcb5e5ad280b03ef5abbe7`:

- Focused auth, AppInbox, client-state, recipe/schema, and matrix validation: 36 files, 187 tests.
- Focused auth persistence security validation: 1 file, 5 tests.
- Exact changed-range test-structure coupling gate: zero current candidates; deleted candidates fully classified.
- `npm run format:check`.
- `npm run check:repo-style:changed -- origin/main` with no new findings.
- `npm run check:repo-structure -- --base origin/main`.
- `npx tsc -p packages/shared-server/tsconfig.json --noEmit`.
- `git diff --check`.
- Independent follow-up review: no Critical, Important, or Minor findings; ready to merge.

Known unrelated failures:

- `npm test`: 900 files total; 895 passed, 4 skipped, and the single untouched `packages/tests/rallar-black-box/distributed-artifact-semantic-coverage-discovery.test.ts` file failed both tests. Totals: 7,831 passed, 9 skipped, 2 failed. Both failures are Playwright test-list discovery errors caused by the runner loading an incompatible or duplicate Playwright test instance; this PR does not touch the failing test, Playwright configuration, or dependencies.
- `npx tsc -p packages/tests/tsconfig.json --noEmit`: existing duplicate/incomplete PGlite, Temporal, WebLLM, and browser ambient declarations plus two existing PGlite type-identity errors outside the changed files.

## Risk and rollback

Risk is confined to test support and one black-box recipe expectation; no production or public API file changes. Queue notification occurs only after `enqueueIfAbsent` completes, and wait resources are removed on success or timeout. The coupling repair removes only redundant internal-call assertions and preserves its public behavioral checks. Roll back by reverting, newest first, `8bfe238c24fd67a4e4bcb5e5ad280b03ef5abbe7`, `ad2330609ba859c3ac2502f6eebbe82dd5b51c29`, `4660304dec63e71a6ec697ec321189993dab1428`, and `d1b8e6fed0e4ab967d799711a8dae931bb44c750`.

## Follow-up

None.
