### PR TITLE
feat: add convenient production profiles

### DIFF
--- a/apps/api-v1/README.md
+++ b/apps/api-v1/README.md
@@ -47,15 +47,21 @@ for retries more than 30 seconds overdue. Queue locks are coordination-only. Dom
 advisory, and CRDT document locks are not queue-claim exceptions. Authoritative persisted and shared
 contracts use mandatory fields by default.
 
-## Production Hardening
+## Production Profiles
 
-Set `RALLAR_API_CONFIGURATION_PROFILE=prod` to select the hardened production snapshot. It requires
-PostgreSQL and PostgreSQL pub/sub, exact HTTPS/WSS public URLs and CORS origins, strict state read
-authorization, admin-only registration, disabled static clients, non-demo administrator identities,
-a stable `RALLAR_AUTH_CREDENTIAL_SECRET` of at least 32 characters, Metered TURN, and an explicit
-black-box operator-token issuer. API-v1 reads the selected profile, allowlisted overrides, and
-environment-only secrets once, validates the complete object, freezes it, and injects its owned
-sections into runtime consumers. There is no environment-name alias or separate hardening reader.
+Set `RALLAR_API_CONFIGURATION_PROFILE=prod` for the default production snapshot. It keeps
+PostgreSQL and PostgreSQL pub/sub, exact HTTPS/WSS public URLs and CORS origins, strict state-read
+authorization, Metered TURN, and the explicit black-box operator-token issuer while enabling public
+registration and the bundled `admin`, `user`, `guest`, `test`, `test2`, `alice`, `bob`, and `charlie`
+logins. Bundled identities are ordinary users: configured administrator and operator client IDs must
+not overlap them.
+
+Set `RALLAR_API_CONFIGURATION_PROFILE=prod-hardened` for admin-only registration, disabled static
+clients, and forced production hardening. Both profiles require a stable
+`RALLAR_AUTH_CREDENTIAL_SECRET` of at least 32 characters and keep secrets outside committed JSON.
+API-v1 reads the selected profile, allowlisted overrides, and environment-only secrets once,
+validates the complete object, freezes it, and injects its owned sections into runtime consumers.
+There is no environment-name alias or separate hardening reader.
 
 See [Production Env Hardening Checklist](../../docs/production-env-hardening-checklist.md) and
 [Environment Variables](../../docs/environment-variables.md).

--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -11,11 +11,12 @@ info:
     `/api/state/apps/{applicationId}/workspaces/{workspaceId}`.
 
     Production deployments select the exact immutable profile with
-    `RALLAR_API_CONFIGURATION_PROFILE=prod`. It requires PostgreSQL and
-    PostgreSQL pub/sub, exact HTTPS/WSS public URLs and CORS origins, strict
-    state read authorization, admin-only registration, disabled static clients,
-    non-demo administrators, Metered TURN credentials, and an explicit
-    black-box operator-token issuer.
+    `RALLAR_API_CONFIGURATION_PROFILE=prod`. It uses PostgreSQL and PostgreSQL
+    pub/sub, exact HTTPS/WSS public URLs and CORS origins, strict state read
+    authorization, public registration, bundled ordinary users, Metered TURN
+    credentials, and an explicit black-box operator-token issuer. Select
+    `prod-hardened` for admin-only registration, disabled static clients, and
+    forced production hardening.
 
 servers:
   - url: http://localhost:8080

