### PR TITLE
Share one group authority read fixture across the mutation tests

### DIFF
--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-lifecycle-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-lifecycle-mutation.test.ts
@@ -12,18 +12,16 @@ import { GroupConnectDeniedError } from '@shared-server/rallar-system/group-stat
 import { toGroupMutationRejectionError } from '@shared-server/rallar-system/group-state/mutation/group-mutation-result.ts';
 import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
 import { GroupPolicyDeniedError } from '@shared-server/rallar-system/group-state/policy/group-policy-result.ts';
-import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
-import type { AuditStamp, Group } from '@shared/api/group-types.ts';
-import { createTestGroup } from '../../../../create-test-group.ts';
+import type { Group } from '@shared/api/group-types.ts';
 
-import { groupMemberStorageKey, groupRef, groupStorageKey, storedEntry } from './group-mutation-test-runtime.ts';
+import { createGroupAuthorityFacts, createGroupAuthorityRead, groupRef } from './group-mutation-test-runtime.ts';
 
 describe('group lifecycle transition computation', () => {
     it('plans from forming into the planned stage and advances the epoch', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('planGroupLayout'),
-            read: transitionRead({ lifecycleState: 'forming', formationEpoch: 2 }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'forming', formationEpoch: 2 }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -41,12 +39,12 @@ describe('group lifecycle transition computation', () => {
     it('replans idempotently from planned: a write that re-pins nothing (decision 28)', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('planGroupLayout'),
-            read: transitionRead({
+            read: createGroupAuthorityRead({
                 lifecycleState: 'planned',
                 formationEpoch: 4,
                 formationElectorate: ['pinned-earlier']
             }),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -65,7 +63,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 4, expectedLayout: PLANNED_LAYOUT }),
             read: connectRead(stored, PLANNED_LAYOUT),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -84,7 +82,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 4, expectedLayout: PLANNED_LAYOUT }),
             read: connectRead({ lifecycleState: 'planned', formationEpoch: 4 }, PLANNED_LAYOUT),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -126,7 +124,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 4, expectedLayout: PLANNED_LAYOUT }),
             read: connectRead({ lifecycleState: 'planned', formationEpoch: 4 }, storedIdentity),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('rejected');
@@ -145,7 +143,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 3, expectedLayout: PLANNED_LAYOUT }),
             read: connectRead({ lifecycleState: 'planned', formationEpoch: 4 }, PLANNED_LAYOUT),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('rejected');
     });
@@ -155,7 +153,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 4, expectedLayout: removed }),
             read: connectRead({ lifecycleState: 'planned', formationEpoch: 4 }, removed),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('rejected');
     });
