### PR TITLE
Close remaining runtime-state predecessor contracts

### DIFF
--- a/apps/api-v1/test/api-login-service.test.ts
+++ b/apps/api-v1/test/api-login-service.test.ts
@@ -1,7 +1,11 @@
 import { AuthUserRepository } from '@shared-server/rallar-system/auth/persistence/auth-user-repository.ts';
 import type { RuntimeStateReadBatchSelection, RuntimeStateReadBatchSelector } from '@shared-server/runtime-state/read-batch/runtime-state-read-batch.ts';
 import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
-import type { RuntimeStateEntry, RuntimeStateTransactionalRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import type {
+    RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
+    RuntimeStateTransactionalRepositoryLike
+} from '@shared-server/runtime-state/runtime-state-repository.ts';
 import assert from 'node:assert/strict';
 import { login, register } from '../src/services/api-login-service.ts';
 
@@ -23,7 +27,6 @@ Deno.test('register prepares a mandatory user command without writing before App
     assert.equal(registered.username, 'new-user');
     assert.equal(registered.displayName, 'New User');
     assert.equal(registered.createdAtEpochMs, 1_234);
-    assert.equal(registered.displayName, 'New User');
     assert.equal(runtimeRepository.data.size, 0);
 
     const userRepository = new AuthUserRepository(runtimeRepository);
@@ -165,6 +168,16 @@ class FakeRuntimeStateRepository implements RuntimeStateTransactionalRepositoryL
         );
     }
 
+    async findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        return (await this.findEntriesByPrefix(namespace, keyPrefix))
+            .filter((entry) => options.afterKey === undefined || entry.key > options.afterKey)
+            .slice(0, options.limit);
+    }
+
     findEntriesByKeys(
         namespace: string,
         keys: readonly string[]
@@ -221,9 +234,6 @@ class FakeRuntimeStateRepository implements RuntimeStateTransactionalRepositoryL
         }
 
         return Promise.resolve(deleted);
-    }
-
-    async lockKey(_namespace: string, _key: string): Promise<void> {
     }
 
     private toKey(namespace: string, key: string): string {

--- a/apps/api-v1/test/composition/create-api-v1-route-installers.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-route-installers.test.ts
@@ -221,6 +221,10 @@ class UnusedRuntimeStateRepository implements RuntimeStateRepositoryLike {
         return rejectUnusedOperation();
     }
 
+    findEntriesByPrefixPage(): Promise<never> {
+        return rejectUnusedOperation();
+    }
+
     readRuntimeStateBatch(
         _selectors: readonly RuntimeStateReadBatchSelector[]
     ): Promise<readonly RuntimeStateReadBatchSelection[]> {

--- a/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
@@ -10,7 +10,7 @@ import { GroupTopologyPlanningService } from '@shared-server/rallar-system/topol
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
 import type { RuntimeStateReadBatchSelection, RuntimeStateReadBatchSelector } from '@shared-server/runtime-state/read-batch/runtime-state-read-batch.ts';
 import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
-import type { RuntimeStateEntry, RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import type { RuntimeStateEntry, RuntimeStateEntryPageOptions, RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import type { GroupPresenceSession, GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { createTestGroup } from '../../../../packages/tests/create-test-group.ts';
@@ -183,6 +183,19 @@ class MemoryRuntimeStateRepository implements RuntimeStateRepositoryLike {
                 .filter(([key]) => key.startsWith(`${namespace}:`))
                 .map(([, entry]) => entry)
         );
+    }
+
+    async findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        return (await this.findAllEntries(namespace))
+            .filter((entry) =>
+                entry.key.startsWith(keyPrefix) &&
+                (options.afterKey === undefined || entry.key > options.afterKey)
+            )
+            .slice(0, options.limit);
     }
 
     readRuntimeStateBatch(

--- a/apps/api-v1/test/request-auth-service.test.ts
+++ b/apps/api-v1/test/request-auth-service.test.ts
@@ -1,7 +1,11 @@
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
 import type { RuntimeStateReadBatchSelection, RuntimeStateReadBatchSelector } from '@shared-server/runtime-state/read-batch/runtime-state-read-batch.ts';
 import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
-import type { RuntimeStateEntry, RuntimeStateTransactionalRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import type {
+    RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
+    RuntimeStateTransactionalRepositoryLike
+} from '@shared-server/runtime-state/runtime-state-repository.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import assert from 'node:assert/strict';
 import { requireApiAuthSession, requireWsAuthSession } from '../src/services/request-auth-service.ts';
@@ -184,6 +188,16 @@ class FakeRuntimeStateRepository implements RuntimeStateTransactionalRepositoryL
         );
     }
 
+    async findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        return (await this.findEntriesByPrefix(namespace, keyPrefix))
+            .filter((entry) => options.afterKey === undefined || entry.key > options.afterKey)
+            .slice(0, options.limit);
+    }
+
     findEntriesByKeys(
         namespace: string,
         keys: readonly string[]
@@ -240,9 +254,6 @@ class FakeRuntimeStateRepository implements RuntimeStateTransactionalRepositoryL
         }
 
         return Promise.resolve(deleted);
-    }
-
-    async lockKey(_namespace: string, _key: string): Promise<void> {
     }
 
     private toKey(namespace: string, key: string): string {

--- a/apps/api-v1/test/services/client-state-service.test.ts
+++ b/apps/api-v1/test/services/client-state-service.test.ts
@@ -5,6 +5,7 @@ import type {
     RuntimeStateConditionalDeleteResult,
     RuntimeStateConditionalWriteResult,
     RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
     RuntimeStateOptimisticTransactionalRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import { TestClientStateEventStore } from '@shared-test/shared-server/test-client-state-event-store.ts';
@@ -427,6 +428,16 @@ class FakeRuntimeStateRepository implements RuntimeStateOptimisticTransactionalR
         );
     }
 
+    async findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        return (await this.findEntriesByPrefix(namespace, keyPrefix))
+            .filter((entry) => options.afterKey === undefined || entry.key > options.afterKey)
+            .slice(0, options.limit);
+    }
+
     findEntriesByKeys(
         namespace: string,
         keys: readonly string[]
@@ -539,9 +550,6 @@ class FakeRuntimeStateRepository implements RuntimeStateOptimisticTransactionalR
         }
 
         return Promise.resolve(deleted);