--- a/apps/api-v1/resources/configuration/prod-hardened-config.json
+++ b/apps/api-v1/resources/configuration/prod-hardened-config.json
@@ -1,6 +1,6 @@
 {
   "profile": {
-    "productionHardening": false
+    "productionHardening": true
   },
   "http": {
     "corsOrigins": [
@@ -19,9 +19,8 @@
     "pubSub": "postgres"
   },
   "authentication": {
-    "registrationMode": "public",
-    "staticClientsMode": "demo",
-    "adminClientIds": []
+    "registrationMode": "admin",
+    "staticClientsMode": "disabled"
   },
   "stateApi": {
     "strictReadAuthorization": true

--- a/apps/api-v1/src/configuration/README.md
+++ b/apps/api-v1/src/configuration/README.md
@@ -19,9 +19,11 @@ defaults-config.json
 ```
 
 The selector is `RALLAR_API_CONFIGURATION_PROFILE`. Absence selects `dev`; the only accepted values
-are the exact, case-sensitive strings `dev`, `prod`, and `prod-in-memory`. The `prod` profile always
-enables production hardening. `RALLAR_PRODUCTION_HARDENING=1` can promote another profile but cannot
-weaken `prod`.
+are the exact, case-sensitive strings `dev`, `prod`, `prod-hardened`, and `prod-in-memory`. `prod`
+uses production infrastructure with public registration and bundled ordinary users.
+`prod-hardened` always enables production hardening, admin-only registration, and disabled static
+clients. `RALLAR_PRODUCTION_HARDENING=1` can promote another profile but cannot weaken
+`prod-hardened`.
 
 ## Environment allowlist
 

--- a/apps/api-v1/src/configuration/api-v1-configuration.ts
+++ b/apps/api-v1/src/configuration/api-v1-configuration.ts
@@ -2,7 +2,7 @@ import type { LoginClientData } from '@shared-server/rallar-system/auth/login/au
 import type { RallarCrdtDocumentTypePolicy } from '@shared/crdt/mod.ts';
 
 export interface ApiV1ConfigurationProfile {
-    readonly name: 'dev' | 'prod' | 'prod-in-memory';
+    readonly name: 'dev' | 'prod' | 'prod-hardened' | 'prod-in-memory';
     readonly productionHardening: boolean;
     readonly appliedEnvironmentOverrideNames: readonly string[];
 }

--- a/apps/api-v1/src/configuration/decode-api-v1-configuration-values.ts
+++ b/apps/api-v1/src/configuration/decode-api-v1-configuration-values.ts
@@ -93,7 +93,12 @@ export class ApiV1ConfigurationValueDecoder implements ApiV1ConfigurationInvaria
     profileName(
         value: ApiV1ConfigurationSourceValue | undefined
     ): ApiV1ConfigurationProfile['name'] {
-        if (value === 'dev' || value === 'prod' || value === 'prod-in-memory') {
+        if (
+            value === 'dev' ||
+            value === 'prod' ||
+            value === 'prod-hardened' ||
+            value === 'prod-in-memory'
+        ) {
             return value;
         }
         this.#issues.push({
@@ -101,7 +106,7 @@ export class ApiV1ConfigurationValueDecoder implements ApiV1ConfigurationInvaria
             path: 'profile.name',
             environmentName: 'RALLAR_API_CONFIGURATION_PROFILE',
             code: 'invalid-profile',
-            message: 'Profile name must be dev, prod, or prod-in-memory.'
+            message: 'Profile name must be dev, prod, prod-hardened, or prod-in-memory.'
         });
         return 'dev';
     }

--- a/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
+++ b/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
@@ -46,14 +46,14 @@ export function decodeApiV1Configuration(
     const structuredValues = new ApiV1ConfigurationStructuredValueDecoder(decoder);
     const profileName = decoder.profileName(input.profileName);
     const configuredHardening = decoder.boolean('profile.productionHardening');
-    if (profileName === 'prod' && configuredHardening === false) {
+    if (profileName === 'prod-hardened' && configuredHardening === false) {
         decoder.invariant(
             'profile.productionHardening',
             'production-profile-hardening-required',
-            'The prod profile always enables production hardening.'
+            'The prod-hardened profile always enables production hardening.'
         );
     }
-    const productionHardening = profileName === 'prod' || configuredHardening === true;
+    const productionHardening = profileName === 'prod-hardened' || configuredHardening === true;
     const appliedEnvironmentOverrideNames = structuredValues.stringSet(
         'profile.appliedEnvironmentOverrideNames',
         input.appliedEnvironmentOverrideNames,
@@ -80,6 +80,7 @@ export function decodeApiV1Configuration(
     const observability = decodeObservability(decoder);
 
     validateApiV1ConfigurationInvariants(decoder, {
+        profileName,
         productionHardening,
         publicApi,
         database,

--- a/apps/api-v1/src/configuration/read-api-v1-configuration-environment.ts
+++ b/apps/api-v1/src/configuration/read-api-v1-configuration-environment.ts
@@ -96,7 +96,12 @@ function readProfileName(
     if (value === undefined) {
         return 'dev';
     }
-    if (value === 'dev' || value === 'prod' || value === 'prod-in-memory') {
+    if (
+        value === 'dev' ||
+        value === 'prod' ||
+        value === 'prod-hardened' ||
+        value === 'prod-in-memory'
+    ) {
         return value;
     }
     throw new ApiV1ConfigurationError([{
@@ -104,7 +109,7 @@ function readProfileName(
         path: 'profile.name',
         environmentName: 'RALLAR_API_CONFIGURATION_PROFILE',
         code: 'invalid-profile-selector',
-        message: 'Profile selector must be exactly dev, prod, or prod-in-memory.'
+        message: 'Profile selector must be exactly dev, prod, prod-hardened, or prod-in-memory.'
     }]);
 }
 

--- a/apps/api-v1/src/configuration/validate-api-v1-configuration-invariants.ts
+++ b/apps/api-v1/src/configuration/validate-api-v1-configuration-invariants.ts
@@ -2,6 +2,7 @@ import type {
     ApiV1AppInboxConfiguration,
     ApiV1AuthenticationConfiguration,
     ApiV1BlackBoxConfiguration,
+    ApiV1ConfigurationProfile,
     ApiV1DatabaseConfiguration,
     ApiV1HttpConfiguration,
     ApiV1IceConfiguration,
@@ -16,6 +17,7 @@ export interface ApiV1ConfigurationInvariantCollector {
 }
 
 export interface ValidateApiV1ConfigurationInvariantsInput {
+    readonly profileName: ApiV1ConfigurationProfile['name'];
     readonly productionHardening: boolean;
     readonly http: ApiV1HttpConfiguration;
     readonly publicApi: ApiV1PublicApiConfiguration;
@@ -140,6 +142,44 @@ export function validateApiV1ConfigurationInvariants(
     }
     if (configuration.productionHardening) {
         validateProductionHardening(collector, configuration);
+    }
+    if (configuration.profileName === 'prod') {
+        validateConvenientProductionPrivileges(collector, configuration);
+    }
+}
+
+function validateConvenientProductionPrivileges(
+    collector: ApiV1ConfigurationInvariantCollector,
+    configuration: ValidateApiV1ConfigurationInvariantsInput
+): void {
+    const operatorToken = configuration.blackBox.operatorToken;
+    if (operatorToken.mode === 'enabled' && operatorToken.allowedClientIds.length === 0) {
+        collector.invariant(
+            'blackBox.operatorToken.allowedClientIds',
+            'production-operator-allowlist-required',
+            'Convenient production operator-token issuance requires an explicit client allowlist.'
+        );
+    }
+    const staticClientIds = new Set(
+        configuration.authentication.staticClients.map((client) => client.clientId)
+    );
+    if (
+        configuration.authentication.adminClientIds.some((clientId) => staticClientIds.has(clientId))
+    ) {
+        collector.invariant(
+            'authentication.adminClientIds',
+            'production-demo-privilege-overlap',
+            'Convenient production administrators must not use bundled demo identities.'
+        );
+    }
+    if (
+        operatorToken.allowedClientIds.some((clientId) => staticClientIds.has(clientId))
+    ) {
+        collector.invariant(
+            'blackBox.operatorToken.allowedClientIds',
+            'production-demo-privilege-overlap',
+            'Convenient production operators must not use bundled demo identities.'
+        );
     }
 }
 

--- a/apps/api-v1/src/main.ts
+++ b/apps/api-v1/src/main.ts
@@ -26,6 +26,7 @@ const configuration = await readApiV1Configuration({
     profileUrls: {
         dev: new URL('../resources/configuration/dev-config.json', import.meta.url),
         prod: new URL('../resources/configuration/prod-config.json', import.meta.url),
+        'prod-hardened': new URL('../resources/configuration/prod-hardened-config.json', import.meta.url),
         'prod-in-memory': new URL('../resources/configuration/prod-in-memory-config.json', import.meta.url)
     },
     staticClientsUrl: new URL('../resources/authorised-clients.json', import.meta.url)

--- a/apps/api-v1/test/configuration/api-v1-configuration-test-fixture.ts
+++ b/apps/api-v1/test/configuration/api-v1-configuration-test-fixture.ts
@@ -196,13 +196,13 @@ export function validDecodeApiV1ConfigurationInput(): MutableDecodeApiV1Configur
 }
 
 export function validConfigurationEnvironment(
-    profile: 'dev' | 'prod' | 'prod-in-memory' = 'dev'
+    profile: 'dev' | 'prod' | 'prod-hardened' | 'prod-in-memory' = 'dev'
 ): Record<string, string> {
     const environment: Record<string, string> = {
         RALLAR_API_CONFIGURATION_PROFILE: profile,
         RALLAR_AUTH_CREDENTIAL_SECRET: CONFIGURATION_SECRET_SENTINELS.authenticationCredentialSecret
     };
-    if (profile === 'prod') {
+    if (profile === 'prod' || profile === 'prod-hardened') {
         return {
             ...environment,
             AUTH_ADMIN_CLIENT_IDS: 'production-operator',

--- a/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
+++ b/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
@@ -77,6 +77,21 @@ Deno.test('committed profiles resolve their intended database, delivery, and ICE
                 meteredApiKey: CONFIGURATION_SECRET_SENTINELS.meteredApiKey,
                 blackBoxOperatorTokenSecret: CONFIGURATION_SECRET_SENTINELS.blackBoxOperatorTokenSecret
             },
+            expected: ['postgres', 'postgres', 'metered', false]
+        },
+        {
+            profileName: 'prod-hardened',
+            environmentSource: {
+                authentication: { adminClientIds: ['production-operator'] },
+                ice: { appName: 'rallar-production', region: 'eu' },
+                blackBox: { operatorToken: { allowedClientIds: ['production-operator'] } }
+            },
+            secretsSource: {
+                authenticationCredentialSecret: 'production-auth-credential-secret-at-least-32-characters',
+                databaseUrl: CONFIGURATION_SECRET_SENTINELS.databaseUrl,
+                meteredApiKey: CONFIGURATION_SECRET_SENTINELS.meteredApiKey,
+                blackBoxOperatorTokenSecret: CONFIGURATION_SECRET_SENTINELS.blackBoxOperatorTokenSecret
+            },
             expected: ['postgres', 'postgres', 'metered', true]
         },
         {
@@ -557,7 +572,7 @@ Deno.test('configuration decoder never retains or renders secret values in failu
 
 Deno.test('production hardening validates the effective configuration and cannot be weakened', () => {
     const input = validDecodeApiV1ConfigurationInput();
-    input.profileName = 'prod';
+    input.profileName = 'prod-hardened';
     input.profileSource = { profile: { productionHardening: false } };
 
     const error = captureConfigurationError(() => decodeApiV1Configuration(input));

--- a/apps/api-v1/test/configuration/read-api-v1-configuration.test.ts
+++ b/apps/api-v1/test/configuration/read-api-v1-configuration.test.ts
@@ -18,6 +18,10 @@ import {
 const DEFAULTS_URL = new URL('../../resources/configuration/defaults-config.json', import.meta.url);
 const DEV_URL = new URL('../../resources/configuration/dev-config.json', import.meta.url);
 const PROD_URL = new URL('../../resources/configuration/prod-config.json', import.meta.url);
+const PROD_HARDENED_URL = new URL(
+    '../../resources/configuration/prod-hardened-config.json',
+    import.meta.url
+);
 const PROD_IN_MEMORY_URL = new URL(
     '../../resources/configuration/prod-in-memory-config.json',
     import.meta.url
@@ -32,7 +36,7 @@ Deno.test('configuration reader selects only absent or exact canonical profiles'
         'dev'
     );
 
-    for (const profile of ['dev', 'prod', 'prod-in-memory'] as const) {
+    for (const profile of ['dev', 'prod', 'prod-hardened', 'prod-in-memory'] as const) {
         const configuration = await readApiV1Configuration(
             readerInput(validConfigurationEnvironment(profile))
         );
@@ -95,7 +99,7 @@ Deno.test('configuration reader applies exact leaf precedence and ignores unrela
     );
 });
 
-Deno.test('configuration reader loads static clients once and disables them outside demo mode', async () => {
+Deno.test('configuration reader loads static clients for convenient production and disables them for hardening', async () => {
     let staticClientReads = 0;
     const devInput = readerInput(validConfigurationEnvironment());
     const configuration = await readApiV1Configuration({
@@ -116,8 +120,54 @@ Deno.test('configuration reader loads static clients once and disables them outs
     const prodConfiguration = await readApiV1Configuration(
         readerInput(validConfigurationEnvironment('prod'))
     );
-    assert.equal(prodConfiguration.authentication.staticClientsMode, 'disabled');
-    assert.deepEqual(prodConfiguration.authentication.staticClients, []);
+    assert.equal(prodConfiguration.profile.productionHardening, false);
+    assert.equal(prodConfiguration.authentication.registrationMode, 'public');
+    assert.equal(prodConfiguration.authentication.staticClientsMode, 'demo');
+    assert.deepEqual(
+        prodConfiguration.authentication.staticClients.map((client) => client.clientId),
+        ['admin', 'user', 'guest', 'test', 'test2', 'alice', 'bob', 'charlie']
+    );
+
+    const hardenedConfiguration = await readApiV1Configuration(
+        readerInput(validConfigurationEnvironment('prod-hardened'))
+    );
+    assert.equal(hardenedConfiguration.profile.productionHardening, true);
+    assert.equal(hardenedConfiguration.authentication.registrationMode, 'admin');
+    assert.equal(hardenedConfiguration.authentication.staticClientsMode, 'disabled');
+    assert.deepEqual(hardenedConfiguration.authentication.staticClients, []);
+});
+
+Deno.test('convenient production keeps bundled users outside privileged identity lists', async () => {
+    for (
+        const [environmentName, clientId] of [
+            ['AUTH_ADMIN_CLIENT_IDS', 'alice'],
+            ['RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS', 'bob']
+        ] as const
+    ) {
+        const environment = {
+            ...validConfigurationEnvironment('prod'),
+            [environmentName]: clientId
+        };
+        const error = await captureConfigurationError(readerInput(environment));
+
+        assert.equal(
+            error.issues.some((issue) => issue.code === 'production-demo-privilege-overlap'),
+            true,
+            environmentName
+        );
+    }
+});
+
+Deno.test('convenient production requires an operator allowlist when token issuance is enabled', async () => {
+    const environment = validConfigurationEnvironment('prod');
+    delete environment.RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS;
+
+    const error = await captureConfigurationError(readerInput(environment));
+
+    assert.equal(
+        error.issues.some((issue) => issue.code === 'production-operator-allowlist-required'),
+        true
+    );
 });
 
 Deno.test('configuration reader preserves ordered arrays and isolates the frozen snapshot', async () => {
@@ -128,6 +178,7 @@ Deno.test('configuration reader preserves ordered arrays and isolates the frozen
         [DEFAULTS_URL.href, defaults],
         [DEV_URL.href, profile],
         [PROD_URL.href, profile],
+        [PROD_HARDENED_URL.href, profile],
         [PROD_IN_MEMORY_URL.href, profile],
         [STATIC_CLIENTS_URL.href, staticClients]
     ]);
@@ -159,7 +210,7 @@ Deno.test('configuration startup summary is useful and contains no secret-derive
 
     assert.deepEqual(summary, {
         profile: 'prod',
-        productionHardening: true,
+        productionHardening: false,
         databaseMode: 'postgres',
         databasePubSub: 'postgres',
         iceMode: 'metered',
@@ -201,6 +252,7 @@ function readerInput(environmentValues: Record<string, string>): ReadApiV1Config
         profileUrls: {
             dev: DEV_URL,
             prod: PROD_URL,
+            'prod-hardened': PROD_HARDENED_URL,
             'prod-in-memory': PROD_IN_MEMORY_URL
         },
         staticClientsUrl: STATIC_CLIENTS_URL

--- a/apps/relic-hunter-server-v1/resources/configuration/defaults-config.json
+++ b/apps/relic-hunter-server-v1/resources/configuration/defaults-config.json
@@ -1,0 +1,5 @@
+{
+  "restAuthorization": {
+    "mode": "authenticated"
+  }
+}

--- a/apps/relic-hunter-server-v1/resources/configuration/prod-config.json
+++ b/apps/relic-hunter-server-v1/resources/configuration/prod-config.json
@@ -1,0 +1,5 @@
+{
+  "restAuthorization": {
+    "mode": "group-policy"
+  }
+}

--- a/apps/relic-hunter-server-v1/resources/configuration/prod-hardened-config.json
+++ b/apps/relic-hunter-server-v1/resources/configuration/prod-hardened-config.json
@@ -1,0 +1,5 @@
+{
+  "restAuthorization": {
+    "mode": "group-policy"
+  }
+}

--- a/apps/relic-hunter-server-v1/resources/relic-hunter-server-v1-openapi.yaml
+++ b/apps/relic-hunter-server-v1/resources/relic-hunter-server-v1-openapi.yaml
@@ -6,8 +6,8 @@ info:
     Relic Hunters HTTP endpoints owned by `apps/relic-hunter-server-v1`.
     Shared Rallar APIs are documented by the API-v1 OpenAPI document.
 
-    REST auth defaults to `RELIC_REST_AUTH_MODE=authenticated` for local/demo
-    use. Production should set `RELIC_REST_AUTH_MODE=group-policy`; then
+    REST auth defaults to `authenticated` for local/demo profiles. The `prod`
+    and `prod-hardened` profiles default to `group-policy`; then
     snapshot reads require full group read permission, commands require room
     send permission, and reset requires active owner/admin permission.
 

--- a/apps/relic-hunter-server-v1/src/main.ts
+++ b/apps/relic-hunter-server-v1/src/main.ts
@@ -30,9 +30,15 @@ const configuration = await readRelicHunterServerConfiguration({
     profileUrls: {
         dev: new URL('../../api-v1/resources/configuration/dev-config.json', import.meta.url),
         prod: new URL('../../api-v1/resources/configuration/prod-config.json', import.meta.url),
+        'prod-hardened': new URL('../../api-v1/resources/configuration/prod-hardened-config.json', import.meta.url),
         'prod-in-memory': new URL('../../api-v1/resources/configuration/prod-in-memory-config.json', import.meta.url)
     },
-    staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url)
+    staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url),
+    relicDefaultsUrl: new URL('../resources/configuration/defaults-config.json', import.meta.url),
+    relicProfileUrls: {
+        prod: new URL('../resources/configuration/prod-config.json', import.meta.url),
+        'prod-hardened': new URL('../resources/configuration/prod-hardened-config.json', import.meta.url)
+    }
 });
 const databaseLifecycle = await createApiV1DatabaseLifecycle({
     database: configuration.apiV1.database,

--- a/apps/relic-hunter-server-v1/src/relic-hunter-server-configuration.ts
+++ b/apps/relic-hunter-server-v1/src/relic-hunter-server-configuration.ts
@@ -1,4 +1,8 @@
-import type { ApiV1Configuration, ApiV1HttpConfiguration } from '@api-v1/src/configuration/api-v1-configuration.ts';
+import type {
+    ApiV1Configuration,
+    ApiV1ConfigurationProfile,
+    ApiV1HttpConfiguration
+} from '@api-v1/src/configuration/api-v1-configuration.ts';
 import {
     readApiV1Configuration,
     type ReadApiV1ConfigurationInput
@@ -29,6 +33,11 @@ export interface RelicHunterServerConfiguration {
     readonly expeditionAi: RelicAiExpeditionConfiguration;
 }
 
+export interface ReadRelicHunterServerConfigurationInput extends ReadApiV1ConfigurationInput {
+    readonly relicDefaultsUrl: URL;
+    readonly relicProfileUrls: Readonly<Partial<Record<ApiV1ConfigurationProfile['name'], URL>>>;
+}
+
 interface RelicHunterServerEnvironmentSource {
     readonly restAuthorizationMode: string | undefined;
     readonly expeditionAiMode: string | undefined;
@@ -36,6 +45,14 @@ interface RelicHunterServerEnvironmentSource {
     readonly expeditionAiOllamaBaseUrl: string | undefined;
     readonly expeditionAiOllamaModel: string | undefined;
 }
+
+type JsonPrimitive = boolean | number | string | null;
+
+interface JsonObject {
+    readonly [key: string]: JsonValue;
+}
+
+type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];
 
 export const RELIC_AI_EXPEDITION_DEFAULT_CONFIGURATION: RelicAiExpeditionConfiguration = Object.freeze({
     mode: 'off',
@@ -45,12 +62,12 @@ export const RELIC_AI_EXPEDITION_DEFAULT_CONFIGURATION: RelicAiExpeditionConfigu
 });
 
 export async function readRelicHunterServerConfiguration(
-    input: ReadApiV1ConfigurationInput
+    input: ReadRelicHunterServerConfigurationInput
 ): Promise<RelicHunterServerConfiguration> {
-    const source = readRelicHunterServerEnvironmentSource(input.environment);
-    const restAuthorization = decodeRelicRestAuthorization(source.restAuthorizationMode);
-    const expeditionAi = decodeRelicAiExpeditionConfiguration(source);
     const apiV1 = await readApiV1Configuration(input);
+    const source = readRelicHunterServerEnvironmentSource(input.environment);
+    const restAuthorization = await readRelicRestAuthorization(input, apiV1.profile.name, source);
+    const expeditionAi = decodeRelicAiExpeditionConfiguration(source);
     if (apiV1.profile.productionHardening && restAuthorization.mode !== 'group-policy') {
         throw new Error(
             'RELIC_REST_AUTH_MODE must be group-policy when production hardening is enabled.'
@@ -68,6 +85,54 @@ export async function readRelicHunterServerConfiguration(
     return configuration;
 }
 
+async function readRelicRestAuthorization(
+    input: ReadRelicHunterServerConfigurationInput,
+    profileName: ApiV1ConfigurationProfile['name'],
+    environment: RelicHunterServerEnvironmentSource
+): Promise<RelicRestAuthorizationConfiguration> {
+    const defaultsMode = await readRelicRestAuthorizationMode(
+        input,
+        input.relicDefaultsUrl,
+        'Relic defaults'
+    );
+    const profileUrl = input.relicProfileUrls[profileName];
+    const profileMode = profileUrl === undefined
+        ? undefined
+        : await readRelicRestAuthorizationMode(input, profileUrl, `Relic ${profileName} profile`);
+    return decodeRelicRestAuthorization(
+        environment.restAuthorizationMode ?? profileMode ?? defaultsMode,
+        environment.restAuthorizationMode === undefined
+            ? 'restAuthorization.mode'
+            : 'RELIC_REST_AUTH_MODE'
+    );
+}
+
+async function readRelicRestAuthorizationMode(
+    input: ReadRelicHunterServerConfigurationInput,
+    url: URL,
+    resourceName: string
+): Promise<string> {
+    let value: JsonValue;
+    try {
+        value = JSON.parse(await input.readTextFile(url)) as JsonValue;
+    }
+    catch {
+        throw new Error(`${resourceName} configuration must be readable JSON.`);
+    }
+    if (!isObject(value) || !hasOnlyKeys(value, ['restAuthorization'])) {
+        throw new Error(`${resourceName} configuration must contain only restAuthorization.`);
+    }
+    const restAuthorization = value.restAuthorization;
+    if (
+        !isObject(restAuthorization) ||
+        !hasOnlyKeys(restAuthorization, ['mode']) ||
+        typeof restAuthorization.mode !== 'string'
+    ) {
+        throw new Error(`${resourceName} restAuthorization must contain one string mode.`);
+    }
+    return restAuthorization.mode;
+}
+
 function readRelicHunterServerEnvironmentSource(
     environment: ReadApiV1ConfigurationInput['environment']
 ): RelicHunterServerEnvironmentSource {
@@ -81,15 +146,16 @@ function readRelicHunterServerEnvironmentSource(
 }
 
 function decodeRelicRestAuthorization(
-    rawMode: string | undefined
+    rawMode: string,
+    sourceName: string
 ): RelicRestAuthorizationConfiguration {
-    if (rawMode === undefined || rawMode === 'authenticated') {
+    if (rawMode === 'authenticated') {
         return { mode: 'authenticated' };
     }
     if (rawMode === 'group-policy') {
         return { mode: 'group-policy' };
     }
-    throw new Error('RELIC_REST_AUTH_MODE must be exactly authenticated or group-policy.');
+    throw new Error(`${sourceName} must be exactly authenticated or group-policy.`);
 }
 
 function decodeRelicAiExpeditionConfiguration(
@@ -169,4 +235,13 @@ function recursivelyFreeze(value: object): void {
         }
     }
     Object.freeze(value);
+}
+
+function hasOnlyKeys(value: JsonObject, expectedKeys: readonly string[]): boolean {
+    const keys = Object.keys(value);
+    return keys.length === expectedKeys.length && keys.every((key) => expectedKeys.includes(key));
+}
+
+function isObject(value: JsonValue): value is JsonObject {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/apps/relic-hunter-server-v1/test/relic-hunter-server-configuration.test.ts
+++ b/apps/relic-hunter-server-v1/test/relic-hunter-server-configuration.test.ts
@@ -33,9 +33,15 @@ describe('Relic Hunter server configuration', () => {
             profileUrls: {
                 dev: apiV1ResourceUrl('dev-config.json'),
                 prod: apiV1ResourceUrl('prod-config.json'),
+                'prod-hardened': apiV1ResourceUrl('prod-hardened-config.json'),
                 'prod-in-memory': apiV1ResourceUrl('prod-in-memory-config.json')
             },
-            staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url)
+            staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url),
+            relicDefaultsUrl: relicResourceUrl('defaults-config.json'),
+            relicProfileUrls: {
+                prod: relicResourceUrl('prod-config.json'),
+                'prod-hardened': relicResourceUrl('prod-hardened-config.json')
+            }
         });
 
         expect(configuration.http).toBe(configuration.apiV1.http);
@@ -104,16 +110,27 @@ describe('Relic Hunter server configuration', () => {
         })).rejects.toThrow('RELIC_AI_EXPEDITION_OLLAMA_BASE_URL');
     });
 
+    it('defaults production profiles to group-policy without a Relic environment override', async () => {
+        const production = await readConfiguration(productionOverrides('prod'));
+        const hardened = await readConfiguration(productionOverrides('prod-hardened'));
+
+        expect(production.restAuthorization).toEqual({ mode: 'group-policy' });
+        expect(hardened.restAuthorization).toEqual({ mode: 'group-policy' });
+    });
+
+    it('applies an explicit Relic policy after the convenient production profile', async () => {
+        const configuration = await readConfiguration({
+            ...productionOverrides('prod'),
+            RELIC_REST_AUTH_MODE: 'authenticated'
+        });
+
+        expect(configuration.restAuthorization).toEqual({ mode: 'authenticated' });
+    });
+
     it('requires group policy when the embedded API enables production hardening', async () => {
         await expect(readConfiguration({
-            RALLAR_API_CONFIGURATION_PROFILE: 'prod',
-            AUTH_ADMIN_CLIENT_IDS: 'production-operator',
-            DATABASE_URL: 'postgres://configuration-test@database.example.test/rallar',
-            METERED_APP_NAME: 'rallar-production',
-            METERED_API_KEY: 'metered-configuration-test-secret',
-            METERED_REGION: 'eu',
-            RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS: 'production-operator',
-            RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET: 'operator-configuration-test-secret'
+            ...productionOverrides('prod-hardened'),
+            RELIC_REST_AUTH_MODE: 'authenticated'
         })).rejects.toThrow(
             'RELIC_REST_AUTH_MODE must be group-policy when production hardening is enabled.'
         );
@@ -135,12 +152,35 @@ async function readConfiguration(
         profileUrls: {
             dev: apiV1ResourceUrl('dev-config.json'),
             prod: apiV1ResourceUrl('prod-config.json'),
+            'prod-hardened': apiV1ResourceUrl('prod-hardened-config.json'),
             'prod-in-memory': apiV1ResourceUrl('prod-in-memory-config.json')
         },
-        staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url)
+        staticClientsUrl: new URL('../../api-v1/resources/authorised-clients.json', import.meta.url),
+        relicDefaultsUrl: relicResourceUrl('defaults-config.json'),
+        relicProfileUrls: {
+            prod: relicResourceUrl('prod-config.json'),
+            'prod-hardened': relicResourceUrl('prod-hardened-config.json')
+        }
     });
 }
 
 function apiV1ResourceUrl(fileName: string): URL {
     return new URL(`../../api-v1/resources/configuration/${fileName}`, import.meta.url);
+}
+
+function relicResourceUrl(fileName: string): URL {
+    return new URL(`../resources/configuration/${fileName}`, import.meta.url);
+}
+
+function productionOverrides(profile: 'prod' | 'prod-hardened'): Readonly<Record<string, string>> {
+    return {
+        RALLAR_API_CONFIGURATION_PROFILE: profile,
+        AUTH_ADMIN_CLIENT_IDS: 'production-operator',
+        DATABASE_URL: 'postgres://configuration-test@database.example.test/rallar',
+        METERED_APP_NAME: 'rallar-production',
+        METERED_API_KEY: 'metered-configuration-test-secret',
+        METERED_REGION: 'eu',
+        RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS: 'production-operator',
+        RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET: 'operator-configuration-test-secret'
+    };
 }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,7 +4,7 @@ This document inventories environment variables used by the apps in this
 repository, plus the repository-level test and infrastructure variables that
 drive those apps.
 
-Last reviewed: 2026-08-23.
+Last reviewed: 2026-08-28.
 
 ## Conventions
 
@@ -18,7 +18,8 @@ Last reviewed: 2026-08-23.
 - Values from local `.env` files are intentionally not recorded here. Only
   variable names and behavior are documented.
 - API-v1 and Relic select production behavior with
-  `RALLAR_API_CONFIGURATION_PROFILE=prod`. The black-box control process uses
+  `RALLAR_API_CONFIGURATION_PROFILE=prod`; use `prod-hardened` when public registration and bundled
+  users must be disabled. The black-box control process uses
   its separate explicit `RALLAR_PRODUCTION_HARDENING=1` switch. See
   [Production Env Hardening Checklist](./production-env-hardening-checklist.md).
 
@@ -56,9 +57,10 @@ defaults-config.json
 ```
 
 `RALLAR_API_CONFIGURATION_PROFILE` accepts only the case-sensitive values
-`dev`, `prod`, and `prod-in-memory`. Absence selects `dev`; `prod` always
-enables hardening. `RALLAR_PRODUCTION_HARDENING=1` may strengthen another
-profile but cannot weaken `prod`.
+`dev`, `prod`, `prod-hardened`, and `prod-in-memory`. Absence selects `dev`;
+`prod` uses production infrastructure with public registration and bundled ordinary users, while
+`prod-hardened` always enables hardening. `RALLAR_PRODUCTION_HARDENING=1` may strengthen another
+profile but cannot weaken `prod-hardened`.
 
 The exact non-secret override allowlist is:
 
@@ -112,7 +114,7 @@ accepted. There are no aliases or transitional readers.
 | Variable                           | Required | Default          | Usage                                                                                                                                                                        |
 | ---------------------------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `RALLAR_API_CONFIGURATION_PROFILE` | No       | `dev`            | Selects one exact committed profile.                                                                                                                                         |
-| `RALLAR_PRODUCTION_HARDENING`      | No       | Profile-owned    | `1` or `true` strengthens a non-prod profile; `0` or `false` cannot weaken `prod`.                                                                                           |
+| `RALLAR_PRODUCTION_HARDENING`      | No       | Profile-owned    | `1` or `true` strengthens another profile; `0` or `false` cannot weaken `prod-hardened`.                                                                                     |
 | `PORT`                             | No       | Profile/defaults | HTTP listen port from `1` through `65535`.                                                                                                                                   |
 | `CORS_ORIGINS`                     | No       | Profile/defaults | Exact comma-separated browser origins. Hardened production requires exact HTTPS origins.                                                                                     |
 | `RALLAR_API_BASE_URL`              | No       | Profile/defaults | Canonical public HTTP API URL.                                                                                                                                               |
@@ -261,16 +263,16 @@ repositories are used.
 
 ### Relic Server Variables
 
-| Variable                              | Required | Default                                                             | Usage                                                                                                                                                                                  |
-| ------------------------------------- | -------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                                | No       | `8090`                                                              | HTTP listen port. Parsed with `Number(...)`; no range validation is applied here.                                                                                                      |
-| `CORS_ORIGINS`                        | No       | `http://localhost:5173,http://localhost:5174,http://localhost:5175` | Allowed browser origins for `/api/*`. Use `*` to reflect any request origin.                                                                                                           |
-| `RALLAR_API_CONFIGURATION_PROFILE`    | No       | `dev`                                                               | Selects the same immutable API-v1 profile used by the embedded server. Production must use `prod`.                                                                                     |
-| `RELIC_REST_AUTH_MODE`                | No       | `authenticated`                                                     | `authenticated` requires login only. `group-policy` requires full group read permission for snapshots, room send permission for commands, and active owner/admin permission for reset. |
-| `RELIC_AI_EXPEDITION_MODE`            | No       | `off`                                                               | Optional server-side expedition setup generation. Supported values: `off`, `mock`, and `ollama`.                                                                                       |
-| `RELIC_AI_EXPEDITION_TIMEOUT_MS`      | No       | `15000`                                                             | Timeout for server-side expedition blueprint generation before procedural fallback. Must be a positive integer.                                                                        |
-| `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` | No       | `http://127.0.0.1:11434`                                            | Private Ollama sidecar base URL used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                      |
-| `RELIC_AI_EXPEDITION_OLLAMA_MODEL`    | No       | `llama-test`                                                        | Ollama model ID used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                                      |
+| Variable                              | Required | Default                                                             | Usage                                                                                                                                                                                        |
+| ------------------------------------- | -------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                                | No       | `8090`                                                              | HTTP listen port. Parsed with `Number(...)`; no range validation is applied here.                                                                                                            |
+| `CORS_ORIGINS`                        | No       | `http://localhost:5173,http://localhost:5174,http://localhost:5175` | Allowed browser origins for `/api/*`. Use `*` to reflect any request origin.                                                                                                                 |
+| `RALLAR_API_CONFIGURATION_PROFILE`    | No       | `dev`                                                               | Selects the same immutable API-v1 profile used by the embedded server. Production uses `prod` by default or `prod-hardened` for forced hardening.                                            |
+| `RELIC_REST_AUTH_MODE`                | No       | Profile-owned                                                       | Local profiles default to `authenticated`; production profiles default to `group-policy`. An explicit override is applied after the profile, but production deployment rejects weakening it. |
+| `RELIC_AI_EXPEDITION_MODE`            | No       | `off`                                                               | Optional server-side expedition setup generation. Supported values: `off`, `mock`, and `ollama`.                                                                                             |
+| `RELIC_AI_EXPEDITION_TIMEOUT_MS`      | No       | `15000`                                                             | Timeout for server-side expedition blueprint generation before procedural fallback. Must be a positive integer.                                                                              |
+| `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` | No       | `http://127.0.0.1:11434`                                            | Private Ollama sidecar base URL used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                            |
+| `RELIC_AI_EXPEDITION_OLLAMA_MODEL`    | No       | `llama-test`                                                        | Ollama model ID used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                                            |
 
 ### Inherited API-v1 Variables
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -77,7 +77,8 @@ Before any database migration, the workflow verifies the token and access to
 all three applications. It then reads redacted Deno Deploy environment metadata
 for `rallar-server` and `relic-hunters`. Both production contexts must contain:
 
-- visible `RALLAR_API_CONFIGURATION_PROFILE=prod`;
+- visible `RALLAR_API_CONFIGURATION_PROFILE=prod` for the default convenient profile, or
+  `prod-hardened` for the locked-down profile;
 - visible non-demo `AUTH_ADMIN_CLIENT_IDS` and
   `RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS`;
 - visible non-empty `METERED_APP_NAME`;
@@ -88,10 +89,11 @@ The applications still require `DATABASE_URL` at runtime. Their assigned Deno
 Deploy PostgreSQL databases supply that value, so the preflight intentionally
 does not require it to appear in redacted environment metadata.
 
-The Relic production context must also contain visible
-`RELIC_REST_AUTH_MODE=group-policy`. The verifier reports names and policy
-failures only; it never prints or uploads the environment listing. Configure
-these values in Deno Deploy before enabling Actions deployment.
+Relic production profiles already select `group-policy`, so
+`RELIC_REST_AUTH_MODE` may be omitted. If the variable is present, the verifier requires the exact
+value `group-policy`. The verifier reports names and policy failures only; it never prints or uploads
+the environment listing. Configure the remaining values in Deno Deploy before enabling Actions
+deployment.
 
 Each deployment uploads the repository root with this command shape:
 

--- a/docs/production-env-hardening-checklist.md
+++ b/docs/production-env-hardening-checklist.md
@@ -2,7 +2,7 @@
 
 API-v1 and Relic hardening belong to the immutable API-v1 configuration
 snapshot. Select it with the exact value
-`RALLAR_API_CONFIGURATION_PROFILE=prod`; there is no environment-name alias or
+`RALLAR_API_CONFIGURATION_PROFILE=prod-hardened`; there is no environment-name alias or
 second hardening validator. The black-box control server is a separate process
 and owns its explicit `RALLAR_PRODUCTION_HARDENING=1` check.
 
@@ -12,7 +12,7 @@ names and configuration paths without reporting secret values.
 
 ## API-v1 Production
 
-- Set `RALLAR_API_CONFIGURATION_PROFILE=prod`.
+- Set `RALLAR_API_CONFIGURATION_PROFILE=prod-hardened`.
 - Keep the profile-owned PostgreSQL, PostgreSQL pub/sub, strict read auth,
   admin-only registration, disabled static clients, Metered ICE, HTTPS/WSS
   public URLs, and exact HTTPS CORS settings unless the deployment has a real
@@ -33,7 +33,7 @@ names and configuration paths without reporting secret values.
 
 The Deno Deploy preflight reads redacted environment metadata for
 `rallar-server` and refuses deployment unless the production context contains
-the exact `prod` selector, required visible values, and the three
+the exact `prod` or `prod-hardened` selector, required visible values, and the three
 repository-managed platform secret names. The assigned Deno Deploy PostgreSQL
 database supplies `DATABASE_URL`, so the preflight does not require it to
 appear in the redacted metadata. The preflight never prints or uploads the
@@ -42,14 +42,15 @@ environment document.
 ## Relic Server Production
 
 - Apply the complete API-v1 production checklist to the embedded server.
-- Set `RELIC_REST_AUTH_MODE=group-policy` in the production context.
+- Keep the `prod-hardened` profile-owned `group-policy` setting. If
+  `RELIC_REST_AUTH_MODE` is present, set it to exactly `group-policy`.
 - Keep `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` private when
   `RELIC_AI_EXPEDITION_MODE=ollama`.
 - Snapshot reads require full group read permission, commands require room send
   permission, and reset requires active owner/admin permission.
 
 The Deno Deploy preflight applies the same API-v1 evidence checks to
-`relic-hunters` and additionally requires the exact Relic group-policy value.
+`relic-hunters` and rejects an explicitly configured Relic policy that is not `group-policy`.
 
 ## Hetzner Disposable Controller
 

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-auth-session.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-auth-session.json
@@ -12,6 +12,15 @@
       "env": "RALLAR_BB_WORKSPACE_ID",
       "default": "default-{runId}"
     },
+    "defaultUsername": {
+      "env": "RALLAR_ALICE_USERNAME",
+      "default": "alice"
+    },
+    "defaultPassword": {
+      "env": "RALLAR_ALICE_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
     "runId": {
       "env": "RALLAR_BB_RUN_ID",
       "default": "local"
@@ -34,6 +43,70 @@
     }
   },
   "steps": [
+    {
+      "name": "loginDefaultUser",
+      "type": "http",
+      "connection": "api",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login/requests/bb-login-default-user-000-{runId}",
+        "body": {
+          "username": "{defaultUsername}",
+          "password": "{defaultPassword}"
+        },
+        "outputs": {
+          "defaultClientId": "body.clientId",
+          "defaultAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "clientId": "string",
+          "accessToken": "string",
+          "username": "{defaultUsername}",
+          "sessionId": "string",
+          "expiresAtEpochMs": "integer"
+        }
+      }
+    },
+    {
+      "name": "deriveDefaultAuthHeader",
+      "type": "set",
+      "output": "defaultAuthHeader",
+      "secret": true,
+      "redactAs": "defaultAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.defaultAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "logoutDefaultUser",
+      "type": "http",
+      "connection": "api",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/logout/requests/bb-logout-default-user-000-{runId}",
+        "headers": {
+          "Authorization": "{defaultAuthHeader}",
+          "x-client-id": "{defaultClientId}"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "loggedOut": true
+        }
+      }
+    },
     {
       "name": "setDisposableUsername",
       "type": "set",

--- a/packages/tests/hetzner/deno-deploy-api-configuration.test.ts
+++ b/packages/tests/hetzner/deno-deploy-api-configuration.test.ts
@@ -25,6 +25,16 @@ describe('Deno Deploy API configuration evidence', () => {
             sharedProductionEnvironment,
             'api-v1'
         )).toEqual([]);
+
+        const hardenedEnvironment = sharedProductionEnvironment.map((entry) =>
+            entry.name === 'RALLAR_API_CONFIGURATION_PROFILE'
+                ? plain(entry.name, 'prod-hardened')
+                : entry
+        );
+        expect(validateDenoDeployApiEnvironment(
+            hardenedEnvironment,
+            'api-v1'
+        )).toEqual([]);
     });
 
     it('treats the Deno Deploy all-context JSON shape as production evidence', () => {
@@ -52,15 +62,54 @@ describe('Deno Deploy API configuration evidence', () => {
         )).toEqual([]);
     });
 
