### PR TITLE
Let a pre-connect state emit find no caches instead of throwing

### DIFF
--- a/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/lifecycle-controller.ts
+++ b/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/lifecycle-controller.ts
@@ -63,6 +63,15 @@ export function createBlackBoxRallarLifecycleController<TConfig, TSession, TConn
 
     const isCurrent = (candidate: number): boolean => candidate === generation && !closeInFlight && !faulted;
 
+    /**
+     * A failed close still aborted every operation it fenced, and its owner
+     * discards the state it could not close. Staying faulted beyond that would
+     * strand a runtime that lives as long as its page.
+     */
+    const clearFailedCloseFault = (): void => {
+        faulted = false;
+    };
+
     const assertConnectionCurrent = (candidate: number): void => {
         if (!isCurrent(candidate)) {
             throw options.connectionClosedError();
@@ -73,9 +82,10 @@ export function createBlackBoxRallarLifecycleController<TConfig, TSession, TConn
         config: TConfig,
         effect: (signal: AbortSignal) => Promise<TSession>
     ): Promise<TSession> => {
-        if (closeInFlight || faulted) {
+        if (closeInFlight) {
             return Promise.reject(options.authenticationClosedError());
         }
+        clearFailedCloseFault();
 
         const key = options.authenticationKey(config);
         const active = authenticationInFlight;
@@ -131,9 +141,10 @@ export function createBlackBoxRallarLifecycleController<TConfig, TSession, TConn
         key: string,
         effect: (context: BlackBoxRallarLifecycleOperationContext) => Promise<TResult>
     ): Promise<TResult> => {
-        if (closeInFlight || faulted) {
+        if (closeInFlight) {
             return Promise.reject(options.connectionClosedError());
         }
+        clearFailedCloseFault();
 
         const active = connectInFlight;
         if (active) {

--- a/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/runtime.ts
+++ b/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/runtime.ts
@@ -1237,6 +1237,11 @@ function createBlackBoxRallarRuntimeInstallation(
                 return diagnostics;
             }
             catch (error) {
+                // Cleanup already dropped this runtime's subscriptions, so it
+                // must stop naming the target it tried to leave. closeRetryConfig
+                // survives so a later close can still reach that target.
+                state = undefined;
+                authenticationState = undefined;
                 throw error;
             }
         }, activeCrdtOpens);

--- a/packages/shared-web/browser/rooms/room-state-store.ts
+++ b/packages/shared-web/browser/rooms/room-state-store.ts
@@ -9,6 +9,7 @@ import { toGroupRefFromScope } from '@shared/api/api-type-utils.ts';
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import { isGroupActive, isSessionInGroup, readGroupVersion } from '@shared/api/group-client-views.ts';
 import { DEFAULT_STATE_WORKSPACE_ID } from '@shared/api/state-types.ts';
+import { readConfiguredValue } from '@shared/cache/RepositoryManager.ts';
 
 import type { RallarStateCacheReadPort } from '../state-cache/rallar-state-store.ts';
 import type { RallarRoomState } from './rallar-room-contracts.ts';
@@ -91,8 +92,13 @@ class RoomStateStore implements RallarRoomStateStorePort {
         options: RallarOnChangeOptions = {}
     ): RallarUnsubscribe {
         this.#listeners.add(listener);
-        if (options.emitCurrent ?? true) {
-            notifyListener(listener, this.state());
+        // Subscribing before a first connect is ordinary; the caches it would
+        // read do not exist yet, and this delivery is a notification.
+        const current = (options.emitCurrent ?? true)
+            ? readConfiguredValue(() => this.state())
+            : undefined;
+        if (current) {
+            notifyListener(listener, current);
         }
         return () => this.#listeners.delete(listener);
     }

--- a/packages/shared-web/browser/session/session-auth-lifecycle.ts
+++ b/packages/shared-web/browser/session/session-auth-lifecycle.ts
@@ -223,7 +223,10 @@ export class BrowserSessionAuthLifecycle implements RallarSessionAuthLifecycle {
         const delayMs = Math.max(0, session.expiresAtEpochMs - Date.now());
         this.input.authRuntime.setAuthExpiryTimer(
             setTimeout(
-                () => void this.expireAuthSessionIfCurrent(session),
+                () =>
+                    void this.expireAuthSessionIfCurrent(session).catch((error) =>
+                        console.error('Failed to expire the Rallar auth session', error)
+                    ),
                 Math.min(delayMs, MAX_AUTH_EXPIRY_TIMEOUT_MS)
             )
         );
@@ -259,10 +262,12 @@ export class BrowserSessionAuthLifecycle implements RallarSessionAuthLifecycle {
         const dataCleanupError = session
             ? await this.cleanupEndedSession(session)
             : undefined;
-        this.input.emitState();
+        // Listeners learn the session ended only from emitAuthState, so a failing
+        // state emit must not stand between them and that notification.
+        const stateEmitError = captureSyncError(() => this.input.emitState());
         this.emitAuthState(reason, undefined);
 
-        const failure = disconnectError ?? revokeError ?? dataCleanupError;
+        const failure = disconnectError ?? revokeError ?? dataCleanupError ?? stateEmitError;
         if (failure) {
             throw failure;
         }
@@ -305,6 +310,18 @@ async function revokeAuthSession(
         (signal) => authApi.logoutFromApi({ requestId, signal, authSession: session }),
         toRallarCommandOptions(operationOptions)
     ).run();
+}
+
+function captureSyncError(operation: () => void): Error | undefined {
+    try {
+        operation();
+        return undefined;
+    }
+    catch (error) {
+        return error instanceof Error
+            ? error
+            : new Error('Rallar session operation failed.');
+    }
 }
 
 async function captureError(operation: () => Promise<void>): Promise<Error | undefined> {

--- a/packages/shared-web/browser/state-cache/rallar-state-store.ts
+++ b/packages/shared-web/browser/state-cache/rallar-state-store.ts
@@ -7,6 +7,7 @@ import type {
     RallarStateListener,
     RallarUnsubscribe
 } from '@shared-web/browser/rallar-shared-contracts.ts';
+import type { RallarRoomState } from '@shared-web/browser/rooms/rallar-room-contracts.ts';
 import type { RallarRoomStateStorePort } from '@shared-web/browser/rooms/room-state-store.ts';
 import { browserStateCacheLifecycle } from '@shared-web/browser/state-cache/browser-state-cache-lifecycle.ts';
 import type { AuthSession, ClientInfo } from '@shared/api/api-config.ts';
@@ -14,6 +15,7 @@ import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import { readActiveClientSessionIds } from '@shared/api/group-client-views.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { DEFAULT_STATE_WORKSPACE_ID, type StateScope } from '@shared/api/state-types.ts';
+import { readConfiguredValue } from '@shared/cache/RepositoryManager.ts';
 import * as clientStateSnapshotsRepository from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupStateSnapshotsRepository from '@shared/repository/group-state-snapshots-repository.ts';
 
@@ -65,6 +67,11 @@ export function createRallarStateCacheReadPort(): RallarStateCacheReadPort {
 }
 
 export namespace RallarStateStore {
+    export interface EmittableState {
+        readonly room: RallarRoomState;
+        readonly people: RallarPeopleState;
+    }
+
     export interface Input {
         readonly runtime: RallarStateRuntimePort;
         readonly roomStateStore: RallarRoomStateStorePort;
@@ -107,15 +114,28 @@ export class RallarStateStore implements RallarStatePort {
     }
 
     emit(): void {
-        const roomState = this.#input.roomStateStore.state();
-        const peopleState = this.peopleState();
-        this.#input.roomStateStore.emit(roomState);
+        const state = this.readEmittableState();
+        if (!state) {
+            return;
+        }
+        this.#input.roomStateStore.emit(state.room);
         for (const listener of this.#peopleStateListeners) {
-            notifyListener(listener, peopleState);
+            notifyListener(listener, state.people);
         }
         for (const listener of this.#afterEmitListeners) {
-            listener();
+            notifyListener(listener, undefined);
         }
+    }
+
+    /**
+     * Connect configures the snapshot repositories, so disconnect and logout can
+     * both emit before they exist. There is no state to report until then.
+     */
+    private readEmittableState(): RallarStateStore.EmittableState | undefined {
+        return readConfiguredValue(() => ({
+            room: this.#input.roomStateStore.state(),
+            people: this.peopleState()
+        }));
     }
 
     onAfterEmit(listener: () => void): RallarUnsubscribe {
@@ -140,8 +160,11 @@ export class RallarStateStore implements RallarStatePort {
         options: RallarOnChangeOptions = {}
     ): RallarUnsubscribe {
         this.#peopleStateListeners.add(listener);
-        if (options.emitCurrent ?? true) {
-            notifyListener(listener, this.peopleState());
+        const current = (options.emitCurrent ?? true)
+            ? readConfiguredValue(() => this.peopleState())
+            : undefined;
+        if (current) {
+            notifyListener(listener, current);
         }
         return () => this.#peopleStateListeners.delete(listener);
     }

--- a/packages/shared-web/browser/state-read/reconciliation.ts
+++ b/packages/shared-web/browser/state-read/reconciliation.ts
@@ -1,6 +1,7 @@
 import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
+import { readConfiguredValue } from '@shared/cache/RepositoryManager.ts';
 import * as clientSnapshots from '@shared/repository/client-state-snapshots-repository.ts';
 import * as groupSnapshots from '@shared/repository/group-state-snapshots-repository.ts';
 
@@ -25,15 +26,7 @@ export function captureStateSnapshotCollectionObservations(
 }
 
 function readConfiguredSnapshots<T>(read: () => T[]): T[] {
-    try {
-        return read();
-    }
-    catch (error) {
-        if (error instanceof Error && error.message.startsWith('Repository not found:')) {
-            return [];
-        }
-        throw error;
-    }
+    return readConfiguredValue(read) ?? [];
 }
 
 export function reconcileCompleteStateSnapshotCollections(

--- a/packages/shared/cache/RepositoryManager.ts
+++ b/packages/shared/cache/RepositoryManager.ts
@@ -2,6 +2,34 @@ import { DisposableRepository, RepositoryToken } from './RepositoryToken.ts';
 
 type ManagedRepository = unknown;
 
+const REPOSITORY_NOT_FOUND_PREFIX = 'Repository not found: ';
+
+/**
+ * Matches on the message because `require` throws a plain `Error`, and test
+ * doubles across the repository reproduce that literal text; a named error type
+ * cannot be introduced without rewriting all of them.
+ */
+export function isRepositoryNotFoundError(error: Error): boolean {
+    return error.message.startsWith(REPOSITORY_NOT_FOUND_PREFIX);
+}
+
+/**
+ * Reads a value that needs a configured repository, reporting nothing when the
+ * repository is absent. For notification paths, whose callers never asked for
+ * state; a caller that reads state directly still gets the failure.
+ */
+export function readConfiguredValue<T>(read: () => T): T | undefined {
+    try {
+        return read();
+    }
+    catch (error) {
+        if (error instanceof Error && isRepositoryNotFoundError(error)) {
+            return undefined;
+        }
+        throw error;
+    }
+}
+
 export class RepositoryManager {
     private readonly repositories = new Map<string, ManagedRepository>();
 
@@ -26,7 +54,7 @@ export class RepositoryManager {
     public require<R>(token: RepositoryToken<R>): R {
         const repository = this.get(token);
         if (repository === undefined) {
-            throw new Error(`Repository not found: ${token.id}`);
+            throw new Error(`${REPOSITORY_NOT_FOUND_PREFIX}${token.id}`);
         }
         return repository;
     }

--- a/packages/tests/shared-test/rallar-browser-runtime-lifecycle-controller.test.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime-lifecycle-controller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createBlackBoxRallarLifecycleController } from '../../shared-test/black-box-runner/browser/rallar-browser-runtime/lifecycle-controller.ts';
 
 type Config = Readonly<{
@@ -21,13 +21,14 @@ function createController() {
 describe('browser Rallar lifecycle controller', () => {
     it('deduplicates matching authentication work and preserves cleanup policy', async () => {
         const controller = createController();
+        const runs: string[] = [];
         let resolveAuthentication!: (session: string) => void;
-        const effect = vi.fn(
-            () =>
-                new Promise<string>((resolve) => {
-                    resolveAuthentication = resolve;
-                })
-        );
+        const effect = () => {
+            runs.push('authentication');
+            return new Promise<string>((resolve) => {
+                resolveAuthentication = resolve;
+            });
+        };
 
         const first = controller.runAuthentication({ key: 'alice' }, effect);
         const second = controller.runAuthentication(
@@ -38,7 +39,7 @@ describe('browser Rallar lifecycle controller', () => {
             effect
         );
 
-        expect(effect).toHaveBeenCalledTimes(1);
+        expect(runs).toEqual(['authentication']);
         expect(controller.authenticationConfig()).toEqual({
             key: 'alice',
             logoutOnClose: true
@@ -49,48 +50,55 @@ describe('browser Rallar lifecycle controller', () => {
 
     it('deduplicates matching connect work', async () => {
         const controller = createController();
+        const runs: string[] = [];
         let resolveConnect!: (value: string) => void;
-        const effect = vi.fn(
-            () =>
-                new Promise<string>((resolve) => {
-                    resolveConnect = resolve;
-                })
-        );
+        const effect = () => {
+            runs.push('connect');
+            return new Promise<string>((resolve) => {
+                resolveConnect = resolve;
+            });
+        };
 
         const first = controller.runConnect('target-a', effect);
         const second = controller.runConnect('target-a', effect);
 
-        expect(effect).toHaveBeenCalledTimes(1);
+        expect(runs).toEqual(['connect']);
         resolveConnect('connected');
         await expect(Promise.all([first, second])).resolves.toEqual(['connected', 'connected']);
     });
 
     it('serializes external authentication behind active connection work', async () => {
         const controller = createController();
+        const runs: string[] = [];
         let resolveConnect!: (value: string) => void;
         const connecting = controller.runConnect(
             'target-a',
-            () =>
-                new Promise<string>((resolve) => {
+            () => {
+                runs.push('connect');
+                return new Promise<string>((resolve) => {
                     resolveConnect = resolve;
-                })
+                });
+            }
         );
-        const authenticationEffect = vi.fn(async () => 'session-b');
 
         const authenticating = controller.runAuthentication(
             { key: 'bob' },
-            authenticationEffect
+            async () => {
+                runs.push('authentication');
+                return 'session-b';
+            }
         );
-        expect(authenticationEffect).not.toHaveBeenCalled();
+        expect(runs).toEqual(['connect']);
 
         resolveConnect('connected');
         await expect(connecting).resolves.toBe('connected');
         await expect(authenticating).resolves.toBe('session-b');
-        expect(authenticationEffect).toHaveBeenCalledTimes(1);
+        expect(runs).toEqual(['connect', 'authentication']);
     });
 
     it('aborts and waits for lifecycle work before single-flight close cleanup', async () => {
         const controller = createController();
+        const cleanupRuns: string[] = [];
         let resolveAuthentication!: (session: string) => void;
         let signal: AbortSignal | undefined;
         const authentication = controller.runAuthentication({ key: 'alice', logoutOnClose: true }, (controllerSignal) => {
@@ -100,34 +108,42 @@ describe('browser Rallar lifecycle controller', () => {
             });
         });
         const authenticationResult = expect(authentication).rejects.toThrow('authentication closed');
-        const cleanup = vi.fn(async (context) => context.authenticationConfig?.logoutOnClose ? 'logged-out' : 'disconnected');
+        const cleanup = async (context: { authenticationConfig?: Config; }) => {
+            const outcome = context.authenticationConfig?.logoutOnClose ? 'logged-out' : 'disconnected';
+            cleanupRuns.push(outcome);
+            return outcome;
+        };
 
         const firstClose = controller.close(cleanup);
         const secondClose = controller.close(cleanup);
         expect(signal?.aborted).toBe(true);
-        expect(cleanup).not.toHaveBeenCalled();
+        expect(cleanupRuns).toEqual([]);
 
         resolveAuthentication('session-1');
         await authenticationResult;
         await expect(Promise.all([firstClose, secondClose])).resolves.toEqual(['logged-out', 'logged-out']);
-        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(cleanupRuns).toEqual(['logged-out']);
     });
 
     it('aborts the current operation generation before waiting for close dependencies', async () => {
         const controller = createController();
+        const cleanupRuns: string[] = [];
         const activeSignal = controller.operationSignal();
         let releasePending!: () => void;
         const pending = new Promise<void>((resolve) => {
             releasePending = resolve;
         });
-        const cleanup = vi.fn(async () => 'closed');
+        const cleanup = async () => {
+            cleanupRuns.push('closed');
+            return 'closed';
+        };
 
         const closing = controller.close(cleanup, [pending]);
 
         expect(activeSignal.aborted).toBe(true);
         expect(controller.operationSignal()).not.toBe(activeSignal);
         expect(controller.operationSignal().aborted).toBe(false);
-        expect(cleanup).not.toHaveBeenCalled();
+        expect(cleanupRuns).toEqual([]);
 
         releasePending();
         await expect(closing).resolves.toBe('closed');
@@ -150,4 +166,32 @@ describe('browser Rallar lifecycle controller', () => {
         await connectionResult;
         await expect(closing).resolves.toBe('closed');
     });
+
+    it('authenticates again after a close that failed', async () => {
+        // A headless agent keeps one runtime for the life of its page, so a
+        // close failure that closed nothing must not end its usefulness.
+        const controller = createController();
+        await expectFailedClose(controller);
+
+        await expect(
+            controller.runAuthentication({ key: 'alice' }, async () => 'session-1')
+        ).resolves.toBe('session-1');
+    });
+
+    it('runs connect work again after a close that failed', async () => {
+        const controller = createController();
+        await expectFailedClose(controller);
+
+        await expect(
+            controller.runConnect('target-a', async () => 'connected')
+        ).resolves.toBe('connected');
+    });
 });
+
+async function expectFailedClose(controller: ReturnType<typeof createController>): Promise<void> {
+    await expect(
+        controller.close(async () => {
+            throw new Error('cleanup failed');
+        })
+    ).rejects.toThrow('cleanup failed');
+}

--- a/packages/tests/shared-test/rallar-browser-runtime/runtime-lifecycle.test.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/runtime-lifecycle.test.ts
@@ -289,3 +289,33 @@ it('rejects new resource effects while runtime close is in progress', async () =
     disconnection.resolve();
     await closing;
 });
+
+it('forgets its connection target after a close that failed', async () => {
+    // A failed close still aborted operations and dropped subscriptions, so the
+    // runtime must not keep naming the target it just tried to leave.
+    const runtime = await loadRuntime();
+    await runtime.connect({
+        connection: 'aliceRtc',
+        actor: 'alice',
+        roomId: 'room-1',
+        rallar: {
+            apiBaseUrl: 'https://api.example.test',
+            username: 'alice',
+            password: 'secret'
+        }
+    });
+    facade.behavior.disconnect.mockRejectedValue(new Error('disconnect failed'));
+    await expect(runtime.close()).rejects.toThrow('disconnect failed');
+    facade.behavior.disconnect.mockResolvedValue(undefined);
+
+    await expect(runtime.connect({
+        connection: 'bobRtc',
+        actor: 'bob',
+        roomId: 'room-2',
+        rallar: {
+            apiBaseUrl: 'https://api.example.test',
+            username: 'bob',
+            password: 'other-secret'
+        }
+    })).resolves.toBeDefined();
+});

--- a/packages/tests/shared-web/session/browser-auth-session-contract.test.ts
+++ b/packages/tests/shared-web/session/browser-auth-session-contract.test.ts
@@ -147,6 +147,35 @@ describe('Rallar auth login, expiry, and registration contract', () => {
         expect(facade.isConnected()).toBe(false);
     });
 
+    it('contains an expiry failure instead of raising an unhandled rejection', async () => {
+        // Both games restore a stored session before connecting, so an already
+        // expired one fires this timer with nothing to catch its rejection. An
+        // escaping rejection fails this file, which is the assertion that matters.
+        const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000);
+        const reported: string[] = [];
+        const consoleError = vi.spyOn(console, 'error').mockImplementation((message) => {
+            reported.push(String(message));
+        });
+        const expiringSession = {
+            ...mocks.ctx.session,
+            expiresAtEpochMs: 1_500
+        };
+        mocks.readSession.mockReturnValue(expiringSession);
+        mocks.clearSession.mockImplementation(() => {
+            throw new Error('storage unavailable');
+        });
+        const facade = createRallarFacade();
+        facade.auth.onChange(() => undefined, { emitCurrent: true });
+
+        await vi.advanceTimersByTimeAsync(500);
+        await Promise.resolve();
+
+        expect(reported).toContain('Failed to expire the Rallar auth session');
+        consoleError.mockRestore();
+    });
+
     it('does not expire a replacement session when an old expiry timer fires', async () => {
         const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
         vi.useFakeTimers();

--- a/packages/tests/shared-web/session/browser-auth-session-teardown-notification.test.ts
+++ b/packages/tests/shared-web/session/browser-auth-session-teardown-notification.test.ts
@@ -1,0 +1,56 @@
+import { BrowserFacadeRuntimeState } from '@shared-web/browser/composition/browser-facade-runtime-state.ts';
+import { BrowserTransportRuntime } from '@shared-web/browser/connection/browser-transport-runtime.ts';
+import type { RallarAuthState } from '@shared-web/browser/session/rallar-auth-facade.ts';
+import { BrowserSessionAuthLifecycle } from '@shared-web/browser/session/session-auth-lifecycle.ts';
+import { describe, expect, it, vi } from 'vitest';
+
+type AuthModule = typeof import('@shared/api/auth.ts');
+
+const mocks = vi.hoisted(() => ({
+    clearSession: vi.fn(),
+    readSession: vi.fn()
+}));
+
+vi.mock(import('@shared/api/auth.ts'), async (importOriginal): Promise<Partial<AuthModule>> => ({
+    ...await importOriginal(),
+    clearSession: mocks.clearSession,
+    readSession: mocks.readSession
+}));
+
+function createAuthLifecycle(
+    emitState: () => void
+): BrowserSessionAuthLifecycle {
+    const transportRuntime = new BrowserTransportRuntime();
+    const runtime = new BrowserFacadeRuntimeState(transportRuntime);
+    return new BrowserSessionAuthLifecycle({
+        connectionRuntime: runtime,
+        transportRuntime,
+        authRuntime: runtime,
+        connectionLifecycle: {
+            connect: () => Promise.reject(new Error('connect is not part of this contract')),
+            disconnect: () => Promise.resolve()
+        },
+        emitState,
+        closeDataScopes: () => Promise.resolve()
+    });
+}
+
+describe('Rallar auth session teardown notification', () => {
+    it('notifies auth listeners even when the state emit fails', async () => {
+        // The app's sign-out rests on this notification, so a failing side
+        // effect must not stand between the teardown and its listeners.
+        const lifecycle = createAuthLifecycle(() => {
+            throw new Error('state emit failed');
+        });
+        const states: RallarAuthState[] = [];
+        lifecycle.onAuthChange((state) => {
+            states.push(state);
+        }, { emitCurrent: false });
+
+        await expect(
+            lifecycle.endAuthSession('logout', { revoke: false })
+        ).rejects.toThrow('state emit failed');
+
+        expect(states.at(-1)).toMatchObject({ authenticated: false, reason: 'logout' });
+    });
+});

--- a/packages/tests/shared-web/session/browser-session-disconnect-before-connect.test.ts
+++ b/packages/tests/shared-web/session/browser-session-disconnect-before-connect.test.ts
@@ -1,0 +1,65 @@
+import type { RallarAuthState } from '@shared-web/browser/session/rallar-auth-facade.ts';
+import type { AuthSession } from '@shared/api/api-config.ts';
+import { describe, expect, it, vi } from 'vitest';
+
+// The browser state caches are configured during connect, so everything here
+// runs with the repositories genuinely unconfigured. Mocking them -- as the
+// auth-session contract fixture does -- is what hid this defect.
+const session: AuthSession = {
+    clientId: 'client-1',
+    accessToken: 'access-token-1',
+    username: 'alice',
+    sessionId: 'session-1',
+    expiresAtEpochMs: Date.now() + 60_000
+};
+
+const mocks = vi.hoisted(() => ({
+    clearSession: vi.fn(),
+    readSession: vi.fn(),
+    logoutFromApi: vi.fn(() => Promise.resolve({ loggedOut: true }))
+}));
+
+vi.mock(import('@shared/api/auth.ts'), async (importOriginal) => ({
+    ...(await importOriginal()),
+    clearSession: mocks.clearSession,
+    readSession: mocks.readSession
+}));
+
+vi.mock(import('@shared-web/browser/auth/session-http-api.ts'), async (importOriginal) => ({
+    ...(await importOriginal()),
+    logoutFromApi: mocks.logoutFromApi
+}));
+
+describe('Rallar session teardown before a first connect', () => {
+    it('resolves disconnect on a page that never connected', async () => {
+        const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+
+        await expect(createRallarFacade().disconnect()).resolves.toBeUndefined();
+    });
+
+    it('subscribes to rooms and people before connect', async () => {
+        // Subscribing on mount and connecting later is the ordinary app shape,
+        // and the initial delivery is a notification like any other emit.
+        const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+        const facade = createRallarFacade();
+
+        expect(() => facade.rooms.onChange(() => undefined)).not.toThrow();
+        expect(() => facade.people.onChange(() => undefined)).not.toThrow();
+    });
+
+    it('notifies auth listeners when logging out before connect', async () => {
+        // The app's sign-out rests on this notification: when it is skipped the
+        // UI stays signed in.
+        mocks.readSession.mockReturnValue(session);
+        const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
+        const facade = createRallarFacade();
+        const states: RallarAuthState[] = [];
+        facade.auth.onChange((state) => {
+            states.push(state);
+        }, { emitCurrent: false });
+
+        await facade.auth.logout();
+
+        expect(states.at(-1)).toMatchObject({ authenticated: false, reason: 'logout' });
+    });
+});

--- a/packages/tests/shared-web/state-cache/rallar-state-store.test.ts
+++ b/packages/tests/shared-web/state-cache/rallar-state-store.test.ts
@@ -1,7 +1,11 @@
 import { BrowserFacadeRuntimeState } from '@shared-web/browser/composition/browser-facade-runtime-state.ts';
 import { BrowserTransportRuntime } from '@shared-web/browser/connection/browser-transport-runtime.ts';
 import { createRoomStateStore } from '@shared-web/browser/rooms/room-state-store.ts';
-import { createRallarStateCacheReadPort, RallarStateStore } from '@shared-web/browser/state-cache/rallar-state-store.ts';
+import {
+    createRallarStateCacheReadPort,
+    RallarStateStore,
+    type RallarStateCacheReadPort
+} from '@shared-web/browser/state-cache/rallar-state-store.ts';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { configureTestCacheRepositories } from '../../cache-repository-config.ts';
 
@@ -33,11 +37,40 @@ describe('Rallar state store', () => {
         expect(unsubscribe).toBeTypeOf('function');
         unsubscribe();
     });
+
+    it('skips emitting while the snapshot repositories are unconfigured', () => {
+        // Disconnect and logout emit state, and both run before a first connect
+        // configures the browser caches.
+        const events: string[] = [];
+        const { stateStore } = createStateStoreFixture(
+            createFailingCacheReads('Repository not found: shared.repository.group-state-snapshots')
+        );
+        stateStore.onPeopleChange(() => {
+            events.push('people');
+        }, { emitCurrent: false });
+        stateStore.onAfterEmit(() => {
+            events.push('derived');
+        });
+
+        expect(() => stateStore.emit()).not.toThrow();
+        expect(events).toEqual([]);
+    });
+
+    it('rethrows emit failures that are not a missing repository', () => {
+        const { stateStore } = createStateStoreFixture(createFailingCacheReads('boom'));
+
+        expect(() => stateStore.emit()).toThrow('boom');
+    });
 });
 
-function createStateStoreFixture() {
+function createStateStoreFixture(
+    cacheOverrides: Partial<RallarStateCacheReadPort> = {}
+) {
     const runtime = new BrowserFacadeRuntimeState(new BrowserTransportRuntime());
-    const stateCache = createRallarStateCacheReadPort();
+    const stateCache: RallarStateCacheReadPort = {
+        ...createRallarStateCacheReadPort(),
+        ...cacheOverrides
+    };
     const roomStateStore = createRoomStateStore({
         runtime,
         readSession: () => undefined,
@@ -50,4 +83,18 @@ function createStateStoreFixture() {
         stateCache
     });
     return { roomStateStore, stateCache, stateStore };
+}
+
+/** Mirrors the browser caches before a first connect configures them. */
+function createFailingCacheReads(message: string): Partial<RallarStateCacheReadPort> {
+    const fail = (): never => {
+        throw new Error(message);
+    };
+    return {
+        readGroupSnapshots: fail,
+        findGroupSnapshotByRef: fail,
+        findFirstGroupRefForSession: fail,
+        readClientSnapshots: fail,
+        findClientSnapshot: fail
+    };
 }


### PR DESCRIPTION
## Problem

`rallar.disconnect()` or `auth.logout()` on a page that never connected throws:

```
Repository not found: shared.repository.group-state-snapshots
```

Both paths emit state; the emit reads the group and client snapshot repositories; and connect configures those repositories only after authentication (`initialiseBrowserCacheRepositories()` is reached solely from `initialise-browser-middleware.ts:196`). Before a first connect they simply do not exist, and `RepositoryManager.require` throws.

This is the root cause of the three failing Hetzner manifests (`03-rtc-smoke`, `04-provider-parity`, `05a-rtc-realtime-stability`) — the headless agent resets at bootstrap, six milliseconds after page load — but the reach is wider:

- **An app can stay signed in after logging out.** In `terminateAuthSession` the disconnect is already error-captured (`:255`), but `this.input.emitState()` at `:262` is not, and its throw skipped `emitAuthState(...)` at `:263`. Relic Hunters' sign-out rests entirely on that notification (`apps/relic-hunters-v1/src/game/useRelicHunters.ts:216-223`).
- **Unhandled rejection from the auth expiry timer.** `scheduleAuthExpiry` fires `() => void this.expireAuthSessionIfCurrent(session)` at `:226` with no catch. Both games restore a stored session at mount before connecting, and an already-expired one fires with `delayMs = 0`.

## Fix

1. **`RallarStateStore.emit()` reports no state when the caches are absent** instead of throwing — a close that finds nothing to close is not a failure. Any other error still propagates (pinned by a test). `rooms.state()` keeps throwing: an explicit read before connect is a caller mistake, while the emit is a notification. This alone makes both disconnect and logout succeed; every participant teardown is already `undefined`-safe.
2. **Recognise the condition once**, next to the `require()` that raises it, and reuse it for the string match `state-read/reconciliation.ts` already carried.
3. **Order the session teardown** so a failing emit cannot swallow the auth notification, aggregating its failure with the rest so nothing is masked; and give the expiry timer a catch.
4. **A failed close no longer faults the black-box runtime forever.** Fresh authentication replaces the state a failed close left behind, and a runtime that lives as long as its page should not be unusable until reload. That branch had no test coverage; it does now.

## Deliberately not included

Slice 2 of the plan — making a never-connected `disconnect()` skip lifecycle cleanup — is **not** here. Skipping cleanup also skips the `transportRuntime.shutdown()` whose generation bump cancels an in-flight connect, and the existing test *"shuts down middleware that resolves after logout during connect"* proved it. Three attempts (fencing the generation, fencing the transport, unifying the deferral) each left that guarantee subtly different. It was the cosmetic "semantic no-op" slice; trading a real cancellation invariant for it is a bad deal, so it is dropped rather than forced.

## Validation

- New `browser-session-disconnect-before-connect.test.ts` reproduces the defect end to end with the repositories genuinely unconfigured — both cases red before the fix. It deliberately avoids `browser-auth-session-contract-fixture.ts`, which stubs the repositories and is why the suite was blind to this.
- New pins: emit skips while unconfigured, emit rethrows anything else, expiry failure is reported not raised, and authenticate/connect both work after a failed close.
- `npm run test:unit`: **8157 passed, 0 failed** (summary line read, not the exit code). shared-web 521, shared-web+shared-test+shared 4719.
- `tsc` for `shared` and `shared-web`, dprint, `check:repo-style:changed origin/main HEAD` — all clean. `check:browser-bundles` passes: no public API surface change, and cache init stays lazy so no graphology enters the narrow entry points.

Verification on the fleet only happens after the black-box SPA redeploys, which needs main's Deploy green. A ~40s green Hetzner run is a path-skipped no-op; a real one takes 8–16 minutes.

Closes the need for #360, which is being closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)