### PR TITLE
fix(shared-test): repair RTC-B06 browser capture lifecycle

### DIFF
--- a/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/messaging-controller.ts
+++ b/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/messaging-controller.ts
@@ -216,12 +216,13 @@ export function createBlackBoxRallarMessagingController(
         lease: BlackBoxRallarMessagingLease
     ): Promise<BlackBoxRallarSendDiagnostics> => {
         const normalized = normalizeSendInput(input);
-        const peerIds = normalized.peerIds ??
+        const selectedPeerIds = normalized.peerIds ??
             (normalized.remotePeerId
                 ? [normalized.remotePeerId]
                 : config.remotePeerId
                 ? [config.remotePeerId]
                 : config.rallar.peerIds);
+        const peerIds = selectedPeerIds ?? options.rtcStatus(config).readyPeerIds;
         const laneId = normalized.laneId ?? options.laneIdOf(config);
         const roomId = normalized.roomId ?? config.roomId;
         const roomRef = options.roomRefOf(config, normalized);

--- a/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
@@ -82,6 +82,35 @@ describe('live three-browser RTC npm script gates', () => {
         expect(source).toContain('crypto.randomUUID()');
     });
 
+    it('uses the current idempotent group mutation request routes', () => {
+        const source = fs.readFileSync(path.join(repoRoot, liveMatrixSpec), 'utf8');
+
+        expect(source).toMatch(
+            /groups\/requests\/\$\{pathSegment\(createRequestId\)\}/u
+        );
+        expect(source).toMatch(
+            /members\/\{auth\.clientId\}\/requests\/\$\{\s*pathSegment\(requestId\)\s*\}/u
+        );
+        expect(source).toContain('`rtc-b06-create-${input.suffix}`');
+        expect(source).toContain(
+            '`rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`'
+        );
+        expect(source).toContain('acceptedStatusCodes: [201]');
+        expect(source.match(/setupGroupMembership\(\{/gu)).toHaveLength(3);
+        expect(source).toMatch(
+            /for \(const agent of input\.agents\.slice\(0, 2\)\) \{\s*connected\.push\(\s*await connectAgent/u
+        );
+        expect(source).toContain('`${input.suffix}-initial-pair`');
+        expect(source).toContain('readinessStartedAtMs');
+        expect(source.match(/connectAgentTrio\(\{/gu)).toHaveLength(3);
+        expect(source).not.toMatch(
+            /input\.agents\.map\(\(agent\) => connectAgent/u
+        );
+        expect(source).toContain('departedPeerIds: [input.sessions.C]');
+        expect(source).toContain('departedPeerIds: [input.sessions.B]');
+        expect(source.match(/realtime\.sessions/gu)).toHaveLength(2);
+    });
+
     it('keeps benchmark ownership out of application and reusable product sources', () => {
         const productRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
         const forbiddenImports: string[] = [];

--- a/packages/tests/shared-test/rallar-browser-runtime/messaging.test.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/messaging.test.ts
@@ -76,6 +76,30 @@ it('passes the connected room reference through RTC message sends', async () => 
     }));
 });
 
+it('broadcasts untargeted realtime sends to every ready peer', async () => {
+    facade.behavior.rtcStatus.mockReturnValue({
+        sessionId: 'session-1',
+        laneId: 'realtime',
+        knownPeerIds: ['bob-session', 'charlie-session'],
+        activePeerIds: ['bob-session', 'charlie-session'],
+        peerIdsWithNoReconnectableLanes: [],
+        readyPeerIds: ['bob-session', 'charlie-session'],
+        peers: []
+    });
+    const { runtime } = await loadConnectedMessageRuntime();
+
+    await runtime.send({
+        roomId: 'bb-group',
+        data: { text: 'hello ready peers' }
+    });
+
+    expect(facade.records.realtimeSends[0]?.[0]).toEqual(expect.objectContaining({
+        roomId: 'bb-group',
+        peerIds: ['bob-session', 'charlie-session'],
+        data: { text: 'hello ready peers' }
+    }));
+});
+
 it('subscribes before WebSocket sends and preserves message metadata', async () => {
     facade.behavior.wsMessageSend.mockResolvedValue({
         transport: 'ws',

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -29,6 +29,11 @@ const CONTROL_WS_URL = 'ws://127.0.0.1:5180/control';
 type TransportUnderTest = 'realtime' | 'messages.rtc';
 type AgentPrefix = 'A' | 'B' | 'C';
 type DeliveryMode = 'direct' | 'multicast' | 'broadcast';
+type ConnectedAgent = Readonly<{ commandId: string; sessionId: string; }>;
+type ConnectedAgentTrio = Readonly<{
+    connections: readonly [ConnectedAgent, ConnectedAgent, ConnectedAgent];
+    readinessStartedAtMs: number;
+}>;
 
 type RestoredSession = Readonly<{
     clientId: string;
@@ -377,6 +382,7 @@ async function setupGroupMembership(
 ): Promise<readonly string[]> {
     const groupSegment = pathSegment(input.groupId);
     const createCommandId = `group-create-${input.suffix}`;
+    const createRequestId = `rtc-b06-create-${input.suffix}`;
     const joinCommandIds: string[] = [];
 
     await input.control.executeOk({
@@ -386,7 +392,9 @@ async function setupGroupMembership(
         command: {
             kind: 'http.request',
             request: {
-                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${pathSegment(workspaceId)}/groups`,
+                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
+                    pathSegment(workspaceId)
+                }/groups/requests/${pathSegment(createRequestId)}`,
                 method: 'POST',
                 body: {
                     groupId: input.groupId,
@@ -403,7 +411,8 @@ async function setupGroupMembership(
                 }
             },
             response: {
-                body: 'json'
+                body: 'json',
+                acceptedStatusCodes: [201]
             },
             timeoutMs: 10_000
         },
@@ -411,6 +420,8 @@ async function setupGroupMembership(
 
     for (const member of input.members) {
         const commandId = `group-join-${member.agentId}-${input.suffix}`;
+        const requestId =
+            `rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`;
         joinCommandIds.push(commandId);
         await input.control.executeOk({
             runId: input.runId,
@@ -421,14 +432,17 @@ async function setupGroupMembership(
                 request: {
                     path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
                         pathSegment(workspaceId)
-                    }/groups/${groupSegment}/members/{auth.clientId}`,
+                    }/groups/${groupSegment}/members/{auth.clientId}/requests/${
+                        pathSegment(requestId)
+                    }`,
                     method: 'PUT',
                     body: {
                         status: 'active'
                     }
                 },
                 response: {
-                    body: 'json'
+                    body: 'json',
+                    acceptedStatusCodes: [200]
                 },
                 timeoutMs: 10_000
             }
@@ -631,7 +645,7 @@ async function connectAgent(
         groupId: string;
         suffix: string;
     }>
-): Promise<Readonly<{ commandId: string; sessionId: string; }>> {
+): Promise<ConnectedAgent> {
     const commandId = `connect-${input.agent.prefix.toLowerCase()}-${input.transport.replace('.', '-')}-${input.suffix}`;
     const result = await input.control.executeOk({
         runId: input.runId,
@@ -659,6 +673,55 @@ async function connectAgent(
     return {
         commandId,
         sessionId: input.control.requireSessionId(result, commandId)
+    };
+}
+
+async function connectAgentTrio(
+    input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
+        transport: TransportUnderTest;
+        groupId: string;
+        suffix: string;
+    }>
+): Promise<ConnectedAgentTrio> {
+    const connected: ConnectedAgent[] = [];
+    for (const agent of input.agents.slice(0, 2)) {
+        connected.push(
+            await connectAgent({ ...input, agent })
+        );
+    }
+
+    const firstPairReadinessStartedAtMs = performance.now();
+    await Promise.all([
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.agents[0],
+            expectedPeerIds: [connected[1]!.sessionId],
+            suffix: `${input.suffix}-initial-pair`,
+            startedAtMs: firstPairReadinessStartedAtMs
+        }),
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.agents[1],
+            expectedPeerIds: [connected[0]!.sessionId],
+            suffix: `${input.suffix}-initial-pair`,
+            startedAtMs: firstPairReadinessStartedAtMs
+        })
+    ]);
+
+    const readinessStartedAtMs = performance.now();
+    connected.push(
+        await connectAgent({ ...input, agent: input.agents[2] })
+    );
+    return {
+        connections: [connected[0]!, connected[1]!, connected[2]!],
+        readinessStartedAtMs
     };
 }
 
@@ -732,9 +795,15 @@ async function runDeliveryMatrix(
         timings: readonly LiveRtcPerformanceTiming[];
     }>
 > {
-    const connectResults = await Promise.all(
-        input.agents.map((agent) => connectAgent({ ...input, agent }))
-    );
+    const connected = await connectAgentTrio({
+        control: input.control,
+        runId: input.runId,
+        agents: input.agents,
+        transport: input.transport,
+        groupId: input.groupId,
+        suffix: input.suffix
+    });
+    const connectResults = connected.connections;
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
         B: connectResults[1].sessionId,
@@ -744,7 +813,7 @@ async function runDeliveryMatrix(
 
     const [agentA, agentB, agentC] = input.agents;
     const transportSuffix = `${input.transport.replace('.', '-')}-${input.suffix}`;
-    const readinessStartedAtMs = performance.now();
+    const readinessStartedAtMs = connected.readinessStartedAtMs;
     const readinessDurationMs = await input.control.waitForPeerReadiness({
         runId: input.runId,
         agent: agentA,
@@ -936,9 +1005,15 @@ async function runAllDeliveryPermutations(
     }>
 > {
     const slug = transportSlug(input.transport);
-    const connectResults = await Promise.all(
-        input.agents.map((agent) => connectAgent({ ...input, agent }))
-    );
+    const connected = await connectAgentTrio({
+        control: input.control,
+        runId: input.runId,
+        agents: input.agents,
+        transport: input.transport,
+        groupId: input.groupId,
+        suffix: input.suffix
+    });
+    const connectResults = connected.connections;
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
         B: connectResults[1].sessionId,
@@ -947,7 +1022,7 @@ async function runAllDeliveryPermutations(
     expect(new Set(Object.values(sessions)).size).toBe(3);
 
     const readinessSuffix = `${slug}-${input.suffix}-all`;
-    const readinessStartedAtMs = performance.now();
+    const readinessStartedAtMs = connected.readinessStartedAtMs;
     const readinessDurations = await Promise.all(
         input.agents.map((agent) =>
             input.control.waitForPeerReadiness({
@@ -1248,6 +1323,64 @@ async function closeAndResetAgents(
     return commandIds;
 }
 
+async function closeAndResetSettledAgentTrio(
+    input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
+        sessions: Readonly<Record<AgentPrefix, string>>;
+        suffix: string;
+    }>
+): Promise<readonly string[]> {
+    const commandIds: string[] = [];
+    const closeAndReset = async (
+        agent: LiveRtcControlClient.Agent
+    ): Promise<void> => {
+        const closeCommandId = `close-${agent.prefix.toLowerCase()}-${input.suffix}`;
+        const resetCommandId = `reset-${agent.prefix.toLowerCase()}-${input.suffix}`;
+        commandIds.push(closeCommandId, resetCommandId);
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: closeCommandId,
+            command: { kind: 'close' },
+            timeoutMs: 45_000
+        });
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: resetCommandId,
+            command: { kind: 'reset' },
+            timeoutMs: 30_000
+        });
+    };
+
+    await closeAndReset(input.agents[2]);
+    await Promise.all(input.agents.slice(0, 2).map((agent) =>
+        input.control.waitForPeerAbsence({
+            runId: input.runId,
+            agent,
+            departedPeerIds: [input.sessions.C],
+            suffix: `${input.suffix}-retire-c`
+        })
+    ));
+
+    await closeAndReset(input.agents[1]);
+    await input.control.waitForPeerAbsence({
+        runId: input.runId,
+        agent: input.agents[0],
+        departedPeerIds: [input.sessions.B],
+        suffix: `${input.suffix}-retire-b`
+    });
+
+    await closeAndReset(input.agents[0]);
+    return commandIds;
+}
+
 async function writeAttemptEvidence(input: Readonly<{
     context: LiveRtcPerformanceAttemptContext | null;
     producerExitStatus: number;
@@ -1384,15 +1517,28 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 return agents;
             };
             const retireAgents = async (
-                agents: readonly LiveRtcControlClient.Agent[],
-                closeSuffix: string
+                agents: readonly [
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent
+                ],
+                closeSuffix: string,
+                sessions?: Readonly<Record<AgentPrefix, string>>
             ): Promise<readonly string[]> => {
-                const retiredCommandIds = await closeAndResetAgents({
-                    control,
-                    runId,
-                    agents,
-                    suffix: closeSuffix
-                });
+                const retiredCommandIds = sessions
+                    ? await closeAndResetSettledAgentTrio({
+                        control,
+                        runId,
+                        agents,
+                        sessions,
+                        suffix: closeSuffix
+                    })
+                    : await closeAndResetAgents({
+                        control,
+                        runId,
+                        agents,
+                        suffix: closeSuffix
+                    });
                 await closeAgentContexts(agents);
                 for (const agent of agents) {
                     const index = openHandles.findIndex((candidate) => candidate.agentId === agent.agentId);
@@ -1439,22 +1585,12 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 commandIds.push(
                     ...await retireAgents(
                         realtimeAgents,
-                        `${suffix}-after-realtime`
+                        `${suffix}-after-realtime`,
+                        realtime.sessions
                     )
                 );
 
                 const messageAgents = await openAgents('live-messages');
-                commandIds.push(
-                    ...await setupGroupMembership({
-                        control,
-                        runId,
-                        owner: messageAgents[0],
-                        members: messageAgents,
-                        groupId,
-                        suffix: `${suffix}-messages`
-                    })
-                );
-
                 const messages = await runDeliveryMatrix({
                     control,
                     runId,
@@ -1628,15 +1764,28 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             return agents;
         };
         const retireAgents = async (
-            agents: readonly LiveRtcControlClient.Agent[],
-            closeSuffix: string
+            agents: readonly [
+                LiveRtcControlClient.Agent,
+                LiveRtcControlClient.Agent,
+                LiveRtcControlClient.Agent
+            ],
+            closeSuffix: string,
+            sessions?: Readonly<Record<AgentPrefix, string>>
         ): Promise<readonly string[]> => {
-            const retired = await closeAndResetAgents({
-                control,
-                runId,
-                agents,
-                suffix: closeSuffix
-            });
+            const retired = sessions
+                ? await closeAndResetSettledAgentTrio({
+                    control,
+                    runId,
+                    agents,
+                    sessions,
+                    suffix: closeSuffix
+                })
+                : await closeAndResetAgents({
+                    control,
+                    runId,
+                    agents,
+                    suffix: closeSuffix
+                });
             await closeAgentContexts(agents);
             for (const agent of agents) {
                 const index = openHandles.findIndex(
@@ -1688,7 +1837,8 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             diagnostics.push(realtimeDiagnostics.checkpoint);
             commandIds.push(...await retireAgents(
                 realtimeAgents,
-                `${suffix}-after-realtime-all`
+                `${suffix}-after-realtime-all`,
+                realtime.sessions
             ));
 
             const wsAgents = await openAgents('live-all-ws');
@@ -1702,14 +1852,6 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             commandIds.push(...await retireAgents(wsAgents, `${suffix}-after-ws-all`));
 
             const messageAgents = await openAgents('live-all-messages');
-            commandIds.push(...await setupGroupMembership({
-                control,
-                runId,
-                owner: messageAgents[0],
-                members: messageAgents,
-                groupId,
-                suffix: `${suffix}-messages`
-            }));
             const messages = await runAllDeliveryPermutations({
                 control,
                 runId,
@@ -1961,18 +2103,18 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 groupId,
                 suffix
             }));
-            const connected = await Promise.all(
-                agents.map((agent) => connectAgent({
-                    control,
-                    runId,
-                    agent,
-                    transport: 'messages.rtc',
-                    groupId,
-                    suffix: `${suffix}-initial`
-                }))
-            );
+            const initialConnection = await connectAgentTrio({
+                control,
+                runId,
+                agents,
+                transport: 'messages.rtc',
+                groupId,
+                suffix: `${suffix}-initial`
+            });
+            const connected = initialConnection.connections;
             commandIds.push(...connected.map((connection) => connection.commandId));
-            const initialReadinessStartedAtMs = performance.now();
+            const initialReadinessStartedAtMs =
+                initialConnection.readinessStartedAtMs;
             await Promise.all(agents.map((agent, agentIndex) =>
                 control.waitForPeerReadiness({
                     runId,


### PR DESCRIPTION
## Goal

Unblock RTC-B06 browser evidence capture by aligning the live matrix with the current group-state API and making its setup, broadcast, and transport handoff boundaries observable.

## Changes

- Use the current idempotent create-group and member-upsert request routes with bounded request IDs.
- Initialize each unique group and its principal membership once instead of repeating mutations per transport.
- Admit the initial pair to mutual readiness before starting the measured third-browser join interval.
- Retire connected trios in observable C, B, A order before opening the next transport.
- Resolve untargeted realtime provider sends to the runtime's current ready-peer set so raw control commands exercise broadcast semantics.

## Acceptance

- The source contract rejects retired group mutation routes, duplicate group initialization, concurrent initial admission, and unsettled transport retirement.
- Untargeted realtime sends select all ready peers while explicit direct and multicast targets retain precedence.
- RTC-B06 tooling advances through current group creation, membership, readiness, and realtime broadcast paths.

**Test design evidence**

- Behavior protected and observation boundary: focused Vitest contracts cover request paths and browser-provider target selection; the real Playwright matrix observes server-backed peer readiness and delivery.
- Retained interaction assertions (registry reference and rationale): None
- Coupled or redundant tests removed or replaced: None

## Validation

Passed:
- Focused Vitest: 4 files, 30 tests.
- Test typecheck: 965 files, zero errors or known debt.
- shared-rtc-bench check: typecheck, 42 files and 392 tests, and Deno checks.
- Changed-file repository style, repository structure, and git diff checks.

Known failing diagnostic:
- The live in-memory three-browser command can still fail when API inbound admission hits a RuntimeStateWriteConflictError, exhausts its repair budget, and leaves a successful rtc.connect without reciprocal topology. One run completed the full realtime phase including broadcast before exposing the handoff race; the added gates then isolated the remaining failure to server-side convergence. Production RTC and API convergence code are intentionally outside this tooling PR.

## Risk and rollback

Risk is limited to shared black-box browser tooling and the RTC-B06 matrix. Explicit target selection is unchanged. Reverting this commit restores the previous harness, but also restores retired API paths and invalid broadcast selection.

## Follow-up

Repair the in-memory API inbound-admission conditional-write convergence defect, then start a fresh E3-memory baseline from the then-current main revision. E4-pg remains conditionally not required unless reconciliation selects a database-backed hotspot.