### PR TITLE
Capture RTC-B06 browser performance evidence

### DIFF
--- a/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
@@ -1,0 +1,1176 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    buildLiveRtcExternalAttempt,
+    buildLiveRtcRetentionCohort,
+    buildLiveRtcAgentDiagnostics,
+    countUnexpectedLiveRtcDeliveries,
+    liveRtcRetentionStateReturned,
+    loadLiveRtcPerformanceAttempt,
+    writeLiveRtcPerformanceEvidence,
+    writeLiveRtcRetentionCohortIfComplete,
+    type LiveRtcPerformanceAttemptContext,
+    type LiveRtcPerformanceRawEvidence
+} from '../../../tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts';
+
+const temporaryDirectories: string[] = [];
+const baselineId = '20260829-0123456789ab-e3-memory';
+const e3DefaultLocator = {
+    workloadId: 'RTC-B06',
+    caseId: 'default',
+    inputKey: 'e3-memory-default',
+    intendedPhase: 'retained',
+    outerOrdinal: 1,
+    environmentId: 'E3-memory',
+    rawResultRelativePath:
+        'artifacts/staging/rtc-b06-default-e3-memory-default-retained-001.json'
+} as const;
+const e3DefaultIdentity = {
+    sampleId: 'rtc-b06-default-e3-memory-default-retained-001-001',
+    workloadId: 'RTC-B06',
+    caseId: 'default',
+    inputKey: 'e3-memory-default',
+    intendedPhase: 'retained',
+    outerOrdinal: 1,
+    innerOrdinal: 1
+} as const;
+const runtimeObservation = {
+    git: {
+        headCommit: 'a'.repeat(40),
+        headTree: 'b'.repeat(40),
+        ref: 'codex/rallar-rtc-performance-baseline-b06',
+        clean: true
+    },
+    runtime: {
+        node: 'v24.0.0',
+        npm: '11.0.0',
+        deno: '2.4.0',
+        playwright: '1.55.0',
+        chromium: '140.0.0.0'
+    },
+    host: {
+        os: 'darwin',
+        kernel: '24.0.0',
+        architecture: 'arm64',
+        logicalCpuCount: 12,
+        cpuModel: 'Apple M4 Pro',
+        totalMemoryBytes: 24 * 1024 * 1024 * 1024,
+        executionContext: 'local'
+    },
+    timing: {
+        startedAtUtc: '2026-08-29T08:00:00.000Z',
+        endedAtUtc: '2026-08-29T08:10:00.000Z',
+        monotonicDurationMs: 600_000,
+        monotonicSource: 'performance.now'
+    },
+    deviations: [],
+    sourceHashes: [
+        {
+            path: 'tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts',
+            sha256: 'c'.repeat(64),
+            kind: 'source'
+        }
+    ],
+    configurationInputs: [],
+    resolvedConfiguration: [],
+    controllerInputs: [],
+    workerCommand: {
+        redactedArgv: {
+            executable: 'npm',
+            arguments: ['run', 'test:rallar:full-stack:memory:live-rtc-3']
+        },
+        projection: {
+            fixedWorkerFlags: [],
+            configurationFlags: []
+        }
+    },
+    allowlistedEnvironment: {}
+} as const;
+
+function e3CaptureManifest() {
+    const retentionAttempts = Array.from({ length: 3 }, (_, index) => {
+        const outerOrdinal = index + 1;
+        const ordinal = String(outerOrdinal).padStart(3, '0');
+        return {
+            workloadId: 'RTC-B06' as const,
+            caseId: 'retention-100',
+            inputKey: 'e3-memory-retention-100',
+            environmentId: 'E3-memory' as const,
+            intendedPhase: 'retained' as const,
+            outerOrdinal,
+            sampleIds: [
+                `rtc-b06-retention-100-e3-memory-retention-100-retained-${ordinal}-001`
+            ]
+        };
+    });
+    return {
+        schema: 'rallar.rtc-baseline.manifest.v1' as const,
+        request: {
+            schema: 'rallar.rtc-baseline.capture-request.v1' as const,
+            baselineId,
+            workloadIds: ['RTC-B06'] as const,
+            environmentId: 'E3-memory' as const,
+            retainedSampleMultiplier: 1,
+            repeatLink: null,
+            conditionalEnvironmentDecisions: []
+        },
+        workloadIds: ['RTC-B06'] as const,
+        cases: [
+            {
+                workloadId: 'RTC-B06' as const,
+                caseId: 'default',
+                inputKey: 'e3-memory-default'
+            },
+            {
+                workloadId: 'RTC-B06' as const,
+                caseId: 'retention-100',
+                inputKey: 'e3-memory-retention-100'
+            }
+        ],
+        outerAttempts: [{
+            workloadId: 'RTC-B06' as const,
+            caseId: 'default',
+            inputKey: 'e3-memory-default',
+            environmentId: 'E3-memory' as const,
+            intendedPhase: 'retained' as const,
+            outerOrdinal: 1,
+            sampleIds: [e3DefaultIdentity.sampleId]
+        }, ...retentionAttempts],
+        expectedCohorts: [{
+            cohortId: 'rtc-b06-e3-memory-retention',
+            workloadId: 'RTC-B06' as const,
+            memberSampleIds: retentionAttempts.flatMap((attempt) => attempt.sampleIds)
+        }],
+        repeatLink: null
+    };
+}
+
+function externalLocator(
+    attempt: ReturnType<typeof e3CaptureManifest>['outerAttempts'][number]
+) {
+    const ordinal = String(attempt.outerOrdinal).padStart(3, '0');
+    return {
+        workloadId: attempt.workloadId,
+        caseId: attempt.caseId,
+        inputKey: attempt.inputKey,
+        environmentId: attempt.environmentId,
+        intendedPhase: attempt.intendedPhase,
+        outerOrdinal: attempt.outerOrdinal,
+        rawResultRelativePath:
+            `artifacts/staging/rtc-b06-${attempt.caseId}-${attempt.inputKey}-${attempt.intendedPhase}-${ordinal}.json`
+    };
+}
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories.splice(0).map((directory) =>
+            rm(directory, { recursive: true, force: true })
+        )
+    );
+});
+
+function agentDiagnostics(agentId: 'agent-a' | 'agent-b' | 'agent-c') {
+    const peers = ['agent-a', 'agent-b', 'agent-c'].filter(
+        (candidate) => candidate !== agentId
+    );
+    return {
+        agentId,
+        settledPeerIds: peers,
+        readyPeerIds: peers,
+        laneStates: peers.map((peerId) => ({
+            peerId,
+            laneId: 'json',
+            isOpen: true,
+            isReconnectable: true
+        })),
+        connectionTimerActive: false,
+        peerCount: 2,
+        connectedPeerCount: 2,
+        relayPeerCount: 0,
+        details: {}
+    } as const;
+}
+
+function defaultRawEvidence(
+    overrides: Partial<LiveRtcPerformanceRawEvidence> = {}
+): LiveRtcPerformanceRawEvidence {
+    return {
+        identity: {
+            workloadId: 'RTC-B06',
+            caseId: 'default',
+            inputKey: 'e3-memory-default',
+            intendedPhase: 'retained',
+            outerOrdinal: 1,
+            environmentId: 'E3-memory'
+        },
+        producer: {
+            provider: 'browser-rallar',
+            browserCount: 3,
+            auth: {
+                A: 'login',
+                B: 'login',
+                C: 'login'
+            },
+            databaseProvider: 'memory',
+            databaseUrl: 'absent',
+            iceMode: 'repository-default',
+            allScenariosRaw: null,
+            retentionSoakRaw: null,
+            retentionCyclesRaw: null,
+            iceModeRaw: null,
+            transports: ['realtime', 'messages.rtc']
+        },
+        runtime: {
+            node: 'v24.0.0',
+            playwright: '1.55.0',
+            chromium: '140.0.0.0'
+        },
+        timings: [
+            {
+                kind: 'peer-ready',
+                transport: 'realtime',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 12
+            },
+            {
+                kind: 'direct-delivery',
+                transport: 'realtime',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b'],
+                durationMs: 4
+            },
+            {
+                kind: 'multicast-delivery',
+                transport: 'realtime',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 5
+            },
+            {
+                kind: 'broadcast-delivery',
+                transport: 'realtime',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 6
+            },
+            {
+                kind: 'peer-ready',
+                transport: 'messages.rtc',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 13
+            },
+            {
+                kind: 'direct-delivery',
+                transport: 'messages.rtc',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b'],
+                durationMs: 7
+            },
+            {
+                kind: 'multicast-delivery',
+                transport: 'messages.rtc',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 8
+            },
+            {
+                kind: 'broadcast-delivery',
+                transport: 'messages.rtc',
+                senderAgentId: 'agent-a',
+                receiverAgentIds: ['agent-b', 'agent-c'],
+                durationMs: 9
+            }
+        ],
+        diagnostics: [
+            {
+                label: 'realtime-final',
+                cycle: null,
+                agents: [
+                    agentDiagnostics('agent-a'),
+                    agentDiagnostics('agent-b'),
+                    agentDiagnostics('agent-c')
+                ]
+            }
+        ],
+        retention: null,
+        assertions: {
+            matrixPassed: true,
+            artifactBundlePassed: true,
+            unexpectedDeliveryCount: 0,
+            reconnectPassed: null
+        },
+        ...overrides
+    };
+}
+
+function retentionRawEvidence(input: Readonly<{
+    environmentId?: 'E3-memory' | 'E4-pg';
+    inputKey?: 'e3-memory-retention-100' | 'e4-pg-retention-100';
+    outerOrdinal: number;
+    cycle0HeapBytes: number;
+    finalHeapBytes: number;
+    stateReturned?: boolean;
+}>): LiveRtcPerformanceRawEvidence {
+    const environmentId = input.environmentId ?? 'E3-memory';
+    const inputKey = input.inputKey ?? 'e3-memory-retention-100';
+    const stateReturned = input.stateReturned ?? true;
+    const checkpoints = Array.from({ length: 11 }, (_, index) => {
+        const cycle = index * 10;
+        const progress = cycle / 100;
+        return {
+            cycle,
+            postGcHeapBytes: Math.round(
+                input.cycle0HeapBytes +
+                    (input.finalHeapBytes - input.cycle0HeapBytes) * progress
+            ),
+            agents: [
+                agentDiagnostics('agent-a'),
+                agentDiagnostics('agent-b'),
+                {
+                    ...agentDiagnostics('agent-c'),
+                    laneStates: cycle === 100 && !stateReturned
+                        ? [{
+                            peerId: 'agent-b',
+                            laneId: 'json',
+                            isOpen: false,
+                            isReconnectable: true
+                        }]
+                        : agentDiagnostics('agent-c').laneStates,
+                    connectionTimerActive: cycle === 100 && !stateReturned
+                }
+            ]
+        } as const;
+    });
+    return {
+        ...defaultRawEvidence(),
+        identity: {
+            workloadId: 'RTC-B06',
+            caseId: 'retention-100',
+            inputKey,
+            intendedPhase: 'retained',
+            outerOrdinal: input.outerOrdinal,
+            environmentId
+        },
+        producer: {
+            ...defaultRawEvidence().producer,
+            databaseProvider: environmentId === 'E4-pg' ? 'postgres' : 'memory',
+            databaseUrl: environmentId === 'E4-pg' ? 'present' : 'absent',
+            iceMode: environmentId === 'E4-pg' ? 'local' : 'repository-default',
+            retentionSoakRaw: '1',
+            retentionCyclesRaw: '100',
+            iceModeRaw: environmentId === 'E4-pg' ? 'local' : null
+        },
+        timings: [
+            {
+                kind: 'reconnect-ready',
+                transport: 'messages.rtc',
+                senderAgentId: 'agent-b',
+                receiverAgentIds: ['agent-c'],
+                durationMs: 14
+            }
+        ],
+        diagnostics: checkpoints.map((checkpoint) => ({
+            label: `retention-cycle-${checkpoint.cycle}`,
+            cycle: checkpoint.cycle,
+            agents: checkpoint.agents
+        })),
+        retention: {
+            cycles: 100,
+            checkpoints,
+            settledStateReturned: stateReturned
+        },
+        assertions: {
+            matrixPassed: true,
+            artifactBundlePassed: true,
+            unexpectedDeliveryCount: 0,
+            reconnectPassed: true
+        }
+    };
+}
+
+function retentionAttempt(input: Readonly<{
+    outerOrdinal: number;
+    cycle0HeapBytes: number;
+    finalHeapBytes: number;
+    stateReturned?: boolean;
+}>) {
+    const ordinal = String(input.outerOrdinal).padStart(3, '0');
+    return buildLiveRtcExternalAttempt({
+        locator: {
+            workloadId: 'RTC-B06',
+            caseId: 'retention-100',
+            inputKey: 'e3-memory-retention-100',
+            intendedPhase: 'retained',
+            outerOrdinal: input.outerOrdinal,
+            environmentId: 'E3-memory',
+            rawResultRelativePath:
+                `artifacts/staging/rtc-b06-retention-100-e3-memory-retention-100-retained-${ordinal}.json`
+        },
+        sampleIdentity: {
+            sampleId:
+                `rtc-b06-retention-100-e3-memory-retention-100-retained-${ordinal}-001`,
+            workloadId: 'RTC-B06',
+            caseId: 'retention-100',
+            inputKey: 'e3-memory-retention-100',
+            intendedPhase: 'retained',
+            outerOrdinal: input.outerOrdinal,
+            innerOrdinal: 1
+        },
+        producerExitStatus: 0,
+        runtimeObservation,
+        rawEvidence: retentionRawEvidence(input)
+    });
+}
+
+describe('live RTC external-attempt evidence', () => {
+    it('loads one exact predeclared attempt from the controller environment', async () => {
+        const repoRoot = await mkdtemp(join(tmpdir(), 'rallar-rtc-b06-context-'));
+        temporaryDirectories.push(repoRoot);
+        const manifest = e3CaptureManifest();
+        const locator = e3DefaultLocator;
+        const baselineRoot = join(repoRoot, 'tmp', 'perf', 'rtc-baseline', baselineId);
+        await mkdir(baselineRoot, { recursive: true });
+        await writeFile(join(baselineRoot, 'manifest.json'), JSON.stringify(manifest));
+        await writeFile(join(baselineRoot, 'environment.json'), JSON.stringify({
+            schema: 'rallar.rtc-baseline.environment.v1',
+            baselineId,
+            workloadIds: ['RTC-B06'],
+            environmentId: 'E3-memory',
+            repeatLink: null,
+            conditionalEnvironmentDecisions: [],
+            observation: runtimeObservation
+        }));
+
+        const context = await loadLiveRtcPerformanceAttempt({
+            repoRoot,
+            environment: {
+                RALLAR_BLACK_BOX_RTC_BASELINE_ID: baselineId,
+                RALLAR_BLACK_BOX_RTC_CASE_ID: locator.caseId,
+                RALLAR_BLACK_BOX_RTC_INPUT_KEY: locator.inputKey,
+                RALLAR_BLACK_BOX_RTC_INTENDED_PHASE: locator.intendedPhase,
+                RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL: String(locator.outerOrdinal)
+            }
+        });
+
+        expect(context).toMatchObject({
+            repoRoot,
+            baselineId,
+            locator,
+            sampleIdentity: e3DefaultIdentity,
+            runtimeObservation
+        });
+        await expect(loadLiveRtcPerformanceAttempt({
+            repoRoot,
+            environment: {
+                RALLAR_BLACK_BOX_RTC_BASELINE_ID: baselineId
+            }
+        })).rejects.toThrow(/missing/i);
+        await expect(loadLiveRtcPerformanceAttempt({
+            repoRoot,
+            environment: {
+                RALLAR_BLACK_BOX_RTC_BASELINE_ID: baselineId,
+                RALLAR_BLACK_BOX_RTC_CASE_ID: locator.caseId,
+                RALLAR_BLACK_BOX_RTC_INPUT_KEY: locator.inputKey,
+                RALLAR_BLACK_BOX_RTC_INTENDED_PHASE: locator.intendedPhase,
+                RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL: '1x'
+            }
+        })).rejects.toThrow(/positive integer/i);
+        await expect(loadLiveRtcPerformanceAttempt({
+            repoRoot,
+            environment: {
+                RALLAR_BLACK_BOX_RTC_BASELINE_ID: '../outside',
+                RALLAR_BLACK_BOX_RTC_CASE_ID: locator.caseId,
+                RALLAR_BLACK_BOX_RTC_INPUT_KEY: locator.inputKey,
+                RALLAR_BLACK_BOX_RTC_INTENDED_PHASE: locator.intendedPhase,
+                RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL: String(locator.outerOrdinal)
+            }
+        })).rejects.toThrow(/canonical/i);
+        await expect(loadLiveRtcPerformanceAttempt({
+            repoRoot,
+            environment: {}
+        })).resolves.toBeNull();
+    });
+
+    it('preserves exact identity plus complete E3 default facts and timing samples', () => {
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence()
+        });
+
+        expect(attempt.schema).toBe('rallar.rtc-baseline.external-attempt.v1');
+        expect(attempt.locator).toEqual(e3DefaultLocator);
+        expect(attempt.producerFacts).toEqual({
+            databaseUrl: 'absent',
+            allScenariosPresent: false,
+            allScenariosRaw: null,
+            retentionSoakPresent: false,
+            retentionSoakRaw: null,
+            retentionCyclesPresent: false,
+            retentionCyclesRaw: null,
+            iceModePresent: false,
+            iceModeRaw: null
+        });
+        expect(attempt.samples).toHaveLength(1);
+        expect(attempt.samples[0]).toMatchObject({
+            identity: e3DefaultIdentity,
+            outcome: 'passed',
+            evidenceClass: 'local-full-stack',
+            runtimeObservation
+        });
+        expect(attempt.samples[0]?.rawEvidence).toEqual(defaultRawEvidence());
+        expect(attempt.samples[0]?.metrics).toEqual([
+            { metric: 'peer-ready.realtime', unit: 'milliseconds', value: 12 },
+            { metric: 'direct-delivery.realtime', unit: 'milliseconds', value: 4 },
+            { metric: 'multicast-delivery.realtime', unit: 'milliseconds', value: 5 },
+            { metric: 'broadcast-delivery.realtime', unit: 'milliseconds', value: 6 },
+            { metric: 'peer-ready.messages-rtc', unit: 'milliseconds', value: 13 },
+            { metric: 'direct-delivery.messages-rtc', unit: 'milliseconds', value: 7 },
+            { metric: 'multicast-delivery.messages-rtc', unit: 'milliseconds', value: 8 },
+            { metric: 'broadcast-delivery.messages-rtc', unit: 'milliseconds', value: 9 }
+        ]);
+    });
+
+    it('fails evidence when one transport timing series is incomplete', () => {
+        const rawEvidence = defaultRawEvidence();
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: {
+                ...rawEvidence,
+                timings: rawEvidence.timings.filter((timing) =>
+                    timing.kind !== 'direct-delivery' || timing.transport !== 'messages.rtc'
+                )
+            }
+        });
+
+        expect(attempt.samples[0]?.outcome).toBe('failed');
+        expect(attempt.samples[0]?.issues).toContainEqual({
+            path: '$.rawEvidence.timings',
+            code: 'missing-receiver-timing',
+            message: 'Receiver-observed direct-delivery timing is required for messages.rtc.'
+        });
+    });
+
+    it('fails evidence when a diagnostic checkpoint omits one browser agent', () => {
+        const rawEvidence = defaultRawEvidence();
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: {
+                ...rawEvidence,
+                diagnostics: rawEvidence.diagnostics.map((checkpoint) => ({
+                    ...checkpoint,
+                    agents: checkpoint.agents.slice(0, 2)
+                }))
+            }
+        });
+
+        expect(attempt.samples[0]?.issues).toContainEqual({
+            path: '$.rawEvidence.diagnostics',
+            code: 'incomplete-rtc-diagnostics',
+            message: 'Every RTC diagnostics checkpoint must contain three distinct browser agents.'
+        });
+    });
+
+    it('accepts DATABASE_URL presence in E3 without treating it as the active provider', () => {
+        const rawEvidence = defaultRawEvidence({
+            producer: {
+                ...defaultRawEvidence().producer,
+                databaseUrl: 'present'
+            }
+        });
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence
+        });
+
+        expect(attempt.producerFacts.databaseUrl).toBe('present');
+        expect(attempt.samples[0]?.outcome).toBe('passed');
+    });
+
+    it('fails retention evidence whose checkpoints repeat an agent identity', () => {
+        const rawEvidence = retentionRawEvidence({
+            outerOrdinal: 1,
+            cycle0HeapBytes: 100,
+            finalHeapBytes: 100
+        });
+        const duplicateAgentCheckpoints = rawEvidence.retention!.checkpoints.map(
+            (checkpoint) => ({
+                ...checkpoint,
+                agents: [
+                    checkpoint.agents[0]!,
+                    checkpoint.agents[0]!,
+                    checkpoint.agents[2]!
+                ]
+            })
+        );
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: {
+                workloadId: 'RTC-B06',
+                caseId: 'retention-100',
+                inputKey: 'e3-memory-retention-100',
+                intendedPhase: 'retained',
+                outerOrdinal: 1,
+                environmentId: 'E3-memory',
+                rawResultRelativePath:
+                    'artifacts/staging/rtc-b06-retention-100-e3-memory-retention-100-retained-001.json'
+            },
+            sampleIdentity: {
+                sampleId: 'rtc-b06-retention-100-e3-memory-retention-100-retained-001-001',
+                workloadId: 'RTC-B06',
+                caseId: 'retention-100',
+                inputKey: 'e3-memory-retention-100',
+                intendedPhase: 'retained',
+                outerOrdinal: 1,
+                innerOrdinal: 1
+            },
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: {
+                ...rawEvidence,
+                diagnostics: duplicateAgentCheckpoints.map((checkpoint) => ({
+                    label: `retention-cycle-${checkpoint.cycle}`,
+                    cycle: checkpoint.cycle,
+                    agents: checkpoint.agents
+                })),
+                retention: {
+                    ...rawEvidence.retention!,
+                    checkpoints: duplicateAgentCheckpoints
+                }
+            }
+        });
+
+        expect(attempt.samples[0]?.issues).toContainEqual({
+            path: '$.rawEvidence.retention.checkpoints',
+            code: 'invalid-retention-checkpoints',
+            message: 'Retention requires cycle 0 and every tenth cycle through 100 with three distinct agents and post-GC facts.'
+        });
+    });
+
+    it('binds E4 all-scenarios facts and requires reconnect evidence', () => {
+        const rawEvidence = defaultRawEvidence({
+            identity: {
+                workloadId: 'RTC-B06',
+                caseId: 'all-scenarios',
+                inputKey: 'e4-pg-all-scenarios',
+                intendedPhase: 'warmup',
+                outerOrdinal: 1,
+                environmentId: 'E4-pg'
+            },
+            producer: {
+                ...defaultRawEvidence().producer,
+                databaseProvider: 'postgres',
+                databaseUrl: 'present',
+                iceMode: 'local',
+                allScenariosRaw: '1',
+                iceModeRaw: 'local'
+            },
+            timings: [
+                ...defaultRawEvidence().timings,
+                {
+                    kind: 'reconnect-ready',
+                    transport: 'messages.rtc',
+                    senderAgentId: 'agent-b',
+                    receiverAgentIds: ['agent-c'],
+                    durationMs: 18
+                }
+            ],
+            assertions: {
+                ...defaultRawEvidence().assertions,
+                reconnectPassed: true
+            }
+        });
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: {
+                workloadId: 'RTC-B06',
+                caseId: 'all-scenarios',
+                inputKey: 'e4-pg-all-scenarios',
+                intendedPhase: 'warmup',
+                outerOrdinal: 1,
+                environmentId: 'E4-pg',
+                rawResultRelativePath:
+                    'artifacts/staging/rtc-b06-all-scenarios-e4-pg-all-scenarios-warmup-001.json'
+            },
+            sampleIdentity: {
+                sampleId: 'rtc-b06-all-scenarios-e4-pg-all-scenarios-warmup-001-001',
+                workloadId: 'RTC-B06',
+                caseId: 'all-scenarios',
+                inputKey: 'e4-pg-all-scenarios',
+                intendedPhase: 'warmup',
+                outerOrdinal: 1,
+                innerOrdinal: 1
+            },
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence
+        });
+
+        expect(attempt.producerFacts).toEqual({
+            databaseUrl: 'present',
+            allScenariosPresent: true,
+            allScenariosRaw: '1',
+            retentionSoakPresent: false,
+            retentionSoakRaw: null,
+            retentionCyclesPresent: false,
+            retentionCyclesRaw: null,
+            iceModePresent: true,
+            iceModeRaw: 'local'
+        });
+        expect(attempt.samples[0]?.metrics).toContainEqual({
+            metric: 'reconnect-ready.messages-rtc',
+            unit: 'milliseconds',
+            value: 18
+        });
+        expect(attempt.samples[0]?.outcome).toBe('passed');
+    });
+
+    it('lets a nonzero producer status override valid-looking matrix evidence', () => {
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 7,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence()
+        });
+
+        expect(attempt.sampleOutcomes[0]?.outcome).toBe('failed');
+        expect(attempt.sampleOutcomes[0]?.issues[0]).toEqual({
+            path: '$.producerExitStatus',
+            code: 'producer-failed',
+            message: 'The live RTC producer exited with status 7.'
+        });
+    });
+
+    it('rejects locator, raw identity, sample identity, and runtime mismatches', () => {
+        expect(() => buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: {
+                ...e3DefaultIdentity,
+                outerOrdinal: 2
+            },
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence()
+        })).toThrow(/sample identity/i);
+
+        expect(() => buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence({
+                identity: {
+                    ...defaultRawEvidence().identity,
+                    environmentId: 'E4-pg'
+                }
+            })
+        })).toThrow(/raw evidence identity/i);
+
+        expect(() => buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence({
+                runtime: {
+                    ...defaultRawEvidence().runtime,
+                    chromium: 'different-browser'
+                }
+            })
+        })).toThrow(/runtime facts/i);
+    });
+});
+
+describe('live RTC retention cohort evidence', () => {
+    it('detects state drift at an intermediate settled checkpoint', () => {
+        const retention = retentionRawEvidence({
+            outerOrdinal: 1,
+            cycle0HeapBytes: 100,
+            finalHeapBytes: 100
+        }).retention!;
+        const checkpoints = retention.checkpoints.map((checkpoint) =>
+            checkpoint.cycle === 50
+                ? {
+                    ...checkpoint,
+                    agents: checkpoint.agents.map((agent) =>
+                        agent.agentId === 'agent-c'
+                            ? { ...agent, connectionTimerActive: true }
+                            : agent
+                    )
+                }
+                : checkpoint
+        );
+
+        expect(liveRtcRetentionStateReturned(checkpoints)).toBe(false);
+    });
+
+    it('uses exact retained membership and applies the primary two-of-three heap rule', () => {
+        const attempts = [
+            retentionAttempt({
+                outerOrdinal: 1,
+                cycle0HeapBytes: 100 * 1024 * 1024,
+                finalHeapBytes: 117 * 1024 * 1024
+            }),
+            retentionAttempt({
+                outerOrdinal: 2,
+                cycle0HeapBytes: 100 * 1024 * 1024,
+                finalHeapBytes: 116 * 1024 * 1024
+            }),
+            retentionAttempt({
+                outerOrdinal: 3,
+                cycle0HeapBytes: 100 * 1024 * 1024,
+                finalHeapBytes: 104 * 1024 * 1024
+            })
+        ];
+        const memberSampleIds = attempts.map(
+            (attempt) => attempt.samples[0]!.identity.sampleId
+        );
+        const cohort = buildLiveRtcRetentionCohort({
+            identity: {
+                cohortId: 'rtc-b06-e3-memory-retention',
+                workloadId: 'RTC-B06',
+                memberSampleIds
+            },
+            attempts
+        });
+
+        expect(cohort.schema).toBe('rallar.rtc-baseline.external-cohort.v1');
+        expect(cohort.identity.memberSampleIds).toEqual(memberSampleIds);
+        expect(cohort.outcome).toBe('failed');
+        expect(cohort.rawEvidence).toEqual({
+            retainedAttemptCount: 3,
+            requiredHeapBreachCount: 2,
+            heapBreachingSampleIds: memberSampleIds.slice(0, 2),
+            stateDriftSampleIds: [],
+            failedMemberSampleIds: []
+        });
+    });
+
+    it('fails immediately for settled peer, lane, or timer drift', () => {
+        const attempts = [
+            retentionAttempt({
+                outerOrdinal: 1,
+                cycle0HeapBytes: 100,
+                finalHeapBytes: 100,
+                stateReturned: false
+            }),
+            retentionAttempt({ outerOrdinal: 2, cycle0HeapBytes: 100, finalHeapBytes: 100 }),
+            retentionAttempt({ outerOrdinal: 3, cycle0HeapBytes: 100, finalHeapBytes: 100 })
+        ];
+        const memberSampleIds = attempts.map(
+            (attempt) => attempt.samples[0]!.identity.sampleId
+        );
+        const cohort = buildLiveRtcRetentionCohort({
+            identity: {
+                cohortId: 'rtc-b06-e3-memory-retention',
+                workloadId: 'RTC-B06',
+                memberSampleIds
+            },
+            attempts
+        });
+
+        expect(cohort.outcome).toBe('failed');
+        expect(cohort.rawEvidence).toMatchObject({
+            heapBreachingSampleIds: [],
+            stateDriftSampleIds: [memberSampleIds[0]],
+            failedMemberSampleIds: [memberSampleIds[0]]
+        });
+    });
+
+    it('uses four-of-six heap breaches for a doubled repeat cohort', () => {
+        const attempts = Array.from({ length: 6 }, (_, index) =>
+            retentionAttempt({
+                outerOrdinal: index + 1,
+                cycle0HeapBytes: 100 * 1024 * 1024,
+                finalHeapBytes: (index < 3 ? 116 : 104) * 1024 * 1024
+            })
+        );
+        const memberSampleIds = attempts.map(
+            (attempt) => attempt.samples[0]!.identity.sampleId
+        );
+        const cohort = buildLiveRtcRetentionCohort({
+            identity: {
+                cohortId: 'rtc-b06-e3-memory-retention',
+                workloadId: 'RTC-B06',
+                memberSampleIds
+            },
+            attempts
+        });
+
+        expect(cohort.outcome).toBe('passed');
+        expect(cohort.rawEvidence).toMatchObject({
+            retainedAttemptCount: 6,
+            requiredHeapBreachCount: 4,
+            heapBreachingSampleIds: memberSampleIds.slice(0, 3)
+        });
+    });
+
+    it('writes the predeclared cohort only after the final retained attempt is staged', async () => {
+        const repoRoot = await mkdtemp(join(tmpdir(), 'rallar-rtc-b06-cohort-'));
+        temporaryDirectories.push(repoRoot);
+        const manifest = e3CaptureManifest();
+        const baselineRoot = join(repoRoot, 'tmp', 'perf', 'rtc-baseline', baselineId);
+        await mkdir(baselineRoot, { recursive: true });
+        await writeFile(join(baselineRoot, 'manifest.json'), JSON.stringify(manifest));
+        const locators = manifest.outerAttempts.filter(
+            (attempt) =>
+                attempt.caseId === 'retention-100' &&
+                attempt.intendedPhase === 'retained'
+        ).map(externalLocator);
+        const attempts = locators.map((locator) => retentionAttempt({
+            outerOrdinal: locator.outerOrdinal,
+            cycle0HeapBytes: 100 * 1024 * 1024,
+            finalHeapBytes: 104 * 1024 * 1024
+        }));
+        const context = (index: number): LiveRtcPerformanceAttemptContext => ({
+            repoRoot,
+            baselineId,
+            locator: {
+                ...locators[index]!,
+                workloadId: 'RTC-B06',
+                caseId: 'retention-100',
+                inputKey: 'e3-memory-retention-100',
+                intendedPhase: 'retained',
+                environmentId: 'E3-memory'
+            },
+            sampleIdentity: attempts[index]!.samples[0]!.identity,
+            runtimeObservation
+        });
+        for (const attempt of attempts.slice(0, 2)) {
+            await writeLiveRtcPerformanceEvidence({
+                repoRoot,
+                baselineId,
+                relativePath: attempt.locator.rawResultRelativePath,
+                evidence: attempt
+            });
+        }
+
+        await expect(writeLiveRtcRetentionCohortIfComplete(context(1))).resolves.toBeNull();
+        await writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: attempts[2]!.locator.rawResultRelativePath,
+            evidence: attempts[2]!
+        });
+        const cohortPath = await writeLiveRtcRetentionCohortIfComplete(context(2));
+        const cohort = JSON.parse(await readFile(cohortPath!, 'utf8'));
+
+        expect(cohortPath).toBe(join(
+            await realpath(repoRoot),
+            'tmp',
+            'perf',
+            'rtc-baseline',
+            baselineId,
+            'artifacts',
+            'staging',
+            'rtc-b06-e3-memory-retention.json'
+        ));
+        expect(cohort.schema).toBe('rallar.rtc-baseline.external-cohort.v1');
+        expect(cohort).toMatchObject({
+            identity: manifest.expectedCohorts[0],
+            outcome: 'passed',
+            rawEvidence: {
+                retainedAttemptCount: 3,
+                requiredHeapBreachCount: 2
+            }
+        });
+    });
+});
+
+describe('live RTC diagnostic normalization', () => {
+    it('sorts stable state and distinguishes absent timers from active timers', () => {
+        const stable = buildLiveRtcAgentDiagnostics('agent-a', {
+            rallar: {
+                rtcStatus: {
+                    activePeerIds: ['peer-c', 'peer-b'],
+                    readyPeerIds: ['peer-c', 'peer-b']
+                },
+                rtcDiagnostics: {
+                    sessionId: 'session-a',
+                    generatedAtEpochMs: 10,
+                    peerCount: 2,
+                    connectedPeerCount: 2,
+                    relayPeerCount: 0,
+                    peers: [
+                        {
+                            peerId: 'peer-c',
+                            connection: {
+                                disconnectPending: false,
+                                reconnecting: false
+                            },
+                            lanes: [{
+                                peerId: 'peer-c',
+                                laneId: 'realtime',
+                                isOpen: true,
+                                isReconnectable: true
+                            }]
+                        },
+                        {
+                            peerId: 'peer-b',
+                            connection: {
+                                disconnectPending: false,
+                                reconnecting: false
+                            },
+                            connectionDiagnostics: {
+                                reconnectAttemptsInFlight: 0,
+                                hasReconnectTimer: false
+                            },
+                            lanes: [{
+                                peerId: 'peer-b',
+                                laneId: 'messages.rtc',
+                                isOpen: true,
+                                isReconnectable: true
+                            }]
+                        }
+                    ]
+                }
+            }
+        });
+        const activeTimer = buildLiveRtcAgentDiagnostics('agent-a', {
+            rallar: {
+                rtcStatus: {
+                    activePeerIds: ['peer-b'],
+                    readyPeerIds: ['peer-b']
+                },
+                rtcDiagnostics: {
+                    sessionId: 'session-a',
+                    generatedAtEpochMs: 11,
+                    peerCount: 1,
+                    connectedPeerCount: 1,
+                    relayPeerCount: 0,
+                    peers: [{
+                        peerId: 'peer-b',
+                        connection: {
+                            disconnectPending: false,
+                            reconnecting: false
+                        },
+                        connectionDiagnostics: {
+                            reconnectAttemptsInFlight: 1,
+                            hasReconnectTimer: true
+                        },
+                        lanes: []
+                    }]
+                }
+            }
+        });
+
+        expect(stable).toMatchObject({
+            settledPeerIds: ['peer-b', 'peer-c'],
+            readyPeerIds: ['peer-b', 'peer-c'],
+            laneStates: [
+                expect.objectContaining({ peerId: 'peer-b' }),
+                expect.objectContaining({ peerId: 'peer-c' })
+            ],
+            connectionTimerActive: false
+        });
+        expect(activeTimer.connectionTimerActive).toBe(true);
+    });
+
+    it('counts delivery to a receiver outside the scenario allowlist', () => {
+        const scenario = {
+            matrixId: 'direct-a-to-b',
+            transport: 'realtime' as const,
+            deliveryMode: 'direct' as const,
+            senderAgentId: 'agent-a',
+            expectedAgentIds: ['agent-b'],
+            allowedAgentIds: ['agent-b']
+        };
+        const event = (agentId: string) => ({
+            agentId,
+            payload: {
+                kind: 'message',
+                transport: 'realtime',
+                payload: {
+                    data: {
+                        matrixId: scenario.matrixId,
+                        deliveryMode: scenario.deliveryMode
+                    }
+                }
+            }
+        });
+
+        expect(countUnexpectedLiveRtcDeliveries({
+            events: [event('agent-b'), event('agent-c')],
+            scenarios: [scenario]
+        })).toBe(1);
+    });
+});
+
+describe('live RTC staged evidence writer', () => {
+    it('creates one confined file and refuses overwrite or traversal', async () => {
+        const repoRoot = await mkdtemp(join(tmpdir(), 'rallar-rtc-b06-'));
+        temporaryDirectories.push(repoRoot);
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence()
+        });
+
+        const absolutePath = await writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: e3DefaultLocator.rawResultRelativePath,
+            evidence: attempt
+        });
+
+        expect(JSON.parse(await readFile(absolutePath, 'utf8'))).toEqual(attempt);
+        await expect(writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: e3DefaultLocator.rawResultRelativePath,
+            evidence: attempt
+        })).rejects.toMatchObject({ code: 'EEXIST' });
+        await expect(writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: '../escaped.json',
+            evidence: attempt
+        })).rejects.toThrow(/confined/i);
+        await expect(writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: 'artifacts/staging/../escaped.json',
+            evidence: attempt
+        })).rejects.toThrow(/confined/i);
+    });
+
+    it('rejects a symlinked staging directory', async () => {
+        const repoRoot = await mkdtemp(join(tmpdir(), 'rallar-rtc-b06-symlink-'));
+        temporaryDirectories.push(repoRoot);
+        const baselineRoot = join(repoRoot, 'tmp', 'perf', 'rtc-baseline', baselineId);
+        const outside = join(repoRoot, 'outside');
+        await mkdir(join(baselineRoot, 'artifacts'), { recursive: true });
+        await mkdir(outside);
+        await symlink(outside, join(baselineRoot, 'artifacts', 'staging'));
+        const attempt = buildLiveRtcExternalAttempt({
+            locator: e3DefaultLocator,
+            sampleIdentity: e3DefaultIdentity,
+            producerExitStatus: 0,
+            runtimeObservation,
+            rawEvidence: defaultRawEvidence()
+        });
+
+        await expect(writeLiveRtcPerformanceEvidence({
+            repoRoot,
+            baselineId,
+            relativePath: e3DefaultLocator.rawResultRelativePath,
+            evidence: attempt
+        })).rejects.toThrow(/unsafe/i);
+    });
+});

