### PR TITLE
Require AppInbox JSON-wire command boundaries

### DIFF
--- a/apps/api-v1/src/routes/client-state-mutation-routes.ts
+++ b/apps/api-v1/src/routes/client-state-mutation-routes.ts
@@ -1,0 +1,454 @@
+import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
+import { encodeAppInboxCommand } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
+import type { ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+import type {
+    ClientInstanceUpsertAppInboxPayload,
+    ClientPrincipalUpsertAppInboxPayload,
+    ClientSessionConnectAppInboxPayload,
+    ClientSessionDisconnectAppInboxPayload,
+    ClientSessionHeartbeatAppInboxPayload
+} from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-contracts.ts';
+import { toAuthenticatedClientMutationContextId } from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
+import { validateClientMutationRequest } from '@shared-server/rallar-system/client-state/mutation/command-validation/validate-client-mutation-request.ts';
+import { ClientMutationRejectedError } from '@shared-server/rallar-system/client-state/validation/client-mutation-rejection.ts';
+import {
+    decodeJsonWireValue,
+    type JsonWireObject,
+    type JsonWireValue
+} from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
+import type {
+    StateSyncCacheHydrationInput,
+    StateSyncCacheHydrationResult
+} from '@shared-server/rallar-system/state-sync/state-sync-cache-hydration.ts';
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import type { StateScope } from '@shared/api/state-types.ts';
+import type { Either } from '@shared/resilience/Either.ts';
+import { Hono, type Context } from 'jsr:@hono/hono@4.11.9';
+import { authorizationDenied } from '../services/request-auth-service.ts';
+import { toApiMutationFailureResponse, toApiMutationRouteFailure } from './api-mutation-route-failure.ts';
+import { readApiMutationRouteRequestId } from './api-mutation-route-ingress.ts';
+import { readClientStateRouteScope } from './read-client-state-route-scope.ts';
+
+const CLIENT_PRINCIPAL_PATH = '/api/state/apps/:applicationId/workspaces/:workspaceId/clients/:principalId';
+const CLIENT_INSTANCE_PATH = `${CLIENT_PRINCIPAL_PATH}/instances/:clientInstanceId`;
+const CLIENT_SESSION_PATH = `${CLIENT_INSTANCE_PATH}/sessions/:sessionId`;
+
+export type ProcessClientAppInbox = (
+    enqueue: AppInboxEnqueueInput,
+    authority: IssuedAuthSession
+) => Promise<Either<AppInboxFailure, ClientStateWritten>>;
+
+export interface ClientStateMutationRouteDependencies {
+    readonly requireApiAuthSession: (
+        request: Readonly<{
+            header(name: string): string | undefined;
+        }>
+    ) => Promise<IssuedAuthSession>;
+    readonly hydrateStateSyncSnapshotCaches: (
+        input: StateSyncCacheHydrationInput
+    ) => Promise<StateSyncCacheHydrationResult>;
+    readonly processClientAppInbox: ProcessClientAppInbox;
+}
+
+export function registerClientStateMutationRoutes(
+    app: Hono,
+    dependencies: ClientStateMutationRouteDependencies
+): void {
+    app.put(
+        `${CLIENT_PRINCIPAL_PATH}/principal/requests/:requestId`,
+        (context) => handleClientPrincipalUpsert(context, dependencies)
+    );
+    app.put(
+        `${CLIENT_INSTANCE_PATH}/requests/:requestId`,
+        (context) => handleClientInstanceUpsert(context, dependencies)
+    );
+    app.put(
+        `${CLIENT_SESSION_PATH}/requests/:requestId`,
+        (context) => handleClientSessionConnect(context, dependencies)
+    );
+    app.post(
+        `${CLIENT_SESSION_PATH}/heartbeat/requests/:requestId`,
+        (context) => handleClientSessionHeartbeat(context, dependencies)
+    );
+    app.post(
+        `${CLIENT_SESSION_PATH}/disconnect/requests/:requestId`,
+        (context) => handleClientSessionDisconnect(context, dependencies)
+    );
+}
+
+async function handleClientPrincipalUpsert(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<Response> {
+    try {
+        const authSession = await dependencies.requireApiAuthSession(context.req);
+        const scope = readClientStateRouteScope(context);
+        const principalId = context.req.param('principalId');
+        assertSelfPrincipal(authSession.clientId, principalId);
+        const requestBody = await readRequestWithRequestId(context);
+        validateClientMutationRequest('upsertPrincipal', requestBody);
+        const request = withActor(requestBody, authSession);
+        return await processClientMutation(
+            context,
+            {
+                dependencies,
+                authority: authSession,
+                enqueue: {
+                    type: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
+                    topicId: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
+                    resourceId: request.requestId,
+                    contextId: toAuthenticatedClientMutationContextId({
+                        scope,
+                        principalId,
+                        callerClientId: authSession.clientId,
+                        callerSessionId: authSession.sessionId
+                    }),
+                    senderId: authSession.clientId,
+                    data: encodeAppInboxCommand(
+                        { scope, principalId, request } satisfies ClientPrincipalUpsertAppInboxPayload,
+                        'Client principal upsert AppInbox command'
+                    )
+                }
+            }
+        );
+    }
+    catch (error) {
+        return toClientMutationFailure(
+            context,
+            error instanceof Error ? error : new Error(String(error))
+        );
+    }
+}
+
+async function handleClientInstanceUpsert(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<Response> {
+    try {
+        const authSession = await dependencies.requireApiAuthSession(context.req);
+        const scope = readClientStateRouteScope(context);
+        const principalId = context.req.param('principalId');
+        const clientInstanceId = context.req.param('clientInstanceId');
+        assertSelfPrincipal(authSession.clientId, principalId);
+        const requestBody = await readRequestWithRequestId(context);
+        validateClientMutationRequest('upsertInstance', requestBody);
+        const request = withActor(requestBody, authSession);
+        return await processClientMutation(
+            context,
+            {
+                dependencies,
+                authority: authSession,
+                enqueue: {
+                    type: AppInboxType.CLIENT_INSTANCE_UPSERT,
+                    topicId: AppInboxType.CLIENT_INSTANCE_UPSERT,
+                    resourceId: request.requestId,
+                    contextId: toAuthenticatedClientMutationContextId({
+                        scope,
+                        principalId,
+                        callerClientId: authSession.clientId,
+                        callerSessionId: authSession.sessionId
+                    }),
+                    senderId: authSession.clientId,
+                    data: encodeAppInboxCommand(
+                        {
+                            scope,
+                            principalId,
+                            clientInstanceId,
+                            request
+                        } satisfies ClientInstanceUpsertAppInboxPayload,
+                        'Client instance upsert AppInbox command'
+                    )
+                }
+            }
+        );
+    }
+    catch (error) {
+        return toClientMutationFailure(
+            context,
+            error instanceof Error ? error : new Error(String(error))
+        );
+    }
+}
+
+async function handleClientSessionConnect(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<Response> {
+    try {
+        const { authSession, route } = await readAuthenticatedClientSessionRoute(
+            context,
+            dependencies
+        );
+        const requestBody = await readRequestWithRequestId(context);
+        validateClientMutationRequest('connectSession', requestBody);
+        const request = withActor(requestBody, authSession);
+        return await processClientMutation(
+            context,
+            {
+                dependencies,
+                authority: authSession,
+                enqueue: toClientSessionEnqueue({
+                    type: AppInboxType.CLIENT_SESSION_CONNECT,
+                    route,
+                    authSession,
+                    request
+                })
+            }
+        );
+    }
+    catch (error) {
+        return toClientMutationFailure(
+            context,
+            error instanceof Error ? error : new Error(String(error))
+        );
+    }
+}
+
+async function handleClientSessionHeartbeat(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<Response> {
+    try {
+        const { authSession, route } = await readAuthenticatedClientSessionRoute(
+            context,
+            dependencies
+        );
+        const requestBody = await readRequestWithRequestId(context);
+        validateClientMutationRequest('heartbeatSession', requestBody);
+        const request = withActor(requestBody, authSession);
+        return await processClientMutation(
+            context,
+            {
+                dependencies,
+                authority: authSession,
+                enqueue: toClientSessionEnqueue({
+                    type: AppInboxType.CLIENT_SESSION_HEARTBEAT,
+                    route,
+                    authSession,
+                    request
+                })
+            }
+        );
+    }
+    catch (error) {
+        return toClientMutationFailure(
+            context,
+            error instanceof Error ? error : new Error(String(error))
+        );
+    }
+}
+
+async function handleClientSessionDisconnect(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<Response> {
+    try {
+        const { authSession, route } = await readAuthenticatedClientSessionRoute(
+            context,
+            dependencies
+        );
+        const requestBody = await readRequestWithRequestId(context);
+        validateClientMutationRequest('disconnectSession', requestBody);
+        const request = withActor(requestBody, authSession);
+        return await processClientMutation(
+            context,
+            {
+                dependencies,
+                authority: authSession,
+                enqueue: toClientSessionEnqueue({
+                    type: AppInboxType.CLIENT_SESSION_DISCONNECT,
+                    route,
+                    authSession,
+                    request
+                })
+            }
+        );
+    }
+    catch (error) {
+        return toClientMutationFailure(
+            context,
+            error instanceof Error ? error : new Error(String(error))
+        );
+    }
+}
+
+interface AuthenticatedClientSessionRoute {
+    readonly authSession: IssuedAuthSession;
+    readonly route: ClientSessionRoute;
+}
+
+interface ClientSessionRoute {
+    readonly scope: StateScope;
+    readonly principalId: string;
+    readonly clientInstanceId: string;
+    readonly sessionId: string;
+}
+
+async function readAuthenticatedClientSessionRoute(
+    context: Context,
+    dependencies: ClientStateMutationRouteDependencies
+): Promise<AuthenticatedClientSessionRoute> {
+    const authSession = await dependencies.requireApiAuthSession(context.req);
+    const route = readClientSessionRoute(context);
+    assertSelfSession(authSession, route.principalId, route.sessionId);
+    return { authSession, route };
+}
+
+interface ClientSessionPayloadByType {
+    [AppInboxType.CLIENT_SESSION_CONNECT]: ClientSessionConnectAppInboxPayload;
+    [AppInboxType.CLIENT_SESSION_HEARTBEAT]: ClientSessionHeartbeatAppInboxPayload;
+    [AppInboxType.CLIENT_SESSION_DISCONNECT]: ClientSessionDisconnectAppInboxPayload;
+}
+
+type ClientSessionAppInboxType = keyof ClientSessionPayloadByType;
+
+interface ClientSessionEnqueueInput<Type extends ClientSessionAppInboxType> {
+    readonly type: Type;
+    readonly route: ClientSessionRoute;
+    readonly authSession: IssuedAuthSession;
+    readonly request: ClientSessionPayloadByType[Type]['request'];
+}
+
+function toClientSessionEnqueue<Type extends ClientSessionAppInboxType>(
+    input: ClientSessionEnqueueInput<Type>
+): AppInboxEnqueueInput {
+    const command = {
+        ...input.route,
+        request: input.request
+    };
+    return {
+        type: input.type,
+        topicId: input.type,
+        resourceId: input.request.requestId,
+        contextId: toAuthenticatedClientMutationContextId({
+            scope: input.route.scope,
+            principalId: input.route.principalId,
+            callerClientId: input.authSession.clientId,
+            callerSessionId: input.authSession.sessionId
+        }),
+        senderId: input.authSession.clientId,
+        data: encodeAppInboxCommand(command, toClientSessionCommandLabel(input.type))
+    };
+}
+
+function toClientSessionCommandLabel(type: ClientSessionAppInboxType): string {
+    switch (type) {
+        case AppInboxType.CLIENT_SESSION_CONNECT:
+            return 'Client session connect AppInbox command';
+        case AppInboxType.CLIENT_SESSION_HEARTBEAT:
+            return 'Client session heartbeat AppInbox command';
+        case AppInboxType.CLIENT_SESSION_DISCONNECT:
+            return 'Client session disconnect AppInbox command';
+    }
+}
+interface ProcessClientMutationInput {
+    readonly dependencies: ClientStateMutationRouteDependencies;
+    readonly authority: IssuedAuthSession;
+    readonly enqueue: AppInboxEnqueueInput;
+}
+
+async function processClientMutation(
+    context: Context,
+    input: ProcessClientMutationInput
+): Promise<Response> {
+    const result = await input.dependencies.processClientAppInbox(
+        input.enqueue,
+        input.authority
+    );
+    if (result.left !== undefined) {
+        throw toApiMutationRouteFailure(result.left);
+    }
+    const written = result.right;
+    if (written === undefined) {
+        throw new Error('Client AppInbox mutation result is unavailable');
+    }
+    const snapshot = written.result.snapshot;
+    await hydrateClientMutationSnapshot(input.dependencies, snapshot);
+    return context.json(snapshot);
+}
+
+async function hydrateClientMutationSnapshot(
+    dependencies: ClientStateMutationRouteDependencies,
+    snapshot: ClientSnapshot
+): Promise<void> {
+    try {
+        await dependencies.hydrateStateSyncSnapshotCaches({ clients: [snapshot] });
+    }
+    catch (error) {
+        console.warn('Failed to hydrate client mutation snapshot cache', error);
+    }
+}
+
+function toClientMutationFailure(context: Context, error: Error): Response {
+    return toApiMutationFailureResponse(
+        context,
+        error
+    );
+}
+
+function readClientSessionRoute(context: Context): ClientSessionRoute {
+    return {
+        scope: readClientStateRouteScope(context),
+        principalId: context.req.param('principalId'),
+        clientInstanceId: context.req.param('clientInstanceId'),
+        sessionId: context.req.param('sessionId')
+    };
+}
+
+interface ClientMutationRequestBody extends JsonWireObject {
+    readonly requestId: string;
+}
+
+async function readRequestWithRequestId(context: Context): Promise<ClientMutationRequestBody> {
+    const requestBody = decodeJsonWireValue(await context.req.json(), 'Client request');
+    if (!isClientMutationRequestBody(requestBody)) {
+        throw new ClientMutationRejectedError('Client request must be a plain object');
+    }
+    const requestId = readApiMutationRouteRequestId({
+        requestId: context.req.param('requestId'),
+        idempotencyKey: context.req.header('idempotency-key'),
+        mutationBody: requestBody
+    });
+    return { ...requestBody, requestId: String(requestId) };
+}
+
+function isClientMutationRequestBody(value: JsonWireValue): value is JsonWireObject {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+type AuthenticatedClientMutationRequest<T extends JsonWireObject> =
+    & T
+    & Readonly<{
+        actorPrincipalId: string;
+        actorSessionId: string;
+    }>;
+
+function withActor<T extends JsonWireObject>(
+    request: T,
+    authSession: Readonly<{ clientId: string; sessionId: string; }>
+): AuthenticatedClientMutationRequest<T> {
+    return {
+        ...request,
+        actorPrincipalId: authSession.clientId,
+        actorSessionId: authSession.sessionId
+    };
+}
+
+function assertSelfPrincipal(clientId: string, principalId: string): void {
+    if (clientId !== principalId) {
+        throw authorizationDenied('Forbidden: principal id does not match authenticated client');
+    }
+}
+
+function assertSelfSession(
+    authSession: Readonly<{ clientId: string; sessionId: string; }>,
+    principalId: string,
+    sessionId: string
+): void {
+    assertSelfPrincipal(authSession.clientId, principalId);
+    if (authSession.sessionId !== sessionId) {
+        throw authorizationDenied('Forbidden: session id does not match authenticated session');
+    }
+}

--- a/apps/api-v1/src/routes/client-state-routes.ts
+++ b/apps/api-v1/src/routes/client-state-routes.ts
@@ -1,50 +1,23 @@
-import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
-import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
 import { type IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import type { ClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-import type { ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
-import {
-    type ClientInstanceUpsertAppInboxPayload,
-    type ClientPrincipalUpsertAppInboxPayload,
-    type ClientSessionConnectAppInboxPayload,
-    type ClientSessionDisconnectAppInboxPayload,
-    type ClientSessionHeartbeatAppInboxPayload
-} from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-contracts.ts';
-import {
-    toAuthenticatedClientMutationContextId
-} from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
-import { validateClientMutationRequest } from '@shared-server/rallar-system/client-state/mutation/command-validation/validate-client-mutation-request.ts';
-import { ClientMutationRejectedError } from '@shared-server/rallar-system/client-state/validation/client-mutation-rejection.ts';
-import {
-    decodeJsonWireValue,
-    type JsonWireObject,
-    type JsonWireValue
-} from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import {
     readStateEventListQuery,
     type StateEventListQuery
 } from '@shared-server/rallar-system/state-events/state-event-listing.ts';
-import {
-    type StateSyncCacheHydrationInput,
-    type StateSyncCacheHydrationResult
-} from '@shared-server/rallar-system/state-sync/state-sync-cache-hydration.ts';
 import type { ClientEvent, ClientPrincipalRef, ClientSnapshot } from '@shared/api/client-types.ts';
-import type { StateScope } from '@shared/api/state-types.ts';
-import type { Either } from '@shared/resilience/Either.ts';
-import { Hono, type Context } from 'jsr:@hono/hono@4.11.9';
+import { Hono } from 'jsr:@hono/hono@4.11.9';
 import { authorizationDenied } from '../services/request-auth-service.ts';
-import { toApiMutationFailureResponse, toApiMutationRouteFailure } from './api-mutation-route-failure.ts';
-import { readApiMutationRouteRequestId } from './api-mutation-route-ingress.ts';
+import {
+    registerClientStateMutationRoutes,
+    type ClientStateMutationRouteDependencies
+} from './client-state-mutation-routes.ts';
 import {
     readCurrentClientSnapshot,
     registerClientStatePointReadRoute,
     type ClientStatePointRead
 } from './client-state-point-read-route.ts';
+import { readClientStateRouteScope } from './read-client-state-route-scope.ts';
 import { toClientStateRouteErrorResponse } from './to-client-state-route-error-response.ts';
-
-const CLIENT_PRINCIPAL_PATH = '/api/state/apps/:applicationId/workspaces/:workspaceId/clients/:principalId';
-const CLIENT_INSTANCE_PATH = `${CLIENT_PRINCIPAL_PATH}/instances/:clientInstanceId`;
-const CLIENT_SESSION_PATH = `${CLIENT_INSTANCE_PATH}/sessions/:sessionId`;
 
 export type ClientStateRouteService =
     & Pick<
@@ -60,25 +33,13 @@ export type ClientStateRouteService =
         readCurrentSnapshot?(ref: ClientPrincipalRef): Promise<ClientSnapshot | undefined>;
     }>;
 
-export type ProcessClientAppInbox = <V>(
-    enqueue: AppInboxEnqueueInput<V>,
-    authority: IssuedAuthSession
-) => Promise<Either<AppInboxFailure, ClientStateWritten>>;
-
-export type ClientStateRouteDependencies = Readonly<{
-    clientStateService: ClientStateRouteService;
-    requireApiAuthSession: (
-        req: {
-            header(name: string): string | undefined;
-        }
-    ) => Promise<IssuedAuthSession>;
-    hydrateStateSyncSnapshotCaches: (
-        input: StateSyncCacheHydrationInput
-    ) => Promise<StateSyncCacheHydrationResult>;
-    processClientAppInbox: ProcessClientAppInbox;
-    readClientSnapshot: ClientStatePointRead;
-    strictReadAuthorization: boolean;
-}>;
+export type ClientStateRouteDependencies =
+    & ClientStateMutationRouteDependencies
+    & Readonly<{
+        clientStateService: ClientStateRouteService;
+        readClientSnapshot: ClientStatePointRead;
+        strictReadAuthorization: boolean;
+    }>;
 
 export function registerClientStateRoutes(
     app: Hono,
@@ -90,7 +51,7 @@ export function registerClientStateRoutes(
         '/api/state/apps/:applicationId/workspaces/:workspaceId/clients',
         async (c) => {
             try {
-                const scope = toScope(c);
+                const scope = readClientStateRouteScope(c);
                 const authSession = await readStrictReadAuthSession(c.req, deps);
                 const snapshots = authSession
                     ? [
@@ -131,7 +92,7 @@ export function registerClientStateRoutes(
                 const principalId = c.req.param('principalId');
                 await assertCanReadClientState(c.req, deps, principalId);
                 const snapshot = await deps.clientStateService.readPresenceSnapshot({
-                    ...toScope(c),
+                    ...readClientStateRouteScope(c),
                     principalId
                 });
 
@@ -155,7 +116,7 @@ export function registerClientStateRoutes(
                 const principalId = c.req.param('principalId');
                 await assertCanReadClientState(c.req, deps, principalId);
                 const ref = {
-                    ...toScope(c),
+                    ...readClientStateRouteScope(c),
                     principalId
                 };
                 const query = readStateEventListQuery(
@@ -189,7 +150,7 @@ export function registerClientStateRoutes(
                 return c.json(
                     await deps.clientStateService.listEventPage(
                         {
-                            ...toScope(c),
+                            ...readClientStateRouteScope(c),
                             principalId
                         },
                         readStateEventListQuery(
@@ -207,237 +168,7 @@ export function registerClientStateRoutes(
         }
     );
 
-    app.put(
-        `${CLIENT_PRINCIPAL_PATH}/principal/requests/:requestId`,
-        (context) => handleClientPrincipalUpsert(context, deps)
-    );
-
-    app.put(
-        `${CLIENT_INSTANCE_PATH}/requests/:requestId`,
-        (context) => handleClientInstanceUpsert(context, deps)
-    );
-
-    app.put(
-        `${CLIENT_SESSION_PATH}/requests/:requestId`,
-        (context) => handleClientSessionConnect(context, deps)
-    );
-
-    app.post(
-        `${CLIENT_SESSION_PATH}/heartbeat/requests/:requestId`,
-        (context) => handleClientSessionHeartbeat(context, deps)
-    );
-
-    app.post(
-        `${CLIENT_SESSION_PATH}/disconnect/requests/:requestId`,
-        (context) => handleClientSessionDisconnect(context, deps)
-    );
-}
-
-async function handleClientPrincipalUpsert(
-    context: Context,
-    dependencies: ClientStateRouteDependencies
-): Promise<Response> {
-    try {
-        const authSession = await dependencies.requireApiAuthSession(context.req);
-        const scope = toScope(context);
-        const principalId = context.req.param('principalId');
-        assertSelfPrincipal(authSession.clientId, principalId);
-        const requestBody = await readRequestWithRequestId(context);
-        validateClientMutationRequest('upsertPrincipal', requestBody);
-        const request = withActor(requestBody, authSession);
-        const snapshot = await processClientAppInbox<ClientPrincipalUpsertAppInboxPayload>(
-            dependencies,
-            {
-                type: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
-                topicId: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
-                resourceId: request.requestId,
-                contextId: toAuthenticatedClientMutationContextId({
-                    scope,
-                    principalId,
-                    callerClientId: authSession.clientId,
-                    callerSessionId: authSession.sessionId
-                }),
-                senderId: authSession.clientId,
-                data: { scope, principalId, request }
-            },
-            authSession
-        );
-        return context.json(snapshot);
-    }
-    catch (error) {
-        return toApiMutationFailureResponse(
-            context,
-            error instanceof Error ? error : new Error(String(error))
-        );
-    }
-}
-
-async function handleClientInstanceUpsert(
-    context: Context,
-    dependencies: ClientStateRouteDependencies
-): Promise<Response> {
-    try {
-        const authSession = await dependencies.requireApiAuthSession(context.req);
-        const scope = toScope(context);
-        const principalId = context.req.param('principalId');
-        const clientInstanceId = context.req.param('clientInstanceId');
-        assertSelfPrincipal(authSession.clientId, principalId);
-        const requestBody = await readRequestWithRequestId(context);
-        validateClientMutationRequest('upsertInstance', requestBody);
-        const request = withActor(requestBody, authSession);
-        const snapshot = await processClientAppInbox<ClientInstanceUpsertAppInboxPayload>(
-            dependencies,
-            {
-                type: AppInboxType.CLIENT_INSTANCE_UPSERT,
-                topicId: AppInboxType.CLIENT_INSTANCE_UPSERT,
-                resourceId: request.requestId,
-                contextId: toAuthenticatedClientMutationContextId({
-                    scope,
-                    principalId,
-                    callerClientId: authSession.clientId,
-                    callerSessionId: authSession.sessionId
-                }),
-                senderId: authSession.clientId,
-                data: { scope, principalId, clientInstanceId, request }
-            },
-            authSession
-        );
-        return context.json(snapshot);
-    }
-    catch (error) {
-        return toApiMutationFailureResponse(
-            context,
-            error instanceof Error ? error : new Error(String(error))
-        );
-    }
-}
-
-async function handleClientSessionConnect(
-    context: Context,
-    dependencies: ClientStateRouteDependencies
-): Promise<Response> {
-    try {
-        const authSession = await dependencies.requireApiAuthSession(context.req);
-        const { scope, principalId, clientInstanceId, sessionId } = readClientSessionRoute(context);
-        assertSelfSession(authSession, principalId, sessionId);
-        const requestBody = await readRequestWithRequestId(context);
-        validateClientMutationRequest('connectSession', requestBody);
-        const request = withActor(requestBody, authSession);
-        const snapshot = await processClientAppInbox<ClientSessionConnectAppInboxPayload>(
-            dependencies,
-            {
-                type: AppInboxType.CLIENT_SESSION_CONNECT,
-                topicId: AppInboxType.CLIENT_SESSION_CONNECT,
-                resourceId: request.requestId,
-                contextId: toAuthenticatedClientMutationContextId({
-                    scope,
-                    principalId,
-                    callerClientId: authSession.clientId,
-                    callerSessionId: authSession.sessionId
-                }),
-                senderId: authSession.clientId,
-                data: { scope, principalId, clientInstanceId, sessionId, request }
-            },
-            authSession
-        );
-        return context.json(snapshot);
-    }
-    catch (error) {
-        return toApiMutationFailureResponse(
-            context,
-            error instanceof Error ? error : new Error(String(error))
-        );
-    }
-}
-
-async function handleClientSessionHeartbeat(
-    context: Context,
-    dependencies: ClientStateRouteDependencies
-): Promise<Response> {
-    try {
-        const authSession = await dependencies.requireApiAuthSession(context.req);
-        const { scope, principalId, clientInstanceId, sessionId } = readClientSessionRoute(context);
-        assertSelfSession(authSession, principalId, sessionId);
-        const requestBody = await readRequestWithRequestId(context);
-        validateClientMutationRequest('heartbeatSession', requestBody);
-        const request = withActor(requestBody, authSession);
-        const snapshot = await processClientAppInbox<ClientSessionHeartbeatAppInboxPayload>(
-            dependencies,
-            {
-                type: AppInboxType.CLIENT_SESSION_HEARTBEAT,
-                topicId: AppInboxType.CLIENT_SESSION_HEARTBEAT,
-                resourceId: request.requestId,
-                contextId: toAuthenticatedClientMutationContextId({
-                    scope,
-                    principalId,
-                    callerClientId: authSession.clientId,
-                    callerSessionId: authSession.sessionId
-                }),
-                senderId: authSession.clientId,
-                data: { scope, principalId, clientInstanceId, sessionId, request }
-            },
-            authSession
-        );
-        return context.json(snapshot);
-    }
-    catch (error) {
-        return toApiMutationFailureResponse(
-            context,
-            error instanceof Error ? error : new Error(String(error))
-        );
-    }
-}
-
-async function handleClientSessionDisconnect(
-    context: Context,
-    dependencies: ClientStateRouteDependencies
-): Promise<Response> {
-    try {
-        const authSession = await dependencies.requireApiAuthSession(context.req);
-        const { scope, principalId, clientInstanceId, sessionId } = readClientSessionRoute(context);
-        assertSelfSession(authSession, principalId, sessionId);
-        const requestBody = await readRequestWithRequestId(context);
-        validateClientMutationRequest('disconnectSession', requestBody);
-        const request = withActor(requestBody, authSession);
-        const snapshot = await processClientAppInbox<ClientSessionDisconnectAppInboxPayload>(
-            dependencies,
-            {
-                type: AppInboxType.CLIENT_SESSION_DISCONNECT,
-                topicId: AppInboxType.CLIENT_SESSION_DISCONNECT,
-                resourceId: request.requestId,
-                contextId: toAuthenticatedClientMutationContextId({
-                    scope,
-                    principalId,
-                    callerClientId: authSession.clientId,
-                    callerSessionId: authSession.sessionId
-                }),
-                senderId: authSession.clientId,
-                data: { scope, principalId, clientInstanceId, sessionId, request }
-            },
-            authSession
-        );
-        return context.json(snapshot);
-    }
-    catch (error) {
-        return toApiMutationFailureResponse(
-            context,
-            error instanceof Error ? error : new Error(String(error))
-        );
-    }
-}
-
-function readClientSessionRoute(context: Context): Readonly<{
-    scope: StateScope;
-    principalId: string;
-    clientInstanceId: string;
-    sessionId: string;
-}> {
-    return {
-        scope: toScope(context),
-        principalId: context.req.param('principalId'),
-        clientInstanceId: context.req.param('clientInstanceId'),
-        sessionId: context.req.param('sessionId')
-    };
+    registerClientStateMutationRoutes(app, deps);
 }
 
 async function listRecentClientEventsForArrayRoute(
@@ -490,125 +221,4 @@ function hydrateClientSnapshots(
 
 function isDefined<T>(value: T | undefined): value is T {
     return value !== undefined;
-}
-
-async function processClientAppInbox<V>(
-    deps: ClientStateRouteDependencies,
-    enqueue: AppInboxEnqueueInput<V>,
-    authority: IssuedAuthSession
-): Promise<ClientSnapshot> {
-    const result = await deps.processClientAppInbox(enqueue, authority);
-    if (result.left !== undefined) {
-        throw toApiMutationRouteFailure(result.left);
-    }
-    const written = result.right;
-    if (written === undefined) {
-        throw new Error('Client AppInbox mutation result is unavailable');
-    }
-    const snapshot = requireClientStateWrittenSnapshot(written);
-    await hydrateClientMutationSnapshot(deps, snapshot);
-    return snapshot;
-}
-
-async function hydrateClientMutationSnapshot(
-    deps: ClientStateRouteDependencies,
-    snapshot: ClientSnapshot
-): Promise<void> {
-    try {
-        await deps.hydrateStateSyncSnapshotCaches({ clients: [snapshot] });
-    }
-    catch (error) {
-        console.warn('Failed to hydrate client mutation snapshot cache', error);
-    }
-}
-
-function requireClientStateWrittenSnapshot(
-    written: ClientStateWritten
-): ClientSnapshot {
-    return written.result.snapshot;
-}
-
-interface ClientMutationRequestBody extends JsonWireObject {
-    readonly requestId: string;
-}
-
-async function readRequestWithRequestId(c: Context): Promise<ClientMutationRequestBody> {
-    const requestBody = decodeJsonWireValue(await c.req.json(), 'Client request');
-    if (!isClientMutationRequestBody(requestBody)) {
-        throw new ClientMutationRejectedError('Client request must be a plain object');
-    }
-    const requestId = readApiMutationRouteRequestId({
-        requestId: c.req.param('requestId'),
-        idempotencyKey: c.req.header('idempotency-key'),
-        mutationBody: requestBody
-    });
-
-    return {
-        ...requestBody,
-        requestId: String(requestId)
-    };
-}
-
-function isClientMutationRequestBody(value: JsonWireValue): value is JsonWireObject {
-    return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function toScope(c: {
-    req: {
-        param(key: 'applicationId' | 'workspaceId'): string;
-    };
-}): StateScope {
-    return {
-        applicationId: c.req.param('applicationId'),
-        workspaceId: c.req.param('workspaceId')
-    };
-}
-
-type AuthenticatedClientMutationRequest<T extends JsonWireObject> =
-    & T
-    & Readonly<{
-        actorPrincipalId: string;
-        actorSessionId: string;
-    }>;
-
-function withActor<T extends JsonWireObject>(
-    request: T,
-    authSession: {
-        clientId: string;
-        sessionId: string;
-    }
-): AuthenticatedClientMutationRequest<T> {
-    return {
-        ...request,
-        actorPrincipalId: authSession.clientId,
-        actorSessionId: authSession.sessionId
-    };
-}
-
-function assertSelfPrincipal(
-    clientId: string,
-    principalId: string
-): void {
-    if (clientId !== principalId) {
-        throw authorizationDenied(
-            'Forbidden: principal id does not match authenticated client'
-        );
-    }
-}
-
-function assertSelfSession(
-    authSession: {
-        clientId: string;
-        sessionId: string;
-    },
-    principalId: string,
-    sessionId: string
-): void {
-    assertSelfPrincipal(authSession.clientId, principalId);
-
-    if (authSession.sessionId !== sessionId) {
-        throw authorizationDenied(
-            'Forbidden: session id does not match authenticated session'
-        );
-    }
 }

--- a/apps/api-v1/src/routes/read-client-state-route-scope.ts
+++ b/apps/api-v1/src/routes/read-client-state-route-scope.ts
@@ -1,0 +1,12 @@
+import type { StateScope } from '@shared/api/state-types.ts';
+
+export function readClientStateRouteScope(context: Readonly<{
+    req: Readonly<{
+        param(key: 'applicationId' | 'workspaceId'): string;
+    }>;
+}>): StateScope {
+    return {
+        applicationId: context.req.param('applicationId'),
+        workspaceId: context.req.param('workspaceId')
+    };
+}

--- a/apps/api-v1/src/routes/state-snapshot-read/create-state-snapshot-read-route-registrars.ts
+++ b/apps/api-v1/src/routes/state-snapshot-read/create-state-snapshot-read-route-registrars.ts
@@ -85,8 +85,8 @@ export function createStateSnapshotReadRouteRegistrars<Runtime extends ApiV1Stat
                 requireApiAuthSession: (request) =>
                     operations.requireApiAuthSession(request, runtime.authSessionRepository),
                 hydrateStateSyncSnapshotCaches,
-                processClientAppInbox: async <V>(
-                    enqueue: AppInboxEnqueueInput<V>,
+                processClientAppInbox: async (
+                    enqueue: AppInboxEnqueueInput,
                     authority: IssuedAuthSession
                 ): Promise<Either<AppInboxFailure, ClientStateWritten>> =>
                     await runtime.appClientInboxService

--- a/apps/api-v1/src/routes/ws-routes.ts
+++ b/apps/api-v1/src/routes/ws-routes.ts
@@ -5,7 +5,7 @@ import type {
     AppClientInboxService
 } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
 import {
-    toAuthorisedWsClientConnectEnqueue,
+    toAuthorisedWsClientConnection,
     type ToAuthorisedWsClientDisconnectEnqueueInput
 } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
 import { type GroupPresenceSessionCleanupAppInboxPayload } from '@shared-server/rallar-system/group-state/presence/group-presence-session-cleanup-app-inbox-payload.ts';
@@ -74,7 +74,7 @@ async function handleWebSocketUpgrade(
         rememberAuthorisedWsConnection(
             connection.id,
             connection.generationId,
-            toAuthorisedWsClientConnectEnqueue(connectInput).data
+            toAuthorisedWsClientConnection(connectInput)
         );
         socketServer.addConnection(connection);
         await input.appClientInboxService.enqueueAuthorisedWsClientConnect(connectInput);

--- a/apps/api-v1/test/client-state/client-state-mutation-routes.test.ts
+++ b/apps/api-v1/test/client-state/client-state-mutation-routes.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'jsr:@hono/hono@4.11.9';
 import assert from 'node:assert/strict';
 
 import { type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type { StateSyncCacheHydrationInput } from '@shared-server/rallar-system/state-sync/state-sync-cache-hydration.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import { Either } from '@shared/resilience/Either.ts';
 
@@ -19,7 +20,7 @@ import {
 const REQUEST_ID = 'ClientMutationRequest_012345';
 
 Deno.test('malformed client REST mutations return terminal 400 before inbox enqueue', async () => {
-    const processCalls: unknown[] = [];
+    const processCalls: AppInboxEnqueueInput[] = [];
     const deps = createClientRouteDeps({
         session: createAuthSession('alice'),
         clientService: {},
@@ -101,7 +102,7 @@ Deno.test('malformed client REST mutations return terminal 400 before inbox enqu
 });
 
 Deno.test('client REST lifecycle accepts equal causal timestamp boundaries', async () => {
-    const processCalls: unknown[] = [];
+    const processCalls: AppInboxEnqueueInput[] = [];
     const deps = createClientRouteDeps({
         session: createAuthSession('alice'),
         clientService: {},
@@ -237,7 +238,7 @@ Deno.test('client mutation routes hydrate the receiving node cache from remotely
         activeSessionCount: 1,
         lastSeenAtEpochMs: 1
     };
-    const hydrationInputs: unknown[] = [];
+    const hydrationInputs: StateSyncCacheHydrationInput[] = [];
     let cachedSnapshot = baseSnapshot;
     const app = new Hono();
     clientStateRoutes.registerClientStateRoutes(app, {
@@ -251,7 +252,7 @@ Deno.test('client mutation routes hydrate the receiving node cache from remotely
             listEventPage: () => Promise.resolve({ events: [], hasMore: false })
         },
         requireApiAuthSession: () => Promise.resolve(createAuthSession('alice')),
-        processClientAppInbox: <V>(_input: AppInboxEnqueueInput<V>) =>
+        processClientAppInbox: (_input: AppInboxEnqueueInput) =>
             Promise.resolve(Either.ofRight({
                 status: 'ok',
                 result: { snapshot, event: null }
@@ -298,9 +299,9 @@ Deno.test('client mutation routes hydrate the receiving node cache from remotely
 
 Deno.test('client mutation routes preserve committed success when cache hydration fails', async () => {
     const snapshot = createClientSnapshot('alice');
-    const warnings: unknown[][] = [];
+    const warnings: Parameters<typeof console.warn>[] = [];
     const originalWarn = console.warn;
-    console.warn = (...args: unknown[]) => warnings.push(args);
+    console.warn = (...args: Parameters<typeof console.warn>) => warnings.push(args);
     try {
         const deps = createClientRouteDeps({
             session: createAuthSession('alice'),

--- a/apps/api-v1/test/client-state/client-state-route-test-runtime.ts
+++ b/apps/api-v1/test/client-state/client-state-route-test-runtime.ts
@@ -10,6 +10,7 @@ import { Either } from '@shared/resilience/Either.ts';
 
 import type { GroupStateRouteAuthSession } from '../../src/group-state/group-state-route-contracts.ts';
 import * as clientStateRoutes from '../../src/routes/client-state-routes.ts';
+import type { ProcessClientAppInbox } from '../../src/routes/client-state-mutation-routes.ts';
 
 export const TEST_SCOPE: StateScope = {
     applicationId: 'app-1',
@@ -44,9 +45,9 @@ export function createClientRouteDeps(
         hydrateStateSyncSnapshotCaches?: clientStateRoutes.ClientStateRouteDependencies[
             'hydrateStateSyncSnapshotCaches'
         ];
-        processClientAppInbox?: <V>(
-            enqueue: AppInboxEnqueueInput<V>,
-            authority: Parameters<clientStateRoutes.ProcessClientAppInbox>[1]
+        processClientAppInbox?: (
+            enqueue: AppInboxEnqueueInput,
+            authority: Parameters<ProcessClientAppInbox>[1]
         ) => Promise<Either<AppInboxFailure, ClientStateWritten> | ClientStateWritten>;
         readClientSnapshot?: clientStateRoutes.ClientStateRouteDependencies[
             'readClientSnapshot'

--- a/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
+++ b/apps/api-v1/test/db/pglite-app-inbox-ws-close-convergence.test.ts
@@ -12,7 +12,7 @@ import { GroupPresenceSummaryWork } from '@shared-server/rallar-system/group-sta
 
 import { GROUP_PRESENCE_SUMMARY_TOPIC as APP_OUTBOX_GROUP_PRESENCE_SUMMARY_TOPIC } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
 
-import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import { toAuthorisedWsClientConnection } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
 import type { PGliteSql } from '../../src/db/pglite-sql-adapter.ts';
 import { toResilienceDto } from '../api-v1-test-queue-resilience.ts';
 import { waitForPGliteQueueRow } from './pglite-app-inbox-test-runtime.ts';
@@ -42,7 +42,7 @@ Deno.test('PGlite client connect conflicts when close commits after lifecycle re
         await pause.reached;
 
         await harness.client.enqueueAuthorisedWsClientDisconnect({
-            connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
+            connection: toAuthorisedWsClientConnection(connectInput),
             disconnectedAtEpochMs: connectedAtEpochMs + 1,
             reason: 'socket-closed'
         });
@@ -103,11 +103,11 @@ Deno.test('PGlite group connect conflicts when cleanup commits after lifecycle r
         await pause.reached;
 
         await harness.group.enqueueGroupSessionCleanup({
-            connection: toAuthorisedWsClientConnectEnqueue({
+            connection: toAuthorisedWsClientConnection({
                 authSession: harness.authority,
                 generationId: wsGenerationId,
                 input: { ...SCOPE, connectedAtEpochMs: wsStartedAtEpochMs }
-            }).data,
+            }),
             disconnectedAtEpochMs: wsStartedAtEpochMs + 1,
             reason: 'socket-closed'
         });
@@ -220,7 +220,7 @@ Deno.test('PGlite client close tombstone suppresses a delayed AppInbox connect r
         const connectEntry = await harness.client.enqueueAuthorisedWsClientConnect(connectInput);
         await delay(sql, connectEntry.key);
         await harness.client.enqueueAuthorisedWsClientDisconnect({
-            connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
+            connection: toAuthorisedWsClientConnection(connectInput),
             disconnectedAtEpochMs: connectedAtEpochMs + 1,
             reason: 'socket-closed'
         });
@@ -275,11 +275,11 @@ Deno.test('PGlite group cleanup tombstone suppresses a delayed presence connect 
         await delay(sql, connectKey);
         assert.equal(
             await harness.group.enqueueGroupSessionCleanup({
-                connection: toAuthorisedWsClientConnectEnqueue({
+                connection: toAuthorisedWsClientConnection({
                     authSession: harness.authority,
                     generationId: wsGenerationId,
                     input: { ...SCOPE, connectedAtEpochMs: wsStartedAtEpochMs }
-                }).data,
+                }),
                 disconnectedAtEpochMs: wsStartedAtEpochMs + 1,
                 reason: 'socket-closed'
             }),
@@ -349,11 +349,11 @@ Deno.test('PGlite lost-close group guard has bounded physical expiry before clea
         assert.ok(expectedExpiry < FUTURE_MS);
 
         await harness.group.enqueueGroupSessionCleanup({
-            connection: toAuthorisedWsClientConnectEnqueue({
+            connection: toAuthorisedWsClientConnection({
                 authSession: harness.authority,
                 generationId: 'different-ws-generation',
                 input: { ...SCOPE, connectedAtEpochMs: wsStartedAtEpochMs }
-            }).data,
+            }),
             disconnectedAtEpochMs: wsStartedAtEpochMs + 100,
             reason: 'socket-closed'
         });

--- a/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
@@ -26,7 +26,10 @@ import {
 } from '../../app-inbox/app-inbox-options.ts';
 import type { AppInboxEntryRepository, AppInboxResultRepository } from '../../app-inbox/app-inbox-persistence-ports.ts';
 import { AppInboxQueueClient } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { AdminExpiredDataPruner } from '../admin-expired-data-pruner.ts';
 import { toAdminPruneExpiredOptions } from '../admin-prune-options.ts';
 import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
@@ -46,7 +49,6 @@ import {
 import { AppInboxType, type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
 
 import { recordRallarTiming, timeRallarAsync, type RallarTimingSink } from '../../observability/timing.ts';
-import { decodeJsonWireValue, type JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import {
     decodeAdminPruneEnqueueResultForCommand,
     decodeAdminPruneRequest,
@@ -212,16 +214,14 @@ export class AppAdminInboxService {
                     resourceId: key.resourceId,
                     contextId: key.contextId,
                     senderId: command.requestedSessionId,
-                    data: command
+                    data: encodeAppInboxCommand(command, 'Admin prune AppInbox command')
                 };
             }
         );
-        const command = decodeAdminPruneCommand(
-            decodeJsonWireValue(reservation.enqueue.data, 'Reserved admin prune command')
-        );
+        const command = decodeAdminPruneCommand(reservation.enqueue.data);
         await assertAdminPruneStoredIdentity(key, reservation.enqueue, command);
         assertMatchingAdminPruneIdentity(identity, command);
-        const enqueued = await this.queueClient.waitForReservedEntryResult<JsonWireValue, AdminPruneEnqueueResult>(
+        const enqueued = await this.queueClient.waitForReservedEntryResult<AdminPruneEnqueueResult>(
             reservation.enqueue,
             (value) => decodeAdminPruneEnqueueResultForCommand(value, command),
             reservation.winner

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts
@@ -1,6 +1,11 @@
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-import { requireExactOptionalKeys, requireRecord, requireString } from '../protocol/exact-object-decoding.ts';
-import { decodeJsonWireValue, type JsonWireValue } from '../protocol/json-wire-identity.ts';
+import { requireExactOptionalKeys, requireString } from '../protocol/exact-object-decoding.ts';
+import {
+    decodeJsonWireText,
+    decodeJsonWireValue,
+    type JsonWireObject,
+    type JsonWireValue
+} from '../protocol/json-wire-identity.ts';
 import { AppInboxType, type AppInboxEnqueueInput } from './app-inbox-contracts.ts';
 
 const APP_INBOX_TYPES = new Set<string>(Object.values(AppInboxType));
@@ -14,9 +19,9 @@ export class AppInboxTypeUnavailableError extends TypeError {
 
 export function decodeAppInboxEnqueue(
     value: unknown
-): AppInboxEnqueueInput<JsonWireValue> {
+): AppInboxEnqueueInput {
     const wire = decodeJsonWireValue(value, 'AppInbox enqueue');
-    const enqueue = requireRecord(wire, 'AppInbox enqueue');
+    const enqueue = requireAppInboxWireObject(wire, 'AppInbox enqueue');
     requireExactOptionalKeys({
         value: enqueue,
         required: ['type', 'data'],
@@ -39,24 +44,38 @@ export function decodeAppInboxEnqueue(
         ...(typeof enqueue.contextId === 'string' ? { contextId: enqueue.contextId } : {}),
         ...(typeof enqueue.senderId === 'string' ? { senderId: enqueue.senderId } : {}),
         ...(Object.prototype.hasOwnProperty.call(enqueue, 'authority')
-            ? {
-                authority: decodeJsonWireValue(
-                    enqueue.authority,
-                    'AppInbox enqueue authority'
-                )
-            }
+            ? { authority: enqueue.authority }
             : {}),
-        data: decodeJsonWireValue(enqueue.data, 'AppInbox enqueue data')
+        data: enqueue.data
     };
+}
+
+function requireAppInboxWireObject(value: JsonWireValue, label: string): JsonWireObject {
+    if (value === null || typeof value !== 'object' || isJsonWireArray(value)) {
+        throw new TypeError(`${label} must be an exact object`);
+    }
+    return value;
+}
+
+function isJsonWireArray(value: JsonWireValue): value is readonly JsonWireValue[] {
+    return Array.isArray(value);
 }
 
 export function decodePersistedAppInboxEnqueue(
     entry: ResourceEntry
-): AppInboxEnqueueInput<JsonWireValue> {
-    const message = requireRecord(JSON.parse(entry.resource), 'Persisted AppInbox message');
-    const payload = requireRecord(message.payload, 'Persisted AppInbox message payload');
+): AppInboxEnqueueInput {
+    const message = requireAppInboxWireObject(
+        decodeJsonWireText(entry.resource, 'Persisted AppInbox message'),
+        'Persisted AppInbox message'
+    );
+    const payload = requireAppInboxWireObject(
+        message.payload,
+        'Persisted AppInbox message payload'
+    );
     if (typeof payload.resource !== 'string') {
         throw new TypeError('Persisted AppInbox message resource is invalid');
     }
-    return decodeAppInboxEnqueue(JSON.parse(payload.resource));
+    return decodeAppInboxEnqueue(
+        decodeJsonWireText(payload.resource, 'Persisted AppInbox command')
+    );
 }

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-command-identity.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-command-identity.ts
@@ -1,5 +1,9 @@
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-import type { JsonWireValue } from '../protocol/json-wire-identity.ts';
+import {
+    decodeJsonWireText,
+    type JsonWireObject,
+    type JsonWireValue
+} from '../protocol/json-wire-identity.ts';
 import { AppInboxTypeUnavailableError, decodeAppInboxEnqueue } from './app-inbox-command-decoding.ts';
 import { AppInboxType, type AppInboxEnqueueInput } from './app-inbox-contracts.ts';
 
@@ -9,7 +13,7 @@ interface ValidAppInboxCommandIdentity {
         operation: AppInboxType;
         operationSource: 'command';
     }>;
-    readonly command: AppInboxEnqueueInput<JsonWireValue>;
+    readonly command: AppInboxEnqueueInput;
 }
 
 interface InvalidAppInboxCommandIdentity {
@@ -90,16 +94,16 @@ export function validateAppInboxCommandIdentity(
 export function validatePersistedAppInboxCommandIdentity(
     input: Readonly<{ topicId: string; resource: string; }>
 ): AppInboxCommandIdentityValidation {
-    let outer: unknown;
+    let outer: JsonWireValue;
     try {
-        outer = JSON.parse(input.resource);
+        outer = decodeJsonWireText(input.resource, 'Persisted AppInbox queue entry');
     }
     catch {
         return toInvalidIdentity(input.topicId, 'corrupt');
     }
     if (
-        !isRecord(outer) ||
-        !isRecord(outer.payload) ||
+        !isJsonWireObject(outer) ||
+        !isJsonWireObject(outer.payload) ||
         typeof outer.payload.typeId !== 'string' ||
         typeof outer.payload.resource !== 'string'
     ) {
@@ -107,9 +111,11 @@ export function validatePersistedAppInboxCommandIdentity(
     }
     const dispatchedOperation = outer.payload.typeId;
 
-    let command: AppInboxEnqueueInput<JsonWireValue>;
+    let command: AppInboxEnqueueInput;
     try {
-        command = decodeAppInboxEnqueue(JSON.parse(outer.payload.resource));
+        command = decodeAppInboxEnqueue(
+            decodeJsonWireText(outer.payload.resource, 'Persisted AppInbox command')
+        );
     }
     catch (error) {
         return toInvalidIdentity(
@@ -118,21 +124,21 @@ export function validatePersistedAppInboxCommandIdentity(
         );
     }
     if (
-        !APP_INBOX_OPERATIONS.has(dispatchedOperation) ||
-        !APP_INBOX_OPERATIONS.has(command.type)
+        !isAppInboxType(dispatchedOperation) ||
+        !isAppInboxType(command.type)
     ) {
         return toInvalidIdentity(input.topicId, 'unavailable');
     }
     if (
         dispatchedOperation !== command.type ||
-        !isOperationForTopic(dispatchedOperation as AppInboxType, input.topicId)
+        !isOperationForTopic(dispatchedOperation, input.topicId)
     ) {
         return toInvalidIdentity(input.topicId, 'corrupt');
     }
     return {
         valid: true,
         identity: {
-            operation: dispatchedOperation as AppInboxType,
+            operation: dispatchedOperation,
             operationSource: 'command'
         },
         command
@@ -169,6 +175,14 @@ function isOperationForTopic(
         : topicId === APP_INBOX_CLIENT_TOPIC && operation.startsWith('CLIENT_');
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return value !== null && typeof value === 'object' && !Array.isArray(value);
+function isAppInboxType(value: string): value is AppInboxType {
+    return APP_INBOX_OPERATIONS.has(value);
+}
+
+function isJsonWireObject(value: JsonWireValue | undefined): value is JsonWireObject {
+    return value !== undefined && value !== null && typeof value === 'object' && !isJsonWireArray(value);
+}
+
+function isJsonWireArray(value: JsonWireValue): value is readonly JsonWireValue[] {
+    return Array.isArray(value);
 }

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-contracts.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-contracts.ts
@@ -59,18 +59,18 @@ export const AppInboxType = {
 
 export type AppInboxType = (typeof AppInboxType)[keyof typeof AppInboxType];
 
-export interface AppInboxEnqueueInput<V> {
+export interface AppInboxEnqueueInput {
     readonly type: AppInboxType;
     readonly topicId?: string;
     readonly resourceId?: string;
     readonly contextId?: string;
     readonly senderId?: string;
     readonly authority?: JsonWireValue;
-    readonly data: V;
+    readonly data: JsonWireValue;
 }
 
 export type AppInboxExecutionMetadata = Readonly<{
-    enqueue: AppInboxEnqueueInput<JsonWireValue>;
+    enqueue: AppInboxEnqueueInput;
     message: ALMessage;
     entry: ResourceEntry;
 }>;

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-handler-registry.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-handler-registry.ts
@@ -113,7 +113,7 @@ export class AppInboxHandlerRegistry {
         entry: ResourceEntry
     ): Promise<void> {
         const type = registration.type;
-        const fallbackEnqueue: AppInboxEnqueueInput<JsonWireValue> = {
+        const fallbackEnqueue: AppInboxEnqueueInput = {
             type,
             resourceId: entry.key.resourceId,
             contextId: entry.key.contextId,
@@ -236,8 +236,8 @@ export class AppInboxHandlerRegistry {
         }
     }
 
-    private recordQueueRetryTiming<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    private recordQueueRetryTiming(
+        enqueue: AppInboxEnqueueInput,
         entry: ResourceEntry,
         classification: Extract<AppInboxErrorClassification, { kind: 'retryable'; }>,
         error: unknown
@@ -269,9 +269,9 @@ export class AppInboxHandlerRegistry {
         });
     }
 
-    private async timePhase<T, V>(
+    private async timePhase<T>(
         operation: string,
-        enqueue: AppInboxEnqueueInput<V>,
+        enqueue: AppInboxEnqueueInput,
         key: Key,
         action: () => Promise<T>,
         details: RallarTimingDetails = {}
@@ -292,7 +292,7 @@ export class AppInboxHandlerRegistry {
         );
     }
 
-    private toTimingDetails<V>(enqueue: AppInboxEnqueueInput<V>, key: Key): RallarTimingDetails {
+    private toTimingDetails(enqueue: AppInboxEnqueueInput, key: Key): RallarTimingDetails {
         return {
             type: enqueue.type,
             topicId: key.topicId,

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-queue-client.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-queue-client.ts
@@ -5,7 +5,6 @@ import { Either } from '@shared/resilience/Either.ts';
 import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import { timeRallarAsync, type RallarTimingDetails, type RallarTimingSink } from '../observability/timing.ts';
 import { serializeCanonicalMutationCommand, type JsonWireValue } from '../protocol/json-wire-identity.ts';
-import { decodeAppInboxEnqueue } from './app-inbox-command-decoding.ts';
 import type { AppInboxEnqueueInput, AppInboxMessageContext } from './app-inbox-contracts.ts';
 import { toUnavailableAppInboxFailure, type AppInboxFailure } from './app-inbox-failure.ts';
 import { normalizeAppInboxOptions, type AppInboxOptions, type NormalizedAppInboxOptions } from './app-inbox-options.ts';
@@ -78,22 +77,22 @@ export class AppInboxQueueClient {
             { serviceId: config.serviceId }
         );
     }
-    async persistReservedEntryAuthority<Authority, Result>(
+    async persistReservedEntryAuthority<Result>(
         context: AppInboxMessageContext<Result>,
-        authority: Authority
+        authority: JsonWireValue
     ): Promise<void> {
         await this.reservationClient.persistAuthority(context, authority);
     }
 
-    async reserveMaterializedEntry<V>(
-        placeholder: AppInboxEnqueueInput<null>,
-        materialize: () => Promise<AppInboxEnqueueInput<V>>
+    async reserveMaterializedEntry(
+        placeholder: AppInboxEnqueueInput,
+        materialize: () => Promise<AppInboxEnqueueInput>
     ): Promise<MaterializedAppInboxReservation> {
         return await this.reservationClient.reserveMaterializedEntry(placeholder, materialize);
     }
 
-    async waitForReservedEntryResult<V, R>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async waitForReservedEntryResult<R>(
+        enqueue: AppInboxEnqueueInput,
         decodeResult: AppInboxResultDecoder<R>,
         wakeOwningQueue: boolean
     ): Promise<Either<AppInboxFailure, R>> {
@@ -110,7 +109,7 @@ export class AppInboxQueueClient {
         );
     }
 
-    public processEntryNoWaiting<V>(enqueue: AppInboxEnqueueInput<V>): void {
+    public processEntryNoWaiting(enqueue: AppInboxEnqueueInput): void {
         this.processEntryUntilCompletionInternal(
             enqueue,
             false,
@@ -132,27 +131,26 @@ export class AppInboxQueueClient {
         });
     }
 
-    public async enqueue<V>(enqueue: AppInboxEnqueueInput<V>): Promise<ResourceEntry> {
-        const wireEnqueue = decodeAppInboxEnqueue(enqueue);
-        const key = this.toKey(wireEnqueue);
+    public async enqueue(enqueue: AppInboxEnqueueInput): Promise<ResourceEntry> {
+        const key = this.toKey(enqueue);
         const receivedIdentity = serializeCanonicalMutationCommand(
-            toLogicalAppInboxCommand(wireEnqueue)
+            toLogicalAppInboxCommand(enqueue)
         );
         const entry = await this.inbox.enqueueIfAbsent(
             newALUntargetedMessage(
                 toAppQueueCreatedBy(this.serviceId),
                 newALRoute(key.topicId, key.contextId, key.resourceId),
-                wireEnqueue.type.toString(),
-                wireEnqueue
+                enqueue.type.toString(),
+                enqueue
             )
         );
         this.wakeOwningQueue?.();
-        await assertMatchingAppInboxCommand(entry, wireEnqueue, receivedIdentity);
+        await assertMatchingAppInboxCommand(entry, enqueue, receivedIdentity);
         return entry;
     }
 
-    public async processEntryUntilCompletion<V>(
-        enqueue: AppInboxEnqueueInput<V>
+    public async processEntryUntilCompletion(
+        enqueue: AppInboxEnqueueInput
     ): Promise<Either<AppInboxFailure, JsonWireValue>> {
         return await this.processEntryUntilCompletionInternal(
             enqueue,
@@ -172,11 +170,11 @@ export class AppInboxQueueClient {
         );
     }
 
-    public async processEntryUntilCompletionResult<V, R>(
-        enqueue: AppInboxEnqueueInput<V>,
+    public async processEntryUntilCompletionResult<R>(
+        enqueue: AppInboxEnqueueInput,
         decodeResult: AppInboxResultDecoder<R>
     ): Promise<Either<AppInboxFailure, R>> {
-        return await this.processEntryUntilCompletionInternal<V, R>(
+        return await this.processEntryUntilCompletionInternal<R>(
             enqueue,
             true,
             true,
@@ -194,8 +192,8 @@ export class AppInboxQueueClient {
         );
     }
 
-    async processEntryUntilCompletionIfResult<V, R>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async processEntryUntilCompletionIfResult<R>(
+        enqueue: AppInboxEnqueueInput,
         enqueueIf: (entry: ResourceEntry) => boolean,
         decodeResult: AppInboxResultDecoder<R>
     ): Promise<Either<AppInboxFailure, R>> {
@@ -218,21 +216,20 @@ export class AppInboxQueueClient {
         );
     }
 
-    private async processEntryUntilCompletionInternal<V, R>(
-        enqueue: AppInboxEnqueueInput<V>,
+    private async processEntryUntilCompletionInternal<R>(
+        enqueue: AppInboxEnqueueInput,
         waitForCompletion: boolean,
         enforceCommandIdentity: boolean,
         enqueuer: (
             key: Key,
-            wireEnqueue: AppInboxEnqueueInput<JsonWireValue>
+            wireEnqueue: AppInboxEnqueueInput
         ) => Promise<ResourceEntry | undefined>,
         decodeResult: AppInboxResultDecoder<R>,
         strictQueueIdentity = false
     ): Promise<Either<AppInboxFailure, R>> {
-        const wireEnqueue = decodeAppInboxEnqueue(enqueue);
-        const key: Key = this.toKey(wireEnqueue, strictQueueIdentity);
+        const key: Key = this.toKey(enqueue, strictQueueIdentity);
         const receivedCommandIdentity = enforceCommandIdentity
-            ? serializeCanonicalMutationCommand(toLogicalAppInboxCommand(wireEnqueue))
+            ? serializeCanonicalMutationCommand(toLogicalAppInboxCommand(enqueue))
             : undefined;
 
         return await timeRallarAsync(
@@ -256,7 +253,7 @@ export class AppInboxQueueClient {
                     'enqueue',
                     enqueue,
                     key,
-                    async () => await enqueuer(key, wireEnqueue)
+                    async () => await enqueuer(key, enqueue)
                 );
                 if (entry) {
                     this.wakeOwningQueue?.();
@@ -265,21 +262,21 @@ export class AppInboxQueueClient {
                     if (!receivedCommandIdentity) {
                         throw new Error('App inbox command identity was not captured');
                     }
-                    await assertMatchingAppInboxCommand(entry, wireEnqueue, receivedCommandIdentity);
+                    await assertMatchingAppInboxCommand(entry, enqueue, receivedCommandIdentity);
                 }
 
                 if (!waitForCompletion) {
                     return Either.ofLeft(toUnavailableAppInboxFailure());
                 }
 
-                return await this.resultWaiter.waitForResult(wireEnqueue, key, decodeResult);
+                return await this.resultWaiter.waitForResult(enqueue, key, decodeResult);
             }
         );
     }
 
-    private async timePhase<T, V>(
+    private async timePhase<T>(
         operation: string,
-        enqueue: AppInboxEnqueueInput<V>,
+        enqueue: AppInboxEnqueueInput,
         key: Key,
         action: () => Promise<T>,
         details: RallarTimingDetails = {}
@@ -304,7 +301,7 @@ export class AppInboxQueueClient {
         );
     }
 
-    private toTimingDetails<V>(enqueue: AppInboxEnqueueInput<V>, key: Key): RallarTimingDetails {
+    private toTimingDetails(enqueue: AppInboxEnqueueInput, key: Key): RallarTimingDetails {
         return {
             type: enqueue.type,
             topicId: key.topicId,
@@ -317,7 +314,7 @@ export class AppInboxQueueClient {
         return this.optionsInput.nowEpochMs?.() ?? Date.now();
     }
 
-    private toKey<V>(enqueue: AppInboxEnqueueInput<V>, strictQueueIdentity = false): Key {
+    private toKey(enqueue: AppInboxEnqueueInput, strictQueueIdentity = false): Key {
         return toPhysicalAppInboxQueueKey(enqueue, this.defaultTopicId, strictQueueIdentity);
     }
 }

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-queue-entry.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-queue-entry.ts
@@ -2,20 +2,18 @@ import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-cont
 import { toAppQueueCreatedBy, toAppQueueKey, toStrictAppInboxQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import type { Key, ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
-import { decodeAppInboxEnqueue } from './app-inbox-command-decoding.ts';
 import type { AppInboxEnqueueInput } from './app-inbox-contracts.ts';
 
-export function toAppInboxResourceEntry<Command>(
-    enqueue: AppInboxEnqueueInput<Command>,
+export function toAppInboxResourceEntry(
+    enqueue: AppInboxEnqueueInput,
     serviceId: string
 ): ResourceEntry {
-    const wire = decodeAppInboxEnqueue(enqueue);
     const key = toPhysicalAppInboxQueueKey(
         {
-            ...wire,
-            topicId: wire.topicId ?? '',
-            resourceId: wire.resourceId ?? '',
-            contextId: wire.contextId ?? ''
+            ...enqueue,
+            topicId: enqueue.topicId ?? '',
+            resourceId: enqueue.resourceId ?? '',
+            contextId: enqueue.contextId ?? ''
         },
         '',
         true
@@ -24,15 +22,15 @@ export function toAppInboxResourceEntry<Command>(
         newALUntargetedMessage(
             toAppQueueCreatedBy(serviceId),
             newALRoute(key.topicId, key.contextId, key.resourceId),
-            wire.type,
-            wire
+            enqueue.type,
+            enqueue
         ),
         'APP_INBOX'
     );
 }
 
-export function toPhysicalAppInboxQueueKey<Command>(
-    enqueue: AppInboxEnqueueInput<Command>,
+export function toPhysicalAppInboxQueueKey(
+    enqueue: AppInboxEnqueueInput,
     defaultTopicId = '',
     strictQueueIdentity = false
 ): Key {

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts
@@ -1,4 +1,8 @@
-import { decodeJsonWireValue, type JsonWireValue } from '../protocol/json-wire-identity.ts';
+import {
+    decodeJsonWireValue,
+    encodeJsonWireValue,
+    type JsonWireValue
+} from '../protocol/json-wire-identity.ts';
 
 export function decodeNullAppInboxCommand(value: JsonWireValue): null {
     if (value !== null) {
@@ -7,9 +11,16 @@ export function decodeNullAppInboxCommand(value: JsonWireValue): null {
     return null;
 }
 
+export function encodeAppInboxCommand<Command>(
+    command: Command,
+    label: string
+): JsonWireValue {
+    return encodeJsonWireValue(command, label);
+}
+
 export function encodeAppInboxResult<Result>(
     result: Result,
     label: string
 ): JsonWireValue {
-    return decodeJsonWireValue(result, label);
+    return encodeJsonWireValue(result, label);
 }

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-reservation-client.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-reservation-client.ts
@@ -2,7 +2,6 @@ import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import type { JsonWireValue } from '../protocol/json-wire-identity.ts';
-import { decodeAppInboxEnqueue } from './app-inbox-command-decoding.ts';
 import { validateAppInboxCommandIdentity } from './app-inbox-command-identity.ts';
 import {
     AppInboxIdempotencyConflictError,
@@ -13,7 +12,7 @@ import {
 import { toAppInboxResourceEntry } from './app-inbox-queue-entry.ts';
 
 export interface MaterializedAppInboxReservation {
-    readonly enqueue: AppInboxEnqueueInput<JsonWireValue>;
+    readonly enqueue: AppInboxEnqueueInput;
     readonly winner: boolean;
 }
 
@@ -49,11 +48,11 @@ export class AppInboxReservationClient {
         this.serviceId = config.serviceId;
     }
 
-    async persistAuthority<Authority, Result>(
+    async persistAuthority<Result>(
         context: AppInboxMessageContext<Result>,
-        authority: Authority
+        authority: JsonWireValue
     ): Promise<void> {
-        const enqueue = decodeAppInboxEnqueue({ ...context.enqueue, authority });
+        const enqueue = { ...context.enqueue, authority };
         const message: ALMessage = {
             ...context.message,
             payload: {
@@ -79,9 +78,9 @@ export class AppInboxReservationClient {
         }
     }
 
-    async reserveMaterializedEntry<Command>(
-        placeholder: AppInboxEnqueueInput<null>,
-        materialize: () => Promise<AppInboxEnqueueInput<Command>>
+    async reserveMaterializedEntry(
+        placeholder: AppInboxEnqueueInput,
+        materialize: () => Promise<AppInboxEnqueueInput>
     ): Promise<MaterializedAppInboxReservation> {
         let winner = false;
         const entry = await this.repository.writeMaterializedIfAbsentOrReplaceExpired(

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-result-waiter.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-result-waiter.ts
@@ -54,8 +54,8 @@ export class AppInboxResultWaiter {
         this.options = config.options;
     }
 
-    async waitForResult<Command, Result>(
-        enqueue: AppInboxEnqueueInput<Command>,
+    async waitForResult<Result>(
+        enqueue: AppInboxEnqueueInput,
         key: Key,
         decodeResult: AppInboxResultDecoder<Result>
     ): Promise<Either<AppInboxFailure, Result>> {
@@ -104,8 +104,8 @@ export class AppInboxResultWaiter {
         }
     }
 
-    private async waitForCompletion<Command>(
-        enqueue: AppInboxEnqueueInput<Command>,
+    private async waitForCompletion(
+        enqueue: AppInboxEnqueueInput,
         key: Key
     ): Promise<boolean> {
         try {
@@ -157,8 +157,8 @@ export class AppInboxResultWaiter {
         }
     }
 
-    private toWaitPolicy<Command>(
-        enqueue: AppInboxEnqueueInput<Command>,
+    private toWaitPolicy(
+        enqueue: AppInboxEnqueueInput,
         key: Key
     ): TryWithPolicy {
         let policy = TryWithPolicy.defaults()
@@ -196,9 +196,9 @@ export class AppInboxResultWaiter {
         return policy;
     }
 
-    private async timePhase<Result, Command>(
+    private async timePhase<Result>(
         operation: string,
-        enqueue: AppInboxEnqueueInput<Command>,
+        enqueue: AppInboxEnqueueInput,
         key: Key,
         action: () => Promise<Result>,
         details: RallarTimingDetails = {}
@@ -220,8 +220,8 @@ export class AppInboxResultWaiter {
     }
 }
 
-function toTimingDetails<Command>(
-    enqueue: AppInboxEnqueueInput<Command>,
+function toTimingDetails(
+    enqueue: AppInboxEnqueueInput,
     key: Key
 ): RallarTimingDetails {
     return {

--- a/packages/shared-server/rallar-system/app-inbox/assert-matching-app-inbox-command.ts
+++ b/packages/shared-server/rallar-system/app-inbox/assert-matching-app-inbox-command.ts
@@ -10,10 +10,10 @@ import { toLogicalAppInboxCommand } from './logical-app-inbox-command.ts';
 
 export async function assertMatchingAppInboxCommand(
     entry: ResourceEntry,
-    incoming: AppInboxEnqueueInput<JsonWireValue>,
+    incoming: AppInboxEnqueueInput,
     receivedCommandIdentity: string
 ): Promise<void> {
-    let existing: AppInboxEnqueueInput<JsonWireValue>;
+    let existing: AppInboxEnqueueInput;
     try {
         existing = decodePersistedAppInboxEnqueue(entry);
     }

--- a/packages/shared-server/rallar-system/app-inbox/logical-app-inbox-command.ts
+++ b/packages/shared-server/rallar-system/app-inbox/logical-app-inbox-command.ts
@@ -4,7 +4,11 @@ import { decodeCrdtMutationCommand } from '../crdt/mutation/crdt-mutation-comman
 import { toDescriptorCommand } from '../group-state/group-mutation-authority.ts';
 import type { GroupMutationDescriptor } from '../group-state/group-state-service-contracts.ts';
 import { validateGroupMutationCommand } from '../group-state/mutation/command-validation/validate-group-mutation-command.ts';
-import { decodeJsonWireValue, type JsonWireObject, type JsonWireValue } from '../protocol/json-wire-identity.ts';
+import {
+    encodeJsonWireValue,
+    type JsonWireObject,
+    type JsonWireValue
+} from '../protocol/json-wire-identity.ts';
 import { readRtcRttAppInboxCommand } from '../rtc-rtt/inbox/rtc-rtt-app-inbox-authority.ts';
 import {
     readDurableTopologyAppInboxCommand,
@@ -19,7 +23,7 @@ export interface LogicalAppInboxCommand {
 }
 
 export function toLogicalAppInboxCommand(
-    enqueue: AppInboxEnqueueInput<JsonWireValue>
+    enqueue: AppInboxEnqueueInput
 ): JsonWireValue {
     const stableAuth = toStableAuthCommand(enqueue.type, enqueue.data);
     if (stableAuth) {
@@ -37,13 +41,13 @@ export function toLogicalAppInboxCommand(
         type: enqueue.type,
         authority: enqueue.authority === undefined
             ? null
-            : decodeJsonWireValue(enqueue.authority, 'AppInbox logical authority'),
+            : enqueue.authority,
         data: enqueue.data
     });
 }
 
 function encodeLogicalCommand(command: LogicalAppInboxCommand): JsonWireValue {
-    return decodeJsonWireValue(command, 'Logical AppInbox command');
+    return encodeJsonWireValue(command, 'Logical AppInbox command');
 }
 
 function toStableGroupCommand(
@@ -66,7 +70,7 @@ function toStableGroupCommand(
     if (command.operation !== expectedOperation) {
         throw new TypeError('Group mutation operation differs from AppInbox type');
     }
-    return decodeJsonWireValue({
+    return encodeJsonWireValue({
         ...command,
         input: { ...command.input, actorSessionId: null }
     }, 'Logical group AppInbox command');
@@ -180,7 +184,7 @@ function toStableDomainCommand(type: AppInboxType, value: JsonWireValue): JsonWi
             if (command.operation !== 'append') {
                 throw new TypeError('CRDT append AppInbox operation is invalid');
             }
-            return decodeJsonWireValue({
+            return encodeJsonWireValue({
                 operation: command.operation,
                 commandId: command.commandId,
                 document: command.document,
@@ -195,7 +199,7 @@ function toStableDomainCommand(type: AppInboxType, value: JsonWireValue): JsonWi
         }
         if (type === AppInboxType.RTC_RTT_SUBMIT) {
             const command = readRtcRttAppInboxCommand(value);
-            return decodeJsonWireValue({
+            return encodeJsonWireValue({
                 actor: command.actor,
                 requestId: command.requestId,
                 commandHash: command.commandHash,
@@ -210,7 +214,7 @@ function toStableDomainCommand(type: AppInboxType, value: JsonWireValue): JsonWi
         if (toTopologyAppInboxType(command.operation) !== type) {
             throw new TypeError('Topology operation differs from AppInbox type');
         }
-        return decodeJsonWireValue({
+        return encodeJsonWireValue({
             actor: { principalId: command.actor.principalId },
             groupRef: command.groupRef,
             requestId: command.requestId,

--- a/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/app-auth-inbox-service.ts
@@ -15,7 +15,6 @@ import type { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
-import { decodeAppInboxEnqueue } from '../../app-inbox/app-inbox-command-decoding.ts';
 import { validateAppInboxCommandIdentity } from '../../app-inbox/app-inbox-command-identity.ts';
 import {
     AppInboxIdempotencyConflictError,
@@ -31,9 +30,11 @@ import { AppInboxHandlerRegistry } from '../../app-inbox/app-inbox-handler-regis
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
 import type { AppInboxEntryRepository, AppInboxResultRepository } from '../../app-inbox/app-inbox-persistence-ports.ts';
 import { AppInboxQueueClient } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { RallarTimingSink } from '../../observability/timing.ts';
-import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import type { AuthMutationService } from '../auth-mutation-service.ts';
 import type { AuthCredentialIssuer } from '../credentials/auth-credential-issuer.ts';
 import { constantTimeAuthDigestEqual } from '../credentials/constant-time-auth-digest-equal.ts';
@@ -202,17 +203,14 @@ export class AppAuthInboxService {
         const decoded = decodeAuthMutationIntent(intent);
         let persisted: Either<AppInboxFailure, AuthMutationResult>;
         try {
-            persisted = await this.queueClient.processEntryUntilCompletionResult<
-                AuthMutationIntent,
-                AuthMutationResult
-            >(
+            persisted = await this.queueClient.processEntryUntilCompletionResult<AuthMutationResult>(
                 {
                     type: toAuthAppInboxType(decoded),
                     topicId: toAuthAppInboxType(decoded),
                     resourceId: decoded.requestId,
                     contextId: toAuthIntentContextId(decoded),
                     senderId: toAuthIntentSenderId(decoded),
-                    data: decoded
+                    data: encodeAppInboxCommand(decoded, 'Auth AppInbox command')
                 },
                 decodeAuthMutationResult
             );
@@ -637,30 +635,32 @@ interface AuthCommandReservation {
     readonly senderId: string;
 }
 
-function toAuthIntentEnqueue(intent: AuthMutationIntent): AppInboxEnqueueInput<AuthMutationIntent> {
+function toAuthIntentEnqueue(intent: AuthMutationIntent): AppInboxEnqueueInput {
     return {
         type: toAuthAppInboxType(intent),
         topicId: toAuthAppInboxType(intent),
         resourceId: intent.requestId,
         contextId: toAuthIntentContextId(intent),
         senderId: toAuthIntentSenderId(intent),
-        data: intent
+        data: encodeAppInboxCommand(intent, 'Auth AppInbox command')
     };
 }
 
-function toAuthInboxEntry(enqueue: AppInboxEnqueueInput<AuthMutationIntent | null>): ResourceEntry {
-    const wire = decodeAppInboxEnqueue(enqueue);
+function toAuthInboxEntry(enqueue: AppInboxEnqueueInput): ResourceEntry {
+    if (!enqueue.topicId || !enqueue.contextId || !enqueue.resourceId) {
+        throw new TypeError('Auth AppInbox queue identity is incomplete');
+    }
     const key = toAppQueueKey({
-        topicId: wire.topicId!,
-        contextId: wire.contextId!,
-        resourceId: wire.resourceId!
+        topicId: enqueue.topicId,
+        contextId: enqueue.contextId,
+        resourceId: enqueue.resourceId
     });
     return QueueBoxUtilities.toResourceEntryFromMsg(
         newALUntargetedMessage(
             toAppQueueCreatedBy('auth-fact-reservation'),
             newALRoute(key.topicId, key.contextId, key.resourceId),
-            wire.type,
-            wire
+            enqueue.type,
+            enqueue
         ),
         'APP_INBOX'
     );
@@ -693,7 +693,7 @@ function readAuthReplayIntent(
         return null;
     }
     try {
-        const intent = decodeAuthMutationIntent(validation.command.data as JsonWireValue);
+        const intent = decodeAuthMutationIntent(validation.command.data);
         const expectedKey = toAppQueueKey({
             topicId: toAuthAppInboxType(intent),
             resourceId: intent.requestId,

--- a/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
@@ -10,7 +10,10 @@ import { AppInboxHandlerRegistry } from '../../app-inbox/app-inbox-handler-regis
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
 import type { AppInboxEntryRepository, AppInboxResultRepository } from '../../app-inbox/app-inbox-persistence-ports.ts';
 import { AppInboxQueueClient, SIMPLER_CLIENT_STATE_APP_INBOX_TOPIC } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { RallarTimingSink } from '../../observability/timing.ts';
 import type { ClientStateService, ClientStateWritten } from '../client-state-service-contracts.ts';
 import {
@@ -130,8 +133,8 @@ export class AppClientInboxService {
         this.handlers.assertRegistrationComplete(CLIENT_STATE_INBOX_REGISTRATION_TYPES);
     }
 
-    public async processAuthenticatedEntryUntilCompletion<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    public async processAuthenticatedEntryUntilCompletion(
+        enqueue: AppInboxEnqueueInput,
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, ClientStateWritten>> {
         const ingress = readAuthenticatedClientMutationIngress(enqueue);
@@ -335,7 +338,7 @@ export class AppClientInboxService {
     private toExpiredSessionsEnqueue(
         atEpochMs: number,
         resourceId: string = 'expire-client-sessions'
-    ): AppInboxEnqueueInput<ClientExpiredSessionsAppInboxPayload> {
+    ): AppInboxEnqueueInput {
         return {
             type: AppInboxType.CLIENT_EXPIRED_SESSIONS,
             topicId: AppInboxType.CLIENT_EXPIRED_SESSIONS,
@@ -343,7 +346,10 @@ export class AppClientInboxService {
             contextId: 'expire-client-sessions',
             senderId: this.serviceId,
             authority: toClientMutationSystemAuthority(this.serviceId),
-            data: { atEpochMs }
+            data: encodeAppInboxCommand(
+                { atEpochMs } satisfies ClientExpiredSessionsAppInboxPayload,
+                'Expired client sessions AppInbox command'
+            )
         };
     }
 }

--- a/packages/shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts
@@ -31,8 +31,8 @@ interface ClientIngressRecord {
     readonly [key: string]: ClientIngressValue;
 }
 
-export function readAuthenticatedClientMutationIngress<Payload>(
-    enqueue: AppInboxEnqueueInput<Payload>
+export function readAuthenticatedClientMutationIngress(
+    enqueue: AppInboxEnqueueInput
 ): AuthenticatedClientMutationIngress {
     const data = requireClientIngressRecord(enqueue.data, 'Client mutation payload');
     const scope = readClientIngressScope(data.scope);

--- a/packages/shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts
@@ -2,6 +2,7 @@ import { type IssuedAuthSession } from '@shared-server/rallar-system/auth/persis
 import { DEFAULT_STATE_APPLICATION_ID, DEFAULT_STATE_WORKSPACE_ID, type StateScope } from '@shared/api/state-types.ts';
 import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
+import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { RegisterAuthorisedWsClientInput } from '../client-state-service-contracts.ts';
 import { toClientMutationIssuedSessionAuthority } from '../mutation/client-mutation-authority.ts';
 import type {
@@ -23,7 +24,7 @@ export interface ToAuthorisedWsClientDisconnectEnqueueInput {
 
 export function toAuthorisedWsClientConnectEnqueue(
     input: ToAuthorisedWsClientConnectEnqueueInput
-): AppInboxEnqueueInput<ClientAuthorisedWsSessionConnectAppInboxPayload> {
+): AppInboxEnqueueInput {
     const connection = toAuthorisedWsClientConnection(input);
     return {
         type: AppInboxType.CLIENT_AUTHORISED_WS_CONNECT,
@@ -35,13 +36,13 @@ export function toAuthorisedWsClientConnectEnqueue(
             connection.scope,
             'connectAuthorisedWsSession'
         ),
-        data: connection
+        data: encodeAppInboxCommand(connection, 'Authorized WebSocket connect AppInbox command')
     };
 }
 
 export function toAuthorisedWsClientDisconnectEnqueue(
     input: ToAuthorisedWsClientDisconnectEnqueueInput
-): AppInboxEnqueueInput<ClientAuthorisedWsSessionDisconnectAppInboxPayload> {
+): AppInboxEnqueueInput {
     const connection = input.connection;
     return {
         type: AppInboxType.CLIENT_AUTHORISED_WS_DISCONNECT,
@@ -57,11 +58,14 @@ export function toAuthorisedWsClientDisconnectEnqueue(
             connection.scope,
             'disconnectAuthorisedWsSession'
         ),
-        data: {
-            connection,
-            disconnectedAtEpochMs: input.disconnectedAtEpochMs,
-            reason: input.reason
-        }
+        data: encodeAppInboxCommand(
+            {
+                connection,
+                disconnectedAtEpochMs: input.disconnectedAtEpochMs,
+                reason: input.reason
+            } satisfies ClientAuthorisedWsSessionDisconnectAppInboxPayload,
+            'Authorized WebSocket disconnect AppInbox command'
+        )
     };
 }
 
@@ -74,7 +78,7 @@ export function toAuthorisedWsClientScope(
     };
 }
 
-function toAuthorisedWsClientConnection(
+export function toAuthorisedWsClientConnection(
     input: ToAuthorisedWsClientConnectEnqueueInput
 ): ClientAuthorisedWsSessionConnectAppInboxPayload {
     const scope = toAuthorisedWsClientScope(input.input);

--- a/packages/shared-server/rallar-system/client-state/mutation/client-mutation-command.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/client-mutation-command.ts
@@ -1,4 +1,7 @@
-import { hashMutationCommand, type JsonWireValue } from '../../protocol/json-wire-identity.ts';
+import {
+    encodeJsonWireValue,
+    hashMutationCommand
+} from '../../protocol/json-wire-identity.ts';
 
 import type {
     ClientMutationAuthority,
@@ -15,14 +18,19 @@ export async function toClientMutationCommand(
     facts: ClientMutationPersistedFacts,
     authority: ClientMutationAuthority
 ): Promise<ClientMutationCommand> {
-    const command = {
+    const command: ClientMutationCommand = {
         ...input,
         authority,
         facts: {
             ...facts,
-            commandHash: await hashMutationCommand({ ...input, authority } as JsonWireValue)
+            commandHash: await hashMutationCommand(
+                encodeJsonWireValue(
+                    { ...input, authority },
+                    'Client mutation command identity'
+                )
+            )
         }
-    } as ClientMutationCommand;
+    };
     validateClientMutationCommand(command);
     return command;
 }

--- a/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
+++ b/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
@@ -17,7 +17,10 @@ import type { AppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import { AppInboxHandlerRegistry } from '../../app-inbox/app-inbox-handler-registry.ts';
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
 import { AppInboxQueueClient } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { RallarTimingSink } from '../../observability/timing.ts';
 import { createCrdtMutationCommand, decodeCrdtMutationCommand } from '../mutation/crdt-mutation-command-codec.ts';
 import {
@@ -148,7 +151,7 @@ export class AppCrdtInboxService {
                 resourceId: decoded.deliveryId,
                 contextId: decoded.documentKey,
                 senderId: decoded.actor.sessionId,
-                data: decoded
+                data: encodeAppInboxCommand(decoded, 'CRDT AppInbox command')
             },
             decodeCrdtMutationResult
         );
@@ -174,7 +177,10 @@ export class AppCrdtInboxService {
                 type,
                 ...key,
                 senderId: reservation.callerId,
-                data: await reservation.materialize()
+                data: encodeAppInboxCommand(
+                    await reservation.materialize(),
+                    'Reserved CRDT AppInbox command'
+                )
             })
         );
         const command = decodeCrdtMutationCommand(reserved.enqueue.data);
@@ -211,7 +217,7 @@ export class AppCrdtInboxService {
             resourceId: decoded.deliveryId,
             contextId: decoded.documentKey,
             senderId: decoded.actor.sessionId,
-            data: decoded
+            data: encodeAppInboxCommand(decoded, 'CRDT AppInbox command')
         });
     }
 
@@ -240,7 +246,7 @@ export class AppCrdtInboxService {
             resourceId: command.deliveryId,
             contextId: command.documentKey,
             senderId: command.actor.sessionId,
-            data: command
+            data: encodeAppInboxCommand(command, 'CRDT append AppInbox command')
         });
         return command;
     }

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts
@@ -183,8 +183,11 @@ export type AuthenticatedGroupMutationInboxType = keyof AuthenticatedGroupMutati
 export type AuthenticatedGroupMutationEnqueue = Readonly<
     {
         [Type in AuthenticatedGroupMutationInboxType]:
-            & Omit<AppInboxEnqueueInput<AuthenticatedGroupMutationPayloadByType[Type]>, 'type'>
-            & Readonly<{ type: Type; }>;
+            & Omit<AppInboxEnqueueInput, 'type' | 'data'>
+            & Readonly<{
+                type: Type;
+                data: AuthenticatedGroupMutationPayloadByType[Type];
+            }>;
     }
 >[AuthenticatedGroupMutationInboxType];
 

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
@@ -2,13 +2,16 @@ import { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
+import { AppInboxType, type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
 import { type AppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import { AppInboxHandlerRegistry } from '../../app-inbox/app-inbox-handler-registry.ts';
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
 import type { AppInboxEntryRepository, AppInboxResultRepository } from '../../app-inbox/app-inbox-persistence-ports.ts';
 import { AppInboxQueueClient, SIMPLER_GROUP_STATE_APP_INBOX_TOPIC } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { GroupFormationGroupMutationSink } from '../../observability/formation-metrics.ts';
 import type { RallarTimingSink } from '../../observability/timing.ts';
@@ -31,9 +34,7 @@ import { decodeGroupStateAppInboxCommand } from './decode-group-state-app-inbox-
 import {
     GROUP_MUTATION_INBOX_TYPES,
     isAuthenticatedGroupMutationEnqueue,
-    type AuthenticatedGroupMutationEnqueue,
-    type AuthenticatedGroupMutationInboxType,
-    type AuthenticatedGroupMutationPayloadByType
+    type AuthenticatedGroupMutationEnqueue
 } from './group-state-inbox-contracts.ts';
 import { GroupStateInboxHandler } from './group-state-inbox-handler.ts';
 import { decodeGroupStateInboxDurableResult } from './group-state-inbox-result-codec.ts';
@@ -110,7 +111,10 @@ export class GroupStateInboxService {
             prepareMutation: (descriptor, authority) =>
                 this.groupStateService.prepareAppInboxMutation(descriptor, authority),
             persistPreparation: (context, preparation) =>
-                this.queueClient.persistReservedEntryAuthority(context, preparation)
+                this.queueClient.persistReservedEntryAuthority(
+                    context,
+                    encodeAppInboxCommand(preparation, 'Group mutation AppInbox authority')
+                )
         });
         this.registerMessageHandlers();
         this.handlers.assertRegistrationComplete(GROUP_MUTATION_INBOX_TYPES);
@@ -162,16 +166,16 @@ export class GroupStateInboxService {
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, GroupStateInboxDurableResult>> {
         const prepared = await this.prepareAuthenticatedGroupMutation(enqueue, authority);
-        return await this.queueClient.processEntryUntilCompletionResult<
-            AuthenticatedGroupMutationPayloadByType[AuthenticatedGroupMutationInboxType],
-            GroupStateInboxDurableResult
-        >(prepared, (value) => decodeGroupStateInboxDurableResult(value, enqueue.type));
+        return await this.queueClient.processEntryUntilCompletionResult<GroupStateInboxDurableResult>(
+            prepared,
+            (value) => decodeGroupStateInboxDurableResult(value, enqueue.type)
+        );
     }
 
     private async prepareAuthenticatedGroupMutation(
         enqueue: AuthenticatedGroupMutationEnqueue,
         authority: IssuedAuthSession
-    ): Promise<AuthenticatedGroupMutationEnqueue> {
+    ): Promise<AppInboxEnqueueInput> {
         if (!isAuthenticatedGroupMutationEnqueue(enqueue)) {
             throw new GroupMutationAuthorizationError(
                 'App inbox type is not an authenticated group mutation.'
@@ -181,7 +185,11 @@ export class GroupStateInboxService {
             toGroupMutationDescriptor(enqueue),
             authority
         );
-        return { ...enqueue, authority: authorized };
+        return {
+            ...enqueue,
+            authority: encodeAppInboxCommand(authorized, 'Group mutation AppInbox authority'),
+            data: encodeAppInboxCommand(enqueue.data, 'Group mutation AppInbox command')
+        };
     }
 
     private registerMessageHandlers(): void {

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -2,6 +2,7 @@ import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInbo
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
+import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
 import { decodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
 import type {
     WsSessionGenerationCloseFacts,
@@ -46,12 +47,10 @@ interface GroupSessionCleanupResult extends InactiveGroupPresenceResult {
     readonly affectedGroups: number;
 }
 
-export type ExpiredGroupPresenceEnqueue = AppInboxEnqueueInput<Readonly<{ commandId: string; }>>;
-
 export function toGroupSessionCleanupEnqueue(
     input: GroupPresenceSessionCleanupAppInboxPayload,
     serviceId: string
-): AppInboxEnqueueInput<GroupPresenceSessionCleanupAppInboxPayload> {
+): AppInboxEnqueueInput {
     const connection = input.connection;
     return {
         type: AppInboxType.GROUP_PRESENCE_SESSION_CLEANUP,
@@ -64,13 +63,13 @@ export function toGroupSessionCleanupEnqueue(
             .join(':'),
         contextId: connection.authSession.sessionId,
         senderId: serviceId,
-        data: input
+        data: encodeAppInboxCommand(input, 'Group presence cleanup AppInbox command')
     };
 }
 
 export function toExpiredPresenceEnqueue(
     preparation: GroupMutationPreparation
-): ExpiredGroupPresenceEnqueue {
+): AppInboxEnqueueInput {
     return {
         type: AppInboxType.GROUP_PRESENCE_EXPIRE,
         resourceId: preparation.queueResourceId,

--- a/packages/shared-server/rallar-system/protocol/json-wire-identity.ts
+++ b/packages/shared-server/rallar-system/protocol/json-wire-identity.ts
@@ -15,8 +15,16 @@ export function decodeJsonWireValue(value: unknown, label = 'JSON wire value'): 
     return value as JsonWireValue;
 }
 
+export function decodeJsonWireText(serialized: string, label = 'JSON wire value'): JsonWireValue {
+    return decodeJsonWireValue(JSON.parse(serialized), label);
+}
+
+export function encodeJsonWireValue<Value>(value: Value, label = 'JSON wire value'): JsonWireValue {
+    assertJsonWireValue(value, label);
+    return value as JsonWireValue;
+}
+
 export async function hashMutationCommand(command: JsonWireValue): Promise<string> {
-    assertJsonWireValue(command, 'Mutation command');
     return `sha256:${await sha256CanonicalJson(command)}`;
 }
 

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-authority.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-authority.ts
@@ -1,9 +1,11 @@
 import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
+import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
 import { GroupMutationAuthorizationError } from '../../group-state/group-mutation-authority.ts';
 import type { GroupStateService } from '../../group-state/group-state-service-contracts.ts';
 import {
     decodeJsonWireValue,
+    encodeJsonWireValue,
     hashMutationCommand,
     type JsonWireObject,
     type JsonWireValue
@@ -35,7 +37,7 @@ export interface VerifyRtcRttAppInboxAuthorityInput {
 
 export async function createRtcRttDurableEnqueue(
     input: CreateRtcRttDurableEnqueueInput
-): Promise<AppInboxEnqueueInput<RtcRttAppInboxCommand>> {
+): Promise<AppInboxEnqueueInput> {
     const session = await input.groupStateService.readIssuedAuthSession(input.request.alSenderId);
     if (!session || session.expiresAtEpochMs <= input.nowEpochMs()) {
         throw new GroupMutationAuthorizationError(
@@ -72,7 +74,7 @@ export async function createRtcRttDurableEnqueue(
     return {
         type: AppInboxType.RTC_RTT_SUBMIT,
         resourceId: requestId,
-        data: command,
+        data: encodeAppInboxCommand(command, 'RTC RTT AppInbox command'),
         authority: decodeJsonWireValue(authority, 'RTC RTT AppInbox authority')
     };
 }
@@ -180,12 +182,12 @@ async function verifyRtcRttCommandHashes(command: RtcRttAppInboxCommand): Promis
     };
     if (
         (await hashMutationCommand(
-                decodeJsonWireValue(canonicalStableCommand, 'RTC RTT stable command')
+                encodeJsonWireValue(canonicalStableCommand, 'RTC RTT stable command')
             )) !== command.commandHash ||
-        (await hashMutationCommand(decodeJsonWireValue({
-                rtt: command.rtt,
-                alSenderId: command.actor.sessionId
-            }, 'RTC RTT mutation command'))) !== command.mutationCommandHash
+        (await hashMutationCommand(encodeJsonWireValue({
+            rtt: command.rtt,
+            alSenderId: command.actor.sessionId
+        }, 'RTC RTT mutation command'))) !== command.mutationCommandHash
     ) {
         throw new GroupMutationAuthorizationError('RTC RTT durable command hash is invalid.');
     }

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
@@ -37,7 +37,7 @@ export class RtcRttAppInboxHandler {
 
     async createEnqueue(
         input: CreateRtcRttAppInboxEnqueueInput
-    ): Promise<AppInboxEnqueueInput<RtcRttAppInboxCommand>> {
+    ): Promise<AppInboxEnqueueInput> {
         return await createRtcRttDurableEnqueue({
             request: input,
             groupStateService: this.dependencies.groupStateService,

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-authority.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-authority.ts
@@ -1,4 +1,5 @@
 import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
+import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { PersistedAuthSession } from '../../auth/persistence/persisted-auth-session.ts';
 import { authSessionProofSecret } from '../../auth/sessions/auth-session-proof-secret.ts';
@@ -21,8 +22,8 @@ import {
     type TopologyMutationAuthorityProof
 } from './topology-mutation-authority-proof.ts';
 
-export interface CreateAuthenticatedTopologyEnqueueInput<V> {
-    readonly enqueue: AppInboxEnqueueInput<V>;
+export interface CreateAuthenticatedTopologyEnqueueInput {
+    readonly enqueue: AppInboxEnqueueInput;
     readonly claimedAuthority: IssuedAuthSession;
     readonly groupStateService: Pick<GroupStateService, 'readIssuedAuthSession'>;
     readonly nowEpochMs: () => number;
@@ -41,9 +42,9 @@ export interface ValidateCurrentTopologySessionInput {
     readonly nowEpochMs: () => number;
 }
 
-export async function createAuthenticatedTopologyEnqueue<V>(
-    input: CreateAuthenticatedTopologyEnqueueInput<V>
-): Promise<AppInboxEnqueueInput<V>> {
+export async function createAuthenticatedTopologyEnqueue(
+    input: CreateAuthenticatedTopologyEnqueueInput
+): Promise<AppInboxEnqueueInput> {
     const command = await readAuthenticatedTopologyCommand(input.enqueue, input.claimedAuthority);
     const currentSession = await validateCurrentTopologySession({
         principalId: command.actor.principalId,
@@ -57,12 +58,12 @@ export async function createAuthenticatedTopologyEnqueue<V>(
     });
 }
 
-export async function createAuthenticatedTopologyEnqueueFromValidatedSession<V>(
+export async function createAuthenticatedTopologyEnqueueFromValidatedSession(
     input: Readonly<{
-        enqueue: AppInboxEnqueueInput<V>;
+        enqueue: AppInboxEnqueueInput;
         currentSession: PersistedAuthSession;
     }>
-): Promise<AppInboxEnqueueInput<V>> {
+): Promise<AppInboxEnqueueInput> {
     const command = await readTopologyCommandForValidatedSession(input.enqueue, {
         principalId: input.currentSession.clientId,
         sessionId: input.currentSession.sessionId
@@ -74,7 +75,10 @@ export async function createAuthenticatedTopologyEnqueueFromValidatedSession<V>(
     const authority: TopologyAppInboxAuthority = command.operation === 'reconfigureTopology'
         ? { kind: 'topology-reconfigure', proof, command }
         : { kind: 'topology-config', proof, command };
-    return { ...input.enqueue, authority };
+    return {
+        ...input.enqueue,
+        authority: encodeAppInboxCommand(authority, 'Topology AppInbox authority')
+    };
 }
 
 export function decodeTopologyAppInboxAuthority(value: unknown): TopologyAppInboxAuthority {

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
@@ -116,8 +116,8 @@ async function hashTopologyHttpMutationSemantic(
     });
 }
 
-export async function readAuthenticatedTopologyCommand<V>(
-    enqueue: AppInboxEnqueueInput<V>,
+export async function readAuthenticatedTopologyCommand(
+    enqueue: AppInboxEnqueueInput,
     authority: IssuedAuthSession
 ): Promise<TopologyAppInboxCommand> {
     return await readTopologyCommandForValidatedSession(enqueue, {
@@ -126,8 +126,8 @@ export async function readAuthenticatedTopologyCommand<V>(
     });
 }
 
-export async function readTopologyCommandForValidatedSession<V>(
-    enqueue: AppInboxEnqueueInput<V>,
+export async function readTopologyCommandForValidatedSession(
+    enqueue: AppInboxEnqueueInput,
     expectedActor: Readonly<{ principalId: string; sessionId: string; }>
 ): Promise<TopologyAppInboxCommand> {
     const command = readDurableTopologyAppInboxCommand(enqueue.data);

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -128,10 +128,10 @@ export class TopologyAppInboxHandler {
         this.dependencies = dependencies;
     }
 
-    async createAuthenticatedEnqueue<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async createAuthenticatedEnqueue(
+        enqueue: AppInboxEnqueueInput,
         authority: IssuedAuthSession
-    ): Promise<AppInboxEnqueueInput<V>> {
+    ): Promise<AppInboxEnqueueInput> {
         return await createAuthenticatedTopologyEnqueue({
             enqueue,
             claimedAuthority: authority,
@@ -152,10 +152,10 @@ export class TopologyAppInboxHandler {
         });
     }
 
-    async createAuthenticatedEnqueueFromValidatedSession<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async createAuthenticatedEnqueueFromValidatedSession(
+        enqueue: AppInboxEnqueueInput,
         currentSession: PersistedAuthSession
-    ): Promise<AppInboxEnqueueInput<V>> {
+    ): Promise<AppInboxEnqueueInput> {
         return await createAuthenticatedTopologyEnqueueFromValidatedSession({
             enqueue,
             currentSession

--- a/packages/shared-server/rallar-system/topology/inbox/topology-inbox-service.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-inbox-service.ts
@@ -13,7 +13,10 @@ import { AppInboxHandlerRegistry } from '../../app-inbox/app-inbox-handler-regis
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
 import type { AppInboxEntryRepository, AppInboxResultRepository } from '../../app-inbox/app-inbox-persistence-ports.ts';
 import { AppInboxQueueClient, SIMPLER_GROUP_STATE_APP_INBOX_TOPIC } from '../../app-inbox/app-inbox-queue-client.ts';
-import { encodeAppInboxResult } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    encodeAppInboxCommand,
+    encodeAppInboxResult
+} from '../../app-inbox/app-inbox-registration-codecs.ts';
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { GroupStateService } from '../../group-state/group-state-service-contracts.ts';
 import type { RallarTimingSink } from '../../observability/timing.ts';
@@ -122,15 +125,15 @@ export class TopologyInboxService {
         handlers.assertRegistrationComplete(TOPOLOGY_CONFIG_INBOX_TYPES);
     }
 
-    async processAuthenticatedEntryUntilCompletion<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async processAuthenticatedEntryUntilCompletion(
+        enqueue: AppInboxEnqueueInput,
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, TopologyAppInboxResult>> {
         return await this.processAuthenticatedEntryUntilCompletionResult(enqueue, authority);
     }
 
-    async processAuthenticatedEntryUntilCompletionResult<V>(
-        enqueue: AppInboxEnqueueInput<V>,
+    async processAuthenticatedEntryUntilCompletionResult(
+        enqueue: AppInboxEnqueueInput,
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, TopologyAppInboxResult>> {
         if (!isTopologyConfigInboxType(enqueue.type)) {
@@ -169,7 +172,10 @@ export class TopologyInboxService {
                         type,
                         ...key,
                         senderId: reservation.callerId,
-                        data: await reservation.materialize()
+                        data: encodeAppInboxCommand(
+                            await reservation.materialize(),
+                            'Topology AppInbox command'
+                        )
                     },
                     currentSession
                 )

--- a/packages/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts
@@ -1,7 +1,10 @@
 import type { GroupRef, GroupStateCausalRevision } from '@shared/api/group-types.ts';
 
 import type { RuntimeStateEntryValue } from '../../../runtime-state/runtime-state-json-store.ts';
-import { hashMutationCommand, type JsonWireValue } from '../../protocol/json-wire-identity.ts';
+import {
+    encodeJsonWireValue,
+    hashMutationCommand
+} from '../../protocol/json-wire-identity.ts';
 import { RTC_TOPOLOGY_REPLAY_RETENTION_MS } from '../replay/consumer/rtc-topology-replay-policy.ts';
 import { validateWorkClaim, type PersistedBoundaryValue } from './rtc-topology-publication-repository-state.ts';
 import type { RtcTopologyPublication } from './rtc-topology-publication.ts';
@@ -53,7 +56,9 @@ export async function hashRtcTopologyExecutionCommand(
         schemaVersion: 1,
         publication
     };
-    return await hashMutationCommand(command as JsonWireValue);
+    return await hashMutationCommand(
+        encodeJsonWireValue(command, 'RTC topology execution command')
+    );
 }
 
 export function createRtcTopologyExecutionReceipt(

--- a/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-authorised-ws.test.ts
@@ -6,7 +6,7 @@ import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persis
 import type { ClientMutationWritten, ClientStateWritten } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
 import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
-import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import { toAuthorisedWsClientConnection } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
 import type { AuthorisedWsClientMutationResult } from '@shared-server/rallar-system/client-state/inbox/client-state-inbox-result-codec.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import { Either } from '@shared/resilience/Either.ts';
@@ -51,7 +51,7 @@ it('rejects authorised websocket disconnect after durable auth revocation', asyn
     await authSessions.deleteSession(authSession);
     const disconnected = await processAppInboxMethod(queue, reader, () =>
         service.processAuthorisedWsClientDisconnect({
-            connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
+            connection: toAuthorisedWsClientConnection(connectInput),
             disconnectedAtEpochMs: Date.now(),
             reason: 'socket-closed'
         }));
@@ -197,7 +197,7 @@ it(
         await processAppInboxMethod(queue, reader, () => service.processAuthorisedWsClientConnect(connectInput));
         const disconnected = await processAppInboxMethod(queue, reader, () =>
             service.processAuthorisedWsClientDisconnect({
-                connection: toAuthorisedWsClientConnectEnqueue(connectInput).data,
+                connection: toAuthorisedWsClientConnection(connectInput),
                 disconnectedAtEpochMs: Date.now(),
                 reason: 'socket-closed'
             }));

--- a/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
+++ b/packages/tests/shared-server/client-state/app-client-inbox-mutation-test-harness.ts
@@ -11,8 +11,9 @@ import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
-import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import type { AppInboxFailure } from '@shared-server/rallar-system/app-inbox/app-inbox-failure.ts';
+import { encodeAppInboxCommand } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
 import {
     type ClientMutationWritten,
     type ClientStateService,
@@ -21,6 +22,7 @@ import {
 import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
 import { toAuthenticatedClientMutationContextId } from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
+import type { JsonWireObject, JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import type { ClientStateEventStore } from '@shared-server/rallar-system/state-events/client-state-event-store.ts';
 
 import { createAppInboxTestDatabase } from '../rallar-system/app-inbox/test-support/app-inbox-test-database.ts';
@@ -147,14 +149,9 @@ function toAuthenticatedClientTestEnqueue<V>(
         data: V;
     }>,
     authority: IssuedAuthSession
-) {
-    const data = input.data as
-        & V
-        & Readonly<{
-            scope: StateScope;
-            principalId: string;
-            request: Readonly<{ requestId: string; }>;
-        }>;
+): AppInboxEnqueueInput {
+    const wireData = encodeAppInboxCommand(input.data, 'Client mutation test command');
+    const data = readAuthenticatedClientTestCommand(wireData);
     return {
         ...input,
         topicId: input.type,
@@ -164,8 +161,46 @@ function toAuthenticatedClientTestEnqueue<V>(
             principalId: data.principalId,
             callerClientId: authority.clientId,
             callerSessionId: authority.sessionId
-        })
+        }),
+        data: wireData
     };
+}
+
+function readAuthenticatedClientTestCommand(value: JsonWireValue): Readonly<{
+    scope: StateScope;
+    principalId: string;
+    request: Readonly<{ requestId: string; }>;
+}> {
+    const command = requireJsonObject(value, 'Client mutation test command');
+    const scope = requireJsonObject(command.scope, 'Client mutation test scope');
+    const request = requireJsonObject(command.request, 'Client mutation test request');
+    if (
+        typeof scope.applicationId !== 'string' ||
+        typeof scope.workspaceId !== 'string' ||
+        typeof command.principalId !== 'string' ||
+        typeof request.requestId !== 'string'
+    ) {
+        throw new TypeError('Client mutation test command is invalid');
+    }
+    return {
+        scope: {
+            applicationId: scope.applicationId,
+            workspaceId: scope.workspaceId
+        },
+        principalId: command.principalId,
+        request: { requestId: request.requestId }
+    };
+}
+
+function requireJsonObject(value: JsonWireValue | undefined, label: string): JsonWireObject {
+    if (value === undefined || value === null || typeof value !== 'object' || isJsonWireArray(value)) {
+        throw new TypeError(`${label} must be an object`);
+    }
+    return value;
+}
+
+function isJsonWireArray(value: JsonWireValue): value is readonly JsonWireValue[] {
+    return Array.isArray(value);
 }
 
 export function issuedSession(clientId: string, sessionId: string): IssuedAuthSession {

--- a/packages/tests/shared-server/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
+++ b/packages/tests/shared-server/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { type GroupMutationDescriptor } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import type { AuthenticatedGroupMutationEnqueue } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
 import { toGroupMutationDescriptor } from '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
@@ -31,8 +31,16 @@ describe('GroupStateInboxService authenticated mutation descriptors', () => {
 
 interface DescriptorCase {
     readonly name: string;
-    readonly enqueue: AppInboxEnqueueInput<unknown>;
+    readonly enqueue: DescriptorEnqueue;
     readonly descriptor: GroupMutationDescriptor;
+}
+
+interface DescriptorEnqueue {
+    readonly type: AppInboxType;
+    readonly resourceId: string;
+    readonly contextId: string;
+    readonly senderId: string;
+    readonly data: AuthenticatedGroupMutationEnqueue['data'];
 }
 
 function descriptorCase(...input: DescriptorCaseArguments): DescriptorCase {
@@ -53,7 +61,7 @@ function descriptorCase(...input: DescriptorCaseArguments): DescriptorCase {
 type DescriptorCaseArguments = readonly [
     name: string,
     type: AppInboxType,
-    data: Record<string, unknown>,
+    data: AuthenticatedGroupMutationEnqueue['data'],
     operation: GroupMutationDescriptor['operation'],
     request: GroupMutationDescriptor['request'],
     targetPrincipalId?: string | null,

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-command-decoding.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-command-decoding.test.ts
@@ -1,8 +1,16 @@
 import { validatePersistedAppInboxCommandIdentity } from '@shared-server/rallar-system/app-inbox/app-inbox-command-identity.ts';
-import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
-import { describe, expect, it } from 'vitest';
+import {
+    AppInboxType,
+    type AppInboxEnqueueInput
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type { JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 describe('persisted AppInbox command decoding', () => {
+    it('uses JSON-wire data as the sole persisted enqueue shape', () => {
+        expectTypeOf<AppInboxEnqueueInput['data']>().toEqualTypeOf<JsonWireValue>();
+    });
+
     it('accepts the exact current JSON-wire command', () => {
         expect(validate(AppInboxType.GROUP_CREATE, {
             type: AppInboxType.GROUP_CREATE,

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-queue-client.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-queue-client.test.ts
@@ -4,6 +4,7 @@ import { toResultsDomain } from '@shared-server/queuebox/postgres/resource-inbox
 import { AppInboxType, type AppInboxEnqueueInput, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { AppInboxHandlerRegistry } from '@shared-server/rallar-system/app-inbox/app-inbox-handler-registry.ts';
 import { AppInboxQueueClient } from '@shared-server/rallar-system/app-inbox/app-inbox-queue-client.ts';
+import { encodeAppInboxCommand } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
 import type { GroupMemberUpsertAppInboxPayload } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
 import { ClientStateEventCollisionError } from '@shared-server/rallar-system/state-events/client-state-event-store.ts';
 import { GroupStateEventCollisionError } from '@shared-server/rallar-system/state-events/group-state-event-store.ts';
@@ -273,7 +274,7 @@ describe('AppInboxQueueClient', () => {
         const queue = new TestResourceInbox();
         const reader = new InboxQueueReader(queue);
         const results = new TestResourceInboxResults();
-        const handledPayloads: GroupMemberUpsertAppInboxPayload[] = [];
+        const handledPayloads: JsonWireValue[] = [];
         const service = new TestAppInboxRuntime(
             {
                 inboxQueueReader: reader,
@@ -293,26 +294,29 @@ describe('AppInboxQueueClient', () => {
             }
         );
         service.onStateMessage(AppInboxType.CLIENT_PRINCIPAL_UPSERT, async (data) => {
-            const payload = data as GroupMemberUpsertAppInboxPayload;
-            handledPayloads.push(payload);
-            return { accepted: payload };
+            handledPayloads.push(data);
+            return { accepted: data };
         });
+        const currentCommand = {
+            scope: SCOPE,
+            groupId: 'group-1',
+            principalId: 'alice',
+            request: {
+                status: 'active' as const,
+                actorPrincipalId: 'alice',
+                requestId: 'sparse-member-upsert'
+            }
+        } satisfies GroupMemberUpsertAppInboxPayload;
         const current = {
             type: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
             resourceId: 'sparse-member-upsert',
             contextId: 'ar-eye-hunter:default:group-1',
             senderId: 'alice',
-            data: {
-                scope: SCOPE,
-                groupId: 'group-1',
-                principalId: 'alice',
-                request: {
-                    status: 'active' as const,
-                    actorPrincipalId: 'alice',
-                    requestId: 'sparse-member-upsert'
-                }
-            }
-        } satisfies AppInboxEnqueueInput<GroupMemberUpsertAppInboxPayload>;
+            data: encodeAppInboxCommand(
+                currentCommand,
+                'Group member upsert test command'
+            )
+        } satisfies AppInboxEnqueueInput;
 
         const pending = service.processEntryUntilCompletion(current);
         await reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
@@ -321,71 +325,71 @@ describe('AppInboxQueueClient', () => {
         await expect(
             service.processEntryUntilCompletion({
                 ...current,
-                data: {
-                    principalId: 'alice',
-                    request: {
-                        requestId: 'sparse-member-upsert',
-                        actorPrincipalId: 'alice',
-                        status: 'active'
-                    },
-                    groupId: 'group-1',
-                    scope: { workspaceId: 'default', applicationId: 'ar-eye-hunter' }
-                }
+                data: encodeAppInboxCommand(
+                    {
+                        principalId: 'alice',
+                        request: {
+                            requestId: 'sparse-member-upsert',
+                            actorPrincipalId: 'alice',
+                            status: 'active'
+                        },
+                        groupId: 'group-1',
+                        scope: { workspaceId: 'default', applicationId: 'ar-eye-hunter' }
+                    } satisfies GroupMemberUpsertAppInboxPayload,
+                    'Reordered group member upsert test command'
+                )
             })
         ).resolves.toEqual(first);
         await expect(
             service.processEntryUntilCompletion({
                 ...current,
-                data: {
-                    ...current.data,
-                    request: { ...current.data.request, status: 'left' }
-                }
+                data: encodeAppInboxCommand(
+                    {
+                        ...currentCommand,
+                        request: { ...currentCommand.request, status: 'left' }
+                    },
+                    'Changed group member upsert test command'
+                )
             })
         ).rejects.toMatchObject({ status: 409 });
         let getterCalls = 0;
-        const unsafe = {
-            ...current,
-            resourceId: 'unsafe-member-upsert',
-            data: {
-                ...current.data,
-                request: { ...current.data.request }
-            }
+        const unsafeCommand = {
+            ...currentCommand,
+            request: { ...currentCommand.request }
         };
-        Object.defineProperty(unsafe.data.request, 'role', {
+        Object.defineProperty(unsafeCommand.request, 'role', {
             enumerable: true,
             get: () => {
                 getterCalls += 1;
                 return 'member';
             }
         });
-        await expect(service.processEntryUntilCompletion(unsafe)).rejects.toThrow(
-            /JSON-safe/u
-        );
+        expect(() =>
+            encodeAppInboxCommand(unsafeCommand, 'Unsafe accessor AppInbox command')
+        ).toThrow(/JSON-safe/u);
         expect(getterCalls).toBe(0);
-        await expect(
-            service.processEntryUntilCompletion({
-                ...current,
-                resourceId: 'unsafe-array',
-                data: { ...current.data, unsafe: [undefined] }
-            })
-        ).rejects.toThrow(/JSON-safe/u);
+        expect(() =>
+            encodeAppInboxCommand(
+                { ...currentCommand, unsafe: [undefined] },
+                'Unsafe array AppInbox command'
+            )
+        ).toThrow(/JSON-safe/u);
         const cycle: Record<string, object> = {};
         cycle.self = cycle;
         for (
-            const [resourceId, value] of [
+            const [label, value] of [
                 ['unsafe-function', () => undefined],
                 ['unsafe-bigint', 1n],
                 ['unsafe-cycle', cycle],
                 ['unsafe-nonfinite', Number.POSITIVE_INFINITY]
             ] as const
         ) {
-            await expect(
-                service.processEntryUntilCompletion({
-                    ...current,
-                    resourceId,
-                    data: { ...current.data, unsafe: value }
-                })
-            ).rejects.toThrow(/JSON-safe/u);
+            expect(() =>
+                encodeAppInboxCommand(
+                    { ...currentCommand, unsafe: value },
+                    `Unsafe ${label} AppInbox command`
+                )
+            ).toThrow(/JSON-safe/u);
         }
         expect(handledPayloads).toEqual([current.data]);
     });
@@ -427,7 +431,7 @@ describe('AppInboxQueueClient', () => {
             resourceId: 'proto-command',
             contextId: 'app:workspace:alice',
             senderId: 'alice',
-            data: firstData
+            data: encodeAppInboxCommand(firstData, 'Prototype-key AppInbox command')
         } as const;
 
         const pending = service.processEntryUntilCompletion(input);
@@ -441,7 +445,7 @@ describe('AppInboxQueueClient', () => {
         await expect(
             service.processEntryUntilCompletion({
                 ...input,
-                data: reorderedData
+                data: encodeAppInboxCommand(reorderedData, 'Reordered prototype-key AppInbox command')
             })
         ).resolves.toEqual(first);
         const changedData: ProtoPayload = JSON.parse(
@@ -451,7 +455,7 @@ describe('AppInboxQueueClient', () => {
         await expect(
             service.processEntryUntilCompletion({
                 ...input,
-                data: changedData
+                data: encodeAppInboxCommand(changedData, 'Changed prototype-key AppInbox command')
             })
         ).rejects.toMatchObject({ status: 409 });
 
@@ -512,15 +516,12 @@ describe('AppInboxQueueClient', () => {
         const unsafeValues = [accessor, cycle, 1n, () => undefined, Number.NaN, [undefined]] as const;
 
         for (const [index, unsafe] of unsafeValues.entries()) {
-            await expect(
-                service.processEntryUntilCompletion({
-                    type: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
-                    resourceId: `unsafe-first-${index}`,
-                    contextId: 'app:workspace:alice',
-                    senderId: 'alice',
-                    data: { unsafe }
-                })
-            ).rejects.toThrow(/JSON-safe/u);
+            expect(() =>
+                encodeAppInboxCommand(
+                    { unsafe },
+                    `Unsafe AppInbox command ${index}`
+                )
+            ).toThrow(/JSON-safe/u);
             expect(await readEntries(queue)).toHaveLength(0);
         }
         expect(getterCalls).toBe(0);
@@ -743,8 +744,8 @@ describe('AppInboxQueueClient', () => {
 });
 
 interface BeginMaterializedReservationInput {
-    readonly placeholder: AppInboxEnqueueInput<null>;
-    readonly materialize: () => Promise<AppInboxEnqueueInput<JsonWireValue>>;
+    readonly placeholder: AppInboxEnqueueInput;
+    readonly materialize: () => Promise<AppInboxEnqueueInput>;
 }
 
 interface MaterializedTestReservation {

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-ws-close-convergence.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-ws-close-convergence.test.ts
@@ -16,7 +16,7 @@ import { AppClientInboxService } from '@shared-server/rallar-system/client-state
 import { requireGroupStateWritten } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-result-codec.ts';
 import { GroupStateInboxService } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
 
-import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import { toAuthorisedWsClientConnection } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
 
 import { type GroupStateWritten } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import {
@@ -295,11 +295,11 @@ async function enqueueClientClose(
     facts: AuthorisedWsCloseFacts
 ): Promise<void> {
     await service.enqueueAuthorisedWsClientDisconnect({
-        connection: toAuthorisedWsClientConnectEnqueue({
+        connection: toAuthorisedWsClientConnection({
             authSession: facts.authSession,
             generationId: facts.generationId,
             input: facts.input
-        }).data,
+        }),
         disconnectedAtEpochMs: facts.disconnectedAtEpochMs,
         reason: facts.reason
     });
@@ -310,11 +310,11 @@ async function enqueueGroupClose(
     facts: AuthorisedWsCloseFacts
 ): Promise<number> {
     return await service.enqueueGroupSessionCleanup({
-        connection: toAuthorisedWsClientConnectEnqueue({
+        connection: toAuthorisedWsClientConnection({
             authSession: facts.authSession,
             generationId: facts.generationId,
             input: facts.input
-        }).data,
+        }),
         disconnectedAtEpochMs: facts.disconnectedAtEpochMs,
         reason: facts.reason
     });

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-ws-close-expiry.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-ws-close-expiry.test.ts
@@ -15,7 +15,7 @@ import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-s
 import { requireGroupStateWritten } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-result-codec.ts';
 import type { GroupStateInboxService } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts';
 
-import { toAuthorisedWsClientConnectEnqueue } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
+import { toAuthorisedWsClientConnection } from '@shared-server/rallar-system/client-state/inbox/authorised-ws-client-app-inbox.ts';
 
 import { type GroupStateWritten } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import { processNext, waitForQueuedType } from './test-support/app-inbox-queue-entry-test-helpers.ts';
@@ -70,11 +70,11 @@ it('bounds a lost-close group guard to the shared retry retention horizon', asyn
     expect(expectedExpiry).toBeLessThan(253_402_300_799_999);
 
     await harness.group.enqueueGroupSessionCleanup({
-        connection: toAuthorisedWsClientConnectEnqueue({
+        connection: toAuthorisedWsClientConnection({
             authSession: facts.authSession,
             generationId: facts.generationId,
             input: { ...facts.input, expiresAtEpochMs: 253_402_300_799_999 }
-        }).data,
+        }),
         disconnectedAtEpochMs: facts.disconnectedAtEpochMs,
         reason: facts.reason
     });

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
@@ -112,10 +112,10 @@ class AtomicAppInboxService {
         this.handlerRegistry.assertRegistrationComplete(expectedTypes);
     }
 
-    processEntryUntilCompletion<V>(
-        input: AppInboxEnqueueInput<V>
+    processEntryUntilCompletion(
+        input: AppInboxEnqueueInput
     ) {
-        return this.queueClient.processEntryUntilCompletion<V>(input);
+        return this.queueClient.processEntryUntilCompletion(input);
     }
 
     processEntryNoWaiting(input: AppInboxMessageContext<JsonWireValue>['enqueue']): void {

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
 import { AppInboxType, type AppInboxEnqueueInput } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { toLogicalAppInboxCommand } from '@shared-server/rallar-system/app-inbox/logical-app-inbox-command.ts';
 import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
@@ -224,7 +223,7 @@ describe('topology AppInbox durable command contract', () => {
                     config
                 }
             })
-        ).rejects.toThrow(/unknown|canonical|invalid/i);
+        ).rejects.toThrow(/contains .* fields: unexpected/i);
     });
 
     it('rejects predecessor identity fields before constructing a durable command', async () => {
@@ -331,9 +330,9 @@ async function topologyCommand(capturedAtEpochMs: number) {
     });
 }
 
-function logicalIdentity<Command>(enqueue: AppInboxEnqueueInput<Command>): string {
+function logicalIdentity(enqueue: AppInboxEnqueueInput): string {
     return serializeCanonicalMutationCommand(
-        toLogicalAppInboxCommand(decodeAppInboxEnqueue(enqueue))
+        toLogicalAppInboxCommand(enqueue)
     );
 }
 

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -18,7 +18,6 @@ import type { GroupStateService } from '@shared-server/rallar-system/group-state
 
 import type { GroupStateAuthorityGuard } from '@shared-server/rallar-system/group-state/persistence/group-state-persistence-contracts.ts';
 
-import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
 import { AppInboxType, type AppInboxEnqueueInput, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
 import type { ComputedRtcTopologyOutbox } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-entry.ts';
@@ -317,9 +316,9 @@ function sessionReader(
 }
 
 function createMessageContext(
-    enqueue: AppInboxEnqueueInput<TopologyAppInboxCommand>
+    enqueue: AppInboxEnqueueInput
 ): AppInboxMessageContext<TopologyAppInboxResult> {
-    const wireEnqueue = decodeAppInboxEnqueue(enqueue);
+    const wireEnqueue = enqueue;
     const message = newALUntargetedMessage(
         'topology-handler-test',
         newALRoute(


### PR DESCRIPTION
## Goal
Make JSON-wire data the sole durable AppInbox enqueue shape and remove generic command payloads from queue, persistence, identity, and result-wait paths.

## Changes
- Make AppInboxEnqueueInput non-generic with JsonWireValue data.
- Encode auth, admin, client, group, CRDT, topology, and RTC-RTT commands before queue ownership.
- Decode persisted JSON text at named protocol boundaries and keep logical identity and hashing on validated wire values.
- Remove queue-side re-decoding and compatibility-style generic helper signatures.
- Split API-v1 client read routes from mutation registration and command translation.
- Expose the authorized WebSocket connection projection separately from its durable enqueue.

## Acceptance
- No AppInboxEnqueueInput generic applications remain in repository TypeScript.
- Exact persisted envelope decoding remains at corruption boundaries.
- Current command producers validate JSON safety before persistence.
- Client mutation read and write entry paths have separate truthful owners.

## Validation
- Shared-server TypeScript check passed.
- API-v1 Deno check passed.
- 90 focused shared-server tests passed.
- 11 focused API-v1 and PGlite tests passed.
- Changed repository style and structure checks passed.
- Repository structure tests: 14 passed.
- Repository governance tests: 343 passed.

## Risk and rollback
The change is compile-time broad but behavior-preserving for current in-repo consumers. Runtime risk is concentrated at command encoding and persisted command decoding; focused domain, identity, retry, and convergence tests cover those paths. Roll back commit 04c371f47 if a current producer was missed.

## Follow-up
Continue the AppInbox handler execution, reservation, waiting, and transaction responsibility split after this PR merges.