### PR TITLE
Fix the two server defects behind the formation-large managed-burst failures

### DIFF
--- a/.github/workflows/api-v1-formation-gate.yml
+++ b/.github/workflows/api-v1-formation-gate.yml
@@ -1,0 +1,77 @@
+name: API v1 Formation Gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/actions/api-v1-black-box-test/**'
+      - '.github/workflows/api-v1-formation-gate.yml'
+      - 'apps/api-v1/**'
+      - 'packages/shared/**'
+      - 'packages/shared-server/**'
+      - 'packages/shared-test/black-box-runner/**'
+      - 'packages/tests/shared-test/**'
+
+permissions:
+  contents: read
+
+jobs:
+  formation-large:
+    name: API v1 formation-large Postgres
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: appdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U app -d appdb"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://app:app@localhost:5432/appdb
+      RALLAR_API_CONFIGURATION_PROFILE: prod-in-memory
+      RALLAR_LOGIN_USER_RATE_LIMIT: '1000'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: npm ci
+      - name: Record exact checkout SHA
+        run: |
+          mkdir -p .artifacts/api-v1-black-box/formation-large
+          git rev-parse HEAD > .artifacts/api-v1-black-box/formation-large/validated-sha.txt
+          git write-tree > .artifacts/api-v1-black-box/formation-large/validated-tree.txt
+      - name: Run unchanged formation-large profile
+        uses: ./.github/actions/api-v1-black-box-test
+        with:
+          backend: postgres
+          api-port: '18080'
+          secondary-api-port: '18081'
+          tertiary-api-port: '18082'
+          artifact-dir: .artifacts/api-v1-black-box/formation-large
+          profile: api-v1-black-box-formation-large
+          run-id: '${{ github.run_id }}-${{ github.run_attempt }}-formation-large'
+      - name: Upload exact-SHA artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-v1-formation-large-${{ github.sha }}
+          path: |
+            .artifacts/api-v1-black-box/formation-large
+            .artifacts/api-v1-black-box/formation-large/api-v1-server.log
+            .artifacts/api-v1-black-box/formation-large/api-v1-server-secondary.log
+            .artifacts/api-v1-black-box/formation-large/api-v1-server-tertiary.log
+          if-no-files-found: error

--- a/apps/api-v1/src/composition/create-api-v1-topology-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-topology-services.ts
@@ -148,9 +148,12 @@ export function createApiV1TopologyServices(
                     sessionIds.has(command.rtt.sessionIdTo)
                 )
                 .map(({ ref }) => ref);
+            // Acceptance judges pair liveness durably: AppInbox executes RTT
+            // submits on any cluster server, and a server-local cache can lag
+            // the joins it is judging, permanently rejecting valid evidence.
             const candidateGroups = (
                 await Promise.all(
-                    groupRefs.map((ref) => input.groupStateService.readSnapshotAtLeast(ref, {}))
+                    groupRefs.map((ref) => groupStateRepository.readSnapshot(ref))
                 )
             ).filter((snapshot) => snapshot !== undefined);
             const overlaySnapshotsByGroupKey = new Map<string, RallarOverlayTopologySnapshot>();

--- a/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
@@ -8,18 +8,16 @@ import { GroupTopologyConfigRepository } from '@shared-server/rallar-system/topo
 import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
-import type { RuntimeStateReadBatchSelection, RuntimeStateReadBatchSelector } from '@shared-server/runtime-state/read-batch/runtime-state-read-batch.ts';
-import { selectRuntimeStateReadBatch } from '@shared-server/runtime-state/read-batch/select-runtime-state-read-batch.ts';
-import type { RuntimeStateEntry, RuntimeStateEntryPageOptions, RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
-import type { GroupPresenceSession, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { GroupMember, GroupPresenceSession, GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { createTestGroup } from '../../../../packages/tests/create-test-group.ts';
+import { FakeRuntimeStateRepository } from '../../../../packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts';
 import { createApiV1TopologyServices, type CreateApiV1TopologyServicesInput } from '../../src/composition/create-api-v1-topology-services.ts';
 
 const NOW_EPOCH_MS = 4_000_000_000_000;
 
 Deno.test('topology composition installs canonical owners and RTT policy inputs', async () => {
-    const runtimeStateRepository = new MemoryRuntimeStateRepository();
+    const runtimeStateRepository = new FakeRuntimeStateRepository();
     const snapshot = createGroupSnapshot();
     const formationEvents: unknown[] = [];
     const input: CreateApiV1TopologyServicesInput = {
@@ -65,12 +63,25 @@ Deno.test('topology composition installs canonical owners and RTT policy inputs'
         replay: { replayWakeCount: 2 }
     });
 
-    await services.groupStateRepository.putPresenceSession(
-        createPresenceSession('session-from', 'alice')
-    );
-    await services.groupStateRepository.putPresenceSession(
-        createPresenceSession('session-to', 'bob')
-    );
+    const sessionFrom = createPresenceSession('session-from', 'alice');
+    const sessionTo = createPresenceSession('session-to', 'bob');
+    await services.groupStateRepository.putGroup(snapshot.group);
+    await services.groupStateRepository.putMember(createActiveMember('alice'));
+    await services.groupStateRepository.putMember(createActiveMember('bob'));
+    await services.groupStateRepository.putPresenceSession(sessionFrom);
+    await services.groupStateRepository.putPresenceSession(sessionTo);
+    await services.groupStateRepository.insertPresenceSummary({
+        applicationId: 'app',
+        workspaceId: 'workspace',
+        groupId: 'group',
+        causalRevision: { groupRevision: 1, presenceRevision: 1 },
+        activePrincipalIds: ['alice', 'bob'],
+        activeSessionIds: ['session-from', 'session-to'],
+        activeSessions: [sessionFrom, sessionTo],
+        activePrincipalCount: 2,
+        activeSessionCount: 2,
+        computedAtEpochMs: 1
+    });
     assert.equal((await services.groupStateRepository.listAllPresenceSessions()).length, 2);
     const policy = await services.rtcRttMutationDependencies.readPolicyInputs({
         actor: { principalId: 'alice', sessionId: 'session-from' },
@@ -87,34 +98,42 @@ Deno.test('topology composition installs canonical owners and RTT policy inputs'
         }
     });
 
-    assert.deepEqual(policy.candidateGroups, [snapshot]);
+    // Candidates come from the durable repository, not the cached service: the
+    // stubbed cache snapshot has no active sessions, so a cache read here
+    // would judge the reporting pair dead.
+    assert.equal(policy.candidateGroups.length, 1);
+    assert.equal(policy.candidateGroups[0]!.group.groupId, 'group');
+    assert.deepEqual(
+        policy.candidateGroups[0]!.activeSessions.map((session) => session.sessionId).sort(),
+        ['session-from', 'session-to']
+    );
     assert.equal(policy.overlaySnapshotsByGroupKey.size, 0);
     assert.equal(policy.degreeLimit, 7);
     assert.deepEqual(formationEvents, []);
 });
 
-function createMinimalInput(): CreateApiV1TopologyServicesInput {
-    const runtimeStateRepository = new MemoryRuntimeStateRepository();
+function createActiveMember(principalId: string): GroupMember {
+    const audit = {
+        atEpochMs: 1,
+        actor: { kind: 'session' as const, principalId, sessionId: `session-${principalId}` },
+        reason: null,
+        traceId: null,
+        requestId: `join-${principalId}`
+    };
     return {
-        runtimeStateRepository,
-        groupStateRepository: new GroupStateRepository(
-            runtimeStateRepository,
-            new InMemoryGroupStateEventStore()
-        ),
-        groupStateService: { readSnapshotAtLeast: () => Promise.resolve(undefined) },
-        groupFormationRttMutation: () => {},
-        topologyOutboxWritten: () => undefined,
-        topologyReplayMetrics: {
-            readMetrics: () => ({}),
-            resetMetrics: () => {}
-        },
-        adminClientIds: [],
-        rtcTopologyOptions: {},
-        rttRefinementGateConfig: {
-            minIntervalMs: 30_000,
-            vivaldiDeltaThresholdMs: 5
-        },
-        nowEpochMs: () => NOW_EPOCH_MS
+        applicationId: 'app',
+        workspaceId: 'workspace',
+        groupId: 'group',
+        principalId,
+        role: principalId === 'alice' ? 'owner' : 'member',
+        status: 'active',
+        joined: audit,
+        updated: audit,
+        left: null,
+        removed: null,
+        banned: null,
+        invitedByPrincipalId: null,
+        invitationExpiresAtEpochMs: null
     };
 }
 
@@ -154,8 +173,8 @@ function createGroupSnapshot(): GroupSnapshot {
             workspaceId: 'workspace',
             groupId: 'group',
             displayName: 'Group',
-            activeMemberCount: 0,
-            ownerPrincipalId: 'owner',
+            activeMemberCount: 2,
+            ownerPrincipalId: 'alice',
             snapshotVersion: 1,
             metadataVersion: 1,
             rosterVersion: 1,
@@ -168,73 +187,4 @@ function createGroupSnapshot(): GroupSnapshot {
         memberCount: 0,
         onlineMemberCount: 0
     };
-}
-
-class MemoryRuntimeStateRepository implements RuntimeStateRepositoryLike {
-    private readonly entries = new Map<string, RuntimeStateEntry>();
-
-    findEntry(namespace: string, key: string): Promise<RuntimeStateEntry | undefined> {
-        return Promise.resolve(this.entries.get(`${namespace}:${key}`));
-    }
-
-    findAllEntries(namespace: string): Promise<readonly RuntimeStateEntry[]> {
-        return Promise.resolve(
-            [...this.entries.entries()]
-                .filter(([key]) => key.startsWith(`${namespace}:`))
-                .map(([, entry]) => entry)
-        );
-    }
-
-    async findEntriesByPrefixPage(
-        namespace: string,
-        keyPrefix: string,
-        options: RuntimeStateEntryPageOptions
-    ): Promise<readonly RuntimeStateEntry[]> {
-        return (await this.findAllEntries(namespace))
-            .filter((entry) =>
-                entry.key.startsWith(keyPrefix) &&
-                (options.afterKey === undefined || entry.key > options.afterKey)
-            )
-            .slice(0, options.limit);
-    }
-
-    readRuntimeStateBatch(
-        selectors: readonly RuntimeStateReadBatchSelector[]
-    ): Promise<readonly RuntimeStateReadBatchSelection[]> {
-        return Promise.resolve(selectRuntimeStateReadBatch(
-            selectors.flatMap((selector) =>
-                [...this.entries]
-                    .filter(([compositeKey]) => compositeKey.startsWith(`${selector.namespace}:`))
-                    .map(([, entry]) => ({ namespace: selector.namespace, entry }))
-            ),
-            selectors
-        ));
-    }
-
-    upsert(
-        namespace: string,
-        key: string,
-        value: string,
-        expireAtTimestamp: number
-    ): Promise<void> {
-        const identity = `${namespace}:${key}`;
-        const current = this.entries.get(identity);
-        this.entries.set(identity, {
-            key,
-            value,
-            expireAtTimestamp,
-            updatedTimestamp: new Date(0).toISOString(),
-            revision: current ? current.revision + 1 : 0
-        });
-        return Promise.resolve();
-    }
-
-    deleteByKey(namespace: string, key: string): Promise<void> {
-        this.entries.delete(`${namespace}:${key}`);
-        return Promise.resolve();
-    }
-
-    deleteExpired(): Promise<number> {
-        return Promise.resolve(0);
-    }
 }

--- a/packages/shared-server/rallar-system/topology/planning/rtc-topology-planner.ts
+++ b/packages/shared-server/rallar-system/topology/planning/rtc-topology-planner.ts
@@ -206,9 +206,12 @@ export class RtcTopologyPlanner {
     }
 
     readRttReportingDegreeLimit(options: RallarRtcTopologyServiceOptions): number {
-        return normalizeRttReportingDegreeLimit(
-            options.rttReportingDegreeLimit,
-            this.readDegreeLimit(options)
+        // A reporting limit below the planning degree limit would reject
+        // evidence for planned edges, so readiness could never cover the plan.
+        const degreeLimit = this.readDegreeLimit(options);
+        return Math.max(
+            normalizeRttReportingDegreeLimit(options.rttReportingDegreeLimit, degreeLimit),
+            degreeLimit
         );
     }
 

--- a/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-rtt-reporting-degree-limit.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/rtc-topology-rtt-reporting-degree-limit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { RtcTopologyPlanner } from '@shared-server/rallar-system/topology/planning/rtc-topology-planner.ts';
+import { RtcTopologyMetrics } from '@shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts';
+
+function createPlanner(): RtcTopologyPlanner {
+    return new RtcTopologyPlanner({}, { metrics: new RtcTopologyMetrics(), durationNowMs: () => 0 });
+}
+
+describe('RTC topology RTT reporting degree limit resolution', () => {
+    // A reporting limit below the planning degree limit structurally rejects
+    // evidence for planned edges, so a raised per-group planning limit must
+    // raise the reporting limit with it even when the server sets its own
+    // reporting value (the api-v1 configuration always does).
+    it('never resolves the reporting limit below the effective planning degree limit', () => {
+        const resolved = createPlanner().readRttReportingDegreeLimit({
+            degreeLimit: 24,
+            rttReportingDegreeLimit: 5
+        });
+
+        expect(resolved).toBe(24);
+    });
+
+    it('lets the server reporting value raise the limit above the planning degree', () => {
+        const resolved = createPlanner().readRttReportingDegreeLimit({
+            degreeLimit: 5,
+            rttReportingDegreeLimit: 12
+        });
+
+        expect(resolved).toBe(12);
+    });
+
+    it('resolves matching planning and reporting values unchanged', () => {
+        const resolved = createPlanner().readRttReportingDegreeLimit({
+            degreeLimit: 5,
+            rttReportingDegreeLimit: 5
+        });
+
+        expect(resolved).toBe(5);
+    });
+
+    it('falls back to the planning degree limit when no server reporting value is set', () => {
+        const resolved = createPlanner().readRttReportingDegreeLimit({
+            degreeLimit: 8
+        });
+
+        expect(resolved).toBe(8);
+    });
+});

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-runtime-integration.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-runtime-integration.test.ts
@@ -211,7 +211,9 @@ describe('RTC topology process runtime integration', () => {
         const metrics = new RtcTopologyMetrics();
         const times = [10, 17];
         const planner = new RtcTopologyPlanner(
-            { topologyKind: 'tree', rttReportingDegreeLimit: 1 },
+            // Reporting resolves no lower than the planning degree limit, so the
+            // sparse setup pins both limits to 1.
+            { topologyKind: 'tree', degreeLimit: 1, rttReportingDegreeLimit: 1 },
             { metrics, durationNowMs: () => times.shift() ?? 17 }
         );
 
@@ -239,7 +241,9 @@ describe('RTC topology process runtime integration', () => {
         const metrics = new RtcTopologyMetrics();
         let clockReads = 0;
         const planner = new RtcTopologyPlanner(
-            { topologyKind: 'tree', rttReportingDegreeLimit: 1 },
+            // Reporting resolves no lower than the planning degree limit, so the
+            // sparse setup pins both limits to 1.
+            { topologyKind: 'tree', degreeLimit: 1, rttReportingDegreeLimit: 1 },
             {
                 metrics,
                 durationNowMs: () => {


### PR DESCRIPTION
## Problem

`bb:api-v1:postgres:formation-large` fails on main (verified at 9c8069be4 and at current head, on both a loaded and a quiet machine): the two managed-burst recipes park in `establishing` with `observedRate < 1` and `thresholdActivatesAtScale` times out. Neither hypothesis from the report survives alone — it is not machine load, and the outcome never arrives as `activated-degraded`. Two stacked server defects cause it; the recipe constants are untouched.

## Root causes

**1. #317 regressed the RTT reporting degree-limit resolution** (`f26f65685`, Aug 23). The api-v1 configuration ownership change made `topology.planning.rttReportingDegreeLimit` an always-present value (5). `normalizeRttReportingDegreeLimit(serverValue, groupFallback)` prefers a defined server value, so the per-group `degreeLimit: 24` the recipes PUT (and that f9cbfb637 wired in as "honor per-group degree limits in RTT acceptance") became dead: acceptance rejected most of the all-pairs burst as `not-reporting-edge`/`over-degree` (119 + 24 of 190 at N=20, measured). Fixed in `RtcTopologyPlanner.readRttReportingDegreeLimit` by clamping the resolution to no lower than the effective planning degree limit — a reporting limit below the plannable degree structurally prevents readiness from ever covering the plan.

**2. RTT acceptance judged pair liveness on a stale cache — red from birth.** RTC_RTT_SUBMIT commands execute on whichever cluster server claims them from the shared AppInbox queue, but `readPolicyInputs` read candidate group snapshots via `readSnapshotAtLeast(ref, {})` — the executing server's cache with no causal floor. Non-primary servers lagging the join burst rejected valid pairs as `no-shared-active-group` (terminal; measured 2–95 pairs per run, only ever on secondary/tertiary). The profile fails identically at the recipes' own last commit `0bcbbeb33`, so it has never been green on a real three-server cluster. Fixed by reading candidates durably from the group-state repository, matching the session query that discovers them. Handler cost is p50 13.4ms / p95 21.5ms.

The large tier's `observedEdgeCount: 0` at poll end is a red herring: the recipe stamps all evidence with one pre-burst timestamp, so once the poll exhausts, everything is past the 60s freshness window.

## CI

The profile is executed by no workflow, which is why #317 went unnoticed. This adds `api-v1-formation-gate.yml`, a path-filtered PR workflow mirroring `api-v1-medium-scale-gate.yml`, running the profile through the existing `api-v1-black-box-test` action (`api-v1-black-box-formation-large` is already in `MANAGED_API_V1_CLUSTER_PROFILES`).

## Validation

- `bb:api-v1:postgres:formation-large`: **passed=4 failed=0, twice consecutively** (managed-medium 9.8s/22.5s, managed-large 37.1s — previously 66s/107s timeouts). Second run on an isolated pinned Postgres after the shared dev container was recreated mid-run twice by concurrent activity.
- `bb:api-v1:postgres:medium-scale` (mutation-path convergence gate): passed, 2754/2754.
- `npm run test:unit` 7946 passed; api-v1 `deno task test` and `deno task check` green; `npm run typecheck` green; `check:repo-style` and `check:repo-style:changed origin/main HEAD` clean; `test:repo-governance` 401 passed.
- New unit test pins the degree-limit resolution; the reworked composition test proves acceptance reads the durable snapshot a stale cache does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)