### PR TITLE
Group activation: the stage-keyed planning gate and accepted-layout delivery (slices 4b+4c)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: 2.9.5
 
       - name: Verify token and application access
         run: |
@@ -287,7 +287,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: 2.9.5
 
       - name: Cache Deno + npm
         uses: actions/cache@v6
@@ -346,7 +346,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: 2.9.5
 
       - name: Cache Deno + npm
         uses: actions/cache@v6
@@ -386,7 +386,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: 2.9.5
 
       - name: Cache Deno + npm
         uses: actions/cache@v6

--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -5678,13 +5678,16 @@ components:
 
     GroupTopologyManagementView:
       type: object
-      required: [groupRef, overlayId, snapshot, config, pending]
+      required: [groupRef, overlayId, snapshot, acceptedSnapshot, config, pending]
       properties:
         groupRef:
           $ref: '#/components/schemas/GroupRef'
         overlayId:
           type: string
         snapshot:
+          $ref: '#/components/schemas/RallarOverlayTopologySnapshot'
+          nullable: true
+        acceptedSnapshot:
           $ref: '#/components/schemas/RallarOverlayTopologySnapshot'
           nullable: true
         config:

--- a/apps/api-v1/src/composition/create-api-v1-runtime.ts
+++ b/apps/api-v1/src/composition/create-api-v1-runtime.ts
@@ -159,6 +159,7 @@ export function constructApiV1Runtime(
         readHydrationIdentity: readAuthorisedWsConnectionIdentity
     });
     const topology = operations.createTopologyServices({
+        database: input.database,
         runtimeStateRepository: mutation.runtimeStateRepository,
         groupStateRepository: mutation.groupsRepository,
         groupStateService: mutation.groupStateService,

--- a/apps/api-v1/src/composition/create-api-v1-runtime.ts
+++ b/apps/api-v1/src/composition/create-api-v1-runtime.ts
@@ -159,7 +159,7 @@ export function constructApiV1Runtime(
         readHydrationIdentity: readAuthorisedWsConnectionIdentity
     });
     const topology = operations.createTopologyServices({
-        database: input.database,
+        pendingReplanReader: mutation.resourceInboxRepository.entries,
         runtimeStateRepository: mutation.runtimeStateRepository,
         groupStateRepository: mutation.groupsRepository,
         groupStateService: mutation.groupStateService,

--- a/apps/api-v1/src/composition/create-api-v1-system-installers.ts
+++ b/apps/api-v1/src/composition/create-api-v1-system-installers.ts
@@ -30,6 +30,7 @@ export interface ApiV1SystemInstallerTopology {
     readonly rtcTopologyOptions: ApiV1TopologyServices['rtcTopologyOptions'];
     readonly topologyQuery: object;
     readonly topologyPlanning: object;
+    readonly topologySnapshotRepository: Pick<ApiV1TopologyServices['topologySnapshotRepository'], 'findSnapshot'>;
     readonly groupStateRepository: Pick<
         ApiV1TopologyServices['groupStateRepository'],
         'readLifecyclePolicy' | 'readSnapshot'
@@ -210,6 +211,7 @@ function createSystemTopicOptions<
         rtcTopologyOptions: topology.rtcTopologyOptions,
         topologyQuery: topology.topologyQuery,
         topologyPlanning: topology.topologyPlanning,
+        topologySnapshotRepository: topology.topologySnapshotRepository,
         rttRefinementService: topology.rttRefinementService,
         rtcTopologyAppOutbox: {
             database: input.database,
@@ -247,6 +249,7 @@ export interface ApiV1SystemTopicOptions<
     readonly rtcTopologyOptions: Topology['rtcTopologyOptions'];
     readonly topologyQuery: Topology['topologyQuery'];
     readonly topologyPlanning: Topology['topologyPlanning'];
+    readonly topologySnapshotRepository: Topology['topologySnapshotRepository'];
     readonly rttRefinementService: Topology['rttRefinementService'];
     readonly rtcTopologyAppOutbox: ApiV1RtcTopologyAppOutboxOptions<Runtime>;
     readonly enqueueRtcRttMutation: InstallRtcRttSystemTopicOptions['enqueueMutation'];
@@ -259,7 +262,7 @@ export interface ApiV1RtcTopologyAppOutboxOptions<Runtime extends ApiV1SystemIns
             | 'executionRepository'
             | 'outboxQueueReader'
             | 'topologyDelivery'
-            | 'topologyQuery'
+            | 'readPlannedTopologySnapshot'
             | 'topologyPlanning'
             | 'rttRefinementService'
             | 'nowEpochMs'
@@ -273,7 +276,7 @@ const PRODUCTION_OPERATIONS: ApiV1SystemInstallerOperations<ApiV1Runtime, ApiV1T
     installTopologyAppOutbox: (options) =>
         installTopologyAppOutbox({
             ...options.rtcTopologyAppOutbox,
-            topologyQuery: options.topologyQuery,
+            readPlannedTopologySnapshot: async (ref) => await options.topologySnapshotRepository.findSnapshot(ref),
             topologyPlanning: options.topologyPlanning,
             rttRefinementService: options.rttRefinementService,
             nowEpochMs: options.rtcTopologyOptions.now ?? Date.now

--- a/apps/api-v1/src/composition/create-api-v1-topology-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-topology-services.ts
@@ -1,4 +1,6 @@
 import * as vivaldiService from '@shared-graph/vivaldi-service.ts';
+import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { PSqlResourceInboxEntryRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import type {
     CachedGroupStateService
@@ -19,9 +21,15 @@ import {
     createGroupTopologyMutationOwners
 } from '@shared-server/rallar-system/topology/mutation/create-group-topology-mutation-owners.ts';
 import { RtcTopologyOutboxWriter } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-writer.ts';
-import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
+import {
+    RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE,
+    RtcTopologySnapshotRepository
+} from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import type { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
 import type { GroupTopologyReconfigureMutation } from '@shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts';
+import {
+    readPendingTopologyReplan
+} from '@shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts';
 import {
     createGroupTopologyRuntimeOwners
 } from '@shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts';
@@ -31,6 +39,7 @@ import {
 } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
 import type { RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
@@ -42,6 +51,7 @@ export interface ApiV1TopologyReplayMetrics {
 }
 
 export interface CreateApiV1TopologyServicesInput {
+    readonly database: PSqlSql;
     readonly runtimeStateRepository: RuntimeStateRepositoryLike;
     readonly groupStateRepository: GroupStateRepository;
     readonly groupStateService: Pick<CachedGroupStateService, 'readSnapshotAtLeast'>;
@@ -97,6 +107,11 @@ export function createApiV1TopologyServices(
     const topologySnapshotRepository = new RtcTopologySnapshotRepository(
         input.runtimeStateRepository
     );
+    const acceptedTopologySnapshotRepository = new RtcTopologySnapshotRepository(
+        input.runtimeStateRepository,
+        RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE
+    );
+    const pendingReplanReader = new PSqlResourceInboxEntryRepository(input.database);
     const rttRepository = new RtcRttRepository(input.runtimeStateRepository, {
         now: nowEpochMs
     });
@@ -114,6 +129,17 @@ export function createApiV1TopologyServices(
         configRepository: topologyConfigRepository,
         topologyService: rtcTopologyService,
         topologySnapshotRepository,
+        acceptedTopologySnapshotRepository,
+        readPendingTopologyReplan: async (groupRef) => await readPendingTopologyReplan(pendingReplanReader, groupRef),
+        readTopologyReplanningMode: async (group) => {
+            const read = await groupStateRepository.readLifecyclePolicy(group.group);
+            if (read.status === 'corrupt') {
+                return 'corrupt';
+            }
+            return read.status === 'present'
+                ? read.policy.topology.replanning
+                : createDefaultGroupLifecyclePolicy().topology.replanning;
+        },
         serverDefaults: {
             ...rtcTopologyOptions,
             topologyKind: rtcTopologyOptions.topologyKind ?? 'auto'

--- a/apps/api-v1/src/composition/create-api-v1-topology-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-topology-services.ts
@@ -1,6 +1,4 @@
 import * as vivaldiService from '@shared-graph/vivaldi-service.ts';
-import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
-import { PSqlResourceInboxEntryRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import type {
     CachedGroupStateService
@@ -28,7 +26,8 @@ import {
 import type { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
 import type { GroupTopologyReconfigureMutation } from '@shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts';
 import {
-    readPendingTopologyReplan
+    readPendingTopologyReplan,
+    type PendingTopologyReplanReader
 } from '@shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts';
 import {
     createGroupTopologyRuntimeOwners
@@ -39,7 +38,6 @@ import {
 } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
 import type { RuntimeStateRepositoryLike } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
-import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
@@ -51,7 +49,8 @@ export interface ApiV1TopologyReplayMetrics {
 }
 
 export interface CreateApiV1TopologyServicesInput {
-    readonly database: PSqlSql;
+    /** The durable queue-entry reader the coalesced pending-replan row lives in. */
+    readonly pendingReplanReader: PendingTopologyReplanReader;
     readonly runtimeStateRepository: RuntimeStateRepositoryLike;
     readonly groupStateRepository: GroupStateRepository;
     readonly groupStateService: Pick<CachedGroupStateService, 'readSnapshotAtLeast'>;
@@ -111,7 +110,7 @@ export function createApiV1TopologyServices(
         input.runtimeStateRepository,
         RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE
     );
-    const pendingReplanReader = new PSqlResourceInboxEntryRepository(input.database);
+
     const rttRepository = new RtcRttRepository(input.runtimeStateRepository, {
         now: nowEpochMs
     });
@@ -130,16 +129,9 @@ export function createApiV1TopologyServices(
         topologyService: rtcTopologyService,
         topologySnapshotRepository,
         acceptedTopologySnapshotRepository,
-        readPendingTopologyReplan: async (groupRef) => await readPendingTopologyReplan(pendingReplanReader, groupRef),
-        readTopologyReplanningMode: async (group) => {
-            const read = await groupStateRepository.readLifecyclePolicy(group.group);
-            if (read.status === 'corrupt') {
-                return 'corrupt';
-            }
-            return read.status === 'present'
-                ? read.policy.topology.replanning
-                : createDefaultGroupLifecyclePolicy().topology.replanning;
-        },
+        readPendingTopologyReplan: async (groupRef) =>
+            await readPendingTopologyReplan(input.pendingReplanReader, groupRef),
+        readLifecyclePolicy: async (ref) => await groupStateRepository.readLifecyclePolicy(ref),
         serverDefaults: {
             ...rtcTopologyOptions,
             topologyKind: rtcTopologyOptions.topologyKind ?? 'auto'

--- a/apps/api-v1/src/runtime/rtc-topology/create-api-rtc-topology-runtime.ts
+++ b/apps/api-v1/src/runtime/rtc-topology/create-api-rtc-topology-runtime.ts
@@ -4,6 +4,7 @@ import {
     RtcTopologyExecutionRepository
 } from '@shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts';
 import {
+    RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE,
     RtcTopologySnapshotRepository
 } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import { RtcTopologyPublicationRepository } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.ts';
@@ -92,9 +93,14 @@ export function createApiRtcTopologyRuntime(
     const replayRepository = new PSqlRtcTopologyReplayRepository(input.database);
     const replayDiagnostics = createRtcTopologyReplayDiagnostics();
     const topologySnapshots = new RtcTopologySnapshotRepository(input.runtimeStateRepository);
+    const acceptedTopologySnapshots = new RtcTopologySnapshotRepository(
+        input.runtimeStateRepository,
+        RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE
+    );
     const reconnectHydrator = new RtcTopologyReconnectHydrator({
         socket: input.webSocketServer,
         topologies: topologySnapshots,
+        acceptedTopologies: acceptedTopologySnapshots,
         groups: input.groupsRepository,
         readIdentity: input.readHydrationIdentity,
         nowEpochMs: input.nowEpochMs,
@@ -146,6 +152,7 @@ export function createApiRtcTopologyRuntime(
                         publications: publicationRepository,
                         outbox: wsQueueBoxServerService.outbox,
                         snapshots: topologySnapshots,
+                        acceptedSnapshots: acceptedTopologySnapshots,
                         sender: wsQueueBoxServerService
                     }),
                     hydrateGap: async (signal) => await reconnectHydrator.hydrateOpenConnections(signal)

--- a/apps/api-v1/test/composition/create-api-v1-runtime.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-runtime.test.ts
@@ -61,9 +61,14 @@ Deno.test('runtime construction stops at a synchronous ownership failure', () =>
     ]);
 });
 
-const MUTATION_RUNTIME = {
-    groupFormationMetrics: { rttMutation: {} }
-} as ApiV1MutationRuntime;
+const MUTATION_RUNTIME: ApiV1MutationRuntime = {
+    groupFormationMetrics: { rttMutation: {} },
+    resourceInboxRepository: {
+        entries: {
+            findByKey: () => Promise.reject(new Error('pending replan not read here'))
+        }
+    }
+} as never;
 const SHARED_RUNTIME = {
     qboxEngine: { wake: () => {} },
     appClientInboxService: {},

--- a/apps/api-v1/test/composition/create-api-v1-system-installers.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-system-installers.test.ts
@@ -161,6 +161,9 @@ function createInput(): CreateApiV1SystemInstallersInput<ApiV1SystemInstallerTop
             rtcTopologyOptions: {},
             topologyQuery: {},
             topologyPlanning: {},
+            topologySnapshotRepository: {
+                findSnapshot: rejectUnusedCrdtRead
+            },
             groupStateRepository: {
                 readLifecyclePolicy: rejectUnusedCrdtRead,
                 readSnapshot: rejectUnusedCrdtRead

--- a/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
@@ -21,6 +21,9 @@ Deno.test('topology composition installs canonical owners and RTT policy inputs'
     const snapshot = createGroupSnapshot();
     const formationEvents: unknown[] = [];
     const input: CreateApiV1TopologyServicesInput = {
+        database: Object.assign(() => Promise.resolve([]), {
+            begin: () => Promise.reject(new Error('not used'))
+        }),
         runtimeStateRepository,
         groupStateRepository: new GroupStateRepository(
             runtimeStateRepository,

--- a/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-topology-services.test.ts
@@ -21,9 +21,9 @@ Deno.test('topology composition installs canonical owners and RTT policy inputs'
     const snapshot = createGroupSnapshot();
     const formationEvents: unknown[] = [];
     const input: CreateApiV1TopologyServicesInput = {
-        database: Object.assign(() => Promise.resolve([]), {
-            begin: () => Promise.reject(new Error('not used'))
-        }),
+        pendingReplanReader: {
+            findByKey: () => Promise.reject(new Error('pending replan not read by construction test'))
+        },
         runtimeStateRepository,
         groupStateRepository: new GroupStateRepository(
             runtimeStateRepository,

--- a/apps/api-v1/test/db/pglite-topology-command.test.ts
+++ b/apps/api-v1/test/db/pglite-topology-command.test.ts
@@ -1,4 +1,5 @@
 import { PSqlGroupStateEventRepository } from '@shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts';
+import type { ReconcileGroupTopologyResult } from '@shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts';
 import assert from 'node:assert/strict';
 
 import {
@@ -57,10 +58,10 @@ Deno.test(
                 updatedAtEpochMs: 123
             });
 
-            const result = scenario.service.planning.computeTopologyFromAuthority(
+            const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
                 scenario.previous
-            );
+            ));
 
             assert.equal(result.snapshot.state, 'removed');
             assert.equal(result.snapshot.updatedAtEpochMs, 123);
@@ -80,10 +81,10 @@ Deno.test(
                 updatedAtEpochMs: 200
             });
 
-            const result = scenario.service.planning.computeTopologyFromAuthority(
+            const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
                 scenario.previous
-            );
+            ));
 
             assert.equal(scenario.authority.group.group.status, 'active');
             assert.equal(result.snapshot.state, 'active');
@@ -106,10 +107,10 @@ Deno.test(
                 updatedAtEpochMs: 201
             });
 
-            const result = scenario.service.planning.computeTopologyFromAuthority(
+            const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
                 scenario.previous
-            );
+            ));
 
             assert.equal(scenario.authority.group.group.status, 'active');
             assert.equal(result.snapshot.state, 'removed');
@@ -132,10 +133,10 @@ Deno.test(
                 updatedAtEpochMs: 202
             });
 
-            const result = scenario.service.planning.computeTopologyFromAuthority(
+            const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
                 scenario.previous
-            );
+            ));
 
             assert.equal(scenario.authority.group.group.status, 'archived');
             assert.equal(result.snapshot.state, 'removed');
@@ -598,3 +599,12 @@ Deno.test(
         });
     }
 );
+
+function requirePlannedTopology(
+    result: ReconcileGroupTopologyResult
+): Extract<ReconcileGroupTopologyResult, { action: 'planned'; }> {
+    if (result.action !== 'planned') {
+        throw new Error('expected a planned topology result');
+    }
+    return result;
+}

--- a/apps/api-v1/test/db/pglite-topology-command.test.ts
+++ b/apps/api-v1/test/db/pglite-topology-command.test.ts
@@ -1,5 +1,5 @@
 import { PSqlGroupStateEventRepository } from '@shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts';
-import type { ReconcileGroupTopologyResult } from '@shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts';
+import { requirePlannedTopology } from '@shared-test/shared-server/require-planned-topology.ts';
 import assert from 'node:assert/strict';
 
 import {
@@ -60,7 +60,8 @@ Deno.test(
 
             const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
-                scenario.previous
+                scenario.previous,
+                { intent: 'full-rebuild', origin: 'automatic' }
             ));
 
             assert.equal(result.snapshot.state, 'removed');
@@ -83,7 +84,8 @@ Deno.test(
 
             const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
-                scenario.previous
+                scenario.previous,
+                { intent: 'full-rebuild', origin: 'automatic' }
             ));
 
             assert.equal(scenario.authority.group.group.status, 'active');
@@ -109,7 +111,8 @@ Deno.test(
 
             const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
-                scenario.previous
+                scenario.previous,
+                { intent: 'full-rebuild', origin: 'automatic' }
             ));
 
             assert.equal(scenario.authority.group.group.status, 'active');
@@ -135,7 +138,8 @@ Deno.test(
 
             const result = requirePlannedTopology(scenario.service.planning.computeTopologyFromAuthority(
                 scenario.authority,
-                scenario.previous
+                scenario.previous,
+                { intent: 'full-rebuild', origin: 'automatic' }
             ));
 
             assert.equal(scenario.authority.group.group.status, 'archived');
@@ -251,7 +255,10 @@ Deno.test(
             });
             assert.deepEqual(authority.rttMeasurements, [storedRtt]);
 
-            service.planning.computeTopologyFromAuthority(authority, previous);
+            service.planning.computeTopologyFromAuthority(authority, previous, {
+                intent: 'full-rebuild',
+                origin: 'automatic'
+            });
 
             assert.deepEqual(plannedRtts, []);
         });
@@ -599,12 +606,3 @@ Deno.test(
         });
     }
 );
-
-function requirePlannedTopology(
-    result: ReconcileGroupTopologyResult
-): Extract<ReconcileGroupTopologyResult, { action: 'planned'; }> {
-    if (result.action !== 'planned') {
-        throw new Error('expected a planned topology result');
-    }
-    return result;
-}

--- a/apps/api-v1/test/db/pglite-topology-test-runtime.ts
+++ b/apps/api-v1/test/db/pglite-topology-test-runtime.ts
@@ -1,4 +1,5 @@
 import { PSqlGroupStateEventRepository } from '@shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts';
+import { requirePlannedTopology } from '@shared-test/shared-server/require-planned-topology.ts';
 import assert from 'node:assert/strict';
 
 import {
@@ -217,14 +218,12 @@ export async function createPGliteTopologyWorkFixture(
         knownGroup: groupSnapshot,
         snapshotSelection: 'prefer-current'
     });
-    const computedTopology = topologyManagement.planning.computeTopologyFromAuthority(
-        authority,
-        undefined
-    );
-    if (computedTopology.action !== 'planned') {
-        throw new Error('expected a planned topology result');
-    }
-    const topology = computedTopology.snapshot;
+    const topology = requirePlannedTopology(
+        topologyManagement.planning.computeTopologyFromAuthority(authority, undefined, {
+            intent: 'full-rebuild',
+            origin: 'automatic'
+        })
+    ).snapshot;
     const expiresAtEpochMs = executionRepository.publicationExpireAtTimestamp();
     const publication = {
         publicationId: toRtcTopologyPublicationId({

--- a/apps/api-v1/test/db/pglite-topology-test-runtime.ts
+++ b/apps/api-v1/test/db/pglite-topology-test-runtime.ts
@@ -217,10 +217,14 @@ export async function createPGliteTopologyWorkFixture(
         knownGroup: groupSnapshot,
         snapshotSelection: 'prefer-current'
     });
-    const topology = topologyManagement.planning.computeTopologyFromAuthority(
+    const computedTopology = topologyManagement.planning.computeTopologyFromAuthority(
         authority,
         undefined
-    ).snapshot;
+    );
+    if (computedTopology.action !== 'planned') {
+        throw new Error('expected a planned topology result');
+    }
+    const topology = computedTopology.snapshot;
     const expiresAtEpochMs = executionRepository.publicationExpireAtTimestamp();
     const publication = {
         publicationId: toRtcTopologyPublicationId({

--- a/apps/api-v1/test/routes/graph-topology-routes.test.ts
+++ b/apps/api-v1/test/routes/graph-topology-routes.test.ts
@@ -639,6 +639,7 @@ function createRouteApp(options: {
                         groupRef,
                         overlayId: 'overlay',
                         snapshot: null,
+                        acceptedSnapshot: null,
                         config: createTopologyConfigView(),
                         pending: null
                     })),

--- a/docs/test-structure-coupling-exceptions.md
+++ b/docs/test-structure-coupling-exceptions.md
@@ -1393,15 +1393,30 @@ moved or changed test.
       "id": "rtc-topology-replay-suppressed-send",
       "domain": "RTC topology replay live delivery",
       "owner": "Rallar server maintainers",
-      "summary": "Expired and corrupt delivery-log entries send nothing: a retention gap is a typed result and corruption propagates without reaching the socket. Executable assertions: \u201creturns a typed retention gap without attempting a send\u201d and \u201cpropagates corruption for a missing unexpired durable reference\u201d.",
+      "summary": "An expired delivery-log entry sends nothing: a retention gap is a typed result the consumer handles, never a stale delivery. Executable assertion: \u201creturns a typed retention gap without attempting a send\u201d.",
       "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#returns a typed retention gap without attempting a send",
-      "coverageRelation": "The named assertions execute the replay entry handler on an expired and on a corrupt entry and observe the owned live-send port; the absence of sends is the constraint that non-deliverable history never reaches members.",
+      "coverageRelation": "The named assertion executes the replay entry handler on an expired entry and observes the owned live-send port; the absence of a send is the constraint that expired history never reaches members.",
       "interactionRequirement": {
         "interactionKind": "absence",
         "ownedPort": "WS queue-box live sender (sendToTargetsWithResult)",
-        "observableEffect": "An expired entry resolves to a gap and a corrupt entry throws, in both cases with zero live sends.",
-        "requiredConstraint": "The live sender remains unused for expired and corrupt delivery-log entries.",
-        "failureRationale": "Sending expired or corrupt history would deliver stale or invalid topology to members instead of surfacing the gap or corruption to the replay consumer."
+        "observableEffect": "An expired entry resolves to a typed gap with zero live sends.",
+        "requiredConstraint": "The live sender remains unused for expired delivery-log entries.",
+        "failureRationale": "Sending expired history would deliver stale topology to members instead of surfacing the gap to the replay consumer."
+      }
+    },
+    {
+      "id": "rtc-topology-replay-corruption-suppressed-send",
+      "domain": "RTC topology replay live delivery",
+      "owner": "Rallar server maintainers",
+      "summary": "A corrupt delivery-log entry sends nothing: corruption propagates to the replay consumer without reaching the socket. Executable assertion: \u201cpropagates corruption for a missing unexpired durable reference\u201d.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#propagates corruption for a missing unexpired durable reference",
+      "coverageRelation": "The named assertion executes the replay entry handler on a corrupt entry and observes the owned live-send port; the absence of a send is the constraint that invalid history never reaches members.",
+      "interactionRequirement": {
+        "interactionKind": "absence",
+        "ownedPort": "WS queue-box live sender (sendToTargetsWithResult)",
+        "observableEffect": "A corrupt entry throws to the consumer with zero live sends.",
+        "requiredConstraint": "The live sender remains unused for corrupt delivery-log entries.",
+        "failureRationale": "Sending invalid history would deliver corrupt topology to members instead of surfacing the corruption to the replay consumer."
       }
     }
   ],
@@ -3401,12 +3416,12 @@ moved or changed test.
       "id": "test-structure-coupling-7694279a835a985d",
       "path": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts",
       "kind": "mock-invocation-count-or-order",
-      "contract": "rtc-topology-replay-suppressed-send",
+      "contract": "rtc-topology-replay-corruption-suppressed-send",
       "disposition": "durable-boundary",
       "boundary": "interaction",
       "owner": "Rallar server maintainers",
       "rationale": "The send-absence assertion directly proves that corruption for a missing durable reference propagates without any live delivery.",
-      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#returns a typed retention gap without attempting a send"
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#propagates corruption for a missing unexpired durable reference"
     }
   ]
 }

--- a/docs/test-structure-coupling-exceptions.md
+++ b/docs/test-structure-coupling-exceptions.md
@@ -1373,6 +1373,36 @@ moved or changed test.
       "summary": "CRDT reservation construction remains connected to canonical durable AppInbox command materialization. Executable assertion: “rejects a CRDT reservation builder disconnected from command materialization”.",
       "semanticCoverage": "packages/tests/repo/mutation-route-ownership/route-owner/mutation-route-owner-analysis.test.ts#rejects a CRDT reservation builder disconnected from command materialization",
       "coverageRelation": "The test replaces the actual CRDT administrative route command-materialization call and executes the mutation-route inventory validator; reading that production route is the executable input that proves reservation construction cannot bypass canonical durable AppInbox command materialization."
+    },
+    {
+      "id": "rtc-topology-replay-single-live-send",
+      "domain": "RTC topology replay live delivery",
+      "owner": "Rallar server maintainers",
+      "summary": "A replayable delivery-log entry produces exactly one live WebSocket send of the immutable outbox message. Executable assertion: \u201cdelivers the exact immutable outbox message when the publication is current\u201d.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#delivers the exact immutable outbox message when the publication is current",
+      "coverageRelation": "The named assertion executes the replay entry handler against a current publication and observes its owned live-send port; the single-send count is the exactly-once delivery constraint of the replay protocol.",
+      "interactionRequirement": {
+        "interactionKind": "count",
+        "ownedPort": "WS queue-box live sender (sendToTargetsWithResult)",
+        "observableEffect": "One handled replay entry emits one live send carrying the durable outbox message bytes.",
+        "requiredConstraint": "Replay emits exactly one live send per handled entry \u2014 never zero, never a duplicate.",
+        "failureRationale": "A duplicate send would double-deliver topology to members and a missing send would silently drop replayed history, both breaking the at-most-once live half of the replay protocol."
+      }
+    },
+    {
+      "id": "rtc-topology-replay-suppressed-send",
+      "domain": "RTC topology replay live delivery",
+      "owner": "Rallar server maintainers",
+      "summary": "Expired and corrupt delivery-log entries send nothing: a retention gap is a typed result and corruption propagates without reaching the socket. Executable assertions: \u201creturns a typed retention gap without attempting a send\u201d and \u201cpropagates corruption for a missing unexpired durable reference\u201d.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#returns a typed retention gap without attempting a send",
+      "coverageRelation": "The named assertions execute the replay entry handler on an expired and on a corrupt entry and observe the owned live-send port; the absence of sends is the constraint that non-deliverable history never reaches members.",
+      "interactionRequirement": {
+        "interactionKind": "absence",
+        "ownedPort": "WS queue-box live sender (sendToTargetsWithResult)",
+        "observableEffect": "An expired entry resolves to a gap and a corrupt entry throws, in both cases with zero live sends.",
+        "requiredConstraint": "The live sender remains unused for expired and corrupt delivery-log entries.",
+        "failureRationale": "Sending expired or corrupt history would deliver stale or invalid topology to members instead of surfacing the gap or corruption to the replay consumer."
+      }
     }
   ],
   "entries": [
@@ -3344,6 +3374,39 @@ moved or changed test.
       "owner": "Rallar repository maintainers",
       "rationale": "Reads the actual CRDT administrative mutation route as the mutated input to the real route validator, proving that disconnecting reservation construction from canonical AppInbox command materialization is rejected.",
       "semanticCoverage": "packages/tests/repo/mutation-route-ownership/route-owner/mutation-route-owner-analysis.test.ts#rejects a CRDT reservation builder disconnected from command materialization"
+    },
+    {
+      "id": "test-structure-coupling-5b530e925eb450cb",
+      "path": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts",
+      "kind": "mock-invocation-count-or-order",
+      "contract": "rtc-topology-replay-single-live-send",
+      "disposition": "durable-boundary",
+      "boundary": "interaction",
+      "owner": "Rallar server maintainers",
+      "rationale": "The single-send count directly proves that one handled replay entry emits exactly one live delivery of the immutable outbox message.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#delivers the exact immutable outbox message when the publication is current"
+    },
+    {
+      "id": "test-structure-coupling-f34d70bf4a6739c1",
+      "path": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts",
+      "kind": "mock-invocation-count-or-order",
+      "contract": "rtc-topology-replay-suppressed-send",
+      "disposition": "durable-boundary",
+      "boundary": "interaction",
+      "owner": "Rallar server maintainers",
+      "rationale": "The send-absence assertion directly proves that an expired entry resolves to a typed retention gap without any live delivery.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#returns a typed retention gap without attempting a send"
+    },
+    {
+      "id": "test-structure-coupling-7694279a835a985d",
+      "path": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts",
+      "kind": "mock-invocation-count-or-order",
+      "contract": "rtc-topology-replay-suppressed-send",
+      "disposition": "durable-boundary",
+      "boundary": "interaction",
+      "owner": "Rallar server maintainers",
+      "rationale": "The send-absence assertion directly proves that corruption for a missing durable reference propagates without any live delivery.",
+      "semanticCoverage": "packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts#returns a typed retention gap without attempting a send"
     }
   ]
 }

--- a/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
@@ -273,11 +273,15 @@ function summarizeTopologyView(
     if (!topologyView) {
         return { present: false };
     }
+    // The layout carrying traffic: the accepted slot once a promotion
+    // produced one; the planned slot may run ahead as a held candidate and
+    // must not be reported as the group's exact topology (decision 24).
+    const trafficSnapshot = topologyView.acceptedSnapshot ?? topologyView.snapshot;
     return {
         present: true,
         topologyKind: topologyView.config.effective.topologyKind,
-        ...(topologyView.snapshot
-            ? { participantCount: topologyView.snapshot.activeSessionIds.length }
+        ...(trafficSnapshot
+            ? { participantCount: trafficSnapshot.activeSessionIds.length }
             : {})
     };
 }

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
@@ -20,6 +20,14 @@ export interface GroupTopologyConfigQueryServiceDependencies {
     readonly readPersistedTopologySnapshot?: (
         groupRef: GroupRef
     ) => Promise<RallarOverlayTopologySnapshot | undefined>;
+    /** The accepted-slot reader (plan slice 4c). Absent in local mode: no promotion exists there. */
+    readonly readPersistedAcceptedTopologySnapshot?: (
+        groupRef: GroupRef
+    ) => Promise<RallarOverlayTopologySnapshot | undefined>;
+    /** Decision 11's transient half. Absent in local mode: no durable queue to consult. */
+    readonly readPendingTopologyReplan?: (
+        groupRef: GroupRef
+    ) => Promise<GroupTopologyManagementView['pending']>;
     readonly configRepository?: GroupTopologyConfigRepository;
     readonly serverDefaults?: GroupTopologyServerOptions;
 }
@@ -43,13 +51,17 @@ export class GroupTopologyConfigQueryService {
             : group
             ? this.dependencies.readLocalTopologySnapshot(group)
             : undefined;
-
+        const [acceptedSnapshot, pending] = await Promise.all([
+            this.dependencies.readPersistedAcceptedTopologySnapshot?.(groupRef),
+            this.dependencies.readPendingTopologyReplan?.(groupRef)
+        ]);
         return {
             groupRef,
             overlayId: toScopedOverlayId(groupRef),
             snapshot: snapshot ?? null,
+            acceptedSnapshot: acceptedSnapshot ?? null,
             config: await this.readConfig(groupRef),
-            pending: null
+            pending: pending ?? null
         };
     }
 

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config-query-service.ts
@@ -3,6 +3,7 @@ import type {
     GroupTopologyConfigPatch,
     GroupTopologyConfigView,
     GroupTopologyManagementView,
+    PendingTopologyReplan,
     StoredGroupTopologyOverride
 } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
@@ -27,7 +28,7 @@ export interface GroupTopologyConfigQueryServiceDependencies {
     /** Decision 11's transient half. Absent in local mode: no durable queue to consult. */
     readonly readPendingTopologyReplan?: (
         groupRef: GroupRef
-    ) => Promise<GroupTopologyManagementView['pending']>;
+    ) => Promise<PendingTopologyReplan | null>;
     readonly configRepository?: GroupTopologyConfigRepository;
     readonly serverDefaults?: GroupTopologyServerOptions;
 }
@@ -45,24 +46,30 @@ export class GroupTopologyConfigQueryService {
     }
 
     async readTopologyView(groupRef: GroupRef): Promise<GroupTopologyManagementView> {
-        const group = await this.dependencies.findGroupSnapshotByRef(groupRef);
-        const snapshot = this.dependencies.readPersistedTopologySnapshot
-            ? await this.dependencies.readPersistedTopologySnapshot(groupRef)
-            : group
-            ? this.dependencies.readLocalTopologySnapshot(group)
-            : undefined;
-        const [acceptedSnapshot, pending] = await Promise.all([
+        const [snapshot, acceptedSnapshot, pending, config] = await Promise.all([
+            this.readViewTopologySnapshot(groupRef),
             this.dependencies.readPersistedAcceptedTopologySnapshot?.(groupRef),
-            this.dependencies.readPendingTopologyReplan?.(groupRef)
+            this.dependencies.readPendingTopologyReplan?.(groupRef),
+            this.readConfig(groupRef)
         ]);
         return {
             groupRef,
             overlayId: toScopedOverlayId(groupRef),
             snapshot: snapshot ?? null,
             acceptedSnapshot: acceptedSnapshot ?? null,
-            config: await this.readConfig(groupRef),
+            config,
             pending: pending ?? null
         };
+    }
+
+    private async readViewTopologySnapshot(
+        groupRef: GroupRef
+    ): Promise<RallarOverlayTopologySnapshot | undefined> {
+        if (this.dependencies.readPersistedTopologySnapshot) {
+            return await this.dependencies.readPersistedTopologySnapshot(groupRef);
+        }
+        const group = await this.dependencies.findGroupSnapshotByRef(groupRef);
+        return group ? this.dependencies.readLocalTopologySnapshot(group) : undefined;
     }
 
     async readConfig(groupRef: GroupRef): Promise<GroupTopologyConfigView> {

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
@@ -19,7 +19,11 @@ export interface GroupTopologyPlanningAuthority {
     readonly config: GroupTopologyConfigView;
     readonly kindHysteresisWidths: RtcTopologyKindHysteresisWidths;
     readonly rttMeasurements: readonly RttMeasurementInfo[];
-    /** The group's replanning mode, read with the rest of the authority (4b). */
+    /**
+     * The replanning mode the planning gate consults. Read from the stored
+     * policy only for stages whose disposition follows it; every other
+     * stage carries the default preset's mode, which its row never reads.
+     */
     readonly replanning: GroupTopologyReplanningRead;
     readonly nowEpochMs: number;
 }

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
@@ -3,6 +3,7 @@ import type { GroupTopologyConfigPatch, GroupTopologyConfigView } from '@shared/
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 
 import type { RtcTopologyKindHysteresisWidths } from '../runtime/rallar-rtc-topology-service.ts';
+import type { GroupTopologyReplanningRead } from './resolve-topology-plan-action.ts';
 
 export type GroupTopologyPlanningSnapshotSelection = 'prefer-current' | 'preserve-known-revision';
 
@@ -18,5 +19,7 @@ export interface GroupTopologyPlanningAuthority {
     readonly config: GroupTopologyConfigView;
     readonly kindHysteresisWidths: RtcTopologyKindHysteresisWidths;
     readonly rttMeasurements: readonly RttMeasurementInfo[];
+    /** The group's replanning mode, read with the rest of the authority (4b). */
+    readonly replanning: GroupTopologyReplanningRead;
     readonly nowEpochMs: number;
 }

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts
@@ -24,8 +24,20 @@ export interface ReconfigureGroupTopologyInput {
     readonly publisher?: GroupTopologyPublisher;
 }
 
-export interface ReconcileGroupTopologyResult {
-    readonly snapshot: RallarOverlayTopologySnapshot;
-    readonly previous: RallarOverlayTopologySnapshot | null;
-    readonly changed: boolean;
-}
+/**
+ * The stage-keyed planning gate's outcome (plan slice 4b): `planned` carries
+ * the candidate to commit and publish — a removal tombstone is a planned
+ * publication too — while `frozen` carries the stored layout the stage
+ * refuses to replace, and nothing may be written or published for it.
+ */
+export type ReconcileGroupTopologyResult =
+    | Readonly<{
+        action: 'planned';
+        snapshot: RallarOverlayTopologySnapshot;
+        previous: RallarOverlayTopologySnapshot | null;
+        changed: boolean;
+    }>
+    | Readonly<{
+        action: 'frozen';
+        current: RallarOverlayTopologySnapshot;
+    }>;

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -6,9 +6,10 @@ import type {
     ReconfigureGroupTopologyResponse
 } from '@shared/api/graph-topology-management-types.ts';
 import { readGroupCreatedByPrincipalId, readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
-import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
 
 import { filterRtcRttMeasurementsForGroup } from '../../rtc-rtt/policy/rtc-rtt-measurement-policy.ts';
 import type { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
@@ -33,8 +34,11 @@ import type {
 } from './group-topology-planning-contracts.ts';
 import { materializeRtcOverlayTopologyBroadcastMessage } from './materialize-rtc-overlay-topology-broadcast-message.ts';
 import {
+    consultsReplanningPolicy,
     resolveTopologyPlanAction,
+    toGroupTopologyReplanningRead,
     type GroupTopologyReplanningRead,
+    type TopologyPlanAction,
     type TopologyWorkOrigin
 } from './resolve-topology-plan-action.ts';
 import {
@@ -55,13 +59,13 @@ export interface GroupTopologyPlanningServiceDependencies {
     ) => readonly RttMeasurementInfo[] | Promise<readonly RttMeasurementInfo[]>;
     readonly topologyMode: 'local' | 'persistent';
     /**
-     * The group's stored replanning mode, for the stage-keyed planning gate
-     * (plan slice 4b). Absent means no policy store exists in this
-     * composition; the default preset's mode then governs.
+     * The stored lifecycle-policy read, for the stage-keyed planning gate
+     * (plan slice 4b) — the same port every other topology consumer takes.
+     * Absent means no policy store exists in this composition; the default
+     * preset's mode then governs (`toGroupTopologyReplanningRead` owns that
+     * fold).
      */
-    readonly readTopologyReplanningMode?: (
-        group: GroupSnapshot
-    ) => GroupTopologyReplanningRead | Promise<GroupTopologyReplanningRead>;
+    readonly readLifecyclePolicy?: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
     readonly publisher?: GroupTopologyPublisher;
     readonly serverDefaults?: GroupTopologyServerOptions;
 }
@@ -84,6 +88,10 @@ export class GroupTopologyPlanningService {
 
     recordTopologyRebuildSkippedFingerprint(): void {
         this.dependencies.topologyService.recordTopologyRebuildSkippedFingerprint();
+    }
+
+    recordTopologyPlanFrozen(): void {
+        this.dependencies.topologyService.recordTopologyPlanFrozen();
     }
 
     async readTopologyPlanningAuthority(
@@ -114,7 +122,7 @@ export class GroupTopologyPlanningService {
     computeTopologyFromAuthority(
         authority: GroupTopologyPlanningAuthority,
         previous: RallarOverlayTopologySnapshot | undefined,
-        planning: TopologyPlanningRequest = { intent: 'full-rebuild', origin: 'automatic' }
+        planning: TopologyPlanningRequest
     ): ReconcileGroupTopologyResult {
         if (!isGroupTopologyActiveAt(authority.group, authority.nowEpochMs)) {
             return removedTopologyResult(authority.group, previous);
@@ -144,7 +152,7 @@ export class GroupTopologyPlanningService {
             authority.nowEpochMs
         );
         this.validateTopology(result.snapshot);
-        return { action: 'planned', ...result };
+        return { ...result, action: 'planned' };
     }
 
     async computeGroupTopology(
@@ -156,7 +164,11 @@ export class GroupTopologyPlanningService {
             knownGroup: group,
             snapshotSelection: 'prefer-current'
         });
-        return this.computeTopologyFromAuthority(authority, previous);
+        // The machinery's own reconcile sweep: automatic by definition.
+        return this.computeTopologyFromAuthority(authority, previous, {
+            intent: 'full-rebuild',
+            origin: 'automatic'
+        });
     }
 
     async reconfigureGroupTopology(
@@ -169,7 +181,11 @@ export class GroupTopologyPlanningService {
             input.requestOptions
         );
         const previous = this.dependencies.topologyService.readSnapshot(group);
-        if (await this.isTopologyPlanFrozen(group, previous, 'commanded')) {
+        // Only freeze gates the explicit reconfigure; a removal-disposition
+        // stage keeps today's local planning (a skip has no snapshot to
+        // answer with — recorded residue, api-v1 converges on the handler).
+        if (await this.readLocalTopologyPlanAction(group, previous, 'commanded') === 'freeze') {
+            this.dependencies.topologyService.recordTopologyPlanFrozen();
             return toReconfigureGroupTopologyResponse({
                 groupRef: input.groupRef,
                 result: { snapshot: requireFrozenTopology(previous), previous: previous ?? null, changed: false },
@@ -232,7 +248,10 @@ export class GroupTopologyPlanningService {
         const group = await this.readReconfigureGroup(input);
         const config = await this.dependencies.queryService.readConfig(input.groupRef);
         const previous = this.dependencies.topologyService.readSnapshot(group);
-        if (await this.isTopologyPlanFrozen(group, previous, 'automatic')) {
+        // The automatic flush writes only when the stage says plan: freeze
+        // holds the candidate and a removal-disposition stage has nothing
+        // for an RTT refresh to improve.
+        if (await this.readLocalTopologyPlanAction(group, previous, 'automatic') !== 'plan') {
             return undefined;
         }
         const result = this.dependencies.topologyService.flushDueRttTopologyUpdate(
@@ -271,38 +290,31 @@ export class GroupTopologyPlanningService {
     }
 
     /**
-     * Only the `follow-replanning-policy` row consults the mode, so only an
-     * `active` group pays the stored-policy read; every other stage carries
-     * the default preset's mode, which its disposition row never reads.
+     * Only stages whose disposition is `follow-replanning-policy` consult
+     * the mode (the gate is spelled off the registry so the two cannot
+     * drift); every other stage carries the default preset's mode, which
+     * its disposition row never reads.
      */
     private async readTopologyReplanningMode(group: GroupSnapshot): Promise<GroupTopologyReplanningRead> {
-        if (group.group.lifecycleState !== 'active' || !this.dependencies.readTopologyReplanningMode) {
-            return createDefaultGroupLifecyclePolicy().topology.replanning;
+        const readLifecyclePolicy = this.dependencies.readLifecyclePolicy;
+        if (!readLifecyclePolicy || !consultsReplanningPolicy(group.group.lifecycleState)) {
+            return toGroupTopologyReplanningRead({ status: 'absent' });
         }
-        return await this.dependencies.readTopologyReplanningMode(group);
+        return toGroupTopologyReplanningRead(await readLifecyclePolicy(group.group));
     }
 
-    /**
-     * The local paths' share of the 4b gate: freeze replacement of an active
-     * stored layout when the stage or the commanded mode says so. The removal
-     * disposition stays with the reconcile path — local mode's explicit
-     * reconfigure keeps today's behavior for stages that publish removal.
-     */
-    private async isTopologyPlanFrozen(
+    /** The local paths' share of the 4b gate, resolved by the one owner. */
+    private async readLocalTopologyPlanAction(
         group: GroupSnapshot,
         previous: RallarOverlayTopologySnapshot | undefined,
         workOrigin: TopologyWorkOrigin
-    ): Promise<boolean> {
-        if (previous?.state !== 'active') {
-            return false;
-        }
-        const replanning = await this.readTopologyReplanningMode(group);
+    ): Promise<TopologyPlanAction> {
         return resolveTopologyPlanAction({
             lifecycleState: group.group.lifecycleState,
-            replanning,
+            replanning: await this.readTopologyReplanningMode(group),
             workOrigin,
             previous
-        }) === 'freeze';
+        });
     }
 
     private async readReconfigureGroup(input: ReconfigureGroupTopologyInput): Promise<GroupSnapshot> {

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -6,6 +6,7 @@ import type {
     ReconfigureGroupTopologyResponse
 } from '@shared/api/graph-topology-management-types.ts';
 import { readGroupCreatedByPrincipalId, readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
@@ -32,7 +33,12 @@ import type {
 } from './group-topology-planning-contracts.ts';
 import { materializeRtcOverlayTopologyBroadcastMessage } from './materialize-rtc-overlay-topology-broadcast-message.ts';
 import {
-    isGroupTopologyPlannableAt,
+    resolveTopologyPlanAction,
+    type GroupTopologyReplanningRead,
+    type TopologyWorkOrigin
+} from './resolve-topology-plan-action.ts';
+import {
+    isGroupTopologyActiveAt,
     selectGroupTopologyPlanningSnapshot
 } from './select-group-topology-planning-snapshot.ts';
 
@@ -48,8 +54,21 @@ export interface GroupTopologyPlanningServiceDependencies {
         group: GroupSnapshot
     ) => readonly RttMeasurementInfo[] | Promise<readonly RttMeasurementInfo[]>;
     readonly topologyMode: 'local' | 'persistent';
+    /**
+     * The group's stored replanning mode, for the stage-keyed planning gate
+     * (plan slice 4b). Absent means no policy store exists in this
+     * composition; the default preset's mode then governs.
+     */
+    readonly readTopologyReplanningMode?: (
+        group: GroupSnapshot
+    ) => GroupTopologyReplanningRead | Promise<GroupTopologyReplanningRead>;
     readonly publisher?: GroupTopologyPublisher;
     readonly serverDefaults?: GroupTopologyServerOptions;
+}
+
+export interface TopologyPlanningRequest {
+    readonly intent: RtcTopologyPlanningIntent;
+    readonly origin: TopologyWorkOrigin;
 }
 
 export class GroupTopologyPlanningService {
@@ -77,15 +96,17 @@ export class GroupTopologyPlanningService {
         const group = input.knownGroup
             ? selectGroupTopologyPlanningSnapshot(input.knownGroup, currentGroup, input.snapshotSelection)
             : requireGroupTopologyPlanningSnapshot(input.groupRef, currentGroup);
-        const [config, rttMeasurements] = await Promise.all([
+        const [config, rttMeasurements, replanning] = await Promise.all([
             this.dependencies.queryService.readResolvedTopologyConfig(group.group, input.requestOptions),
-            this.readRawRttMeasurements(group)
+            this.readRawRttMeasurements(group),
+            this.readTopologyReplanningMode(group)
         ]);
         return {
             group,
             config,
             kindHysteresisWidths: this.dependencies.topologyService.readKindHysteresisWidths(),
             rttMeasurements,
+            replanning,
             nowEpochMs: this.dependencies.topologyService.readNowEpochMs()
         };
     }
@@ -93,10 +114,22 @@ export class GroupTopologyPlanningService {
     computeTopologyFromAuthority(
         authority: GroupTopologyPlanningAuthority,
         previous: RallarOverlayTopologySnapshot | undefined,
-        planningIntent: RtcTopologyPlanningIntent = 'full-rebuild'
+        planning: TopologyPlanningRequest = { intent: 'full-rebuild', origin: 'automatic' }
     ): ReconcileGroupTopologyResult {
-        if (!isGroupTopologyPlannableAt(authority.group, authority.nowEpochMs)) {
+        if (!isGroupTopologyActiveAt(authority.group, authority.nowEpochMs)) {
             return removedTopologyResult(authority.group, previous);
+        }
+        const action = resolveTopologyPlanAction({
+            lifecycleState: authority.group.group.lifecycleState,
+            replanning: authority.replanning,
+            workOrigin: planning.origin,
+            previous
+        });
+        if (action === 'publish-removal') {
+            return removedTopologyResult(authority.group, previous);
+        }
+        if (action === 'freeze') {
+            return { action: 'frozen', current: requireFrozenTopology(previous) };
         }
         const filteredRttMeasurements = this.filterRttMeasurementsForGroup(
             authority.group,
@@ -107,11 +140,11 @@ export class GroupTopologyPlanningService {
         const result = this.dependencies.topologyService.planGroupTopologyAt(
             authority.group,
             filteredRttMeasurements,
-            { previous, topologyOptions: authority.config.effective, planningIntent },
+            { previous, topologyOptions: authority.config.effective, planningIntent: planning.intent },
             authority.nowEpochMs
         );
         this.validateTopology(result.snapshot);
-        return result;
+        return { action: 'planned', ...result };
     }
 
     async computeGroupTopology(
@@ -136,6 +169,14 @@ export class GroupTopologyPlanningService {
             input.requestOptions
         );
         const previous = this.dependencies.topologyService.readSnapshot(group);
+        if (await this.isTopologyPlanFrozen(group, previous, 'commanded')) {
+            return toReconfigureGroupTopologyResponse({
+                groupRef: input.groupRef,
+                result: { snapshot: requireFrozenTopology(previous), previous: previous ?? null, changed: false },
+                config,
+                published: false
+            });
+        }
         const result = this.dependencies.topologyService.updateGroupTopology(
             group,
             this.filterRttMeasurementsForGroup(
@@ -167,6 +208,9 @@ export class GroupTopologyPlanningService {
         }
         const previous = this.dependencies.topologyService.readSnapshot(group);
         const result = await this.computeGroupTopology(group, previous);
+        if (result.action === 'frozen') {
+            return result;
+        }
         this.observeCommittedTopology(group, result.snapshot);
         return result;
     }
@@ -188,6 +232,9 @@ export class GroupTopologyPlanningService {
         const group = await this.readReconfigureGroup(input);
         const config = await this.dependencies.queryService.readConfig(input.groupRef);
         const previous = this.dependencies.topologyService.readSnapshot(group);
+        if (await this.isTopologyPlanFrozen(group, previous, 'automatic')) {
+            return undefined;
+        }
         const result = this.dependencies.topologyService.flushDueRttTopologyUpdate(
             group,
             this.filterRttMeasurementsForGroup(
@@ -221,6 +268,41 @@ export class GroupTopologyPlanningService {
             this.dependencies.topologyService.removeGroupTopology(group);
         }
         return Promise.resolve();
+    }
+
+    /**
+     * Only the `follow-replanning-policy` row consults the mode, so only an
+     * `active` group pays the stored-policy read; every other stage carries
+     * the default preset's mode, which its disposition row never reads.
+     */
+    private async readTopologyReplanningMode(group: GroupSnapshot): Promise<GroupTopologyReplanningRead> {
+        if (group.group.lifecycleState !== 'active' || !this.dependencies.readTopologyReplanningMode) {
+            return createDefaultGroupLifecyclePolicy().topology.replanning;
+        }
+        return await this.dependencies.readTopologyReplanningMode(group);
+    }
+
+    /**
+     * The local paths' share of the 4b gate: freeze replacement of an active
+     * stored layout when the stage or the commanded mode says so. The removal
+     * disposition stays with the reconcile path — local mode's explicit
+     * reconfigure keeps today's behavior for stages that publish removal.
+     */
+    private async isTopologyPlanFrozen(
+        group: GroupSnapshot,
+        previous: RallarOverlayTopologySnapshot | undefined,
+        workOrigin: TopologyWorkOrigin
+    ): Promise<boolean> {
+        if (previous?.state !== 'active') {
+            return false;
+        }
+        const replanning = await this.readTopologyReplanningMode(group);
+        return resolveTopologyPlanAction({
+            lifecycleState: group.group.lifecycleState,
+            replanning,
+            workOrigin,
+            previous
+        }) === 'freeze';
     }
 
     private async readReconfigureGroup(input: ReconfigureGroupTopologyInput): Promise<GroupSnapshot> {
@@ -323,6 +405,15 @@ function requireGroupTopologyPlanningSnapshot(
     return snapshot;
 }
 
+function requireFrozenTopology(
+    previous: RallarOverlayTopologySnapshot | undefined
+): RallarOverlayTopologySnapshot {
+    if (!previous) {
+        throw new TypeError('A frozen topology plan requires a stored layout');
+    }
+    return previous;
+}
+
 function removedTopologyResult(
     group: GroupSnapshot,
     previous: RallarOverlayTopologySnapshot | undefined
@@ -331,6 +422,7 @@ function removedTopologyResult(
         ...new Set([...(previous?.activeSessionIds ?? []), ...readGroupMemberSessionIds(group)])
     ].sort(compareRtcTopologyIdentifiers);
     return {
+        action: 'planned',
         snapshot: {
             sourceGroupStateCausalRevision: group.causalRevision,
             state: 'removed',

--- a/packages/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts
+++ b/packages/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts
@@ -1,0 +1,59 @@
+import type {
+    GroupLifecycleState,
+    GroupTopologyReplanningMode
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import { resolveGroupTopologyWorkDisposition } from '@shared/api/group-lifecycle/resolve-group-topology-work-disposition.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+/**
+ * Who asked for this topology work: `automatic` is the machinery's own
+ * follow-up (coalesced membership deltas, RTT refreshes, reconcile sweeps);
+ * `commanded` carries an application or operator intent (the reconfigure
+ * family and the lifecycle transitions' follow-up enqueues).
+ */
+export type TopologyWorkOrigin = 'automatic' | 'commanded';
+
+/** The replanning mode as read: an unreadable policy is its own input. */
+export type GroupTopologyReplanningRead = GroupTopologyReplanningMode | 'corrupt';
+
+export type TopologyPlanAction = 'plan' | 'publish-removal' | 'freeze';
+
+export interface ResolveTopologyPlanActionInput {
+    readonly lifecycleState: GroupLifecycleState;
+    readonly replanning: GroupTopologyReplanningRead;
+    readonly workOrigin: TopologyWorkOrigin;
+    readonly previous: RallarOverlayTopologySnapshot | undefined;
+}
+
+/**
+ * The total stage-keyed planning gate (plan slice 4b, C6): every topology
+ * write path resolves one of three actions from the stage disposition.
+ * `freeze` is replacement suppression, never establishment suppression — a
+ * group whose planned slot is absent or tombstoned may always produce its
+ * first layout (today's phased flow plans while already `connecting`, and
+ * the formation deadline evaluates that plan), so only an active planned
+ * row freezes. `active` follows the replanning policy: `commanded` queues
+ * automatic work (the layout moves only on an application command, product
+ * decision 2's table) and an unreadable policy holds automatic replanning
+ * closed; `auto` and `debounced` are indistinguishable on main until
+ * decision 31 lands, so both plan.
+ */
+export function resolveTopologyPlanAction(input: ResolveTopologyPlanActionInput): TopologyPlanAction {
+    const disposition = resolveGroupTopologyWorkDisposition(input.lifecycleState);
+    if (disposition === 'publish-removal') {
+        return 'publish-removal';
+    }
+    if (disposition === 'plan') {
+        return 'plan';
+    }
+    if (input.previous?.state !== 'active') {
+        return 'plan';
+    }
+    if (disposition === 'freeze') {
+        return 'freeze';
+    }
+    if (input.replanning === 'corrupt') {
+        return input.workOrigin === 'automatic' ? 'freeze' : 'plan';
+    }
+    return input.replanning === 'commanded' && input.workOrigin === 'automatic' ? 'freeze' : 'plan';
+}

--- a/packages/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts
+++ b/packages/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts
@@ -1,3 +1,4 @@
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type {
     GroupLifecycleState,
     GroupTopologyReplanningMode
@@ -5,11 +6,16 @@ import type {
 import { resolveGroupTopologyWorkDisposition } from '@shared/api/group-lifecycle/resolve-group-topology-work-disposition.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
+
 /**
  * Who asked for this topology work: `automatic` is the machinery's own
- * follow-up (coalesced membership deltas, RTT refreshes, reconcile sweeps);
- * `commanded` carries an application or operator intent (the reconfigure
- * family and the lifecycle transitions' follow-up enqueues).
+ * follow-up — coalesced membership deltas, including the lifecycle
+ * transitions' presence-summary follow-ups, plus RTT refreshes and
+ * reconcile sweeps; `commanded` carries an application or operator intent
+ * (the reconfigure family). The transitions' follow-ups ride the automatic
+ * channel deliberately: under `commanded` replanning a group's
+ * post-transition replan also waits for the application (C7).
  */
 export type TopologyWorkOrigin = 'automatic' | 'commanded';
 
@@ -17,6 +23,30 @@ export type TopologyWorkOrigin = 'automatic' | 'commanded';
 export type GroupTopologyReplanningRead = GroupTopologyReplanningMode | 'corrupt';
 
 export type TopologyPlanAction = 'plan' | 'publish-removal' | 'freeze';
+
+/**
+ * Exactly the `follow-replanning-policy` disposition row consults the
+ * stored replanning mode, so this is the one gate for paying the policy
+ * read — spelled off the registry so the two cannot drift.
+ */
+export function consultsReplanningPolicy(lifecycleState: GroupLifecycleState): boolean {
+    return resolveGroupTopologyWorkDisposition(lifecycleState) === 'follow-replanning-policy';
+}
+
+/**
+ * The stored policy folded to the resolver's input, owned once: a group
+ * with no stored policy follows the default preset's mode, and an
+ * unreadable policy stays its own input so the resolver can fail
+ * automatic replanning closed.
+ */
+export function toGroupTopologyReplanningRead(read: GroupLifecyclePolicyRead): GroupTopologyReplanningRead {
+    if (read.status === 'corrupt') {
+        return 'corrupt';
+    }
+    return read.status === 'present'
+        ? read.policy.topology.replanning
+        : createDefaultGroupLifecyclePolicy().topology.replanning;
+}
 
 export interface ResolveTopologyPlanActionInput {
     readonly lifecycleState: GroupLifecycleState;
@@ -32,19 +62,16 @@ export interface ResolveTopologyPlanActionInput {
  * group whose planned slot is absent or tombstoned may always produce its
  * first layout (today's phased flow plans while already `connecting`, and
  * the formation deadline evaluates that plan), so only an active planned
- * row freezes. `active` follows the replanning policy: `commanded` queues
+ * row freezes. `active` follows the replanning policy: `commanded` holds
  * automatic work (the layout moves only on an application command, product
- * decision 2's table) and an unreadable policy holds automatic replanning
- * closed; `auto` and `debounced` are indistinguishable on main until
- * decision 31 lands, so both plan.
+ * decision 2's table) and an unreadable policy fails automatic replanning
+ * closed the same way; `auto` and `debounced` are indistinguishable on
+ * main until decision 31 lands, so both plan.
  */
 export function resolveTopologyPlanAction(input: ResolveTopologyPlanActionInput): TopologyPlanAction {
     const disposition = resolveGroupTopologyWorkDisposition(input.lifecycleState);
-    if (disposition === 'publish-removal') {
-        return 'publish-removal';
-    }
-    if (disposition === 'plan') {
-        return 'plan';
+    if (disposition === 'publish-removal' || disposition === 'plan') {
+        return disposition;
     }
     if (input.previous?.state !== 'active') {
         return 'plan';
@@ -52,8 +79,7 @@ export function resolveTopologyPlanAction(input: ResolveTopologyPlanActionInput)
     if (disposition === 'freeze') {
         return 'freeze';
     }
-    if (input.replanning === 'corrupt') {
-        return input.workOrigin === 'automatic' ? 'freeze' : 'plan';
-    }
-    return input.replanning === 'commanded' && input.workOrigin === 'automatic' ? 'freeze' : 'plan';
+    disposition satisfies 'follow-replanning-policy';
+    const automaticHeld = input.replanning === 'commanded' || input.replanning === 'corrupt';
+    return automaticHeld && input.workOrigin === 'automatic' ? 'freeze' : 'plan';
 }

--- a/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
+++ b/packages/shared-server/rallar-system/topology/planning/select-group-topology-planning-snapshot.ts
@@ -1,5 +1,4 @@
 import { compareGroupCausalRevision, readGroupCausalRevision } from '@shared/api/group-client-views.ts';
-import type { GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { isTuplePreservingGroupLivenessReduction } from '@shared/repository/group-state-snapshot-revision.ts';
 import { GroupStateSnapshotIncomparableError } from '@shared/repository/group-state-snapshots-repository.ts';
@@ -16,37 +15,6 @@ export function isGroupTopologyActiveAt(
         snapshot.group.status === 'active' &&
         (snapshot.group.expiresAtEpochMs === null ||
             snapshot.group.expiresAtEpochMs > observedAtEpochMs)
-    );
-}
-
-/**
- * The formation window (Phase 5, M7): FORMING holds topology planning, so a
- * forming group has no planned overlay to establish and no dials to command.
- * Every other intent state plans -- RECONFIGURING exists precisely to redo
- * establishment work. Groups with immediate formation are created ACTIVE and
- * never enter FORMING, which keeps today's behaviour byte-identical for them.
- * The rows deliberately preserve today's `!== 'forming'` behaviour for the
- * unreachable stages; the total stage-keyed work disposition
- * (`resolveGroupTopologyWorkDisposition`) replaces this gate in the
- * held-layout slice.
- */
-const TOPOLOGY_PLANNABLE: Readonly<Record<GroupLifecycleState, boolean>> = {
-    dormant: true,
-    forming: false,
-    planned: true,
-    connecting: true,
-    active: true,
-    reconfiguring: true,
-    reconnecting: true
-};
-
-export function isGroupTopologyPlannableAt(
-    snapshot: GroupSnapshot,
-    observedAtEpochMs: number
-): boolean {
-    return (
-        isGroupTopologyActiveAt(snapshot, observedAtEpochMs) &&
-        TOPOLOGY_PLANNABLE[snapshot.group.lifecycleState]
     );
 }
 

--- a/packages/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.ts
@@ -8,6 +8,7 @@ import type { WsServerLiveSendStatus } from '@shared/services/ws-queue-box-serve
 import { decodePersistedALMessageValue } from '@shared/al-contracts/al-message-persistence-validation.ts';
 import { toCanonicalRtcTopologyGroupIdentity } from '../../persistence/rtc-topology-identifiers.ts';
 import type { RtcTopologyPublication } from '../../publication/rtc-topology-publication.ts';
+import { toDeliverableTopologySnapshot } from '../deliverable-topology-snapshot.ts';
 import type { RtcTopologyDeliveryLogEntry } from '../delivery/rtc-topology-delivery-contracts.ts';
 import type {
     RtcTopologyReplayEntryHandler,
@@ -64,20 +65,18 @@ export class RtcTopologyReplayEntryHandlerService implements RtcTopologyReplayEn
         signal: AbortSignal
     ): Promise<RtcTopologyReplayEntryHandlingResult> {
         throwIfAborted(signal);
-        const [publication, outbox, acceptedSnapshot, plannedSnapshot] = await Promise.all([
+        // The decision compares against the planned row: it is written in the
+        // same transaction as every publication, so the log can never run
+        // ahead of it — the invariant the corruption checks enforce. The
+        // asynchronously promoted accepted row may trail the log and is read
+        // only when the rare repair branch needs delivery content.
+        const [publication, outbox, plannedSnapshot] = await Promise.all([
             this.#publications.findPublication(entry.groupRef, entry.publicationId),
             this.#outbox.getItem(entry.outboxKey),
-            this.#acceptedSnapshots.findSnapshot(entry.groupRef),
             this.#snapshots.findSnapshot(entry.groupRef)
         ]);
         throwIfAborted(signal);
 
-        // The decision compares against the planned row: it is written in the
-        // same transaction as every publication, so the log can never run
-        // ahead of it — the invariant the corruption checks enforce. The
-        // accepted row is promoted asynchronously and may trail the log
-        // indefinitely under a hold landing, so it must not be the
-        // comparison baseline.
         const decision = decideRtcTopologyReplayEntry({
             entry,
             publication,
@@ -89,14 +88,14 @@ export class RtcTopologyReplayEntryHandlerService implements RtcTopologyReplayEn
             return decision;
         }
 
-        // Repair content converges members on the layout carrying traffic:
-        // the accepted row whenever a promotion has produced one, the planned
-        // row only before that (product decisions 24/30, plan slice 4c).
         const isCurrentRepair = decision.status === 'deliver-current';
         const message = isCurrentRepair
             ? materializeRtcTopologyCurrentRepairMessage({
                 entry,
-                currentSnapshot: acceptedSnapshot ?? decision.currentSnapshot,
+                currentSnapshot: toDeliverableTopologySnapshot({
+                    planned: decision.currentSnapshot,
+                    accepted: await this.#acceptedSnapshots.findSnapshot(entry.groupRef)
+                }) ?? decision.currentSnapshot,
                 databaseNowEpochMs
             })
             : decision.message;

--- a/packages/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.ts
@@ -38,6 +38,8 @@ interface RtcTopologyReplayEntryHandlerOptions {
     readonly publications: RtcTopologyReplayPublicationReader;
     readonly outbox: RtcTopologyReplayOutboxReader;
     readonly snapshots: RtcTopologyReplaySnapshotReader;
+    /** The accepted slot: repair pins to it whenever it exists (plan slice 4c). */
+    readonly acceptedSnapshots: RtcTopologyReplaySnapshotReader;
     readonly sender: RtcTopologyReplayLiveSender;
 }
 
@@ -45,12 +47,14 @@ export class RtcTopologyReplayEntryHandlerService implements RtcTopologyReplayEn
     readonly #publications: RtcTopologyReplayPublicationReader;
     readonly #outbox: RtcTopologyReplayOutboxReader;
     readonly #snapshots: RtcTopologyReplaySnapshotReader;
+    readonly #acceptedSnapshots: RtcTopologyReplaySnapshotReader;
     readonly #sender: RtcTopologyReplayLiveSender;
 
     constructor(options: RtcTopologyReplayEntryHandlerOptions) {
         this.#publications = options.publications;
         this.#outbox = options.outbox;
         this.#snapshots = options.snapshots;
+        this.#acceptedSnapshots = options.acceptedSnapshots;
         this.#sender = options.sender;
     }
 
@@ -60,29 +64,39 @@ export class RtcTopologyReplayEntryHandlerService implements RtcTopologyReplayEn
         signal: AbortSignal
     ): Promise<RtcTopologyReplayEntryHandlingResult> {
         throwIfAborted(signal);
-        const [publication, outbox, currentSnapshot] = await Promise.all([
+        const [publication, outbox, acceptedSnapshot, plannedSnapshot] = await Promise.all([
             this.#publications.findPublication(entry.groupRef, entry.publicationId),
             this.#outbox.getItem(entry.outboxKey),
+            this.#acceptedSnapshots.findSnapshot(entry.groupRef),
             this.#snapshots.findSnapshot(entry.groupRef)
         ]);
         throwIfAborted(signal);
 
+        // The decision compares against the planned row: it is written in the
+        // same transaction as every publication, so the log can never run
+        // ahead of it — the invariant the corruption checks enforce. The
+        // accepted row is promoted asynchronously and may trail the log
+        // indefinitely under a hold landing, so it must not be the
+        // comparison baseline.
         const decision = decideRtcTopologyReplayEntry({
             entry,
             publication,
             outbox,
-            currentSnapshot,
+            currentSnapshot: plannedSnapshot,
             databaseNowEpochMs
         });
         if (decision.status === 'gap') {
             return decision;
         }
 
+        // Repair content converges members on the layout carrying traffic:
+        // the accepted row whenever a promotion has produced one, the planned
+        // row only before that (product decisions 24/30, plan slice 4c).
         const isCurrentRepair = decision.status === 'deliver-current';
         const message = isCurrentRepair
             ? materializeRtcTopologyCurrentRepairMessage({
                 entry,
-                currentSnapshot: decision.currentSnapshot,
+                currentSnapshot: acceptedSnapshot ?? decision.currentSnapshot,
                 databaseNowEpochMs
             })
             : decision.message;

--- a/packages/shared-server/rallar-system/topology/replay/deliverable-topology-snapshot.ts
+++ b/packages/shared-server/rallar-system/topology/replay/deliverable-topology-snapshot.ts
@@ -1,0 +1,49 @@
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+export interface ToDeliverableTopologySnapshotInput {
+    readonly planned: RallarOverlayTopologySnapshot | undefined;
+    readonly accepted: RallarOverlayTopologySnapshot | undefined;
+    /**
+     * When delivery addresses one member, selection is member-aware: a
+     * session named only in the held planned candidate still receives its
+     * candidate assignment. Absent for broadcast repair, which delivers one
+     * row to the members that row names.
+     */
+    readonly sessionId?: string;
+}
+
+/**
+ * The delivery-content rule for repair and reconnect hydration (plan slice
+ * 4c, product decisions 1/24/30): members converge on the layout carrying
+ * traffic — the accepted row once a promotion produced one, the planned row
+ * before that. Two qualifiers keep the rule honest. A planned removal
+ * tombstone always wins: it is the teardown signal (I15), the accepted slot
+ * only ever holds active layouts (a tombstone never promotes), and nothing
+ * deletes the accepted row today — without this clause a torn-down overlay
+ * would be resurrected from the stale accepted layout forever. And a
+ * session named only in the planned candidate receives the candidate: under
+ * a hold the candidate is what that member dials, and refusing it would
+ * starve the very coverage the activation criterion measures.
+ *
+ * The replay *decision* deliberately does not use this rule — it compares
+ * the log against the planned row, whose same-transaction write is the
+ * corruption invariant. Only delivered content resolves here.
+ */
+export function toDeliverableTopologySnapshot(
+    input: ToDeliverableTopologySnapshotInput
+): RallarOverlayTopologySnapshot | undefined {
+    const { planned, accepted, sessionId } = input;
+    if (planned?.state === 'removed') {
+        return planned;
+    }
+    if (
+        sessionId !== undefined &&
+        accepted !== undefined &&
+        !accepted.activeSessionIds.includes(sessionId) &&
+        planned !== undefined &&
+        planned.activeSessionIds.includes(sessionId)
+    ) {
+        return planned;
+    }
+    return accepted ?? planned;
+}

--- a/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydration.ts
+++ b/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydration.ts
@@ -7,6 +7,7 @@ import type {
     RtcTopologyReplayDiagnosticsSink,
     RtcTopologyReplayHydrationOutcome
 } from '../consumer/rtc-topology-replay-diagnostics.ts';
+import { toDeliverableTopologySnapshot } from '../deliverable-topology-snapshot.ts';
 import { materializeRtcTopologyHydrationMessage } from './rtc-topology-hydration-message.ts';
 
 export const RTC_TOPOLOGY_HYDRATION_PAGE_SIZE = 100;
@@ -76,15 +77,17 @@ export class RtcTopologyReconnectHydration {
      * Both slots are scanned (plan slice 4c): the planned namespace names
      * every dialing member — a connecting group has no accepted row — while
      * the accepted namespace names members the traffic layout still carries
-     * after a replan moved the planned row past them. Delivery itself always
-     * chooses accepted-first, so the two scans agree on content and the pair
-     * set only dedupes work.
+     * after a replan moved the planned row past them. Delivery content is
+     * resolved by the one shared rule for every pair regardless of which
+     * scan found it, so a pair is attempted at most once per pass; a pair
+     * whose attempt asked for a retry keeps its retry mark for the next
+     * pass instead of being re-attempted by the second scan.
      */
     async hydrate(input: RtcTopologyReconnectHydration.Input): Promise<ReadonlySet<ConnectionContext>> {
         const state: HydrationScanState = {
             matched: new Set<ConnectionContext>(),
             retry: new Set<ConnectionContext>(),
-            hydratedPairs: new Set<string>()
+            attemptedPairs: new Set<string>()
         };
         await this.#scanTopologyPages(this.#topologies, input, state);
         await this.#scanTopologyPages(this.#acceptedTopologies, input, state);
@@ -134,17 +137,16 @@ export class RtcTopologyReconnectHydration {
         );
         for (const connection of candidates) {
             const pair = `${scannedTopology.overlayId}\u0000${connection.id}`;
-            if (state.hydratedPairs.has(pair)) {
+            if (state.attemptedPairs.has(pair)) {
                 continue;
             }
+            state.attemptedPairs.add(pair);
             state.matched.add(connection);
             const outcome = await this.#hydrateTopology(connection, scannedTopology, input);
             this.#diagnostics?.({ kind: 'hydration', outcome });
             if (outcome === 'retry') {
                 state.retry.add(connection);
-                continue;
             }
-            state.hydratedPairs.add(pair);
         }
     }
 
@@ -194,14 +196,15 @@ export class RtcTopologyReconnectHydration {
             if (!this.#isCurrent(connection)) {
                 return 'stale-generation';
             }
-            // Hydration content is accepted-first: the layout carrying
-            // traffic when it exists, the planned row only before a first
-            // promotion (product decisions 1/30).
             const [acceptedTopology, plannedTopology] = await Promise.all([
                 this.#acceptedTopologies.findSnapshot(scannedTopology.groupRef),
                 this.#topologies.findSnapshot(scannedTopology.groupRef)
             ]);
-            const currentTopology = acceptedTopology ?? plannedTopology;
+            const currentTopology = toDeliverableTopologySnapshot({
+                planned: plannedTopology,
+                accepted: acceptedTopology,
+                sessionId: connection.id
+            });
             throwIfAborted(input);
             const authorizationAfter = await this.#groups.readSnapshot(scannedTopology.groupRef);
             throwIfAborted(input);
@@ -250,7 +253,7 @@ export class RtcTopologyReconnectHydration {
 interface HydrationScanState {
     readonly matched: Set<ConnectionContext>;
     readonly retry: Set<ConnectionContext>;
-    readonly hydratedPairs: Set<string>;
+    readonly attemptedPairs: Set<string>;
 }
 
 interface IsAuthorizedInput {

--- a/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydration.ts
+++ b/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydration.ts
@@ -33,6 +33,8 @@ export namespace RtcTopologyReconnectHydration {
     export interface Dependencies {
         readonly socket: JsonWebSocketServer;
         readonly topologies: TopologyReader;
+        /** The accepted slot: hydration pins to it whenever it exists (plan slice 4c). */
+        readonly acceptedTopologies: TopologyReader;
         readonly groups: GroupReader;
         readonly readIdentity: (
             connection: ConnectionContext
@@ -52,6 +54,7 @@ export namespace RtcTopologyReconnectHydration {
 export class RtcTopologyReconnectHydration {
     readonly #socket: JsonWebSocketServer;
     readonly #topologies: RtcTopologyReconnectHydration.TopologyReader;
+    readonly #acceptedTopologies: RtcTopologyReconnectHydration.TopologyReader;
     readonly #groups: RtcTopologyReconnectHydration.GroupReader;
     readonly #readIdentity: RtcTopologyReconnectHydration.Dependencies['readIdentity'];
     readonly #nowEpochMs: () => number;
@@ -61,6 +64,7 @@ export class RtcTopologyReconnectHydration {
     constructor(dependencies: RtcTopologyReconnectHydration.Dependencies) {
         this.#socket = dependencies.socket;
         this.#topologies = dependencies.topologies;
+        this.#acceptedTopologies = dependencies.acceptedTopologies;
         this.#groups = dependencies.groups;
         this.#readIdentity = dependencies.readIdentity;
         this.#nowEpochMs = dependencies.nowEpochMs;
@@ -68,46 +72,80 @@ export class RtcTopologyReconnectHydration {
         this.#yield = dependencies.yield;
     }
 
+    /**
+     * Both slots are scanned (plan slice 4c): the planned namespace names
+     * every dialing member — a connecting group has no accepted row — while
+     * the accepted namespace names members the traffic layout still carries
+     * after a replan moved the planned row past them. Delivery itself always
+     * chooses accepted-first, so the two scans agree on content and the pair
+     * set only dedupes work.
+     */
     async hydrate(input: RtcTopologyReconnectHydration.Input): Promise<ReadonlySet<ConnectionContext>> {
-        const matched = new Set<ConnectionContext>();
-        const retry = new Set<ConnectionContext>();
+        const state: HydrationScanState = {
+            matched: new Set<ConnectionContext>(),
+            retry: new Set<ConnectionContext>(),
+            hydratedPairs: new Set<string>()
+        };
+        await this.#scanTopologyPages(this.#topologies, input, state);
+        await this.#scanTopologyPages(this.#acceptedTopologies, input, state);
+        this.#recordUnmatched(input.connections, state.matched, state.retry);
+        return state.retry;
+    }
+
+    async #scanTopologyPages(
+        reader: RtcTopologyReconnectHydration.TopologyReader,
+        input: RtcTopologyReconnectHydration.Input,
+        state: HydrationScanState
+    ): Promise<void> {
         let afterKey: string | undefined;
         while (true) {
             throwIfAborted(input);
             let page: readonly RuntimeStateEntryValue<RallarOverlayTopologySnapshot>[];
             try {
-                page = await this.#topologies.listSnapshotEntriesPage({
+                page = await reader.listSnapshotEntriesPage({
                     afterKey,
                     limit: RTC_TOPOLOGY_HYDRATION_PAGE_SIZE
                 });
             }
             catch {
                 throwIfAborted(input);
-                this.#recordScanRetries(input.connections, retry);
-                break;
+                this.#recordScanRetries(input.connections, state.retry);
+                return;
             }
             for (const entry of page) {
                 throwIfAborted(input);
-                const candidates = input.connections.filter((connection) =>
-                    entry.value.activeSessionIds.includes(connection.id)
-                );
-                for (const connection of candidates) {
-                    matched.add(connection);
-                    const outcome = await this.#hydrateTopology(connection, entry.value, input);
-                    this.#diagnostics?.({ kind: 'hydration', outcome });
-                    if (outcome === 'retry') {
-                        retry.add(connection);
-                    }
-                }
+                await this.#hydrateScannedTopology(entry.value, input, state);
             }
             if (page.length < RTC_TOPOLOGY_HYDRATION_PAGE_SIZE) {
-                break;
+                return;
             }
             afterKey = page.at(-1)!.entry.key;
             await this.#yield();
         }
-        this.#recordUnmatched(input.connections, matched, retry);
-        return retry;
+    }
+
+    async #hydrateScannedTopology(
+        scannedTopology: RallarOverlayTopologySnapshot,
+        input: RtcTopologyReconnectHydration.Input,
+        state: HydrationScanState
+    ): Promise<void> {
+        const candidates = input.connections.filter((connection) =>
+            scannedTopology.activeSessionIds.includes(connection.id)
+        );
+        for (const connection of candidates) {
+            const pair = `${scannedTopology.overlayId}\u0000${connection.id}`;
+            if (state.hydratedPairs.has(pair)) {
+                continue;
+            }
+            state.matched.add(connection);
+            const outcome = await this.#hydrateTopology(connection, scannedTopology, input);
+            this.#diagnostics?.({ kind: 'hydration', outcome });
+            if (outcome === 'retry') {
+                state.retry.add(connection);
+                continue;
+            }
+            state.hydratedPairs.add(pair);
+        }
     }
 
     #recordScanRetries(
@@ -156,7 +194,14 @@ export class RtcTopologyReconnectHydration {
             if (!this.#isCurrent(connection)) {
                 return 'stale-generation';
             }
-            const currentTopology = await this.#topologies.findSnapshot(scannedTopology.groupRef);
+            // Hydration content is accepted-first: the layout carrying
+            // traffic when it exists, the planned row only before a first
+            // promotion (product decisions 1/30).
+            const [acceptedTopology, plannedTopology] = await Promise.all([
+                this.#acceptedTopologies.findSnapshot(scannedTopology.groupRef),
+                this.#topologies.findSnapshot(scannedTopology.groupRef)
+            ]);
+            const currentTopology = acceptedTopology ?? plannedTopology;
             throwIfAborted(input);
             const authorizationAfter = await this.#groups.readSnapshot(scannedTopology.groupRef);
             throwIfAborted(input);
@@ -200,6 +245,12 @@ export class RtcTopologyReconnectHydration {
     #isCurrent(connection: ConnectionContext): boolean {
         return this.#socket.connections.get(connection.id) === connection && connection.isOpen;
     }
+}
+
+interface HydrationScanState {
+    readonly matched: Set<ConnectionContext>;
+    readonly retry: Set<ConnectionContext>;
+    readonly hydratedPairs: Set<string>;
 }
 
 interface IsAuthorizedInput {

--- a/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.ts
+++ b/packages/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.ts
@@ -17,6 +17,7 @@ export namespace RtcTopologyReconnectHydrator {
     export interface Dependencies {
         readonly socket: JsonWebSocketServer;
         readonly topologies: RtcTopologyReconnectHydration.TopologyReader;
+        readonly acceptedTopologies: RtcTopologyReconnectHydration.TopologyReader;
         readonly groups: RtcTopologyReconnectHydration.GroupReader;
         readonly readIdentity: (
             connection: ConnectionContext
@@ -48,6 +49,7 @@ export class RtcTopologyReconnectHydrator {
         this.#hydration = new RtcTopologyReconnectHydration({
             socket: dependencies.socket,
             topologies: dependencies.topologies,
+            acceptedTopologies: dependencies.acceptedTopologies,
             groups: dependencies.groups,
             readIdentity: dependencies.readIdentity,
             nowEpochMs: dependencies.nowEpochMs,

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -23,6 +23,7 @@ import {
 } from '../../mutation/rtc-topology-mutations.ts';
 import type { RtcTopologyWorkRuntime } from '../../mutation/rtc-topology-outbox-work.ts';
 import type { RtcTopologyExecutionRepository } from '../../persistence/rtc-topology-execution-repository.ts';
+import type { ReconcileGroupTopologyResult } from '../../planning/group-topology-planning-contracts.ts';
 import type { GroupTopologyPlanningService } from '../../planning/group-topology-planning-service.ts';
 import {
     materializeRtcOverlayTopologyBroadcastMessage,
@@ -36,7 +37,7 @@ import {
     toRtcTopologyDeliveryAppendInput
 } from '../delivery/rtc-topology-delivery-validation.ts';
 import { finishRtcTopologyReservation, finishRtcTopologyWork } from './finish-rtc-topology-work.ts';
-import { isChangeGatedGroupRevisionWork } from './rtc-topology-coalesced-group-revision-work.ts';
+import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
 import { computeAuthorityTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
 import {
     readRtcTopologyWorkEnvelope,
@@ -73,6 +74,7 @@ interface RtcTopologyWorkHandlerOptions {
         | 'computeTopologyFromAuthority'
         | 'observeCommittedTopology'
         | 'recordTopologyPublication'
+        | 'recordTopologyPlanFrozen'
         | 'recordTopologyRebuildSkippedFingerprint'
     >;
     readonly executionRepository: RtcTopologyExecutionRepository;
@@ -135,7 +137,7 @@ type AcceptedRtcTopologyWork =
         decision: 'skipped-frozen';
         work: PersistedRtcTopologyWork;
         group: GroupSnapshot;
-        criterionPetition: CommittedCriterionPetition | null;
+        criterionPetition: CommittedCriterionPetition;
     }>
     | Readonly<{
         decision: 'skipped-rtt-refinement';
@@ -232,33 +234,46 @@ async function processLoadedRtcTopologyWork(
     options.wakeReplay?.();
 }
 
-async function computeAcceptedRtcTopologyWork(
+/**
+ * The RTT-refinement claim gate defers the replan, never the activation
+ * decision: the measurement that carries a connecting group across its
+ * threshold must still petition the criterion, or activation waits for the
+ * next deadline evaluation. A removed stored plan never petitions — its
+ * empty edge set would read as trivially-complete readiness.
+ */
+async function computeRttRefinementSkip(
     input: ComputeAcceptedRtcTopologyWorkInput
-): Promise<AcceptedRtcTopologyWork> {
-    const { options, workEnvelope, workId, attemptCount, read } = input;
-    const work = workEnvelope.data;
+): Promise<AcceptedRtcTopologyWork | null> {
+    const work = input.workEnvelope.data;
     if (
-        work.kind === 'rtt-refresh' &&
-        options.rttRefinementService &&
-        !options.rttRefinementService.claimWork({
+        work.kind !== 'rtt-refresh' ||
+        !input.options.rttRefinementService ||
+        input.options.rttRefinementService.claimWork({
             observationId: work.refinementObservationId,
-            workId,
+            workId: input.workId,
             groupKey: toWebRtcGroupKey(work.groupSnapshot.group),
             rtt: work.rtt,
             expireAtEpochMs: input.expireAtEpochMs
         })
     ) {
-        // The gate defers the replan, never the activation decision: the
-        // measurement that carries a connecting group across its threshold
-        // must still petition the criterion, or activation waits for the next
-        // deadline evaluation. A removed stored plan never petitions — its
-        // empty edge set would read as trivially-complete readiness.
-        await input.deferredCriterionPetitioner.request(work, read);
-        return {
-            decision: 'skipped-rtt-refinement',
-            work,
-            group: work.groupSnapshot
-        };
+        return null;
+    }
+    await input.deferredCriterionPetitioner.request(work, input.read);
+    return {
+        decision: 'skipped-rtt-refinement',
+        work,
+        group: work.groupSnapshot
+    };
+}
+
+async function computeAcceptedRtcTopologyWork(
+    input: ComputeAcceptedRtcTopologyWorkInput
+): Promise<AcceptedRtcTopologyWork> {
+    const { options, workEnvelope, read } = input;
+    const work = workEnvelope.data;
+    const rttRefinementSkip = await computeRttRefinementSkip(input);
+    if (rttRefinementSkip !== null) {
+        return rttRefinementSkip;
     }
     const membershipDeltaWork = work.kind === 'group-revision';
     const authority = await options.topologyPlanning.readTopologyPlanningAuthority({
@@ -269,28 +284,24 @@ async function computeAcceptedRtcTopologyWork(
     });
     const inputFingerprint = await computeAuthorityTopologyInputFingerprint(authority);
     const changeGated = work.kind === 'group-revision' && isChangeGatedGroupRevisionWork(work);
-    if (changeGated && read.snapshot?.value.state === 'active') {
-        const storedFingerprint = await options.executionRepository.readTopologyInputFingerprint(
-            authority.group.group
-        );
-        if (storedFingerprint === inputFingerprint) {
-            return { decision: 'skipped-fingerprint', work, group: authority.group };
-        }
+    if (changeGated && await isFingerprintUnchanged(input, authority, inputFingerprint)) {
+        return { decision: 'skipped-fingerprint', work, group: authority.group };
     }
     const computedTopology = options.topologyPlanning.computeTopologyFromAuthority(
         authority,
         read.snapshot?.value,
         {
             intent: membershipDeltaWork ? 'membership-delta' : 'full-rebuild',
-            origin: work.kind === 'rtt-refresh' || changeGated ? 'automatic' : 'commanded'
+            origin: toTopologyWorkOrigin(work)
         }
     );
     if (computedTopology.action === 'frozen') {
+        // The union's own payload is the row the freeze decision named.
         return {
             decision: 'skipped-frozen',
             work,
             group: authority.group,
-            criterionPetition: read.snapshot ? { authority, planned: read.snapshot.value } : null
+            criterionPetition: { authority, planned: computedTopology.current }
         };
     }
     // RTT is deliberately outside the fingerprint, so an RTT refresh always
@@ -308,6 +319,41 @@ async function computeAcceptedRtcTopologyWork(
             criterionPetition: { authority, planned: read.snapshot.value }
         };
     }
+    return await computeCommittedTopologyWork({
+        base: input,
+        authority,
+        planned: computedTopology,
+        inputFingerprint
+    });
+}
+
+async function isFingerprintUnchanged(
+    input: ComputeAcceptedRtcTopologyWorkInput,
+    authority: GroupTopologyPlanningAuthority,
+    inputFingerprint: string
+): Promise<boolean> {
+    if (input.read.snapshot?.value.state !== 'active') {
+        return false;
+    }
+    const storedFingerprint = await input.options.executionRepository.readTopologyInputFingerprint(
+        authority.group.group
+    );
+    return storedFingerprint === inputFingerprint;
+}
+
+interface ComputeCommittedTopologyWorkInput {
+    readonly base: ComputeAcceptedRtcTopologyWorkInput;
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly planned: Extract<ReconcileGroupTopologyResult, { action: 'planned'; }>;
+    readonly inputFingerprint: string;
+}
+
+async function computeCommittedTopologyWork(
+    input: ComputeCommittedTopologyWorkInput
+): Promise<AcceptedRtcTopologyWork> {
+    const { authority, planned, inputFingerprint } = input;
+    const { options, workEnvelope, workId, attemptCount, read } = input.base;
+    const work = workEnvelope.data;
     const publicationExpireAtTimestamp = work.publish
         ? options.executionRepository.publicationExpireAtTimestamp()
         : null;
@@ -316,7 +362,7 @@ async function computeAcceptedRtcTopologyWork(
         : toTopologyPublication({
             envelope: workEnvelope,
             group: authority.group,
-            snapshot: computedTopology.snapshot,
+            snapshot: planned.snapshot,
             facts: {
                 workId,
                 createdAtEpochMs: work.requestedAtEpochMs,
@@ -336,17 +382,11 @@ async function computeAcceptedRtcTopologyWork(
         } as const);
     const computed = computeTopologyMutation({
         read,
-        candidate: computedTopology.snapshot,
+        candidate: planned.snapshot,
         publication,
         facts
     });
-    validateTopologyMutation({
-        read,
-        candidate: computedTopology.snapshot,
-        publication,
-        facts,
-        computed
-    });
+    validateTopologyMutation({ read, candidate: planned.snapshot, publication, facts, computed });
     if (computed.outcome === 'retry') {
         throw new RuntimeStateWriteConflictError();
     }
@@ -360,7 +400,7 @@ async function computeAcceptedRtcTopologyWork(
         computed,
         publication,
         inputFingerprint,
-        criterionPetition: { authority, planned: computedTopology.snapshot }
+        criterionPetition: { authority, planned: planned.snapshot }
     };
 }
 
@@ -378,12 +418,8 @@ async function writeAcceptedRtcTopologyWork(
         options.topologyPlanning.recordTopologyRebuildSkippedFingerprint();
         return;
     }
-    if (accepted.decision === 'skipped-unchanged') {
-        await writeUnchangedTopologyWork(options, entry, accepted);
-        return;
-    }
-    if (accepted.decision === 'skipped-frozen') {
-        await writeFrozenTopologyWork(options, entry, accepted);
+    if (accepted.decision === 'skipped-unchanged' || accepted.decision === 'skipped-frozen') {
+        await writeSkippedTopologyWork(options, entry, accepted);
         return;
     }
     const computed = accepted.computed;
@@ -420,15 +456,18 @@ async function writeAcceptedRtcTopologyWork(
 }
 
 /**
- * The unchanged path's transaction: the fingerprint refresh, plus the
- * promotion reconcile — a request a stale-stage cycle failed to mint is
- * re-derived from the stored row here, so accepted and planned can never
- * diverge silently.
+ * The one transaction both skip decisions share: the promotion reconcile —
+ * a request a stale cycle failed to mint is re-derived from the stored row
+ * here, so accepted and planned can never diverge silently — plus the
+ * reservation finish. Only the unchanged decision refreshes the input
+ * fingerprint: the frozen path must NOT write it, because the stale
+ * fingerprint is decision 11's latched signal that the stored layout
+ * trails the authority.
  */
-async function writeUnchangedTopologyWork(
+async function writeSkippedTopologyWork(
     options: RtcTopologyWorkHandlerOptions,
     entry: ResourceEntry,
-    accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-unchanged'; }>
+    accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-unchanged' | 'skipped-frozen'; }>
 ): Promise<void> {
     const promotionRequest = await readTopologyPromotionRequest({
         publication: options.topologyPublication,
@@ -437,41 +476,22 @@ async function writeUnchangedTopologyWork(
         target: accepted.criterionPetition?.planned ?? null
     });
     await runInPSqlTransaction(options.database, async (transaction) => {
-        await options.executionRepository.writeTopologyInputFingerprint(
-            transaction,
-            accepted.group.group,
-            accepted.inputFingerprint
-        );
+        if (accepted.decision === 'skipped-unchanged') {
+            await options.executionRepository.writeTopologyInputFingerprint(
+                transaction,
+                accepted.group.group,
+                accepted.inputFingerprint
+            );
+        }
         await writeTopologyPromotionRequest(transaction, promotionRequest);
         await finishRtcTopologyReservation(transaction, entry);
     });
-    options.topologyPlanning.recordTopologyPublication(false);
-    await petitionCommittedCriterion(options, accepted.criterionPetition);
-}
-
-/**
- * The frozen path (plan slice 4b): the stage or the commanded mode refuses a
- * replacement, so nothing is written — not even the input fingerprint, which
- * must keep signalling that the stored layout trails the authority. The
- * criterion still measures the frozen candidate, and the promotion reconcile
- * still heals an accepted row that trails it.
- */
-async function writeFrozenTopologyWork(
-    options: RtcTopologyWorkHandlerOptions,
-    entry: ResourceEntry,
-    accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-frozen'; }>
-): Promise<void> {
-    const promotionRequest = await readTopologyPromotionRequest({
-        publication: options.topologyPublication,
-        serviceId: options.serviceId,
-        entry,
-        target: accepted.criterionPetition?.planned ?? null
-    });
-    await runInPSqlTransaction(options.database, async (transaction) => {
-        await writeTopologyPromotionRequest(transaction, promotionRequest);
-        await finishRtcTopologyReservation(transaction, entry);
-    });
-    options.topologyPlanning.recordTopologyPublication(false);
+    if (accepted.decision === 'skipped-frozen') {
+        options.topologyPlanning.recordTopologyPlanFrozen();
+    }
+    else {
+        options.topologyPlanning.recordTopologyPublication(false);
+    }
     await petitionCommittedCriterion(options, accepted.criterionPetition);
 }
 

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -132,6 +132,12 @@ type AcceptedRtcTopologyWork =
         criterionPetition: CommittedCriterionPetition | null;
     }>
     | Readonly<{
+        decision: 'skipped-frozen';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+        criterionPetition: CommittedCriterionPetition | null;
+    }>
+    | Readonly<{
         decision: 'skipped-rtt-refinement';
         work: PersistedRtcTopologyWork;
         group: GroupSnapshot;
@@ -274,8 +280,19 @@ async function computeAcceptedRtcTopologyWork(
     const computedTopology = options.topologyPlanning.computeTopologyFromAuthority(
         authority,
         read.snapshot?.value,
-        membershipDeltaWork ? 'membership-delta' : 'full-rebuild'
+        {
+            intent: membershipDeltaWork ? 'membership-delta' : 'full-rebuild',
+            origin: work.kind === 'rtt-refresh' || changeGated ? 'automatic' : 'commanded'
+        }
     );
+    if (computedTopology.action === 'frozen') {
+        return {
+            decision: 'skipped-frozen',
+            work,
+            group: authority.group,
+            criterionPetition: read.snapshot ? { authority, planned: read.snapshot.value } : null
+        };
+    }
     // RTT is deliberately outside the fingerprint, so an RTT refresh always
     // replans — but an unchanged planned graph publishes nothing (M8). The
     // criterion petition fences on the stored row, not the recomputed
@@ -365,6 +382,10 @@ async function writeAcceptedRtcTopologyWork(
         await writeUnchangedTopologyWork(options, entry, accepted);
         return;
     }
+    if (accepted.decision === 'skipped-frozen') {
+        await writeFrozenTopologyWork(options, entry, accepted);
+        return;
+    }
     const computed = accepted.computed;
     if (computed.outcome === 'superseded') {
         await finishRtcTopologyWork(options.database, entry);
@@ -421,6 +442,32 @@ async function writeUnchangedTopologyWork(
             accepted.group.group,
             accepted.inputFingerprint
         );
+        await writeTopologyPromotionRequest(transaction, promotionRequest);
+        await finishRtcTopologyReservation(transaction, entry);
+    });
+    options.topologyPlanning.recordTopologyPublication(false);
+    await petitionCommittedCriterion(options, accepted.criterionPetition);
+}
+
+/**
+ * The frozen path (plan slice 4b): the stage or the commanded mode refuses a
+ * replacement, so nothing is written — not even the input fingerprint, which
+ * must keep signalling that the stored layout trails the authority. The
+ * criterion still measures the frozen candidate, and the promotion reconcile
+ * still heals an accepted row that trails it.
+ */
+async function writeFrozenTopologyWork(
+    options: RtcTopologyWorkHandlerOptions,
+    entry: ResourceEntry,
+    accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-frozen'; }>
+): Promise<void> {
+    const promotionRequest = await readTopologyPromotionRequest({
+        publication: options.topologyPublication,
+        serviceId: options.serviceId,
+        entry,
+        target: accepted.criterionPetition?.planned ?? null
+    });
+    await runInPSqlTransaction(options.database, async (transaction) => {
         await writeTopologyPromotionRequest(transaction, promotionRequest);
         await finishRtcTopologyReservation(transaction, entry);
     });

--- a/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts
@@ -11,7 +11,7 @@ import {
     toCanonicalGroupTopologyConfigPatch
 } from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot, GroupStateCausalRevision } from '@shared/api/group-types.ts';
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import { toAppQueueCreatedBy, toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import { AppOutboxType } from '../../../app-outbox/app-outbox-type.ts';
@@ -130,6 +130,43 @@ function readPreviousMessageIdentity(previousEntry: ResourceEntry): CoalescedMes
     return {
         tsEpochMs: message.id.ts,
         expiresAtEpochMs: message.constraints?.expiresAtMs ?? null
+    };
+}
+
+export interface PendingTopologyReplanReader {
+    findByKey(key: Key): Promise<ResourceEntry | null>;
+}
+
+/** Decision 11's transient half: a replan is queued and due at T. */
+export interface PendingTopologyReplan {
+    readonly reconfigureQueued: boolean;
+    readonly dueAtEpochMs: number | null;
+}
+
+/**
+ * The transient half of product decision 11: is a replan queued for this
+ * group, and when is it due? Read straight off the coalesced group-revision
+ * row (I14 — its `dueAtEpochMs` doubles as the read surface's "when will
+ * this settle"). A row in a terminal status is settled work, not pending; a
+ * present row whose envelope no longer decodes still reports queued, with a
+ * null due time, rather than hiding work the queue will attempt.
+ */
+export async function readPendingTopologyReplan(
+    reader: PendingTopologyReplanReader,
+    groupRef: GroupRef
+): Promise<PendingTopologyReplan | null> {
+    const entry = await reader.findByKey(toAppQueueKey({
+        topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
+        resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(toScopedOverlayId(groupRef)),
+        contextId: groupStateGroupStorageKey(groupRef)
+    }));
+    if (entry === null || !isMutableCoalescedStatus(entry.status)) {
+        return null;
+    }
+    const envelope = tryReadCoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork>(entry);
+    return {
+        reconfigureQueued: true,
+        dueAtEpochMs: envelope?.data[COALESCED_APP_OUTBOX_WORK_FIELD].dueAtEpochMs ?? null
     };
 }
 

--- a/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts
@@ -5,6 +5,7 @@ import { decodePersistedALMessage } from '@shared/al-contracts/al-message-persis
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { validateAuthoritativeGroupSnapshot } from '@shared/api/authoritative-state-validation.ts';
+import type { PendingTopologyReplan } from '@shared/api/graph-topology-management-types.ts';
 import { compareGroupCausalRevision, readGroupCausalRevision } from '@shared/api/group-client-views.ts';
 import {
     isPreserveOnlyCanonicalGroupTopologyConfigPatch,
@@ -26,6 +27,7 @@ import {
 import { groupStateGroupStorageKey } from '../../../group-state/persistence/aggregate/group-aggregate-storage-keys.ts';
 import { APP_OUTBOX_RTC_TOPOLOGY_TOPIC } from '../../mutation/rtc-topology-outbox-entry.ts';
 import type { RtcTopologyGroupRevisionWork } from '../../mutation/rtc-topology-outbox-work.ts';
+import type { TopologyWorkOrigin } from '../../planning/resolve-topology-plan-action.ts';
 import type { PersistedRtcTopologyWork } from './rtc-topology-work-codec.ts';
 
 export interface RtcTopologyCoalescedGroupRevisionInput {
@@ -137,30 +139,36 @@ export interface PendingTopologyReplanReader {
     findByKey(key: Key): Promise<ResourceEntry | null>;
 }
 
-/** Decision 11's transient half: a replan is queued and due at T. */
-export interface PendingTopologyReplan {
-    readonly reconfigureQueued: boolean;
-    readonly dueAtEpochMs: number | null;
+/** The stored coalesced head row's exact durable key, shared by writer and reader. */
+export function toCoalescedGroupRevisionKey(groupRef: GroupRef): Key {
+    return toAppQueueKey({
+        topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
+        resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(toScopedOverlayId(groupRef)),
+        contextId: groupStateGroupStorageKey(groupRef)
+    });
 }
 
 /**
  * The transient half of product decision 11: is a replan queued for this
  * group, and when is it due? Read straight off the coalesced group-revision
- * row (I14 — its `dueAtEpochMs` doubles as the read surface's "when will
- * this settle"). A row in a terminal status is settled work, not pending; a
- * present row whose envelope no longer decodes still reports queued, with a
- * null due time, rather than hiding work the queue will attempt.
+ * head row (I14 — its `dueAtEpochMs` doubles as the read surface's "when
+ * will this settle"). Queued means the queue will still attempt it: a
+ * waiting row (NEW/RETRY) and an executing row (RESERVED) both report
+ * queued; a terminal row is settled work. A present row whose envelope no
+ * longer decodes still reports queued, with a null due time, rather than
+ * hiding work the queue will attempt. Known residue, recorded in the plan:
+ * a delta parked on a causal-suffixed successor row behind a reserved head
+ * is invisible to this point read for at most its debounce window — the
+ * head is RESERVED (reported queued) while the successor is minted, so the
+ * blind window opens only between the head completing and the successor
+ * dequeuing.
  */
 export async function readPendingTopologyReplan(
     reader: PendingTopologyReplanReader,
     groupRef: GroupRef
 ): Promise<PendingTopologyReplan | null> {
-    const entry = await reader.findByKey(toAppQueueKey({
-        topicId: APP_OUTBOX_RTC_TOPOLOGY_TOPIC,
-        resourceId: toRtcTopologyCoalescedGroupRevisionResourceId(toScopedOverlayId(groupRef)),
-        contextId: groupStateGroupStorageKey(groupRef)
-    }));
-    if (entry === null || !isMutableCoalescedStatus(entry.status)) {
+    const entry = await reader.findByKey(toCoalescedGroupRevisionKey(groupRef));
+    if (entry === null || !isPendingCoalescedStatus(entry.status)) {
         return null;
     }
     const envelope = tryReadCoalescedAppOutboxWorkEnvelope<RtcTopologyGroupRevisionWork>(entry);
@@ -170,11 +178,32 @@ export async function readPendingTopologyReplan(
     };
 }
 
+function isPendingCoalescedStatus(status: EntityStatus): boolean {
+    return isMutableCoalescedStatus(status) || status === EntityStatus.RESERVED;
+}
+
 /**
  * The M3 change gate applies only to coalesced group-revision recomputes whose
  * request carries a preserve-only topology-config patch; explicit reconfigures
  * and per-command work always rebuilds.
  */
+/**
+ * Exhaustive origin classification for every persisted work kind: RTT
+ * refreshes and the change-gated coalesced deltas (the presence-summary
+ * channel, which also carries the lifecycle transitions' follow-ups) are
+ * the machinery's own work; a per-command group-revision enqueue — the
+ * reconfigure family and config receipts — carries application or operator
+ * intent. A new work kind fails the anchor below instead of silently
+ * classifying as `commanded` past the freeze.
+ */
+export function toTopologyWorkOrigin(work: PersistedRtcTopologyWork): TopologyWorkOrigin {
+    if (work.kind === 'rtt-refresh') {
+        return 'automatic';
+    }
+    work.kind satisfies 'group-revision';
+    return isChangeGatedGroupRevisionWork(work) ? 'automatic' : 'commanded';
+}
+
 export function isChangeGatedGroupRevisionWork(work: PersistedRtcTopologyWork): boolean {
     return (
         work.kind === 'group-revision' &&

--- a/packages/shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts
@@ -2,6 +2,7 @@ import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
 import type { GroupTopologyManagementView } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 
+import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
 import { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
 import type { GroupTopologyServerOptions } from '../config/group-topology-config.ts';
 import type { GroupTopologyConfigRepository } from '../config/persistence/group-topology-config-repository.ts';
@@ -14,7 +15,6 @@ import {
     GroupTopologyPlanningService,
     type GroupTopologyPlanningServiceDependencies
 } from '../planning/group-topology-planning-service.ts';
-import type { GroupTopologyReplanningRead } from '../planning/resolve-topology-plan-action.ts';
 import type { RallarRtcTopologyService } from './rallar-rtc-topology-service.ts';
 
 export interface CreateGroupTopologyRuntimeOwnersInput {
@@ -33,9 +33,7 @@ export interface CreateGroupTopologyRuntimeOwnersInput {
     readonly readPendingTopologyReplan?: (
         groupRef: GroupRef
     ) => Promise<GroupTopologyManagementView['pending']>;
-    readonly readTopologyReplanningMode?: (
-        group: GroupSnapshot
-    ) => GroupTopologyReplanningRead | Promise<GroupTopologyReplanningRead>;
+    readonly readLifecyclePolicy?: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
     readonly publisher?: GroupTopologyPublisher;
     readonly serverDefaults?: GroupTopologyServerOptions;
 }
@@ -49,14 +47,15 @@ export function createGroupTopologyRuntimeOwners(
     input: CreateGroupTopologyRuntimeOwnersInput
 ): GroupTopologyRuntimeOwners {
     const topologySnapshotRepository = input.topologySnapshotRepository;
+    const acceptedTopologySnapshotRepository = input.acceptedTopologySnapshotRepository;
     const query = new GroupTopologyConfigQueryService({
         findGroupSnapshotByRef: input.findGroupSnapshotByRef,
         readLocalTopologySnapshot: (group) => input.topologyService.readSnapshot(group),
         readPersistedTopologySnapshot: topologySnapshotRepository
             ? async (groupRef) => await topologySnapshotRepository.findSnapshot(groupRef)
             : undefined,
-        readPersistedAcceptedTopologySnapshot: input.acceptedTopologySnapshotRepository
-            ? async (groupRef) => await input.acceptedTopologySnapshotRepository?.findSnapshot(groupRef)
+        readPersistedAcceptedTopologySnapshot: acceptedTopologySnapshotRepository
+            ? async (groupRef) => await acceptedTopologySnapshotRepository.findSnapshot(groupRef)
             : undefined,
         readPendingTopologyReplan: input.readPendingTopologyReplan,
         configRepository: input.configRepository,
@@ -69,7 +68,7 @@ export function createGroupTopologyRuntimeOwners(
         readCurrentGroupSnapshot: input.readCurrentGroupSnapshot,
         readRttMeasurements: input.readRttMeasurements,
         topologyMode: topologySnapshotRepository ? 'persistent' : 'local',
-        readTopologyReplanningMode: input.readTopologyReplanningMode,
+        readLifecyclePolicy: input.readLifecyclePolicy,
         publisher: input.publisher,
         serverDefaults: input.serverDefaults
     };

--- a/packages/shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts
@@ -1,4 +1,5 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
+import type { GroupTopologyManagementView } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
@@ -13,6 +14,7 @@ import {
     GroupTopologyPlanningService,
     type GroupTopologyPlanningServiceDependencies
 } from '../planning/group-topology-planning-service.ts';
+import type { GroupTopologyReplanningRead } from '../planning/resolve-topology-plan-action.ts';
 import type { RallarRtcTopologyService } from './rallar-rtc-topology-service.ts';
 
 export interface CreateGroupTopologyRuntimeOwnersInput {
@@ -27,6 +29,13 @@ export interface CreateGroupTopologyRuntimeOwnersInput {
     readonly configRepository?: GroupTopologyConfigRepository;
     readonly topologyService: RallarRtcTopologyService;
     readonly topologySnapshotRepository?: RtcTopologySnapshotRepository;
+    readonly acceptedTopologySnapshotRepository?: RtcTopologySnapshotRepository;
+    readonly readPendingTopologyReplan?: (
+        groupRef: GroupRef
+    ) => Promise<GroupTopologyManagementView['pending']>;
+    readonly readTopologyReplanningMode?: (
+        group: GroupSnapshot
+    ) => GroupTopologyReplanningRead | Promise<GroupTopologyReplanningRead>;
     readonly publisher?: GroupTopologyPublisher;
     readonly serverDefaults?: GroupTopologyServerOptions;
 }
@@ -46,6 +55,10 @@ export function createGroupTopologyRuntimeOwners(
         readPersistedTopologySnapshot: topologySnapshotRepository
             ? async (groupRef) => await topologySnapshotRepository.findSnapshot(groupRef)
             : undefined,
+        readPersistedAcceptedTopologySnapshot: input.acceptedTopologySnapshotRepository
+            ? async (groupRef) => await input.acceptedTopologySnapshotRepository?.findSnapshot(groupRef)
+            : undefined,
+        readPendingTopologyReplan: input.readPendingTopologyReplan,
         configRepository: input.configRepository,
         serverDefaults: input.serverDefaults
     });
@@ -56,6 +69,7 @@ export function createGroupTopologyRuntimeOwners(
         readCurrentGroupSnapshot: input.readCurrentGroupSnapshot,
         readRttMeasurements: input.readRttMeasurements,
         topologyMode: topologySnapshotRepository ? 'persistent' : 'local',
+        readTopologyReplanningMode: input.readTopologyReplanningMode,
         publisher: input.publisher,
         serverDefaults: input.serverDefaults
     };

--- a/packages/shared-server/rallar-system/topology/runtime/install-topology-app-outbox.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/install-topology-app-outbox.ts
@@ -1,11 +1,11 @@
 import type { Group, GroupRef } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { AppOutboxType } from '../../app-outbox/app-outbox-type.ts';
 import type { GroupMutationCommand } from '../../group-state/mutation/group-mutation-contracts.ts';
 import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/group-lifecycle-policy-repository.ts';
 import type { RtcRttRefinementService } from '../../rtc-rtt/topic/rtc-rtt-refinement-service.ts';
-import type { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
 import { createRtcTopologyOutboxPublisher } from '../mutation/rtc-topology-outbox-work.ts';
 import type { RtcTopologyExecutionRepository } from '../persistence/rtc-topology-execution-repository.ts';
 import type { GroupTopologyGroupSnapshotReader } from '../planning/group-topology-planning-contracts.ts';
@@ -26,7 +26,10 @@ export interface InstallTopologyAppOutboxOptions {
     readonly wakeReplay?: () => void;
     readonly findGroupSnapshotByRef: GroupTopologyGroupSnapshotReader;
     readonly executionRepository: RtcTopologyExecutionRepository;
-    readonly topologyQuery: GroupTopologyConfigQueryService;
+    /** The planned slot alone — the deadline timer needs no wider view. */
+    readonly readPlannedTopologySnapshot: (
+        ref: GroupRef
+    ) => Promise<RallarOverlayTopologySnapshot | undefined>;
     readonly topologyPlanning: GroupTopologyPlanningService;
     readonly rttRefinementService?: RtcRttRefinementService;
     readonly topologyDelivery?: RtcTopologyDeliveryOptions;
@@ -60,10 +63,7 @@ export function installTopologyAppOutbox(
             createFormationTimerWorkHandler({
                 findGroupSnapshotByRef: async (ref, readOptions) =>
                     await options.findGroupSnapshotByRef(ref, readOptions),
-                readPlannedTopology: async (ref) => {
-                    const view = await options.topologyQuery.readTopologyView(ref);
-                    return view.snapshot;
-                },
+                readPlannedTopology: async (ref) => await options.readPlannedTopologySnapshot(ref) ?? null,
                 topologyPlanning: options.topologyPlanning,
                 readLifecyclePolicy: options.formationCriterion.readLifecyclePolicy,
                 submitCommand: options.formationCriterion.submitCommand,

--- a/packages/shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts
@@ -87,6 +87,11 @@ export class RallarRtcTopologyService {
         this.metrics.recordFingerprintSkip();
     }
 
+    /** A stage or policy hold refused a replacement (4b) — not a publish attempt. */
+    recordTopologyPlanFrozen(): void {
+        this.metrics.recordPlanFrozen();
+    }
+
     updateGroupTopology(
         group: GroupSnapshot,
         rttMeasurements: readonly RttMeasurementInfo[] = [],

--- a/packages/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts
+++ b/packages/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.ts
@@ -32,6 +32,7 @@ export interface RallarRtcTopologyMetrics {
     readonly topologyPublishedCount: number;
     readonly topologyPublishSkippedUnchangedCount: number;
     readonly topologyRebuildSkippedFingerprintCount: number;
+    readonly topologyPlanFrozenCount: number;
     readonly topologyRemovalRequestCount: number;
     readonly topologyRemovedCount: number;
     readonly topologyRemoveMissCount: number;
@@ -71,6 +72,7 @@ interface RtcTopologyMetricsState {
     topologyPublishedCount: number;
     topologyPublishSkippedUnchangedCount: number;
     topologyRebuildSkippedFingerprintCount: number;
+    topologyPlanFrozenCount: number;
     topologyRemovalRequestCount: number;
     topologyRemovedCount: number;
     topologyRemoveMissCount: number;
@@ -210,6 +212,10 @@ export class RtcTopologyMetrics {
         this.state.topologyRebuildSkippedFingerprintCount += 1;
     }
 
+    recordPlanFrozen(): void {
+        this.state.topologyPlanFrozenCount += 1;
+    }
+
     recordRemoval(removed: boolean): void {
         this.state.topologyRemovalRequestCount += 1;
         if (removed) {
@@ -265,6 +271,7 @@ function createRtcTopologyMetricsState(): RtcTopologyMetricsState {
         topologyPublishedCount: 0,
         topologyPublishSkippedUnchangedCount: 0,
         topologyRebuildSkippedFingerprintCount: 0,
+        topologyPlanFrozenCount: 0,
         topologyRemovalRequestCount: 0,
         topologyRemovedCount: 0,
         topologyRemoveMissCount: 0

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
@@ -188,7 +188,9 @@
             "groupId": "{managedGroupId}",
             "lifecycleState": "forming",
             "formationEpoch": 0,
-            "formationElectorate": ["{aliceClientId}"]
+            "formationElectorate": [
+              "{aliceClientId}"
+            ]
           }
         }
       }
@@ -209,12 +211,14 @@
         "status": 200,
         "bodyAnyOf": [
           {
-            "snapshot": null
+            "snapshot": null,
+            "acceptedSnapshot": null
           },
           {
             "snapshot": {
               "state": "removed"
-            }
+            },
+            "acceptedSnapshot": null
           }
         ]
       }
@@ -238,7 +242,9 @@
           "formationEpoch": 0,
           "formationAttemptCount": 0,
           "establishmentStartedAtEpochMs": null,
-          "managerPrincipalIds": ["{aliceClientId}"]
+          "managerPrincipalIds": [
+            "{aliceClientId}"
+          ]
         }
       }
     },
@@ -498,7 +504,8 @@
         "body": {
           "snapshot": {
             "state": "active"
-          }
+          },
+          "acceptedSnapshot": null
         }
       }
     },
@@ -534,7 +541,9 @@
             "observedEdgeCount": 0,
             "observedRate": 0
           },
-          "managerPrincipalIds": ["{aliceClientId}"]
+          "managerPrincipalIds": [
+            "{aliceClientId}"
+          ]
         }
       }
     },
@@ -557,6 +566,33 @@
           "group": {
             "lifecycleState": "active",
             "formationEpoch": 2
+          }
+        }
+      }
+    },
+    {
+      "name": "acceptedLayoutPromotedAfterActivate",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 100,
+          "backoffMultiplier": 2
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "acceptedSnapshot": {
+            "state": "active"
           }
         }
       }

--- a/packages/shared-test/shared-server/require-planned-topology.ts
+++ b/packages/shared-test/shared-server/require-planned-topology.ts
@@ -1,0 +1,15 @@
+import type { ReconcileGroupTopologyResult } from '@shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts';
+
+/**
+ * Narrows a planning result to its planned arm for tests that assert on the
+ * candidate. One shared owner so every runtime's guard moves together when
+ * the union grows a new action.
+ */
+export function requirePlannedTopology(
+    result: ReconcileGroupTopologyResult
+): Extract<ReconcileGroupTopologyResult, { action: 'planned'; }> {
+    if (result.action !== 'planned') {
+        throw new Error(`expected a planned topology result, got ${result.action}`);
+    }
+    return result;
+}

--- a/packages/shared/api/graph-topology-management-types.ts
+++ b/packages/shared/api/graph-topology-management-types.ts
@@ -156,13 +156,14 @@ export type GroupTopologyManagementView = Readonly<{
      */
     acceptedSnapshot: RallarOverlayTopologySnapshot | null;
     config: GroupTopologyConfigView;
-    pending:
-        | Readonly<{
-            reconfigureQueued: boolean;
-            dueAtEpochMs: number | null;
-        }>
-        | null;
+    pending: PendingTopologyReplan | null;
 }>;
+
+/** Decision 11's transient half: a replan is queued and due at T. */
+export interface PendingTopologyReplan {
+    readonly reconfigureQueued: boolean;
+    readonly dueAtEpochMs: number | null;
+}
 
 export type PutGroupTopologyConfigRequest = Readonly<{
     requestId: string;

--- a/packages/shared/api/graph-topology-management-types.ts
+++ b/packages/shared/api/graph-topology-management-types.ts
@@ -149,6 +149,12 @@ export type GroupTopologyManagementView = Readonly<{
     groupRef: GroupRef;
     overlayId: string;
     snapshot: RallarOverlayTopologySnapshot | null;
+    /**
+     * The accepted layout — the one carrying traffic (product decisions
+     * 24/42). Null until a first promotion; `snapshot` stays the planned
+     * slot, which may run ahead of it as a held candidate.
+     */
+    acceptedSnapshot: RallarOverlayTopologySnapshot | null;
     config: GroupTopologyConfigView;
     pending:
         | Readonly<{

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -202,6 +202,24 @@ describe('Deploy workflow release gate', () => {
         }
     });
 
+    it('pins every Deno Deploy command away from the 2.9.6 argument duplication regression', async () => {
+        const workflow = await readFile(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+        for (
+            const jobName of [
+                'deno-deploy-preflight',
+                'deploy-api',
+                'deploy-control-server',
+                'deploy-relic-api'
+            ]
+        ) {
+            const jobBlock = getJobBlock(workflow, jobName);
+
+            expect(jobBlock).toContain('deno-version: 2.9.5');
+            expect(jobBlock).not.toContain('deno-version: v2.x');
+        }
+    });
+
     it('documents provider settings that prevent feature-branch deployment contexts', async () => {
         const runbook = await readFile(path.join(repoRoot, 'docs/production-deployment.md'), 'utf8');
 

--- a/packages/tests/shared-server/integration/postgres/topology-frozen-work.test.ts
+++ b/packages/tests/shared-server/integration/postgres/topology-frozen-work.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestGroupStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
+
+import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { createPSqlResourceInboxRepository } from '@shared-server/queuebox/postgres/create-p-sql-resource-inbox-repository.ts';
+import { PSqlQueueBox } from '@shared-server/queuebox/postgres/p-sql-queue-box.ts';
+import { PSqlGroupStateEventRepository } from '@shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts';
+import { computeRtcTopologyEntry } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-entry.ts';
+import { createRtcTopologyOutboxPublisher } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.ts';
+import { RtcTopologyExecutionRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts';
+import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
+import { createRtcTopologyWorkHandler } from '@shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts';
+import { createGroupTopologyRuntimeOwners } from '@shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts';
+import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
+import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+import { ResilienceDto } from '@shared/queuebox/DequeueResourceEntryController.ts';
+import { EntityStatus, type Key } from '@shared/queuebox/ResourceEntry.ts';
+import { CircuitBreakerPolicy } from '@shared/resilience/circuit-breaker.ts';
+import { OutboxQueueReader } from '@shared/services/OutboxQueueReader.ts';
+import { AppOutboxType } from '@shared-server/rallar-system/app-outbox/app-outbox-type.ts';
+import { Temporal } from '@js-temporal/polyfill';
+
+import {
+    cleanupTopologyApplicationRows,
+    createPostgresSql,
+    seedTopologyGroup,
+    topologyGroupSnapshot
+} from '../../rallar-system/topology/concurrency/postgres-topology-concurrency-fixtures.ts';
+
+const postgresIt = process.env.RALLAR_POSTGRES_INTEGRATION === '1' ? it : it.skip;
+
+describe('Postgres topology frozen work', () => {
+    postgresIt(
+        'freezes a connecting group\'s replacement: entry finished, snapshot and fingerprint untouched',
+        async () => {
+            const databaseUrl = process.env.DATABASE_URL;
+            if (!databaseUrl) {
+                throw new Error('DATABASE_URL is required when Postgres integration is enabled');
+            }
+            const applicationId = `topology-frozen-${crypto.randomUUID()}`;
+            const groupRef = { applicationId, workspaceId: 'frozen', groupId: 'room' };
+            const dialing = connectingSnapshot(topologyGroupSnapshot(groupRef), 1);
+            const sql = await createPostgresSql(databaseUrl);
+            const atEpochMs = Date.now();
+            try {
+                const harness = createFrozenWorkHarness(sql, () => atEpochMs);
+                await seedTopologyGroup(sql, dialing);
+
+                // Cycle 1: no stored row — establishment plans even while
+                // connecting (freeze is replacement suppression only).
+                await runTopologyWork(harness, dialing, 'first', atEpochMs);
+                const planned = await harness.snapshots.findSnapshot(groupRef);
+                expect(planned?.state).toBe('active');
+                const storedFingerprint = await harness.executionRepository
+                    .readTopologyInputFingerprint(groupRef);
+                expect(storedFingerprint).not.toBeNull();
+
+                // Cycle 2: a later membership revision while still dialing —
+                // the replacement freezes, the entry completes, and neither
+                // the snapshot nor the staleness-latch fingerprint moves.
+                // The enqueue-time snapshot carries the later revision; the
+                // membership-delta read deliberately preserves it.
+                const later = connectingSnapshot(topologyGroupSnapshot(groupRef), 2);
+                await runTopologyWork(harness, later, 'second', atEpochMs + 1);
+
+                const afterFreeze = await harness.snapshots.findSnapshot(groupRef);
+                expect(afterFreeze).toEqual(planned);
+                await expect(
+                    harness.executionRepository.readTopologyInputFingerprint(groupRef)
+                ).resolves.toBe(storedFingerprint);
+                expect(harness.topologyService.readMetrics().topologyPlanFrozenCount).toBe(1);
+            }
+            finally {
+                await cleanupTopologyApplicationRows(sql, applicationId);
+                await sql.end();
+            }
+        },
+        30_000
+    );
+});
+
+interface FrozenWorkHarness {
+    readonly outboxQueueReader: OutboxQueueReader;
+    readonly resources: ReturnType<typeof createPSqlResourceInboxRepository>;
+    readonly snapshots: RtcTopologySnapshotRepository;
+    readonly executionRepository: RtcTopologyExecutionRepository;
+    readonly topologyService: RallarRtcTopologyService;
+}
+
+function createFrozenWorkHarness(sql: PSqlSql, now: () => number): FrozenWorkHarness {
+    const resources = createPSqlResourceInboxRepository(sql);
+    const outboxQueueReader = new OutboxQueueReader(new PSqlQueueBox(resources));
+    const runtime = createRtcTopologyOutboxPublisher({
+        outboxQueueReader,
+        senderId: 'topology-frozen-test',
+        now
+    });
+    const runtimeRepository = new PSqlRuntimeStateRepository(sql);
+    const groupStateRepository = createTestGroupStateRepository(
+        runtimeRepository,
+        new PSqlGroupStateEventRepository(sql)
+    );
+    const topologyService = new RallarRtcTopologyService({ now });
+    const topologyManagement = createGroupTopologyRuntimeOwners({
+        findGroupSnapshotByRef: async (ref) => await groupStateRepository.readSnapshot(ref),
+        readCurrentGroupSnapshot: async (ref) => await groupStateRepository.readSnapshot(ref),
+        readRttMeasurements: () => [],
+        topologyService,
+        topologySnapshotRepository: new RtcTopologySnapshotRepository(runtimeRepository)
+    });
+    const executionRepository = new RtcTopologyExecutionRepository(
+        runtimeRepository,
+        undefined,
+        now
+    );
+    // The member seed mints presence-summary work this harness does not
+    // exercise; a no-op consumer keeps the dequeue loop quiet.
+    outboxQueueReader.onOutboxMessageDo(AppOutboxType.GROUP_PRESENCE_SUMMARY, {
+        onMessage: async () => {}
+    });
+    outboxQueueReader.onOutboxMessageDo(
+        runtime.workType,
+        createRtcTopologyWorkHandler({
+            runtime,
+            database: sql,
+            topologyPlanning: topologyManagement.planning,
+            executionRepository,
+            serviceId: 'topology-frozen-test'
+        })
+    );
+    return {
+        outboxQueueReader,
+        resources,
+        snapshots: new RtcTopologySnapshotRepository(runtimeRepository),
+        executionRepository,
+        topologyService
+    };
+}
+
+async function runTopologyWork(
+    harness: FrozenWorkHarness,
+    groupSnapshot: GroupSnapshot,
+    name: string,
+    atEpochMs: number
+): Promise<void> {
+    const entry = computeRtcTopologyEntry({
+        commandId: `${groupSnapshot.group.applicationId}-${name}`,
+        aggregateRef: groupSnapshot.group,
+        acceptedCausalRevision: groupSnapshot.causalRevision,
+        groupSnapshot,
+        effectKind: 'rtc-topology-recompute',
+        payloadKind: 'group-revision',
+        createdAtEpochMs: atEpochMs,
+        expireAtEpochMs: atEpochMs + 60_000,
+        senderId: 'topology-frozen-test',
+        resourceId: `${groupSnapshot.group.applicationId}-${name}-topology`,
+        requestOptions: toCanonicalGroupTopologyConfigPatch({}),
+        publish: true
+    });
+    expect(await harness.resources.entries.writeIfAbsentOrMatch(entry)).toBe('inserted');
+    await runUntilCompleted(harness, entry.key);
+}
+
+async function runUntilCompleted(harness: FrozenWorkHarness, key: Key): Promise<void> {
+    for (let iteration = 0; iteration < 40; iteration += 1) {
+        const target = await harness.resources.entries.findAnyByKey(key);
+        if (target?.status === EntityStatus.COMPLETED) {
+            return;
+        }
+        if (target?.status === EntityStatus.FAILED) {
+            throw new Error(`Topology work failed: ${key.resourceId}`);
+        }
+        await harness.outboxQueueReader.dequeueOutbox(
+            OutboxQueueReader.OUTBOX_DEQUEUE_TYPES,
+            createResilience()
+        );
+        await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`Topology work did not complete: ${key.resourceId}`);
+}
+
+function createResilience(): ResilienceDto {
+    const duration = Temporal.Duration.from({ seconds: 10 });
+    return ResilienceDto.toResilienceDto(
+        new CircuitBreakerPolicy(100, duration, duration, duration),
+        1,
+        1,
+        1,
+        1
+    );
+}
+
+function connectingSnapshot(base: GroupSnapshot, groupRevision: number): GroupSnapshot {
+    return {
+        ...base,
+        causalRevision: { ...base.causalRevision, groupRevision },
+        group: {
+            ...base.group,
+            lifecycleState: 'connecting',
+            snapshotVersion: groupRevision
+        }
+    };
+}

--- a/packages/tests/shared-server/rallar-system/admin-support/create-admin-support-use-cases.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-support/create-admin-support-use-cases.test.ts
@@ -381,6 +381,7 @@ describe('admin support use cases', () => {
                 createdAtEpochMs: NOW_EPOCH_MS - 2_000,
                 updatedAtEpochMs: NOW_EPOCH_MS - 1_000
             },
+            acceptedSnapshot: null,
             pending: null
         };
         const service = createService({

--- a/packages/tests/shared-server/rallar-system/topology/config/group-topology-config-query-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/group-topology-config-query-service.test.ts
@@ -62,7 +62,28 @@ describe('GroupTopologyConfigQueryService', () => {
         await expect(query.readTopologyView(GROUP_REF)).resolves.toMatchObject({
             groupRef: GROUP_REF,
             snapshot: persistedSnapshot,
+            acceptedSnapshot: null,
             pending: null
+        });
+    });
+
+    it('carries both layout slots and the queued replan when their readers are wired', async () => {
+        const persistedSnapshot = { overlayId: 'planned-overlay' } as never;
+        const acceptedSnapshot = { overlayId: 'accepted-overlay' } as never;
+        const group = { group: GROUP_REF } as GroupSnapshot;
+        const query = new GroupTopologyConfigQueryService({
+            findGroupSnapshotByRef: async () => group,
+            readLocalTopologySnapshot: () => undefined,
+            readPersistedTopologySnapshot: async () => persistedSnapshot,
+            readPersistedAcceptedTopologySnapshot: async () => acceptedSnapshot,
+            readPendingTopologyReplan: async () => ({ reconfigureQueued: true, dueAtEpochMs: 4_500 }),
+            serverDefaults: { topologyKind: 'tree', degreeLimit: 7 }
+        });
+
+        await expect(query.readTopologyView(GROUP_REF)).resolves.toMatchObject({
+            snapshot: persistedSnapshot,
+            acceptedSnapshot,
+            pending: { reconfigureQueued: true, dueAtEpochMs: 4_500 }
         });
     });
 

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -438,6 +438,7 @@ function reconfigureRead(): GroupTopologyReconfigureRead {
             },
             kindHysteresisWidths: { meshExitWidth: 1, treeExitWidth: 1 },
             rttMeasurements: [],
+            replanning: 'debounced',
             nowEpochMs: NOW_EPOCH_MS
         },
         authorityGuard: groupAuthorityGuard()

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -438,7 +438,7 @@ function reconfigureRead(): GroupTopologyReconfigureRead {
             },
             kindHysteresisWidths: { meshExitWidth: 1, treeExitWidth: 1 },
             rttMeasurements: [],
-            replanning: 'debounced',
+            replanning: 'auto',
             nowEpochMs: NOW_EPOCH_MS
         },
         authorityGuard: groupAuthorityGuard()

--- a/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
@@ -670,6 +670,7 @@ describe('RTC topology APP_OUTBOX work', () => {
                 computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
+                recordTopologyPlanFrozen: vi.fn(),
                 recordTopologyRebuildSkippedFingerprint: vi.fn()
             },
             executionRepository: new RtcTopologyExecutionRepository(runtimeRepository),
@@ -771,6 +772,7 @@ describe('RTC topology APP_OUTBOX work', () => {
                 computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
+                recordTopologyPlanFrozen: vi.fn(),
                 recordTopologyRebuildSkippedFingerprint: vi.fn()
             } as never,
             executionRepository: new RtcTopologyExecutionRepository(runtimeRepository),
@@ -838,6 +840,7 @@ describe('RTC topology APP_OUTBOX work', () => {
                 computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
+                recordTopologyPlanFrozen: vi.fn(),
                 recordTopologyRebuildSkippedFingerprint: vi.fn()
             },
             executionRepository: new RtcTopologyExecutionRepository(new FakeRuntimeStateRepository()),

--- a/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { GROUP_LIFECYCLE_STATES, type GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 
 import { resolveGroupTopologyConfig } from '@shared-server/rallar-system/topology/config/group-topology-config.ts';
+import type { ReconcileGroupTopologyResult } from '@shared-server/rallar-system/topology/planning/group-topology-planning-contracts.ts';
 import { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
+import type { GroupTopologyReplanningRead } from '@shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
 import { createTestGroup } from '../../../../create-test-group.ts';
 
@@ -26,6 +28,7 @@ describe('GroupTopologyPlanningService', () => {
             config,
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
             rttMeasurements: [],
+            replanning: 'auto',
             nowEpochMs: 2_000
         });
     });
@@ -55,6 +58,7 @@ describe('GroupTopologyPlanningService', () => {
                 config: resolveGroupTopologyConfig({}),
                 kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
                 rttMeasurements: [],
+                replanning: 'debounced',
                 nowEpochMs: 2_000
             },
             undefined
@@ -81,17 +85,17 @@ describe('GroupTopologyPlanningService', () => {
             undefined
         );
 
-        expect(result.snapshot.state).toBe('removed');
-        expect(Object.values(result.snapshot.nextHopsBySessionId).flat()).toEqual([]);
+        expect(requirePlanned(result).snapshot.state).toBe('removed');
+        expect(Object.values(requirePlanned(result).snapshot.nextHopsBySessionId).flat()).toEqual([]);
     });
 
     it('drops a previously planned topology when the group returns to FORMING', () => {
         const active = groupWithSessionsIn('active');
         const service = createPlanningService({ group: active });
-        const planned = service.computeTopologyFromAuthority(
+        const planned = requirePlanned(service.computeTopologyFromAuthority(
             planningAuthority(active),
             undefined
-        );
+        ));
         expect(planned.snapshot.state).not.toBe('removed');
 
         const forming = groupWithSessionsIn('forming');
@@ -99,26 +103,132 @@ describe('GroupTopologyPlanningService', () => {
             planningAuthority(forming),
             planned.snapshot
         );
-        expect(held.snapshot.state).toBe('removed');
+        expect(requirePlanned(held).snapshot.state).toBe('removed');
     });
 
-    it('plans in every non-forming lifecycle state', () => {
-        for (
-            const lifecycleState of GROUP_LIFECYCLE_STATES.filter(
-                (candidate) => candidate !== 'forming'
+    it('resolves every stage with no stored layout: removal for dormant and forming, a first plan everywhere else', () => {
+        for (const lifecycleState of GROUP_LIFECYCLE_STATES) {
+            const group = groupWithSessionsIn(lifecycleState);
+            const service = createPlanningService({ group });
+
+            const result = requirePlanned(service.computeTopologyFromAuthority(
+                planningAuthority(group),
+                undefined
+            ));
+
+            if (lifecycleState === 'dormant' || lifecycleState === 'forming') {
+                expect(result.snapshot.state).toBe('removed');
+                continue;
+            }
+            // Freeze is replacement suppression, never establishment
+            // suppression: a dialing stage still produces its first layout.
+            expect(result.snapshot.state).not.toBe('removed');
+            expect(result.snapshot.activeSessionIds).toEqual(['session-a', 'session-b']);
+        }
+    });
+
+    it('resolves every stage against an active stored layout to the 4b disposition table', () => {
+        const seed = groupWithSessionsIn('active');
+        const stored = requirePlanned(
+            createPlanningService({ group: seed }).computeTopologyFromAuthority(
+                planningAuthority(seed),
+                undefined
             )
-        ) {
+        ).snapshot;
+        const frozenStages: GroupLifecycleState[] = ['connecting', 'reconnecting'];
+        for (const lifecycleState of GROUP_LIFECYCLE_STATES) {
             const group = groupWithSessionsIn(lifecycleState);
             const service = createPlanningService({ group });
 
             const result = service.computeTopologyFromAuthority(
                 planningAuthority(group),
-                undefined
+                stored
             );
 
-            expect(result.snapshot.state).not.toBe('removed');
-            expect(result.snapshot.activeSessionIds).toEqual(['session-a', 'session-b']);
+            if (frozenStages.includes(lifecycleState)) {
+                expect(result).toEqual({ action: 'frozen', current: stored });
+                continue;
+            }
+            const planned = requirePlanned(result);
+            if (lifecycleState === 'dormant' || lifecycleState === 'forming') {
+                expect(planned.snapshot.state).toBe('removed');
+                continue;
+            }
+            expect(planned.snapshot.state).not.toBe('removed');
         }
+    });
+
+    it('freezes automatic replanning of an active stored layout under commanded mode, but plans commanded work', () => {
+        const group = groupWithSessionsIn('active');
+        const service = createPlanningService({ group });
+        const stored = requirePlanned(service.computeTopologyFromAuthority(
+            planningAuthority(group),
+            undefined
+        )).snapshot;
+
+        const automatic = service.computeTopologyFromAuthority(
+            planningAuthority(group, 'commanded'),
+            stored,
+            { intent: 'full-rebuild', origin: 'automatic' }
+        );
+        expect(automatic).toEqual({ action: 'frozen', current: stored });
+
+        const commanded = service.computeTopologyFromAuthority(
+            planningAuthority(group, 'commanded'),
+            stored,
+            { intent: 'full-rebuild', origin: 'commanded' }
+        );
+        expect(requirePlanned(commanded).snapshot.state).not.toBe('removed');
+    });
+
+    it('fails automatic replanning closed on a corrupt policy, and C7: a departure does not move a commanded layout', () => {
+        const group = groupWithSessionsIn('active');
+        const service = createPlanningService({ group });
+        const stored = requirePlanned(service.computeTopologyFromAuthority(
+            planningAuthority(group),
+            undefined
+        )).snapshot;
+
+        expect(service.computeTopologyFromAuthority(
+            planningAuthority(group, 'corrupt'),
+            stored,
+            { intent: 'full-rebuild', origin: 'automatic' }
+        )).toEqual({ action: 'frozen', current: stored });
+
+        // C7: presence expiry flows in as automatic membership-delta work; a
+        // commanded group keeps its stored layout naming the departed session.
+        const departed = {
+            ...group,
+            activeSessions: group.activeSessions.slice(0, 1),
+            onlineMemberCount: 1
+        };
+        const afterDeparture = service.computeTopologyFromAuthority(
+            planningAuthority(departed, 'commanded'),
+            stored,
+            { intent: 'membership-delta', origin: 'automatic' }
+        );
+        expect(afterDeparture).toEqual({ action: 'frozen', current: stored });
+    });
+
+    it('freezes the local reconfigure path for a dialing stage', async () => {
+        const group = groupWithSessionsIn('connecting');
+        const topologyService = new RallarRtcTopologyService({ now: () => 2_000 });
+        const service = createPlanningService({ group, topologyService });
+        const stored = requirePlanned(service.computeTopologyFromAuthority(
+            planningAuthority(group),
+            undefined
+        )).snapshot;
+        topologyService.observeCommittedTopologySnapshot(stored);
+
+        const response = await service.reconfigureGroupTopology({
+            groupRef: group.group,
+            groupSnapshot: group,
+            publisher: () => 1
+        });
+
+        expect(response.changed).toBe(false);
+        expect(response.published).toBe(false);
+        expect(response.snapshot).toEqual(topologyService.readSnapshot(group));
     });
 
     it('does not report a topology publication when the delivery owner reaches no session', async () => {
@@ -160,21 +270,36 @@ function groupWithSessionsIn(
     };
 }
 
-function planningAuthority(group: ReturnType<typeof createTopologyTestGroupSnapshot>) {
+function planningAuthority(
+    group: ReturnType<typeof createTopologyTestGroupSnapshot>,
+    replanning: GroupTopologyReplanningRead = 'debounced'
+) {
     return {
         group,
         config: resolveGroupTopologyConfig({}),
         kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
         rttMeasurements: [],
+        replanning,
         nowEpochMs: 2_000
     };
+}
+
+function requirePlanned(
+    result: ReconcileGroupTopologyResult
+): Extract<ReconcileGroupTopologyResult, { action: 'planned'; }> {
+    expect(result.action).toBe('planned');
+    if (result.action !== 'planned') {
+        throw new Error('expected a planned topology result');
+    }
+    return result;
 }
 
 function createPlanningService(input: {
     group: ReturnType<typeof createTopologyTestGroupSnapshot>;
     config?: ReturnType<typeof resolveGroupTopologyConfig>;
+    topologyService?: RallarRtcTopologyService;
 }): GroupTopologyPlanningService {
-    const topologyService = new RallarRtcTopologyService({ now: () => 2_000 });
+    const topologyService = input.topologyService ?? new RallarRtcTopologyService({ now: () => 2_000 });
     return new GroupTopologyPlanningService({
         findGroupSnapshotByRef: async () => input.group,
         readCurrentGroupSnapshot: async () => input.group,

--- a/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
@@ -7,6 +7,7 @@ import type { ReconcileGroupTopologyResult } from '@shared-server/rallar-system/
 import { GroupTopologyPlanningService } from '@shared-server/rallar-system/topology/planning/group-topology-planning-service.ts';
 import type { GroupTopologyReplanningRead } from '@shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
+import { requirePlannedTopology } from '@shared-test/shared-server/require-planned-topology.ts';
 import { createTestGroup } from '../../../../create-test-group.ts';
 
 import { createTopologyTestGroupRef, createTopologyTestGroupSnapshot } from '../config/mutation/group-topology-config-mutation-test-fixtures.ts';
@@ -61,7 +62,8 @@ describe('GroupTopologyPlanningService', () => {
                 replanning: 'debounced',
                 nowEpochMs: 2_000
             },
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         );
 
         expect(result).toMatchObject({
@@ -82,28 +84,31 @@ describe('GroupTopologyPlanningService', () => {
 
         const result = service.computeTopologyFromAuthority(
             planningAuthority(forming),
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         );
 
-        expect(requirePlanned(result).snapshot.state).toBe('removed');
-        expect(Object.values(requirePlanned(result).snapshot.nextHopsBySessionId).flat()).toEqual([]);
+        expect(requirePlannedTopology(result).snapshot.state).toBe('removed');
+        expect(Object.values(requirePlannedTopology(result).snapshot.nextHopsBySessionId).flat()).toEqual([]);
     });
 
     it('drops a previously planned topology when the group returns to FORMING', () => {
         const active = groupWithSessionsIn('active');
         const service = createPlanningService({ group: active });
-        const planned = requirePlanned(service.computeTopologyFromAuthority(
+        const planned = requirePlannedTopology(service.computeTopologyFromAuthority(
             planningAuthority(active),
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         ));
         expect(planned.snapshot.state).not.toBe('removed');
 
         const forming = groupWithSessionsIn('forming');
         const held = createPlanningService({ group: forming }).computeTopologyFromAuthority(
             planningAuthority(forming),
-            planned.snapshot
+            planned.snapshot,
+            { intent: 'full-rebuild', origin: 'automatic' }
         );
-        expect(requirePlanned(held).snapshot.state).toBe('removed');
+        expect(requirePlannedTopology(held).snapshot.state).toBe('removed');
     });
 
     it('resolves every stage with no stored layout: removal for dormant and forming, a first plan everywhere else', () => {
@@ -111,9 +116,10 @@ describe('GroupTopologyPlanningService', () => {
             const group = groupWithSessionsIn(lifecycleState);
             const service = createPlanningService({ group });
 
-            const result = requirePlanned(service.computeTopologyFromAuthority(
+            const result = requirePlannedTopology(service.computeTopologyFromAuthority(
                 planningAuthority(group),
-                undefined
+                undefined,
+                { intent: 'full-rebuild', origin: 'automatic' }
             ));
 
             if (lifecycleState === 'dormant' || lifecycleState === 'forming') {
@@ -129,10 +135,11 @@ describe('GroupTopologyPlanningService', () => {
 
     it('resolves every stage against an active stored layout to the 4b disposition table', () => {
         const seed = groupWithSessionsIn('active');
-        const stored = requirePlanned(
+        const stored = requirePlannedTopology(
             createPlanningService({ group: seed }).computeTopologyFromAuthority(
                 planningAuthority(seed),
-                undefined
+                undefined,
+                { intent: 'full-rebuild', origin: 'automatic' }
             )
         ).snapshot;
         const frozenStages: GroupLifecycleState[] = ['connecting', 'reconnecting'];
@@ -142,14 +149,15 @@ describe('GroupTopologyPlanningService', () => {
 
             const result = service.computeTopologyFromAuthority(
                 planningAuthority(group),
-                stored
+                stored,
+                { intent: 'full-rebuild', origin: 'automatic' }
             );
 
             if (frozenStages.includes(lifecycleState)) {
                 expect(result).toEqual({ action: 'frozen', current: stored });
                 continue;
             }
-            const planned = requirePlanned(result);
+            const planned = requirePlannedTopology(result);
             if (lifecycleState === 'dormant' || lifecycleState === 'forming') {
                 expect(planned.snapshot.state).toBe('removed');
                 continue;
@@ -161,9 +169,10 @@ describe('GroupTopologyPlanningService', () => {
     it('freezes automatic replanning of an active stored layout under commanded mode, but plans commanded work', () => {
         const group = groupWithSessionsIn('active');
         const service = createPlanningService({ group });
-        const stored = requirePlanned(service.computeTopologyFromAuthority(
+        const stored = requirePlannedTopology(service.computeTopologyFromAuthority(
             planningAuthority(group),
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         )).snapshot;
 
         const automatic = service.computeTopologyFromAuthority(
@@ -178,15 +187,16 @@ describe('GroupTopologyPlanningService', () => {
             stored,
             { intent: 'full-rebuild', origin: 'commanded' }
         );
-        expect(requirePlanned(commanded).snapshot.state).not.toBe('removed');
+        expect(requirePlannedTopology(commanded).snapshot.state).not.toBe('removed');
     });
 
     it('fails automatic replanning closed on a corrupt policy, and C7: a departure does not move a commanded layout', () => {
         const group = groupWithSessionsIn('active');
         const service = createPlanningService({ group });
-        const stored = requirePlanned(service.computeTopologyFromAuthority(
+        const stored = requirePlannedTopology(service.computeTopologyFromAuthority(
             planningAuthority(group),
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         )).snapshot;
 
         expect(service.computeTopologyFromAuthority(
@@ -214,9 +224,10 @@ describe('GroupTopologyPlanningService', () => {
         const group = groupWithSessionsIn('connecting');
         const topologyService = new RallarRtcTopologyService({ now: () => 2_000 });
         const service = createPlanningService({ group, topologyService });
-        const stored = requirePlanned(service.computeTopologyFromAuthority(
+        const stored = requirePlannedTopology(service.computeTopologyFromAuthority(
             planningAuthority(group),
-            undefined
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
         )).snapshot;
         topologyService.observeCommittedTopologySnapshot(stored);
 
@@ -229,6 +240,9 @@ describe('GroupTopologyPlanningService', () => {
         expect(response.changed).toBe(false);
         expect(response.published).toBe(false);
         expect(response.snapshot).toEqual(topologyService.readSnapshot(group));
+        // A frozen plan is a policy hold, not a publish attempt.
+        expect(topologyService.readMetrics().topologyPlanFrozenCount).toBe(1);
+        expect(topologyService.readMetrics().topologyPublishAttemptCount).toBe(0);
     });
 
     it('does not report a topology publication when the delivery owner reaches no session', async () => {
@@ -272,7 +286,7 @@ function groupWithSessionsIn(
 
 function planningAuthority(
     group: ReturnType<typeof createTopologyTestGroupSnapshot>,
-    replanning: GroupTopologyReplanningRead = 'debounced'
+    replanning: GroupTopologyReplanningRead = 'auto'
 ) {
     return {
         group,
@@ -282,16 +296,6 @@ function planningAuthority(
         replanning,
         nowEpochMs: 2_000
     };
-}
-
-function requirePlanned(
-    result: ReconcileGroupTopologyResult
-): Extract<ReconcileGroupTopologyResult, { action: 'planned'; }> {
-    expect(result.action).toBe('planned');
-    if (result.action !== 'planned') {
-        throw new Error('expected a planned topology result');
-    }
-    return result;
 }
 
 function createPlanningService(input: {

--- a/packages/tests/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/resolve-topology-plan-action.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { GROUP_LIFECYCLE_STATES } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+import { resolveTopologyPlanAction, type ResolveTopologyPlanActionInput } from '@shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts';
+
+const ACTIVE_PREVIOUS = { state: 'active' } as RallarOverlayTopologySnapshot;
+const REMOVED_PREVIOUS = { state: 'removed' } as RallarOverlayTopologySnapshot;
+
+function action(input: Partial<ResolveTopologyPlanActionInput>): ReturnType<typeof resolveTopologyPlanAction> {
+    return resolveTopologyPlanAction({
+        lifecycleState: 'active',
+        replanning: 'debounced',
+        workOrigin: 'automatic',
+        previous: ACTIVE_PREVIOUS,
+        ...input
+    });
+}
+
+describe('resolveTopologyPlanAction', () => {
+    it('is total over the stage registry against an active stored layout', () => {
+        const byStage = Object.fromEntries(
+            GROUP_LIFECYCLE_STATES.map((lifecycleState) => [lifecycleState, action({ lifecycleState })])
+        );
+        expect(byStage).toEqual({
+            dormant: 'publish-removal',
+            forming: 'publish-removal',
+            planned: 'plan',
+            connecting: 'freeze',
+            active: 'plan',
+            reconfiguring: 'plan',
+            reconnecting: 'freeze'
+        });
+    });
+
+    it('never suppresses establishment: absent and tombstoned slots always plan outside the removal rows', () => {
+        for (const lifecycleState of GROUP_LIFECYCLE_STATES) {
+            for (const previous of [undefined, REMOVED_PREVIOUS]) {
+                const resolved = action({ lifecycleState, replanning: 'commanded', previous });
+                expect(resolved).toBe(
+                    lifecycleState === 'dormant' || lifecycleState === 'forming'
+                        ? 'publish-removal'
+                        : 'plan'
+                );
+            }
+        }
+    });
+
+    it('follows the replanning policy only for active groups', () => {
+        expect(action({ replanning: 'commanded', workOrigin: 'automatic' })).toBe('freeze');
+        expect(action({ replanning: 'commanded', workOrigin: 'commanded' })).toBe('plan');
+        expect(action({ replanning: 'corrupt', workOrigin: 'automatic' })).toBe('freeze');
+        expect(action({ replanning: 'corrupt', workOrigin: 'commanded' })).toBe('plan');
+        expect(action({ replanning: 'auto' })).toBe('plan');
+        expect(action({ replanning: 'debounced' })).toBe('plan');
+    });
+
+    it('freezes dialing stages for commanded work too', () => {
+        expect(action({ lifecycleState: 'connecting', workOrigin: 'commanded' })).toBe('freeze');
+        expect(action({ lifecycleState: 'reconnecting', workOrigin: 'commanded' })).toBe('freeze');
+    });
+});

--- a/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-websocket-publication.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-websocket-publication.test.ts
@@ -489,7 +489,7 @@ interface InstallTopologyTestTopicsOptions {
     readonly topologyQuery?: GroupTopologyRuntimeOwners['query'];
     readonly topologyPlanning?: GroupTopologyRuntimeOwners['planning'];
     readonly rtcTopologyAppOutbox?:
-        & Omit<InstallTopologyAppOutboxOptions, 'senderId' | 'findGroupSnapshotByRef' | 'topologyQuery' | 'topologyPlanning' | 'nowEpochMs'>
+        & Omit<InstallTopologyAppOutboxOptions, 'senderId' | 'findGroupSnapshotByRef' | 'readPlannedTopologySnapshot' | 'topologyPlanning' | 'nowEpochMs'>
         & Readonly<{
             findGroupSnapshotByRef?: GroupTopologyGroupSnapshotReader;
         }>;
@@ -502,15 +502,17 @@ function installTopologyTestTopics(
     if (!options.rtcTopologyAppOutbox) {
         return;
     }
-    if (!options.topologyQuery || !options.topologyPlanning) {
-        throw new TypeError('RTC topology AppOutbox requires query and planning owners');
+    if (!options.topologyPlanning) {
+        throw new TypeError('RTC topology AppOutbox requires the planning owner');
     }
     installTopologyAppOutbox({
         ...options.rtcTopologyAppOutbox,
         senderId: service.name,
         findGroupSnapshotByRef: options.rtcTopologyAppOutbox.findGroupSnapshotByRef ??
             ((ref) => groupStateSnapshotsRepository.findGroupStateSnapshotByRef(ref)),
-        topologyQuery: options.topologyQuery,
+        // No formation criterion is installed here, so the deadline timer
+        // that owns this reader never runs.
+        readPlannedTopologySnapshot: async () => undefined,
         topologyPlanning: options.topologyPlanning,
         nowEpochMs: Date.now
     });

--- a/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-websocket-publication.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-websocket-publication.test.ts
@@ -60,6 +60,9 @@ describe('RTC topology websocket publication', () => {
             snapshots: {
                 findSnapshot: async () => fixture.currentSnapshot
             },
+            acceptedSnapshots: {
+                findSnapshot: async () => undefined
+            },
             sender: service
         });
 

--- a/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
@@ -114,6 +114,7 @@ function createRead() {
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
             rttMeasurements: [],
+            replanning: 'debounced' as const,
             nowEpochMs: 1_000
         },
         authorityGuard: createTopologyTestAuthorityGuard()

--- a/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
@@ -114,7 +114,7 @@ function createRead() {
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
             rttMeasurements: [],
-            replanning: 'debounced' as const,
+            replanning: 'auto' as const,
             nowEpochMs: 1_000
         },
         authorityGuard: createTopologyTestAuthorityGuard()

--- a/packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts
@@ -82,6 +82,35 @@ describe('RtcTopologyReplayEntryHandlerService', () => {
         expect(message.targets).toMatchObject({ recipientPeerIds: ['session-2'] });
     });
 
+    it('repairs onto the removal tombstone even when a stale accepted row survives (teardown wins)', async () => {
+        const fixture = createRtcTopologyReplayFixture();
+        const tombstone = {
+            ...fixture.currentSnapshot,
+            state: 'removed' as const,
+            nextHopsBySessionId: Object.fromEntries(
+                fixture.currentSnapshot.activeSessionIds.map((sessionId) => [sessionId, []])
+            ),
+            version: fixture.currentSnapshot.version + 2,
+            updatedAtEpochMs: fixture.currentSnapshot.updatedAtEpochMs + 2
+        };
+        const staleAccepted = {
+            ...fixture.currentSnapshot,
+            version: fixture.currentSnapshot.version + 1,
+            updatedAtEpochMs: fixture.currentSnapshot.updatedAtEpochMs + 1
+        };
+        const { handler, send } = createHandler({
+            ...fixture,
+            currentSnapshot: tombstone,
+            acceptedSnapshot: staleAccepted
+        });
+
+        await expect(
+            handler.handle(fixture.entry, fixture.databaseNowEpochMs, new AbortController().signal)
+        ).resolves.toEqual({ status: 'current-repair' });
+        const message = send.mock.calls[0]![0];
+        expect(message.payload.resource).toBe(JSON.stringify(tombstone));
+    });
+
     it('treats no current local recipient as successful handling', async () => {
         const fixture = createRtcTopologyReplayFixture();
         const { handler } = createHandler(fixture, 'no-recipients');

--- a/packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/consumer/rtc-topology-replay-entry-handler.test.ts
@@ -6,6 +6,7 @@ import { AppTopics } from '@shared/api/api-config.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import { createRtcTopologyReplayFixture } from './rtc-topology-replay-fixture.ts';
 
 describe('RtcTopologyReplayEntryHandlerService', () => {
@@ -51,6 +52,34 @@ describe('RtcTopologyReplayEntryHandlerService', () => {
             recipientPeerIds: ['session-2']
         });
         expect(message.constraints?.expiresAtMs).toBe(fixture.entry.retainUntilEpochMs);
+    });
+
+    it('repairs onto the accepted layout whenever the accepted slot exists (4c)', async () => {
+        const fixture = createRtcTopologyReplayFixture();
+        const plannedAhead = {
+            ...fixture.currentSnapshot,
+            version: fixture.currentSnapshot.version + 5,
+            updatedAtEpochMs: fixture.currentSnapshot.updatedAtEpochMs + 5
+        };
+        const acceptedSnapshot = {
+            ...fixture.currentSnapshot,
+            activeSessionIds: ['session-2'],
+            nextHopsBySessionId: { 'session-2': [] },
+            version: fixture.currentSnapshot.version + 1,
+            updatedAtEpochMs: fixture.currentSnapshot.updatedAtEpochMs + 1
+        };
+        const { handler, send } = createHandler({
+            ...fixture,
+            currentSnapshot: plannedAhead,
+            acceptedSnapshot
+        });
+
+        await expect(
+            handler.handle(fixture.entry, fixture.databaseNowEpochMs, new AbortController().signal)
+        ).resolves.toEqual({ status: 'current-repair' });
+        const message = send.mock.calls[0]![0];
+        expect(message.payload.resource).toBe(JSON.stringify(acceptedSnapshot));
+        expect(message.targets).toMatchObject({ recipientPeerIds: ['session-2'] });
     });
 
     it('treats no current local recipient as successful handling', async () => {
@@ -107,6 +136,7 @@ function createHandler(
         & Readonly<{
             publication?: RtcTopologyPublication;
             outbox?: ResourceEntry;
+            acceptedSnapshot?: RallarOverlayTopologySnapshot;
         }>,
     sendStatus: 'sent-live' | 'no-recipients' | 'partial-failure' | 'failed' = 'sent-live'
 ) {
@@ -121,6 +151,9 @@ function createHandler(
             },
             snapshots: {
                 findSnapshot: vi.fn(async () => fixture.currentSnapshot)
+            },
+            acceptedSnapshots: {
+                findSnapshot: vi.fn(async () => fixture.acceptedSnapshot)
             },
             sender: { sendToTargetsWithResult: send }
         }),

--- a/packages/tests/shared-server/rallar-system/topology/replay/deliverable-topology-snapshot.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/deliverable-topology-snapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+import { toDeliverableTopologySnapshot } from '@shared-server/rallar-system/topology/replay/deliverable-topology-snapshot.ts';
+
+function snapshot(
+    state: 'active' | 'removed',
+    activeSessionIds: readonly string[]
+): RallarOverlayTopologySnapshot {
+    return { state, activeSessionIds } as RallarOverlayTopologySnapshot;
+}
+
+describe('toDeliverableTopologySnapshot', () => {
+    it('prefers the accepted layout whenever a promotion produced one', () => {
+        const planned = snapshot('active', ['a', 'b']);
+        const accepted = snapshot('active', ['a']);
+        expect(toDeliverableTopologySnapshot({ planned, accepted })).toBe(accepted);
+        expect(toDeliverableTopologySnapshot({ planned, accepted: undefined })).toBe(planned);
+        expect(toDeliverableTopologySnapshot({ planned: undefined, accepted })).toBe(accepted);
+        expect(toDeliverableTopologySnapshot({ planned: undefined, accepted: undefined })).toBeUndefined();
+    });
+
+    it('lets a planned removal tombstone win: teardown is never shadowed by the stale accepted row', () => {
+        const tombstone = snapshot('removed', ['a', 'b']);
+        const accepted = snapshot('active', ['a', 'b']);
+        expect(toDeliverableTopologySnapshot({ planned: tombstone, accepted })).toBe(tombstone);
+        expect(
+            toDeliverableTopologySnapshot({ planned: tombstone, accepted, sessionId: 'a' })
+        ).toBe(tombstone);
+    });
+
+    it('serves a member named only in the held planned candidate their candidate assignment', () => {
+        const planned = snapshot('active', ['a', 'newcomer']);
+        const accepted = snapshot('active', ['a']);
+        expect(
+            toDeliverableTopologySnapshot({ planned, accepted, sessionId: 'newcomer' })
+        ).toBe(planned);
+        expect(toDeliverableTopologySnapshot({ planned, accepted, sessionId: 'a' })).toBe(accepted);
+        // A member neither row names still resolves the traffic layout; the
+        // caller's own membership guard answers no-topology.
+        expect(toDeliverableTopologySnapshot({ planned, accepted, sessionId: 'ghost' })).toBe(accepted);
+    });
+});

--- a/packages/tests/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.test.ts
@@ -1,3 +1,4 @@
+import type { RtcTopologyReconnectHydration } from '@shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydration.ts';
 import { RtcTopologyReconnectHydrator } from '@shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.ts';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { decodePersistedALMessageValue } from '@shared/al-contracts/al-message-persistence-validation.ts';
@@ -54,6 +55,49 @@ describe('RtcTopologyReconnectHydrator', () => {
 
         const message = harness.sentMessages(connection)[0] as { payload: { resource: string; }; };
         expect(JSON.parse(message.payload.resource)).toEqual(current);
+    });
+
+    it('hydrates the accepted layout whenever the accepted slot exists (4c)', async () => {
+        const planned = createTopology({ version: 6 });
+        const accepted = createTopology({ version: 5 });
+        const harness = createHarness({
+            scanTopology: planned,
+            currentTopology: planned,
+            acceptedTopologies: {
+                listSnapshotEntriesPage: async () => [],
+                findSnapshot: async () => accepted
+            }
+        });
+        const connection = harness.addConnection('session-1', 'generation-1');
+
+        await harness.hydrator.hydrateOpenConnections(new AbortController().signal);
+
+        const message = harness.sentMessages(connection)[0] as { payload: { resource: string; }; };
+        expect(JSON.parse(message.payload.resource)).toEqual(accepted);
+        expect(harness.outcomes).toEqual(['sent']);
+    });
+
+    it('finds a member only the accepted layout still names through the second scan (4c)', async () => {
+        const planned = createTopology({ version: 7, activeSessionIds: ['session-9'] });
+        const accepted = createTopology({ version: 6 });
+        const harness = createHarness({
+            scanTopology: planned,
+            currentTopology: planned,
+            acceptedTopologies: {
+                listSnapshotEntriesPage: async () => [{
+                    entry: { key: accepted.groupRef.groupId },
+                    value: accepted
+                } as never],
+                findSnapshot: async () => accepted
+            }
+        });
+        const connection = harness.addConnection('session-1', 'generation-1');
+
+        await harness.hydrator.hydrateOpenConnections(new AbortController().signal);
+
+        const message = harness.sentMessages(connection)[0] as { payload: { resource: string; }; };
+        expect(JSON.parse(message.payload.resource)).toEqual(accepted);
+        expect(harness.outcomes).toEqual(['sent']);
     });
 
     it('never writes to a replacement generation that appears during authorization', async () => {
@@ -259,6 +303,7 @@ interface HarnessOverrides {
     readonly scanTopology?: RallarOverlayTopologySnapshot;
     readonly currentTopology?: RallarOverlayTopologySnapshot;
     readonly topologies?: readonly RallarOverlayTopologySnapshot[];
+    readonly acceptedTopologies?: RtcTopologyReconnectHydration.TopologyReader;
     readonly beforeAuthorizationReturns?: () => Promise<void>;
     readonly scheduler?: ManualScheduler;
     readonly currentTopologyFailures?: number;
@@ -284,6 +329,10 @@ function createHarness(overrides: HarnessOverrides = {}) {
     const hydrator = new RtcTopologyReconnectHydrator({
         socket,
         batchWindowMs: 25,
+        acceptedTopologies: overrides.acceptedTopologies ?? {
+            listSnapshotEntriesPage: async () => [],
+            findSnapshot: async () => undefined
+        },
         topologies: {
             listSnapshotEntriesPage: async ({ afterKey, limit }) => {
                 pageLimits.push(limit);

--- a/packages/tests/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/hydration/rtc-topology-reconnect-hydrator.test.ts
@@ -77,6 +77,45 @@ describe('RtcTopologyReconnectHydrator', () => {
         expect(harness.outcomes).toEqual(['sent']);
     });
 
+    it('hydrates the removal tombstone even when a stale accepted row survives (teardown wins)', async () => {
+        const tombstone = { ...createTopology({ version: 8 }), state: 'removed' as const };
+        const staleAccepted = createTopology({ version: 7 });
+        const harness = createHarness({
+            scanTopology: tombstone,
+            currentTopology: tombstone,
+            acceptedTopologies: {
+                listSnapshotEntriesPage: async () => [],
+                findSnapshot: async () => staleAccepted
+            }
+        });
+        const connection = harness.addConnection('session-1', 'generation-1');
+
+        await harness.hydrator.hydrateOpenConnections(new AbortController().signal);
+
+        const message = harness.sentMessages(connection)[0] as { payload: { resource: string; }; };
+        expect(JSON.parse(message.payload.resource)).toEqual(tombstone);
+    });
+
+    it('serves a member named only in the held planned candidate their candidate assignment (4c)', async () => {
+        const planned = createTopology({ version: 9, activeSessionIds: ['session-1', 'session-2'] });
+        const accepted = createTopology({ version: 8, activeSessionIds: ['session-2'] });
+        const harness = createHarness({
+            scanTopology: planned,
+            currentTopology: planned,
+            acceptedTopologies: {
+                listSnapshotEntriesPage: async () => [],
+                findSnapshot: async () => accepted
+            }
+        });
+        const connection = harness.addConnection('session-1', 'generation-1');
+
+        await harness.hydrator.hydrateOpenConnections(new AbortController().signal);
+
+        const message = harness.sentMessages(connection)[0] as { payload: { resource: string; }; };
+        expect(JSON.parse(message.payload.resource)).toEqual(planned);
+        expect(harness.outcomes).toEqual(['sent']);
+    });
+
     it('finds a member only the accepted layout still names through the second scan (4c)', async () => {
         const planned = createTopology({ version: 7, activeSessionIds: ['session-9'] });
         const accepted = createTopology({ version: 6 });
@@ -84,10 +123,7 @@ describe('RtcTopologyReconnectHydrator', () => {
             scanTopology: planned,
             currentTopology: planned,
             acceptedTopologies: {
-                listSnapshotEntriesPage: async () => [{
-                    entry: { key: accepted.groupRef.groupId },
-                    value: accepted
-                } as never],
+                listSnapshotEntriesPage: async () => [toSnapshotPageEntry(accepted)],
                 findSnapshot: async () => accepted
             }
         });
@@ -440,6 +476,21 @@ function requireHarnessWebSocket(
         throw new Error(`Missing test WebSocket for ${context.id}`);
     }
     return webSocket;
+}
+
+function toSnapshotPageEntry(
+    snapshot: RallarOverlayTopologySnapshot
+): { entry: { key: string; value: string; expireAtTimestamp: number; updatedTimestamp: string; revision: number; }; value: RallarOverlayTopologySnapshot; } {
+    return {
+        entry: {
+            key: snapshot.groupRef.groupId,
+            value: JSON.stringify(snapshot),
+            expireAtTimestamp: Number.MAX_SAFE_INTEGER,
+            updatedTimestamp: '2026-08-10T00:00:00.000Z',
+            revision: 1
+        },
+        value: snapshot
+    };
 }
 
 function createTopology(

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
@@ -46,6 +46,7 @@ describe('formation timer work handler', () => {
                     config: resolveGroupTopologyConfig({}),
                     kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
                     rttMeasurements: [],
+                    replanning: 'debounced' as const,
                     nowEpochMs
                 })
             },
@@ -229,6 +230,7 @@ function unusedTopologyPlanning(group: ReturnType<typeof formationGroup>, nowEpo
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
             rttMeasurements: [],
+            replanning: 'debounced' as const,
             nowEpochMs
         })
     };

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
@@ -46,7 +46,7 @@ describe('formation timer work handler', () => {
                     config: resolveGroupTopologyConfig({}),
                     kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
                     rttMeasurements: [],
-                    replanning: 'debounced' as const,
+                    replanning: 'auto' as const,
                     nowEpochMs
                 })
             },
@@ -230,7 +230,7 @@ function unusedTopologyPlanning(group: ReturnType<typeof formationGroup>, nowEpo
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
             rttMeasurements: [],
-            replanning: 'debounced' as const,
+            replanning: 'auto' as const,
             nowEpochMs
         })
     };

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.test.ts
@@ -556,6 +556,16 @@ describe('readPendingTopologyReplan', () => {
         expect(keys).toEqual([computedEntry().key]);
     });
 
+    it('reads an executing (reserved) row as still queued', async () => {
+        const reserved = { ...computedEntry(), status: EntityStatus.RESERVED };
+        await expect(
+            readPendingTopologyReplan({ findByKey: async () => reserved }, GROUP_REF)
+        ).resolves.toEqual({
+            reconfigureQueued: true,
+            dueAtEpochMs: BASE_EPOCH_MS + DEBOUNCE_MS
+        });
+    });
+
     it('reads a settled row as no pending work', async () => {
         const settled = { ...computedEntry(), status: EntityStatus.COMPLETED };
         await expect(

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.test.ts
@@ -10,6 +10,7 @@ import type { RtcTopologyGroupRevisionWork } from '@shared-server/rallar-system/
 import {
     computeCoalescedRtcTopologyGroupRevisionWork,
     mergeRtcTopologyGroupRevisionWork,
+    readPendingTopologyReplan,
     toRtcTopologyCoalescedGroupRevisionResourceId
 } from '@shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts';
 import { computeRtcTopologyInputFingerprint } from '@shared-server/rallar-system/topology/replay/work/rtc-topology-input-fingerprint.ts';
@@ -23,7 +24,7 @@ import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { AuditStamp, GroupSnapshot } from '@shared/api/group-types.ts';
 import { isIdempotentHandlerFinalizedRelease } from '@shared/queuebox/queue-box-types.ts';
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { isCanonicalRtcTopologyWorkEntry } from '@shared/queuebox/rtc-topology-work-entry-contract.ts';
 import { createTestGroup } from '../../../../../create-test-group.ts';
 
@@ -519,3 +520,53 @@ function withSessions(snapshot: GroupSnapshot, sessionIds: readonly string[]): G
         }))
     };
 }
+
+describe('readPendingTopologyReplan', () => {
+    function computedEntry(): ResourceEntry {
+        return computeCoalescedRtcTopologyGroupRevisionWork({
+            aggregateRef: GROUP_REF,
+            groupSnapshot: createGroupSnapshot(4, 3),
+            requestedAtEpochMs: BASE_EPOCH_MS,
+            expireAtEpochMs: EXPIRE_AT_EPOCH_MS,
+            recomputeDebounceMs: DEBOUNCE_MS,
+            senderId: 'server-1',
+            previousEntry: null
+        }).entry;
+    }
+
+    it('reads a queued replan and its due time off the coalesced row', async () => {
+        await expect(
+            readPendingTopologyReplan({ findByKey: async () => computedEntry() }, GROUP_REF)
+        ).resolves.toEqual({
+            reconfigureQueued: true,
+            dueAtEpochMs: BASE_EPOCH_MS + DEBOUNCE_MS
+        });
+    });
+
+    it('reads null when no row exists and asks with the stored row\'s exact key', async () => {
+        const keys: Key[] = [];
+        await expect(
+            readPendingTopologyReplan({
+                findByKey: async (key) => {
+                    keys.push(key);
+                    return null;
+                }
+            }, GROUP_REF)
+        ).resolves.toBeNull();
+        expect(keys).toEqual([computedEntry().key]);
+    });
+
+    it('reads a settled row as no pending work', async () => {
+        const settled = { ...computedEntry(), status: EntityStatus.COMPLETED };
+        await expect(
+            readPendingTopologyReplan({ findByKey: async () => settled }, GROUP_REF)
+        ).resolves.toBeNull();
+    });
+
+    it('reports a queued replan with an unknown due time when the envelope no longer decodes', async () => {
+        const corrupt = { ...computedEntry(), resource: '{"not":"an-envelope"}' };
+        await expect(
+            readPendingTopologyReplan({ findByKey: async () => corrupt }, GROUP_REF)
+        ).resolves.toEqual({ reconfigureQueued: true, dueAtEpochMs: null });
+    });
+});

--- a/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/runtime/rtc-topology-metrics.test.ts
@@ -39,6 +39,7 @@ describe('RtcTopologyMetrics', () => {
         metrics.recordPublish(true);
         metrics.recordPublish(false);
         metrics.recordFingerprintSkip();
+        metrics.recordPlanFrozen();
         metrics.recordRemoval(true);
         metrics.recordRemoval(false);
 
@@ -74,6 +75,7 @@ describe('RtcTopologyMetrics', () => {
             topologyPublishedCount: 1,
             topologyPublishSkippedUnchangedCount: 1,
             topologyRebuildSkippedFingerprintCount: 1,
+            topologyPlanFrozenCount: 1,
             topologyRemovalRequestCount: 2,
             topologyRemovedCount: 1,
             topologyRemoveMissCount: 1,
@@ -115,6 +117,7 @@ describe('RtcTopologyMetrics', () => {
             topologyPublishedCount: 0,
             topologyPublishSkippedUnchangedCount: 0,
             topologyRebuildSkippedFingerprintCount: 0,
+            topologyPlanFrozenCount: 0,
             topologyRemovalRequestCount: 0,
             topologyRemovedCount: 0,
             topologyRemoveMissCount: 0,

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -788,6 +788,69 @@ returns `publish-superseded`, so a dominated candidate's publication can be broa
 **Gates:** baseline, both profiles, **medium-scale**, `topology-replay`, state-write,
 `test:integration:postgres`.
 
+### PR 5 delivery record — slices 4b + 4c (executed 2026-08-27, branch `codex/group-activation-planning-gate`)
+
+Delivered as designed, with these recorded rulings where the slice text left the semantics open:
+
+- **Freeze is replacement suppression, never establishment suppression.** "Write no replacement" is
+  read literally: `connecting`/`reconnecting` (and `active` under suppression) freeze only when the
+  planned slot holds an **active** row; an absent or tombstoned slot always plans. This is
+  load-bearing for today's phased flow — `start-establishment` jumps `forming → connecting` and the
+  first real plan is produced while already `connecting`; a stage-only freeze would starve the
+  deadline timer (it throws-to-retry on a missing/tombstoned planned row) and the criterion would
+  never have a layout to measure. The one behavior change for a producible stage: `connecting` no
+  longer replans mid-dial — the candidate stays frozen (the slice's own mitigation, the transitions'
+  unconditional follow-up enqueue, reconsiders latest authority after the stage advances).
+- **The decision has one owner.** `resolveTopologyPlanAction` (pure, total via the stage registry;
+  beside the planning service) resolves `plan | publish-removal | freeze` from stage, replanning
+  mode, work origin and previous-row state. `computeTopologyFromAuthority` applies it — still the
+  single production gate both runtimes converge on — and now returns a discriminated
+  `planned | frozen` result, so the compiler censused every consumer. The work handler maps `frozen`
+  to a new `skipped-frozen` decision: entry finished, **no snapshot and no fingerprint write** (the
+  fingerprint must keep saying the stored layout trails the authority — decision 11's latched
+  signal), criterion petitioned on the stored row, promotion reconcile still runs. The local-mode
+  bypasses (`reconfigureGroupTopology`, `flushDueGroupTopology`) consult the same resolver;
+  local-mode explicit reconfigure of a removal-disposition stage keeps today's planning (a skip
+  there has no snapshot to answer with — recorded residue, api-v1's paths all converge on the
+  handler).
+- **`active` follows the policy now, minimally.** The authority read resolves the group's stored
+  `topology.replanning` (absent → default preset, unreadable → `'corrupt'`). `auto`/`debounced`
+  plan (indistinguishable until decision 31). `commanded` freezes **change-gated coalesced** work
+  and RTT refreshes (origin `automatic`); non-change-gated group-revision work — the reconfigure
+  family and the lifecycle transitions' follow-up enqueues — carries origin `commanded` and plans.
+  A corrupt policy fails automatic replanning closed, commanded work still plans. C6 closes here:
+  the six stage-blind enqueue paths all converge on the gated compute. C7's mechanism lands with a
+  pinned test: a departure arriving as automatic work under `commanded` freezes — the layout keeps
+  naming the departed session until the application reconfigures; 10a owns the observable axes.
+- **4c delivery is accepted-first with a planned fallback, not accepted-only.** Repair
+  (`deliver-current`) and hydration content resolve `accepted ?? planned` — decisions 1/30: the
+  layout carrying traffic when a promotion has produced one, the frozen planned candidate before
+  that (`connecting`, pre-first-promotion, operator-activated). One split matters: the replay
+  **decision** still compares the log against the **planned** row — it is written in the same
+  transaction as every publication, so the log can never run ahead of it, which is exactly the
+  invariant the decision's corruption checks enforce; the asynchronously promoted accepted row may
+  trail the log indefinitely under hold, and using it as the comparison baseline made the
+  `topology-replay` proof read healthy entries as "historical newer than current" corruption. Only
+  the repair **content** is accepted-first. Replay's transport of newer planned
+  publications is untouched — the browser's stage gate owns dialing (slice 8); what changed is that
+  repair and hydration can no longer put `active` members onto an unaccepted planned layout. The
+  hydrator scans **both** namespaces (the planned scan finds dialing members, the accepted scan
+  finds members a replan moved past) deduplicating per `(overlay, connection)` pair — the cost the
+  plan's table priced as "the hydrator's paged-CAS reader".
+- **The view carries both slots without a rename.** `GroupTopologyManagementView` gains required
+  `acceptedSnapshot` (null until first promotion); `snapshot` stays the planned slot. `pending` is
+  finally populated: `readPendingTopologyReplan` (owned beside the coalesced row it decodes) reads
+  the row by its exact durable key via `findByKey`, reports `{reconfigureQueued, dueAtEpochMs}` for
+  a mutable row, `null` for absent/settled rows, and queued-with-unknown-due for a row whose
+  envelope no longer decodes. api-v1 wires it straight over the database handle
+  (`PSqlResourceInboxEntryRepository`), so the query service needs no queue-engine dependency.
+- **A PR-4 post-review defect fixed beneath this PR** (`1c2967a11`, on the PR-4 branch): the
+  promotion mint gate's fresh reads ran inside the publication transaction on the shared database
+  handle — pooled Postgres works, single-session PGlite deadlocks and wedges the AppInbox loop
+  (caught by the black-box memory leg). Doctrine recorded: **enqueue-side gate reads run before the
+  transaction opens; only the idempotent mint commits inside it.** The frozen and unchanged paths
+  here follow the same shape.
+
 ## Slice 5 — The command family: `plan`, `connect`, `pause`, `resume`, `reset`, `start` (dark)
 
 Per-command cost is the checkpoint-recovered 18-file / ~23-site census: a new `AppInboxType`; a payload type and an

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -851,6 +851,55 @@ Delivered as designed, with these recorded rulings where the slice text left the
   transaction opens; only the idempotent mint commits inside it.** The frozen and unchanged paths
   here follow the same shape.
 
+#### PR 5 review-repair record (ten-angle max-effort review + gap sweep, executed 2026-08-28)
+
+Fifteen confirmed findings, all repaired in the PR. The rulings the repairs added:
+
+- **Delivery content has one owner with two qualifiers.** `toDeliverableTopologySnapshot` (replay/)
+  resolves repair and hydration content: accepted-first, **except** a planned removal tombstone
+  always wins — the accepted slot only ever holds active layouts (a tombstone never promotes) and
+  nothing deletes it today, so without this clause a torn-down overlay is resurrected from the stale
+  accepted row forever (the teardown signal I15 protects) — and, member-aware, a session named only
+  in the held planned candidate receives its candidate assignment, or a `commanded` hold starves the
+  very coverage the criterion measures. The replay **decision** stays planned-pinned and now reads
+  the accepted row only on the repair branch (the hot path pays nothing). Accepted-slot deletion on
+  teardown belongs to slice 5e's `reset`.
+- **`pending` means "the queue will still attempt it":** NEW, RETRY and RESERVED all report queued.
+  Recorded residue: a delta parked on a causal-suffixed successor row behind a reserved head is
+  invisible to the point read for at most its debounce window (the head reads queued while
+  reserved); revivable-but-unrevived FAILED rows honestly read as not queued. `PendingTopologyReplan`
+  is now the one named contract in the shared API, and api-v1 feeds the reader the mutation
+  runtime's own entries repository — no raw database handle, no second repository instance.
+- **The policy fold has one owner beside the resolver**: `toGroupTopologyReplanningRead` (absent →
+  default preset, corrupt stays corrupt) and `consultsReplanningPolicy` (spelled off the disposition
+  registry, so the read gate cannot drift from the row that consumes it). The planning service takes
+  the same `readLifecyclePolicy` port every other topology consumer takes. `workOrigin` is owned by
+  an exhaustive `toTopologyWorkOrigin` beside the work kinds — a new kind fails the anchor instead
+  of silently classifying `commanded` past the freeze — and the origin doc is corrected: the
+  transitions' follow-ups ride the **automatic** coalesced presence chain, so a `commanded` group's
+  post-transition replan also waits for the application (C7), which is the intended semantics.
+- **The frozen path is observable and honest**: a dedicated `topologyPlanFrozenCount` (a hold is not
+  a failed publish attempt), the skipped-frozen arm carries the union's own payload (non-null
+  criterion petition, no phantom frozen-without-row state), both skip decisions share one writer
+  with the fingerprint non-write guarded on the discriminant, and the local `flushDue` path now
+  skips for removal-disposition stages too. Hydration's pair set dedupes **attempts** (a retry pair
+  keeps its mark for the next pass instead of being re-attempted by the second scan — no duplicate
+  sends, no false requires-retry throw on a fully hydrated gap pass).
+- **The gate list grew what the review demanded**: the frozen write path has a real-Postgres
+  handler-level test (establishment plans while `connecting`, the replacement freezes with the entry
+  completed and the fingerprint latch untouched); the lifecycle-transitions recipe pins
+  `acceptedSnapshot: null` through establishment and a post-activation poll proves the promotion
+  lands the accepted slot over REST; the admin-support narrative summarizes the traffic layout, not
+  the held candidate; the formation deadline timer reads the planned slot directly instead of the
+  widened management view.
+- **Refuted for the record**: the transition follow-up enqueue the freeze relies on does exist —
+  `compute-lifecycle-transition` marks presence-summary work and `group-presence-summary-effects`
+  mints the coalesced topology row unconditionally; and the accepted slot can never hold a tombstone
+  (`computePlannedLayoutPromotion` returns `no-planned-layout` for any non-active planned identity).
+  Accepted residue: `preserve-known-revision` membership-delta work can evaluate the gate on an
+  enqueue-time stage for one cycle — the pre-existing selection semantics; every producible
+  stale-stage pairing today resolves to the same action the fresh stage would.
+
 ## Slice 5 — The command family: `plan`, `connect`, `pause`, `resume`, `reset`, `start` (dark)
 
 Per-command cost is the checkpoint-recovered 18-file / ~23-site census: a new `AppInboxType`; a payload type and an


### PR DESCRIPTION
Slices 4b + 4c of `playground/rtc-design/2026-08-22-group-activation-implementation-plan.md` (PR 5 per the plan's fourth checkpoint — slice 4 completes). Rebased onto `main` after #359 merged.

## What lands

**4b — the total stage-keyed planning gate.** `isGroupTopologyPlannableAt` and its `TOPOLOGY_PLANNABLE` table are retired. The slice-1b disposition registry (`resolveGroupTopologyWorkDisposition`) goes live through one new pure owner, `resolveTopologyPlanAction`, which resolves every topology write to `plan`, `publish-removal`, or `freeze` from four inputs: stage, replanning mode, work origin, and the stored row's state. `computeTopologyFromAuthority` applies it — still the single gate both runtimes converge on — and now returns a discriminated `planned | frozen` result, so the compiler censused every consumer. The work handler maps `frozen` to a new `skipped-frozen` arm: entry finished, **no snapshot write and no fingerprint write** (staleness must keep signalling), criterion petitioned on the stored row, promotion reconcile intact. The local-mode `reconfigure`/`flushDue` bypasses consult the same resolver.

Two rulings carry the weight (recorded in the plan):

- **Freeze suppresses replacement, never establishment.** Only an *active* stored row freezes; absent or tombstoned slots always plan. Today's phased flow produces its first layout while already `connecting` — a stage-only freeze would starve the formation deadline timer and the activation criterion. The behavior change for a producible stage: `connecting` no longer replans mid-dial; the frozen candidate is what the criterion measures, and the transitions' follow-up enqueues replan from latest authority after the stage advances.
- **`active` follows the replanning policy, minimally.** The planning authority now carries the group's stored `topology.replanning` (read only for active groups; absent → default preset; unreadable → fails automatic replanning closed). `commanded` freezes change-gated coalesced work and RTT refreshes; explicit reconfigures and transition follow-ups carry origin `commanded` and plan. This closes **C6** — the six stage-blind enqueue paths all converge on the gated compute — and lands **C7**'s mechanism with a pinned test: a departure arriving as automatic work under `commanded` keeps the layout naming the dead session until the application reconfigures (10a owns the observable axes).

**4c — delivery pinned to the layout carrying traffic.** Repair (`deliver-current`) and reconnect hydration resolve **`accepted ?? planned`** (decisions 1/30): the accepted row whenever a promotion has produced one, the frozen planned candidate before that. Replay transport of newer planned publications is untouched — the browser's stage gate owns dialing — but repair and hydration can no longer put `active` members onto an unaccepted planned layout. The hydrator scans **both** namespaces (planned finds dialing members; accepted finds members a replan moved past), deduplicating per `(overlay, connection)` pair. The criterion petition was verified already planned-pinned.

**The management view carries both slots, and `pending` finally lives.** `GroupTopologyManagementView` gains required `acceptedSnapshot` (null until first promotion; `snapshot` stays the planned slot — no rename), mirrored in OpenAPI. The inert `pending` field is populated by `readPendingTopologyReplan`, owned beside the coalesced row it decodes: the durable row read by its exact key, reporting `{reconfigureQueued, dueAtEpochMs}` for a mutable row, `null` when absent or settled, and queued-with-unknown-due when the envelope no longer decodes. api-v1 wires it directly over the database handle — no queue-engine dependency in the query service.

## What the gates taught us

The dedicated `topology-replay` proof caught a real 4c defect on the first cut: using the accepted row as the replay **decision's** comparison baseline made healthy log entries read as "historical publication appears newer than current topology" corruption — the accepted row is promoted asynchronously and may trail the log indefinitely under a hold landing, while the planned row is written in the same transaction as every publication and can never trail it. The fix splits the roles: the decision compares against the planned row (the log-consistency invariant), and only the repair **content** is accepted-first. Recorded in the plan's delivery record.

## Commands executed

| Command | Result | Notes |
| --- | --- | --- |
| `check:repo-style:changed` | PASS | After naming the pending output contract and typing a test collector. |
| `typecheck` + `typecheck:tests` | PASS | The result union censused every consumer, including the Deno app tests tsc never sees. |
| `check:browser-bundles` | PASS | The view widening is type-only. |
| `test:unit` (full) | PASS | Includes the rewritten planning matrix, the pure action-matrix test, accepted-first repair/hydration tests, and the pending-reader tests. |
| `test:deno` | PASS | Both servers; the PGlite topology suites narrow through the union. |
| `test:repo-governance` | PASS | |
| black-box memory (isolated) | PASS — 32/32 | On the final head. |
| black-box postgres (isolated) | PASS — full profile | |
| `topology-replay` profile | PASS | After the decision-baseline repair above; first run failed honestly. |
| medium-scale | PASS | On the final head; constants untouched. |
| `test:integration:postgres` | PASS — 25/25 + presence-expiry 10/10 | A concurrent session's stale worktree copy of the presence suite gets globbed into this script's substring filter and fails on its own old code; this tree's files are green. |
| state-write | PASS — "performance comparison passed", twice | Control captured at the PR base (`1c2967a11`) in a worktree; candidates at the pre-review head and again after the review repairs (which only lightened the hot path), each on a freshly migrated pinned 5433 container; no regression-reason profile needed. |

## Max-effort review and repairs

A ten-angle review (five correctness angles, reuse/simplification/efficiency/altitude/conventions) with a cross-verified gap sweep confirmed **15 findings**, all repaired in `d1b0446b2`:

1. **The teardown signal could be shadowed forever.** The accepted slot is written only by promotion and never deleted, so once the planned row became a removal tombstone, accepted-first repair and hydration would resurrect the dead layout — permanently, once the tombstone aged out of log retention. Delivery content now has one owner (`toDeliverableTopologySnapshot`) with the tombstone-wins clause, and slice 5e's `reset` owns accepted-slot deletion.
2. **Accepted-first starved dialing members.** A session named only in the held planned candidate got `no-topology` from hydration and was excluded from repair audiences — under `commanded` mode, where nothing republishes, that stalls the very coverage the activation criterion measures. The content rule is member-aware: a planned-only member receives their candidate assignment.
3. **`pending` lied during execution.** A RESERVED row read as settled; it now reads as queued (the successor-row debounce window is recorded residue), and `PendingTopologyReplan` is the one named contract in the shared API, fed by the mutation runtime's own entries repository instead of a raw database handle.
4. **The hydration pair set dedupes attempts, not outcomes** — a retry pair keeps its mark for the next pass instead of being re-attempted by the second scan: no duplicate sends, no false requires-retry throw on a fully hydrated gap pass.
5. **The origin classification fails closed for the future**: an exhaustive `toTopologyWorkOrigin` beside the work kinds replaces the call-site heuristic that would have classified any new kind as `commanded` past the freeze, and the origin doc is corrected — transition follow-ups ride the *automatic* presence chain, so a `commanded` group's post-transition replan also waits for the application (C7, as intended).
6. The rest: the replay hot path reads the accepted row only on the repair branch; the policy fold and its read gate are owned beside the resolver (spelled off the disposition registry, through the same `readLifecyclePolicy` port every consumer takes); the frozen path gains `topologyPlanFrozenCount` (a hold is not a failed publish), a non-null criterion petition from the union's own payload, one shared skip writer with the fingerprint non-write guarded on the discriminant, and a **real-Postgres handler-level test**; the local `flushDue` skips removal-disposition stages; the lifecycle-transitions recipe pins `acceptedSnapshot: null` through establishment and a post-activation poll proves the promotion over REST; the admin-support narrative summarizes the traffic layout, not the held candidate; the deadline timer reads the planned slot directly; the oversized compute was split under the 60-line ceiling; the coupling-registry corruption entry is anchored to its own contract and assertion.

**Refuted for the record** (in the plan): the transition follow-up enqueue the freeze relies on exists (the presence-summary chain mints the coalesced row unconditionally), and the accepted slot can never hold a tombstone (`computePlannedLayoutPromotion` refuses non-active identities).


Every gate re-ran green after the review repairs and the rebase onto the merged #359: style, coupling, typechecks, bundles, full unit (8,190), test:deno, governance, black-box memory 32/32 and postgres full profile (including the extended lifecycle-transitions recipe proving the promotion over REST), topology-replay, medium-scale, integration-postgres (with the new frozen-path test), and the state-write comparison.
