### PR TITLE
Stop the agent bootstrap reset from faulting the browser runtime

### DIFF
--- a/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/runtime.ts
+++ b/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/runtime.ts
@@ -1163,7 +1163,10 @@ function createBlackBoxRallarRuntimeInstallation(
                 logout = true;
                 emitDiagnostic(config, 'rallar.browser.cleanup.logout_completed');
             }
-            else {
+            // Disconnecting a facade this runtime never connected reaches browser
+            // state caches that exist only after authentication, and the throw
+            // faults the runtime for the rest of the page's life.
+            else if (config || rallar.isConnected()) {
                 if (config) {
                     emitDiagnostic(config, 'rallar.browser.cleanup.disconnect_started');
                 }

--- a/packages/shared-test/rallar-bb-test/browser-adapter.ts
+++ b/packages/shared-test/rallar-bb-test/browser-adapter.ts
@@ -3013,9 +3013,9 @@ class BrowserCommandAdapter {
     ): Promise<{
         webSocketCount: number;
         rallar?: unknown;
-        errors?: unknown[];
+        errors?: BrowserAdapterCloseFailure[];
     }> {
-        const errors: unknown[] = [];
+        const errors: BrowserAdapterCloseFailure[] = [];
         const webSockets = [...this.webSockets.entries()];
         webSockets.forEach(([connection, socket]) => {
             try {
@@ -3052,7 +3052,13 @@ class BrowserCommandAdapter {
         }
 
         if (errors.length > 0 && !options.tolerant) {
-            throw new Error('Failed to close one or more browser adapter resources.');
+            // The collected causes are the only record of why a close failed:
+            // the adapter runs in the agent browser and its throw is all the
+            // fleet artifact keeps.
+            throw new Error(
+                `Failed to close one or more browser adapter resources: ${toBrowserCloseFailureSummary(errors)}`,
+                { cause: errors[0]?.error }
+            );
         }
 
         return {
@@ -3080,4 +3086,19 @@ export function createRallarBlackBoxBrowserTestRuntime(
             runtime.recordEvent(toRallarBrowserEventInput(event));
         }
     });
+}
+
+interface BrowserAdapterCloseFailure {
+    readonly connection: string;
+    readonly error: unknown;
+}
+
+function toBrowserCloseFailureSummary(
+    failures: readonly BrowserAdapterCloseFailure[]
+): string {
+    return failures
+        .map((failure) =>
+            `${failure.connection}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`
+        )
+        .join('; ');
 }

--- a/packages/tests/shared-test/rallar-bb-browser-adapter-close-failure.test.ts
+++ b/packages/tests/shared-test/rallar-bb-browser-adapter-close-failure.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { expect, it } from 'vitest';
+import { createRallarBlackBoxBrowserTestRuntime } from '../../shared-test/rallar-bb-test/browser-adapter.ts';
+
+const REPOSITORY_ERROR_MESSAGE = 'Repository not found: shared.repository.group-state-snapshots';
+
+function createRuntimeWithFailingClose(): ReturnType<typeof createRallarBlackBoxBrowserTestRuntime> {
+    return createRallarBlackBoxBrowserTestRuntime({
+        rallarRuntime: {
+            authenticate: async () => ({ status: 'authenticated' }),
+            connect: async () => ({ status: 'connected' }),
+            send: async () => ({ sent: true }),
+            refreshRoom: async () => undefined,
+            close: async () => {
+                throw new Error(REPOSITORY_ERROR_MESSAGE);
+            },
+            health: async () => ({ connected: true })
+        }
+    });
+}
+
+it('names the failing resource and keeps its cause when a reset cannot close', async () => {
+    // The agent runs in a browser, so this throw is the only record of the
+    // failure that reaches the fleet artifact.
+    const runtime = createRuntimeWithFailingClose();
+
+    const result = await runtime.execute({
+        kind: 'reset',
+        commandId: 'reset-control-1'
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.message).toContain('rallar');
+    expect(result.error?.message).toContain(REPOSITORY_ERROR_MESSAGE);
+});

--- a/packages/tests/shared-test/rallar-browser-runtime/browser-rallar-runtime-test-harness.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/browser-rallar-runtime-test-harness.ts
@@ -6,14 +6,16 @@ import {
     facadeRecords,
     facadeSession,
     rallarFacadeTestDouble,
-    resetBrowserRuntimeFacadeTestDouble
+    resetBrowserRuntimeFacadeTestDouble,
+    setFacadeConnected
 } from './browser-runtime-facade-test-double.ts';
 
 export const facade = {
     behavior: facadeBehavior,
     records: facadeRecords,
     session: facadeSession,
-    rallar: rallarFacadeTestDouble
+    rallar: rallarFacadeTestDouble,
+    setConnected: setFacadeConnected
 };
 
 interface TestWindow {

--- a/packages/tests/shared-test/rallar-browser-runtime/browser-runtime-facade-test-double.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/browser-runtime-facade-test-double.ts
@@ -82,6 +82,13 @@ const records: BrowserRuntimeFacadeRecords = {
     directorAppointments: []
 };
 
+let facadeConnected = true;
+
+/** Mirrors a page facade that has never connected, as on a freshly loaded agent. */
+export function setFacadeConnected(connected: boolean): void {
+    facadeConnected = connected;
+}
+
 export const facadeSession: AuthSession = {
     clientId: 'client-1',
     accessToken: 'access-token-1',
@@ -298,7 +305,7 @@ export const rallarFacadeTestDouble: BlackBoxBrowserRallarRuntimeDependency = {
         await facadeBehavior.disconnect();
     },
     status: () => 'connected',
-    isConnected: () => true,
+    isConnected: () => facadeConnected,
     session: () => facadeSession,
     auth,
     rooms,
@@ -313,6 +320,7 @@ export const rallarFacadeTestDouble: BlackBoxBrowserRallarRuntimeDependency = {
 export function resetBrowserRuntimeFacadeTestDouble(): void {
     vi.resetAllMocks();
     clearRecords();
+    facadeConnected = true;
     facadeBehavior.login.mockResolvedValue(facadeSession);
     facadeBehavior.registerAndLogin.mockResolvedValue(facadeSession);
     facadeBehavior.logout.mockResolvedValue(undefined);

--- a/packages/tests/shared-test/rallar-browser-runtime/runtime-lifecycle.test.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/runtime-lifecycle.test.ts
@@ -207,6 +207,48 @@ it('deduplicates concurrent close cleanup', async () => {
     expect(facade.records.realtimeUnsubscribeCount).toBe(1);
 });
 
+it('closes a never-connected runtime without disconnecting the page facade', async () => {
+    // A headless agent resets at bootstrap, before anything connects. Reaching
+    // into the page facade there hits browser caches that only exist after
+    // authentication, and a throwing close faults the runtime for good.
+    facade.setConnected(false);
+    facade.behavior.disconnect.mockRejectedValue(
+        new Error('Repository not found: shared.repository.group-state-snapshots')
+    );
+    const runtime = await loadRuntime();
+
+    const closeResult = await runtime.close();
+
+    expect(facade.records.disconnectCount).toBe(0);
+    expect(closeResult).toMatchObject({
+        status: 'closed',
+        disconnected: false,
+        cleanupErrors: []
+    });
+});
+
+it('authenticates after a close that found nothing to clean up', async () => {
+    facade.setConnected(false);
+    facade.behavior.disconnect.mockRejectedValue(
+        new Error('Repository not found: shared.repository.group-state-snapshots')
+    );
+    const runtime = await loadRuntime();
+    await runtime.close();
+
+    const session = await runtime.authenticate({
+        connection: 'aliceRtc',
+        actor: 'alice',
+        roomId: 'room-1',
+        rallar: {
+            apiBaseUrl: 'https://api.example.test',
+            username: 'alice',
+            password: 'secret'
+        }
+    });
+
+    expect(session).toBeDefined();
+});
+
 it('fences send completion after runtime close without serializing sends', async () => {
     const send = createDeferred<readonly RallarRealtimeSendResult[]>();
     facade.behavior.realtimeSend.mockReturnValueOnce(send.promise);


### PR DESCRIPTION
## Problem

The three RTC-flavoured Hetzner manifests — `03-rtc-smoke-2-agent`, `04-provider-parity-2-agent`, `05a-rtc-realtime-stability-2-agent-5s` — fail on every main push that actually executes them, while `01-health` and `02-composite-evidence` pass. The passing pair only runs `health`/`stats`; the failing three are exactly the manifests that authenticate. All three fail with the same pair of messages:

```
reset-control-1 : Failed to close one or more browser adapter resources.
recipe          : Authentication was cancelled because the Rallar runtime closed.
```

(The occasional green Hetzner run is a path-filtered no-op that skips the matrix — 40s versus 8–16 minutes.)

## Root cause

Evidence: `rallar.browser.close_failed` in the fleet artifact carries `Error: Repository not found: shared.repository.group-state-snapshots`, thrown from a `disconnected` handler → `state()` → `readGroupSnapshots`. The event timeline shows it **6 ms after `rallar.browser.runtime_loaded`**, before anything connects.

1. The headless agent runs `reset` at bootstrap (`browser-control-agent.ts`, `commandId: reset-control-1`).
2. `reset` closes the black-box Rallar runtime, whose close effect called `rallar.disconnect()` unconditionally.
3. Disconnecting a facade that never connected emits a state notification that reads the group-state snapshot repository — but the browser configures those caches in `initialiseBrowserRuntimeStores(sessionId)`, i.e. only after authentication. So the disconnect throws.
4. The lifecycle controller latches `faulted = true` on a failed close and clears it only on a later *successful* close, so every subsequent `runAuthentication` rejects with "Authentication was cancelled because the Rallar runtime closed".
5. The runtime is created once per page load (`createRallarBlackBoxBrowserControlAgent`) and `rallarRuntime` is `readonly`, so the fault outlives every recipe that worker serves.

Health-only manifests never authenticate, which is exactly why they pass.

## Fix

Disconnect only a facade this runtime configured, or one still connected (`config || rallar.isConnected()`). On a fresh agent both are false — `isConnected()` requires connect state `connected` *and* middleware — so the pristine close now succeeds, leaves the lifecycle unfaulted, and the next recipe authenticates. After a real recipe a config exists, so teardown is unchanged.

Second, smaller change: `closeOwnedResources` collected per-resource causes and then threw a bare message, discarding them. That is why the fleet artifact named neither the resource nor the cause, and why this took artifact forensics rather than a read of `failures.json`. The throw now names the resource and its cause and sets `cause`.

## Validation

- New test reproduces the fleet exactly (fails before the fix): closing a never-connected runtime whose `disconnect()` throws the repository error, plus a second test proving authentication still works afterwards — the permanent poisoning.
- New test pins the adapter's close error to name resource and cause.
- `packages/tests/shared-test` + `packages/tests/rallar-black-box`: 2473 passed. Browser-runtime suite 71 passed.
- `npm run test:unit`: 7949 passed, 0 failed (summary line verified).
- `tsc -p packages/shared-test`, dprint, and `check:repo-style:changed origin/main HEAD` all clean.

Not verified here: the fleet itself. The agents load the SPA bundle from `blackbox.rallar.intactss.com`, so this reaches them only after a successful deploy — and the Cloudflare SPA build jobs have been skipped while main's Release Gate was red. Expected order is #358 green → deploy runs → next main-push manifest run exercises the fix.

Out of scope, worth a follow-up: `rallar.disconnect()` on a never-connected facade throwing at all is a shared-web robustness gap; this PR avoids the call rather than changing production browser code. The `faulted` latch with no recovery path other than a successful close is also worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)