### PR TITLE
Pin the topology convergence recipe to the held reconfigure landing

### DIFF
--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1169,7 +1169,7 @@
           }
         ]
       },
-      "description": "No-browser three-server convergence test for immutable RTC topology revisions and PostgreSQL-backed WebSocket fanout."
+      "description": "No-browser three-server convergence test for immutable RTC topology revisions and PostgreSQL-backed WebSocket fanout. The group pins the hold reconfigure landing so the only group-state.event envelopes are the two mutations it commits: under apply, the route-less applyPlannedLayout promotion emits a third envelope that the exact-revision assertions would consume. Route-less promotion is covered by api-v1-state-topology-churn."
     },
     {
       "id": "api-v1-state-topology-churn",
@@ -1202,7 +1202,7 @@
           }
         ]
       },
-      "description": "Bounded three-server load recipe with 12 clients contending across two groups and disconnect/reconnect presence churn."
+      "description": "Bounded three-server load recipe with 12 clients contending across two groups and disconnect/reconnect presence churn. Both groups take the default apply reconfigure landing and the recipe issues no lifecycle command, so the accepted layout each closing reconfigure lands can only have come from the route-less applyPlannedLayout promotion."
     },
     {
       "id": "api-v1-state-write-convergence",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-rtc-topology-convergence.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-rtc-topology-convergence.json
@@ -204,7 +204,12 @@
           "displayName": "{groupName}",
           "kind": "room",
           "joinMode": "open",
-          "createdByPrincipalId": "{aliceClientId}"
+          "createdByPrincipalId": "{aliceClientId}",
+          "lifecyclePolicy": {
+            "topology": {
+              "reconfigureLanding": "hold"
+            }
+          }
         }
       },
       "expect": {
@@ -828,6 +833,28 @@
               "groupId": "{groupId}"
             }
           }
+        }
+      }
+    },
+    {
+      "name": "heldLandingLeftAcceptedLayoutUnpromoted",
+      "type": "http",
+      "connection": "apiPrimary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
+          },
+          "acceptedSnapshot": null
         }
       }
     },

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-state-topology-churn.json
@@ -1226,6 +1226,66 @@
           "outboxId": "string"
         }
       }
