### PR TITLE
Repair the RTT filter test fixture for the reporting-limit floor

### DIFF
--- a/apps/api-v1/test/db/pglite-topology-command.test.ts
+++ b/apps/api-v1/test/db/pglite-topology-command.test.ts
@@ -160,7 +160,7 @@ Deno.test(
             };
             const group = topologyGroupSnapshotWithSessionIds(
                 groupRef,
-                ['session-a', 'session-b', 'session-c'],
+                ['session-a', 'session-b', 'session-c', 'session-d'],
                 nowEpochMs
             );
             const runtime = new PSqlRuntimeStateRepository(sql);
@@ -208,11 +208,15 @@ Deno.test(
                     return super.planGroupTopologyAt(...args);
                 }
             }
+            // The reporting limit resolves no lower than the planning degree
+            // limit, so a non-reporting pair needs both endpoints at full
+            // planned degree: a four-session ring keeps every selection
+            // exactly the planned hops and leaves the a-c chord outside.
             const topologyService = new RecordingTopologyService({
                 now: () => nowEpochMs,
                 topologyKind: 'tree',
                 degreeLimit: 2,
-                rttReportingDegreeLimit: 1
+                rttReportingDegreeLimit: 2
             });
             const service = createGroupTopologyRuntimeOwners({
                 findGroupSnapshotByRef: () => group,
@@ -226,17 +230,18 @@ Deno.test(
                 serverDefaults: {
                     topologyKind: 'tree',
                     degreeLimit: 2,
-                    rttReportingDegreeLimit: 1
+                    rttReportingDegreeLimit: 2
                 }
             });
             const previous = activeTopologySnapshot({
                 groupRef,
                 sourceGroupStateCausalRevision: { groupRevision: 1, presenceRevision: 1 },
-                activeSessionIds: ['session-a', 'session-b', 'session-c'],
+                activeSessionIds: ['session-a', 'session-b', 'session-c', 'session-d'],
                 nextHopsBySessionId: {
-                    'session-a': ['session-b'],
+                    'session-a': ['session-b', 'session-d'],
                     'session-b': ['session-a', 'session-c'],
-                    'session-c': ['session-b']
+                    'session-c': ['session-b', 'session-d'],
+                    'session-d': ['session-a', 'session-c']
                 }
             });
             const authority = await service.planning.readTopologyPlanningAuthority({


### PR DESCRIPTION
## Problem

Main is red since #357 merged: the Release Gate inside `Deploy Web + API` fails in the api-v1 Deno suite —

`PGlite topology planning filters RTTs outside recomputed group reporting edges` (`apps/api-v1/test/db/pglite-topology-command.test.ts:250`), expecting `plannedRtts` to be `[]` and getting the stored `session-a`↔`session-c` measurement. First failing push run: 33088988200. The Release Gate passed on the previous main push (#351), whose Deploy failed only at the pre-existing `Verify Deno Deploy access` step, so #357 introduced this failure. (It was also visible in the branch validation logs before merge — the suite printed `505 passed | 1 failed` — but a `tail` pipe masked the exit code and it was read as green. That miss is mine.)

## Why the test broke

#357 made the RTT reporting limit resolve no lower than the effective planning degree limit — the invariant the formation recipes depend on. This fixture encoded the now-forbidden configuration (reporting 1 under planning degree 2): with three sessions and an effective limit of 2, rendezvous padding makes every pair a reporting pair, so the a–c measurement can no longer be filtered. The production behavior the test protects — planning drops measurements outside the reporting selection — is intact.

## Fix

Give the fixture a four-session ring at matching limits (2/2). Every endpoint sits at full planned degree, each reporting selection is exactly its planned hops, and the a–c chord stays deterministically outside them, so the filter assertion is meaningful again. Same repair shape as the two sparse-fallback tests adjusted in #357 itself.

## Validation

- `apps/api-v1` `deno task test`: 506 passed | 0 failed (summary line verified, not just exit code).
- Remaining `test:deno` stages: control server 84/84, relic server check+test 5/5, shared-test scenario files 146/146 (run from a workspace with `node_modules`; a fresh worktree without it makes the scenario CLI subprocess exit 1 across the board — environmental, not code).
- Not run here: e2e/full-stack — the branch Release Gate covers them on this PR.

Pre-existing failures this PR does not address: `Verify Deno Deploy access` in Deploy (failing on every main push since at least #347) and the Hetzner manifest trio 03/04/05a (identical failure set before and after #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)