-    it('requires the Relic policy in addition to the embedded API-v1 prod environment', () => {
+    it('uses the Relic production profile policy and rejects a conflicting explicit override', () => {
         expect(validateDenoDeployApiEnvironment(
             sharedProductionEnvironment,
             'relic'
-        )).toEqual(['RELIC_REST_AUTH_MODE is missing from the production context.']);
+        )).toEqual([]);
         expect(validateDenoDeployApiEnvironment(
             [...sharedProductionEnvironment, plain('RELIC_REST_AUTH_MODE', 'group-policy')],
             'relic'
         )).toEqual([]);
+        expect(validateDenoDeployApiEnvironment(
+            [...sharedProductionEnvironment, plain('RELIC_REST_AUTH_MODE', 'authenticated')],
+            'relic'
+        )).toEqual([
+            'RELIC_REST_AUTH_MODE must equal group-policy when explicitly configured in the production context.'
+        ]);
+    });
+
+    it('rejects bundled privileged client IDs for the convenient prod profile', () => {
+        for (
+            const [environmentName, clientIds] of [
+                ['AUTH_ADMIN_CLIENT_IDS', 'operations-admin,alice'],
+                ['RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS', 'bob,operations-admin']
+            ] as const
+        ) {
+            const invalidEnvironment = sharedProductionEnvironment.map((entry) =>
+                entry.name === environmentName
+                    ? plain(environmentName, clientIds)
+                    : entry
+            );
+
+            expect(validateDenoDeployApiEnvironment(invalidEnvironment, 'api-v1')).toContain(
+                `${environmentName} must not include bundled demo client IDs for the prod profile.`
+            );
+        }
+
+        const hardenedEnvironment = sharedProductionEnvironment.map((entry) => {
+            if (entry.name === 'RALLAR_API_CONFIGURATION_PROFILE') {
+                return plain(entry.name, 'prod-hardened');
+            }
+            if (entry.name === 'AUTH_ADMIN_CLIENT_IDS') {
+                return plain(entry.name, 'alice');
+            }
+            if (entry.name === 'RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS') {
+                return plain(entry.name, 'bob');
+            }
+            return entry;
+        });
+        expect(validateDenoDeployApiEnvironment(hardenedEnvironment, 'api-v1')).toEqual([]);
     });
 
     it('rejects an absent or non-prod selector and missing production secrets', () => {
@@ -77,7 +126,7 @@ describe('Deno Deploy API configuration evidence', () => {
                 : entry
         );
         expect(validateDenoDeployApiEnvironment(wrongSelector, 'api-v1')).toContain(
-            'RALLAR_API_CONFIGURATION_PROFILE must equal prod in the production context.'
+            'RALLAR_API_CONFIGURATION_PROFILE must equal prod or prod-hardened in the production context.'
         );
 
         const missingSecret = sharedProductionEnvironment.filter(
@@ -101,7 +150,7 @@ describe('Deno Deploy API configuration evidence', () => {
         const errors = validateDenoDeployApiEnvironment(invalid, 'relic');
 
         expect(errors).toContain(
-            'RELIC_REST_AUTH_MODE must equal group-policy in the production context.'
+            'RELIC_REST_AUTH_MODE must equal group-policy when explicitly configured in the production context.'
         );
         expect(JSON.stringify(errors)).not.toContain(secretValue);
     });

--- a/scripts/deploy/verify-deno-deploy-api-configuration.mjs
+++ b/scripts/deploy/verify-deno-deploy-api-configuration.mjs
@@ -1,8 +1,10 @@
+import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
+const BUNDLED_DEMO_CLIENT_IDS = readBundledDemoClientIds();
+
 const REQUIRED_SHARED_VALUES = new Map([
-    ['RALLAR_API_CONFIGURATION_PROFILE', 'prod'],
     ['AUTH_ADMIN_CLIENT_IDS', undefined],
     ['RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS', undefined],
     ['METERED_APP_NAME', undefined]
@@ -21,21 +23,74 @@ export function validateDenoDeployApiEnvironment(document, target) {
 
     const productionEntries = collectProductionEnvironmentEntries(document);
     const errors = [];
+    const productionProfile = requireProductionProfile(errors, productionEntries);
     for (const [name, expectedValue] of REQUIRED_SHARED_VALUES) {
         requireVisibleValue({ errors, entries: productionEntries, name, expectedValue });
+    }
+    if (productionProfile === 'prod') {
+        requireNoBundledDemoClientIds(errors, productionEntries, 'AUTH_ADMIN_CLIENT_IDS');
+        requireNoBundledDemoClientIds(
+            errors,
+            productionEntries,
+            'RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS'
+        );
     }
     for (const name of REQUIRED_SHARED_SECRETS) {
         requireSecret(errors, productionEntries, name);
     }
     if (target === 'relic') {
-        requireVisibleValue({
+        requireOptionalRelicPolicy({
             errors,
             entries: productionEntries,
-            name: 'RELIC_REST_AUTH_MODE',
-            expectedValue: 'group-policy'
+            name: 'RELIC_REST_AUTH_MODE'
         });
     }
     return errors;
+}
+
+function requireProductionProfile(errors, entries) {
+    const name = 'RALLAR_API_CONFIGURATION_PROFILE';
+    const entry = entries.get(name);
+    if (!entry) {
+        errors.push(`${name} is missing from the production context.`);
+        return undefined;
+    }
+    if (entry.secret || !entry.value) {
+        errors.push(`${name} must be a visible non-empty production value.`);
+        return undefined;
+    }
+    if (entry.value !== 'prod' && entry.value !== 'prod-hardened') {
+        errors.push(`${name} must equal prod or prod-hardened in the production context.`);
+        return undefined;
+    }
+    return entry.value;
+}
+
+function requireNoBundledDemoClientIds(errors, entries, name) {
+    const entry = entries.get(name);
+    if (!entry || entry.secret || !entry.value) {
+        return;
+    }
+    const clientIds = entry.value.split(',').map((clientId) => clientId.trim());
+    if (clientIds.some((clientId) => BUNDLED_DEMO_CLIENT_IDS.has(clientId))) {
+        errors.push(`${name} must not include bundled demo client IDs for the prod profile.`);
+    }
+}
+
+function requireOptionalRelicPolicy({ errors, entries, name }) {
+    const entry = entries.get(name);
+    if (!entry) {
+        return;
+    }
+    if (entry.secret || !entry.value) {
+        errors.push(`${name} must be a visible non-empty production value when configured.`);
+        return;
+    }
+    if (entry.value !== 'group-policy') {
+        errors.push(
+            `${name} must equal group-policy when explicitly configured in the production context.`
+        );
+    }
 }
 
 function collectProductionEnvironmentEntries(document) {
@@ -141,6 +196,18 @@ function readFirstString(object, names) {
 
 function isObject(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readBundledDemoClientIds() {
+    const url = new URL('../../apps/api-v1/resources/authorised-clients.json', import.meta.url);
+    const clients = JSON.parse(readFileSync(url, 'utf8'));
+    if (
+        !Array.isArray(clients) ||
+        clients.some((client) => !isObject(client) || typeof client.clientId !== 'string')
+    ) {
+        throw new TypeError('Bundled API-v1 clients must contain string clientId values.');
+    }
+    return new Set(clients.map((client) => client.clientId));
 }
 
 async function main(args) {


### PR DESCRIPTION
## Goal\n\nMake API-v1 and Relic Hunter production deployments usable with public registration and bundled default users, while retaining an explicit hardened production profile.\n\n## Changes\n\n- Make the prod API profile the convenient production mode with public registration, bundled demo users, and production services.\n- Add prod-hardened to preserve the prior hardened authentication behavior.\n- Add Relic Hunter defaults, prod, and prod-hardened overlays with production group-policy authorization.\n- Require a non-empty operator allowlist in prod and reject bundled demo identities from administrator and operator privilege lists.\n- Align deployment preflight with runtime profile and privileged-identity validation.\n- Extend the API-v1 authentication black-box recipe through registration, login, session validation, refresh, and logout.\n- Update OpenAPI descriptions and production configuration documentation.\n\n## Acceptance\n\n- The prod API profile supports bearer-free registration and bundled default-user login.\n- The prod-hardened profile keeps administrator-only registration and disables bundled users.\n- Relic Hunter derives its authorization mode from the selected production profile without a separate production environment override.\n- Convenient production startup and deployment preflight reject an empty operator allowlist and bundled privileged identities.\n- The authentication black-box recipe observes a successful newly registered user session.\n\n**Test design evidence**\n\n- Behavior protected and observation boundary: Production profile decoding and invariants are observed at the configuration boundary; registration and login are observed through the API-v1 black-box HTTP contract.\n- Retained interaction assertions (registry reference and rationale): None\n- Coupled or redundant tests removed or replaced: None\n\n## Validation\n\n- API-v1 configuration tests: 22 passed, 0 failed.\n- API-v1 type check and focused lint: passed.\n- Relic Hunter type check, test suite, and focused lint: 5 tests with 13 steps passed.\n- Deployment preflight tests: 7 passed.\n- Shared-test TypeScript and Deno checks: passed.\n- Repository governance: 401 tests passed.\n- Changed repository style, repository structure, formatting, and diff checks: passed.\n- Postgres medium-scale API-v1 black-box gate: 2,757 successes, 0 failures.\n\n## Risk and rollback\n\nThe prod profile intentionally becomes less hardened, so deployments that require the prior strict behavior must select prod-hardened. Rollback is configuration-only by selecting prod-hardened; no database migration or persisted-data rollback is required.\n\n## Follow-up\n\nNone