--- a/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
@@ -10,6 +10,8 @@ const repoRoot = process.cwd();
 const packageJson = JSON.parse(
     fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
 ) as PackageManifest;
+const liveMatrixSpec =
+    'tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts';
 
 const REQUIRED_LIVE_RTC_GATE_ENV = [
     'RALLAR_BLACK_BOX_FULL_STACK=1',
@@ -52,5 +54,64 @@ describe('live three-browser RTC npm script gates', () => {
         for (const requiredEnv of REQUIRED_LIVE_RTC_GATE_ENV) {
             expect(script).toContain(requiredEnv);
         }
+        expect(script).toContain(liveMatrixSpec);
+    });
+
+    it('keeps exhaustive and retention selectors owned by the invoking attempt', () => {
+        const memory = packageJson.scripts?.[
+            'test:rallar:full-stack:memory:live-rtc-3'
+        ] ?? '';
+        const postgres = packageJson.scripts?.[
+            'test:rallar:full-stack:postgres:live-rtc-3'
+        ] ?? '';
+        const postgresAll = packageJson.scripts?.[
+            'test:rallar:full-stack:postgres:live-rtc-3:all'
+        ] ?? '';
+
+        expect(memory).not.toContain('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=');
+        expect(postgres).not.toContain('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=');
+        expect(postgresAll).toContain('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=1');
+        expect(memory).not.toContain('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=');
+        expect(postgres).not.toContain('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=');
+    });
+
+    it('keeps benchmark ownership out of application and reusable product sources', () => {
+        const productRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
+        const forbiddenImports: string[] = [];
+
+        for (const root of productRoots) {
+            for (const file of sourceFiles(root)) {
+                if (
+                    file.includes(`${path.sep}shared-rtc-bench${path.sep}`) ||
+                    file.includes(`${path.sep}tests${path.sep}`)
+                ) {
+                    continue;
+                }
+                const source = fs.readFileSync(file, 'utf8');
+                if (
+                    /(?:from|import\s*\(|require\s*\()\s*['"][^'"]*shared-rtc-bench/.test(
+                        source
+                    )
+                ) {
+                    forbiddenImports.push(path.relative(repoRoot, file));
+                }
+            }
+        }
+
+        expect(forbiddenImports).toEqual([]);
     });
 });
+
+function sourceFiles(root: string): string[] {
+    const files: string[] = [];
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+        const absolutePath = path.join(root, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...sourceFiles(absolutePath));
+        }
+        else if (entry.isFile() && /\.(?:c|m)?(?:j|t)sx?$/.test(entry.name)) {
+            files.push(absolutePath);
+        }
+    }
+    return files;
+}

--- a/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
@@ -75,6 +75,13 @@ describe('live three-browser RTC npm script gates', () => {
         expect(postgres).not.toContain('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=');
     });
 
+    it('uses cryptographically secure live run and session identities', () => {
+        const source = fs.readFileSync(path.join(repoRoot, liveMatrixSpec), 'utf8');
+
+        expect(source).not.toContain('Math.random()');
+        expect(source).toContain('crypto.randomUUID()');
+    });
+
     it('keeps benchmark ownership out of application and reusable product sources', () => {
         const productRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
         const forbiddenImports: string[] = [];

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -1351,7 +1351,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 )
             });
 
-            const suffix = `live3-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const suffix = `live3-${Date.now()}-${crypto.randomUUID()}`;
             const runId = `rallar-live-three-browser-${suffix}`;
             const groupId = `${roomSeed}-${suffix}`;
             const allHandles: LiveRtcControlClient.Agent[] = [];
@@ -1602,7 +1602,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             baseUrl: CONTROL_BASE_URL,
             diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
         });
-        const suffix = `live3-all-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const suffix = `live3-all-${Date.now()}-${crypto.randomUUID()}`;
         const runId = `rallar-live-three-browser-all-${suffix}`;
         const groupId = `${roomSeed}-${suffix}`;
         const allHandles: LiveRtcControlClient.Agent[] = [];
@@ -1914,7 +1914,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             baseUrl: CONTROL_BASE_URL,
             diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
         });
