### PR TITLE
Rename group lifecycle stage establishing to connecting

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -1216,7 +1216,7 @@ paths:
       tags: [Group State]
       summary: Start group establishment
       description: |
-        Moves formation intent from FORMING to ESTABLISHING and advances the
+        Moves formation intent from FORMING to CONNECTING and advances the
         formation epoch.
 
         Authorization follows the group's lifecycle policy: the establishment
@@ -1260,7 +1260,7 @@ paths:
       tags: [Group State]
       summary: Activate the group
       description: |
-        Moves formation intent from ESTABLISHING or RECONFIGURING to ACTIVE and
+        Moves formation intent from CONNECTING or RECONFIGURING to ACTIVE and
         advances the formation epoch.
 
         Authorization follows the group's lifecycle policy: the establishment
@@ -4593,7 +4593,7 @@ components:
           nullable: true
         lifecycleState:
           type: string
-          enum: [forming, establishing, active, reconfiguring]
+          enum: [forming, connecting, active, reconfiguring]
         formationEpoch:
           type: integer
           format: int64
@@ -4630,7 +4630,7 @@ components:
           $ref: '#/components/schemas/GroupRef'
         lifecycleState:
           type: string
-          enum: [forming, establishing, active, reconfiguring]
+          enum: [forming, connecting, active, reconfiguring]
         formationEpoch:
           type: integer
           format: int64