@@ -163,8 +161,8 @@ describe('group lifecycle transition computation', () => {
     it('starts establishment from forming and advances the formation epoch', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('startGroupEstablishment'),
-            read: transitionRead({ lifecycleState: 'forming', formationEpoch: 2 }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'forming', formationEpoch: 2 }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -188,14 +186,14 @@ describe('group lifecycle transition computation', () => {
         for (const { operation, lifecycleState } of cases) {
             const computed = computeGroupMutation({
                 command: transitionCommand(operation),
-                read: transitionRead({ lifecycleState }),
-                facts: transitionFacts()
+                read: createGroupAuthorityRead({ lifecycleState }),
+                facts: createGroupAuthorityFacts()
             });
             expect(computed.outcome).toBe('write');
             if (computed.outcome !== 'write') {
                 continue;
             }
-            // transitionRead loads the actor as the only active member.
+            // createGroupAuthorityRead loads the actor as the only active member.
             expect((computed.guard.value as Group).formationElectorate).toEqual(['alice']);
         }
     });
@@ -204,8 +202,8 @@ describe('group lifecycle transition computation', () => {
         for (const from of ['connecting', 'reconfiguring'] as const) {
             const computed = computeGroupMutation({
                 command: transitionCommand('activateGroup'),
-                read: transitionRead({ lifecycleState: from, formationEpoch: 1 }),
-                facts: transitionFacts()
+                read: createGroupAuthorityRead({ lifecycleState: from, formationEpoch: 1 }),
+                facts: createGroupAuthorityFacts()
             });
             expect(computed.outcome).toBe('write');
             if (computed.outcome !== 'write') {
@@ -220,8 +218,8 @@ describe('group lifecycle transition computation', () => {
     it('reopens establishment only from active', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('reopenGroupEstablishment'),
-            read: transitionRead({ lifecycleState: 'active', formationEpoch: 4 }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'active', formationEpoch: 4 }),
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('write');
         if (computed.outcome !== 'write') {
@@ -236,22 +234,22 @@ describe('group lifecycle transition computation', () => {
         expect(() =>
             computeGroupMutation({
                 command: transitionCommand('startGroupEstablishment'),
-                read: transitionRead({ lifecycleState: 'active', formationEpoch: 1 }),
-                facts: transitionFacts()
+                read: createGroupAuthorityRead({ lifecycleState: 'active', formationEpoch: 1 }),
+                facts: createGroupAuthorityFacts()
             })
         ).toThrowError(GroupPolicyDeniedError);
     });
 
     it('denies a non-manager under the managed policy', () => {
-        const read = transitionRead(
+        const read = createGroupAuthorityRead(
             { lifecycleState: 'forming', formationEpoch: 0, ownerPrincipalId: 'owner-alice' },
-            { policyStatus: 'managed', actorPrincipalId: 'bob' }
+            { policy: 'managed', actorPrincipalId: 'bob' }
         );
         expect(() =>
             computeGroupMutation({
                 command: transitionCommand('startGroupEstablishment', 'bob'),
                 read,
-                facts: transitionFacts('bob')
+                facts: createGroupAuthorityFacts('bob')
             })
         ).toThrowError(GroupPolicyDeniedError);
     });
@@ -259,8 +257,8 @@ describe('group lifecycle transition computation', () => {
     it('rejects on a corrupt stored policy instead of failing open', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('startGroupEstablishment'),
-            read: transitionRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policyStatus: 'corrupt' }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policy: 'corrupt' }),
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('rejected');
     });
@@ -303,7 +301,7 @@ describe('group lifecycle transition computation', () => {
         const computed = computeGroupMutation({
             command: connectCommand({ expectedFormationEpoch: 4, expectedLayout: PLANNED_LAYOUT }),
             read: connectRead({ lifecycleState: 'planned', formationEpoch: 4 }, PLANNED_LAYOUT),
-            facts: transitionFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -403,8 +401,8 @@ describe('group lifecycle transition computation', () => {
         expect(() =>
             computeGroupMutation({
                 command: principalFail,
-                read: transitionRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
-                facts: transitionFacts()
+                read: createGroupAuthorityRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
+                facts: createGroupAuthorityFacts()
             })
         ).toThrowError(/criterion-commanded only/);
     });
@@ -439,8 +437,8 @@ describe('group lifecycle transition computation', () => {
     it('leaves the recorded outcome untouched on manual activation', () => {
         const computed = computeGroupMutation({
             command: transitionCommand('activateGroup'),
-            read: transitionRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'connecting', formationEpoch: 1 }),
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('write');
         if (computed.outcome !== 'write') {
@@ -453,8 +451,8 @@ describe('group lifecycle transition computation', () => {
         // optimistic is any-member initiated, so a plain member may command.
         const computed = computeGroupMutation({
             command: transitionCommand('startGroupEstablishment'),
-            read: transitionRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policyStatus: 'absent' }),
-            facts: transitionFacts()
+            read: createGroupAuthorityRead({ lifecycleState: 'forming', formationEpoch: 0 }, { policy: 'absent' }),
+            facts: createGroupAuthorityFacts()
         });
         expect(computed.outcome).toBe('write');
     });
@@ -537,7 +535,7 @@ function connectRead(
     plannedLayoutIdentity: GroupLayoutIdentity | null
 ): GroupMutationRead {
     return {
-        ...transitionRead(groupOverrides),
+        ...createGroupAuthorityRead(groupOverrides),
         plannedLayoutRow: plannedLayoutIdentity === null ? null : {
             snapshot: plannedSnapshotFor(plannedLayoutIdentity),
             revision: 5
@@ -551,7 +549,7 @@ function criterionRead(
     plannedLayoutIdentity: GroupLayoutIdentity | null = PLANNED_LAYOUT
 ): GroupMutationRead {
     return {
-        ...transitionRead(groupOverrides),
+        ...createGroupAuthorityRead(groupOverrides),
         actorMember: null,
         actorMemberEntry: null,
         plannedLayoutRow: plannedLayoutIdentity === null ? null : {
@@ -591,94 +589,8 @@ function criterionCommand(
 
 function criterionFacts(): GroupMutationFacts {
     return {
-        ...transitionFacts(),
+        ...createGroupAuthorityFacts(),
         internalAuthority: 'formation-criterion',
         authenticatedAuthority: null
-    };
-}
-
-interface TransitionReadOptions {
-    readonly policyStatus?: 'absent' | 'present' | 'managed' | 'corrupt';
-    readonly actorPrincipalId?: string;
-}
-
-function transitionRead(groupOverrides: Partial<Group>, options: TransitionReadOptions = {}): GroupMutationRead {
-    const actorPrincipalId = options.actorPrincipalId ?? 'alice';
-    const audit = lifecycleAuditStamp(1_000, actorPrincipalId);
-    const group = createTestGroup({ ...groupRef('pure-room'), ...groupOverrides });
-    const actorMember = {
-        ...groupRef('pure-room'),
-        principalId: actorPrincipalId,
-        role: 'member' as const,
-        status: 'active' as const,
-        invitedByPrincipalId: null,
-        invitationExpiresAtEpochMs: null,
-        left: null,
-        removed: null,
-        banned: null,
-        joined: audit,
-        updated: audit
-    };
-    const policyStatus = options.policyStatus ?? 'absent';
-    const lifecyclePolicy = policyStatus === 'corrupt'
-        ? { status: 'corrupt' as const, reason: 'stored policy is not an object' }
-        : policyStatus === 'absent'
-        ? { status: 'absent' as const }
-        : {
-            status: 'present' as const,
-            policy: resolveGroupLifecyclePolicyPreset(policyStatus === 'managed' ? 'managed' : 'optimistic')
-        };
-    return {
-        idempotency: null,
-        group: storedEntry(groupStorageKey(), group),
-        expiredGroupEntry: null,
-        actorMember,
-        targetMember: null,
-        authorityMember: null,
-        directorMember: null,
-        actorMemberEntry: storedEntry(groupMemberStorageKey(actorPrincipalId), actorMember),
-        targetMemberEntry: null,
-        authorityMemberEntry: null,
-        directorMemberEntry: null,
-        targetPresence: null,
-        expiredTargetPresenceEntry: null,
-        targetAdmission: null,
-        authorityAdmission: null,
-        directorAdmission: null,
-        authorityPresenceSessions: [],
-        authorityPresenceSessionEntries: [],
-        presenceSummary: null,
-        lifecyclePolicy,
-        activeMemberPrincipalIds: [actorPrincipalId],
-        plannedLayoutRow: null,
-        acceptedLayoutRow: null
-    } as GroupMutationRead;
-}
-
-function transitionFacts(principalId = 'alice'): GroupMutationFacts {
-    return {
-        nowEpochMs: 2_000,
-        expireAtEpochMs: 253_402_300_799_999,
-        serviceId: 'group-service',
-        eventId: 'event-1',
-        commandHash: `sha256:${'a'.repeat(64)}`,
-        attemptCount: 1,
-        resolvedJoinCode: null,
-        joinCodeVerifier: null,
-        internalAuthority: 'none',
-        authenticatedAuthority: {
-            principalId,
-            sessionId: `${principalId}-session`
-        }
-    };
-}
-
-function lifecycleAuditStamp(atEpochMs: number, principalId: string): AuditStamp {
-    return {
-        atEpochMs,
-        actor: { kind: 'principal', principalId },
-        reason: null,
-        traceId: null,
-        requestId: 'seed'
     };
 }

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
@@ -1,3 +1,4 @@
+import type { GroupMutationFacts, GroupMutationRead } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import {
     type RuntimeStateGuardedBatch,
     type RuntimeStateGuardedBatchEffect,
@@ -15,8 +16,10 @@ import type {
     RuntimeStateOptimisticTransactionRepositoryLike
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
 import { TestGroupStateEventStore } from '@shared-test/shared-server/test-group-state-event-store.ts';
-import type { GroupEvent, GroupPresenceSession, GroupRef } from '@shared/api/group-types.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import type { AuditStamp, Group, GroupEvent, GroupPresenceSession, GroupRef } from '@shared/api/group-types.ts';
 import type { StateScope } from '@shared/api/state-types.ts';
+import { createTestGroup } from '../../../../create-test-group.ts';
 import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
 
 export const SCOPE: StateScope = {
@@ -79,6 +82,109 @@ export function presenceFor(
 
 export function groupRef(groupId: string): GroupRef {
     return { ...SCOPE, groupId };
+}
+
+export interface GroupAuthorityReadOptions {
+    readonly policy?: 'absent' | 'corrupt' | 'optimistic' | 'managed' | 'server-auto';
+    readonly actorPrincipalId?: string;
+    readonly actorIsMember?: boolean;
+    readonly activeMemberPrincipalIds?: readonly string[];
+}
+
+export function createGroupAuthorityRead(
+    groupOverrides: Partial<Group>,
+    options: GroupAuthorityReadOptions = {}
+): GroupMutationRead {
+    const actorPrincipalId = options.actorPrincipalId ?? 'alice';
+    const actorMember = createGroupAuthorityActorMember(actorPrincipalId);
+    return {
+        idempotency: null,
+        group: storedEntry(groupStorageKey(), createTestGroup({ ...groupRef('pure-room'), ...groupOverrides })),
+        expiredGroupEntry: null,
+        actorMember: options.actorIsMember === false ? null : actorMember,
+        targetMember: null,
+        authorityMember: null,
+        directorMember: null,
+        actorMemberEntry: options.actorIsMember === false
+            ? null
+            : storedEntry(groupMemberStorageKey(actorPrincipalId), actorMember),
+        targetMemberEntry: null,
+        authorityMemberEntry: null,
+        directorMemberEntry: null,
+        targetPresence: null,
+        expiredTargetPresenceEntry: null,
+        targetAdmission: null,
+        authorityAdmission: null,
+        directorAdmission: null,
+        authorityPresenceSessions: [],
+        authorityPresenceSessionEntries: [],
+        presenceSummary: null,
+        lifecyclePolicy: toLifecyclePolicyRead(options.policy ?? 'absent'),
+        activeMemberPrincipalIds: options.activeMemberPrincipalIds ??
+            (options.actorIsMember === false ? [] : [actorPrincipalId]),
+        plannedLayoutRow: null,
+        acceptedLayoutRow: null
+    } as GroupMutationRead;
+}
+
+export function createGroupAuthorityFacts(principalId = 'alice'): GroupMutationFacts {
+    return {
+        nowEpochMs: 2_000,
+        expireAtEpochMs: 253_402_300_799_999,
+        serviceId: 'group-service',
+        eventId: 'event-1',
+        commandHash: `sha256:${'a'.repeat(64)}`,
+        attemptCount: 1,
+        resolvedJoinCode: null,
+        joinCodeVerifier: null,
+        internalAuthority: 'none',
+        authenticatedAuthority: {
+            principalId,
+            sessionId: `${principalId}-session`
+        }
+    };
+}
+
+export function createGroupAuthorityAuditStamp(atEpochMs: number, principalId: string): AuditStamp {
+    return {
+        atEpochMs,
+        actor: { kind: 'principal', principalId },
+        reason: null,
+        traceId: null,
+        requestId: 'seed'
+    };
+}
+
+function createGroupAuthorityActorMember(principalId: string) {
+    const audit = createGroupAuthorityAuditStamp(1_000, principalId);
+    return {
+        ...groupRef('pure-room'),
+        principalId,
+        role: 'member' as const,
+        status: 'active' as const,
+        invitedByPrincipalId: null,
+        invitationExpiresAtEpochMs: null,
+        left: null,
+        removed: null,
+        banned: null,
+        joined: audit,
+        updated: audit
+    };
+}
+
+function toLifecyclePolicyRead(requested: NonNullable<GroupAuthorityReadOptions['policy']>) {
+    if (requested === 'corrupt') {
+        return { status: 'corrupt' as const, reason: 'stored policy is not an object' };
+    }
+    if (requested === 'absent') {
+        return { status: 'absent' as const };
+    }
+    return {
+        status: 'present' as const,
+        policy: requested === 'server-auto'
+            ? { ...resolveGroupLifecyclePolicyPreset('optimistic'), initiator: 'server-auto' as const }
+            : resolveGroupLifecyclePolicyPreset(requested)
+    };
 }
 
 export class ApplyingGuardedBatchRepository extends FakeRuntimeStateRepository {

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-transport-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-transport-mutation.test.ts
@@ -1,32 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import type {
-    GroupMutationCommand,
-    GroupMutationFacts,
-    GroupMutationRead
-} from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
+import type { GroupMutationCommand } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import { GROUP_MUTATION_INTERNAL_AUTHORITY_MODES } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
 import { GroupPolicyDeniedError } from '@shared-server/rallar-system/group-state/policy/group-policy-result.ts';
-import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import { GROUP_LIFECYCLE_STATES } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupPolicyDenied } from '@shared/api/group-policy-types.ts';
-import type { AuditStamp, Group } from '@shared/api/group-types.ts';
+import type { Group } from '@shared/api/group-types.ts';
 import { GROUP_PRESENCE_SUMMARY_TOPIC } from '@shared/queuebox/GroupPresenceSummaryEntryContract.ts';
-import { createTestGroup } from '../../../../create-test-group.ts';
 
-import { groupMemberStorageKey, groupRef, groupStorageKey, storedEntry } from './group-mutation-test-runtime.ts';
+import { createGroupAuthorityAuditStamp, createGroupAuthorityFacts, createGroupAuthorityRead, groupRef } from './group-mutation-test-runtime.ts';
 
 describe('group transport mutation computation', () => {
     it('pauses a flowing group by halting transport alone', () => {
         const computed = computeGroupMutation({
             command: transportCommand('pauseGroupTransport'),
-            read: transportRead({
+            read: createGroupAuthorityRead({
                 transportState: 'flowing',
                 lifecycleState: 'active',
                 formationEpoch: 3
             }),
-            facts: transportFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -46,8 +40,8 @@ describe('group transport mutation computation', () => {
     it('resumes a halted group by restoring flow', () => {
         const computed = computeGroupMutation({
             command: transportCommand('resumeGroupTransport'),
-            read: transportRead({ transportState: 'halted', lifecycleState: 'reconnecting' }),
-            facts: transportFacts()
+            read: createGroupAuthorityRead({ transportState: 'halted', lifecycleState: 'reconnecting' }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -64,8 +58,8 @@ describe('group transport mutation computation', () => {
     ])('answers no-op when %s finds the valve already at %s', (operation, transportState) => {
         const computed = computeGroupMutation({
             command: transportCommand(operation),
-            read: transportRead({ transportState }),
-            facts: transportFacts()
+            read: createGroupAuthorityRead({ transportState }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('no-op');
@@ -81,12 +75,12 @@ describe('group transport mutation computation', () => {
     it('arms no formation timer: the only outbox entry is the presence summary', () => {
         const computed = computeGroupMutation({
             command: transportCommand('pauseGroupTransport'),
-            read: transportRead({
+            read: createGroupAuthorityRead({
                 transportState: 'flowing',
                 lifecycleState: 'connecting',
                 establishmentStartedAtEpochMs: 1_500
             }),
-            facts: transportFacts()
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -109,8 +103,8 @@ describe('group transport mutation computation', () => {
     it.each(GROUP_LIFECYCLE_STATES)('halts a flowing group in the %s stage', (lifecycleState) => {
         const computed = computeGroupMutation({
             command: transportCommand('pauseGroupTransport'),
-            read: transportRead({ transportState: 'flowing', lifecycleState }),
-            facts: transportFacts()
+            read: createGroupAuthorityRead({ transportState: 'flowing', lifecycleState }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -127,8 +121,8 @@ describe('group transport mutation computation', () => {
         const denial = readTransportDenial(() =>
             computeGroupMutation({
                 command: transportCommand('pauseGroupTransport'),
-                read: transportRead({ transportState: 'flowing' }, { policy: 'server-auto' }),
-                facts: transportFacts()
+                read: createGroupAuthorityRead({ transportState: 'flowing' }, { policy: 'server-auto' }),
+                facts: createGroupAuthorityFacts()
             })
         );
 
@@ -143,7 +137,7 @@ describe('group transport mutation computation', () => {
         const denial = readTransportDenial(() =>
             computeGroupMutation({
                 command: transportCommand('resumeGroupTransport', 'bob'),
-                read: transportRead(
+                read: createGroupAuthorityRead(
                     { transportState: 'halted' },
                     {
                         policy: 'managed',
@@ -151,7 +145,7 @@ describe('group transport mutation computation', () => {
                         activeMemberPrincipalIds: ['alice', 'bob']
                     }
                 ),
-                facts: transportFacts('bob')
+                facts: createGroupAuthorityFacts('bob')
             })
         );
 
@@ -162,8 +156,8 @@ describe('group transport mutation computation', () => {
     it('allows the valve to the manager the same policy resolves', () => {
         const computed = computeGroupMutation({
             command: transportCommand('resumeGroupTransport'),
-            read: transportRead({ transportState: 'halted' }, { policy: 'managed' }),
-            facts: transportFacts()
+            read: createGroupAuthorityRead({ transportState: 'halted' }, { policy: 'managed' }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('write');
@@ -173,8 +167,8 @@ describe('group transport mutation computation', () => {
         const denial = readTransportDenial(() =>
             computeGroupMutation({
                 command: transportCommand('pauseGroupTransport'),
-                read: transportRead({ transportState: 'flowing' }, { actorIsMember: false }),
-                facts: transportFacts()
+                read: createGroupAuthorityRead({ transportState: 'flowing' }, { actorIsMember: false }),
+                facts: createGroupAuthorityFacts()
             })
         );
 
@@ -189,12 +183,12 @@ describe('group transport mutation computation', () => {
             const denial = readTransportDenial(() =>
                 computeGroupMutation({
                     command: transportCommand('pauseGroupTransport'),
-                    read: transportRead({
+                    read: createGroupAuthorityRead({
                         transportState: 'flowing',
                         status,
-                        [status]: transportAuditStamp(1_500, 'alice')
+                        [status]: createGroupAuthorityAuditStamp(1_500, 'alice')
                     }),
-                    facts: transportFacts()
+                    facts: createGroupAuthorityFacts()
                 })
             );
 
@@ -205,8 +199,8 @@ describe('group transport mutation computation', () => {
     it('fails closed on an unreadable stored policy instead of reading it as permissive', () => {
         const computed = computeGroupMutation({
             command: transportCommand('pauseGroupTransport'),
-            read: transportRead({ transportState: 'flowing' }, { policy: 'corrupt' }),
-            facts: transportFacts()
+            read: createGroupAuthorityRead({ transportState: 'flowing' }, { policy: 'corrupt' }),
+            facts: createGroupAuthorityFacts()
         });
 
         expect(computed.outcome).toBe('rejected');
@@ -225,8 +219,8 @@ describe('group transport mutation computation', () => {
         expect(() =>
             computeGroupMutation({
                 command: internalTransportCommand(),
-                read: transportRead({ transportState: 'flowing' }),
-                facts: { ...transportFacts(), internalAuthority, authenticatedAuthority: null }
+                read: createGroupAuthorityRead({ transportState: 'flowing' }),
+                facts: { ...createGroupAuthorityFacts(), internalAuthority, authenticatedAuthority: null }
             })
         ).toThrowError(TypeError);
     });
@@ -276,107 +270,4 @@ function transportCommand(
             traceId: null
         }
     } as GroupMutationCommand;
-}
-
-interface TransportReadOptions {
-    readonly policy?: 'absent' | 'corrupt' | 'optimistic' | 'managed' | 'server-auto';
-    readonly actorPrincipalId?: string;
-    readonly actorIsMember?: boolean;
-    readonly activeMemberPrincipalIds?: readonly string[];
-}
-
-function transportRead(
-    groupOverrides: Partial<Group>,
-    options: TransportReadOptions = {}
-): GroupMutationRead {
-    const actorPrincipalId = options.actorPrincipalId ?? 'alice';
-    const actorMember = transportActorMember(actorPrincipalId);
-    return {
-        idempotency: null,
-        group: storedEntry(groupStorageKey(), createTestGroup({ ...groupRef('pure-room'), ...groupOverrides })),
-        expiredGroupEntry: null,
-        actorMember: options.actorIsMember === false ? null : actorMember,
-        targetMember: null,
-        authorityMember: null,
-        directorMember: null,
-        actorMemberEntry: options.actorIsMember === false
-            ? null
-            : storedEntry(groupMemberStorageKey(actorPrincipalId), actorMember),
-        targetMemberEntry: null,
-        authorityMemberEntry: null,
-        directorMemberEntry: null,
-        targetPresence: null,
-        expiredTargetPresenceEntry: null,
-        targetAdmission: null,
-        authorityAdmission: null,
-        directorAdmission: null,
-        authorityPresenceSessions: [],
-        authorityPresenceSessionEntries: [],
-        presenceSummary: null,
-        lifecyclePolicy: transportPolicyRead(options.policy ?? 'absent'),
-        activeMemberPrincipalIds: options.activeMemberPrincipalIds ??
-            (options.actorIsMember === false ? [] : [actorPrincipalId]),
-        plannedLayoutRow: null,
-        acceptedLayoutRow: null
-    } as GroupMutationRead;
-}
-
-function transportActorMember(principalId: string) {
-    const audit = transportAuditStamp(1_000, principalId);
-    return {
-        ...groupRef('pure-room'),
-        principalId,
-        role: 'member' as const,
-        status: 'active' as const,
-        invitedByPrincipalId: null,
-        invitationExpiresAtEpochMs: null,
-        left: null,
-        removed: null,
-        banned: null,
-        joined: audit,
-        updated: audit
-    };
-}
-
-function transportPolicyRead(requested: NonNullable<TransportReadOptions['policy']>) {
-    if (requested === 'corrupt') {
-        return { status: 'corrupt' as const, reason: 'stored policy is not an object' };
-    }
-    if (requested === 'absent') {
-        return { status: 'absent' as const };
-    }
-    return {
-        status: 'present' as const,
-        policy: requested === 'server-auto'
-            ? { ...resolveGroupLifecyclePolicyPreset('optimistic'), initiator: 'server-auto' as const }
-            : resolveGroupLifecyclePolicyPreset(requested)
-    };
-}
-
-function transportFacts(principalId = 'alice'): GroupMutationFacts {
-    return {
-        nowEpochMs: 2_000,
-        expireAtEpochMs: 253_402_300_799_999,
-        serviceId: 'group-service',
-        eventId: 'event-1',
-        commandHash: `sha256:${'a'.repeat(64)}`,
-        attemptCount: 1,
-        resolvedJoinCode: null,
-        joinCodeVerifier: null,
-        internalAuthority: 'none',
-        authenticatedAuthority: {
-            principalId,
-            sessionId: `${principalId}-session`
-        }
-    };
-}
-
-function transportAuditStamp(atEpochMs: number, principalId: string): AuditStamp {
-    return {
-        atEpochMs,
-        actor: { kind: 'principal', principalId },
-        reason: null,
-        traceId: null,
-        requestId: 'seed'
-    };
 }


### PR DESCRIPTION
Stacked on #365 — that PR introduces `group-transport-mutation.test.ts`, the second copy this change removes. Review/merge #365 first; the base retargets to `main` automatically once it lands.

## What

`group-lifecycle-mutation.test.ts` and `group-transport-mutation.test.ts` each built the same `GroupMutationRead` decision surface under different names:

| lifecycle | transport |
| --- | --- |
| `transitionRead` | `transportRead` (+ `transportActorMember`, `transportPolicyRead`) |
| `transitionFacts` | `transportFacts` |
| `lifecycleAuditStamp` | `transportAuditStamp` |

The facts and audit-stamp builders were byte-identical. The read builders differed only in their option bag, where transport's was the superset (`policy` also accepting `'server-auto'`, plus `actorIsMember` and `activeMemberPrincipalIds`).

This moves the transport implementation into `group-mutation-test-runtime.ts` — which both files already imported `groupRef`, `storedEntry`, `groupStorageKey` and `groupMemberStorageKey` from — as `createGroupAuthorityRead` / `createGroupAuthorityFacts` / `createGroupAuthorityAuditStamp`, and points both files at it. Both local copies are gone.

## Notes for review

- **`createGroupAuthorityAuditStamp` is exported**, unlike the other two moved helpers' internals. The transport file calls the audit stamp directly outside its read builder, so keeping it private would have left a third copy behind.
- **Three lifecycle call sites re-key** `policyStatus:` onto the superset's `policy:`. Lifecycle's `'present'` variant had no caller and folds into `'optimistic'` — both already resolved to `resolveGroupLifecyclePolicyPreset('optimistic')`.
- **`connectRead` / `criterionRead` / `criterionFacts` stay in the lifecycle file** and now spread the shared builder rather than the local one.
- The private policy helper is named `toLifecyclePolicyRead`, deliberately *not* `resolveGroupAuthorityPolicy…` — that name already belongs to the production function under test in `aggregate/resolve-group-authority-policy.ts`.

No assertion or test title changed: every `expect(...)`, `it(...)`, `it.each(...)` and `describe(...)` line in both files is byte-identical to its pre-change form.

## Verification

| Command | Result |
| --- | --- |
| `npx vitest run packages/tests/shared-server/rallar-system/group-state/mutation` | 26 files, 161 tests passed |
| `npx vitest run packages/tests/shared-server/rallar-system/group-state` (blast radius) | 73 files, 400 tests passed |
| `npm run typecheck` | pass — incl. `typecheck:tests`, 962 test files enforced, 0 errors |
| `npm run check:repo-style:changed -- origin/main HEAD` | PASS: no new repository style findings |
| `npm run check:repo-style:changed -- origin/claude/group-activation-pause-resume HEAD` | PASS (isolates this commit from #365) |
| `npm run check:test-structure-coupling` | PASS: registry entries complete and current |
| `npx dprint check` (touched dir) | clean |

Not run: `npm run test:ci` and `npm run build` — this touches only test fixtures under `packages/tests`, and branch CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)