-        const suffix = `live3-retention-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const suffix = `live3-retention-${Date.now()}-${crypto.randomUUID()}`;
         const runId = `rallar-live-three-browser-retention-${suffix}`;
         const groupId = `${roomSeed}-${suffix}`;
         const commandIds: string[] = [];

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -1,15 +1,25 @@
 import {
     expect,
     test,
-    type APIRequestContext,
     type Browser,
     type BrowserContext,
-    type Page,
-    type TestInfo
+    type Page
 } from '@playwright/test';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { openTab } from './full-stack-helpers.ts';
+import {
+    buildLiveRtcExternalAttempt,
+    captureLiveRtcPostGcHeap,
+    LiveRtcControlClient,
+    liveRtcRetentionStateReturned,
+    loadLiveRtcPerformanceAttempt,
+    writeLiveRtcPerformanceEvidence,
+    writeLiveRtcRetentionCohortIfComplete,
+    type LiveRtcDiagnosticsCheckpoint,
+    type LiveRtcPerformanceAttemptContext,
+    type LiveRtcPerformanceRawEvidence,
+    type LiveRtcPerformanceTiming,
+    type LiveRtcRetentionCheckpoint
+} from './live-rtc-performance-evidence.ts';
 
 const SPA_BASE_URL = envValue('VITE_RALLAR_SPA_BASE_URL') ??
     'http://localhost:5176';
@@ -39,46 +49,6 @@ type AgentAuth =
         session: RestoredSession;
     }>;
 
-type AgentHandle = Readonly<{
-    context: BrowserContext;
-    page: Page;
-    prefix: AgentPrefix;
-    agentId: string;
-    actor: string;
-    connection: string;
-}>;
-
-type ControlResult = Readonly<{
-    agentId?: string;
-    commandId?: string;
-    ok?: boolean;
-    result?: Readonly<{
-        value?: unknown;
-    }>;
-    error?: unknown;
-}>;
-
-type ControlEvent = Readonly<{
-    kind?: string;
-    agentId?: string;
-    payload?: unknown;
-}>;
-
-type ControlRunSnapshot = Readonly<{
-    agents?: readonly Readonly<{ agentId?: string; }>[];
-    results?: readonly ControlResult[];
-    events?: readonly ControlEvent[];
-}>;
-
-type DeliveryScenarioRecord = Readonly<{
-    matrixId: string;
-    transport: TransportUnderTest;
-    deliveryMode: DeliveryMode;
-    senderAgentId: string;
-    expectedAgentIds: readonly string[];
-    allowedAgentIds: readonly string[];
-}>;
-
 const apiBaseUrl = envValue('VITE_RALLAR_API_BASE_URL');
 const roomSeed = firstEnvValue('VITE_RALLAR_ROOM_ID', 'VITE_RALLAR_GROUP_ID');
 const applicationId = envValue('VITE_RALLAR_APPLICATION_ID') ?? 'ar-eye-hunter';
@@ -96,6 +66,9 @@ const liveMatrixEnabled = booleanEnv('RALLAR_BLACK_BOX_LIVE_RTC_MATRIX');
 const liveAllScenariosEnabled = booleanEnv(
     'RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS'
 );
+const liveRetentionSoakEnabled = booleanEnv(
+    'RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK'
+);
 const agentAAuth = resolveAgentAuth('A');
 const agentBAuth = resolveAgentAuth('B');
 const agentCAuth = resolveAgentAuth('C');
@@ -112,6 +85,10 @@ const hasThreeAgentConfig = Boolean(
 function envValue(key: string): string | undefined {
     const value = process.env[key]?.trim();
     return value && value.length > 0 ? value : undefined;
+}
+
+function rawEnvironmentValue(key: string): string | null {
+    return process.env[key] ?? null;
 }
 
 function firstEnvValue(...keys: readonly string[]): string | undefined {
@@ -192,36 +169,12 @@ function resolveAgentAuth(prefix: AgentPrefix): AgentAuth | undefined {
     };
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-    return value && typeof value === 'object' && !Array.isArray(value)
-        ? value as Record<string, unknown>
-        : {};
-}
-
-function stringValue(value: unknown): string | undefined {
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function numberValue(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function stringArrayValue(value: unknown): readonly string[] {
-    return Array.isArray(value)
-        ? value.filter((entry): entry is string => typeof entry === 'string')
-        : [];
-}
-
 function pathSegment(value: string): string {
     return encodeURIComponent(value);
 }
 
 function transportSlug(transport: TransportUnderTest): string {
     return transport.replace('.', '-');
-}
-
-function safeFileName(value: string): string {
-    return value.replace(/[^a-zA-Z0-9_.-]+/g, '-');
 }
 
 function agentAuth(prefix: AgentPrefix): AgentAuth {
@@ -251,166 +204,9 @@ function actorFor(prefix: AgentPrefix, suffix: string): string {
     ) ?? `agent-${prefix.toLowerCase()}-${suffix}`;
 }
 
-async function fetchRun(
-    request: APIRequestContext,
-    runId: string
-): Promise<ControlRunSnapshot> {
-    const response = await request.get(
-        `${CONTROL_BASE_URL}/runs/${encodeURIComponent(runId)}`
-    );
-    expect(response.ok()).toBe(true);
-    return await response.json() as ControlRunSnapshot;
-}
-
-async function enqueueCommand(
-    request: APIRequestContext,
-    runId: string,
-    agentId: string,
-    commandId: string,
-    command: unknown
-): Promise<void> {
-    const response = await request.post(
-        `${CONTROL_BASE_URL}/runs/${encodeURIComponent(runId)}/agents/${encodeURIComponent(agentId)}/commands`,
-        {
-            data: {
-                commandId,
-                command
-            }
-        }
-    );
-    expect(
-        response.status(),
-        `Expected command ${commandId} for agent ${agentId} to enqueue: ${await response.text()}`
-    ).toBe(202);
-}
-
-async function waitForCommandResult(
-    request: APIRequestContext,
-    runId: string,
-    commandId: string,
-    timeout = 45_000
-): Promise<ControlResult> {
-    let latest: ControlResult | undefined;
-    await expect.poll(async () => {
-        const run = await fetchRun(request, runId);
-        latest = run.results?.find((result) => result.commandId === commandId);
-        return Boolean(latest);
-    }, {
-        timeout
-    }).toBe(true);
-
-    if (!latest) {
-        throw new Error(`Command ${commandId} did not return a result.`);
-    }
-    return latest;
-}
-
-async function executeResult(
-    request: APIRequestContext,
-    runId: string,
-    agentId: string,
-    commandId: string,
-    command: unknown,
-    timeout?: number
-): Promise<ControlResult> {
-    await enqueueCommand(request, runId, agentId, commandId, command);
-    return await waitForCommandResult(request, runId, commandId, timeout);
-}
-
-async function executeOk(
-    request: APIRequestContext,
-    runId: string,
-    agentId: string,
-    commandId: string,
-    command: unknown,
-    timeout?: number
-): Promise<ControlResult> {
-    const result = await executeResult(
-        request,
-        runId,
-        agentId,
-        commandId,
-        command,
-        timeout
-    );
-    expect(
-        result.ok,
-        `Expected command ${commandId} for agent ${agentId} to succeed: ${JSON.stringify(result)}`
-    ).toBe(true);
-    return result;
-}
-
-function resultValue(result: ControlResult): Record<string, unknown> {
-    return asRecord(result.result?.value);
-}
-
-function requireSessionId(result: ControlResult, commandId: string): string {
-    const sessionId = stringValue(resultValue(result).sessionId);
-    if (!sessionId) {
-        throw new Error(`Connect result ${commandId} did not include a sessionId.`);
-    }
-    return sessionId;
-}
-
-function eventPayload(event: ControlEvent): Record<string, unknown> {
-    return asRecord(event.payload);
-}
-
-function runtimeEventPayload(event: ControlEvent): Record<string, unknown> {
-    const payload = eventPayload(event);
-    if (typeof payload.kind === 'string') {
-        return payload;
-    }
-
-    return asRecord(payload.payload ?? payload);
-}
-
-function messageData(event: ControlEvent): Record<string, unknown> {
-    const runtimeEvent = runtimeEventPayload(event);
-    const runtimePayload = asRecord(runtimeEvent.payload);
-    return asRecord(runtimePayload.data ?? runtimeEvent.data);
-}
-
-function isMessageFor(
-    event: ControlEvent,
-    input: Readonly<{
-        agentId: string;
-        transport: TransportUnderTest;
-        matrixId: string;
-        deliveryMode: string;
-    }>
-): boolean {
-    const runtimeEvent = runtimeEventPayload(event);
-    const data = messageData(event);
-    return event.agentId === input.agentId &&
-        runtimeEvent.kind === 'message' &&
-        runtimeEvent.transport === input.transport &&
-        data.matrixId === input.matrixId &&
-        data.deliveryMode === input.deliveryMode;
-}
-
-async function waitForMessage(
-    request: APIRequestContext,
-    runId: string,
-    input: Readonly<{
-        agentId: string;
-        transport: TransportUnderTest;
-        matrixId: string;
-        deliveryMode: string;
-    }>
-): Promise<void> {
-    await expect.poll(async () => {
-        const run = await fetchRun(request, runId);
-        return run.events?.some((event) => isMessageFor(event, input)) ?? false;
-    }, {
-        message: `Expected ${input.agentId} to receive ${input.transport} ${input.deliveryMode} ${input.matrixId}`,
-        timeout: 60_000
-    }).toBe(true);
-}
-
 function rallarConnectConfig(
     transport: TransportUnderTest
-): Record<string, unknown> {
+): object {
     return {
         apiBaseUrl,
         restoreSession: true,
@@ -425,29 +221,33 @@ function rallarConnectConfig(
     };
 }
 
-function sendPayload(
-    transport: TransportUnderTest,
-    groupId: string,
-    targetSessionIds: readonly string[] | undefined,
-    payload: Record<string, unknown>,
-    minSnapshotVersion?: number
-): Record<string, unknown> {
-    if (transport === 'messages.rtc') {
+function sendPayload(input: Readonly<{
+    transport: TransportUnderTest;
+    groupId: string;
+    targetSessionIds?: readonly string[];
+    payload: object;
+    minSnapshotVersion?: number;
+}>): object {
+    if (input.transport === 'messages.rtc') {
         return {
-            roomId: groupId,
-            ...(targetSessionIds ? { nextHopPeerIds: targetSessionIds } : {}),
+            roomId: input.groupId,
+            ...(input.targetSessionIds
+                ? { nextHopPeerIds: input.targetSessionIds }
+                : {}),
             typeId: messagesRtcTypeId,
             topicId: messagesRtcTopicId,
-            ...(minSnapshotVersion !== undefined ? { minSnapshotVersion } : {}),
-            payload
+            ...(input.minSnapshotVersion !== undefined
+                ? { minSnapshotVersion: input.minSnapshotVersion }
+                : {}),
+            payload: input.payload
         };
     }
 
     return {
-        roomId: groupId,
-        ...(targetSessionIds ? { peerIds: targetSessionIds } : {}),
+        roomId: input.groupId,
+        ...(input.targetSessionIds ? { peerIds: input.targetSessionIds } : {}),
         openTimeoutMs: 20_000,
-        data: payload
+        data: input.payload
     };
 }
 
@@ -462,7 +262,7 @@ async function openAgent(
         connection: string;
         groupId: string;
     }>
-): Promise<AgentHandle> {
+): Promise<LiveRtcControlClient.Agent> {
     const context = await browser.newContext();
     const page = await context.newPage();
 
@@ -527,8 +327,14 @@ async function openAgentTrio(
         suffix: string;
         label: string;
     }>
-): Promise<readonly [AgentHandle, AgentHandle, AgentHandle]> {
-    const handles: AgentHandle[] = [];
+): Promise<
+    readonly [
+        LiveRtcControlClient.Agent,
+        LiveRtcControlClient.Agent,
+        LiveRtcControlClient.Agent
+    ]
+> {
+    const handles: LiveRtcControlClient.Agent[] = [];
     for (const prefix of ['A', 'B', 'C'] as const) {
         const agentName = `${input.label}-${prefix.toLowerCase()}-${input.suffix}`;
         handles.push(
@@ -544,11 +350,15 @@ async function openAgentTrio(
         );
     }
 
-    return handles as [AgentHandle, AgentHandle, AgentHandle];
+    return handles as [
+        LiveRtcControlClient.Agent,
+        LiveRtcControlClient.Agent,
+        LiveRtcControlClient.Agent
+    ];
 }
 
 async function closeAgentContexts(
-    agents: readonly AgentHandle[]
+    agents: readonly LiveRtcControlClient.Agent[]
 ): Promise<void> {
     await Promise.all(
         agents.map((agent) => agent.context.close().catch(() => undefined))
@@ -556,11 +366,11 @@ async function closeAgentContexts(
 }
 
 async function setupGroupMembership(
-    request: APIRequestContext,
-    runId: string,
     input: Readonly<{
-        owner: AgentHandle;
-        members: readonly AgentHandle[];
+        control: LiveRtcControlClient;
+        runId: string;
+        owner: LiveRtcControlClient.Agent;
+        members: readonly LiveRtcControlClient.Agent[];
         groupId: string;
         suffix: string;
     }>
@@ -569,49 +379,59 @@ async function setupGroupMembership(
     const createCommandId = `group-create-${input.suffix}`;
     const joinCommandIds: string[] = [];
 
-    await executeOk(request, runId, input.owner.agentId, createCommandId, {
-        kind: 'http.request',
-        request: {
-            path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${pathSegment(workspaceId)}/groups`,
-            method: 'POST',
-            body: {
-                groupId: input.groupId,
-                displayName: input.groupId,
-                description: 'Created by rallar-black-box live three-browser matrix',
-                kind: 'room',
-                joinMode: 'open',
-                createdByPrincipalId: '{auth.clientId}',
-                metadata: {
-                    source: 'rallar-black-box',
-                    matrix: 'live-three-browser',
-                    suffix: input.suffix
-                }
-            }
-        },
-        response: {
-            body: 'json'
-        },
-        timeoutMs: 10_000
-    });
-
-    for (const member of input.members) {
-        const commandId = `group-join-${member.agentId}-${input.suffix}`;
-        joinCommandIds.push(commandId);
-        await executeOk(request, runId, member.agentId, commandId, {
+    await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.owner.agentId,
+        commandId: createCommandId,
+        command: {
             kind: 'http.request',
             request: {
-                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
-                    pathSegment(workspaceId)
-                }/groups/${groupSegment}/members/{auth.clientId}`,
-                method: 'PUT',
+                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${pathSegment(workspaceId)}/groups`,
+                method: 'POST',
                 body: {
-                    status: 'active'
+                    groupId: input.groupId,
+                    displayName: input.groupId,
+                    description: 'Created by rallar-black-box live three-browser matrix',
+                    kind: 'room',
+                    joinMode: 'open',
+                    createdByPrincipalId: '{auth.clientId}',
+                    metadata: {
+                        source: 'rallar-black-box',
+                        matrix: 'live-three-browser',
+                        suffix: input.suffix
+                    }
                 }
             },
             response: {
                 body: 'json'
             },
             timeoutMs: 10_000
+        },
+    });
+
+    for (const member of input.members) {
+        const commandId = `group-join-${member.agentId}-${input.suffix}`;
+        joinCommandIds.push(commandId);
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: member.agentId,
+            commandId,
+            command: {
+                kind: 'http.request',
+                request: {
+                    path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
+                        pathSegment(workspaceId)
+                    }/groups/${groupSegment}/members/{auth.clientId}`,
+                    method: 'PUT',
+                    body: {
+                        status: 'active'
+                    }
+                },
+                response: {
+                    body: 'json'
+                },
+                timeoutMs: 10_000
+            }
         });
     }
 
@@ -619,10 +439,10 @@ async function setupGroupMembership(
 }
 
 async function verifyGroupStateReadback(
-    request: APIRequestContext,
-    runId: string,
-    owner: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        owner: LiveRtcControlClient.Agent;
         groupId: string;
         suffix: string;
     }>
@@ -630,12 +450,11 @@ async function verifyGroupStateReadback(
     const groupSegment = pathSegment(input.groupId);
     const readCommandId = `group-read-${input.suffix}`;
     const eventsCommandId = `group-events-${input.suffix}`;
-    const readResult = await executeOk(
-        request,
-        runId,
-        owner.agentId,
-        readCommandId,
-        {
+    const readResult = await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.owner.agentId,
+        commandId: readCommandId,
+        command: {
             kind: 'http.request',
             request: {
                 path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
@@ -648,15 +467,14 @@ async function verifyGroupStateReadback(
             },
             timeoutMs: 10_000
         }
-    );
-    expect(resultValue(readResult).status).toBe(200);
+    });
+    expect(input.control.resultValue(readResult).status).toBe(200);
 
-    const eventsResult = await executeOk(
-        request,
-        runId,
-        owner.agentId,
-        eventsCommandId,
-        {
+    const eventsResult = await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.owner.agentId,
+        commandId: eventsCommandId,
+        command: {
             kind: 'http.request',
             request: {
                 path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
@@ -669,36 +487,40 @@ async function verifyGroupStateReadback(
             },
             timeoutMs: 10_000
         }
-    );
-    expect(resultValue(eventsResult).status).toBe(200);
+    });
+    expect(input.control.resultValue(eventsResult).status).toBe(200);
     return [readCommandId, eventsCommandId];
 }
 
 async function configureAgentForServerCommands(
-    request: APIRequestContext,
-    runId: string,
-    agent: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agent: LiveRtcControlClient.Agent;
         groupId: string;
         suffix: string;
     }>
 ): Promise<string> {
-    const commandId = `configure-server-${agent.prefix.toLowerCase()}-${input.suffix}`;
-    await executeOk(request, runId, agent.agentId, commandId, {
-        kind: 'configure',
-        config: {
-            runId,
-            agentId: agent.agentId,
+    const commandId = `configure-server-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
+    await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.agent.agentId,
+        commandId,
+        command: {
+            kind: 'configure',
+            config: {
+            runId: input.runId,
+            agentId: input.agent.agentId,
             apiBaseUrl,
-            actor: agent.actor,
-            sessionId: agent.agentId,
+            actor: input.agent.actor,
+            sessionId: input.agent.agentId,
             roomId: input.groupId,
             control: {
                 mode: 'live-all-scenarios',
                 providerMode: 'browser-rallar'
             },
             defaults: {
-                connection: agent.connection,
+                connection: input.agent.connection,
                 providerMode: 'browser-rallar'
             },
             rallar: {
@@ -706,40 +528,51 @@ async function configureAgentForServerCommands(
                 restoreSession: true,
                 leaveRoomOnClose: false
             }
+            }
         }
     });
     return commandId;
 }
 
 async function runWebSocketOpenSendCloseMatrix(
-    request: APIRequestContext,
-    runId: string,
-    agents: readonly AgentHandle[],
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly LiveRtcControlClient.Agent[];
         groupId: string;
         suffix: string;
     }>
 ): Promise<readonly string[]> {
     const commandIds: string[] = [];
-    for (const agent of agents) {
+    for (const agent of input.agents) {
         commandIds.push(
-            await configureAgentForServerCommands(request, runId, agent, input)
+            await configureAgentForServerCommands({ ...input, agent })
         );
         const connection = `ws-${agent.prefix.toLowerCase()}-${input.suffix}`;
         const openCommandId = `ws-open-${agent.prefix.toLowerCase()}-${input.suffix}`;
         const sendCommandId = `ws-send-${agent.prefix.toLowerCase()}-${input.suffix}`;
         const closeCommandId = `ws-close-${agent.prefix.toLowerCase()}-${input.suffix}`;
         commandIds.push(openCommandId, sendCommandId, closeCommandId);
-        await executeOk(request, runId, agent.agentId, openCommandId, {
-            kind: 'ws.open',
-            connection,
-            url: apiWebSocketUrl(),
-            timeoutMs: 15_000
-        }, 30_000);
-        await executeOk(request, runId, agent.agentId, sendCommandId, {
-            kind: 'ws.send',
-            connection,
-            data: {
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: openCommandId,
+            command: {
+                kind: 'ws.open',
+                connection,
+                url: apiWebSocketUrl(),
+                timeoutMs: 15_000
+            },
+            timeoutMs: 30_000
+        });
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: sendCommandId,
+            command: {
+                kind: 'ws.send',
+                connection,
+                data: {
                 id: {
                     v: 2,
                     msgId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
@@ -768,36 +601,46 @@ async function runWebSocketOpenSendCloseMatrix(
                         matrixId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
                         agentId: agent.agentId,
                         groupId: input.groupId,
-                        runId
+                        runId: input.runId
                     })
                 }
             }
+            }
         });
-        await executeOk(request, runId, agent.agentId, closeCommandId, {
-            kind: 'ws.close',
-            connection,
-            code: 1000,
-            reason: 'live-all-scenarios-complete'
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: closeCommandId,
+            command: {
+                kind: 'ws.close',
+                connection,
+                code: 1000,
+                reason: 'live-all-scenarios-complete'
+            }
         });
     }
     return commandIds;
 }
 
 async function connectAgent(
-    request: APIRequestContext,
-    runId: string,
-    agent: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agent: LiveRtcControlClient.Agent;
         transport: TransportUnderTest;
         groupId: string;
         suffix: string;
     }>
 ): Promise<Readonly<{ commandId: string; sessionId: string; }>> {
-    const commandId = `connect-${agent.prefix.toLowerCase()}-${input.transport.replace('.', '-')}-${input.suffix}`;
-    const result = await executeOk(request, runId, agent.agentId, commandId, {
+    const commandId = `connect-${input.agent.prefix.toLowerCase()}-${input.transport.replace('.', '-')}-${input.suffix}`;
+    const result = await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.agent.agentId,
+        commandId,
+        command: {
         kind: 'rtc.connect',
-        connection: `${agent.connection}-${input.transport.replace('.', '-')}`,
-        actor: agent.actor,
+        connection: `${input.agent.connection}-${input.transport.replace('.', '-')}`,
+        actor: input.agent.actor,
         roomId: input.groupId,
         applicationId,
         workspaceId,
@@ -809,49 +652,21 @@ async function connectAgent(
         transport: input.transport,
         rallar: rallarConnectConfig(input.transport),
         timeoutMs: 45_000
-    }, 60_000);
+        },
+        timeoutMs: 60_000
+    });
 
     return {
         commandId,
-        sessionId: requireSessionId(result, commandId)
+        sessionId: input.control.requireSessionId(result, commandId)
     };
 }
 
