### PR TITLE
Make the group inbox descriptor contract total over its declared family

### DIFF
--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-descriptor-contract.test.ts
@@ -2,15 +2,30 @@ import { describe, expect, it } from 'vitest';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { type GroupMutationDescriptor } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
-import type { AuthenticatedGroupMutationEnqueue } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
+import {
+    AUTHENTICATED_GROUP_INBOX_TYPES,
+    type AuthenticatedGroupMutationEnqueue
+} from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
 import { toGroupMutationDescriptor } from '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
+import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { SCOPE } from './group-state-inbox-test-runtime.ts';
 
 const groupId = 'descriptor-room';
 const actor = { actorPrincipalId: 'owner', actorSessionId: 'owner-session' };
+const connectLayout: GroupLayoutIdentity = {
+    groupRevision: 3,
+    presenceRevision: 2,
+    version: 1,
+    state: 'active'
+};
 
 describe('GroupStateInboxService authenticated mutation descriptors', () => {
     it('maps every authenticated GROUP_* AppInbox variant to one exact descriptor', () => {
+        // Totality first: a variant with no case would otherwise pass this
+        // suite by never being exercised.
+        const covered = new Set<AppInboxType>(descriptorCases.map((testCase) => testCase.enqueue.type));
+        expect([...covered].sort()).toEqual([...AUTHENTICATED_GROUP_INBOX_TYPES].sort());
+
         for (const testCase of descriptorCases) {
             expect(toGroupMutationDescriptor(testCase.enqueue as AuthenticatedGroupMutationEnqueue), testCase.name).toEqual(testCase.descriptor);
         }
@@ -63,7 +78,7 @@ type DescriptorCaseArguments = readonly [
     type: AppInboxType,
     data: AuthenticatedGroupMutationEnqueue['data'],
     operation: GroupMutationDescriptor['operation'],
-    request: GroupMutationDescriptor['request'],
+    request: AuthenticatedGroupMutationEnqueue['data']['request'],
     targetPrincipalId?: string | null,
     sessionId?: string | null
 ];
@@ -113,6 +128,57 @@ const descriptorCases: readonly DescriptorCase[] = [
         'appointDirector',
         { ...actor, requestId: 'appoint-director' }
     ),
+    descriptorCase(
+        'establishment-start',
+        AppInboxType.GROUP_ESTABLISHMENT_START,
+        { scope: SCOPE, groupId, request: { ...actor, requestId: 'establishment-start' } },
+        'startGroupEstablishment',
+        { ...actor, requestId: 'establishment-start' }
+    ),
+    descriptorCase(
+        'plan',
+        AppInboxType.GROUP_PLAN,
+        { scope: SCOPE, groupId, request: { ...actor, requestId: 'plan' } },
+        'planGroupLayout',
+        { ...actor, requestId: 'plan' }
+    ),
+    // `connect` alone names the layout it means to dial, so its causal fence
+    // must survive the descriptor untouched.
+    descriptorCase(
+        'connect',
+        AppInboxType.GROUP_CONNECT,
+        {
+            scope: SCOPE,
+            groupId,
+            request: {
+                expectedFormationEpoch: 4,
+                expectedLayout: connectLayout,
+                ...actor,
+                requestId: 'connect'
+            }
+        },
+        'connectGroup',
+        {
+            expectedFormationEpoch: 4,
+            expectedLayout: connectLayout,
+            ...actor,
+            requestId: 'connect'
+        }
+    ),
+    descriptorCase(
+        'activate',
+        AppInboxType.GROUP_ACTIVATE,
+        { scope: SCOPE, groupId, request: { ...actor, requestId: 'activate' } },
+        'activateGroup',
+        { ...actor, requestId: 'activate' }
+    ),
+    descriptorCase(
+        'establishment-reopen',
+        AppInboxType.GROUP_ESTABLISHMENT_REOPEN,
+        { scope: SCOPE, groupId, request: { ...actor, requestId: 'establishment-reopen' } },
+        'reopenGroupEstablishment',
+        { ...actor, requestId: 'establishment-reopen' }
+    ),
     descriptorCase('join', AppInboxType.GROUP_JOIN, { scope: SCOPE, groupId, request: { ...actor, requestId: 'join' } }, 'joinGroup', {
         ...actor,
         requestId: 'join'
@@ -153,6 +219,32 @@ const descriptorCases: readonly DescriptorCase[] = [
         },
         'acceptGroupInvite',
         { ...actor, requestId: 'invite-accept' }
+    ),
+    descriptorCase(
+        'admission-grant',
+        AppInboxType.GROUP_ADMISSION_GRANT,
+        {
+            scope: SCOPE,
+            groupId,
+            principalId: 'member',
+            request: { ...actor, requestId: 'admission-grant' }
+        },
+        'grantGroupAdmission',
+        { ...actor, requestId: 'admission-grant' },
+        'member'
+    ),
+    descriptorCase(
+        'admission-decline',
+        AppInboxType.GROUP_ADMISSION_DECLINE,
+        {
+            scope: SCOPE,
+            groupId,
+            principalId: 'member',
+            request: { ...actor, requestId: 'admission-decline' }
+        },
+        'declineGroupAdmission',
+        { ...actor, requestId: 'admission-decline' },
+        'member'
     ),
     descriptorCase(
         'rotate-join-code',


### PR DESCRIPTION
## What

`group-state-inbox-descriptor-contract.test.ts` claimed to map *every* authenticated `GROUP_*` AppInbox variant to one exact descriptor, but it walked a hand-written `descriptorCases` table that had fallen seven variants behind `AUTHENTICATED_GROUP_INBOX_TYPES`:

`GROUP_ESTABLISHMENT_START`, `GROUP_PLAN`, `GROUP_CONNECT`, `GROUP_ACTIVATE`, `GROUP_ESTABLISHMENT_REOPEN`, `GROUP_ADMISSION_GRANT`, `GROUP_ADMISSION_DECLINE`.

All seven reach `toGroupMutationDescriptor` in production; none were exercised here.

## Change

- Added the seven missing `descriptorCase(...)` rows, placed in `AUTHENTICATED_GROUP_INBOX_TYPES` declaration order so the table stays auditable against the family.
- Made the suite total: it now asserts the set of types the table covers equals `AUTHENTICATED_GROUP_INBOX_TYPES`. A future AppInbox type cannot reach the descriptor translator without a case here.
- `connect` carries `expectedFormationEpoch` and `expectedLayout` inside its request (product decision 32), unlike the other lifecycle payloads. The case `request` element is therefore typed as the union the enqueue family declares, `AuthenticatedGroupMutationEnqueue['data']['request']`, rather than the narrower `GroupMutationDescriptor['request']` union that predates the fence.

The coverage assertion runs first, inside the existing `it`, because a variant with no case would otherwise pass the suite by never being exercised — the assertion is what makes the test's existing name true.

## Verification

The coverage assertion was proven to bite: removing the `plan` case fails the suite and names `GROUP_PLAN` in the diff.

| Command | Result |
| --- | --- |
| `npx vitest run packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-descriptor-contract.test.ts` | pass (2 tests) |
| `npx vitest run packages/tests/shared-server/rallar-system/group-state` | pass (71 files, 370 tests) |
| `npm run typecheck` | pass |
| `npm run check:repo-style:changed -- origin/main HEAD` | pass, 0 new findings |
| `npm run check:test-structure-coupling -- --changed origin/main HEAD` | pass (advisory) |
| `npx dprint check <touched file>` | clean |

`npm run typecheck` initially failed on `apps/rallar-black-box/vite.config.ts` (`TS2307: Cannot find module '@vitejs/plugin-react'`). That reproduced identically with this file reverted to `origin/main`: the package is declared and locked but was never materialised in this clone. `npm install` repaired it and left `package-lock.json` unchanged. No source change was involved.

## Note for the reviewer

PR #365 (open) touches this same test file, adding `GROUP_TRANSPORT_PAUSE` / `GROUP_TRANSPORT_RESUME` to the family **and** their two `descriptorCase` rows. The two changes are semantically compatible — #365 already satisfies the totality assertion — but it inserts its rows immediately before `rotate-join-code`, where this PR inserts the two admission rows, so expect a small textual conflict in that hunk.

I left the positional `descriptorCase(...)` / `DescriptorCaseArguments` rest-tuple shape alone. It is a pre-existing deviation from the repo standard's "at four parameters, use one named input interface; do not evade with tuples or rest parameters" rule, and touched-file closure would normally rewrite it — but doing so would rewrite all 24 rows and collide with #365 across the whole file. Worth doing as its own change once #365 lands.

Do not merge — for owner review.