### PR TITLE
fix: remove production profile legacy overrides

### DIFF
--- a/apps/api-v1/src/configuration/README.md
+++ b/apps/api-v1/src/configuration/README.md
@@ -22,14 +22,13 @@ The selector is `RALLAR_API_CONFIGURATION_PROFILE`. Absence selects `dev`; the o
 are the exact, case-sensitive strings `dev`, `prod`, `prod-hardened`, and `prod-in-memory`. `prod`
 uses production infrastructure with public registration and bundled ordinary users.
 `prod-hardened` always enables production hardening, admin-only registration, and disabled static
-clients. `RALLAR_PRODUCTION_HARDENING=1` can promote another profile but cannot weaken
-`prod-hardened`.
+clients. Hardening is owned only by the selected profile.
 
 ## Environment allowlist
 
 The configuration reader recognizes only these operational overrides:
 
-- Profile: `RALLAR_API_CONFIGURATION_PROFILE`, `RALLAR_PRODUCTION_HARDENING`.
+- Profile: `RALLAR_API_CONFIGURATION_PROFILE`.
 - HTTP and public URLs: `PORT`, `CORS_ORIGINS`, `RALLAR_API_BASE_URL`,
   `RALLAR_WS_BASE_URL`.
 - Database: `RALLAR_SQL_BACKEND`, `RALLAR_PGLITE_DATA_DIR`,