-async function waitForPeerReadiness(
-    request: APIRequestContext,
-    runId: string,
-    agent: AgentHandle,
-    expectedPeerIds: readonly string[],
-    suffix: string
-): Promise<void> {
-    let attempt = 0;
-    await expect.poll(async () => {
-        const result = await executeResult(
-            request,
-            runId,
-            agent.agentId,
-            `health-ready-${agent.prefix.toLowerCase()}-${suffix}-${attempt++}`,
-            { kind: 'health' },
-            15_000
-        ).catch(() => undefined);
-        if (!result?.ok) {
-            return [];
-        }
-
-        return stringArrayValue(
-            asRecord(asRecord(resultValue(result).rallar).rtcStatus).readyPeerIds
-        );
-    }, {
-        message: `Expected ${agent.agentId} to see ready peers ${expectedPeerIds.join(', ')} for ${suffix}`,
-        timeout: 60_000
-    }).toEqual(expect.arrayContaining(expectedPeerIds));
-}
-
 async function sendMatrixPayload(
-    request: APIRequestContext,
-    runId: string,
-    sender: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        sender: LiveRtcControlClient.Agent;
         transport: TransportUnderTest;
         groupId: string;
         suffix: string;
@@ -861,35 +676,50 @@ async function sendMatrixPayload(
     }>
 ): Promise<string> {
     const commandId = `send-${input.matrixId}`;
-    await executeOk(request, runId, sender.agentId, commandId, {
-        kind: 'rtc.send',
-        connection: `${sender.connection}-${input.transport.replace('.', '-')}`,
-        transport: input.transport,
-        applicationId,
-        workspaceId,
-        roomRef: {
+    await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.sender.agentId,
+        commandId,
+        command: {
+            kind: 'rtc.send',
+            connection: `${input.sender.connection}-${input.transport.replace('.', '-')}`,
+            transport: input.transport,
             applicationId,
             workspaceId,
-            groupId: input.groupId
+            roomRef: {
+                applicationId,
+                workspaceId,
+                groupId: input.groupId
+            },
+            timeoutMs: 60_000,
+            send: sendPayload({
+                transport: input.transport,
+                groupId: input.groupId,
+                targetSessionIds: input.targetSessionIds,
+                payload: {
+                    topic: 'rallar.black-box.live-three-browser',
+                    matrixId: input.matrixId,
+                    deliveryMode: input.deliveryMode,
+                    transport: input.transport,
+                    runId: input.runId,
+                    groupId: input.groupId
+                }
+            })
         },
-        timeoutMs: 60_000,
-        send: sendPayload(input.transport, input.groupId, input.targetSessionIds, {
-            topic: 'rallar.black-box.live-three-browser',
-            matrixId: input.matrixId,
-            deliveryMode: input.deliveryMode,
-            transport: input.transport,
-            runId,
-            groupId: input.groupId
-        })
-    }, 70_000);
+        timeoutMs: 70_000
+    });
     return commandId;
 }
 
 async function runDeliveryMatrix(
-    request: APIRequestContext,
-    runId: string,
-    agents: readonly [AgentHandle, AgentHandle, AgentHandle],
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
         transport: TransportUnderTest;
         groupId: string;
         suffix: string;
@@ -898,11 +728,12 @@ async function runDeliveryMatrix(
     Readonly<{
         commandIds: readonly string[];
         sessions: Readonly<Record<AgentPrefix, string>>;
-        matrixIds: readonly string[];
+        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+        timings: readonly LiveRtcPerformanceTiming[];
     }>
 > {
     const connectResults = await Promise.all(
-        agents.map((agent) => connectAgent(request, runId, agent, input))
+        input.agents.map((agent) => connectAgent({ ...input, agent }))
     );
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
@@ -911,30 +742,49 @@ async function runDeliveryMatrix(
     };
     expect(new Set(Object.values(sessions)).size).toBe(3);
 
-    const [agentA, agentB, agentC] = agents;
+    const [agentA, agentB, agentC] = input.agents;
     const transportSuffix = `${input.transport.replace('.', '-')}-${input.suffix}`;
-    await waitForPeerReadiness(
-        request,
-        runId,
-        agentA,
-        [sessions.B, sessions.C],
-        transportSuffix
-    );
+    const readinessStartedAtMs = performance.now();
+    const readinessDurationMs = await input.control.waitForPeerReadiness({
+        runId: input.runId,
+        agent: agentA,
+        expectedPeerIds: [sessions.B, sessions.C],
+        suffix: transportSuffix,
+        startedAtMs: readinessStartedAtMs
+    });
+    const timings: LiveRtcPerformanceTiming[] = [{
+        kind: 'peer-ready',
+        transport: input.transport,
+        senderAgentId: agentA.agentId,
+        receiverAgentIds: [agentB.agentId, agentC.agentId],
+        durationMs: readinessDurationMs
+    }];
 
     const directMatrixId = `direct-${input.transport}-${input.suffix}`;
     const multicastMatrixId = `multicast-${input.transport}-${input.suffix}`;
     const broadcastMatrixId = `broadcast-${input.transport}-${input.suffix}`;
-    const sendDirect = await sendMatrixPayload(request, runId, agentA, {
+    const directStartedAtMs = performance.now();
+    const sendDirect = await sendMatrixPayload({
         ...input,
+        sender: agentA,
         deliveryMode: 'direct',
         targetSessionIds: [sessions.B],
         matrixId: directMatrixId
     });
-    await waitForMessage(request, runId, {
+    const directDurationMs = await input.control.waitForMessage({
+        runId: input.runId,
         agentId: agentB.agentId,
         transport: input.transport,
         matrixId: directMatrixId,
-        deliveryMode: 'direct'
+        deliveryMode: 'direct',
+        startedAtMs: directStartedAtMs
+    });
+    timings.push({
+        kind: 'direct-delivery',
+        transport: input.transport,
+        senderAgentId: agentA.agentId,
+        receiverAgentIds: [agentB.agentId],
+        durationMs: directDurationMs
     });
     await openTab(agentB.page, 'manual-rallar', 'black-box-runner');
     await expect(
@@ -942,46 +792,72 @@ async function runDeliveryMatrix(
     )
         .toContainText(directMatrixId, { timeout: 30_000 });
 
-    const sendMulticast = await sendMatrixPayload(request, runId, agentA, {
+    const multicastStartedAtMs = performance.now();
+    const sendMulticast = await sendMatrixPayload({
         ...input,
+        sender: agentA,
         deliveryMode: 'multicast',
         targetSessionIds: [sessions.B, sessions.C],
         matrixId: multicastMatrixId
     });
-    await Promise.all([
-        waitForMessage(request, runId, {
+    const multicastDurations = await Promise.all([
+        input.control.waitForMessage({
+            runId: input.runId,
             agentId: agentB.agentId,
             transport: input.transport,
             matrixId: multicastMatrixId,
-            deliveryMode: 'multicast'
+            deliveryMode: 'multicast',
+            startedAtMs: multicastStartedAtMs
         }),
-        waitForMessage(request, runId, {
+        input.control.waitForMessage({
+            runId: input.runId,
             agentId: agentC.agentId,
             transport: input.transport,
             matrixId: multicastMatrixId,
-            deliveryMode: 'multicast'
+            deliveryMode: 'multicast',
+            startedAtMs: multicastStartedAtMs
         })
     ]);
+    timings.push({
+        kind: 'multicast-delivery',
+        transport: input.transport,
+        senderAgentId: agentA.agentId,
+        receiverAgentIds: [agentB.agentId, agentC.agentId],
+        durationMs: Math.max(...multicastDurations)
+    });
 
-    const sendBroadcast = await sendMatrixPayload(request, runId, agentA, {
+    const broadcastStartedAtMs = performance.now();
+    const sendBroadcast = await sendMatrixPayload({
         ...input,
+        sender: agentA,
         deliveryMode: 'broadcast',
         matrixId: broadcastMatrixId
     });
-    await Promise.all([
-        waitForMessage(request, runId, {
+    const broadcastDurations = await Promise.all([
+        input.control.waitForMessage({
+            runId: input.runId,
             agentId: agentB.agentId,
             transport: input.transport,
             matrixId: broadcastMatrixId,
-            deliveryMode: 'broadcast'
+            deliveryMode: 'broadcast',
+            startedAtMs: broadcastStartedAtMs
         }),
-        waitForMessage(request, runId, {
+        input.control.waitForMessage({
+            runId: input.runId,
             agentId: agentC.agentId,
             transport: input.transport,
             matrixId: broadcastMatrixId,
-            deliveryMode: 'broadcast'
+            deliveryMode: 'broadcast',
+            startedAtMs: broadcastStartedAtMs
         })
     ]);
+    timings.push({
+        kind: 'broadcast-delivery',
+        transport: input.transport,
+        senderAgentId: agentA.agentId,
+        receiverAgentIds: [agentB.agentId, agentC.agentId],
+        durationMs: Math.max(...broadcastDurations)
+    });
     await openTab(agentC.page, 'manual-rallar', 'black-box-runner');
     await expect(
         agentC.page.locator('#panel-manual-rallar .received-inbox-panel')
@@ -989,19 +865,13 @@ async function runDeliveryMatrix(
         .toContainText(broadcastMatrixId, { timeout: 30_000 });
 
     if (input.transport === 'realtime') {
-        const healthA = await executeOk(
-            request,
-            runId,
-            agentA.agentId,
-            `health-a-${input.suffix}`,
-            {
-                kind: 'health'
-            }
-        );
-        const readyPeerIds = stringArrayValue(
-            asRecord(asRecord(resultValue(healthA).rallar).rtcStatus).readyPeerIds
-        );
-        expect(readyPeerIds).toEqual(
+        const healthA = await input.control.executeOk({
+            runId: input.runId,
+            agentId: agentA.agentId,
+            commandId: `health-a-${input.suffix}`,
+            command: { kind: 'health' }
+        });
+        expect(input.control.readyPeerIds(healthA)).toEqual(
             expect.arrayContaining([sessions.B, sessions.C])
         );
     }
@@ -1014,15 +884,45 @@ async function runDeliveryMatrix(
             sendBroadcast
         ],
         sessions,
-        matrixIds: [directMatrixId, multicastMatrixId, broadcastMatrixId]
+        scenarios: [
+            {
+                matrixId: directMatrixId,
+                transport: input.transport,
+                deliveryMode: 'direct',
+                senderAgentId: agentA.agentId,
+                expectedAgentIds: [agentB.agentId],
+                allowedAgentIds: [agentB.agentId]
+            },
+            {
+                matrixId: multicastMatrixId,
+                transport: input.transport,
+                deliveryMode: 'multicast',
+                senderAgentId: agentA.agentId,
+                expectedAgentIds: [agentB.agentId, agentC.agentId],
+                allowedAgentIds: [agentB.agentId, agentC.agentId]
+            },
+            {
+                matrixId: broadcastMatrixId,
+                transport: input.transport,
+                deliveryMode: 'broadcast',
+                senderAgentId: agentA.agentId,
+                expectedAgentIds: [agentB.agentId, agentC.agentId],
+                allowedAgentIds: input.agents.map((agent) => agent.agentId)
+            }
+        ],
+        timings
     };
 }
 
 async function runAllDeliveryPermutations(
-    request: APIRequestContext,
-    runId: string,
-    agents: readonly [AgentHandle, AgentHandle, AgentHandle],
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
         transport: TransportUnderTest;
         groupId: string;
         suffix: string;
@@ -1031,12 +931,13 @@ async function runAllDeliveryPermutations(
     Readonly<{
         commandIds: readonly string[];
         sessions: Readonly<Record<AgentPrefix, string>>;
-        scenarios: readonly DeliveryScenarioRecord[];
+        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+        timings: readonly LiveRtcPerformanceTiming[];
     }>
 > {
     const slug = transportSlug(input.transport);
     const connectResults = await Promise.all(
-        agents.map((agent) => connectAgent(request, runId, agent, input))
+        input.agents.map((agent) => connectAgent({ ...input, agent }))
     );
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
@@ -1046,42 +947,67 @@ async function runAllDeliveryPermutations(
     expect(new Set(Object.values(sessions)).size).toBe(3);
 
     const readinessSuffix = `${slug}-${input.suffix}-all`;
-    await Promise.all(
-        agents.map((agent) =>
-            waitForPeerReadiness(
-                request,
-                runId,
+    const readinessStartedAtMs = performance.now();
+    const readinessDurations = await Promise.all(
+        input.agents.map((agent) =>
+            input.control.waitForPeerReadiness({
+                runId: input.runId,
                 agent,
-                agents
+                expectedPeerIds: input.agents
                     .filter((candidate) => candidate.agentId !== agent.agentId)
                     .map((candidate) => sessions[candidate.prefix]),
-                readinessSuffix
-            )
+                suffix: readinessSuffix,
+                startedAtMs: readinessStartedAtMs
+            })
         )
     );
 
     const commandIds = connectResults.map((result) => result.commandId);
-    const scenarios: DeliveryScenarioRecord[] = [];
+    const scenarios: LiveRtcControlClient.DeliveryScenario[] = [];
+    const timings: LiveRtcPerformanceTiming[] = input.agents.map(
+        (agent, index) => ({
+            kind: 'peer-ready',
+            transport: input.transport,
+            senderAgentId: agent.agentId,
+            receiverAgentIds: input.agents
+                .filter((candidate) => candidate.agentId !== agent.agentId)
+                .map((candidate) => candidate.agentId),
+            durationMs: readinessDurations[index]!
+        })
+    );
 
-    for (const sender of agents) {
-        const receivers = agents.filter((agent) => agent.agentId !== sender.agentId);
+    for (const sender of input.agents) {
+        const receivers = input.agents.filter(
+            (agent) => agent.agentId !== sender.agentId
+        );
 
         for (const receiver of receivers) {
             const matrixId =
                 `${slug}-direct-${sender.prefix.toLowerCase()}-to-${receiver.prefix.toLowerCase()}-${input.suffix}`;
+            const startedAtMs = performance.now();
             commandIds.push(
-                await sendMatrixPayload(request, runId, sender, {
+                await sendMatrixPayload({
                     ...input,
+                    sender,
                     deliveryMode: 'direct',
                     targetSessionIds: [sessions[receiver.prefix]],
                     matrixId
                 })
             );
-            await waitForMessage(request, runId, {
+            const durationMs = await input.control.waitForMessage({
+                runId: input.runId,
                 agentId: receiver.agentId,
                 transport: input.transport,
                 matrixId,
-                deliveryMode: 'direct'
+                deliveryMode: 'direct',
+                startedAtMs
+            });
+            timings.push({
+                kind: 'direct-delivery',
+                transport: input.transport,
+                senderAgentId: sender.agentId,
+                receiverAgentIds: [receiver.agentId],
+                durationMs
             });
             scenarios.push({
                 matrixId,
@@ -1094,24 +1020,35 @@ async function runAllDeliveryPermutations(
         }
 
         const multicastMatrixId = `${slug}-multicast-${sender.prefix.toLowerCase()}-${input.suffix}`;
+        const multicastStartedAtMs = performance.now();
         commandIds.push(
-            await sendMatrixPayload(request, runId, sender, {
+            await sendMatrixPayload({
                 ...input,
+                sender,
                 deliveryMode: 'multicast',
                 targetSessionIds: receivers.map((receiver) => sessions[receiver.prefix]),
                 matrixId: multicastMatrixId
             })
         );
-        await Promise.all(
+        const multicastDurations = await Promise.all(
             receivers.map((receiver) =>
-                waitForMessage(request, runId, {
+                input.control.waitForMessage({
+                    runId: input.runId,
                     agentId: receiver.agentId,
                     transport: input.transport,
                     matrixId: multicastMatrixId,
-                    deliveryMode: 'multicast'
+                    deliveryMode: 'multicast',
+                    startedAtMs: multicastStartedAtMs
                 })
             )
         );
+        timings.push({
+            kind: 'multicast-delivery',
+            transport: input.transport,
+            senderAgentId: sender.agentId,
+            receiverAgentIds: receivers.map((receiver) => receiver.agentId),
+            durationMs: Math.max(...multicastDurations)
+        });
         scenarios.push({
             matrixId: multicastMatrixId,
             transport: input.transport,
@@ -1122,110 +1059,101 @@ async function runAllDeliveryPermutations(
         });
 
         const broadcastMatrixId = `${slug}-broadcast-${sender.prefix.toLowerCase()}-${input.suffix}`;
+        const broadcastStartedAtMs = performance.now();
         commandIds.push(
-            await sendMatrixPayload(request, runId, sender, {
+            await sendMatrixPayload({
                 ...input,
+                sender,
                 deliveryMode: 'broadcast',
                 matrixId: broadcastMatrixId
             })
         );
-        await Promise.all(
+        const broadcastDurations = await Promise.all(
             receivers.map((receiver) =>
-                waitForMessage(request, runId, {
+                input.control.waitForMessage({
+                    runId: input.runId,
                     agentId: receiver.agentId,
                     transport: input.transport,
                     matrixId: broadcastMatrixId,
-                    deliveryMode: 'broadcast'
+                    deliveryMode: 'broadcast',
+                    startedAtMs: broadcastStartedAtMs
                 })
             )
         );
+        timings.push({
+            kind: 'broadcast-delivery',
+            transport: input.transport,
+            senderAgentId: sender.agentId,
+            receiverAgentIds: receivers.map((receiver) => receiver.agentId),
+            durationMs: Math.max(...broadcastDurations)
+        });
         scenarios.push({
             matrixId: broadcastMatrixId,
             transport: input.transport,
             deliveryMode: 'broadcast',
             senderAgentId: sender.agentId,
             expectedAgentIds: receivers.map((receiver) => receiver.agentId),
-            allowedAgentIds: agents.map((agent) => agent.agentId)
+            allowedAgentIds: input.agents.map((agent) => agent.agentId)
         });
     }
 
     return {
         commandIds,
         sessions,
-        scenarios
+        scenarios,
+        timings
     };
 }
 
-async function expectNoUnexpectedDeliveries(
-    request: APIRequestContext,
-    runId: string,
-    scenarios: readonly DeliveryScenarioRecord[]
-): Promise<void> {
-    const run = await fetchRun(request, runId);
-    const scenarioById = new Map(
-        scenarios.map((scenario) => [scenario.matrixId, scenario])
-    );
-    const unexpected = (run.events ?? [])
-        .map((event) => {
-            const data = messageData(event);
-            const matrixId = stringValue(data.matrixId);
-            const scenario = matrixId ? scenarioById.get(matrixId) : undefined;
-            if (
-                !scenario || !event.agentId ||
-                scenario.allowedAgentIds.includes(event.agentId)
-            ) {
-                return undefined;
-            }
-            return {
-                matrixId,
-                transport: scenario.transport,
-                deliveryMode: scenario.deliveryMode,
-                senderAgentId: scenario.senderAgentId,
-                unexpectedAgentId: event.agentId,
-                expectedAgentIds: scenario.expectedAgentIds
-            };
-        })
-        .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
-    expect(unexpected).toEqual([]);
-}
-
 async function runNackProbe(
-    request: APIRequestContext,
-    runId: string,
-    agent: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agent: LiveRtcControlClient.Agent;
         groupId: string;
         suffix: string;
         targetSessionId: string;
     }>
 ): Promise<string> {
     const commandId = `nack-not-yet-in-sync-${input.suffix}`;
-    const result = await executeResult(request, runId, agent.agentId, commandId, {
-        kind: 'rtc.send',
-        connection: `${agent.connection}-messages-rtc`,
-        transport: 'messages.rtc',
-        applicationId,
-        workspaceId,
-        roomRef: {
+    const result = await input.control.executeResult({
+        runId: input.runId,
+        agentId: input.agent.agentId,
+        commandId,
+        command: {
+            kind: 'rtc.send',
+            connection: `${input.agent.connection}-messages-rtc`,
+            transport: 'messages.rtc',
             applicationId,
             workspaceId,
-            groupId: input.groupId
+            roomRef: {
+                applicationId,
+                workspaceId,
+                groupId: input.groupId
+            },
+            minSnapshotVersion: 9_999_999,
+            timeoutMs: 45_000,
+            send: sendPayload({
+                transport: 'messages.rtc',
+                groupId: input.groupId,
+                targetSessionIds: [input.targetSessionId],
+                payload: {
+                    topic: 'rallar.black-box.live-three-browser.nack',
+                    matrixId: `nack-${input.suffix}`,
+                    deliveryMode: 'nack',
+                    transport: 'messages.rtc',
+                    runId: input.runId,
+                    groupId: input.groupId
+                },
+                minSnapshotVersion: 9_999_999
+            })
         },
-        minSnapshotVersion: 9_999_999,
-        timeoutMs: 45_000,
-        send: sendPayload('messages.rtc', input.groupId, [input.targetSessionId], {
-            topic: 'rallar.black-box.live-three-browser.nack',
-            matrixId: `nack-${input.suffix}`,
-            deliveryMode: 'nack',
-            transport: 'messages.rtc',
-            runId,
-            groupId: input.groupId
-        }, 9_999_999)
-    }, 60_000);
-    const run = await fetchRun(request, runId);
+        timeoutMs: 60_000
+    });
+    const run = await input.control.fetchRun(input.runId);
     const evidence = JSON.stringify({
         result,
-        events: run.events?.filter((event) => event.agentId === agent.agentId)
+        events: run.events?.filter((event) => event.agentId === input.agent.agentId)
             .slice(-12)
     }).toLowerCase();
     expect(
@@ -1237,46 +1165,51 @@ async function runNackProbe(
 }
 
 async function expectClosedTransportFailure(
-    request: APIRequestContext,
-    runId: string,
-    agent: AgentHandle,
     input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agent: LiveRtcControlClient.Agent;
         groupId: string;
         suffix: string;
         targetSessionId: string;
     }>
 ): Promise<readonly string[]> {
-    const closeCommandId = `close-before-stale-send-${agent.prefix.toLowerCase()}-${input.suffix}`;
-    await executeOk(request, runId, agent.agentId, closeCommandId, {
-        kind: 'close'
-    }, 45_000);
+    const closeCommandId =
+        `close-before-stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
+    await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.agent.agentId,
+        commandId: closeCommandId,
+        command: { kind: 'close' },
+        timeoutMs: 45_000
+    });
 
-    const staleSendCommandId = `stale-send-${agent.prefix.toLowerCase()}-${input.suffix}`;
-    const staleResult = await executeResult(
-        request,
-        runId,
-        agent.agentId,
-        staleSendCommandId,
-        {
+    const staleSendCommandId =
+        `stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
+    const staleResult = await input.control.executeResult({
+        runId: input.runId,
+        agentId: input.agent.agentId,
+        commandId: staleSendCommandId,
+        command: {
             kind: 'rtc.send',
-            connection: `${agent.connection}-messages-rtc`,
+            connection: `${input.agent.connection}-messages-rtc`,
             transport: 'messages.rtc',
             timeoutMs: 10_000,
-            send: sendPayload(
-                'messages.rtc',
-                input.groupId,
-                [input.targetSessionId],
-                {
+            send: sendPayload({
+                transport: 'messages.rtc',
+                groupId: input.groupId,
+                targetSessionIds: [input.targetSessionId],
+                payload: {
                     topic: 'rallar.black-box.live-three-browser.stale-send',
                     matrixId: `stale-send-${input.suffix}`,
                     deliveryMode: 'stale-send',
                     transport: 'messages.rtc',
-                    runId
+                    runId: input.runId
                 }
-            )
+            })
         },
-        30_000
-    );
+        timeoutMs: 30_000
+    });
     expect(staleResult.ok).toBe(false);
     expect(JSON.stringify(staleResult).toLowerCase()).toMatch(
         /not connected|runtime|closed|connect/
@@ -1285,159 +1218,102 @@ async function expectClosedTransportFailure(
 }
 
 async function closeAndResetAgents(
-    request: APIRequestContext,
-    runId: string,
-    agents: readonly AgentHandle[],
-    suffix: string
+    input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly LiveRtcControlClient.Agent[];
+        suffix: string;
+    }>
 ): Promise<readonly string[]> {
     const commandIds: string[] = [];
-    for (const agent of agents) {
-        const closeCommandId = `close-${agent.prefix.toLowerCase()}-${suffix}`;
-        const resetCommandId = `reset-${agent.prefix.toLowerCase()}-${suffix}`;
+    for (const agent of input.agents) {
+        const closeCommandId = `close-${agent.prefix.toLowerCase()}-${input.suffix}`;
+        const resetCommandId = `reset-${agent.prefix.toLowerCase()}-${input.suffix}`;
         commandIds.push(closeCommandId, resetCommandId);
-        await executeResult(request, runId, agent.agentId, closeCommandId, {
-            kind: 'close'
-        }, 45_000);
-        await executeResult(request, runId, agent.agentId, resetCommandId, {
-            kind: 'reset'
-        }, 30_000);
+        await input.control.executeResult({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: closeCommandId,
+            command: { kind: 'close' },
+            timeoutMs: 45_000
+        });
+        await input.control.executeResult({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: resetCommandId,
+            command: { kind: 'reset' },
+            timeoutMs: 30_000
+        });
     }
     return commandIds;
 }
 
-async function expectArtifactBundle(
-    request: APIRequestContext,
-    runId: string,
-    commandIds: readonly string[]
-): Promise<void> {
-    const response = await request.get(
-        `${CONTROL_BASE_URL}/runs/${encodeURIComponent(runId)}/artifacts`
-    );
-    expect(response.ok()).toBe(true);
-    const bundle = await response.json() as {
-        files?: Record<string, string>;
-    };
-    const report = bundle.files?.['report.json'] ?? '';
-    const events = bundle.files?.['events.jsonl'] ?? '';
-    expect(report).toContain(commandIds[0]);
-    expect(events).toContain('rallar.browser');
-}
-
-async function attachRunSummary(
-    request: APIRequestContext,
-    testInfo: TestInfo,
-    runId: string
-): Promise<void> {
-    const run = await fetchRun(request, runId);
-    const body = JSON.stringify(
-        {
-            runId,
-            agents: run.agents?.map((agent) => agent.agentId),
-            resultCount: run.results?.length ?? 0,
-            eventCount: run.events?.length ?? 0
-        },
-        null,
-        2
-    );
-    await testInfo.attach('live-rtc-three-browser-run-summary.json', {
-        body,
-        contentType: 'application/json'
-    });
-    await writePerfArtifact(
-        `live-rtc-three-browser-run-summary-${safeFileName(runId)}.json`,
-        body
-    );
-}
-
-async function attachRtcDiagnosticsSnapshot(
-    request: APIRequestContext,
-    testInfo: TestInfo,
-    runId: string,
-    agents: readonly AgentHandle[],
-    label: string
-): Promise<readonly string[]> {
-    const commandIds: string[] = [];
-    const snapshots = [];
-    for (const agent of agents) {
-        const commandId = `rtc-diagnostics-${agent.prefix.toLowerCase()}-${label}`;
-        commandIds.push(commandId);
-        const result = await executeOk(request, runId, agent.agentId, commandId, {
-            kind: 'health',
-            includeRtcDiagnostics: true
-        }, 30_000);
-        snapshots.push(compactRtcDiagnosticsResult(agent, result));
-    }
-
-    const body = JSON.stringify(
-        {
-            runId,
-            label,
-            capturedAtEpochMs: Date.now(),
-            snapshots
-        },
-        null,
-        2
-    );
-    await testInfo.attach(`live-rtc-diagnostics-${label}.json`, {
-        body,
-        contentType: 'application/json'
-    });
-    await writePerfArtifact(
-        `live-rtc-diagnostics-${safeFileName(label)}.json`,
-        body
-    );
-    return commandIds;
-}
-
-async function writePerfArtifact(fileName: string, body: string): Promise<void> {
-    const outDir = envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR');
-    if (!outDir) {
+async function writeAttemptEvidence(input: Readonly<{
+    context: LiveRtcPerformanceAttemptContext | null;
+    producerExitStatus: number;
+    timings: readonly LiveRtcPerformanceTiming[];
+    diagnostics: readonly LiveRtcDiagnosticsCheckpoint[];
+    retention: LiveRtcPerformanceRawEvidence['retention'];
+    assertions: LiveRtcPerformanceRawEvidence['assertions'];
+}>): Promise<void> {
+    if (!input.context) {
         return;
     }
-    await mkdir(outDir, { recursive: true });
-    await writeFile(join(outDir, fileName), body);
-}
-
-function compactRtcDiagnosticsResult(
-    agent: AgentHandle,
-    result: ControlResult
-) {
-    const rallar = asRecord(resultValue(result).rallar);
-    const diagnostics = asRecord(rallar.rtcDiagnostics);
-    const peers = Array.isArray(diagnostics.peers) ? diagnostics.peers : [];
-    return {
-        agentId: agent.agentId,
-        prefix: agent.prefix,
-        commandId: result.commandId,
-        sessionId: stringValue(diagnostics.sessionId),
-        generatedAtEpochMs: numberValue(diagnostics.generatedAtEpochMs),
-        peerCount: numberValue(diagnostics.peerCount),
-        connectedPeerCount: numberValue(diagnostics.connectedPeerCount),
-        relayPeerCount: numberValue(diagnostics.relayPeerCount),
-        rtcDiagnosticsError: rallar.rtcDiagnosticsError,
-        groupManager: diagnostics.groupManager,
-        overlayAdoption: diagnostics.overlayAdoption,
-        peers: peers.map(compactRtcPeerDiagnostics)
+    const environmentId = input.context.locator.environmentId;
+    const e4 = environmentId === 'E4-pg';
+    const rawEvidence: LiveRtcPerformanceRawEvidence = {
+        identity: {
+            workloadId: 'RTC-B06',
+            caseId: input.context.locator.caseId,
+            inputKey: input.context.locator.inputKey,
+            intendedPhase: input.context.locator.intendedPhase,
+            outerOrdinal: input.context.locator.outerOrdinal,
+            environmentId
+        },
+        producer: {
+            provider: 'browser-rallar',
+            browserCount: 3,
+            auth: {
+                A: agentAuth('A').kind,
+                B: agentAuth('B').kind,
+                C: agentAuth('C').kind
+            },
+            databaseProvider: e4 ? 'postgres' : 'memory',
+            databaseUrl: envValue('DATABASE_URL') ? 'present' : 'absent',
+            iceMode: e4 ? 'local' : 'repository-default',
+            allScenariosRaw:
+                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS'),
+            retentionSoakRaw:
+                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK'),
+            retentionCyclesRaw:
+                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES'),
+            iceModeRaw: rawEnvironmentValue('RALLAR_ICE_MODE'),
+            transports: ['realtime', 'messages.rtc']
+        },
+        runtime: {
+            node: input.context.runtimeObservation.runtime.node,
+            playwright: input.context.runtimeObservation.runtime.playwright,
+            chromium: input.context.runtimeObservation.runtime.chromium
+        },
+        timings: input.timings,
+        diagnostics: input.diagnostics,
+        retention: input.retention,
+        assertions: input.assertions
     };
-}
-
-function compactRtcPeerDiagnostics(peerValue: unknown) {
-    const peer = asRecord(peerValue);
-    const connection = asRecord(peer.connection);
-    const candidatePair = asRecord(peer.selectedCandidatePair);
-    const connectionDiagnostics = asRecord(peer.connectionDiagnostics);
-    return {
-        peerId: stringValue(peer.peerId),
-        connectionState: stringValue(connection.connectionState),
-        iceConnectionState: stringValue(connection.iceConnectionState),
-        signalingState: stringValue(connection.signalingState),
-        usesRelay: peer.usesRelay === true,
-        statsAvailable: peer.statsAvailable === true,
-        currentRoundTripTime: numberValue(candidatePair.currentRoundTripTime),
-        connectionDiagnostics: Object.keys(connectionDiagnostics).length > 0
-            ? connectionDiagnostics
-            : undefined
-    };
+    const attempt = buildLiveRtcExternalAttempt({
+        locator: input.context.locator,
+        sampleIdentity: input.context.sampleIdentity,
+        producerExitStatus: input.producerExitStatus,
+        runtimeObservation: input.context.runtimeObservation,
+        rawEvidence
+    });
+    await writeLiveRtcPerformanceEvidence({
+        repoRoot: input.context.repoRoot,
+        baselineId: input.context.baselineId,
+        relativePath: input.context.locator.rawResultRelativePath,
+        evidence: attempt
+    });
+    await writeLiveRtcRetentionCohortIfComplete(input.context);
 }
 
 test.describe('full-stack live three-browser RTC matrix', () => {
@@ -1459,15 +1335,44 @@ test.describe('full-stack live three-browser RTC matrix', () => {
         }, testInfo) => {
             test.setTimeout(360_000);
 
+            const evidenceContext = await loadLiveRtcPerformanceAttempt({
+                repoRoot: process.cwd(),
+                environment: process.env
+            });
+            test.skip(
+                evidenceContext !== null && evidenceContext.locator.caseId !== 'default',
+                'The predeclared B06 attempt selects a different matrix case.'
+            );
+            const control = new LiveRtcControlClient({
+                request,
+                baseUrl: CONTROL_BASE_URL,
+                diagnosticsOutDir: envValue(
+                    'RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR'
+                )
+            });
+
             const suffix = `live3-${Date.now()}-${Math.random().toString(16).slice(2)}`;
             const runId = `rallar-live-three-browser-${suffix}`;
             const groupId = `${roomSeed}-${suffix}`;
-            const allHandles: AgentHandle[] = [];
-            const openHandles: AgentHandle[] = [];
+            const allHandles: LiveRtcControlClient.Agent[] = [];
+            const openHandles: LiveRtcControlClient.Agent[] = [];
             const commandIds: string[] = [];
+            const timings: LiveRtcPerformanceTiming[] = [];
+            const diagnostics: LiveRtcDiagnosticsCheckpoint[] = [];
+            const scenarios: LiveRtcControlClient.DeliveryScenario[] = [];
+            let producerExitStatus = 0;
+            let matrixPassed = false;
+            let artifactBundlePassed = false;
+            let unexpectedDeliveryCount = 0;
             const openAgents = async (
                 label: string
-            ): Promise<readonly [AgentHandle, AgentHandle, AgentHandle]> => {
+            ): Promise<
+                readonly [
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent
+                ]
+            > => {
                 const agents = await openAgentTrio(browser, {
                     runId,
                     groupId,
@@ -1479,15 +1384,15 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 return agents;
             };
             const retireAgents = async (
-                agents: readonly AgentHandle[],
+                agents: readonly LiveRtcControlClient.Agent[],
                 closeSuffix: string
             ): Promise<readonly string[]> => {
-                const retiredCommandIds = await closeAndResetAgents(
-                    request,
+                const retiredCommandIds = await closeAndResetAgents({
+                    control,
                     runId,
                     agents,
-                    closeSuffix
-                );
+                    suffix: closeSuffix
+                });
                 await closeAgentContexts(agents);
                 for (const agent of agents) {
                     const index = openHandles.findIndex((candidate) => candidate.agentId === agent.agentId);
@@ -1501,7 +1406,9 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             try {
                 const realtimeAgents = await openAgents('live-realtime');
                 commandIds.push(
-                    ...await setupGroupMembership(request, runId, {
+                    ...await setupGroupMembership({
+                        control,
+                        runId,
                         owner: realtimeAgents[0],
                         members: realtimeAgents,
                         groupId,
@@ -1509,26 +1416,26 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     })
                 );
 
-                const realtime = await runDeliveryMatrix(
-                    request,
+                const realtime = await runDeliveryMatrix({
+                    control,
                     runId,
-                    realtimeAgents,
-                    {
-                        transport: 'realtime',
-                        groupId,
-                        suffix
-                    }
-                );
+                    agents: realtimeAgents,
+                    transport: 'realtime',
+                    groupId,
+                    suffix
+                });
                 commandIds.push(...realtime.commandIds);
-                commandIds.push(
-                    ...await attachRtcDiagnosticsSnapshot(
-                        request,
-                        testInfo,
-                        runId,
-                        realtimeAgents,
-                        `realtime-${suffix}`
-                    )
-                );
+                timings.push(...realtime.timings);
+                scenarios.push(...realtime.scenarios);
+                const realtimeDiagnostics = await control.captureDiagnostics({
+                    testInfo,
+                    runId,
+                    agents: realtimeAgents,
+                    label: `realtime-${suffix}`,
+                    cycle: null
+                });
+                commandIds.push(...realtimeDiagnostics.commandIds);
+                diagnostics.push(realtimeDiagnostics.checkpoint);
                 commandIds.push(
                     ...await retireAgents(
                         realtimeAgents,
@@ -1538,7 +1445,9 @@ test.describe('full-stack live three-browser RTC matrix', () => {
 
                 const messageAgents = await openAgents('live-messages');
                 commandIds.push(
-                    ...await setupGroupMembership(request, runId, {
+                    ...await setupGroupMembership({
+                        control,
+                        runId,
                         owner: messageAgents[0],
                         members: messageAgents,
                         groupId,
@@ -1546,66 +1455,71 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     })
                 );
 
-                const messages = await runDeliveryMatrix(
-                    request,
+                const messages = await runDeliveryMatrix({
+                    control,
                     runId,
-                    messageAgents,
-                    {
-                        transport: 'messages.rtc',
-                        groupId,
-                        suffix
-                    }
-                );
+                    agents: messageAgents,
+                    transport: 'messages.rtc',
+                    groupId,
+                    suffix
+                });
                 commandIds.push(...messages.commandIds);
+                timings.push(...messages.timings);
+                scenarios.push(...messages.scenarios);
                 commandIds.push(
-                    await runNackProbe(request, runId, messageAgents[0], {
+                    await runNackProbe({
+                        control,
+                        runId,
+                        agent: messageAgents[0],
+                        groupId,
+                        suffix,
+                        targetSessionId: messages.sessions.B
+                    })
+                );
+                const messageDiagnostics = await control.captureDiagnostics({
+                    testInfo,
+                    runId,
+                    agents: messageAgents,
+                    label: `messages-rtc-${suffix}`,
+                    cycle: null
+                });
+                commandIds.push(...messageDiagnostics.commandIds);
+                diagnostics.push(messageDiagnostics.checkpoint);
+                commandIds.push(
+                    ...await expectClosedTransportFailure({
+                        control,
+                        runId,
+                        agent: messageAgents[2],
                         groupId,
                         suffix,
                         targetSessionId: messages.sessions.B
                     })
                 );
                 commandIds.push(
-                    ...await attachRtcDiagnosticsSnapshot(
-                        request,
-                        testInfo,
+                    ...await closeAndResetAgents({
+                        control,
                         runId,
-                        messageAgents,
-                        `messages-rtc-${suffix}`
-                    )
-                );
-                commandIds.push(
-                    ...await expectClosedTransportFailure(
-                        request,
-                        runId,
-                        messageAgents[2],
-                        {
-                            groupId,
-                            suffix,
-                            targetSessionId: messages.sessions.B
-                        }
-                    )
-                );
-                commandIds.push(
-                    ...await closeAndResetAgents(
-                        request,
-                        runId,
-                        [messageAgents[0], messageAgents[1]],
-                        `${suffix}-final`
-                    )
+                        agents: [messageAgents[0], messageAgents[1]],
+                        suffix: `${suffix}-final`
+                    })
                 );
 
-                await expectArtifactBundle(request, runId, commandIds);
+                unexpectedDeliveryCount = await control.unexpectedDeliveryCount({
+                    runId,
+                    scenarios
+                });
+                expect(unexpectedDeliveryCount).toBe(0);
+                await control.expectArtifactBundle({ runId, commandIds });
+                artifactBundlePassed = true;
 
                 await expect.poll(async () => {
-                    const run = await fetchRun(request, runId);
+                    const run = await control.fetchRun(runId);
                     const resultIds = new Set(
                         (run.results ?? [])
                             .filter((result) => result.ok === true)
                             .map((result) => result.commandId)
                     );
-                    const topics = (run.events ?? [])
-                        .map((event) => stringValue(runtimeEventPayload(event).topic))
-                        .filter((topic): topic is string => Boolean(topic));
+                    const topics = control.runtimeTopics(run);
                     return {
                         agents: (run.agents ?? [])
                             .filter((agent) => allHandles.some((handle) => handle.agentId === agent.agentId))
@@ -1624,22 +1538,42 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     keyCommandsComplete: true,
                     fakeTopicCount: 0
                 });
+                matrixPassed = true;
+            }
+            catch (error) {
+                producerExitStatus = 1;
+                throw error;
             }
             finally {
                 if (allHandles.length > 0) {
-                    await attachRunSummary(request, testInfo, runId).catch(() => undefined);
+                    await control.attachRunSummary({ testInfo, runId }).catch(
+                        () => undefined
+                    );
                 }
                 await Promise.all(openHandles.map(async (handle) => {
-                    await executeResult(
-                        request,
+                    await control.executeResult({
                         runId,
-                        handle.agentId,
-                        `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
-                        { kind: 'close' },
-                        15_000
-                    ).catch(() => undefined);
+                        agentId: handle.agentId,
+                        commandId:
+                            `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
+                        command: { kind: 'close' },
+                        timeoutMs: 15_000
+                    }).catch(() => undefined);
                     await handle.context.close();
                 }));
+                await writeAttemptEvidence({
+                    context: evidenceContext,
+                    producerExitStatus,
+                    timings,
+                    diagnostics,
+                    retention: null,
+                    assertions: {
+                        matrixPassed,
+                        artifactBundlePassed,
+                        unexpectedDeliveryCount,
+                        reconnectPassed: null
+                    }
+                });
             }
         }
     );
@@ -1654,16 +1588,35 @@ test.describe('full-stack live three-browser RTC matrix', () => {
         );
         test.setTimeout(720_000);
 
+        const evidenceContext = await loadLiveRtcPerformanceAttempt({
+            repoRoot: process.cwd(),
+            environment: process.env
+        });
+        test.skip(
+            evidenceContext !== null &&
+                evidenceContext.locator.caseId !== 'all-scenarios',
+            'The predeclared B06 attempt selects a different matrix case.'
+        );
+        const control = new LiveRtcControlClient({
+            request,
+            baseUrl: CONTROL_BASE_URL,
+            diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
+        });
         const suffix = `live3-all-${Date.now()}-${Math.random().toString(16).slice(2)}`;
         const runId = `rallar-live-three-browser-all-${suffix}`;
         const groupId = `${roomSeed}-${suffix}`;
-        const allHandles: AgentHandle[] = [];
-        const openHandles: AgentHandle[] = [];
+        const allHandles: LiveRtcControlClient.Agent[] = [];
+        const openHandles: LiveRtcControlClient.Agent[] = [];
         const commandIds: string[] = [];
-        const scenarios: DeliveryScenarioRecord[] = [];
-        const openAgents = async (
-            label: string
-        ): Promise<readonly [AgentHandle, AgentHandle, AgentHandle]> => {
+        const scenarios: LiveRtcControlClient.DeliveryScenario[] = [];
+        const timings: LiveRtcPerformanceTiming[] = [];
+        const diagnostics: LiveRtcDiagnosticsCheckpoint[] = [];
+        let producerExitStatus = 0;
+        let matrixPassed = false;
+        let artifactBundlePassed = false;
+        let reconnectPassed = false;
+        let unexpectedDeliveryCount = 0;
+        const openAgents = async (label: string) => {
             const agents = await openAgentTrio(browser, {
                 runId,
                 groupId,
@@ -1675,210 +1628,467 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             return agents;
         };
         const retireAgents = async (
-            agents: readonly AgentHandle[],
+            agents: readonly LiveRtcControlClient.Agent[],
             closeSuffix: string
         ): Promise<readonly string[]> => {
-            const retiredCommandIds = await closeAndResetAgents(
-                request,
+            const retired = await closeAndResetAgents({
+                control,
                 runId,
                 agents,
-                closeSuffix
-            );
+                suffix: closeSuffix
+            });
             await closeAgentContexts(agents);
             for (const agent of agents) {
-                const index = openHandles.findIndex((candidate) => candidate.agentId === agent.agentId);
+                const index = openHandles.findIndex(
+                    (candidate) => candidate.agentId === agent.agentId
+                );
                 if (index >= 0) {
                     openHandles.splice(index, 1);
                 }
             }
-            return retiredCommandIds;
+            return retired;
         };
 
         try {
             const realtimeAgents = await openAgents('live-all-realtime');
-            commandIds.push(
-                ...await setupGroupMembership(request, runId, {
-                    owner: realtimeAgents[0],
-                    members: realtimeAgents,
-                    groupId,
-                    suffix
-                })
-            );
-            commandIds.push(
-                ...await verifyGroupStateReadback(request, runId, realtimeAgents[0], {
-                    groupId,
-                    suffix
-                })
-            );
-
-            const realtime = await runAllDeliveryPermutations(
-                request,
+            commandIds.push(...await setupGroupMembership({
+                control,
                 runId,
-                realtimeAgents,
-                {
-                    transport: 'realtime',
-                    groupId,
-                    suffix
-                }
-            );
+                owner: realtimeAgents[0],
+                members: realtimeAgents,
+                groupId,
+                suffix
+            }));
+            commandIds.push(...await verifyGroupStateReadback({
+                control,
+                runId,
+                owner: realtimeAgents[0],
+                groupId,
+                suffix
+            }));
+            const realtime = await runAllDeliveryPermutations({
+                control,
+                runId,
+                agents: realtimeAgents,
+                transport: 'realtime',
+                groupId,
+                suffix
+            });
             commandIds.push(...realtime.commandIds);
             scenarios.push(...realtime.scenarios);
-            await expectNoUnexpectedDeliveries(request, runId, realtime.scenarios);
-            commandIds.push(
-                ...await retireAgents(
-                    realtimeAgents,
-                    `${suffix}-after-realtime-all`
-                )
-            );
+            timings.push(...realtime.timings);
+            const realtimeDiagnostics = await control.captureDiagnostics({
+                testInfo,
+                runId,
+                agents: realtimeAgents,
+                label: `all-realtime-${suffix}`,
+                cycle: null
+            });
+            commandIds.push(...realtimeDiagnostics.commandIds);
+            diagnostics.push(realtimeDiagnostics.checkpoint);
+            commandIds.push(...await retireAgents(
+                realtimeAgents,
+                `${suffix}-after-realtime-all`
+            ));
 
             const wsAgents = await openAgents('live-all-ws');
-            commandIds.push(
-                ...await runWebSocketOpenSendCloseMatrix(
-                    request,
-                    runId,
-                    wsAgents,
-                    {
-                        groupId,
-                        suffix
-                    }
-                )
-            );
-            commandIds.push(
-                ...await retireAgents(wsAgents, `${suffix}-after-ws-all`)
-            );
+            commandIds.push(...await runWebSocketOpenSendCloseMatrix({
+                control,
+                runId,
+                agents: wsAgents,
+                groupId,
+                suffix
+            }));
+            commandIds.push(...await retireAgents(wsAgents, `${suffix}-after-ws-all`));
 
             const messageAgents = await openAgents('live-all-messages');
-            commandIds.push(
-                ...await setupGroupMembership(request, runId, {
-                    owner: messageAgents[0],
-                    members: messageAgents,
-                    groupId,
-                    suffix: `${suffix}-messages`
-                })
-            );
-
-            const messages = await runAllDeliveryPermutations(
-                request,
+            commandIds.push(...await setupGroupMembership({
+                control,
                 runId,
-                messageAgents,
-                {
-                    transport: 'messages.rtc',
-                    groupId,
-                    suffix
-                }
-            );
+                owner: messageAgents[0],
+                members: messageAgents,
+                groupId,
+                suffix: `${suffix}-messages`
+            }));
+            const messages = await runAllDeliveryPermutations({
+                control,
+                runId,
+                agents: messageAgents,
+                transport: 'messages.rtc',
+                groupId,
+                suffix
+            });
             commandIds.push(...messages.commandIds);
             scenarios.push(...messages.scenarios);
-            await expectNoUnexpectedDeliveries(request, runId, messages.scenarios);
-
-            commandIds.push(
-                await runNackProbe(request, runId, messageAgents[0], {
-                    groupId,
-                    suffix,
-                    targetSessionId: messages.sessions.B
-                })
-            );
-            commandIds.push(
-                ...await expectClosedTransportFailure(
-                    request,
+            timings.push(...messages.timings);
+            commandIds.push(await runNackProbe({
+                control,
+                runId,
+                agent: messageAgents[0],
+                groupId,
+                suffix,
+                targetSessionId: messages.sessions.B
+            }));
+            commandIds.push(...await expectClosedTransportFailure({
+                control,
+                runId,
+                agent: messageAgents[2],
+                groupId,
+                suffix,
+                targetSessionId: messages.sessions.B
+            }));
+            await Promise.all(messageAgents.slice(0, 2).map((agent) =>
+                control.waitForPeerAbsence({
                     runId,
-                    messageAgents[2],
-                    {
-                        groupId,
-                        suffix,
-                        targetSessionId: messages.sessions.B
-                    }
-                )
-            );
-
-            const reconnectC = await connectAgent(request, runId, messageAgents[2], {
+                    agent,
+                    departedPeerIds: [messages.sessions.C],
+                    suffix: `${suffix}-reconnect-c`
+                })
+            ));
+            const reconnectStartedAtMs = performance.now();
+            const reconnectC = await connectAgent({
+                control,
+                runId,
+                agent: messageAgents[2],
                 transport: 'messages.rtc',
                 groupId,
                 suffix: `${suffix}-reconnect-c`
             });
             commandIds.push(reconnectC.commandId);
-            await waitForPeerReadiness(
-                request,
+            const reconnectDurations = await Promise.all(
+                messageAgents.slice(0, 2).map((agent) =>
+                    control.waitForPeerReadiness({
+                        runId,
+                        agent,
+                        expectedPeerIds: [reconnectC.sessionId],
+                        suffix: `${suffix}-reconnect-c`,
+                        startedAtMs: reconnectStartedAtMs
+                    })
+                )
+            );
+            await control.waitForPeerReadiness({
                 runId,
-                messageAgents[1],
-                [reconnectC.sessionId],
-                `${suffix}-reconnect-c`
-            );
+                agent: messageAgents[2],
+                expectedPeerIds: [messages.sessions.A, messages.sessions.B],
+                suffix: `${suffix}-reconnect-c-settled`,
+                startedAtMs: reconnectStartedAtMs
+            });
+            timings.push({
+                kind: 'reconnect-ready',
+                transport: 'messages.rtc',
+                senderAgentId: messageAgents[2].agentId,
+                receiverAgentIds: [
+                    messageAgents[0].agentId,
+                    messageAgents[1].agentId
+                ],
+                durationMs: Math.max(...reconnectDurations)
+            });
             const reconnectMatrixId = `messages-rtc-reconnect-b-to-c-${suffix}`;
-            commandIds.push(
-                await sendMatrixPayload(request, runId, messageAgents[1], {
-                    transport: 'messages.rtc',
-                    groupId,
-                    suffix,
-                    deliveryMode: 'direct',
-                    targetSessionIds: [reconnectC.sessionId],
-                    matrixId: reconnectMatrixId
-                })
-            );
-            await waitForMessage(request, runId, {
+            const reconnectMessageStartedAtMs = performance.now();
+            commandIds.push(await sendMatrixPayload({
+                control,
+                runId,
+                sender: messageAgents[1],
+                transport: 'messages.rtc',
+                groupId,
+                suffix,
+                deliveryMode: 'direct',
+                targetSessionIds: [reconnectC.sessionId],
+                matrixId: reconnectMatrixId
+            }));
+            await control.waitForMessage({
+                runId,
                 agentId: messageAgents[2].agentId,
                 transport: 'messages.rtc',
                 matrixId: reconnectMatrixId,
-                deliveryMode: 'direct'
+                deliveryMode: 'direct',
+                startedAtMs: reconnectMessageStartedAtMs
             });
-
-            commandIds.push(
-                ...await closeAndResetAgents(
-                    request,
-                    runId,
-                    messageAgents,
-                    `${suffix}-final-all`
-                )
-            );
-            await expectNoUnexpectedDeliveries(request, runId, scenarios);
-            await expectArtifactBundle(request, runId, commandIds);
+            reconnectPassed = true;
+            const messageDiagnostics = await control.captureDiagnostics({
+                testInfo,
+                runId,
+                agents: messageAgents,
+                label: `all-messages-${suffix}`,
+                cycle: null
+            });
+            commandIds.push(...messageDiagnostics.commandIds);
+            diagnostics.push(messageDiagnostics.checkpoint);
+            commandIds.push(...await closeAndResetAgents({
+                control,
+                runId,
+                agents: messageAgents,
+                suffix: `${suffix}-final-all`
+            }));
+            unexpectedDeliveryCount = await control.unexpectedDeliveryCount({
+                runId,
+                scenarios
+            });
+            expect(unexpectedDeliveryCount).toBe(0);
+            await control.expectArtifactBundle({ runId, commandIds });
+            artifactBundlePassed = true;
 
             await expect.poll(async () => {
-                const run = await fetchRun(request, runId);
+                const run = await control.fetchRun(runId);
                 const resultIds = new Set(
                     (run.results ?? [])
                         .filter((result) => result.ok === true)
                         .map((result) => result.commandId)
                 );
-                const topics = (run.events ?? [])
-                    .map((event) => stringValue(runtimeEventPayload(event).topic))
-                    .filter((topic): topic is string => Boolean(topic));
                 return {
-                    agents: (run.agents ?? [])
-                        .filter((agent) => allHandles.some((handle) => handle.agentId === agent.agentId))
-                        .length,
+                    agents: (run.agents ?? []).filter((agent) =>
+                        allHandles.some((handle) => handle.agentId === agent.agentId)
+                    ).length,
                     keyCommandsComplete: commandIds
                         .filter((commandId) => !commandId.startsWith('stale-send-'))
                         .filter((commandId) => !commandId.startsWith('close-before-stale-send-'))
                         .filter((commandId) => !commandId.startsWith('nack-not-yet-in-sync-'))
                         .every((commandId) => resultIds.has(commandId)),
-                    fakeTopicCount: topics.filter((topic) => topic.startsWith('rallar.bb.fake.')).length,
+                    fakeTopicCount: control.runtimeTopics(run)
+                        .filter((topic) => topic.startsWith('rallar.bb.fake.')).length,
                     scenarioCount: scenarios.length
                 };
-            }, {
-                timeout: 20_000
-            }).toEqual({
+            }, { timeout: 20_000 }).toEqual({
                 agents: allHandles.length,
                 keyCommandsComplete: true,
                 fakeTopicCount: 0,
                 scenarioCount: 24
             });
+            matrixPassed = true;
+        }
+        catch (error) {
+            producerExitStatus = 1;
+            throw error;
         }
         finally {
             if (allHandles.length > 0) {
-                await attachRunSummary(request, testInfo, runId).catch(() => undefined);
+                await control.attachRunSummary({ testInfo, runId }).catch(() => undefined);
             }
             await Promise.all(openHandles.map(async (handle) => {
-                await executeResult(
-                    request,
+                await control.executeResult({
                     runId,
-                    handle.agentId,
-                    `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
-                    { kind: 'close' },
-                    15_000
-                ).catch(() => undefined);
+                    agentId: handle.agentId,
+                    commandId: `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
+                    command: { kind: 'close' },
+                    timeoutMs: 15_000
+                }).catch(() => undefined);
                 await handle.context.close();
             }));
+            await writeAttemptEvidence({
+                context: evidenceContext,
+                producerExitStatus,
+                timings,
+                diagnostics,
+                retention: null,
+                assertions: {
+                    matrixPassed,
+                    artifactBundlePassed,
+                    unexpectedDeliveryCount,
+                    reconnectPassed
+                }
+            });
+        }
+    });
+
+    test('returns RTC state and post-GC heap to baseline after 100 reconnect cycles', async ({
+        browser,
+        request
+    }, testInfo) => {
+        test.skip(
+            !liveRetentionSoakEnabled,
+            'Set RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=1 and RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES=100 to run retention evidence.'
+        );
+        test.setTimeout(1_800_000);
+
+        const evidenceContext = await loadLiveRtcPerformanceAttempt({
+            repoRoot: process.cwd(),
+            environment: process.env
+        });
+        test.skip(
+            evidenceContext !== null &&
+                evidenceContext.locator.caseId !== 'retention-100',
+            'The predeclared B06 attempt selects a different matrix case.'
+        );
+        const control = new LiveRtcControlClient({
+            request,
+            baseUrl: CONTROL_BASE_URL,
+            diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
+        });
+        const suffix = `live3-retention-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const runId = `rallar-live-three-browser-retention-${suffix}`;
+        const groupId = `${roomSeed}-${suffix}`;
+        const commandIds: string[] = [];
+        const timings: LiveRtcPerformanceTiming[] = [];
+        const diagnostics: LiveRtcDiagnosticsCheckpoint[] = [];
+        const checkpoints: LiveRtcRetentionCheckpoint[] = [];
+        const agents = await openAgentTrio(browser, {
+            runId,
+            groupId,
+            suffix,
+            label: 'live-retention'
+        });
+        let producerExitStatus = 0;
+        let matrixPassed = false;
+        let artifactBundlePassed = false;
+        let reconnectPassed = false;
+        const unexpectedDeliveryCount = 0;
+
+        const captureCheckpoint = async (cycle: number): Promise<void> => {
+            const captured = await control.captureDiagnostics({
+                testInfo,
+                runId,
+                agents,
+                label: `retention-${cycle}-${suffix}`,
+                cycle
+            });
+            commandIds.push(...captured.commandIds);
+            diagnostics.push(captured.checkpoint);
+            checkpoints.push({
+                cycle,
+                postGcHeapBytes: await captureLiveRtcPostGcHeap(
+                    agents.map((agent) => agent.page)
+                ),
+                agents: captured.checkpoint.agents
+            });
+        };
+
+        try {
+            commandIds.push(...await setupGroupMembership({
+                control,
+                runId,
+                owner: agents[0],
+                members: agents,
+                groupId,
+                suffix
+            }));
+            const connected = await Promise.all(
+                agents.map((agent) => connectAgent({
+                    control,
+                    runId,
+                    agent,
+                    transport: 'messages.rtc',
+                    groupId,
+                    suffix: `${suffix}-initial`
+                }))
+            );
+            commandIds.push(...connected.map((connection) => connection.commandId));
+            const initialReadinessStartedAtMs = performance.now();
+            await Promise.all(agents.map((agent, agentIndex) =>
+                control.waitForPeerReadiness({
+                    runId,
+                    agent,
+                    expectedPeerIds: connected
+                        .filter((_, connectionIndex) => connectionIndex !== agentIndex)
+                        .map((connection) => connection.sessionId),
+                    suffix: `${suffix}-initial`,
+                    startedAtMs: initialReadinessStartedAtMs
+                })
+            ));
+            await captureCheckpoint(0);
+
+            let currentSessionId = connected[2].sessionId;
+            for (let cycle = 1; cycle <= 100; cycle += 1) {
+                const closeCommandId = `retention-close-c-${cycle}-${suffix}`;
+                await control.executeOk({
+                    runId,
+                    agentId: agents[2].agentId,
+                    commandId: closeCommandId,
+                    command: { kind: 'close' },
+                    timeoutMs: 45_000
+                });
+                commandIds.push(closeCommandId);
+                await Promise.all(agents.slice(0, 2).map((agent) =>
+                    control.waitForPeerAbsence({
+                        runId,
+                        agent,
+                        departedPeerIds: [currentSessionId],
+                        suffix: `${suffix}-${cycle}`
+                    })
+                ));
+                const reconnectStartedAtMs = performance.now();
+                const reconnected = await connectAgent({
+                    control,
+                    runId,
+                    agent: agents[2],
+                    transport: 'messages.rtc',
+                    groupId,
+                    suffix: `${suffix}-${cycle}`
+                });
+                commandIds.push(reconnected.commandId);
+                const reconnectDurations = await Promise.all(
+                    agents.slice(0, 2).map((agent) =>
+                        control.waitForPeerReadiness({
+                            runId,
+                            agent,
+                            expectedPeerIds: [reconnected.sessionId],
+                            suffix: `${suffix}-${cycle}`,
+                            startedAtMs: reconnectStartedAtMs
+                        })
+                    )
+                );
+                await control.waitForPeerReadiness({
+                    runId,
+                    agent: agents[2],
+                    expectedPeerIds: [connected[0].sessionId, connected[1].sessionId],
+                    suffix: `${suffix}-${cycle}-settled`,
+                    startedAtMs: reconnectStartedAtMs
+                });
+                timings.push({
+                    kind: 'reconnect-ready',
+                    transport: 'messages.rtc',
+                    senderAgentId: agents[2].agentId,
+                    receiverAgentIds: [agents[0].agentId, agents[1].agentId],
+                    durationMs: Math.max(...reconnectDurations)
+                });
+                currentSessionId = reconnected.sessionId;
+                if (cycle % 10 === 0) {
+                    await captureCheckpoint(cycle);
+                }
+            }
+            reconnectPassed = true;
+            matrixPassed = true;
+            commandIds.push(...await closeAndResetAgents({
+                control,
+                runId,
+                agents,
+                suffix: `${suffix}-final`
+            }));
+            await control.expectArtifactBundle({ runId, commandIds });
+            artifactBundlePassed = true;
+        }
+        catch (error) {
+            producerExitStatus = 1;
+            throw error;
+        }
+        finally {
+            await control.attachRunSummary({ testInfo, runId }).catch(() => undefined);
+            await Promise.all(agents.map(async (agent) => {
+                await control.executeResult({
+                    runId,
+                    agentId: agent.agentId,
+                    commandId: `best-effort-close-${agent.prefix.toLowerCase()}-${suffix}`,
+                    command: { kind: 'close' },
+                    timeoutMs: 15_000
+                }).catch(() => undefined);
+                await agent.context.close();
+            }));
+            await writeAttemptEvidence({
+                context: evidenceContext,
+                producerExitStatus,
+                timings,
+                diagnostics,
+                retention: {
+                    cycles: 100,
+                    checkpoints,
+                    settledStateReturned: liveRtcRetentionStateReturned(checkpoints)
+                },
+                assertions: {
+                    matrixPassed,
+                    artifactBundlePassed,
+                    unexpectedDeliveryCount,
+                    reconnectPassed
+                }
+            });
         }
     });
 });

--- a/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
@@ -1,0 +1,1801 @@
+import {
+    expect,
+    type APIRequestContext,
+    type BrowserContext,
+    type Page,
+    type TestInfo
+} from '@playwright/test';
+import { lstat, mkdir, open, readFile, realpath, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { deriveRtcBaselineExternalAttempts } from '../../../packages/shared-rtc-bench/baseline/catalog/rtc-baseline-workload-manifest.ts';
+import {
+    decodeRtcBaselineEnvironment,
+    decodeRtcBaselineExternalAttempt,
+    decodeRtcBaselineManifest
+} from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-artifact-decoding.ts';
+import {
+    validateRtcBaselineExternalAttempt,
+    validateRtcBaselineExternalCohort
+} from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-artifact-validation.ts';
+import type {
+    RtcBaselineAttemptLocatorDto,
+    RtcBaselineCohortIdentityDto,
+    RtcBaselineEnvironmentDto,
+    RtcBaselineExternalAttemptDto,
+    RtcBaselineExternalCohortDto,
+    RtcBaselineIssueDto,
+    RtcBaselineJson,
+    RtcBaselineRuntimeObservationDto,
+    RtcBaselineSampleDto,
+    RtcBaselineSampleIdentityDto
+} from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-contracts.ts';
+
+export interface LiveRtcPerformanceIdentity {
+    workloadId: 'RTC-B06';
+    caseId: 'default' | 'all-scenarios' | 'retention-100';
+    inputKey:
+        | 'e3-memory-default'
+        | 'e3-memory-all-scenarios'
+        | 'e3-memory-retention-100'
+        | 'e4-pg-default'
+        | 'e4-pg-all-scenarios'
+        | 'e4-pg-retention-100';
+    intendedPhase: 'warmup' | 'retained';
+    outerOrdinal: number;
+    environmentId: 'E3-memory' | 'E4-pg';
+}
+
+export interface LiveRtcPerformanceProducer {
+    provider: 'browser-rallar';
+    browserCount: 3;
+    auth: Readonly<{
+        A: 'login' | 'restore';
+        B: 'login' | 'restore';
+        C: 'login' | 'restore';
+    }>;
+    databaseProvider: 'memory' | 'postgres';
+    databaseUrl: 'present' | 'absent';
+    iceMode: 'repository-default' | 'local';
+    allScenariosRaw: string | null;
+    retentionSoakRaw: string | null;
+    retentionCyclesRaw: string | null;
+    iceModeRaw: string | null;
+    transports: readonly ['realtime', 'messages.rtc'];
+}
+
+export interface LiveRtcPerformanceRuntime {
+    node: string;
+    playwright: string;
+    chromium: string;
+}
+
+export interface LiveRtcPerformanceTiming {
+    kind:
+        | 'peer-ready'
+        | 'direct-delivery'
+        | 'multicast-delivery'
+        | 'broadcast-delivery'
+        | 'reconnect-ready';
+    transport: 'realtime' | 'messages.rtc';
+    senderAgentId: string;
+    receiverAgentIds: readonly string[];
+    durationMs: number;
+}
+
+export interface LiveRtcAgentDiagnostics {
+    agentId: string;
+    settledPeerIds: readonly string[];
+    readyPeerIds: readonly string[];
+    laneStates: readonly LiveRtcLaneDiagnostics[];
+    connectionTimerActive: boolean;
+    peerCount: number;
+    connectedPeerCount: number;
+    relayPeerCount: number;
+    details: RtcBaselineJson;
+}
+
+export interface LiveRtcLaneDiagnostics {
+    peerId: string;
+    laneId: string;
+    isOpen: boolean;
+    isReconnectable: boolean;
+}
+
+export interface LiveRtcDiagnosticsCheckpoint {
+    label: string;
+    cycle: number | null;
+    agents: readonly LiveRtcAgentDiagnostics[];
+}
+
+export interface LiveRtcRetentionCheckpoint {
+    cycle: number;
+    postGcHeapBytes: number;
+    agents: readonly LiveRtcAgentDiagnostics[];
+}
+
+export interface LiveRtcRetentionEvidence {
+    cycles: 100;
+    checkpoints: readonly LiveRtcRetentionCheckpoint[];
+    settledStateReturned: boolean;
+}
+
+export interface LiveRtcPerformanceAssertions {
+    matrixPassed: boolean;
+    artifactBundlePassed: boolean;
+    unexpectedDeliveryCount: number;
+    reconnectPassed: boolean | null;
+}
+
+export interface LiveRtcPerformanceRawEvidence {
+    identity: LiveRtcPerformanceIdentity;
+    producer: LiveRtcPerformanceProducer;
+    runtime: LiveRtcPerformanceRuntime;
+    timings: readonly LiveRtcPerformanceTiming[];
+    diagnostics: readonly LiveRtcDiagnosticsCheckpoint[];
+    retention: LiveRtcRetentionEvidence | null;
+    assertions: LiveRtcPerformanceAssertions;
+}
+
+export interface BuildLiveRtcExternalAttemptInput {
+    locator: RtcBaselineAttemptLocatorDto;
+    sampleIdentity: RtcBaselineSampleIdentityDto;
+    producerExitStatus: number;
+    runtimeObservation: RtcBaselineRuntimeObservationDto;
+    rawEvidence: LiveRtcPerformanceRawEvidence;
+}
+
+export interface BuildLiveRtcRetentionCohortInput {
+    identity: RtcBaselineCohortIdentityDto;
+    attempts: readonly RtcBaselineExternalAttemptDto[];
+}
+
+export interface WriteLiveRtcPerformanceEvidenceInput {
+    repoRoot: string;
+    baselineId: string;
+    relativePath: string;
+    evidence: RtcBaselineExternalAttemptDto | RtcBaselineExternalCohortDto;
+}
+
+export interface LoadLiveRtcPerformanceAttemptInput {
+    repoRoot: string;
+    environment: Readonly<Record<string, string | undefined>>;
+}
+
+export interface LiveRtcPerformanceAttemptContext {
+    repoRoot: string;
+    baselineId: string;
+    locator: LiveRtcPerformanceAttemptLocator;
+    sampleIdentity: RtcBaselineSampleIdentityDto;
+    runtimeObservation: RtcBaselineRuntimeObservationDto;
+}
+
+export interface LiveRtcPerformanceAttemptLocator extends RtcBaselineAttemptLocatorDto {
+    workloadId: 'RTC-B06';
+    caseId: LiveRtcPerformanceIdentity['caseId'];
+    inputKey: LiveRtcPerformanceIdentity['inputKey'];
+    environmentId: LiveRtcPerformanceIdentity['environmentId'];
+}
+
+export namespace LiveRtcControlClient {
+    export interface Agent {
+        context: BrowserContext;
+        page: Page;
+        prefix: 'A' | 'B' | 'C';
+        agentId: string;
+        actor: string;
+        connection: string;
+    }
+
+    export interface Result {
+        agentId?: string;
+        commandId?: string;
+        ok?: boolean;
+        result?: Readonly<{ value?: RtcBaselineJson; }>;
+        error?: RtcBaselineJson;
+    }
+
+    export interface Event {
+        kind?: string;
+        agentId?: string;
+        payload?: RtcBaselineJson;
+    }
+
+    export interface RunSnapshot {
+        agents?: readonly Readonly<{ agentId?: string; }>[];
+        results?: readonly Result[];
+        events?: readonly Event[];
+    }
+
+    export interface DeliveryScenario {
+        matrixId: string;
+        transport: 'realtime' | 'messages.rtc';
+        deliveryMode: 'direct' | 'multicast' | 'broadcast';
+        senderAgentId: string;
+        expectedAgentIds: readonly string[];
+        allowedAgentIds: readonly string[];
+    }
+
+    export interface ExecuteInput {
+        runId: string;
+        agentId: string;
+        commandId: string;
+        command: object;
+        timeoutMs?: number;
+    }
+
+    export interface WaitForMessageInput {
+        runId: string;
+        agentId: string;
+        transport: 'realtime' | 'messages.rtc';
+        matrixId: string;
+        deliveryMode: string;
+        startedAtMs: number;
+    }
+
+    export interface WaitForPeerReadinessInput {
+        runId: string;
+        agent: Agent;
+        expectedPeerIds: readonly string[];
+        suffix: string;
+        startedAtMs: number;
+    }
+
+    export interface WaitForPeerAbsenceInput {
+        runId: string;
+        agent: Agent;
+        departedPeerIds: readonly string[];
+        suffix: string;
+    }
+
+    export interface CaptureDiagnosticsInput {
+        testInfo: TestInfo;
+        runId: string;
+        agents: readonly Agent[];
+        label: string;
+        cycle: number | null;
+    }
+
+    export interface CapturedDiagnostics {
+        commandIds: readonly string[];
+        checkpoint: LiveRtcDiagnosticsCheckpoint;
+    }
+}
+
+export class LiveRtcControlClient {
+    readonly #request: APIRequestContext;
+    readonly #baseUrl: string;
+    readonly #diagnosticsOutDir: string | undefined;
+
+    constructor(input: Readonly<{
+        request: APIRequestContext;
+        baseUrl: string;
+        diagnosticsOutDir?: string;
+    }>) {
+        this.#request = input.request;
+        this.#baseUrl = input.baseUrl;
+        this.#diagnosticsOutDir = input.diagnosticsOutDir;
+    }
+
+    async fetchRun(runId: string): Promise<LiveRtcControlClient.RunSnapshot> {
+        const response = await this.#request.get(
+            `${this.#baseUrl}/runs/${encodeURIComponent(runId)}`
+        );
+        expect(response.ok()).toBe(true);
+        return decodeControlRunSnapshot(normalizeJson(await response.json()));
+    }
+
+    async executeResult(
+        input: LiveRtcControlClient.ExecuteInput
+    ): Promise<LiveRtcControlClient.Result> {
+        const response = await this.#request.post(
+            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/agents/${encodeURIComponent(input.agentId)}/commands`,
+            {
+                data: {
+                    commandId: input.commandId,
+                    command: input.command
+                }
+            }
+        );
+        expect(
+            response.status(),
+            `Expected command ${input.commandId} for agent ${input.agentId} to enqueue: ${await response.text()}`
+        ).toBe(202);
+
+        let latest: LiveRtcControlClient.Result | undefined;
+        await expect.poll(async () => {
+            const run = await this.fetchRun(input.runId);
+            latest = run.results?.find(
+                (result) => result.commandId === input.commandId
+            );
+            return Boolean(latest);
+        }, {
+            timeout: input.timeoutMs ?? 45_000
+        }).toBe(true);
+        if (!latest) {
+            throw new Error(`Command ${input.commandId} did not return a result.`);
+        }
+        return latest;
+    }
+
+    async executeOk(
+        input: LiveRtcControlClient.ExecuteInput
+    ): Promise<LiveRtcControlClient.Result> {
+        const result = await this.executeResult(input);
+        expect(
+            result.ok,
+            `Expected command ${input.commandId} for agent ${input.agentId} to succeed: ${JSON.stringify(result)}`
+        ).toBe(true);
+        return result;
+    }
+
+    resultValue(
+        result: LiveRtcControlClient.Result
+    ): { [key: string]: RtcBaselineJson; } {
+        return jsonRecord(result.result?.value) ?? {};
+    }
+
+    requireSessionId(
+        result: LiveRtcControlClient.Result,
+        commandId: string
+    ): string {
+        const sessionId = stringValue(this.resultValue(result).sessionId);
+        if (!sessionId) {
+            throw new Error(`Connect result ${commandId} did not include a sessionId.`);
+        }
+        return sessionId;
+    }
+
+    readyPeerIds(result: LiveRtcControlClient.Result): readonly string[] {
+        return stringArrayValue(
+            jsonRecord(
+                jsonRecord(this.resultValue(result).rallar)?.rtcStatus
+            )?.readyPeerIds
+        );
+    }
+
+    runtimeTopics(run: LiveRtcControlClient.RunSnapshot): readonly string[] {
+        return (run.events ?? [])
+            .map((event) => stringValue(runtimeEventPayload(event).topic))
+            .filter((topic): topic is string => Boolean(topic));
+    }
+
+    async waitForMessage(
+        input: LiveRtcControlClient.WaitForMessageInput
+    ): Promise<number> {
+        await expect.poll(async () => {
+            const run = await this.fetchRun(input.runId);
+            return run.events?.some((event) => isMessageFor(event, input)) ?? false;
+        }, {
+            message:
+                `Expected ${input.agentId} to receive ${input.transport} ${input.deliveryMode} ${input.matrixId}`,
+            timeout: 60_000
+        }).toBe(true);
+        return performance.now() - input.startedAtMs;
+    }
+
+    async waitForPeerReadiness(
+        input: LiveRtcControlClient.WaitForPeerReadinessInput
+    ): Promise<number> {
+        let attempt = 0;
+        await expect.poll(async () => {
+            const result = await this.executeResult({
+                runId: input.runId,
+                agentId: input.agent.agentId,
+                commandId:
+                    `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
+                command: { kind: 'health' },
+                timeoutMs: 15_000
+            }).catch(() => undefined);
+            if (!result?.ok) {
+                return [];
+            }
+            return stringArrayValue(
+                jsonRecord(
+                    jsonRecord(this.resultValue(result).rallar)?.rtcStatus
+                )?.readyPeerIds
+            );
+        }, {
+            message:
+                `Expected ${input.agent.agentId} to see ready peers ${input.expectedPeerIds.join(', ')} for ${input.suffix}`,
+            timeout: 60_000
+        }).toEqual(expect.arrayContaining([...input.expectedPeerIds]));
+        return performance.now() - input.startedAtMs;
+    }
+
+    async waitForPeerAbsence(
+        input: LiveRtcControlClient.WaitForPeerAbsenceInput
+    ): Promise<void> {
+        let attempt = 0;
+        await expect.poll(async () => {
+            const result = await this.executeResult({
+                runId: input.runId,
+                agentId: input.agent.agentId,
+                commandId:
+                    `health-absent-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
+                command: { kind: 'health' },
+                timeoutMs: 15_000
+            }).catch(() => undefined);
+            if (!result?.ok) {
+                return input.departedPeerIds;
+            }
+            const readyPeerIds = this.readyPeerIds(result);
+            return input.departedPeerIds.filter((peerId) => readyPeerIds.includes(peerId));
+        }, {
+            message:
+                `Expected ${input.agent.agentId} to observe departed peers ${input.departedPeerIds.join(', ')} for ${input.suffix}`,
+            timeout: 60_000
+        }).toEqual([]);
+    }
+
+    async unexpectedDeliveryCount(input: Readonly<{
+        runId: string;
+        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+    }>): Promise<number> {
+        const run = await this.fetchRun(input.runId);
+        return countUnexpectedLiveRtcDeliveries({
+            events: run.events ?? [],
+            scenarios: input.scenarios
+        });
+    }
+
+    async expectArtifactBundle(input: Readonly<{
+        runId: string;
+        commandIds: readonly string[];
+    }>): Promise<void> {
+        const response = await this.#request.get(
+            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/artifacts`
+        );
+        expect(response.ok()).toBe(true);
+        const bundle = requiredJsonRecord(
+            normalizeJson(await response.json()),
+            '$.artifactBundle'
+        );
+        const files = requiredJsonRecord(bundle.files, '$.artifactBundle.files');
+        const report = stringValue(files['report.json']) ?? '';
+        const events = stringValue(files['events.jsonl']) ?? '';
+        expect(report).toContain(input.commandIds[0]);
+        expect(events).toContain('rallar.browser');
+    }
+
+    async attachRunSummary(input: Readonly<{
+        testInfo: TestInfo;
+        runId: string;
+    }>): Promise<void> {
+        const run = await this.fetchRun(input.runId);
+        const body = JSON.stringify(
+            {
+                runId: input.runId,
+                agents: run.agents?.map((agent) => agent.agentId),
+                resultCount: run.results?.length ?? 0,
+                eventCount: run.events?.length ?? 0
+            },
+            null,
+            2
+        );
+        await input.testInfo.attach('live-rtc-three-browser-run-summary.json', {
+            body,
+            contentType: 'application/json'
+        });
+        await this.#writeDiagnosticsArtifact(
+            `live-rtc-three-browser-run-summary-${safeFileName(input.runId)}.json`,
+            body
+        );
+    }
+
+    async captureDiagnostics(
+        input: LiveRtcControlClient.CaptureDiagnosticsInput
+    ): Promise<LiveRtcControlClient.CapturedDiagnostics> {
+        const commandIds: string[] = [];
+        const agents: LiveRtcAgentDiagnostics[] = [];
+        for (const agent of input.agents) {
+            const commandId =
+                `rtc-diagnostics-${agent.prefix.toLowerCase()}-${input.label}`;
+            commandIds.push(commandId);
+            const result = await this.executeOk({
+                runId: input.runId,
+                agentId: agent.agentId,
+                commandId,
+                command: {
+                    kind: 'health',
+                    includeRtcDiagnostics: true
+                },
+                timeoutMs: 30_000
+            });
+            agents.push(
+                buildLiveRtcAgentDiagnostics(agent.agentId, this.resultValue(result))
+            );
+        }
+        const checkpoint: LiveRtcDiagnosticsCheckpoint = {
+            label: input.label,
+            cycle: input.cycle,
+            agents
+        };
+        const body = JSON.stringify(
+            {
+                runId: input.runId,
+                capturedAtEpochMs: Date.now(),
+                ...checkpoint
+            },
+            null,
+            2
+        );
+        await input.testInfo.attach(`live-rtc-diagnostics-${input.label}.json`, {
+            body,
+            contentType: 'application/json'
+        });
+        await this.#writeDiagnosticsArtifact(
+            `live-rtc-diagnostics-${safeFileName(input.label)}.json`,
+            body
+        );
+        return { commandIds, checkpoint };
+    }
+
+    async #writeDiagnosticsArtifact(fileName: string, body: string): Promise<void> {
+        if (!this.#diagnosticsOutDir) {
+            return;
+        }
+        await mkdir(this.#diagnosticsOutDir, { recursive: true });
+        await writeFile(resolve(this.#diagnosticsOutDir, fileName), body);
+    }
+}
+
+const FIVE_MEBIBYTES = 5 * 1024 * 1024;
+const LIVE_RTC_BASELINE_ID =
+    /^\d{8}-[0-9a-f]{12}-e(?:3-memory|4-pg)(?:-repeat-01)?$/u;
+const attemptIdentityFields = [
+    'workloadId',
+    'caseId',
+    'inputKey',
+    'intendedPhase',
+    'outerOrdinal'
+] as const;
+
+export async function loadLiveRtcPerformanceAttempt(
+    input: LoadLiveRtcPerformanceAttemptInput
+): Promise<LiveRtcPerformanceAttemptContext | null> {
+    const names = [
+        'RALLAR_BLACK_BOX_RTC_BASELINE_ID',
+        'RALLAR_BLACK_BOX_RTC_CASE_ID',
+        'RALLAR_BLACK_BOX_RTC_INPUT_KEY',
+        'RALLAR_BLACK_BOX_RTC_INTENDED_PHASE',
+        'RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL'
+    ] as const;
+    const values = names.map((name) => {
+        const value = input.environment[name];
+        return value !== undefined && value.length > 0 ? value : undefined;
+    });
+    if (values.every((value) => value === undefined)) {
+        return null;
+    }
+    const missing = names.filter((_, index) => values[index] === undefined);
+    if (missing.length > 0) {
+        throw new Error(`Live RTC evidence environment is missing ${missing.join(', ')}.`);
+    }
+    const [baselineId, caseId, inputKey, intendedPhase, ordinalRaw] = values as [
+        string,
+        string,
+        string,
+        string,
+        string
+    ];
+    assertCanonicalLiveRtcBaselineId(baselineId);
+    if (!/^[1-9][0-9]*$/u.test(ordinalRaw)) {
+        throw new Error('RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL must be a positive integer.');
+    }
+    const outerOrdinal = Number(ordinalRaw);
+    if (!Number.isSafeInteger(outerOrdinal)) {
+        throw new Error('RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL must be a safe positive integer.');
+    }
+    const baselineRoot = resolve(
+        input.repoRoot,
+        'tmp',
+        'perf',
+        'rtc-baseline',
+        baselineId
+    );
+    const manifest = await readBaselineManifest(baselineRoot);
+    const environment = await readBaselineEnvironment(baselineRoot);
+    const locator = deriveRtcBaselineExternalAttempts(manifest, 'RTC-B06').find(
+        (attempt) =>
+            attempt.caseId === caseId &&
+            attempt.inputKey === inputKey &&
+            attempt.intendedPhase === intendedPhase &&
+            attempt.outerOrdinal === outerOrdinal
+    );
+    if (!locator || !isLiveRtcPerformanceAttemptLocator(locator)) {
+        throw new Error('Live RTC evidence environment does not identify a predeclared attempt.');
+    }
+    const outerAttempt = manifest.outerAttempts.find(
+        (attempt) =>
+            attempt.workloadId === locator.workloadId &&
+            attempt.caseId === locator.caseId &&
+            attempt.inputKey === locator.inputKey &&
+            attempt.intendedPhase === locator.intendedPhase &&
+            attempt.outerOrdinal === locator.outerOrdinal
+    );
+    if (!outerAttempt || outerAttempt.sampleIds.length !== 1) {
+        throw new Error('Live RTC evidence requires exactly one predeclared sample per attempt.');
+    }
+    if (!environment.observation) {
+        throw new Error('Live RTC baseline initialization is missing its runtime observation.');
+    }
+    if (
+        manifest.request.baselineId !== baselineId ||
+        environment.baselineId !== baselineId ||
+        environment.environmentId !== locator.environmentId ||
+        !environment.workloadIds.includes('RTC-B06')
+    ) {
+        throw new Error('Live RTC manifest and environment do not match the selected attempt.');
+    }
+    return {
+        repoRoot: input.repoRoot,
+        baselineId,
+        locator,
+        sampleIdentity: {
+            sampleId: outerAttempt.sampleIds[0]!,
+            workloadId: outerAttempt.workloadId,
+            caseId: outerAttempt.caseId,
+            inputKey: outerAttempt.inputKey,
+            intendedPhase: outerAttempt.intendedPhase,
+            outerOrdinal: outerAttempt.outerOrdinal,
+            innerOrdinal: 1
+        },
+        runtimeObservation: environment.observation
+    };
+}
+
+function isLiveRtcPerformanceAttemptLocator(
+    locator: RtcBaselineAttemptLocatorDto
+): locator is LiveRtcPerformanceAttemptLocator {
+    if (locator.workloadId !== 'RTC-B06') {
+        return false;
+    }
+    if (locator.environmentId === 'E3-memory') {
+        return locator.inputKey === `e3-memory-${locator.caseId}` &&
+            ['default', 'all-scenarios', 'retention-100'].includes(locator.caseId);
+    }
+    if (locator.environmentId === 'E4-pg') {
+        return locator.inputKey === `e4-pg-${locator.caseId}` &&
+            ['default', 'all-scenarios', 'retention-100'].includes(locator.caseId);
+    }
+    return false;
+}
+
+export function buildLiveRtcExternalAttempt(
+    input: BuildLiveRtcExternalAttemptInput
+): RtcBaselineExternalAttemptDto {
+    assertAttemptIdentity(input);
+    assertProducerMatchesIdentity(input.rawEvidence);
+    assertRuntimeMatchesObservation(input);
+    const issues = attemptIssues(input);
+    const sample: RtcBaselineSampleDto = {
+        schema: 'rallar.rtc-baseline.sample.v1',
+        identity: input.sampleIdentity,
+        outcome: issues.length === 0 ? 'passed' : 'failed',
+        evidenceClass: 'local-full-stack',
+        metrics: performanceMetrics(input.rawEvidence),
+        rawEvidence: normalizeJson(input.rawEvidence),
+        rawReferences: [],
+        issues,
+        runtimeObservation: input.runtimeObservation
+    };
+    const attempt: RtcBaselineExternalAttemptDto = {
+        schema: 'rallar.rtc-baseline.external-attempt.v1',
+        locator: input.locator,
+        producerExitStatus: input.producerExitStatus,
+        producerFacts: producerFacts(input.rawEvidence),
+        sampleOutcomes: [sampleOutcome(sample)],
+        samples: [sample],
+        issues: []
+    };
+    assertValidBuiltEvidence(validateRtcBaselineExternalAttempt(attempt));
+    return attempt;
+}
+
+function assertRuntimeMatchesObservation(input: BuildLiveRtcExternalAttemptInput): void {
+    const observed = input.runtimeObservation.runtime;
+    const raw = input.rawEvidence.runtime;
+    if (
+        raw.node !== observed.node ||
+        raw.playwright !== observed.playwright ||
+        raw.chromium !== observed.chromium
+    ) {
+        throw new Error('Live RTC runtime facts do not match the baseline observation.');
+    }
+}
+
+export function buildLiveRtcRetentionCohort(
+    input: BuildLiveRtcRetentionCohortInput
+): RtcBaselineExternalCohortDto {
+    if (input.identity.workloadId !== 'RTC-B06') {
+        throw new Error('Live RTC retention cohort workload must be RTC-B06.');
+    }
+    const samples = retainedSamplesInIdentityOrder(input);
+    const requiredHeapBreachCount = heapBreachThreshold(samples.length);
+    const heapBreachingSampleIds = samples
+        .filter(retentionHeapBreached)
+        .map((sample) => sample.identity.sampleId);
+    const stateDriftSampleIds = samples
+        .filter(retentionStateDrifted)
+        .map((sample) => sample.identity.sampleId);
+    const failedMemberSampleIds = samples
+        .filter((sample) => sample.outcome !== 'passed' || sample.issues.length > 0)
+        .map((sample) => sample.identity.sampleId);
+    const issues: RtcBaselineIssueDto[] = [];
+    if (heapBreachingSampleIds.length >= requiredHeapBreachCount) {
+        issues.push({
+            path: '$.rawEvidence.heapBreachingSampleIds',
+            code: 'retention-heap-threshold-breached',
+            message:
+                `${heapBreachingSampleIds.length} retained attempts breached the ${requiredHeapBreachCount}-attempt heap threshold.`
+        });
+    }
+    if (stateDriftSampleIds.length > 0) {
+        issues.push({
+            path: '$.rawEvidence.stateDriftSampleIds',
+            code: 'retention-state-drift',
+            message: 'Settled peer, lane, or connection-timer state did not return to cycle 0.'
+        });
+    }
+    if (failedMemberSampleIds.length > 0) {
+        issues.push({
+            path: '$.rawEvidence.failedMemberSampleIds',
+            code: 'retention-member-failed',
+            message: 'Every retention cohort member must be a passing external sample.'
+        });
+    }
+    const cohort: RtcBaselineExternalCohortDto = {
+        schema: 'rallar.rtc-baseline.external-cohort.v1',
+        identity: input.identity,
+        outcome: issues.length === 0 ? 'passed' : 'failed',
+        rawEvidence: {
+            retainedAttemptCount: samples.length,
+            requiredHeapBreachCount,
+            heapBreachingSampleIds,
+            stateDriftSampleIds,
+            failedMemberSampleIds
+        },
+        issues,
+        samples
+    };
+    assertValidBuiltEvidence(validateRtcBaselineExternalCohort(cohort));
+    return cohort;
+}
+
+export async function writeLiveRtcRetentionCohortIfComplete(
+    context: LiveRtcPerformanceAttemptContext
+): Promise<string | null> {
+    if (
+        context.locator.caseId !== 'retention-100' ||
+        context.locator.intendedPhase !== 'retained'
+    ) {
+        return null;
+    }
+    const baselineRoot = resolve(
+        context.repoRoot,
+        'tmp',
+        'perf',
+        'rtc-baseline',
+        context.baselineId
+    );
+    const manifest = await readBaselineManifest(baselineRoot);
+    const identity = manifest.expectedCohorts.find((cohort) =>
+        cohort.workloadId === 'RTC-B06' &&
+        cohort.memberSampleIds.includes(context.sampleIdentity.sampleId)
+    );
+    if (!identity) {
+        throw new Error('Live RTC retention attempt is not owned by a predeclared cohort.');
+    }
+    if (identity.memberSampleIds.at(-1) !== context.sampleIdentity.sampleId) {
+        return null;
+    }
+    const memberSampleIds = new Set(identity.memberSampleIds);
+    const locators = deriveRtcBaselineExternalAttempts(manifest, 'RTC-B06').filter(
+        (locator) => manifest.outerAttempts.some((attempt) =>
+            attempt.workloadId === locator.workloadId &&
+            attempt.caseId === locator.caseId &&
+            attempt.inputKey === locator.inputKey &&
+            attempt.intendedPhase === locator.intendedPhase &&
+            attempt.outerOrdinal === locator.outerOrdinal &&
+            attempt.sampleIds.length === 1 &&
+            memberSampleIds.has(attempt.sampleIds[0]!)
+        )
+    );
+    if (locators.length !== identity.memberSampleIds.length) {
+        throw new Error('Live RTC retention cohort manifest membership is incomplete.');
+    }
+    const attempts = await Promise.all(
+        locators.map((locator) => readExternalAttempt(
+            resolve(baselineRoot, locator.rawResultRelativePath)
+        ))
+    );
+    const cohort = buildLiveRtcRetentionCohort({ identity, attempts });
+    return writeLiveRtcPerformanceEvidence({
+        repoRoot: context.repoRoot,
+        baselineId: context.baselineId,
+        relativePath: `artifacts/staging/${identity.cohortId}.json`,
+        evidence: cohort
+    });
+}
+
+export async function writeLiveRtcPerformanceEvidence(
+    input: WriteLiveRtcPerformanceEvidenceInput
+): Promise<string> {
+    assertCanonicalLiveRtcBaselineId(input.baselineId);
+    if (
+        isAbsolute(input.relativePath) ||
+        !input.relativePath.startsWith('artifacts/staging/')
+    ) {
+        throw new Error('Live RTC staged evidence must be confined beneath artifacts/staging.');
+    }
+    normalizeJson(input.evidence);
+    const realRepoRoot = await realpath(input.repoRoot);
+    const baselineRoot = resolve(
+        realRepoRoot,
+        'tmp',
+        'perf',
+        'rtc-baseline',
+        input.baselineId
+    );
+    const stagingRoot = resolve(baselineRoot, 'artifacts', 'staging');
+    const outputPath = resolve(baselineRoot, input.relativePath);
+    const confinedRelativePath = relative(stagingRoot, outputPath);
+    if (
+        confinedRelativePath === '' ||
+        confinedRelativePath === '..' ||
+        confinedRelativePath.startsWith(`..${sep}`) ||
+        isAbsolute(confinedRelativePath)
+    ) {
+        throw new Error('Live RTC staged evidence path is not confined beneath artifacts/staging.');
+    }
+    await createConfinedDirectories(realRepoRoot, dirname(outputPath));
+    const file = await open(outputPath, 'wx');
+    try {
+        await file.writeFile(`${JSON.stringify(input.evidence)}\n`, 'utf8');
+        await file.sync();
+    }
+    finally {
+        await file.close();
+    }
+    return outputPath;
+}
+
+export async function captureLiveRtcPostGcHeap(
+    pages: readonly Page[]
+): Promise<number> {
+    let totalUsedBytes = 0;
+    for (const page of pages) {
+        const session = await page.context().newCDPSession(page);
+        try {
+            await session.send('HeapProfiler.collectGarbage');
+            const usage = await session.send('Runtime.getHeapUsage');
+            const usedSize = requiredJsonRecord(
+                normalizeJson(usage),
+                '$.heapUsage'
+            ).usedSize;
+            if (typeof usedSize !== 'number' || !Number.isFinite(usedSize)) {
+                throw new Error('Chromium did not return a finite post-GC heap size.');
+            }
+            totalUsedBytes += usedSize;
+        }
+        finally {
+            await session.detach();
+        }
+    }
+    return totalUsedBytes;
+}
+
+function assertAttemptIdentity(input: BuildLiveRtcExternalAttemptInput): void {
+    if (input.locator.workloadId !== 'RTC-B06') {
+        throw new Error('Live RTC external attempt workload must be RTC-B06.');
+    }
+    const sampleMismatch = attemptIdentityFields.some(
+        (field) => input.sampleIdentity[field] !== input.locator[field]
+    ) || input.sampleIdentity.innerOrdinal !== 1;
+    if (sampleMismatch) {
+        throw new Error('Live RTC sample identity does not match the attempt locator.');
+    }
+    const rawIdentity = input.rawEvidence.identity;
+    const rawMismatch = attemptIdentityFields.some(
+        (field) => rawIdentity[field] !== input.locator[field]
+    ) || rawIdentity.environmentId !== input.locator.environmentId;
+    if (rawMismatch) {
+        throw new Error('Live RTC raw evidence identity does not match the attempt locator.');
+    }
+}
+
+function assertProducerMatchesIdentity(rawEvidence: LiveRtcPerformanceRawEvidence): void {
+    const e4 = rawEvidence.identity.environmentId === 'E4-pg';
+    const producer = rawEvidence.producer;
+    const allScenarios = rawEvidence.identity.caseId === 'all-scenarios';
+    const retention = rawEvidence.identity.caseId === 'retention-100';
+    if (
+        producer.browserCount !== 3 ||
+        producer.provider !== 'browser-rallar' ||
+        producer.transports[0] !== 'realtime' ||
+        producer.transports[1] !== 'messages.rtc'
+    ) {
+        throw new Error('Live RTC producer must use three browser-rallar agents and both RTC transports.');
+    }
+    if (
+        (e4 && (
+            producer.databaseProvider !== 'postgres' ||
+            producer.databaseUrl !== 'present' ||
+            producer.iceMode !== 'local' ||
+            producer.iceModeRaw !== 'local'
+        )) ||
+        (!e4 && (
+            producer.databaseProvider !== 'memory' ||
+            producer.iceMode !== 'repository-default' ||
+            producer.iceModeRaw !== null
+        ))
+    ) {
+        throw new Error('Live RTC database and ICE facts do not match the environment identity.');
+    }
+    if (
+        producer.allScenariosRaw !== (allScenarios ? '1' : null) ||
+        producer.retentionSoakRaw !== (retention ? '1' : null) ||
+        producer.retentionCyclesRaw !== (retention ? '100' : null)
+    ) {
+        throw new Error('Live RTC case selectors do not match the attempt identity.');
+    }
+}
+
+function attemptIssues(input: BuildLiveRtcExternalAttemptInput): RtcBaselineIssueDto[] {
+    const issues: RtcBaselineIssueDto[] = [];
+    if (input.producerExitStatus !== 0) {
+        issues.push({
+            path: '$.producerExitStatus',
+            code: 'producer-failed',
+            message: `The live RTC producer exited with status ${input.producerExitStatus}.`
+        });
+    }
+    const evidence = input.rawEvidence;
+    if (!evidence.assertions.matrixPassed) {
+        issues.push(assertionIssue('matrixPassed', 'The live RTC matrix assertion failed.'));
+    }
+    if (!evidence.assertions.artifactBundlePassed) {
+        issues.push(assertionIssue('artifactBundlePassed', 'The control artifact bundle assertion failed.'));
+    }
+    if (evidence.assertions.unexpectedDeliveryCount !== 0) {
+        issues.push(assertionIssue('unexpectedDeliveryCount', 'Unexpected RTC deliveries were observed.'));
+    }
+    for (const required of requiredTimingSeries(evidence.identity.caseId)) {
+        if (!evidence.timings.some((timing) =>
+            timing.kind === required.kind && timing.transport === required.transport
+        )) {
+            issues.push({
+                path: '$.rawEvidence.timings',
+                code: 'missing-receiver-timing',
+                message:
+                    `Receiver-observed ${required.kind} timing is required for ${required.transport}.`
+            });
+        }
+    }
+    if (evidence.diagnostics.length === 0) {
+        issues.push({
+            path: '$.rawEvidence.diagnostics',
+            code: 'missing-rtc-diagnostics',
+            message: 'At least one complete three-agent RTC diagnostics snapshot is required.'
+        });
+    }
+    else if (evidence.diagnostics.some(
+        (checkpoint) => checkpoint.agents.length !== 3 ||
+            new Set(checkpoint.agents.map((agent) => agent.agentId)).size !== 3
+    )) {
+        issues.push({
+            path: '$.rawEvidence.diagnostics',
+            code: 'incomplete-rtc-diagnostics',
+            message: 'Every RTC diagnostics checkpoint must contain three distinct browser agents.'
+        });
+    }
+    if (evidence.identity.caseId === 'retention-100') {
+        issues.push(...retentionAttemptIssues(evidence));
+    }
+    else if (evidence.retention !== null) {
+        issues.push({
+            path: '$.rawEvidence.retention',
+            code: 'unexpected-retention-evidence',
+            message: 'Only the retention-100 case may contain retention checkpoints.'
+        });
+    }
+    return issues;
+}
+
+function assertionIssue(
+    field: keyof LiveRtcPerformanceAssertions,
+    message: string
+): RtcBaselineIssueDto {
+    return {
+        path: `$.rawEvidence.assertions.${field}`,
+        code: 'matrix-correctness-failed',
+        message
+    };
+}
+
+function requiredTimingSeries(
+    caseId: LiveRtcPerformanceIdentity['caseId']
+): readonly Readonly<{
+    kind: LiveRtcPerformanceTiming['kind'];
+    transport: LiveRtcPerformanceTiming['transport'];
+}>[] {
+    if (caseId === 'retention-100') {
+        return [{ kind: 'reconnect-ready', transport: 'messages.rtc' }];
+    }
+    const kinds = [
+        'peer-ready',
+        'direct-delivery',
+        'multicast-delivery',
+        'broadcast-delivery'
+    ] as const;
+    const delivery = (['realtime', 'messages.rtc'] as const).flatMap(
+        (transport) => kinds.map((kind) => ({ kind, transport }))
+    );
+    return caseId === 'all-scenarios'
+        ? [...delivery, { kind: 'reconnect-ready', transport: 'messages.rtc' } as const]
+        : delivery;
+}
+
+function retentionAttemptIssues(
+    evidence: LiveRtcPerformanceRawEvidence
+): RtcBaselineIssueDto[] {
+    if (!evidence.retention) {
+        return [{
+            path: '$.rawEvidence.retention',
+            code: 'missing-retention-evidence',
+            message: 'The retention-100 case requires 100-cycle retention evidence.'
+        }];
+    }
+    const cycles = evidence.retention.checkpoints.map((checkpoint) => checkpoint.cycle);
+    const expectedCycles = Array.from({ length: 11 }, (_, index) => index * 10);
+    const checkpointsComplete = evidence.retention.cycles === 100 &&
+        JSON.stringify(cycles) === JSON.stringify(expectedCycles) &&
+        evidence.retention.checkpoints.every(
+            (checkpoint) =>
+                checkpoint.postGcHeapBytes >= 0 &&
+                checkpoint.agents.length === 3 &&
+                new Set(checkpoint.agents.map((agent) => agent.agentId)).size === 3
+        );
+    const issues: RtcBaselineIssueDto[] = checkpointsComplete
+        ? []
+        : [{
+            path: '$.rawEvidence.retention.checkpoints',
+            code: 'invalid-retention-checkpoints',
+            message: 'Retention requires cycle 0 and every tenth cycle through 100 with three distinct agents and post-GC facts.'
+        }];
+    const stateReturned = liveRtcRetentionStateReturned(
+        evidence.retention.checkpoints
+    );
+    if (evidence.retention.settledStateReturned !== stateReturned) {
+        issues.push({
+            path: '$.rawEvidence.retention.settledStateReturned',
+            code: 'retention-state-assertion-mismatch',
+            message: 'The stored settled-state assertion does not match the retained checkpoints.'
+        });
+    }
+    if (!stateReturned) {
+        issues.push({
+            path: '$.rawEvidence.retention.checkpoints',
+            code: 'retention-state-drift',
+            message: 'Settled peer, lane, count, or connection-timer state did not return to cycle 0.'
+        });
+    }
+    return issues;
+}
+
+function producerFacts(rawEvidence: LiveRtcPerformanceRawEvidence) {
+    const producer = rawEvidence.producer;
+    return {
+        databaseUrl: producer.databaseUrl,
+        allScenariosPresent: producer.allScenariosRaw !== null,
+        allScenariosRaw: producer.allScenariosRaw,
+        retentionSoakPresent: producer.retentionSoakRaw !== null,
+        retentionSoakRaw: producer.retentionSoakRaw,
+        retentionCyclesPresent: producer.retentionCyclesRaw !== null,
+        retentionCyclesRaw: producer.retentionCyclesRaw,
+        iceModePresent: producer.iceModeRaw !== null,
+        iceModeRaw: producer.iceModeRaw
+    } as const;
+}
+
+function performanceMetrics(rawEvidence: LiveRtcPerformanceRawEvidence) {
+    const timingGroups = new Map<string, number[]>();
+    for (const timing of rawEvidence.timings) {
+        if (!Number.isFinite(timing.durationMs) || timing.durationMs < 0) {
+            throw new Error('Live RTC timing durations must be finite nonnegative numbers.');
+        }
+        const metric = `${timing.kind}.${timing.transport.replace('.', '-')}`;
+        const values = timingGroups.get(metric) ?? [];
+        values.push(timing.durationMs);
+        timingGroups.set(metric, values);
+    }
+    const metrics = [...timingGroups].map(([metric, values]) => ({
+        metric,
+        unit: 'milliseconds',
+        value: median(values)
+    }));
+    const retention = rawEvidence.retention;
+    if (retention) {
+        const first = retention.checkpoints[0];
+        const last = retention.checkpoints.at(-1);
+        if (first && last) {
+            metrics.push(
+                {
+                    metric: 'post-gc-heap.cycle-0',
+                    unit: 'bytes',
+                    value: first.postGcHeapBytes
+                },
+                {
+                    metric: 'post-gc-heap.cycle-100',
+                    unit: 'bytes',
+                    value: last.postGcHeapBytes
+                }
+            );
+        }
+    }
+    return metrics;
+}
+
+function median(values: readonly number[]): number {
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[middle - 1]! + sorted[middle]!) / 2
+        : sorted[middle]!;
+}
+
+function sampleOutcome(sample: RtcBaselineSampleDto) {
+    return {
+        identity: sample.identity,
+        outcome: sample.outcome,
+        issues: sample.issues
+    };
+}
+
+function retainedSamplesInIdentityOrder(
+    input: BuildLiveRtcRetentionCohortInput
+): RtcBaselineSampleDto[] {
+    const samples = input.attempts.map((attempt) => {
+        const sample = attempt.samples[0];
+        const outcome = attempt.sampleOutcomes[0];
+        const locator = attempt.locator;
+        const locatorMatchesSample = sample !== undefined && attemptIdentityFields.every(
+            (field) => sample.identity[field] === locator[field]
+        );
+        const expectedInputKey = locator.environmentId === 'E3-memory'
+            ? 'e3-memory-retention-100'
+            : 'e4-pg-retention-100';
+        if (
+            attempt.samples.length !== 1 ||
+            attempt.sampleOutcomes.length !== 1 ||
+            !sample ||
+            !outcome ||
+            !locatorMatchesSample ||
+            sample.identity.innerOrdinal !== 1 ||
+            outcome.identity.sampleId !== sample.identity.sampleId ||
+            locator.workloadId !== 'RTC-B06' ||
+            locator.caseId !== 'retention-100' ||
+            locator.intendedPhase !== 'retained' ||
+            locator.inputKey !== expectedInputKey ||
+            input.identity.cohortId !==
+                `rtc-b06-${locator.environmentId.toLowerCase()}-retention`
+        ) {
+            throw new Error('Live RTC retention attempts must be exact retained B06 members.');
+        }
+        return sample;
+    });
+    const sampleById = new Map(
+        samples.map((sample) => [sample.identity.sampleId, sample])
+    );
+    if (
+        new Set(input.identity.memberSampleIds).size !== input.identity.memberSampleIds.length ||
+        samples.length !== input.identity.memberSampleIds.length
+    ) {
+        throw new Error('Live RTC retention attempts do not exactly match cohort membership.');
+    }
+    const ordered: RtcBaselineSampleDto[] = [];
+    for (const sampleId of input.identity.memberSampleIds) {
+        const sample = sampleById.get(sampleId);
+        if (!sample) {
+            throw new Error('Live RTC retention attempts do not exactly match cohort membership.');
+        }
+        ordered.push(sample);
+    }
+    return ordered;
+}
+
+function heapBreachThreshold(sampleCount: number): number {
+    if (sampleCount === 3) {
+        return 2;
+    }
+    if (sampleCount === 6) {
+        return 4;
+    }
+    throw new Error('Live RTC retention cohort requires exactly 3 primary or 6 repeat samples.');
+}
+
+function retentionHeapBreached(sample: RtcBaselineSampleDto): boolean {
+    const retention = retentionEvidence(sample);
+    if (!retention) {
+        return false;
+    }
+    const cycle0 = retention.checkpoints[0]?.postGcHeapBytes;
+    const final = retention.checkpoints.at(-1)?.postGcHeapBytes;
+    return cycle0 !== undefined && final !== undefined &&
+        final > cycle0 * 1.1 && final > cycle0 + FIVE_MEBIBYTES;
+}
+
+function retentionStateDrifted(sample: RtcBaselineSampleDto): boolean {
+    const retention = retentionEvidence(sample);
+    return !retention ||
+        !retention.settledStateReturned ||
+        !liveRtcRetentionStateReturned(retention.checkpoints);
+}
+
+export function liveRtcRetentionStateReturned(
+    checkpoints: readonly LiveRtcRetentionCheckpoint[]
+): boolean {
+    const first = checkpoints[0];
+    if (!first) {
+        return false;
+    }
+    const firstAgentIds = first.agents.map((agent) => agent.agentId).sort();
+    return checkpoints.every((checkpoint) => {
+        const checkpointAgentIds = checkpoint.agents
+            .map((agent) => agent.agentId)
+            .sort();
+        return checkpoint.agents.length === first.agents.length &&
+            JSON.stringify(checkpointAgentIds) === JSON.stringify(firstAgentIds) &&
+            first.agents.every((agent) => {
+                const observed = checkpoint.agents.find(
+                    (candidate) => candidate.agentId === agent.agentId
+                );
+                return observed !== undefined &&
+                    JSON.stringify(stableAgentState(observed)) ===
+                        JSON.stringify(stableAgentState(agent));
+            });
+    });
+}
+
+function retentionEvidence(sample: RtcBaselineSampleDto): LiveRtcRetentionEvidence | null {
+    const raw = jsonRecord(sample.rawEvidence);
+    if (!raw) {
+        return null;
+    }
+    const retention = jsonRecord(raw.retention);
+    if (
+        !retention ||
+        retention.cycles !== 100 ||
+        typeof retention.settledStateReturned !== 'boolean' ||
+        !Array.isArray(retention.checkpoints)
+    ) {
+        return null;
+    }
+    const checkpoints: LiveRtcRetentionCheckpoint[] = [];
+    for (const value of retention.checkpoints) {
+        const checkpoint = decodeRetentionCheckpoint(value);
+        if (!checkpoint) {
+            return null;
+        }
+        checkpoints.push(checkpoint);
+    }
+    return {
+        cycles: 100,
+        checkpoints,
+        settledStateReturned: retention.settledStateReturned
+    };
+}
+
+function stableAgentState(agent: LiveRtcAgentDiagnostics) {
+    return {
+        settledPeerIds: [...agent.settledPeerIds].sort(),
+        readyPeerIds: [...agent.readyPeerIds].sort(),
+        laneStates: [...agent.laneStates].sort(compareLaneStates),
+        connectionTimerActive: agent.connectionTimerActive,
+        peerCount: agent.peerCount,
+        connectedPeerCount: agent.connectedPeerCount,
+        relayPeerCount: agent.relayPeerCount
+    };
+}
+
+function decodeRetentionCheckpoint(
+    value: RtcBaselineJson
+): LiveRtcRetentionCheckpoint | null {
+    const checkpoint = jsonRecord(value);
+    if (
+        !checkpoint ||
+        !isFiniteNonnegativeNumber(checkpoint.cycle) ||
+        !isFiniteNonnegativeNumber(checkpoint.postGcHeapBytes) ||
+        !Array.isArray(checkpoint.agents)
+    ) {
+        return null;
+    }
+    const agents: LiveRtcAgentDiagnostics[] = [];
+    for (const agentValue of checkpoint.agents) {
+        const agent = decodeAgentDiagnostics(agentValue);
+        if (!agent) {
+            return null;
+        }
+        agents.push(agent);
+    }
+    return {
+        cycle: checkpoint.cycle,
+        postGcHeapBytes: checkpoint.postGcHeapBytes,
+        agents
+    };
+}
+
+function decodeAgentDiagnostics(
+    value: RtcBaselineJson
+): LiveRtcAgentDiagnostics | null {
+    const agent = jsonRecord(value);
+    const settledPeerIds = agent ? exactStringArray(agent.settledPeerIds) : null;
+    const readyPeerIds = agent ? exactStringArray(agent.readyPeerIds) : null;
+    if (
+        !agent ||
+        typeof agent.agentId !== 'string' ||
+        !settledPeerIds ||
+        !readyPeerIds ||
+        !Array.isArray(agent.laneStates) ||
+        typeof agent.connectionTimerActive !== 'boolean' ||
+        !isFiniteNonnegativeNumber(agent.peerCount) ||
+        !isFiniteNonnegativeNumber(agent.connectedPeerCount) ||
+        !isFiniteNonnegativeNumber(agent.relayPeerCount) ||
+        agent.details === undefined
+    ) {
+        return null;
+    }
+    const laneStates: LiveRtcLaneDiagnostics[] = [];
+    for (const laneValue of agent.laneStates) {
+        const lane = decodeLaneDiagnostics(laneValue);
+        if (!lane) {
+            return null;
+        }
+        laneStates.push(lane);
+    }
+    return {
+        agentId: agent.agentId,
+        settledPeerIds,
+        readyPeerIds,
+        laneStates,
+        connectionTimerActive: agent.connectionTimerActive,
+        peerCount: agent.peerCount,
+        connectedPeerCount: agent.connectedPeerCount,
+        relayPeerCount: agent.relayPeerCount,
+        details: agent.details
+    };
+}
+
+function decodeLaneDiagnostics(
+    value: RtcBaselineJson
+): LiveRtcLaneDiagnostics | null {
+    const lane = jsonRecord(value);
+    return lane &&
+        typeof lane.peerId === 'string' &&
+        typeof lane.laneId === 'string' &&
+        typeof lane.isOpen === 'boolean' &&
+        typeof lane.isReconnectable === 'boolean'
+        ? {
+            peerId: lane.peerId,
+            laneId: lane.laneId,
+            isOpen: lane.isOpen,
+            isReconnectable: lane.isReconnectable
+        }
+        : null;
+}
+
+function jsonRecord(
+    value: RtcBaselineJson | undefined
+): { [key: string]: RtcBaselineJson; } | null {
+    return value !== undefined &&
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+        ? value
+        : null;
+}
+
+function exactStringArray(value: RtcBaselineJson | undefined): readonly string[] | null {
+    return Array.isArray(value) &&
+        value.every((entry): entry is string => typeof entry === 'string')
+        ? value
+        : null;
+}
+
+function isFiniteNonnegativeNumber(
+    value: RtcBaselineJson | undefined
+): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function decodeControlRunSnapshot(
+    value: RtcBaselineJson
+): LiveRtcControlClient.RunSnapshot {
+    const run = requiredJsonRecord(value, '$.controlRun');
+    const agents = optionalJsonArray(run.agents, '$.controlRun.agents').map(
+        (entry, index) => {
+            const agent = requiredJsonRecord(entry, `$.controlRun.agents[${index}]`);
+            return {
+                agentId: requiredString(
+                    agent.agentId,
+                    `$.controlRun.agents[${index}].agentId`
+                )
+            };
+        }
+    );
+    const results = optionalJsonArray(run.results, '$.controlRun.results').map(
+        (entry, index) => {
+            const result = requiredJsonRecord(entry, `$.controlRun.results[${index}]`);
+            const resultEnvelope = result.result === undefined
+                ? null
+                : requiredJsonRecord(
+                    result.result,
+                    `$.controlRun.results[${index}].result`
+                );
+            return {
+                agentId: optionalString(
+                    result.agentId,
+                    `$.controlRun.results[${index}].agentId`
+                ),
+                commandId: requiredString(
+                    result.commandId,
+                    `$.controlRun.results[${index}].commandId`
+                ),
+                ok: requiredBoolean(
+                    result.ok,
+                    `$.controlRun.results[${index}].ok`
+                ),
+                ...(resultEnvelope ? { result: { value: resultEnvelope.value } } : {}),
+                ...(result.error !== undefined ? { error: result.error } : {})
+            };
+        }
+    );
+    const events = optionalJsonArray(run.events, '$.controlRun.events').map(
+        (entry, index) => {
+            const event = requiredJsonRecord(entry, `$.controlRun.events[${index}]`);
+            return {
+                kind: optionalString(event.kind, `$.controlRun.events[${index}].kind`),
+                agentId: optionalString(
+                    event.agentId,
+                    `$.controlRun.events[${index}].agentId`
+                ),
+                ...(event.payload !== undefined ? { payload: event.payload } : {})
+            };
+        }
+    );
+    return { agents, results, events };
+}
+
+function optionalJsonArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): readonly RtcBaselineJson[] {
+    return value === undefined ? [] : requiredJsonArray(value, path);
+}
+
+function optionalString(
+    value: RtcBaselineJson | undefined,
+    path: string
+): string | undefined {
+    return value === undefined ? undefined : requiredString(value, path);
+}
+
+function stringValue(value: RtcBaselineJson | undefined): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: RtcBaselineJson | undefined): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function stringArrayValue(value: RtcBaselineJson | undefined): readonly string[] {
+    return Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+}
+
+function runtimeEventPayload(
+    event: LiveRtcControlClient.Event
+): { [key: string]: RtcBaselineJson; } {
+    const payload = jsonRecord(event.payload) ?? {};
+    return typeof payload.kind === 'string'
+        ? payload
+        : jsonRecord(payload.payload) ?? payload;
+}
+
+function messageData(
+    event: LiveRtcControlClient.Event
+): { [key: string]: RtcBaselineJson; } {
+    const runtimeEvent = runtimeEventPayload(event);
+    const runtimePayload = jsonRecord(runtimeEvent.payload) ?? {};
+    return jsonRecord(runtimePayload.data ?? runtimeEvent.data) ?? {};
+}
+
+export function countUnexpectedLiveRtcDeliveries(input: Readonly<{
+    events: readonly LiveRtcControlClient.Event[];
+    scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+}>): number {
+    const scenarioById = new Map(
+        input.scenarios.map((scenario) => [scenario.matrixId, scenario])
+    );
+    return input.events.filter((event) => {
+        const matrixId = stringValue(messageData(event).matrixId);
+        const scenario = matrixId ? scenarioById.get(matrixId) : undefined;
+        return scenario !== undefined &&
+            event.agentId !== undefined &&
+            !scenario.allowedAgentIds.includes(event.agentId);
+    }).length;
+}
+
+function isMessageFor(
+    event: LiveRtcControlClient.Event,
+    input: LiveRtcControlClient.WaitForMessageInput
+): boolean {
+    const runtimeEvent = runtimeEventPayload(event);
+    const data = messageData(event);
+    return event.agentId === input.agentId &&
+        runtimeEvent.kind === 'message' &&
+        runtimeEvent.transport === input.transport &&
+        data.matrixId === input.matrixId &&
+        data.deliveryMode === input.deliveryMode;
+}
+
+export function buildLiveRtcAgentDiagnostics(
+    agentId: string,
+    resultValue: RtcBaselineJson | object
+): LiveRtcAgentDiagnostics {
+    const normalized = normalizeJson(resultValue);
+    const root = requiredJsonRecord(normalized, '$');
+    const rallar = requiredJsonRecord(root.rallar, '$.rallar');
+    const status = requiredJsonRecord(rallar.rtcStatus, '$.rallar.rtcStatus');
+    const diagnostics = requiredJsonRecord(
+        rallar.rtcDiagnostics,
+        '$.rallar.rtcDiagnostics'
+    );
+    const settledPeerIds = requiredStringArray(
+        status.activePeerIds,
+        '$.rallar.rtcStatus.activePeerIds'
+    ).sort();
+    const readyPeerIds = requiredStringArray(
+        status.readyPeerIds,
+        '$.rallar.rtcStatus.readyPeerIds'
+    ).sort();
+    const peers = requiredJsonArray(
+        diagnostics.peers,
+        '$.rallar.rtcDiagnostics.peers'
+    );
+    const peerRecords = peers.map((peer, index) =>
+        requiredJsonRecord(peer, `$.rallar.rtcDiagnostics.peers[${index}]`)
+    );
+    const laneStates = peerRecords.flatMap((peer) => {
+        const peerId = requiredString(peer.peerId, 'RTC diagnostic peerId');
+        const lanes = requiredJsonArray(peer.lanes, `RTC diagnostic lanes for ${peerId}`);
+        return lanes.map((laneValue, index) => {
+            const lane = requiredJsonRecord(
+                laneValue,
+                `RTC diagnostic lane ${index} for ${peerId}`
+            );
+            return {
+                peerId,
+                laneId: requiredString(lane.laneId, `RTC diagnostic laneId for ${peerId}`),
+                isOpen: requiredBoolean(lane.isOpen, `RTC diagnostic isOpen for ${peerId}`),
+                isReconnectable: requiredBoolean(
+                    lane.isReconnectable,
+                    `RTC diagnostic isReconnectable for ${peerId}`
+                )
+            };
+        });
+    }).sort(compareLaneStates);
+    const connectionTimerActive = peerRecords.some((peer) => {
+        const connection = requiredJsonRecord(
+            peer.connection,
+            'RTC diagnostic peer connection'
+        );
+        const connectionDiagnostics = jsonRecord(peer.connectionDiagnostics);
+        return connection.disconnectPending === true ||
+            connection.reconnecting === true ||
+            connectionDiagnostics?.hasReconnectTimer === true ||
+            (numberValue(connectionDiagnostics?.reconnectAttemptsInFlight) ?? 0) !== 0;
+    });
+    return {
+        agentId,
+        settledPeerIds,
+        readyPeerIds,
+        laneStates,
+        connectionTimerActive,
+        peerCount: requiredNonnegativeNumber(diagnostics.peerCount, 'RTC peerCount'),
+        connectedPeerCount: requiredNonnegativeNumber(
+            diagnostics.connectedPeerCount,
+            'RTC connectedPeerCount'
+        ),
+        relayPeerCount: requiredNonnegativeNumber(
+            diagnostics.relayPeerCount,
+            'RTC relayPeerCount'
+        ),
+        details: normalizeJson({
+            sessionId: diagnostics.sessionId ?? null,
+            generatedAtEpochMs: diagnostics.generatedAtEpochMs,
+            status,
+            diagnostics,
+            rtcDiagnosticsError: rallar.rtcDiagnosticsError ?? null
+        })
+    };
+}
+
+function compareLaneStates(
+    left: LiveRtcLaneDiagnostics,
+    right: LiveRtcLaneDiagnostics
+): number {
+    return left.peerId.localeCompare(right.peerId) ||
+        left.laneId.localeCompare(right.laneId);
+}
+
+function requiredJsonRecord(
+    value: RtcBaselineJson | undefined,
+    path: string
+): { [key: string]: RtcBaselineJson; } {
+    const record = jsonRecord(value);
+    if (!record) {
+        throw new Error(`${path} must be a JSON object.`);
+    }
+    return record;
+}
+
+function requiredJsonArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): readonly RtcBaselineJson[] {
+    if (!Array.isArray(value)) {
+        throw new Error(`${path} must be a JSON array.`);
+    }
+    return value;
+}
+
+function requiredStringArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): string[] {
+    const values = exactStringArray(value);
+    if (!values) {
+        throw new Error(`${path} must contain only strings.`);
+    }
+    return [...values];
+}
+
+function requiredString(value: RtcBaselineJson | undefined, field: string): string {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`${field} must be a nonempty string.`);
+    }
+    return value;
+}
+
+function requiredBoolean(value: RtcBaselineJson | undefined, field: string): boolean {
+    if (typeof value !== 'boolean') {
+        throw new Error(`${field} must be boolean.`);
+    }
+    return value;
+}
+
+function requiredNonnegativeNumber(
+    value: RtcBaselineJson | undefined,
+    field: string
+): number {
+    if (!isFiniteNonnegativeNumber(value)) {
+        throw new Error(`${field} must be a finite nonnegative number.`);
+    }
+    return value;
+}
+
+function safeFileName(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_.-]+/g, '-');
+}
+
+function normalizeJson(value: RtcBaselineJson | object): RtcBaselineJson {
+    assertJsonValue(value, '$');
+    return JSON.parse(JSON.stringify(value)) as RtcBaselineJson;
+}
+
+function assertJsonValue(value: RtcBaselineJson | object, path: string): void {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+        return;
+    }
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw new Error(`${path} contains a non-finite number.`);
+        }
+        return;
+    }
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            if (!(index in value)) {
+                throw new Error(`${path}[${index}] is a sparse array entry.`);
+            }
+            assertJsonValue(value[index], `${path}[${index}]`);
+        }
+        return;
+    }
+    if (typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
+        throw new Error(`${path} is not a plain JSON value.`);
+    }
+    for (const [field, entry] of Object.entries(value)) {
+        if (entry === undefined) {
+            throw new Error(`${path}.${field} is undefined.`);
+        }
+        assertJsonValue(entry, `${path}.${field}`);
+    }
+}
+
+async function createConfinedDirectories(
+    root: string,
+    targetDirectory: string
+): Promise<void> {
+    const targetRelativePath = relative(root, targetDirectory);
+    if (
+        targetRelativePath === '..' ||
+        targetRelativePath.startsWith(`..${sep}`) ||
+        isAbsolute(targetRelativePath)
+    ) {
+        throw new Error('Live RTC evidence directory is not confined to the repository root.');
+    }
+    let current = root;
+    for (const segment of targetRelativePath.split(sep).filter(Boolean)) {
+        current = resolve(current, segment);
+        try {
+            const metadata = await lstat(current);
+            if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+                throw new Error(`Live RTC evidence directory component is unsafe: ${current}`);
+            }
+        }
+        catch (error) {
+            if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
+                throw error;
+            }
+            await mkdir(current);
+        }
+    }
+}
+
+function assertValidBuiltEvidence(issues: readonly RtcBaselineIssueDto[]): void {
+    if (issues.length > 0) {
+        throw new Error(`Live RTC evidence builder produced an invalid contract: ${JSON.stringify(issues)}`);
+    }
+}
+
+function assertCanonicalLiveRtcBaselineId(baselineId: string): void {
+    if (!LIVE_RTC_BASELINE_ID.test(baselineId)) {
+        throw new Error('Live RTC evidence requires a canonical E3-memory or E4-pg baseline ID.');
+    }
+}
+
+async function readBaselineManifest(baselineRoot: string) {
+    const value = normalizeJson(JSON.parse(
+        await readFile(resolve(baselineRoot, 'manifest.json'), 'utf8')
+    ));
+    const decoded = decodeRtcBaselineManifest(value);
+    if (!decoded.ok) {
+        throw new Error(`Live RTC manifest is invalid: ${JSON.stringify(decoded.issues)}`);
+    }
+    return decoded.value;
+}
+
+async function readBaselineEnvironment(
+    baselineRoot: string
+): Promise<RtcBaselineEnvironmentDto> {
+    const value = normalizeJson(JSON.parse(
+        await readFile(resolve(baselineRoot, 'environment.json'), 'utf8')
+    ));
+    const decoded = decodeRtcBaselineEnvironment(value);
+    if (!decoded.ok) {
+        throw new Error(`Live RTC environment is invalid: ${JSON.stringify(decoded.issues)}`);
+    }
+    return decoded.value;
+}
+
+async function readExternalAttempt(path: string): Promise<RtcBaselineExternalAttemptDto> {
+    const value = normalizeJson(JSON.parse(await readFile(path, 'utf8')));
+    const decoded = decodeRtcBaselineExternalAttempt(value);
+    if (!decoded.ok) {
+        throw new Error(`Live RTC external attempt is invalid: ${JSON.stringify(decoded.issues)}`);
+    }
+    return decoded.value;
+}


### PR DESCRIPTION
## Goal

Add the reviewed RTC-B06 browser capture boundary so live three-browser RTC runs can produce strict E3-memory, E4-pg, and retention evidence from predeclared baseline attempts.

## Changes

- Extract the live RTC control client, diagnostics normalization, evidence validation, and confined writers into a dedicated Playwright support module.
- Bind each produced sample to the exact predeclared baseline, environment, case, attempt, runtime, and producer identity.
- Extend the live matrix with the default capture, exhaustive scenario capture, and 100-cycle post-GC retention capture.
- Stage external-attempt evidence only after the relevant matrix assertions complete, and write a retention cohort only when all predeclared retained attempts are present.
- Guard npm selector ownership so default memory/Postgres commands remain default-only, the explicit Postgres all-scenarios command owns exhaustive mode, and retention remains attempt-controlled.
- Generate live run and session identifiers with cryptographically secure UUIDs.
- Add focused coverage for incomplete timings, malformed diagnostics, identity/runtime mismatches, database-provider facts, retention state drift, heap thresholds, path confinement, symlink rejection, and secure identifier generation.

## Acceptance

- Playwright enumerates exactly the default, exhaustive, and 100-cycle retention cases.
- Valid evidence preserves exact predeclared identity and complete transport timing/diagnostic facts.
- Producer failure, identity mismatch, incomplete timing, missing agent diagnostics, state drift, or retention threshold failure makes the sample fail closed.
- Application and reusable product sources do not import benchmark ownership.
- Run/session identifiers do not depend on cryptographically insecure randomness.

**Test design evidence**

- Behavior protected and observation boundary: predeclared shared-rtc-bench attempt to real Playwright browser/control observations to one confined external-attempt artifact, plus a cohort only after all retained attempts exist.
- Retained interaction assertions (registry reference and rationale): None
- Coupled or redundant tests removed or replaced: Control/evidence mechanics were extracted from the matrix and are now exercised directly; the end-to-end matrix assertions remain the runtime boundary.

## Validation

Passed:
- npx vitest run packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts — 2 files, 23 tests.
- npm run typecheck:tests — 965 test files, 0 errors and 0 known-debt files.
- npm --workspace @ar-eye-hunter/shared-rtc-bench run check — TypeScript, 42 files/392 tests, and Deno checks.
- Playwright list for the live RTC matrix — exactly 3 tests.
- npm run check:repo-style:changed -- origin/main — no new findings.
- Focused directory style scan — exit 0; warning-only pre-existing findings did not name a touched file.
- npm run check:repo-structure — passed.
- git diff --check and staged diff checks — passed.

Skipped:
- Real E3/E4 browser captures. Those require this support to merge first and are the next plan phase.

## Risk and rollback

The main risk is changing shared control flow inside the existing live matrix while extracting evidence ownership. Focused tests preserve script and evidence contracts, and existing live assertions remain in the matrix. Revert commits 13e0f2d946b6d4ac0c51e64a5ddc338bc392f56f and 021ed5088ac56d68d775dcbc63b68899a57b8ccd to remove the support without changing product APIs or deployment behavior.

## Follow-up

After merge, run the predeclared E3-memory capture and then the conditional E4-pg capture/repeats required by the baseline decision rules.