--- a/apps/api-v1/test/services/ws-topic-room-authorizer.test.ts
+++ b/apps/api-v1/test/services/ws-topic-room-authorizer.test.ts
@@ -144,7 +144,7 @@ Deno.test('API room authorization observes remote bans and deletion across warm 
 });
 
 Deno.test('API room authorization blocks pre-activation app data when policy says so', async () => {
-    const snapshot = createEstablishingSnapshot();
+    const snapshot = createConnectingSnapshot();
     const authorizer = createApiV1RoomWsAuthorizer({
         readCurrentSnapshot: () => Promise.resolve(snapshot)
     }, {
@@ -166,7 +166,7 @@ Deno.test('API room authorization blocks pre-activation app data when policy say
 });
 
 Deno.test('API room authorization fails closed on a corrupt policy before activation', async () => {
-    const snapshot = createEstablishingSnapshot();
+    const snapshot = createConnectingSnapshot();
     const authorizer = createApiV1RoomWsAuthorizer({
         readCurrentSnapshot: () => Promise.resolve(snapshot)
     }, {
@@ -197,7 +197,7 @@ Deno.test('API room authorization reads no policy for active groups', async () =
 });
 
 Deno.test('API room authorization exempts the CRDT topics from the data-policy gate', async () => {
-    const snapshot = createEstablishingSnapshot();
+    const snapshot = createConnectingSnapshot();
     let policyReads = 0;
     const authorizer = createApiV1RoomWsAuthorizer({
         readCurrentSnapshot: () => Promise.resolve(snapshot)
@@ -248,11 +248,11 @@ function roomChatInput(snapshot: GroupSnapshot) {
     };
 }
 
-function createEstablishingSnapshot(): GroupSnapshot {
+function createConnectingSnapshot(): GroupSnapshot {
     const snapshot = createSnapshot();
     return {
         ...snapshot,
-        group: { ...snapshot.group, lifecycleState: 'establishing', formationEpoch: 1 }
+        group: { ...snapshot.group, lifecycleState: 'connecting', formationEpoch: 1 }
     };
 }
 

--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -49,22 +49,22 @@ Formation intent has four states and four transitions
 create (formation: phased) --> forming
 create (formation: immediate) --> active
 
-forming        -- start-establishment -->  establishing
-establishing   -- activate ------------->  active
+forming        -- start-establishment -->  connecting
+connecting     -- activate ------------->  active
 active         -- reopen-establishment ->  reconfiguring
 reconfiguring  -- activate ------------->  active
-establishing   -- fail-formation ------->  forming
+connecting     -- fail-formation ------->  forming
 reconfiguring  -- fail-formation ------->  forming
 ```
 
-| Transition             | From                            | To              |
-| ---------------------- | ------------------------------- | --------------- |
-| `start-establishment`  | `forming`                       | `establishing`  |
-| `activate`             | `establishing`, `reconfiguring` | `active`        |
-| `reopen-establishment` | `active`                        | `reconfiguring` |
-| `fail-formation`       | `establishing`, `reconfiguring` | `forming`       |
+| Transition             | From                          | To              |
+| ---------------------- | ----------------------------- | --------------- |
+| `start-establishment`  | `forming`                     | `connecting`    |
+| `activate`             | `connecting`, `reconfiguring` | `active`        |
+| `reopen-establishment` | `active`                      | `reconfiguring` |
+| `fail-formation`       | `connecting`, `reconfiguring` | `forming`       |
 
-`reconfiguring` is a distinct state, not `establishing` with a flag: the read surface tells a group
+`reconfiguring` is a distinct state, not `connecting` with a flag: the read surface tells a group
 that was active and is repairing its overlay apart from one that has never been active. The data
 gate does not read that difference — under `blocked-until-active` both block, because
 `canSendGroupMessage` tests only `lifecycleState !== 'active'` (see
@@ -131,7 +131,7 @@ overlay is planned or published and the server commands no dials. The browser is
 with no server overlay, `WebRtcGroupManager.targetPeerIdsForGroup` falls back to the group's online
 members and `computeOutboundDialPlan` dials up to `maxPeerConnections` of them, so a
 presence-connected forming lobby still makes bounded bootstrap RTC attempts. Holding those is not
-built (see [Not In V1](#not-in-v1)). `establishing`, `active`, and `reconfiguring` all plan.
+built (see [Not In V1](#not-in-v1)). `connecting`, `active`, and `reconfiguring` all plan.
 `api-v1-group-lifecycle-transitions` pins it: `GET …/topology` is `null` or `state: 'removed'`
 while forming, the `overlay.topology` hydration a forming member receives announces `removed`, and
 a plan exists after `start-establishment`. The admin `reconfigureGroupTopology` path bypasses the
@@ -148,7 +148,7 @@ never the ability to be in the group.
 ### Recipes
 
 `api-v1-group-lifecycle-transitions` walks a `managed` group with `activation.mode: 'manual'`
-through `forming` → `establishing` (epoch 1) → `active` (2) → `reconfiguring` (3) → `active` (4),
+through `forming` → `connecting` (epoch 1) → `active` (2) → `reconfiguring` (3) → `active` (4),
 pins `formationElectorate: [creator]` at creation, the non-manager denial `forbidden-role`, and the
 illegal-transition denial. Manual activation is pinned there because the managed preset's default
 `threshold-or-deadline` would otherwise auto-activate underneath the deterministic walk.
@@ -201,7 +201,7 @@ reads them. Establishment pacing is whatever the browser's existing dial budget 
   not start rather than starting degraded.
 - `drop-in-social`'s `activation.mode: 'threshold'` never evaluates. `immediate` formation creates
   the group `active`, `server-auto` denies every principal-commanded transition, and the criterion
-  only runs in `establishing` or `reconfiguring`. What the preset actually buys is the open-until-50
+  only runs in `connecting` or `reconfiguring`. What the preset actually buys is the open-until-50
   admission window, which binds from creation.
 
 ### Absent policy
@@ -498,7 +498,7 @@ exhausting both attempts and re-opening as a joinable lobby (`allOrNothingFloorR
 
 `computeFormationCriterionCommand`
 (`packages/shared-server/rallar-system/topology/replay/work/compute-formation-criterion-command.ts`)
-is the single evaluation function: it returns `null` unless the group is `establishing` or
+is the single evaluation function: it returns `null` unless the group is `connecting` or
 `reconfiguring`, reads the policy (corrupt → `null`; absent → optimistic, whose `manual` mode waits),
 derives readiness from the supplied plan and evidence, evaluates the criterion, and returns the
 command it asks for — `activateGroup` with `observedRate` and a `degraded` flag, or
@@ -517,19 +517,19 @@ and the per-group interval floor has elapsed — 5 ms and 30 s by default, overr
 `RALLAR_RTC_TOPOLOGY_RTT_VIVALDI_DELTA_MS` and `RALLAR_RTC_TOPOLOGY_RTT_REFINEMENT_MIN_INTERVAL_MS`)
 does not compute a plan, so it would not petition — and under a
 burst of reports the measurement that carries the group across its threshold is exactly the one
-deferred. `createDeferredCriterionPetitioner` closes that gap: a deferred item for an `establishing`
+deferred. `createDeferredCriterionPetitioner` closes that gap: a deferred item for a `connecting`
 group with an active stored plan petitions at most once per
 `DEFAULT_DEFERRED_CRITERION_PETITION_MIN_INTERVAL_MS` = 1 000 ms per group, process-locally; damped
 requests arm one trailing timer per group, because the crossing measurement lives at the burst's
 tail by construction. The trailing petition re-reads the stored plan and petitions only if it is
 still active; it is best-effort and only warns on failure. Two bounds are deliberate: it petitions
-for `establishing` only — a `reconfiguring` group under refinement-deferred work waits for the next
+for `connecting` only — a `reconfiguring` group under refinement-deferred work waits for the next
 computed plan or the deadline — and a removed stored plan never petitions, since its empty edge set
 would read as trivially complete.
 
 **The time leg** exists because deadline expiry generates no evidence. The transitions arm it
 themselves (`computeFormationTimerEntries` in `formation-timer-outbox-entry.ts`), in the same
-AppInbox transaction: entering `establishing` or `reconfiguring` under a deadline mode writes one
+AppInbox transaction: entering `connecting` or `reconfiguring` under a deadline mode writes one
 `FORMATION_TIMER` app-outbox entry due at `now + deadlineMs`; a below-floor return with attempts
 remaining writes one `retry` entry due after the backoff. Entries are inserted with
 `dequeueAudit.nextTs` at their due time, so every queue backend holds them invisible until then —
@@ -537,7 +537,7 @@ native scheduling, no polling or requeue loop — and each carries the post-tran
 `formationEpoch`. The consumer (`create-formation-timer-work-handler.ts`) throws if an entry is not
 yet due (clock-skew defence; the retry release walks it forward), drops it if the group is gone or
 its epoch moved on, and then: a `retry` entry for a `forming` group submits `startGroupEstablishment`
-under `formation-criterion` authority; a `deadline` entry for an `establishing` or `reconfiguring`
+under `formation-criterion` authority; a `deadline` entry for a `connecting` or `reconfiguring`
 group reads the planning authority and the stored plan and runs the same evaluation function. If no
 plan is stored at deadline time the entry does nothing.
 
@@ -551,7 +551,7 @@ its id) and otherwise a typed idempotency-conflict rejection, never a second tra
 that lands after the group left the transition's source states is a `lifecycle-transition-invalid`
 rejection the mutation compute absorbs. The compute does not compare the petition's epoch with the
 stored one, so the one window left open is a petition that waits in the queue while the group cycles
-back into a legal source state at a later epoch — `establishing` → `forming` → `establishing` under
+back into a legal source state at a later epoch — `connecting` → `forming` → `connecting` under
 the retry backoff, or `active` → `reconfiguring` by operator command — and is then applied with the
 older evidence.
 
@@ -601,7 +601,7 @@ default five reporting peers. `docs/rallar-rtc-rtt-reporting.md` owns the wider 
 until the group's `lifecycleState` is `active`. It is one added denial at the existing per-message
 predicate: `canSendGroupMessage` in `group-state/policy/group-message-policy.ts` denies `group-data-blocked-until-active` when
 the resolved value is `blocked-until-active` and the group is not `active` — so `forming`,
-`establishing`, and `reconfiguring` all block, which is the meaning `reconfiguring` exists to carry.
+`connecting`, and `reconfiguring` all block, which is the meaning `reconfiguring` exists to carry.
 
 The room authorizer (`rallar-system/websocket/ws-topic-room-authorizer.ts`, composed in
 `apps/api-v1/src/services/ws-topic-room-authorizer.ts`) supplies the value lazily: it reads the
@@ -681,7 +681,7 @@ admitted member in the payload — and `ownership-transferred` carries `fromPrin
 | Route                                                              | Body                              | Success                                  |
 | ------------------------------------------------------------------ | --------------------------------- | ---------------------------------------- |
 | `POST …/groups/requests/{requestId}` with `lifecyclePolicy`        | `GroupLifecyclePolicyInput`       | `201` snapshot                           |
-| `POST …/groups/{groupId}/lifecycle/establish/requests/{requestId}` | `GroupLifecycleTransitionRequest` | `200` snapshot, `forming → establishing` |
+| `POST …/groups/{groupId}/lifecycle/establish/requests/{requestId}` | `GroupLifecycleTransitionRequest` | `200` snapshot, `forming → connecting`   |
 | `POST …/lifecycle/activate/requests/{requestId}`                   | same                              | `200` snapshot, `→ active`               |
 | `POST …/lifecycle/reopen/requests/{requestId}`                     | same                              | `200` snapshot, `active → reconfiguring` |
 | `POST …/admissions/{principalId}/grant/requests/{requestId}`       | `GrantGroupAdmissionRequest`      | `200` snapshot, member `active`          |
@@ -778,7 +778,7 @@ Recorded at the scale tiers and not fixed, because real heartbeat-cadence report
   under 19-writer endpoint contention.
 - Before the edge-trigger landed, threshold activation under bursty evidence waited for the
   deadline evaluation because the evidence-leg petition rode the refinement gate's debounce. The
-  edge-trigger closes that for `establishing` groups; the deadline remains the backstop.
+  edge-trigger closes that for `connecting` groups; the deadline remains the backstop.
 
 ## Not In V1
 

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -107,7 +107,7 @@ export function validateStoredGroup(group: unknown, ref: GroupRef): asserts grou
     nullablePositiveSafeInteger(value.purgeAfterEpochMs, 'Stored group purgeAfterEpochMs');
     requireOneOf(
         value.lifecycleState,
-        ['forming', 'establishing', 'active', 'reconfiguring'],
+        ['forming', 'connecting', 'active', 'reconfiguring'],
         'Stored group lifecycleState'
     );
     requireNonNegativeSafeInteger(value.formationEpoch, 'Stored group formationEpoch');

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-formation-criterion-command.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-formation-criterion-command.ts
@@ -40,7 +40,7 @@ export async function computeFormationCriterionCommand(
     input: ComputeFormationCriterionCommandInput
 ): Promise<GroupMutationCommand | null> {
     const group = input.group.group;
-    if (group.lifecycleState !== 'establishing' && group.lifecycleState !== 'reconfiguring') {
+    if (group.lifecycleState !== 'connecting' && group.lifecycleState !== 'reconfiguring') {
         return null;
     }
     const policyRead = await input.readLifecyclePolicy(group);
@@ -196,7 +196,7 @@ export function createDeferredCriterionPetitioner(
     return {
         async request(work, read) {
             if (
-                work.groupSnapshot.group.lifecycleState !== 'establishing' ||
+                work.groupSnapshot.group.lifecycleState !== 'connecting' ||
                 read.snapshot === null ||
                 read.snapshot.value.state !== 'active'
             ) {

--- a/packages/shared-server/rallar-system/topology/replay/work/create-formation-timer-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-formation-timer-work-handler.ts
@@ -82,7 +82,7 @@ async function processFormationTimerWork(
         return;
     }
     const lifecycleState = snapshot.group.lifecycleState;
-    if (lifecycleState !== 'establishing' && lifecycleState !== 'reconfiguring') {
+    if (lifecycleState !== 'connecting' && lifecycleState !== 'reconfiguring') {
         return;
     }
     const [authority, planned] = await Promise.all([

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -222,7 +222,7 @@ async function computeAcceptedRtcTopologyWork(
         })
     ) {
         // The gate defers the replan, never the activation decision: the
-        // measurement that carries an establishing group across its threshold
+        // measurement that carries a connecting group across its threshold
         // must still petition the criterion, or activation waits for the next
         // deadline evaluation. A removed stored plan never petitions — its
         // empty edge set would read as trivially-complete readiness.

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -952,7 +952,7 @@
           }
         ]
       },
-      "description": "Drives the three lifecycle transition commands on a managed-preset group -- forming to establishing to active to reconfiguring and back -- with formation-epoch assertions, a non-manager denial, and an illegal-transition denial."
+      "description": "Drives the three lifecycle transition commands on a managed-preset group -- forming to connecting to active to reconfiguring and back -- with formation-epoch assertions, a non-manager denial, and an illegal-transition denial."
     },
     {
       "id": "api-v1-group-formation-criterion",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-approval.json
@@ -682,7 +682,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1,
             "formationElectorate": ["{aliceClientId}"]
           }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-windows.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-admission-windows.json
@@ -572,7 +572,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -584,7 +584,7 @@
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{closedGroupId}/join/requests/join-closed-establishing-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{closedGroupId}/join/requests/join-closed-connecting-{runId}",
         "headers": {
           "Authorization": "{bobAuthHeader}",
           "x-client-id": "{bobClientId}"
@@ -782,7 +782,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1,
             "formationElectorate": ["{aliceClientId}", "{bobClientId}"]
           }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-data-policy.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-data-policy.json
@@ -855,7 +855,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
@@ -213,7 +213,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -369,7 +369,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1,
             "formationElectorate": ["{aliceClientId}", "{bobClientId}"]
           }
@@ -533,7 +533,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -560,7 +560,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "readiness": {
             "plannedEdgeCount": 1,
             "observedEdgeCount": 0,
@@ -694,7 +694,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
@@ -1365,7 +1365,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -1392,7 +1392,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "readiness": {
             "observedEdgeCount": 0,
             "observedRate": 0

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
@@ -825,7 +825,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -852,7 +852,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "readiness": {
             "observedEdgeCount": 0,
             "observedRate": 0

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
@@ -469,7 +469,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -526,7 +526,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "formationEpoch": 1,
           "establishmentStartedAtEpochMs": "integer",
           "readiness": {

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-manager-succession.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-manager-succession.json
@@ -31,7 +31,7 @@
       "default": "local"
     },
     "leaveGroupId": "succession-leave-room-{runId}",
-    "zeroEstablishingGroupId": "zero-establishing-room-{runId}"
+    "zeroConnectingGroupId": "zero-connecting-room-{runId}"
   },
   "execution": {
     "correlation": {
@@ -272,7 +272,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1,
             "formationElectorate": ["{aliceClientId}", "{bobClientId}"]
           }
@@ -422,14 +422,14 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
       }
     },
     {
-      "name": "managerLeavesMidEstablishing",
+      "name": "managerLeavesMidConnecting",
       "type": "http",
       "connection": "primary",
       "request": {
@@ -470,7 +470,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "managerPrincipalIds": ["{bobClientId}"]
         }
       }
@@ -499,19 +499,19 @@
       }
     },
     {
-      "name": "createZeroEstablishingGroup",
+      "name": "createZeroConnectingGroup",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/requests/group-create-zero-establishing-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/requests/group-create-zero-connecting-{runId}",
         "headers": {
           "Authorization": "{bobAuthHeader}",
           "x-client-id": "{bobClientId}"
         },
         "body": {
-          "groupId": "{zeroEstablishingGroupId}",
-          "displayName": "Zero manager establishing {runId}",
+          "groupId": "{zeroConnectingGroupId}",
+          "displayName": "Zero manager connecting {runId}",
           "kind": "room",
           "joinMode": "open",
           "createdByPrincipalId": "{bobClientId}",
@@ -541,12 +541,12 @@
       }
     },
     {
-      "name": "aliceJoinsTheZeroEstablishingGroup",
+      "name": "aliceJoinsTheZeroConnectingGroup",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/join/requests/join-alice-zero-establishing-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/join/requests/join-alice-zero-connecting-{runId}",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
@@ -571,7 +571,7 @@
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/lifecycle/establish/requests/establish-zero-establishing-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/lifecycle/establish/requests/establish-zero-connecting-{runId}",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
@@ -582,19 +582,19 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
       }
     },
     {
-      "name": "soleManagerLeavesMidEstablishing",
+      "name": "soleManagerLeavesMidConnecting",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "PUT",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/members/{aliceClientId}/requests/leave-zero-establishing-alice-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/members/{aliceClientId}/requests/leave-zero-connecting-alice-{runId}",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
@@ -616,12 +616,12 @@
       }
     },
     {
-      "name": "zeroManagersMidEstablishingInTheView",
+      "name": "zeroManagersMidConnectingInTheView",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "GET",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/formation",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/formation",
         "headers": {
           "Authorization": "{bobAuthHeader}",
           "x-client-id": "{bobClientId}"
@@ -630,18 +630,18 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "managerPrincipalIds": []
         }
       }
     },
     {
-      "name": "zeroManagerBlocksActivateMidEstablishing",
+      "name": "zeroManagerBlocksActivateMidConnecting",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/lifecycle/activate/requests/activate-zero-establishing-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/lifecycle/activate/requests/activate-zero-connecting-{runId}",
         "headers": {
           "Authorization": "{bobAuthHeader}",
           "x-client-id": "{bobClientId}"
@@ -659,12 +659,12 @@
       }
     },
     {
-      "name": "membershipStaysSafeMidEstablishing",
+      "name": "membershipStaysSafeMidConnecting",
       "type": "http",
       "connection": "primary",
       "request": {
         "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroEstablishingGroupId}/join/requests/rejoin-zero-establishing-alice-{runId}",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{zeroConnectingGroupId}/join/requests/rejoin-zero-connecting-alice-{runId}",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
@@ -571,7 +571,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -825,7 +825,7 @@
         "status": 200,
         "body": {
           "group": {
-            "lifecycleState": "establishing",
+            "lifecycleState": "connecting",
             "formationEpoch": 1
           }
         }
@@ -852,7 +852,7 @@
       "expect": {
         "status": 200,
         "body": {
-          "lifecycleState": "establishing",
+          "lifecycleState": "connecting",
           "readiness": {
             "plannedEdgeCount": 1,
             "observedEdgeCount": 0,

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -430,7 +430,7 @@ export function validateAuthoritativeGroupSnapshot(
     }
     enumValue(
         group.lifecycleState,
-        ['forming', 'establishing', 'active', 'reconfiguring'],
+        ['forming', 'connecting', 'active', 'reconfiguring'],
         'GroupSnapshot.group.lifecycleState'
     );
     nonNegativeInteger(group.formationEpoch, 'GroupSnapshot.group.formationEpoch');

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
@@ -2,7 +2,7 @@ import type { PrincipalId } from '../group-types.ts';
 
 export type GroupLifecycleState =
     | 'forming'
-    | 'establishing'
+    | 'connecting'
     | 'active'
     | 'reconfiguring';
 

--- a/packages/shared/api/group-lifecycle/group-lifecycle-transitions.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-transitions.ts
@@ -17,13 +17,13 @@ export type GroupLifecycleTransitionOutcome =
 
 const TRANSITION_SOURCES: Readonly<Record<GroupLifecycleTransition, readonly GroupLifecycleState[]>> = {
     'start-establishment': ['forming'],
-    activate: ['establishing', 'reconfiguring'],
+    activate: ['connecting', 'reconfiguring'],
     'reopen-establishment': ['active'],
-    'fail-formation': ['establishing', 'reconfiguring']
+    'fail-formation': ['connecting', 'reconfiguring']
 };
 
 const TRANSITION_TARGETS: Readonly<Record<GroupLifecycleTransition, GroupLifecycleState>> = {
-    'start-establishment': 'establishing',
+    'start-establishment': 'connecting',
     activate: 'active',
     'reopen-establishment': 'reconfiguring',
     'fail-formation': 'forming'

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -190,7 +190,7 @@ function validateDeltaGroup(
     }
     enumValue(
         group.lifecycleState,
-        ['forming', 'establishing', 'active', 'reconfiguring'],
+        ['forming', 'connecting', 'active', 'reconfiguring'],
         `${label}.lifecycleState`
     );
     nonNegativeInteger(group.formationEpoch, `${label}.formationEpoch`);

--- a/packages/tests/shared-server/rallar-system/group-state/group-lifecycle-command-policy.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/group-lifecycle-command-policy.test.ts
@@ -206,7 +206,7 @@ describe('canCommandGroupLifecycleTransition', () => {
         const members = [member('alice', 'owner')];
         expect(
             command({
-                overrides: { lifecycleState: 'establishing' },
+                overrides: { lifecycleState: 'connecting' },
                 members,
                 actorPrincipalId: 'alice',
                 policy: OPTIMISTIC,

--- a/packages/tests/shared-server/rallar-system/group-state/group-lifecycle-safety-baseline.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/group-lifecycle-safety-baseline.test.ts
@@ -14,7 +14,7 @@ import { createTestGroup } from '../../../create-test-group.ts';
 
 import { groupMemberStorageKey, groupRef, groupStorageKey, storedEntry } from './mutation/group-mutation-test-runtime.ts';
 
-const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = ['forming', 'establishing', 'active', 'reconfiguring'];
+const EVERY_LIFECYCLE_STATE: readonly GroupLifecycleState[] = ['forming', 'connecting', 'active', 'reconfiguring'];
 
 /**
  * The safety-baseline invariant of the lifecycle plan: phases gate

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-lifecycle-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-lifecycle-mutation.test.ts
@@ -27,7 +27,7 @@ describe('group lifecycle transition computation', () => {
         }
         expect(computed.guard.kind).toBe('group');
         const written = computed.guard.value as Group;
-        expect(written.lifecycleState).toBe('establishing');
+        expect(written.lifecycleState).toBe('connecting');
         expect(written.formationEpoch).toBe(3);
         expect(written.snapshotVersion).toBe(2);
         expect(computed.event.eventType).toBe('group-updated');
@@ -36,7 +36,7 @@ describe('group lifecycle transition computation', () => {
     it('pins the formation electorate to the roster read at every epoch advance', () => {
         const cases = [
             { operation: 'startGroupEstablishment', lifecycleState: 'forming' },
-            { operation: 'activateGroup', lifecycleState: 'establishing' },
+            { operation: 'activateGroup', lifecycleState: 'connecting' },
             { operation: 'reopenGroupEstablishment', lifecycleState: 'active' }
         ] as const;
         for (const { operation, lifecycleState } of cases) {
@@ -54,8 +54,8 @@ describe('group lifecycle transition computation', () => {
         }
     });
 
-    it('activates from establishing and from reconfiguring', () => {
-        for (const from of ['establishing', 'reconfiguring'] as const) {
+    it('activates from connecting and from reconfiguring', () => {
+        for (const from of ['connecting', 'reconfiguring'] as const) {
             const computed = computeGroupMutation({
                 command: transitionCommand('activateGroup'),
                 read: transitionRead({ lifecycleState: from, formationEpoch: 1 }),
@@ -123,7 +123,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: criterionCommand('failGroupFormation', { observedRate: 0.3 }),
             read: criterionRead({
-                lifecycleState: 'establishing',
+                lifecycleState: 'connecting',
                 formationEpoch: 2,
                 establishmentStartedAtEpochMs: 1_500,
                 formationAttemptCount: 1
@@ -151,7 +151,7 @@ describe('group lifecycle transition computation', () => {
         expect(() =>
             computeGroupMutation({
                 command: transitionCommand('failGroupFormation' as never),
-                read: transitionRead({ lifecycleState: 'establishing', formationEpoch: 1 }),
+                read: transitionRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
                 facts: transitionFacts()
             })
         ).toThrowError(/criterion-commanded only/);
@@ -166,7 +166,7 @@ describe('group lifecycle transition computation', () => {
         ) {
             const computed = computeGroupMutation({
                 command: criterionCommand('activateGroup', { observedRate: 0.97, degraded }),
-                read: criterionRead({ lifecycleState: 'establishing', formationEpoch: 1 }),
+                read: criterionRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
                 facts: criterionFacts()
             });
             expect(computed.outcome).toBe('write');
@@ -182,7 +182,7 @@ describe('group lifecycle transition computation', () => {
     it('leaves the recorded outcome untouched on manual activation', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('activateGroup'),
-            read: transitionRead({ lifecycleState: 'establishing', formationEpoch: 1 }),
+            read: transitionRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
             facts: transitionFacts()
         });
         expect(computed.outcome).toBe('write');

--- a/packages/tests/shared-server/rallar-system/group-state/policy/group-policy.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/policy/group-policy.test.ts
@@ -401,7 +401,7 @@ describe('group policy helpers', () => {
         expect(
             canSendGroupMessage({
                 snapshot: snapshot({
-                    lifecycleState: 'establishing',
+                    lifecycleState: 'connecting',
                     activeSessions: [session('alice-session', 'alice')]
                 }),
                 actor: ACTOR,
@@ -420,7 +420,7 @@ describe('group policy helpers', () => {
         expect(
             canSendGroupMessage({
                 snapshot: snapshot({
-                    lifecycleState: 'establishing',
+                    lifecycleState: 'connecting',
                     activeSessions: [session('alice-session', 'alice')]
                 }),
                 actor: ACTOR,
@@ -603,7 +603,7 @@ describe('group policy helpers', () => {
             expectCode(
                 canSendGroupMessage({
                     snapshot: snapshot({
-                        lifecycleState: 'establishing',
+                        lifecycleState: 'connecting',
                         activeSessions: [session('alice-session', 'alice')]
                     }),
                     actor: ACTOR,

--- a/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
@@ -697,10 +697,10 @@ describe('RTC topology APP_OUTBOX work', () => {
     });
 
     // The refinement gate defers the replan, never the activation decision:
-    // deferred RTT work for an establishing group still petitions the
+    // deferred RTT work for a connecting group still petitions the
     // criterion, so the measurement that crosses the threshold activates the
     // group instead of waiting for the deadline evaluation.
-    it('petitions the criterion for an establishing group when the gate defers the replan', async () => {
+    it('petitions the criterion for a connecting group when the gate defers the replan', async () => {
         const queue = new InMemoryQueueBox();
         const runtime = createRtcTopologyOutboxPublisher({
             outboxQueueReader: new OutboxQueueReader(queue),
@@ -720,7 +720,7 @@ describe('RTC topology APP_OUTBOX work', () => {
             ...base,
             group: {
                 ...base.group,
-                lifecycleState: 'establishing',
+                lifecycleState: 'connecting',
                 establishmentStartedAtEpochMs: 500
             }
         };

--- a/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
@@ -103,7 +103,7 @@ describe('GroupTopologyPlanningService', () => {
     });
 
     it('plans in every non-forming lifecycle state', () => {
-        for (const lifecycleState of ['establishing', 'active', 'reconfiguring'] as const) {
+        for (const lifecycleState of ['connecting', 'active', 'reconfiguring'] as const) {
             const group = groupWithSessionsIn(lifecycleState);
             const service = createPlanningService({ group });
 

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
@@ -18,7 +18,7 @@ describe('formation timer work handler', () => {
             ...base,
             group: createTestGroup({
                 ...base.group,
-                lifecycleState: 'establishing',
+                lifecycleState: 'connecting',
                 formationEpoch: 1,
                 formationAttemptCount: 1,
                 establishmentStartedAtEpochMs: 1_000

--- a/packages/tests/shared/group-admission-decision.test.ts
+++ b/packages/tests/shared/group-admission-decision.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 const NOW = 1_700_000_000_000;
 const STATES: readonly GroupLifecycleState[] = [
     'forming',
-    'establishing',
+    'connecting',
     'active',
     'reconfiguring'
 ];
@@ -41,7 +41,7 @@ describe('group admission decision', () => {
     it('closed admits only while forming', () => {
         expect(decision({ mode: 'closed' }, { lifecycleState: 'forming' }))
             .toEqual({ kind: 'admit' });
-        for (const lifecycleState of ['establishing', 'active', 'reconfiguring'] as const) {
+        for (const lifecycleState of ['connecting', 'active', 'reconfiguring'] as const) {
             expect(deniedCode(decision({ mode: 'closed' }, { lifecycleState })))
                 .toBe('group-admission-closed');
         }

--- a/packages/tests/shared/group-lifecycle-transitions.test.ts
+++ b/packages/tests/shared/group-lifecycle-transitions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import { computeGroupLifecycleTransition, type GroupLifecycleTransition } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 
-const STATES: readonly GroupLifecycleState[] = ['forming', 'establishing', 'active', 'reconfiguring'];
+const STATES: readonly GroupLifecycleState[] = ['forming', 'connecting', 'active', 'reconfiguring'];
 
 // The complete machine: every cell is either the one allowed target or denied.
 const ALLOWED_CELLS: ReadonlyArray<{
@@ -11,8 +11,8 @@ const ALLOWED_CELLS: ReadonlyArray<{
     from: GroupLifecycleState;
     to: GroupLifecycleState;
 }> = [
-    { transition: 'start-establishment', from: 'forming', to: 'establishing' },
-    { transition: 'activate', from: 'establishing', to: 'active' },
+    { transition: 'start-establishment', from: 'forming', to: 'connecting' },
+    { transition: 'activate', from: 'connecting', to: 'active' },
     { transition: 'activate', from: 'reconfiguring', to: 'active' },
     { transition: 'reopen-establishment', from: 'active', to: 'reconfiguring' }
 ];

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -131,6 +131,88 @@ amend this document and the semantic PR explanation before implementation contin
 `build`, `test:repo-governance`, repository structure, and a fresh state-write control when the
 selected work changes a mutation path.
 
+### Initial checkpoint — executed 2026-08-27 against `main` @ `9c8069be4`
+
+The ten-surface census re-ran as six parallel surface censuses plus a current-main gate run. `main`
+moved ~33 commits past this plan's last amendment (#327), including the shared-server ownership
+series (#329–#350). Verdict: **no numbered implementation decision is invalidated; PR 1 (slice 1a)
+and PR 2 (slice 1b + 1c) stand as selected.** Corrected evidence for 1a/1b/1c is folded into those
+sections directly. Corrections affecting later slices are recorded here and must be folded into
+those slices at their own I20 checkpoints:
+
+- **The group-mutation spine did not move in #344–#350; the AppInbox plumbing under it did.**
+  Handler execution split into `app-inbox/handler/` (#348: `AppInboxHandlerRegistry`,
+  `AppInboxHandlerExecutor`, `AppInboxTransactionWriter`, `createAppInboxHandlerRuntime`) and
+  client execution into `app-inbox/client/` (#349: `AppInboxCommandClient` replacing the deleted
+  `AppInboxQueueClient`, `AppInboxQueueEntryWriter`, `createAppInboxClientRuntime`,
+  `AppInboxResultWaiter`). Generic JSON-wire command decode is `decodeAppInboxEnqueue` /
+  `decodePersistedAppInboxEnqueue` in `app-inbox/app-inbox-command-decoding.ts` (#346).
+- **I16 is already complete and is struck as a work item.** `mutationDescriptor` takes one named
+  `MutationDescriptorInput` since #338 (`7f530fdbd`, one day after this plan's last edit); the call
+  census (36 sites / 9 files / 22 in `to-group-mutation-descriptor.ts`) matches the plan.
+  `toGroupMutationDescriptor` itself has always taken one parameter. 5a no longer carries a
+  refactor.
+- **Slice 3's named owner `validateTrustedAuthorityMode` does not exist.** The capability is split:
+  mode validity sits in `validateGroupMutationFacts` (an untyped string list), and the
+  mode × operation matrix sits in `validateGroupMutationAuthority` →
+  `validateInternalMutationAuthority` → `validateFormationCriterionAuthority`
+  (`command-validation/validate-group-mutation-authority.ts`). Slice 3 extends both, not one
+  function. The current internal-mode union is
+  `'none' | 'expiry' | 'session-cleanup' | 'formation-criterion'` on
+  `GroupMutationFacts.internalAuthority` (`group-mutation-contracts.ts`).
+- **Slice 5's registry census is 18 files / ~23 sites**, not ~15 registries; the recovered list
+  adds `GROUP_MUTATION_INBOX_TYPES`, `AuthenticatedGroupMutationPayloadByType`,
+  `TARGET_GROUP_MUTATION_OPERATIONS`, `PRESENCE_GROUP_MUTATION_OPERATIONS`, the
+  `decodeGroupMutationOperation` 23-arm switch, the member result-validation switch, the route
+  contracts, and the black-box causal-evidence census
+  (`state-write-evidence/api-v1-state-write-group-causal-evidence.ts`).
+- **Slice 2 naming**: the aggregate allowlist is `GROUP_KEYS` in
+  `authoritative-state-validation.ts` (no symbol named `AUTHORITATIVE_STATE` exists). All four
+  hand-maintained lists sit at 31 keys with the same six-key formation tail. The serialized-JSON
+  pin lives at `group-state/inbox/group-state-inbox-transaction-result.test.ts`, and its key order
+  differs from `createTestGroup`'s — both need the append-at-end discipline independently.
+- **Slice 4a**: `RtcTopologySnapshotRepository` is **not** namespace/childKey-parameterisable on
+  current main — `RTC_TOPOLOGY_SNAPSHOTS_NAMESPACE` is a module constant, the constructor takes
+  only the runtime repository, and `childKey` exists only on the publication repository. The
+  accepted-layout slot is a small new surface (parameterise the namespace or add a sibling), not a
+  config flip. `DEFAULT_RTC_TOPOLOGY_PUBLICATION_RETENTION_MS` no longer exists; retention is
+  `RTC_TOPOLOGY_REPLAY_RETENTION_MS` (#345).
+- **Slice 4b / C6**: the five stage-blind topology write paths verify exactly (all in
+  `graph-topology-routes.ts`, all via `assertCanManageGroupRef` → business status only), plus a
+  sixth non-route path: `apps/api-v1/src/admin-operations/recompute-api-admin-topology.ts` issuing
+  `reconfigureTopology`. `isGroupTopologyPlannableAt` has exactly one production call site.
+- **Slice 8c**: `match.ts` is now a thin composition file; the readiness wait and the `sendJson`
+  fallback moved to `game/match/rallar-game-match-egress-runtime.ts`, with a second `sendJson` in
+  `game/transport/rallar-game-presence-egress-runtime.ts`. The five outbound dial entry points
+  verify and all converge on `ensurePeerConnectionStarted` → `computeRtcPeerDtoIfAbsent` (single
+  call site).
+- **Slice 11**: the deadline-hole premise changed on main. `e6a2faef6` flipped the formation-timer
+  handler's missing-plan path from silent early return to a thrown retry, so the pre-existing gap
+  is now unbounded retry while the planned read stays null, not a silently never-failed group. The
+  repair is still owed; its shape changed. Timer-id headroom is thin: `fnv1a64` renders ≤13
+  base-36 characters, so `ft-deadline-<epoch>-<hash>` sits near the 36-character cap.
+- **Slice 12**: `GroupEventType` is a 16-member string-literal union, not a `Record` — 12a's
+  "only the `Record<GroupEventType, true>` one is compiler-checked" claim must be re-derived when
+  that slice is selected. `validateGroupPresenceSummaryCausalRevision` (the watermark pattern to
+  copy) is module-private in `compute-group-presence-summary.ts`. The coalesced-work ownership is
+  split across three files (`rtc-topology-coalesced-group-revision-work.ts` computation/merge,
+  `coalesced-app-outbox-work-service.ts` generation CAS, `coalesced-app-outbox-work-envelope.ts`
+  metadata shape) — the #341/#343 shape; its exact-key metadata list lives in
+  `rtc-topology-work-codec.ts`.
+- **Pre-existing latent asymmetry, recorded for 1b**: `compute-formation-criterion-command.ts`
+  gates the criterion at line 43 on `establishing | reconfiguring` but the debounced petition path
+  at line 199 on `establishing` alone, so a `reconfiguring` group reaches the criterion only
+  through the timer path. 1b's total stage functions make this class of divergence impossible; 1a
+  renames both literals without changing the asymmetry.
+
+Current-main gates: `check:repo-structure`, `typecheck`, `typecheck:tests`, `test:repo-governance`,
+`test:deno`, `build`, `test:unit` pass on `9c8069be4` (the one `test:unit` failure was a
+machine-local Deno-rewired `node_modules/.bin/playwright` link, repaired and re-verified — not a
+repository fact). `format:check` fails on 25 files of pre-existing dprint drift from the #344–#350
+series — none in slice 1a's file set; branch CI does not run `format:check`, and the drift belongs
+to a maintainer formatting commit on `main`, not to a delivery PR. No state-write control was run:
+the selected work changes no mutation path.
+
 ## Corrections — resolved
 
 Four corrections changed a recorded product decision and have been ruled on. They are recorded here
@@ -190,13 +272,24 @@ shadow delivery schedule.
 
 ### 1a — The `establishing → connecting` rename
 
-**Lands:** the single rename everywhere in one commit — the enum in `group-lifecycle-policy.ts`;
-~20 production comparison literals; the three untyped runtime validators, each holding
+**Lands** (inventory corrected at the 2026-08-27 checkpoint): the single rename everywhere in one
+commit — the enum in `group-lifecycle-policy.ts`; the stage values inside `TRANSITION_SOURCES` and
+`TRANSITION_TARGETS`; the eight production stage literals in the topology-work predicates and one
+comment; the three untyped runtime validators, each holding
 `['forming', 'establishing', 'active', 'reconfiguring']` as a bare `readonly string[]`
-(`authoritative-state-validation.ts:433`, `group-state-delta.ts:193`,
-`validate-persisted-group.ts:110`); both OpenAPI enum lines; 23 recipe assertions across 8 files;
-~72 typed test literals; and the stage-derived identifiers in recipes and routes
-(`/lifecycle/establish/`, `start-establishment-{runId}`).
+(`authoritative-state-validation.ts`, `group-state-delta.ts`, `validate-persisted-group.ts`); both
+OpenAPI `lifecycleState` enum lines plus the two all-caps stage mentions in the establish/activate
+route descriptions; 23 recipe assertions across 9 files; 24 typed test literals across 10 files;
+the stage-derived recipe identifiers (`zeroEstablishingGroupId` and its references,
+`zero-establishing-room-{runId}`, `join-closed-establishing-{runId}`, one `recipe-matrix.json`
+scenario description); and the 19 stage-describing lines in
+`docs/rallar-group-formation-architecture.md`, so the doc stays truthful about the wire value until
+slice 14's full rewrite. The command-derived `/lifecycle/establish/` path and
+`start-establishment-{runId}` request id are **not** part of this rename — an earlier draft's
+parenthetical listing them contradicted I1, 5d and 8d; no occurrence of `establishment` anywhere in
+the repository is stage-derived, and the two words meet only at `group-lifecycle-transitions.ts`'s
+`'start-establishment': 'establishing'` entry, where the key is the command and the value is the
+stage.
 
 **Dark:** nothing. The value is on the wire the moment a group establishes. That is why it goes first
 and alone.
@@ -219,6 +312,13 @@ per transition. It cannot express `connect` landing in either `connecting` or `r
 `fail-formation` landing in `forming`, `active` **or** `dormant` (product decisions 28 and 35). **The
 table shape changes, not just its entries**, and product decision 41 fixes the replacement shape:
 keyed on `(stage, command) → stage`, so the next stage is a table entry rather than a refactor.
+Checkpoint addition (2026-08-27): `TRANSITION_SOURCES` is a co-equal second table in the same file —
+`Record<GroupLifecycleTransition, readonly GroupLifecycleState[]>`, the legality half, membership
+tested by a runtime `includes` — and the `(stage, command)` registry replaces **both**. Beyond
+`EVERY_LIFECYCLE_STATE`, the registry derivation also covers the hand-written stage arrays in
+`group-lifecycle-transitions.test.ts` and `group-admission-decision.test.ts` and the two
+three-element `as const` "every state except forming" subsets in `group-admission-decision.test.ts`
+and `group-topology-planning-service.test.ts`.
 
 The library: the seven-stage transition table with C2's landing rule and the `connect` precondition;
 `resolveDialLayoutRoles(stage) → none | planned | accepted | accepted-and-planned`; the complete
@@ -263,8 +363,13 @@ carrying no trigger, and `replanning: 'commanded'` with `server-auto` is the new
 minimum layout age, `after` settle time, presence fallback timer, per-preset
 `maxConcurrentEdgeSetups`, RTC setup timeout, status dwell, and the `active ↔ degraded` hysteresis
 width — as clamped constants with matrices. Note that the live debounce value now arrives as
-`topology.recompute.n` from the api-v1 configuration defaults, not from the exported
-`DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS`, which has no references at all and should be deleted.
+`topology.recompute.formationDebounceMs` (500 ms) from the api-v1 configuration defaults, not from
+the exported `DEFAULT_TOPOLOGY_RECOMPUTE_DEBOUNCE_MS`, which has no references at all and should be
+deleted. Checkpoint addition (2026-08-27): two more hand-maintained lists join this slice's edit
+inventory — the stored-policy exact-keys list in `decode-stored-group-lifecycle-policy.ts` (a new
+root policy key breaks every stored row unless the codec lands in the same change) and the
+configuration source allowlist in `decode-api-v1-configuration-source.ts`, which is separate from
+the decoder in `decode-api-v1-configuration.ts`.
 
 **Gates:** baseline + the policy matrix test.
 
@@ -440,9 +545,9 @@ stable-command translation return `undefined` and silently change the canonical 
 `toDescriptorCommand` has a `default:` arm that misroutes an unlisted operation into the _membership_
 builder; `GROUP_MUTATION_OPERATIONS` is an untyped `Set` of bare strings.
 
-- **5a — `plan` and `connect` plumbing, dark**: registered on no route, emitted by no producer. Also
-  refactors `mutationDescriptor` to a named input interface across its ~22 call sites (I16), before
-  four new commands inherit a seven-argument call site.
+- **5a — `plan` and `connect` plumbing, dark**: registered on no route, emitted by no producer.
+  (I16's `mutationDescriptor` refactor was found already complete at the 2026-08-27 checkpoint —
+  #338 landed the named `MutationDescriptorInput` — so 5a carries no refactor.)
 - **5b — `connect` semantics, dark**: binding the dialing stage to the expected planned identity — the
   expected-layout fence and the two typed denials `no-planned-layout` / `planned-layout-superseded` (product decision 32), and `plan`'s
   idempotence from `planned` (product decision 28). Needs 4b. The caller-supplied-expected-state shape


### PR DESCRIPTION
## Goal

Deliver slice 1a of `playground/rtc-design/2026-08-22-group-activation-implementation-plan.md`
(product decision 1: `establishing` is renamed `connecting`): one mechanical, value-complete rename
of the group lifecycle stage, landed first and alone so every later slice works in the final
vocabulary. Product decision 14 forbids the shim that would stage it.

The first commit carries the plan's initial Slice 0 checkpoint: the ten-surface census re-run
against `main` @ `9c8069be4` (post #329–#350), recorded as a plan amendment with the corrected
1a/1b/1c evidence folded into their sections. No numbered implementation decision is invalidated;
PR 2 remains slice 1b + 1c. Notable census verdicts: I16's `mutationDescriptor` refactor was
already completed by #338 (struck as a work item), slice 3's named owner
`validateTrustedAuthorityMode` does not exist (the capability is split across
`validateGroupMutationFacts` and `validateGroupMutationAuthority`), and the 1a parenthetical
naming `/lifecycle/establish/` contradicted I1/5d/8d and is struck.

## Changes

- `GroupLifecycleState` member `'establishing'` → `'connecting'`, and the stage values inside
  `TRANSITION_SOURCES` / `TRANSITION_TARGETS` (the `'start-establishment'` keys stay).
- The eight production stage literals (two criterion gates, one timer-handler gate, one comment)
  and the three untyped runtime validator arrays (`authoritative-state-validation.ts`,
  `group-state-delta.ts`, `validate-persisted-group.ts`).
- Both OpenAPI `lifecycleState` enum lines plus the two all-caps stage mentions in the
  establish/activate route descriptions.
- 23 recipe `lifecycleState` assertions across 9 black-box recipe files; the stage-derived recipe
  identifiers and step names (`zeroEstablishingGroupId` → `zeroConnectingGroupId`,
  `managerLeavesMidEstablishing` → `managerLeavesMidConnecting`, …); one `recipe-matrix.json`
  scenario description.
- 24 typed test literals across 10 test files, including `EVERY_LIFECYCLE_STATE`, `STATES`, and
  the `createEstablishingSnapshot` → `createConnectingSnapshot` helper.
- The 19 stage-describing lines in `docs/rallar-group-formation-architecture.md`, so the doc stays
  truthful about the wire value until slice 14's full rewrite.
- Plan document: the Slice 0 initial-checkpoint amendment and corrected 1a/1b/1c evidence.

Deliberately untouched: the `establishment` policy namespace, the `start-establishment` /
`reopen-establishment` commands, their `/lifecycle/establish` and `/lifecycle/reopen` routes and
request ids (command-derived; they retire in slices 5d/8d), and the two legitimate English uses of
"establishing" in `docs/test-structure-coupling-exceptions.md`.

## How the slice preserves the plan's three properties

1. **Absent policy behaves exactly as today**: the creation ternary in
   `create-initial-group-mutation.ts` (`'forming' : 'active'`) is untouched; no manifest, recipe,
   or app that omits `lifecyclePolicy` sees any behavioural change — only the transient stage's
   name on the wire.
2. **Membership, presence, admission and WS connectivity work in every stage**: the
   safety-baseline constant `EVERY_LIFECYCLE_STATE` renames in lockstep, so the baseline still
   enumerates all four stages; no predicate's shape changes.
3. **No stage command becomes reachable over HTTP**: no route, AppInbox type, or operation is
   added or removed.

## Acceptance

- `rg -i establishing` hits only the historical planning documents under `playground/rtc-design/`
  and the two protected English uses in `docs/test-structure-coupling-exceptions.md`. Verified.
- The value `connecting` is on the wire wherever `establishing` was: recipes assert it, OpenAPI
  declares it, and all three runtime validators accept it (and no longer accept `establishing`).

## Validation

All local gates passed; nothing was skipped:

| Command | Result |
| --- | --- |
| `npx dprint check` over the 30 changed files | passed |
| Focused vitest (the 10 directly affected test files + the policy matrix) | passed |
| `npm run typecheck` / `npm run typecheck:tests` | passed / passed |
| `npm run check:repo-style:changed -- origin/main HEAD` | passed |
| `npm run check:repo-structure` / `npm run test:repo-governance` | passed / passed |
| `npm run test:unit` (958 files) | passed |
| `npm run test:deno` | passed |
| `npm run build` | passed |
| `npm run test:api-v1:black-box:memory` | passed |
| `npm run test:api-v1:black-box:postgres` (fresh migrated DB) | passed — 32 + 6 cluster recipes, 0 failures |

The same current-main baseline was run on `9c8069be4` before branching (all passed after repairing
a machine-local Deno-rewired `node_modules/.bin/playwright` link). No medium-scale or state-write
run locally — no mutation semantics change — but CI's path classifier auto-triggered both the
**API v1 Medium-Scale Gate** and the **Topology Replay Gate** on this PR and both passed.

Note: repo-wide `npm run format:check` fails on `main` today from 25 files of pre-existing dprint
drift (the #344–#350 series), none of which this PR touches; the changed files are dprint-clean.

## Risk and rollback

The rename is value-complete in one commit; the known failure mode (a partial landing) fails at
runtime in the black-box recipes, which is why both profiles run here. No mutation semantics and no
persisted-shape change beyond the enum value: a reused local Postgres holding pre-rename group rows
or queued snapshots will fail exact-value validation on decode — drop and remigrate local databases
(hard cutover per product decision 14; nothing deployed needs migrating). Rollback is reverting the
rename commit.

## Follow-up

None.