+    },
+    {
+      "name": "sharedAcceptedLayoutPromotedWithoutLifecycleCommand",
+      "type": "http",
+      "connection": "apiTertiary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{sharedGroupId}/topology",
+        "headers": {
+          "Authorization": "{ownerAuthHeader}",
+          "x-client-id": "{ownerClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 100,
+          "backoffMultiplier": 2
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
+          },
+          "acceptedSnapshot": {
+            "state": "active"
+          }
+        }
+      }
+    },
+    {
+      "name": "churnAcceptedLayoutPromotedWithoutLifecycleCommand",
+      "type": "http",
+      "connection": "apiSecondary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{churnGroupId}/topology",
+        "headers": {
+          "Authorization": "{ownerAuthHeader}",
+          "x-client-id": "{ownerClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 100,
+          "backoffMultiplier": 2
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
+          },
+          "acceptedSnapshot": {
+            "state": "active"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-three-server-recipe-semantics.test.ts
@@ -215,6 +215,68 @@ describe('API-v1 three-server recipe semantics', () => {
         }
     });
 
+    // The two envelopes the exact-revision assertions consume are the two
+    // earliest buffered group-state.event frames, so any third envelope in the
+    // window is read as a mutation. Under the apply landing the route-less
+    // applyPlannedLayout promotion emits exactly such an envelope, and whether
+    // it lands before the sockets open is a race the group's own load decides.
+    it('pins the held reconfigure landing the exact-revision assertions depend on', () => {
+        const { entries } = readMatrix();
+        const entry = entries.find((candidate) => candidate.id === 'api-v1-rtc-topology-convergence');
+        const recipe = readRecipe(entry!.recipe);
+        const allSteps = flattenRecipeSteps(recipe.steps as Array<Record<string, unknown>>);
+
+        expect(allSteps.find((step) => step.name === 'createGroupOnPrimary')).toMatchObject({
+            request: {
+                body: {
+                    lifecyclePolicy: { topology: { reconfigureLanding: 'hold' } }
+                }
+            }
+        });
+        expect(
+            allSteps.find((step) => step.name === 'heldLandingLeftAcceptedLayoutUnpromoted')
+        ).toMatchObject({
+            expect: {
+                body: {
+                    snapshot: { state: 'active' },
+                    acceptedSnapshot: null
+                }
+            }
+        });
+    });
+
+    it('covers the route-less accepted-layout promotion the convergence recipe holds back', () => {
+        const recipe = readRecipe('tests/api-v1/api-v1-state-topology-churn.json');
+        const steps = recipe.steps as Array<Record<string, unknown>>;
+
+        for (
+            const [stepName, connection] of [
+                ['sharedAcceptedLayoutPromotedWithoutLifecycleCommand', 'apiTertiary'],
+                ['churnAcceptedLayoutPromotedWithoutLifecycleCommand', 'apiSecondary']
+            ] as const
+        ) {
+            expect(steps.find((step) => step.name === stepName), stepName).toMatchObject({
+                connection,
+                request: {
+                    poll: {
+                        maxAttempts: 20,
+                        maxDurationMs: 15000
+                    }
+                },
+                expect: {
+                    body: {
+                        acceptedSnapshot: { state: 'active' }
+                    }
+                }
+            });
+        }
+
+        // Both groups take the default apply landing and no step drives a
+        // lifecycle transition, so promotion through activation cannot be what
+        // these two steps observe.
+        expect(JSON.stringify(recipe)).not.toContain('lifecycle');
+    });
+
     it('defines bounded three-server multi-client and multi-group churn coverage', () => {
         const { entries } = readMatrix();
         const entry = entries.find((candidate) => candidate.id === 'api-v1-state-topology-churn');

--- a/packages/tests/shared-test/state-write-recipe-evidence.test.ts
+++ b/packages/tests/shared-test/state-write-recipe-evidence.test.ts
@@ -56,16 +56,20 @@ describe('API-v1 state-write recipe evidence', () => {
             'assertPrimaryExactRevisions',
             'assertTertiaryExactRevisions',
             'assertEnvelopePayloadsAcrossPrimaryAndTertiary',
+            'heldLandingLeftAcceptedLayoutUnpromoted',
             'closeAliceWebSocket',
             'closeBobWebSocket',
             'logoutAliceThroughPrimary',
             'logoutBobThroughSecondary'
         ];
-        expect(recipe.steps).toHaveLength(32);
+        // The held-landing read and the four cleanup steps are not assert
+        // steps, so the synthetic execution below stands them in as SETs.
+        const trailingNonAssertCount = 5;
+        expect(recipe.steps).toHaveLength(33);
         expect(recipe.steps.slice(-terminalNames.length).map((step) => step.name))
             .toEqual(terminalNames);
 
-        const assertionSteps = recipe.steps.slice(-terminalNames.length, -4);
+        const assertionSteps = recipe.steps.slice(-terminalNames.length, -trailingNonAssertCount);
         expect(assertionSteps[0].actual).toEqual({
             firstRevision: '{primaryFirstEnvelope.resultingCausalRevision.groupRevision}',
             secondRevision: '{primarySecondEnvelope.resultingCausalRevision.groupRevision}'
@@ -105,7 +109,7 @@ describe('API-v1 state-write recipe evidence', () => {
                 },
                 [step.name]: { type: 'assert' }
             })),
-            ...terminalNames.slice(-4).map((name, index) => ({
+            ...terminalNames.slice(-trailingNonAssertCount).map((name, index) => ({
                 SET: {
                     request: {
                         output: `${name}Observed`,
@@ -123,7 +127,7 @@ describe('API-v1 state-write recipe evidence', () => {
             variables
         });
 
-        expect(report.summary).toMatchObject({ total: 7, success: 7, failure: 0 });
+        expect(report.summary).toMatchObject({ total: 8, success: 8, failure: 0 });
         for (const name of terminalNames) {
             expect(report.resultsByName[name], name).toHaveLength(1);
         }


### PR DESCRIPTION
## Goal

Remove the timing race behind the `api-v1-rtc-topology-convergence` flake seen on 2026-08-28 (API
v1 Medium-Scale Gate run 33167650043, failure at `assertPrimaryExactRevisions-i30-r1`, green on
rerun), without weakening the exact-revision assertion that is the recipe's whole point — and
replace the live promotion exposure it gives up with coverage that actually asserts something.

## Changes

**`api-v1-rtc-topology-convergence.json`** — `createGroupOnPrimary` now pins
`lifecyclePolicy.topology.reconfigureLanding: "hold"`, matching what PR #359 already did for
`api-v1-state-write-convergence` and `api-v1-group-state-reconnect-resync`. A new
`heldLandingLeftAcceptedLayoutUnpromoted` step reads the group topology after the assertions and
requires `acceptedSnapshot: null`, so the pin cannot lapse unnoticed.

**`api-v1-state-topology-churn.json`** — the two closing `topology/reconfigure` calls were queued
and never verified. Each is now followed by a polled topology read requiring
`acceptedSnapshot.state: "active"`, read back through a different cluster node than the one that
issued the reconfigure.

**`recipe-matrix.json`** — both matrix entries carry the rationale in their `description`, which is
the only place in the repo that records it (no plan or doc mentions `reconfigureLanding` or the
route-less promotion).

**Test pins** — `api-v1-three-server-recipe-semantics.test.ts` gains two cases: one pinning the
held landing and its accepted-layout assertion, one pinning the churn recipe's promotion polls plus
the two facts that make that coverage valid. `state-write-recipe-evidence.test.ts` is updated for
the added step; the held-landing read is not an assert step, so it joins the trailing steps the
synthetic execution stands in as SETs.

## Acceptance

The failure was diagnosed before anything was changed, and reproduced deterministically:
moving `establishBaselineTopology` to after both sockets open turns the race into a certainty and
fails with the same `assertPrimaryExactRevisions-i30-r1` signature as CI.

The numbers name the cause. The recipe's mutations committed at group revisions **6 and 7**, while
the matched envelopes carried **5 and 6** — revision 5 being the route-less `applyPlannedLayout`
promotion's own envelope, which took the first slot and pushed the second mutation out of the
matched window. `computeApplyPlannedLayout` returns a write result with `eventType:
'group-updated'`, so the promotion is an ordinary group mutation that emits a third
`group-state.event`; `waitForWsMessages` resolves each expectation with `findIndex`, so even under
`ordered: false` it consumes the two *earliest buffered* frames. Under normal timing the promotion
commits before the sockets open and is dropped for want of an audience, which is why this was green
locally and failed once on a loaded runner directly after the 2757-op churn recipe.

Applying the `hold` pin to that same forced-race recipe made it pass, with `acceptedSnapshot: null`
and `acceptedLayoutIdentity: null` confirming no promotion ran.

A promotion-tolerant assertion was considered and rejected: the wait matches earliest-buffered
frames and the envelope payload is an opaque JSON string, so the two frames cannot be selected by
revision; and draining before the mutations does not help, because a promotion can be triggered
*by* those mutations and commits on whichever node dequeues the work.

**Test design evidence**

- Behavior protected and observation boundary: that two concurrent mutations issued through two API
  nodes are each observed exactly once, at their committed group revision, on sockets attached to
  two different nodes — observed at the WebSocket envelope boundary. Newly protected: that a group
  on the `apply` landing promotes its planned layout to accepted with no lifecycle command
  (decision 27), observed at the `GET .../topology` boundary. `readTopologyPromotionRequest` and
  `createTopologyPromotionWorkHandler` had no test coverage at all, and the convergence recipe
  asserted nothing about the accepted layout, so this end-to-end path was previously unasserted.
- Retained interaction assertions (registry reference and rationale): None
- Coupled or redundant tests removed or replaced: None. The convergence recipe's incidental
  exposure to the promotion is replaced by an asserted poll in the churn recipe, where both groups
  take the default `apply` landing and the recipe drives no lifecycle transition at all
  (`grep -c lifecycle` returns 0) — so an accepted layout there can only have come from the
  route-less path, and the activation path is not reachable to confound it.

## Validation

Passed:

- `npm run test:api-v1:black-box:postgres` — standard profile 32/32, cluster profile 6/6, exit 0.
  Run on isolated ports 18180/18181/18182 per the repo's black-box isolation protocol. Per-recipe
  summaries confirm the new assertions executed rather than being skipped: convergence 36 → 37
  successes, churn 125 → 127.
- `npx vitest run packages/tests/shared-test/` — 96 files, 919 tests.
- `npm run test:repo-governance` — 27 files, 401 tests.
- `scenario-black-box.ts --validate --strict` on both edited recipes — 0 errors, 0 warnings,
  unchanged from their `HEAD` versions.
- `npx dprint check` on all five changed files.
- `node scripts/check-changed-repo-style.mjs origin/main HEAD` — no new findings.
- `node scripts/check-test-structure-coupling.mjs --changed origin/main HEAD` — all 7 candidates
  classified, registry current.

Failed (pre-existing, unrelated to this change):

- `node scripts/check-tests-typecheck.mjs` reports
  `apps/rallar-black-box/vite.config.ts: Cannot find module '@vitejs/plugin-react'`. This is an
  incomplete local `npm install` — the package is declared in `apps/rallar-black-box/package.json`
  and present in `package-lock.json`, but absent from `node_modules`. The same run reports
  "960 test files enforced, 0 files carrying known debt (0 errors)". CI installs from the lockfile
  and is unaffected.

Skipped:

- `npm run test:ci` and `npm run build` — this change touches only two black-box recipes, their
  matrix descriptions, and two test files; the black-box suite and the two vitest sweeps above are
  the blast radius. Branch CI covers the rest.

## Risk and rollback

Low. No production code changes — recipes, matrix metadata, and tests only.

The one behavioral trade is that the convergence recipe no longer exercises the route-less
promotion. That exposure was never asserted, so nothing regresses silently, and the churn recipe now
asserts the same path on two groups after real presence churn. If the churn poll ever proves
flaky under load, note that it is an HTTP poll with a 15s budget over a durable row rather than a
WebSocket envelope match, so it degrades by retrying rather than by mismatching.

Rollback is `git revert` of the single commit.

## Follow-up

None