-    }
-
-    async lockKey(_namespace: string, _key: string): Promise<void> {
     }
 
     private toKey(namespace: string, key: string): string {

--- a/packages/shared-rtc-bench/workloads/topology/synthetic-rtc-rtt-runtime-state-repository.ts
+++ b/packages/shared-rtc-bench/workloads/topology/synthetic-rtc-rtt-runtime-state-repository.ts
@@ -5,6 +5,7 @@ import type {
 import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
 import type {
     RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
     RuntimeStateRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
 
@@ -23,6 +24,19 @@ export class SyntheticRtcRttRuntimeStateRepository implements RuntimeStateReposi
                 .map(([, entry]) => ({ ...entry }))
                 .sort((left, right) => left.key.localeCompare(right.key))
         );
+    }
+
+    async findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        return (await this.findAllEntries(namespace))
+            .filter((entry) =>
+                entry.key.startsWith(keyPrefix) &&
+                (options.afterKey === undefined || entry.key > options.afterKey)
+            )
+            .slice(0, options.limit);
     }
 
     readRuntimeStateBatch(

--- a/packages/shared-server/al-runtime/postgres/read-runtime-state-entries-by-prefix.ts
+++ b/packages/shared-server/al-runtime/postgres/read-runtime-state-entries-by-prefix.ts
@@ -1,8 +1,5 @@
 import type { RuntimeStateEntry } from '@shared-server/runtime-state/runtime-state-repository.ts';
-import {
-    isRuntimeStatePrefixPageRepositoryLike,
-    type RuntimeStateTransactionalRepositoryLike
-} from '@shared-server/runtime-state/runtime-state-repository.ts';
+import type { RuntimeStateTransactionalRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
 
 export const RUNTIME_STATE_PREFIX_READ_PAGE_SIZE = 1_000;
 
@@ -12,13 +9,6 @@ export async function* readRuntimeStateEntriesByPrefix(
     prefix: string,
     pageSize: number = RUNTIME_STATE_PREFIX_READ_PAGE_SIZE
 ): AsyncGenerator<RuntimeStateEntry> {
-    if (!isRuntimeStatePrefixPageRepositoryLike(repository)) {
-        for (const entry of await repository.findEntriesByPrefix(namespace, prefix)) {
-            yield entry;
-        }
-        return;
-    }
-
     const limit = Math.max(1, Math.floor(pageSize));
     let afterKey: string | undefined;
 

--- a/packages/shared-server/runtime-state/runtime-state-json-store.ts
+++ b/packages/shared-server/runtime-state/runtime-state-json-store.ts
@@ -3,7 +3,6 @@ import { decodeJsonWireValue, type JsonWireValue } from '../rallar-system/protoc
 import type { RuntimeStateReadBatchSelector } from './read-batch/runtime-state-read-batch.ts';
 import {
     isRuntimeStateConditionalRepositoryLike,
-    isRuntimeStatePrefixPageRepositoryLike,
     type RuntimeStateConditionalDeleteResult,
     type RuntimeStateConditionalRepositoryLike,
     type RuntimeStateConditionalWriteResult,
@@ -172,24 +171,14 @@ export class RuntimeStateJsonStore {
         options: RuntimeStateEntryPageOptions
     ): Promise<readonly RuntimeStateEntry[]> {
         const limit = Math.max(1, Math.floor(options.limit));
-
-        if (isRuntimeStatePrefixPageRepositoryLike(this.repository)) {
-            return await this.repository.findEntriesByPrefixPage(
-                namespace,
-                keyPrefix,
-                {
-                    afterKey: options.afterKey,
-                    limit
-                }
-            );
-        }
-
-        return (await this.listEntries(namespace, keyPrefix))
-            .filter((entry) =>
-                options.afterKey === undefined ||
-                entry.key.localeCompare(options.afterKey) > 0
-            )
-            .slice(0, limit);
+        return await this.repository.findEntriesByPrefixPage(
+            namespace,
+            keyPrefix,
+            {
+                afterKey: options.afterKey,
+                limit
+            }
+        );
     }
 
     protected async toLiveJsonValues(

--- a/packages/shared-server/runtime-state/runtime-state-repository.ts
+++ b/packages/shared-server/runtime-state/runtime-state-repository.ts
@@ -20,6 +20,11 @@ export interface RuntimeStateEntryPageOptions {
 export interface RuntimeStateRepositoryLike {
     findEntry(namespace: string, key: string): Promise<RuntimeStateEntry | undefined>;
     findAllEntries(namespace: string): Promise<readonly RuntimeStateEntry[]>;
+    findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]>;
     readRuntimeStateBatch(
         selectors: readonly RuntimeStateReadBatchSelector[]
     ): Promise<readonly RuntimeStateReadBatchSelection[]>;
@@ -103,14 +108,6 @@ export type RuntimeStateGuardedBatchTransactionalRepositoryLike =
         ): Promise<T>;
     }>;
 
-export interface RuntimeStatePrefixPageRepositoryLike {
-    findEntriesByPrefixPage(
-        namespace: string,
-        keyPrefix: string,
-        options: RuntimeStateEntryPageOptions
-    ): Promise<readonly RuntimeStateEntry[]>;
-}
-
 export function isRuntimeStateTransactionalRepositoryLike(
     repository: RuntimeStateRepositoryLike
 ): repository is RuntimeStateTransactionalRepositoryLike {
@@ -155,12 +152,6 @@ export function assertRuntimeStateUpsertExpectedRevision(
         Number.MAX_SAFE_INTEGER - 1,
         'runtime state upsert expected revision'
     );
-}
-
-export function isRuntimeStatePrefixPageRepositoryLike(
-    repository: RuntimeStateRepositoryLike
-): repository is RuntimeStateRepositoryLike & RuntimeStatePrefixPageRepositoryLike {
-    return 'findEntriesByPrefixPage' in repository;
 }
 
 function assertRuntimeStateExpectedRevisionWithinLimit(

--- a/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-receipt-evidence.ts
+++ b/packages/shared-test/black-box-runner/state-write-evidence/api-v1-state-write-receipt-evidence.ts
@@ -110,6 +110,9 @@ function createStateWriteEvidenceRuntimeStateRepository(
         findAllEntries: async () => {
             throw unsupportedRuntimeStateEvidenceOperation('findAllEntries');
         },
+        findEntriesByPrefixPage: async () => {
+            throw unsupportedRuntimeStateEvidenceOperation('findEntriesByPrefixPage');
+        },
         readRuntimeStateBatch: async (
             selectors: readonly RuntimeStateReadBatchSelector[]
         ): Promise<readonly RuntimeStateReadBatchSelection[]> => await readRuntimeStateBatch(sql, selectors),

--- a/packages/tests/api-v1/client-and-group-state-repositories.test.ts
+++ b/packages/tests/api-v1/client-and-group-state-repositories.test.ts
@@ -1705,8 +1705,6 @@ class FakeRuntimeStateRepository implements RuntimeStateTransactionalRepositoryL
         return deleted;
     }
 
-    async lockKey(_namespace: string, _key: string): Promise<void> {}
-
     findStoredEntry(namespace: string): RuntimeStateEntry | undefined {
         return [...this.data.entries()].find(
             ([compositeKey]) => this.toNamespace(compositeKey) === namespace

--- a/packages/tests/api-v1/fake-optimistic-runtime-state-repository.ts
+++ b/packages/tests/api-v1/fake-optimistic-runtime-state-repository.ts
@@ -9,7 +9,6 @@ import type {
 import * as RuntimeStateTestSupport from '../shared-server/runtime-state/test-support/fake-runtime-state-repository.ts';
 
 export class FakeRuntimeStateRepository extends RuntimeStateTestSupport.FakeRuntimeStateRepository {
-    readonly lockedKeys: Array<Readonly<{ namespace: string; key: string; }>> = [];
     readonly conditionalWrites: Array<
         Readonly<{
             operation: 'insert' | 'replace' | 'delete';
@@ -118,9 +117,5 @@ export class FakeRuntimeStateRepository extends RuntimeStateTestSupport.FakeRunt
             expectedRevision
         });
         return await super.deleteIfRevision(namespace, key, expectedRevision);
-    }
-
-    override async lockKey(namespace: string, key: string): Promise<void> {
-        this.lockedKeys.push({ namespace, key });
     }
 }

--- a/packages/tests/api-v1/psql-inbound-admission-backend.test.ts
+++ b/packages/tests/api-v1/psql-inbound-admission-backend.test.ts
@@ -60,7 +60,7 @@ describe('PSqlInboundAdmissionBackend', () => {
         ]);
     });
 
-    it('conditionally advances the sender version without a domain lock', async () => {
+    it('conditionally advances the sender version with durable inbox effects', async () => {
         const repository = new FakeRuntimeStateRepository();
         const namespace = 'psql-test:inbound:admission';
         const store = createALInboundAdmissionStore({
@@ -84,7 +84,6 @@ describe('PSqlInboundAdmissionBackend', () => {
         });
 
         expect(status).toBe('committed');
-        expect(repository.lockedKeys).toEqual([]);
         expect(repository.conditionalWrites.length).toBeGreaterThan(0);
 
         const versionEntry = await repository.findEntry(namespace, `${namespace}:version:peer-1`);
@@ -117,15 +116,11 @@ describe('PSqlInboundAdmissionBackend', () => {
                 }
             ]
         });
-        repository.lockedKeys.length = 0;
-
         const acceptance = await store.acceptControlMessage(
             newALAckControlMessage('peer-2', 'self', 'msg-1', 'delivered')
         );
 
         expect(acceptance.handled).toBe(true);
-        expect(repository.lockedKeys).toEqual([]);
-
         const versionEntry = await repository.findEntry(namespace, `${namespace}:version:peer-1`);
         expect(JSON.parse(versionEntry!.value)).toEqual({
             senderId: 'peer-1',
@@ -218,8 +213,6 @@ describe('PSqlOutboundAdmissionBackend', () => {
         });
 
         expect(status).toBe('committed');
-        expect(repository.lockedKeys).toEqual([]);
-
         const versionEntry = await repository.findEntry(namespace, `${namespace}:version:self`);
         expect(JSON.parse(versionEntry!.value)).toEqual({
             senderId: 'self',
@@ -240,7 +233,6 @@ describe('PSqlOutboundAdmissionBackend', () => {
             }
         });
 
-        repository.lockedKeys.length = 0;
         const claimed = await store.claimReadyEffects<TestPreparedOutboundSend>(
             'worker-1',
             1,
@@ -250,8 +242,6 @@ describe('PSqlOutboundAdmissionBackend', () => {
 
         expect(claimed).toHaveLength(1);
         expect(claimed[0].effectId).toBe(effectId);
-        expect(repository.lockedKeys).toEqual([]);
-
         await store.completeEffect(effectId, 'worker-1');
         expect(
             await repository.findEntry(namespace, `${namespace}:effect:${effectId}`)
@@ -281,15 +271,11 @@ describe('PSqlOutboundAdmissionBackend', () => {
             ],
             durableEffects: []
         });
-        repository.lockedKeys.length = 0;
-
         const acceptance = await store.acceptControlMessage(
             newALAckControlMessage('peer-1', 'self', msg.id.msgId)
         );
 
         expect(acceptance.handled).toBe(true);
-        expect(repository.lockedKeys).toEqual([]);
-
         const versionEntry = await repository.findEntry(namespace, `${namespace}:version:self`);
         expect(JSON.parse(versionEntry!.value)).toEqual({
             senderId: 'self',

--- a/packages/tests/shared-server/auth/auth-persistence-security.test.ts
+++ b/packages/tests/shared-server/auth/auth-persistence-security.test.ts
@@ -224,7 +224,7 @@ it('rejects explicit predecessor rows after the current storage cutover', async 
     }
 });
 
-it('allows exactly one websocket-ticket consumer without a domain lock', async () => {
+it('allows exactly one websocket-ticket consumer under concurrency', async () => {
     const runtime = new FakeRuntimeStateRepository();
     const repository = new AuthSessionRepository(runtime);
     const expiresAtEpochMs = Date.now() + 60_000;
@@ -250,7 +250,6 @@ it('allows exactly one websocket-ticket consumer without a domain lock', async (
     ]);
 
     expect(results.filter((result) => result !== undefined)).toHaveLength(1);
-    expect(runtime.locks).toEqual([]);
 });
 
 it('persists only ticket digests and canonical ticket records', async () => {

--- a/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
+++ b/packages/tests/shared-server/auth/auth-ticket-conflict.test.ts
@@ -96,7 +96,6 @@ async function selectsSingleConcurrentWinner(): Promise<void> {
 
     expect(consumeResults.filter((result) => result.right !== undefined)).toHaveLength(1);
     expect(consumeResults.filter((result) => result.left?.status === 404)).toHaveLength(1);
-    expect(runtimeRepository.locks).toEqual([]);
 }
 
 async function expectSingleRegistrationWinner(

--- a/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-expiry.test.ts
@@ -196,8 +196,6 @@ it('does not rewrite an expired session when a late disconnect cleanup arrives',
     const runtimeRepository = new FakeRuntimeStateRepository();
     const expiresAtEpochMs = Date.now() - 1_000;
     await seedConnectedSession(runtimeRepository, expiresAtEpochMs);
-    runtimeRepository.locks.splice(0);
-
     const now = expiresAtEpochMs + 1;
     const service = createClientStatePhaseTestDriver(runtimeRepository, () => now);
     const principalRef = toClientPrincipalRef('alice');
@@ -234,7 +232,6 @@ it('does not rewrite an expired session when a late disconnect cleanup arrives',
         'session-connected',
         'session-expired'
     ]);
-    expect(runtimeRepository.locks).toEqual([]);
 });
 
 it('ignores a late heartbeat from an expired connection generation', async () => {

--- a/packages/tests/shared-server/client-state/client-mutation-session-lifecycle.test.ts
+++ b/packages/tests/shared-server/client-state/client-mutation-session-lifecycle.test.ts
@@ -378,5 +378,4 @@ async function expectTerminalDisconnect(runtime: AggregateBarrierRepository): Pr
             (event) => event.requestId === 'disconnect-terminal'
         )
     ).toHaveLength(1);
-    expect(runtime.locks).toEqual([]);
 }

--- a/packages/tests/shared-server/group-state/mutation/group-aggregate-mutation-concurrency.test.ts
+++ b/packages/tests/shared-server/group-state/mutation/group-aggregate-mutation-concurrency.test.ts
@@ -46,7 +46,6 @@ describe('convergent group and presence state', () => {
         const snapshot = await requireSnapshot(runtime, 'capacity-room');
         expect(snapshot.memberCount).toBe(2);
         expect(snapshot.group.snapshotVersion).toBe(2);
-        expect(runtime.locks).toEqual([]);
     });
 
     it('converges join versus ban under either valid serialization order', async () => {

--- a/packages/tests/shared-server/group-state/presence/group-presence-expiry-retry.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-expiry-retry.test.ts
@@ -123,7 +123,6 @@ describe('group presence expiry retry', () => {
         expect(events).toHaveLength(1);
         expect(events[0]?.reason).toBe('expired');
         expect(events[0]?.requestId).toContain('expire-group-presence');
-        expect(runtime.locks).toEqual([]);
     });
 
     it('rebases socket cleanup observations at different times without idempotency conflict', async () => {
@@ -161,7 +160,6 @@ describe('group presence expiry retry', () => {
         expect(results).toHaveLength(2);
         expect(events).toHaveLength(1);
         expect(events[0]?.requestId).toContain('cleanup-group-presence-session');
-        expect(runtime.locks).toEqual([]);
     });
 
     it('replays exact duplicate expiry work with one terminal effect', async () => {
@@ -196,7 +194,6 @@ describe('group presence expiry retry', () => {
         expect(events).toHaveLength(1);
         expect(events[0]?.requestId).toContain('expire-group-presence');
         expect(runtime.conditionalOperations[0]).toBe('delete:group-state:sessions');
-        expect(runtime.locks).toEqual([]);
     });
 
     it('re-reads expiry state and exposes bounded exhaustion after delete conflicts', async () => {

--- a/packages/tests/shared-server/group-state/presence/group-presence-retry.test.ts
+++ b/packages/tests/shared-server/group-state/presence/group-presence-retry.test.ts
@@ -126,8 +126,6 @@ describe('Group presence lifecycle retry', () => {
             lastHeartbeatAtEpochMs: expiresAtEpochMs - 1_000,
             expiresAtEpochMs
         });
-        runtimeRepository.locks.splice(0);
-
         const now = expiresAtEpochMs + 1;
         const runtime = createTestGroupStateRuntime({
             runtimeRepository,
@@ -161,7 +159,6 @@ describe('Group presence lifecycle retry', () => {
             'session-connected',
             'session-disconnected'
         ]);
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('does not let a late heartbeat revive a terminal generation', async () => {

--- a/packages/tests/shared-server/rallar-system/rtc-rtt/persistence/rtc-rtt-repository-convergence.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-rtt/persistence/rtc-rtt-repository-convergence.test.ts
@@ -26,7 +26,6 @@ import {
 describe('RTC RTT repository convergence', () => {
     it('optimistically admits only one of two endpoint-cap races', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
-        vi.spyOn(runtimeRepository, 'lockKey').mockResolvedValue();
         const repository = new RtcRttRepository(runtimeRepository, {
             now: () => 1
         });
@@ -97,7 +96,6 @@ describe('RTC RTT repository convergence', () => {
 
         expect(results.filter((result) => result.updated)).toHaveLength(1);
         expect(await repository.listMeasurements()).toHaveLength(1);
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it.each(rttWriteCandidateCorruptions)(

--- a/packages/tests/shared-server/rallar-system/rtc-rtt/persistence/rtc-rtt-repository-read-write.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-rtt/persistence/rtc-rtt-repository-read-write.test.ts
@@ -46,8 +46,6 @@ describe('RTC RTT repository reads and writes', () => {
             expect(await repository.listMeasurementsForSessionIds(['session-a', 'session-c'])).toEqual(
                 []
             );
-            expect(runtimeRepository.locks).toEqual([]);
-
             now = 1_051;
             vi.setSystemTime(now);
             expect(await repository.findMeasurement('session-a', 'session-b')).toBeUndefined();
@@ -57,7 +55,7 @@ describe('RTC RTT repository reads and writes', () => {
         }
     });
 
-    it('accepts a newer RTT without invoking an application lock', async () => {
+    it('accepts a newer RTT with its revision guard', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
         const repository = new RtcRttRepository(runtimeRepository, {
             now: () => 1
@@ -72,7 +70,6 @@ describe('RTC RTT repository reads and writes', () => {
                 version: 1
             })
         ).resolves.toBe(true);
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('fails closed when the single-attempt RTT write sees equal-version divergence', async () => {

--- a/packages/tests/shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.test.ts
@@ -43,7 +43,7 @@ describe('RTC topology snapshot repository', () => {
         expect('putSnapshot' in repository).toBe(false);
     });
 
-    it('stores topology snapshots without invoking application locks', async () => {
+    it('stores topology snapshots with a revision guard', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
         const repository = new RtcTopologySnapshotRepository(runtimeRepository);
         const groupRef = createGroupRef();
@@ -52,7 +52,6 @@ describe('RTC topology snapshot repository', () => {
         await expect(repository.observeSnapshot(snapshot)).resolves.toBe('inserted');
 
         expect(await repository.findSnapshot(groupRef)).toEqual(snapshot);
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('treats reordered topology object keys as one semantic tuple across decision and CAS', async () => {
@@ -92,7 +91,7 @@ describe('RTC topology snapshot repository', () => {
         ).resolves.toEqual(beforeDuplicate);
     });
 
-    it('lets exactly one snapshot planner claim an absent predecessor without locks', async () => {
+    it('lets exactly one snapshot planner claim an absent predecessor under concurrency', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
         const repository = new RtcTopologySnapshotRepository(runtimeRepository);
         const groupRef = createGroupRef();
@@ -127,7 +126,6 @@ describe('RTC topology snapshot repository', () => {
 
         expect(results.filter((result) => result.status === 'accepted')).toHaveLength(1);
         expect(results.filter((result) => result.status !== 'accepted')).toHaveLength(1);
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('observes topology snapshots monotonically by source revision before version', async () => {

--- a/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.test.ts
@@ -72,20 +72,16 @@ describe('RTC topology publication repository', () => {
         ).resolves.toEqual({ publication, inserted: false });
     });
 
-    it('claims immutable publications without invoking an application lock', async () => {
+    it('claims an immutable publication with its snapshot guard', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
-        vi.spyOn(runtimeRepository, 'lockKey').mockRejectedValue(
-            new Error('targeted publication locks are forbidden')
-        );
         const repository = new RtcTopologyPublicationRepository(runtimeRepository);
         const snapshot = createTopologySnapshot(createGroupRef(), 1);
-        const publication = createPublication(snapshot, 'work-no-lock');
+        const publication = createPublication(snapshot, 'work-snapshot-guard');
 
         await expect(putOrLoadTopologyPublication(repository, publication, snapshot)).resolves.toEqual({
             publication,
             inserted: true
         });
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('accepts documented optional AL envelope sections on durable publications', async () => {
@@ -148,9 +144,8 @@ describe('RTC topology publication repository', () => {
         });
     });
 
-    it('lets exactly one immutable publication claim a work id without locks', async () => {
+    it('lets exactly one immutable publication claim a work id under concurrency', async () => {
         const runtimeRepository = new FakeRuntimeStateRepository();
-        vi.spyOn(runtimeRepository, 'lockKey').mockResolvedValue();
         const repository = new RtcTopologyPublicationRepository(runtimeRepository);
         const first = createPublication(createTopologySnapshot(createGroupRef(), 1), 'work-race');
         const secondSnapshot = {
@@ -202,7 +197,6 @@ describe('RTC topology publication repository', () => {
         expect(results.find((result) => result.status === 'rejected')).toMatchObject({
             reason: { code: 'rtc-topology-publication-collision' }
         });
-        expect(runtimeRepository.locks).toEqual([]);
     });
 
     it('requests recomputation when the topology predecessor moves before commit', async () => {

--- a/packages/tests/shared-server/rallar-system/topology/rtc-topology-snapshot-repository.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/rtc-topology-snapshot-repository.test.ts
@@ -12,7 +12,7 @@ import { RuntimeStateWriteConflictError } from '@shared-server/runtime-state/opt
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import { describe, expect, it, vi } from 'vitest';
 
-import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
+import { FakeRuntimeStateRepository } from '../../runtime-state/test-support/fake-runtime-state-repository.ts';
 import {
     createGroupRef,
     createPublication,
@@ -20,7 +20,7 @@ import {
     putOrLoadTopologyPublication,
     reorderJsonObjectKeys,
     topologyInvariantCases
-} from '../rtc-topology-repository-test-fixtures.ts';
+} from './rtc-topology-repository-test-fixtures.ts';
 
 describe('RTC topology snapshot repository', () => {
     it('rejects extra persisted snapshot fields before topology decisions run', () => {

--- a/packages/tests/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.test.ts
@@ -376,7 +376,7 @@ describe('runtime-state guarded batches', () => {
             expect(cteSource).toMatch(/authority/iu);
         }
         expect(query.source).not.toMatch(
-            /for\s+update|pg_advisory|lockKey/iu
+            /for\s+update|pg_advisory/iu
         );
         for (
             const secret of [

--- a/packages/tests/shared-server/runtime-state/runtime-state-conditional-writes.test.ts
+++ b/packages/tests/shared-server/runtime-state/runtime-state-conditional-writes.test.ts
@@ -116,6 +116,7 @@ describe('runtime-state conditional writes', () => {
         const repository: RuntimeStateRepositoryLike = {
             findEntry: () => Promise.resolve(undefined),
             findAllEntries: () => Promise.resolve([]),
+            findEntriesByPrefixPage: () => Promise.resolve([]),
             readRuntimeStateBatch: (selectors) =>
                 Promise.resolve(
                     selectRuntimeStateReadBatch([], selectors)
@@ -163,6 +164,7 @@ describe('runtime-state conditional writes', () => {
         const repository: RuntimeStateRepositoryLike = {
             findEntry: () => Promise.resolve(expiredEntry),
             findAllEntries: () => Promise.resolve([expiredEntry]),
+            findEntriesByPrefixPage: () => Promise.resolve([expiredEntry]),
             readRuntimeStateBatch: (selectors) =>
                 Promise.resolve(
                     selectRuntimeStateReadBatch(
@@ -234,6 +236,7 @@ describe('runtime-state conditional writes', () => {
         const baseRepository: RuntimeStateRepositoryLike = {
             findEntry: () => Promise.resolve(undefined),
             findAllEntries: () => Promise.resolve([]),
+            findEntriesByPrefixPage: () => Promise.resolve([]),
             readRuntimeStateBatch: (selectors) =>
                 Promise.resolve(
                     selectRuntimeStateReadBatch([], selectors)

--- a/packages/tests/shared-server/runtime-state/runtime-state-repository-contract.test.ts
+++ b/packages/tests/shared-server/runtime-state/runtime-state-repository-contract.test.ts
@@ -1,0 +1,13 @@
+import type { RuntimeStateEntry, RuntimeStateEntryPageOptions, RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import { expectTypeOf, it } from 'vitest';
+
+type RequiredPrefixPageRead = (
+    namespace: string,
+    keyPrefix: string,
+    options: RuntimeStateEntryPageOptions
+) => Promise<readonly RuntimeStateEntry[]>;
+
+it('requires every runtime-state repository to provide bounded prefix reads', () => {
+    expectTypeOf<RuntimeStateRepositoryLike['findEntriesByPrefixPage']>()
+        .toEqualTypeOf<RequiredPrefixPageRead>();
+});

--- a/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
+++ b/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
@@ -26,7 +26,6 @@ import { TestGroupStateEventStore } from '@shared-test/shared-server/test-group-
 export class FakeRuntimeStateRepository
     implements RuntimeStateGuardedBatchTransactionalRepositoryLike, TestClientStateEventStoreOwner, TestGroupStateEventStoreOwner {
     readonly data = new Map<string, RuntimeStateEntry>();
-    readonly locks: Array<Readonly<{ namespace: string; key: string; }>> = [];
     readonly clientStateEventStore = new TestClientStateEventStore();
     readonly groupStateEventStore = new TestGroupStateEventStore();
     beforeUpsert?: (namespace: string, key: string) => void | Promise<void>;
@@ -297,11 +296,6 @@ export class FakeRuntimeStateRepository
         }
 
         return Promise.resolve(deleted);
-    }
-
-    lockKey(namespace: string, key: string): Promise<void> {
-        this.locks.push({ namespace, key });
-        return Promise.resolve();
     }
 
     private toKey(namespace: string, key: string): string {

--- a/packages/tests/shared/psql-json-persistence-provider.test.ts
+++ b/packages/tests/shared/psql-json-persistence-provider.test.ts
@@ -140,6 +140,14 @@ function createRepository(): RuntimeStateRepositoryLike {
                 .filter((entry): entry is RuntimeStateEntry => entry !== undefined)
                 .sort((left, right) => left.key.localeCompare(right.key));
         },
+        async findEntriesByPrefixPage(namespace, keyPrefix, options) {
+            return (await this.findAllEntries(namespace))
+                .filter((entry) =>
+                    entry.key.startsWith(keyPrefix) &&
+                    (options.afterKey === undefined || entry.key > options.afterKey)
+                )
+                .slice(0, options.limit);
+        },
         async readRuntimeStateBatch(selectors) {
             const namespaces = new Set(selectors.map((selector) => selector.namespace));
             return selectRuntimeStateReadBatch(

--- a/scripts/perf/client-list-fanout-bench.ts
+++ b/scripts/perf/client-list-fanout-bench.ts
@@ -10,6 +10,7 @@ import type {
     RuntimeStateConditionalDeleteResult,
     RuntimeStateConditionalWriteResult,
     RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
     RuntimeStateOptimisticTransactionalRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import type { AuditStamp, ClientInstance, ClientPrincipal, ClientSession } from '@shared/api/client-types.ts';
@@ -183,6 +184,25 @@ class CountingRuntimeStateRepository implements RuntimeStateOptimisticTransactio
         return Promise.resolve(rows);
     }
 
+    findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        const rows = [...this.data.entries()]
+            .filter(
+                ([compositeKey]) =>
+                    this.toNamespace(compositeKey) === namespace &&
+                    this.toStoreKey(compositeKey).startsWith(keyPrefix) &&
+                    (options.afterKey === undefined ||
+                        this.toStoreKey(compositeKey) > options.afterKey)
+            )
+            .map(([, entry]) => ({ ...entry }))
+            .sort((left, right) => left.key.localeCompare(right.key))
+            .slice(0, options.limit);
+        return Promise.resolve(rows);
+    }
+
     findEntriesByKeys(
         namespace: string,
         keys: readonly string[]
@@ -290,10 +310,6 @@ class CountingRuntimeStateRepository implements RuntimeStateOptimisticTransactio
             }
         }
         return Promise.resolve(deleted);
-    }
-
-    lockKey(_namespace: string, _key: string): Promise<void> {
-        return Promise.resolve();
     }
 
     resetCounters(): void {

--- a/scripts/perf/group-list-fanout-bench.ts
+++ b/scripts/perf/group-list-fanout-bench.ts
@@ -9,6 +9,7 @@ import type {
 import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
 import type {
     RuntimeStateEntry,
+    RuntimeStateEntryPageOptions,
     RuntimeStateOptimisticTransactionalRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import {
@@ -286,6 +287,25 @@ export class CountingRuntimeStateRepository implements RuntimeStateOptimisticTra
         return Promise.resolve(rows);
     }
 
+    findEntriesByPrefixPage(
+        namespace: string,
+        keyPrefix: string,
+        options: RuntimeStateEntryPageOptions
+    ): Promise<readonly RuntimeStateEntry[]> {
+        const rows = [...this.data.entries()]
+            .filter(
+                ([compositeKey]) =>
+                    this.toNamespace(compositeKey) === namespace &&
+                    this.toStoreKey(compositeKey).startsWith(keyPrefix) &&
+                    (options.afterKey === undefined ||
+                        this.toStoreKey(compositeKey) > options.afterKey)
+            )
+            .map(([, entry]) => ({ ...entry }))
+            .sort((left, right) => left.key.localeCompare(right.key))
+            .slice(0, options.limit);
+        return Promise.resolve(rows);
+    }
+
     findEntriesByKeys(
         namespace: string,
         keys: readonly string[]
@@ -384,10 +404,6 @@ export class CountingRuntimeStateRepository implements RuntimeStateOptimisticTra
             }
         }
         return Promise.resolve(deleted);
-    }
-
-    lockKey(_namespace: string, _key: string): Promise<void> {
-        return Promise.resolve();
     }
 
     resetCounters(): void {

--- a/scripts/perf/runtime-validation-bench.ts
+++ b/scripts/perf/runtime-validation-bench.ts
@@ -3,7 +3,11 @@ import {
     RUNTIME_STATE_PREFIX_READ_PAGE_SIZE
 } from '@shared-server/al-runtime/postgres/read-runtime-state-entries-by-prefix.ts';
 import { readRateLimiter } from '@shared-server/http/rate-limit-service.ts';
-import { listRecentStateEvents } from '@shared-server/rallar-system/state-events/state-event-listing.ts';
+import type { JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
+import {
+    listRecentStateEvents,
+    type StateEventListable
+} from '@shared-server/rallar-system/state-events/state-event-listing.ts';
 import { resolveStateSyncRecipients } from '@shared-server/rallar-system/state-sync/state-sync-routing.ts';
 import type {
     RuntimeStateReadBatchSelection,
@@ -15,24 +19,28 @@ import type {
     RuntimeStateEntryPageOptions,
     RuntimeStateTransactionalRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import { newALBroadcastMessage, newALEventRoute } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
-import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { AuditStamp as ClientAuditStamp, ClientSnapshot } from '@shared/api/client-types.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import { ObservableLatestRepository } from '@shared/cache/ObservableLatestRepository.ts';
 import { RateLimiterPolicy } from '@shared/resilience/Resilience.ts';
+import { ConnectionContext, JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 
-type JsonRecord = Record<string, unknown>;
+interface BenchDetails {
+    [key: string]: JsonWireValue | undefined;
+}
 
-type BenchResult = {
+interface BenchResult {
     name: string;
     sizeLabel: string;
     run: number;
     durationMs: number;
     memoryBefore: Deno.MemoryUsage;
     memoryAfter: Deno.MemoryUsage;
-    details: JsonRecord;
-};
+    details: BenchDetails;
+}
 
 const OUT = Deno.args.find((arg) => arg.startsWith('--out='))?.slice('--out='.length) ??
     'tmp/perf/results/runtime-validation-bench.json';
@@ -41,9 +49,19 @@ const MODE = Deno.args.find((arg) => arg.startsWith('--mode='))?.slice('--mode='
 const RUNS = Number(Deno.args.find((arg) => arg.startsWith('--runs='))?.slice('--runs='.length) ?? '3');
 
 const gc = () => {
-    const maybeGc = (globalThis as unknown as { gc?: () => void; }).gc;
-    maybeGc?.();
+    readOptionalGarbageCollector(globalThis)?.();
 };
+
+function readOptionalGarbageCollector(runtime: typeof globalThis): (() => void) | undefined {
+    if (!('gc' in runtime)) {
+        return undefined;
+    }
+    const garbageCollector = runtime.gc;
+    if (typeof garbageCollector !== 'function') {
+        return undefined;
+    }
+    return () => garbageCollector();
+}
 
 function now(): number {
     return performance.now();
@@ -54,12 +72,12 @@ function memory(): Deno.MemoryUsage {
     return Deno.memoryUsage();
 }
 
-async function measure(
+async function measure<TResult>(
     name: string,
     sizeLabel: string,
     run: number,
-    details: JsonRecord,
-    action: () => unknown | Promise<unknown>
+    details: BenchDetails,
+    action: () => TResult | Promise<TResult>
 ): Promise<BenchResult> {
     const memoryBefore = memory();
     const start = now();
@@ -93,7 +111,7 @@ async function waitUntil(
     }
 }
 
-function makeEvent(index: number): JsonRecord {
+function makeEvent(index: number): JsonWireValue {
     return {
         eventId: `event-${String(index).padStart(8, '0')}`,
         eventType: index % 5 === 0 ? 'presence' : 'snapshot',
@@ -110,8 +128,8 @@ function makeEvent(index: number): JsonRecord {
 }
 
 function runEagerEventPipeline(rowJson: readonly string[], limit: number): number {
-    const parsed = rowJson.map((value) => JSON.parse(value));
-    return listRecentStateEvents(parsed as never[], { limit }).length;
+    const parsed = rowJson.map(decodeBenchmarkStateEvent);
+    return listRecentStateEvents(parsed, { limit }).length;
 }
 
 function runPagedEventPipeline(rowJson: readonly string[], limit: number): number {
@@ -122,8 +140,32 @@ function runPagedEventPipeline(rowJson: readonly string[], limit: number): numbe
 
 function runRecentEventPipeline(rowJson: readonly string[], limit: number): number {
     const recentRows = rowJson.slice(-limit);
-    const parsed = recentRows.map((value) => JSON.parse(value));
-    return listRecentStateEvents(parsed as never[], { limit }).length;
+    const parsed = recentRows.map(decodeBenchmarkStateEvent);
+    return listRecentStateEvents(parsed, { limit }).length;
+}
+
+function decodeBenchmarkStateEvent(rowJson: string): StateEventListable {
+    return decodeBenchmarkStateEventValue(JSON.parse(rowJson));
+}
+
+function decodeBenchmarkStateEventValue(value: unknown): StateEventListable {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError('Benchmark state event must be an object');
+    }
+    if (
+        !('eventId' in value) || typeof value.eventId !== 'string' ||
+        !('eventType' in value) || typeof value.eventType !== 'string' ||
+        !('snapshotVersion' in value) || typeof value.snapshotVersion !== 'number' ||
+        !('occurredAtEpochMs' in value) || typeof value.occurredAtEpochMs !== 'number'
+    ) {
+        throw new TypeError('Benchmark state event is missing its ordering fields');
+    }
+    return {
+        eventId: value.eventId,
+        eventType: value.eventType,
+        snapshotVersion: value.snapshotVersion,
+        occurredAtEpochMs: value.occurredAtEpochMs
+    };
 }
 
 function makeRuntimeStateEntries(size: number): readonly RuntimeStateEntry[] {
@@ -266,7 +308,7 @@ async function benchRuntimePrefix(results: BenchResult[]): Promise<void> {
         const entries = makeRuntimeStateEntries(size);
         for (let run = 1; run <= RUNS; run++) {
             const fullRepo = new RuntimeStatePrefixBenchRepository(entries, namespace);
-            const fullDetails: JsonRecord = {
+            const fullDetails: BenchDetails = {
                 rows: size,
                 pageSize: undefined
             };
@@ -293,7 +335,7 @@ async function benchRuntimePrefix(results: BenchResult[]): Promise<void> {
             );
 
             const pagedRepo = new RuntimeStatePrefixBenchRepository(entries, namespace);
-            const pagedDetails: JsonRecord = {
+            const pagedDetails: BenchDetails = {
                 rows: size,
                 pageSize: RUNTIME_STATE_PREFIX_READ_PAGE_SIZE
             };
@@ -370,7 +412,7 @@ async function benchCacheRetention(results: BenchResult[]): Promise<void> {
     const sizes = [1_000, 10_000, 100_000];
     for (const size of sizes) {
         for (let run = 1; run <= RUNS; run++) {
-            const repo = new ObservableLatestRepository<string, JsonRecord>({ ttlMs: 0 });
+            const repo = new ObservableLatestRepository<string, JsonWireValue>({ ttlMs: 0 });
             results.push(
                 await measure(
                     'cache.observable-expired-retained-before-delete',
@@ -425,7 +467,7 @@ async function benchCacheRetention(results: BenchResult[]): Promise<void> {
                 }
             });
 
-            const autoRepo = new ObservableLatestRepository<string, JsonRecord>({
+            const autoRepo = new ObservableLatestRepository<string, JsonWireValue>({
                 ttlMs: 0,
                 deleteExpiredIntervalMs: 1
             });
@@ -495,58 +537,86 @@ async function benchRateLimiter(results: BenchResult[]): Promise<void> {
     }
 }
 
-class FakeSocket {
-    readyState: number = WebSocket.OPEN;
+class BenchmarkSocket extends EventTarget implements WebSocket {
+    readonly CONNECTING = WebSocket.CONNECTING;
+    readonly OPEN = WebSocket.OPEN;
+    readonly CLOSING = WebSocket.CLOSING;
+    readonly CLOSED = WebSocket.CLOSED;
+    readonly binaryType: BinaryType = 'blob';
+    readonly bufferedAmount = 0;
+    readonly extensions = '';
+    readonly protocol = '';
+    readonly readyState = WebSocket.OPEN;
+    readonly url = 'ws://runtime-validation-benchmark';
+    onclose = null;
+    onerror = null;
+    onmessage = null;
+    onopen = null;
     sentBytes = 0;
     sentCount = 0;
-    addEventListener(_type: string, _listener: unknown): void {}
-    close(): void {
-        this.readyState = WebSocket.CLOSED;
-    }
-    send(data: string): void {
-        this.sentBytes += data.length;
+
+    close(): void {}
+
+    send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+        this.sentBytes += typeof data === 'string'
+            ? data.length
+            : data instanceof Blob
+            ? data.size
+            : data.byteLength;
         this.sentCount += 1;
     }
 }
 
-type EncodedFakeSocketMessage = Readonly<{
-    text: string;
-}>;
-
 function makeClientSnapshot(index: number, sessionsPerClient: number, liveUntil: number): ClientSnapshot {
+    const principalId = `principal-${index}`;
+    const audit = makeAuditStamp();
     return {
+        stateRevision: index + 1,
         principal: {
             applicationId: 'app',
             workspaceId: 'workspace',
-            principalId: `principal-${index}`,
-            username: `principal-${index}`,
+            principalId,
+            username: principalId,
+            displayName: principalId,
+            avatarUrl: null,
+            authProvider: null,
+            externalSubjectId: null,
             status: 'active',
+            disabled: null,
+            deleted: null,
             roles: [],
             metadata: {},
             snapshotVersion: index + 1,
             profileVersion: index + 1,
             presenceVersion: index + 1,
-            created: { atEpochMs: 1, byServiceId: 'perf' },
-            updated: { atEpochMs: 1, byServiceId: 'perf' }
+            created: audit,
+            updated: audit,
+            lastSeenAtEpochMs: liveUntil - 1_000
         },
         instances: [],
         activeSessions: Array.from({ length: sessionsPerClient }, (_, sessionIndex) => ({
             applicationId: 'app',
             workspaceId: 'workspace',
-            principalId: `principal-${index}`,
+            principalId,
             clientInstanceId: `instance-${index}`,
             sessionId: `session-${index}-${sessionIndex}`,
+            generationId: `generation-${index}-${sessionIndex}`,
+            generationVersion: 1,
             status: 'active',
+            disconnectedAtEpochMs: null,
+            disconnectReason: null,
             presenceState: 'online',
             transport: 'ws',
+            connectionId: `session-${index}-${sessionIndex}`,
             connectedAtEpochMs: 1_700_000_000_000,
             authenticatedAtEpochMs: 1_700_000_000_000,
             lastHeartbeatAtEpochMs: liveUntil - 1_000,
             expiresAtEpochMs: liveUntil
         })),
         isOnline: true,
-        activeSessionCount: sessionsPerClient
-    } as unknown as ClientSnapshot;
+        activeSessionCount: sessionsPerClient,
+        lastSeenAtEpochMs: liveUntil - 1_000
+    };
 }
 
 function makeGroupSnapshot(
@@ -555,88 +625,103 @@ function makeGroupSnapshot(
     sessionsPerClient: number,
     liveUntil: number
 ): GroupSnapshot {
+    const ref = {
+        applicationId: 'app',
+        workspaceId: 'workspace',
+        groupId: `group-${groupIndex}`
+    };
+    const audit = makeAuditStamp();
     return {
+        causalRevision: {
+            groupRevision: groupIndex + 1,
+            presenceRevision: groupIndex + 1
+        },
         group: {
-            applicationId: 'app',
-            workspaceId: 'workspace',
-            groupId: `group-${groupIndex}`,
+            ...ref,
+            slug: null,
             displayName: `Group ${groupIndex}`,
+            description: null,
             kind: 'room',
             status: 'active',
+            archived: null,
+            deleted: null,
             joinMode: 'open',
+            maxMembers: null,
+            maxSessionsPerMember: null,
             metadata: {},
+            activeMemberCount: memberCount,
+            ownerPrincipalId: 'principal-0',
             snapshotVersion: groupIndex + 1,
             metadataVersion: groupIndex + 1,
             rosterVersion: groupIndex + 1,
             presenceVersion: groupIndex + 1,
-            created: { atEpochMs: 1, byServiceId: 'perf' },
-            updated: { atEpochMs: 1, byServiceId: 'perf' }
+            created: audit,
+            updated: audit,
+            expiresAtEpochMs: null,
+            emptySinceEpochMs: null,
+            purgeAfterEpochMs: null,
+            lifecycleState: 'active',
+            formationEpoch: 1,
+            formationAttemptCount: 1,
+            lastFormationOutcome: {
+                outcome: 'activated',
+                observedRate: 1,
+                atEpochMs: audit.atEpochMs,
+                formationEpoch: 1
+            },
+            establishmentStartedAtEpochMs: audit.atEpochMs,
+            formationElectorate: Array.from(
+                { length: memberCount },
+                (_, index) => `principal-${index}`
+            )
         },
         members: Array.from({ length: memberCount }, (_, index) => ({
-            applicationId: 'app',
-            workspaceId: 'workspace',
-            groupId: `group-${groupIndex}`,
+            ...ref,
             principalId: `principal-${index}`,
-            role: 'member',
+            role: index === 0 ? 'owner' : 'member',
             status: 'active',
-            joined: { atEpochMs: 1_700_000_000_000, byServiceId: 'perf' },
-            updated: { atEpochMs: 1_700_000_000_000, byServiceId: 'perf' }
+            joined: audit,
+            updated: audit,
+            invitedByPrincipalId: null,
+            invitationExpiresAtEpochMs: null,
+            left: null,
+            removed: null,
+            banned: null
         })),
         activeSessions: Array.from({ length: memberCount * sessionsPerClient }, (_, index) => ({
-            applicationId: 'app',
-            workspaceId: 'workspace',
-            groupId: `group-${groupIndex}`,
+            ...ref,
             sessionId: `session-${Math.floor(index / sessionsPerClient)}-${index % sessionsPerClient}`,
             principalId: `principal-${Math.floor(index / sessionsPerClient)}`,
+            generationId: `generation-${index}`,
+            generationVersion: 1,
+            status: 'active',
+            disconnectedAtEpochMs: null,
+            disconnectReason: null,
             connectedAtEpochMs: 1_700_000_000_000,
             lastHeartbeatAtEpochMs: liveUntil - 1_000,
             expiresAtEpochMs: liveUntil
         })),
         memberCount,
         onlineMemberCount: memberCount
-    } as unknown as GroupSnapshot;
+    };
 }
 
-function makeWsServer(connectionIds: readonly string[]): {
-    connections: Map<string, { id: string; socket: FakeSocket; isOpen: boolean; }>;
-    broadcast: (data: unknown, filter?: (ctx: { id: string; isOpen: boolean; }) => boolean) => number;
-    encode: (data: unknown) => EncodedFakeSocketMessage;
-    sendEncoded: (connectionId: string, encoded: EncodedFakeSocketMessage) => void;
-} {
-    const connections = new Map<string, { id: string; socket: FakeSocket; isOpen: boolean; }>();
-    for (const id of connectionIds) {
-        connections.set(id, { id, socket: new FakeSocket(), isOpen: true });
-    }
+function makeAuditStamp(): ClientAuditStamp {
     return {
-        connections,
-        encode(data: unknown): EncodedFakeSocketMessage {
-            return {
-                text: JSON.stringify(data)
-            };
-        },
-        sendEncoded(connectionId: string, encoded: EncodedFakeSocketMessage): void {
-            const ctx = connections.get(connectionId);
-            if (!ctx || !ctx.isOpen) {
-                throw new Error(`Connection not open: ${connectionId}`);
-            }
-            ctx.socket.send(encoded.text);
-        },
-        broadcast(data: unknown, filter?: (ctx: { id: string; isOpen: boolean; }) => boolean): number {
-            const encoded = JSON.stringify(data);
-            let count = 0;
-            for (const ctx of connections.values()) {
-                if (!ctx.isOpen) {
-                    continue;
-                }
-                if (filter && !filter(ctx)) {
-                    continue;
-                }
-                ctx.socket.send(encoded);
-                count += 1;
-            }
-            return count;
-        }
+        atEpochMs: 1_700_000_000_000,
+        actor: { kind: 'service', serviceId: 'runtime-validation-benchmark' },
+        reason: null,
+        traceId: null,
+        requestId: null
     };
+}
+
+function makeWsServer(connectionIds: readonly string[]): JsonWebSocketServer {
+    const server = new JsonWebSocketServer();
+    for (const id of connectionIds) {
+        server.addConnection(new ConnectionContext(id, new BenchmarkSocket()));
+    }
+    return server;
 }
 
 async function benchStateSync(results: BenchResult[]): Promise<void> {
@@ -662,13 +747,18 @@ async function benchStateSync(results: BenchResult[]): Promise<void> {
             size.sessionsPerClient,
             liveUntilEpochMs
         );
-        const message = {
-            id: 'message-1',
-            payload: {
-                typeId: AppTopics.groupStateSnapshot,
-                resource: JSON.stringify(groupSnapshot)
-            }
-        };
+        const message = newALBroadcastMessage(
+            'runtime-validation-benchmark',
+            newALEventRoute(
+                AppTopics.groupStateSnapshot,
+                groupSnapshot.group.groupId,
+                groupSnapshot.group.groupId
+            ),
+            'room',
+            AppTopics.groupStateSnapshot,
+            groupSnapshot,
+            { groupRef: groupSnapshot.group }
+        );
 
         for (let run = 1; run <= RUNS; run++) {
             results.push(
@@ -685,8 +775,8 @@ async function benchStateSync(results: BenchResult[]): Promise<void> {
                     },
                     () => {
                         const recipients = resolveStateSyncRecipients(
-                            webSocketServer as never,
-                            message as never,
+                            webSocketServer,
+                            message,
                             {
                                 readClientSnapshots: () => clientSnapshots,
                                 now: () => nowEpochMs
@@ -762,7 +852,7 @@ async function benchLatestRepositoryCleanup(results: BenchResult[]): Promise<voi
     const sizes = [1_000, 10_000, 100_000];
     for (const size of sizes) {
         for (let run = 1; run <= RUNS; run++) {
-            const repo = new LatestRepository<string, JsonRecord>({ ttlMs: 0 });
+            const repo = new LatestRepository<string, JsonWireValue>({ ttlMs: 0 });
             for (let i = 0; i < size; i++) {
                 repo.set(`key-${i}`, { i });
             }
@@ -781,7 +871,7 @@ async function benchLatestRepositoryCleanup(results: BenchResult[]): Promise<voi
 }
 
 async function benchCacheLeakChurn(results: BenchResult[]): Promise<void> {
-    const repo = new ObservableLatestRepository<string, JsonRecord>({ ttlMs: 0 });
+    const repo = new ObservableLatestRepository<string, JsonWireValue>({ ttlMs: 0 });
     const batchSize = 10_000;
     const batches = 10;
     for (let batch = 1; batch <= batches; batch++) {
@@ -842,7 +932,7 @@ async function benchCacheLeakChurn(results: BenchResult[]): Promise<void> {
 }
 
 async function benchCacheAutoEvictionChurn(results: BenchResult[]): Promise<void> {
-    const repo = new ObservableLatestRepository<string, JsonRecord>({
+    const repo = new ObservableLatestRepository<string, JsonWireValue>({
         ttlMs: 0,
         deleteExpiredIntervalMs: 1
     });

--- a/scripts/perf/runtime-validation-bench.ts
+++ b/scripts/perf/runtime-validation-bench.ts
@@ -255,8 +255,6 @@ class RuntimeStatePrefixBenchRepository implements RuntimeStateTransactionalRepo
     async deleteExpired(): Promise<number> {
         return 0;
     }
-
-    async lockKey(): Promise<void> {}
 }
 
 async function benchRuntimePrefix(results: BenchResult[]): Promise<void> {


### PR DESCRIPTION
## Summary

- make bounded prefix paging mandatory on `RuntimeStateRepositoryLike` and remove both read-capability fallback paths
- implement the current paging contract in every in-repo adapter, fake, and performance repository
- delete obsolete fake-only runtime `lockKey` APIs and assertions that preserved a predecessor contract absent from production
- type the touched runtime validation harness at its decode and WebSocket boundaries, and consolidate the lone topology persistence test folder

No compatibility adapter, alias, or fallback remains for the removed surfaces.

## Validation

- `npx tsc -p packages/shared-server/tsconfig.json --noEmit`
- `npx tsc -p packages/shared-rtc-bench/tsconfig.json --noEmit`
- `npm run typecheck:tests` — 934 files, 0 errors
- `cd apps/api-v1 && deno task check`
- `npx vitest run packages/tests/shared-server` — 299 passed, 4 skipped; 1769 tests passed, 9 skipped
- affected API-v1 tests — 5 files, 12 tests; post-cleanup API-v1 tests — 2 files, 36 tests
- moved topology repository suite — 80 tests
- `npm run check:repo-style:changed -- "$(git merge-base HEAD origin/main)" WORKTREE` — no new findings
- `npm run check:repo-structure -- --base origin/main` — pass with no findings
- `npm run test:repo-structure` — 14 tests
- `npm run test:repo-governance` — 343 tests
- runtime validation modes `runtime-prefix`, `events`, `state-sync`, and `serialization` execute successfully

## Performance evidence

The three-run runtime-prefix candidate kept every repository call bounded to 1,000 rows: 2 calls for 1,000 rows, 11 for 10,000, and 101 for 100,000, with zero unbounded prefix calls. This is synthetic in-memory evidence for bounded call behavior, not a PostgreSQL latency claim.