--- a/apps/api-v1/src/configuration/decode-api-v1-configuration-source.ts
+++ b/apps/api-v1/src/configuration/decode-api-v1-configuration-source.ts
@@ -194,7 +194,6 @@ const CONFIGURATION_KEYS_BY_PATH: Readonly<Record<string, ReadonlySet<string>>> 
 };
 
 const ENVIRONMENT_NAME_BY_PATH: Readonly<Record<string, string>> = {
-    'profile.productionHardening': 'RALLAR_PRODUCTION_HARDENING',
     'http.port': 'PORT',
     'http.corsOrigins': 'CORS_ORIGINS',
     'publicApi.apiBaseUrl': 'RALLAR_API_BASE_URL',

--- a/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
+++ b/apps/api-v1/src/configuration/decode-api-v1-configuration.ts
@@ -45,15 +45,15 @@ export function decodeApiV1Configuration(
     );
     const structuredValues = new ApiV1ConfigurationStructuredValueDecoder(decoder);
     const profileName = decoder.profileName(input.profileName);
-    const configuredHardening = decoder.boolean('profile.productionHardening');
-    if (profileName === 'prod-hardened' && configuredHardening === false) {
+    const configuredProductionHardening = decoder.boolean('profile.productionHardening');
+    const productionHardening = profileName === 'prod-hardened';
+    if (configuredProductionHardening !== productionHardening) {
         decoder.invariant(
             'profile.productionHardening',
-            'production-profile-hardening-required',
-            'The prod-hardened profile always enables production hardening.'
+            'profile-hardening-mismatch',
+            'Production hardening must match the selected profile.'
         );
     }
-    const productionHardening = profileName === 'prod-hardened' || configuredHardening === true;
     const appliedEnvironmentOverrideNames = structuredValues.stringSet(
         'profile.appliedEnvironmentOverrideNames',
         input.appliedEnvironmentOverrideNames,

--- a/apps/api-v1/src/configuration/read-api-v1-configuration-environment.ts
+++ b/apps/api-v1/src/configuration/read-api-v1-configuration-environment.ts
@@ -171,11 +171,6 @@ function decodeJson(raw: string): ApiV1ConfigurationSourceValue {
 
 const ENVIRONMENT_SETTINGS: readonly EnvironmentSetting[] = [
     {
-        name: 'RALLAR_PRODUCTION_HARDENING',
-        decode: decodeBoolean,
-        apply: (source, value) => source.profile.productionHardening = value
-    },
-    {
         name: 'PORT',
         decode: decodeNumber,
         apply: (source, value) => source.http.port = value

--- a/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
+++ b/apps/api-v1/test/configuration/decode-api-v1-configuration.test.ts
@@ -583,6 +583,25 @@ Deno.test('production hardening validates the effective configuration and cannot
     assert.equal(error.issues.some((issue) => issue.path === 'ice.mode'), true);
 });
 
+Deno.test('only the prod-hardened profile enables production hardening', () => {
+    for (const profileName of ['dev', 'prod', 'prod-in-memory'] as const) {
+        const input = validDecodeApiV1ConfigurationInput();
+        input.profileName = profileName;
+        input.profileSource = { profile: { productionHardening: true } };
+
+        const error = captureConfigurationError(() => decodeApiV1Configuration(input));
+
+        assert.equal(
+            error.issues.some((issue) =>
+                issue.path === 'profile.productionHardening' &&
+                issue.code === 'profile-hardening-mismatch'
+            ),
+            true,
+            profileName
+        );
+    }
+});
+
 function captureConfigurationError(run: () => void): ApiV1ConfigurationError {
     try {
         run();

--- a/apps/api-v1/test/configuration/read-api-v1-configuration.test.ts
+++ b/apps/api-v1/test/configuration/read-api-v1-configuration.test.ts
@@ -57,6 +57,23 @@ Deno.test('configuration reader selects only absent or exact canonical profiles'
     }
 });
 
+Deno.test('configuration reader keeps production hardening profile-owned', async () => {
+    const environment = {
+        ...validConfigurationEnvironment('prod'),
+        RALLAR_PRODUCTION_HARDENING: '1'
+    };
+
+    const configuration = await readApiV1Configuration(readerInput(environment));
+
+    assert.equal(configuration.profile.productionHardening, false);
+    assert.equal(
+        configuration.profile.appliedEnvironmentOverrideNames.includes(
+            'RALLAR_PRODUCTION_HARDENING'
+        ),
+        false
+    );
+});
+
 Deno.test('configuration reader applies exact leaf precedence and ignores unrelated environment', async () => {
     const environment = {
         ...validConfigurationEnvironment(),

--- a/apps/relic-hunter-server-v1/src/relic-hunter-server-configuration.ts
+++ b/apps/relic-hunter-server-v1/src/relic-hunter-server-configuration.ts
@@ -70,7 +70,7 @@ export async function readRelicHunterServerConfiguration(
     const expeditionAi = decodeRelicAiExpeditionConfiguration(source);
     if (apiV1.profile.productionHardening && restAuthorization.mode !== 'group-policy') {
         throw new Error(
-            'RELIC_REST_AUTH_MODE must be group-policy when production hardening is enabled.'
+            'Relic profile restAuthorization.mode must be group-policy when production hardening is enabled.'
         );
     }
 
@@ -90,6 +90,14 @@ async function readRelicRestAuthorization(
     profileName: ApiV1ConfigurationProfile['name'],
     environment: RelicHunterServerEnvironmentSource
 ): Promise<RelicRestAuthorizationConfiguration> {
+    if (
+        (profileName === 'prod' || profileName === 'prod-hardened') &&
+        environment.restAuthorizationMode !== undefined
+    ) {
+        throw new Error(
+            `RELIC_REST_AUTH_MODE must be omitted when the ${profileName} profile owns the policy.`
+        );
+    }
     const defaultsMode = await readRelicRestAuthorizationMode(
         input,
         input.relicDefaultsUrl,

--- a/apps/relic-hunter-server-v1/test/relic-hunter-server-configuration.test.ts
+++ b/apps/relic-hunter-server-v1/test/relic-hunter-server-configuration.test.ts
@@ -118,22 +118,15 @@ describe('Relic Hunter server configuration', () => {
         expect(hardened.restAuthorization).toEqual({ mode: 'group-policy' });
     });
 
-    it('applies an explicit Relic policy after the convenient production profile', async () => {
-        const configuration = await readConfiguration({
-            ...productionOverrides('prod'),
-            RELIC_REST_AUTH_MODE: 'authenticated'
-        });
-
-        expect(configuration.restAuthorization).toEqual({ mode: 'authenticated' });
-    });
-
-    it('requires group policy when the embedded API enables production hardening', async () => {
-        await expect(readConfiguration({
-            ...productionOverrides('prod-hardened'),
-            RELIC_REST_AUTH_MODE: 'authenticated'
-        })).rejects.toThrow(
-            'RELIC_REST_AUTH_MODE must be group-policy when production hardening is enabled.'
-        );
+    it('rejects Relic policy overrides for production profiles', async () => {
+        for (const profile of ['prod', 'prod-hardened'] as const) {
+            await expect(readConfiguration({
+                ...productionOverrides(profile),
+                RELIC_REST_AUTH_MODE: 'group-policy'
+            })).rejects.toThrow(
+                `RELIC_REST_AUTH_MODE must be omitted when the ${profile} profile owns the policy.`
+            );
+        }
     });
 });
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -59,8 +59,7 @@ defaults-config.json
 `RALLAR_API_CONFIGURATION_PROFILE` accepts only the case-sensitive values
 `dev`, `prod`, `prod-hardened`, and `prod-in-memory`. Absence selects `dev`;
 `prod` uses production infrastructure with public registration and bundled ordinary users, while
-`prod-hardened` always enables hardening. `RALLAR_PRODUCTION_HARDENING=1` may strengthen another
-profile but cannot weaken `prod-hardened`.
+`prod-hardened` always enables hardening. API-v1 hardening is owned only by the selected profile.
 
 The exact non-secret override allowlist is:
 
@@ -114,7 +113,6 @@ accepted. There are no aliases or transitional readers.
 | Variable                           | Required | Default          | Usage                                                                                                                                                                        |
 | ---------------------------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `RALLAR_API_CONFIGURATION_PROFILE` | No       | `dev`            | Selects one exact committed profile.                                                                                                                                         |
-| `RALLAR_PRODUCTION_HARDENING`      | No       | Profile-owned    | `1` or `true` strengthens another profile; `0` or `false` cannot weaken `prod-hardened`.                                                                                     |
 | `PORT`                             | No       | Profile/defaults | HTTP listen port from `1` through `65535`.                                                                                                                                   |
 | `CORS_ORIGINS`                     | No       | Profile/defaults | Exact comma-separated browser origins. Hardened production requires exact HTTPS origins.                                                                                     |
 | `RALLAR_API_BASE_URL`              | No       | Profile/defaults | Canonical public HTTP API URL.                                                                                                                                               |
@@ -133,14 +131,14 @@ accepted. There are no aliases or transitional readers.
 
 ### Auth And Rate Limits
 
-| Variable                        | Required | Default  | Usage                                                                                                                                                                                                                                                                                       |
-| ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH_REGISTRATION_MODE`        | No       | `public` | When set to `admin`, `/api/auth/register` requires an authenticated admin client. Other values behave like public registration.                                                                                                                                                             |
-| `AUTH_ADMIN_CLIENT_IDS`         | No       | `admin`  | Comma-separated platform-admin allow-list for admin-only registration, topology management, CRDT admin routes, admin operations, and admin support explain routes.                                                                                                                          |
-| `AUTH_STATIC_CLIENTS_MODE`      | No       | `demo`   | `demo` enables bundled local clients such as `admin/admin`, `user/user`, and tests. `disabled` removes static clients from login and registration conflict checks.                                                                                                                          |
-| `RALLAR_AUTH_CREDENTIAL_SECRET` | Yes      | None     | Stable server-only HMAC secret for deterministically reconstructing AppInbox-issued access tokens and one-time tickets without persisting their plaintext. Must contain at least 32 characters and remain unchanged for the lifetime of outstanding sessions, tickets, and durable results. |
-| `RALLAR_LOGIN_IP_RATE_LIMIT`    | No       | `30`     | Login attempts per client IP per 60 seconds. Must be a positive integer.                                                                                                                                                                                                                    |
-| `RALLAR_LOGIN_USER_RATE_LIMIT`  | No       | `5`      | Login attempts per client IP plus username per 60 seconds. Must be a positive integer. Root memory-mode scripts raise this to `100`.                                                                                                                                                        |
+| Variable                        | Required | Default       | Usage                                                                                                                                                                                                                                                                                       |
+| ------------------------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_REGISTRATION_MODE`        | No       | Profile-owned | Exact values are `public` or `admin`. `admin` requires an authenticated admin client for `/api/auth/register`; any other value rejects startup.                                                                                                                                             |
+| `AUTH_ADMIN_CLIENT_IDS`         | No       | `admin`       | Comma-separated platform-admin allow-list for admin-only registration, topology management, CRDT admin routes, admin operations, and admin support explain routes.                                                                                                                          |
+| `AUTH_STATIC_CLIENTS_MODE`      | No       | `demo`        | `demo` enables bundled local clients such as `admin/admin`, `user/user`, and tests. `disabled` removes static clients from login and registration conflict checks.                                                                                                                          |
+| `RALLAR_AUTH_CREDENTIAL_SECRET` | Yes      | None          | Stable server-only HMAC secret for deterministically reconstructing AppInbox-issued access tokens and one-time tickets without persisting their plaintext. Must contain at least 32 characters and remain unchanged for the lifetime of outstanding sessions, tickets, and durable results. |
+| `RALLAR_LOGIN_IP_RATE_LIMIT`    | No       | `30`          | Login attempts per client IP per 60 seconds. Must be a positive integer.                                                                                                                                                                                                                    |
+| `RALLAR_LOGIN_USER_RATE_LIMIT`  | No       | `5`           | Login attempts per client IP plus username per 60 seconds. Must be a positive integer. Root memory-mode scripts raise this to `100`.                                                                                                                                                        |
 
 ### Realtime Topology And Group Formation
 
@@ -169,32 +167,32 @@ accepted. There are no aliases or transitional readers.
 
 ### Black Box Operator Tokens
 
-| Variable                                 | Required                               | Default            | Usage                                                                                                                                                                  |
-| ---------------------------------------- | -------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET` | Yes for `/api/black-box/control-token` | None               | HMAC secret used by API-v1 to issue short-lived control-server operator tokens. The same value must be configured on the black-box control server.                     |
-| `RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS` | No                                     | `86400000`         | TTL for logged-in operator tokens. Production hardening requires an explicit positive TTL. Prefer short TTLs and bearer headers.                                       |
-| `RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS`   | No                                     | Any logged-in user | Optional comma-separated allow-list of authenticated client IDs that may request `/api/black-box/control-token`. Production hardening requires an explicit allow-list. |
+| Variable                                 | Required                                | Default            | Usage                                                                                                                                                                                  |
+| ---------------------------------------- | --------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RALLAR_BLACK_BOX_OPERATOR_TOKEN_SECRET` | Yes for `/api/black-box/control-token`  | None               | HMAC secret used by API-v1 to issue short-lived control-server operator tokens. The same value must be configured on the black-box control server.                                     |
+| `RALLAR_BLACK_BOX_OPERATOR_TOKEN_TTL_MS` | No                                      | `86400000`         | TTL for logged-in operator tokens. Production hardening requires an explicit positive TTL. Prefer short TTLs and bearer headers.                                                       |
+| `RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS`   | Required for `prod` and `prod-hardened` | Any logged-in user | Comma-separated allow-list of authenticated client IDs that may request `/api/black-box/control-token`. Production requires a non-empty allow-list with no bundled demo IDs in `prod`. |
 
 ### ICE / WebRTC
 
 | Variable                                | Required                                                                   | Default                         | Usage                                                                                                                      |
 | --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `RALLAR_ICE_MODE`                       | No                                                                         | Profile-owned                   | ICE provider. Supported values: `metered`, `local`. `local` returns an empty ICE server list and avoids Metered API calls. |
-| `RALLAR_RTC_RTT_REPORTING_DEGREE_LIMIT` | No                                                                         | RTC topology `degreeLimit`, `5` | Positive integer cap for accepted RTC RTT reporting edges per endpoint. Invalid values fall back to the topology degree.   |
+| `RALLAR_RTC_RTT_REPORTING_DEGREE_LIMIT` | No                                                                         | RTC topology `degreeLimit`, `5` | Positive integer cap for accepted RTC RTT reporting edges per endpoint. Invalid values reject startup.                     |
 | `METERED_APP_NAME`                      | Required when `RALLAR_ICE_MODE=metered` and `/api/webrtc/ice` is requested | None                            | Metered TURN app name. Used in `https://<app>.metered.live/...`.                                                           |
 | `METERED_API_KEY`                       | Required when `RALLAR_ICE_MODE=metered` and `/api/webrtc/ice` is requested | None                            | Metered TURN API key. Server-only secret.                                                                                  |
 | `METERED_REGION`                        | No                                                                         | `eu`                            | Optional override for the mandatory Metered TURN region. Ignored when ICE mode is `local`.                                 |
 
 ### Timing And App Inbox Tuning
 
-| Variable                                      | Required | Default | Usage                                                                         |
-| --------------------------------------------- | -------- | ------- | ----------------------------------------------------------------------------- |
-| `RALLAR_TIMING_LOGS`                          | No       | Enabled | Enables console timing sink. Values `0`, `false`, `no`, and `off` disable it. |
-| `RALLAR_APP_INBOX_PHASE_TIMING`               | No       | `false` | Enables phase timing in app inbox processing.                                 |
-| `RALLAR_APP_INBOX_WAIT_MAX_ELAPSED_MS`        | No       | `30000` | Max app inbox wait time. Invalid numbers fall back.                           |
-| `RALLAR_APP_INBOX_WAIT_RETRY_INTERVAL_MS`     | No       | `250`   | Initial app inbox retry interval. Invalid numbers fall back.                  |
-| `RALLAR_APP_INBOX_WAIT_MAX_RETRY_INTERVAL_MS` | No       | `1000`  | Max app inbox retry interval. Invalid numbers fall back.                      |
-| `RALLAR_APP_INBOX_WAIT_JITTER_RATIO`          | No       | `0.1`   | App inbox retry jitter ratio. Invalid numbers fall back.                      |
+| Variable                                      | Required | Default | Usage                                                                                                                            |
+| --------------------------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `RALLAR_TIMING_LOGS`                          | No       | Enabled | Enables the console timing sink. Exact values `0` and `false` disable it; `1` and `true` enable it. Other values reject startup. |
+| `RALLAR_APP_INBOX_PHASE_TIMING`               | No       | `false` | Enables phase timing in app inbox processing.                                                                                    |
+| `RALLAR_APP_INBOX_WAIT_MAX_ELAPSED_MS`        | No       | `30000` | Max app inbox wait time. Invalid values reject startup.                                                                          |
+| `RALLAR_APP_INBOX_WAIT_RETRY_INTERVAL_MS`     | No       | `250`   | Initial app inbox retry interval. Invalid values reject startup.                                                                 |
+| `RALLAR_APP_INBOX_WAIT_MAX_RETRY_INTERVAL_MS` | No       | `1000`  | Max app inbox retry interval. Invalid values reject startup.                                                                     |
+| `RALLAR_APP_INBOX_WAIT_JITTER_RATIO`          | No       | `0.1`   | App inbox retry jitter ratio. Invalid values reject startup.                                                                     |
 
 ### Scripts
 
@@ -263,16 +261,16 @@ repositories are used.
 
 ### Relic Server Variables
 
-| Variable                              | Required | Default                                                             | Usage                                                                                                                                                                                        |
-| ------------------------------------- | -------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                                | No       | `8090`                                                              | HTTP listen port. Parsed with `Number(...)`; no range validation is applied here.                                                                                                            |
-| `CORS_ORIGINS`                        | No       | `http://localhost:5173,http://localhost:5174,http://localhost:5175` | Allowed browser origins for `/api/*`. Use `*` to reflect any request origin.                                                                                                                 |
-| `RALLAR_API_CONFIGURATION_PROFILE`    | No       | `dev`                                                               | Selects the same immutable API-v1 profile used by the embedded server. Production uses `prod` by default or `prod-hardened` for forced hardening.                                            |
-| `RELIC_REST_AUTH_MODE`                | No       | Profile-owned                                                       | Local profiles default to `authenticated`; production profiles default to `group-policy`. An explicit override is applied after the profile, but production deployment rejects weakening it. |
-| `RELIC_AI_EXPEDITION_MODE`            | No       | `off`                                                               | Optional server-side expedition setup generation. Supported values: `off`, `mock`, and `ollama`.                                                                                             |
-| `RELIC_AI_EXPEDITION_TIMEOUT_MS`      | No       | `15000`                                                             | Timeout for server-side expedition blueprint generation before procedural fallback. Must be a positive integer.                                                                              |
-| `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` | No       | `http://127.0.0.1:11434`                                            | Private Ollama sidecar base URL used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                            |
-| `RELIC_AI_EXPEDITION_OLLAMA_MODEL`    | No       | `llama-test`                                                        | Ollama model ID used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                                                            |
+| Variable                              | Required | Default                                                             | Usage                                                                                                                                             |
+| ------------------------------------- | -------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                                | No       | `8090`                                                              | HTTP listen port. Parsed with `Number(...)`; no range validation is applied here.                                                                 |
+| `CORS_ORIGINS`                        | No       | `http://localhost:5173,http://localhost:5174,http://localhost:5175` | Allowed browser origins for `/api/*`. Use `*` to reflect any request origin.                                                                      |
+| `RALLAR_API_CONFIGURATION_PROFILE`    | No       | `dev`                                                               | Selects the same immutable API-v1 profile used by the embedded server. Production uses `prod` by default or `prod-hardened` for forced hardening. |
+| `RELIC_REST_AUTH_MODE`                | No       | Profile-owned                                                       | Local profiles default to `authenticated` and may override the mode. Production profiles own `group-policy` and reject this variable.             |
+| `RELIC_AI_EXPEDITION_MODE`            | No       | `off`                                                               | Optional server-side expedition setup generation. Supported values: `off`, `mock`, and `ollama`.                                                  |
+| `RELIC_AI_EXPEDITION_TIMEOUT_MS`      | No       | `15000`                                                             | Timeout for server-side expedition blueprint generation before procedural fallback. Must be a positive integer.                                   |
+| `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` | No       | `http://127.0.0.1:11434`                                            | Private Ollama sidecar base URL used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                 |
+| `RELIC_AI_EXPEDITION_OLLAMA_MODEL`    | No       | `llama-test`                                                        | Ollama model ID used only when `RELIC_AI_EXPEDITION_MODE=ollama`.                                                                                 |
 
 ### Inherited API-v1 Variables
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -89,11 +89,13 @@ The applications still require `DATABASE_URL` at runtime. Their assigned Deno
 Deploy PostgreSQL databases supply that value, so the preflight intentionally
 does not require it to appear in redacted environment metadata.
 
-Relic production profiles already select `group-policy`, so
-`RELIC_REST_AUTH_MODE` may be omitted. If the variable is present, the verifier requires the exact
-value `group-policy`. The verifier reports names and policy failures only; it never prints or uploads
-the environment listing. Configure the remaining values in Deno Deploy before enabling Actions
-deployment.
+Relic production profiles select `group-policy`, so `RELIC_REST_AUTH_MODE` must be omitted. The
+verifier reports names and policy failures only; it never prints or uploads the environment listing.
+Configure the remaining values in Deno Deploy before enabling Actions deployment.
+
+The preflight rejects the retired `ENVIRONMENT` and API-v1
+`RALLAR_PRODUCTION_HARDENING` names. Select `prod-hardened` instead of configuring a separate API
+hardening switch.
 
 Each deployment uploads the repository root with this command shape:
 

--- a/docs/production-env-hardening-checklist.md
+++ b/docs/production-env-hardening-checklist.md
@@ -42,15 +42,15 @@ environment document.
 ## Relic Server Production
 
 - Apply the complete API-v1 production checklist to the embedded server.
-- Keep the `prod-hardened` profile-owned `group-policy` setting. If
-  `RELIC_REST_AUTH_MODE` is present, set it to exactly `group-policy`.
+- Keep the `prod-hardened` profile-owned `group-policy` setting and omit
+  `RELIC_REST_AUTH_MODE`.
 - Keep `RELIC_AI_EXPEDITION_OLLAMA_BASE_URL` private when
   `RELIC_AI_EXPEDITION_MODE=ollama`.
 - Snapshot reads require full group read permission, commands require room send
   permission, and reset requires active owner/admin permission.
 
 The Deno Deploy preflight applies the same API-v1 evidence checks to
-`relic-hunters` and rejects an explicitly configured Relic policy that is not `group-policy`.
+`relic-hunters` and rejects any explicitly configured Relic policy.
 
 ## Hetzner Disposable Controller
 

--- a/packages/tests/hetzner/deno-deploy-api-configuration.test.ts
+++ b/packages/tests/hetzner/deno-deploy-api-configuration.test.ts
@@ -62,21 +62,30 @@ describe('Deno Deploy API configuration evidence', () => {
         )).toEqual([]);
     });
 
-    it('uses the Relic production profile policy and rejects a conflicting explicit override', () => {
+    it('rejects retired production configuration names', () => {
+        for (const target of ['api-v1', 'relic'] as const) {
+            for (const name of ['ENVIRONMENT', 'RALLAR_PRODUCTION_HARDENING']) {
+                expect(validateDenoDeployApiEnvironment(
+                    [...sharedProductionEnvironment, plain(name, 'legacy-value')],
+                    target
+                )).toContain(`${name} is retired and must be removed from the production context.`);
+            }
+        }
+    });
+
+    it('uses the Relic production profile policy and rejects explicit overrides', () => {
         expect(validateDenoDeployApiEnvironment(
             sharedProductionEnvironment,
             'relic'
         )).toEqual([]);
-        expect(validateDenoDeployApiEnvironment(
-            [...sharedProductionEnvironment, plain('RELIC_REST_AUTH_MODE', 'group-policy')],
-            'relic'
-        )).toEqual([]);
-        expect(validateDenoDeployApiEnvironment(
-            [...sharedProductionEnvironment, plain('RELIC_REST_AUTH_MODE', 'authenticated')],
-            'relic'
-        )).toEqual([
-            'RELIC_REST_AUTH_MODE must equal group-policy when explicitly configured in the production context.'
-        ]);
+        for (const value of ['group-policy', 'authenticated']) {
+            expect(validateDenoDeployApiEnvironment(
+                [...sharedProductionEnvironment, plain('RELIC_REST_AUTH_MODE', value)],
+                'relic'
+            )).toEqual([
+                'RELIC_REST_AUTH_MODE is profile-owned and must be removed from the production context.'
+            ]);
+        }
     });
 
     it('rejects bundled privileged client IDs for the convenient prod profile', () => {
@@ -150,7 +159,7 @@ describe('Deno Deploy API configuration evidence', () => {
         const errors = validateDenoDeployApiEnvironment(invalid, 'relic');
 
         expect(errors).toContain(
-            'RELIC_REST_AUTH_MODE must equal group-policy when explicitly configured in the production context.'
+            'RELIC_REST_AUTH_MODE is profile-owned and must be removed from the production context.'
         );
         expect(JSON.stringify(errors)).not.toContain(secretValue);
     });

--- a/scripts/deploy/verify-deno-deploy-api-configuration.mjs
+++ b/scripts/deploy/verify-deno-deploy-api-configuration.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from 'node:url';
 
 const BUNDLED_DEMO_CLIENT_IDS = readBundledDemoClientIds();
 
+const RETIRED_PRODUCTION_NAMES = ['ENVIRONMENT', 'RALLAR_PRODUCTION_HARDENING'];
+
 const REQUIRED_SHARED_VALUES = new Map([
     ['AUTH_ADMIN_CLIENT_IDS', undefined],
     ['RALLAR_BLACK_BOX_OPERATOR_CLIENT_IDS', undefined],
@@ -23,6 +25,11 @@ export function validateDenoDeployApiEnvironment(document, target) {
 
     const productionEntries = collectProductionEnvironmentEntries(document);
     const errors = [];
+    for (const name of RETIRED_PRODUCTION_NAMES) {
+        if (productionEntries.has(name)) {
+            errors.push(`${name} is retired and must be removed from the production context.`);
+        }
+    }
     const productionProfile = requireProductionProfile(errors, productionEntries);
     for (const [name, expectedValue] of REQUIRED_SHARED_VALUES) {
         requireVisibleValue({ errors, entries: productionEntries, name, expectedValue });
@@ -38,12 +45,10 @@ export function validateDenoDeployApiEnvironment(document, target) {
     for (const name of REQUIRED_SHARED_SECRETS) {
         requireSecret(errors, productionEntries, name);
     }
-    if (target === 'relic') {
-        requireOptionalRelicPolicy({
-            errors,
-            entries: productionEntries,
-            name: 'RELIC_REST_AUTH_MODE'
-        });
+    if (target === 'relic' && productionEntries.has('RELIC_REST_AUTH_MODE')) {
+        errors.push(
+            'RELIC_REST_AUTH_MODE is profile-owned and must be removed from the production context.'
+        );
     }
     return errors;
 }
@@ -74,22 +79,6 @@ function requireNoBundledDemoClientIds(errors, entries, name) {
     const clientIds = entry.value.split(',').map((clientId) => clientId.trim());
     if (clientIds.some((clientId) => BUNDLED_DEMO_CLIENT_IDS.has(clientId))) {
         errors.push(`${name} must not include bundled demo client IDs for the prod profile.`);
-    }
-}
-
-function requireOptionalRelicPolicy({ errors, entries, name }) {
-    const entry = entries.get(name);
-    if (!entry) {
-        return;
-    }
-    if (entry.secret || !entry.value) {
-        errors.push(`${name} must be a visible non-empty production value when configured.`);
-        return;
-    }
-    if (entry.value !== 'group-policy') {
-        errors.push(
-            `${name} must equal group-policy when explicitly configured in the production context.`
-        );
     }
 }
 


### PR DESCRIPTION
## Goal

Remove the production compatibility paths retained by #368 so API-v1 and Relic production policy is owned by canonical profiles, while preserving the convenient `prod` profile and Hetzner `prod-in-memory` PGlite behavior.

## Changes

- Remove API-v1 support for the retired `RALLAR_PRODUCTION_HARDENING` override and derive effective hardening only from `prod-hardened`.
- Reject profile hardening mismatches while still running the complete hardened invariant set.
- Reject `RELIC_REST_AUTH_MODE` for Relic `prod` and `prod-hardened`; local profiles retain their explicit development override.
- Make Deno deployment preflight reject `ENVIRONMENT`, API-v1 `RALLAR_PRODUCTION_HARDENING`, and Relic `RELIC_REST_AUTH_MODE`.
- Add regression coverage and correct the touched operational configuration inventory.

## Acceptance

- `prod` keeps public registration and bundled ordinary users.
- `prod-hardened` is the only profile that enables API-v1 production hardening.
- Production Relic authorization is `group-policy` and cannot be overridden by environment.
- No API-v1 or Relic production compatibility reader remains for the retired variables.
- The separate black-box control-server hardening contract remains unchanged.
- Hetzner continues to normalize to `prod-in-memory` with in-memory PGlite.

## Validation

- `deno test --allow-read test/configuration` in `apps/api-v1`: 24 passed.
- `deno task check && deno task test` in `apps/relic-hunter-server-v1`: 5 tests / 12 steps passed.
- Focused Deno deployment and Hetzner tests: 108 passed.
- Clean-checkout Deno/Hetzner deployment gate: 116 passed.
- `npm run test:api-v1:black-box:memory` from the clean commit: 32 recipes passed, 0 failed, 0 skipped.
- `npm run test:repo-governance`: 401 passed.
- Dprint, Deno lint, repository structure, changed-style, diff, and legacy review checks completed without changed-code errors.
- Independent code review found no remaining issues after fixes.

## Risk and rollback

The next production deployment intentionally fails preflight until retired variables are removed from Deno Deploy. Roll back this commit to restore temporary compatibility, then restore the prior variables only if an emergency rollback requires the old runtime.

## Follow-up

Before deployment, remove `ENVIRONMENT` from both `rallar-server` and `relic-hunters`, and remove `RELIC_REST_AUTH_MODE` from `relic-hunters`. No secret values need to change.
