### PR TITLE
fix(rtc): restore browser convergence for B06

### DIFF
--- a/docs/rallar-convergent-state-and-rtc-topology.md
+++ b/docs/rallar-convergent-state-and-rtc-topology.md
@@ -468,8 +468,16 @@ only the revision probe.
 Browser point readers expose the response source and authoritative revision
 metadata. They reject malformed authoritative bodies, missing or invalid
 metadata headers, and header/body revision disagreement. A room session refresh
-uses one exact group point read without a floor; top-level room and people
-refreshes continue to use complete durable collections.
+uses one exact group point read without a floor, then performs a best-effort
+exact topology read-through for an active local session and adopts the current
+server overlay. Top-level room and people refreshes continue to use complete
+durable collections.
+
+Group presence and client presence converge independently. RTC reconciliation
+therefore treats sessions in an accepted active group snapshot as connectable
+while the client collection catches up; an explicit session-scoped offline
+observation remains a disconnect fence. This prevents a fresh room read from
+discovering a valid peer without ever starting its RTC dial.
 
 Before targeted, heartbeat, or complete collection reads, browser repair
 captures the observed snapshot identity. An authoritative `404`, heartbeat

--- a/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/messaging-controller.ts
+++ b/packages/shared-test/black-box-runner/browser/rallar-browser-runtime/messaging-controller.ts
@@ -216,12 +216,13 @@ export function createBlackBoxRallarMessagingController(
         lease: BlackBoxRallarMessagingLease
     ): Promise<BlackBoxRallarSendDiagnostics> => {
         const normalized = normalizeSendInput(input);
-        const peerIds = normalized.peerIds ??
+        const selectedPeerIds = normalized.peerIds ??
             (normalized.remotePeerId
                 ? [normalized.remotePeerId]
                 : config.remotePeerId
                 ? [config.remotePeerId]
                 : config.rallar.peerIds);
+        const peerIds = selectedPeerIds ?? options.rtcStatus(config).readyPeerIds;
         const laneId = normalized.laneId ?? options.laneIdOf(config);
         const roomId = normalized.roomId ?? config.roomId;
         const roomRef = options.roomRefOf(config, normalized);

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1603,6 +1603,9 @@
       "expectedExitCode": 0,
       "artifactName": "api-v1-scope-isolation",
       "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
         "httpServices": [
           {
             "name": "Rallar API",

--- a/packages/shared-web/browser/composition/browser-communication-composition.ts
+++ b/packages/shared-web/browser/composition/browser-communication-composition.ts
@@ -77,7 +77,6 @@ export function createBrowserMessagingComposition(
         resolveRoomRef: (room) => input.state.roomStateStore.resolveRoomRef(room),
         resolveRoomMinSnapshotVersion: (room, explicit) =>
             input.state.roomStateStore.resolveRoomMinSnapshotVersion(room, explicit),
-        resolveRoomPeerIds: input.state.resolveRoomPeerIds,
         readMessageMaxPayloadBytes: () =>
             input.state.readDefaults()?.messages?.maxPayloadBytes ??
                 RALLAR_DEFAULT_MAX_MESSAGE_PAYLOAD_BYTES

--- a/packages/shared-web/browser/messages/browser-rallar-message-sender.ts
+++ b/packages/shared-web/browser/messages/browser-rallar-message-sender.ts
@@ -43,7 +43,6 @@ export namespace BrowserRallarMessageSender {
             room: string | GroupRef | undefined,
             explicitMinSnapshotVersion?: number
         ): number | undefined;
-        resolveRoomPeerIds(room: string | GroupRef): readonly string[];
     }
 
     export interface WsUnicastInput<T> {
@@ -92,14 +91,6 @@ export class BrowserRallarMessageSender {
         const target = this.resolveRtcMessageTarget(input);
         const context = await this.input.connect();
         const message = this.toRtcMessage(input, target, this.input.requireSession());
-        if (this.input.resolveRoomPeerIds(target.roomRef).length === 0) {
-            return toRallarMessageSendResult('rtc', message, {
-                status: 'no-route',
-                message,
-                entries: [],
-                reason: 'No RTC peers are desired for this room.'
-            });
-        }
         const enqueueResult = await context.middleware.rtcRxStreamer.enqueueOutboxIfAbsent(message);
         wakeQueueBoxEngineIfQueued(context.middleware.qboxEngine, enqueueResult);
         return toRallarMessageSendResult('rtc', message, enqueueResult);

--- a/packages/shared-web/browser/messages/browser-rallar-messages-controller.ts
+++ b/packages/shared-web/browser/messages/browser-rallar-messages-controller.ts
@@ -34,7 +34,6 @@ export namespace BrowserRallarMessagesController {
             room: string | GroupRef | undefined,
             explicitMinSnapshotVersion?: number
         ): number | undefined;
-        resolveRoomPeerIds(room: string | GroupRef): readonly string[];
         readMessageMaxPayloadBytes?(): number;
     }
 }
@@ -63,8 +62,7 @@ export class BrowserRallarMessagesController {
             resolveCurrentRoomRef: input.resolveCurrentRoomRef,
             toRoomId: input.toRoomId,
             resolveRoomRef: input.resolveRoomRef,
-            resolveRoomMinSnapshotVersion: input.resolveRoomMinSnapshotVersion,
-            resolveRoomPeerIds: input.resolveRoomPeerIds
+            resolveRoomMinSnapshotVersion: input.resolveRoomMinSnapshotVersion
         });
 
         const rtc: RallarMessagesOperations['rtc'] = {

--- a/packages/shared-web/browser/rooms/browser-rallar-rooms.ts
+++ b/packages/shared-web/browser/rooms/browser-rallar-rooms.ts
@@ -18,6 +18,7 @@ import type {
 import { throwRallarValidationIssue } from '@shared-web/browser/rooms/rallar-room-validation.ts';
 import type { RallarStateSnapshotAcceptanceInput } from '@shared-web/browser/state-cache/rallar-state-store.ts';
 import { emitBrowserStateReadDiagnostic } from '@shared-web/browser/state-read/diagnostics.ts';
+import { hydrateGroupTopologyOverlays } from '@shared-web/browser/state-read/hydrate-group-topology-overlays.ts';
 import { readStateGroupSnapshot, type StateGroupSnapshotRead } from '@shared-web/browser/state-read/point-read.ts';
 import { refreshStateSnapshots } from '@shared-web/browser/state-read/refresh-state-snapshots.ts';
 import type { AuthSession } from '@shared/api/api-config.ts';
@@ -374,6 +375,16 @@ async function refreshRoom(
                 toRallarCommandOptions(operationOptions)
             ).run();
             await input.acceptSnapshots({ context, clients: [], groups: [response.snapshot], scope });
+            await hydrateGroupTopologyOverlays({
+                groupSnapshots: [response.snapshot],
+                sessionId: context.session.sessionId,
+                webRtcGroupManager: context.middleware.webRtcGroupManager,
+                scope,
+                apiRequest: {
+                    ...toRallarCommandOptions(operationOptions),
+                    authSession: context.session
+                }
+            });
         }
         catch (error) {
             if (error instanceof ApiHttpError && error.status === 404 && observed) {

--- a/packages/shared/alm/ALInboundMessageRuntime.ts
+++ b/packages/shared/alm/ALInboundMessageRuntime.ts
@@ -79,18 +79,9 @@ type BufferedReleaseOptions = Readonly<{
 }>;
 
 export class ALInboundMessageRuntime {
-    private static readonly MAX_COMMIT_ATTEMPTS = 10;
-    private static readonly COMMIT_RETRY_INTERVAL_MSECS = 10;
-    private static readonly COMMIT_MAX_RETRY_INTERVAL_MSECS = 50;
-    private static readonly COMMIT_MAX_ELAPSED_MSECS = 500;
-    private static readonly COMMIT_RETRY_POLICY = RetryPolicies
-        .optimisticCommit('al-inbound-commit')
-        .maxAttempts(ALInboundMessageRuntime.MAX_COMMIT_ATTEMPTS)
-        .retryIntervalMsecs(ALInboundMessageRuntime.COMMIT_RETRY_INTERVAL_MSECS)
-        .maxRetryIntervalMsecs(
-            ALInboundMessageRuntime.COMMIT_MAX_RETRY_INTERVAL_MSECS
-        )
-        .maxElapsedMsecs(ALInboundMessageRuntime.COMMIT_MAX_ELAPSED_MSECS);
+    private static readonly COMMIT_RETRY_POLICY = RetryPolicies.optimisticCommit(
+        'al-inbound-commit'
+    );
     private static readonly EFFECT_LEASE_MS = 10_000;
     private static readonly MAX_EFFECT_BATCH = 16;
 

--- a/packages/shared/alm/ALInboundMessageRuntime.ts
+++ b/packages/shared/alm/ALInboundMessageRuntime.ts
@@ -20,6 +20,7 @@ import type {
     ALInboundPlanner,
     ALPersistedInboundEffect
 } from './ALInboundAdmissionStore.ts';
+import { ALAdmissionBackendConflictError } from './ALAdmissionBackendConflictError.ts';
 import {
     createALInboundAdmissionStore,
     createInMemoryALInboundAdmissionState,
@@ -140,13 +141,35 @@ export class ALInboundMessageRuntime {
         await this.ready();
 
         if (isALControlTypeId(msg.payload.typeId)) {
-            const acceptance = await this.admissionStore.acceptControlMessage(msg);
+            const acceptance = await this.acceptControlMessageWithRetry(msg);
             await this.drainDurableEffectsIfIdle();
             await this.input.onControlMessage?.(msg, acceptance);
             return;
         }
 
         await this.handleIncomingMessageWithAdmission(msg, fromPeerId);
+    }
+
+    private async acceptControlMessageWithRetry(
+        msg: ALMessage
+    ): Promise<ALControlAcceptance> {
+        return await tryWithPolicy(
+            async () => {
+                try {
+                    return await this.admissionStore.acceptControlMessage(msg);
+                }
+                catch (error) {
+                    if (error instanceof ALAdmissionBackendConflictError) {
+                        throw new RetryableConflictError(
+                            'Inbound control-message admission conflict',
+                            { cause: error }
+                        );
+                    }
+                    throw error;
+                }
+            },
+            ALInboundMessageRuntime.COMMIT_RETRY_POLICY
+        );
     }
 
     private async handleIncomingMessageWithAdmission(

--- a/packages/shared/services/WebRtcGroupManager.ts
+++ b/packages/shared/services/WebRtcGroupManager.ts
@@ -440,6 +440,7 @@ export class WebRtcGroupManager {
 
     private onlinePeerIds(): Set<PeerId> {
         const onlinePeerIds = new Set<PeerId>();
+        const explicitlyOfflinePeerIds = new Set<PeerId>();
 
         for (const clientKey of this.clientCache.keys()) {
             const client = this.clientCache.read(clientKey) ??
@@ -450,6 +451,21 @@ export class WebRtcGroupManager {
 
             for (const sessionId of readActiveClientSessionIds(client)) {
                 onlinePeerIds.add(sessionId);
+            }
+            if (!('principal' in client) && !client.isOnline) {
+                explicitlyOfflinePeerIds.add(client.sessionId);
+            }
+        }
+
+        // Group presence and client presence converge independently. A fresh
+        // room point read can therefore observe a newly active session before
+        // the client collection does. The group is authoritative for its own
+        // active sessions, so that cache lag must not suppress the RTC dial.
+        for (const group of this.groupsByKey.values()) {
+            for (const peerId of group.targetPeerIds()) {
+                if (!explicitlyOfflinePeerIds.has(peerId)) {
+                    onlinePeerIds.add(peerId);
+                }
             }
         }
 

--- a/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
@@ -82,6 +82,35 @@ describe('live three-browser RTC npm script gates', () => {
         expect(source).toContain('crypto.randomUUID()');
     });
 
+    it('uses the current idempotent group mutation request routes', () => {
+        const source = fs.readFileSync(path.join(repoRoot, liveMatrixSpec), 'utf8');
+
+        expect(source).toMatch(
+            /groups\/requests\/\$\{pathSegment\(createRequestId\)\}/u
+        );
+        expect(source).toMatch(
+            /members\/\{auth\.clientId\}\/requests\/\$\{\s*pathSegment\(requestId\)\s*\}/u
+        );
+        expect(source).toContain('`rtc-b06-create-${input.suffix}`');
+        expect(source).toContain(
+            '`rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`'
+        );
+        expect(source).toContain('acceptedStatusCodes: [201]');
+        expect(source.match(/setupGroupMembership\(\{/gu)).toHaveLength(3);
+        expect(source).toMatch(
+            /for \(const agent of input\.agents\.slice\(0, 2\)\) \{\s*connected\.push\(\s*await connectAgent/u
+        );
+        expect(source).toContain('`${input.suffix}-initial-pair`');
+        expect(source).toContain('readinessStartedAtMs');
+        expect(source.match(/connectAgentTrio\(\{/gu)).toHaveLength(3);
+        expect(source).not.toMatch(
+            /input\.agents\.map\(\(agent\) => connectAgent/u
+        );
+        expect(source).toContain('departedPeerIds: [input.sessions.C]');
+        expect(source).toContain('departedPeerIds: [input.sessions.B]');
+        expect(source.match(/realtime\.sessions/gu)).toHaveLength(2);
+    });
+
     it('keeps benchmark ownership out of application and reusable product sources', () => {
         const productRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
         const forbiddenImports: string[] = [];

--- a/packages/tests/shared-test/rallar-browser-runtime/messaging.test.ts
+++ b/packages/tests/shared-test/rallar-browser-runtime/messaging.test.ts
@@ -76,6 +76,30 @@ it('passes the connected room reference through RTC message sends', async () => 
     }));
 });
 
+it('broadcasts untargeted realtime sends to every ready peer', async () => {
+    facade.behavior.rtcStatus.mockReturnValue({
+        sessionId: 'session-1',
+        laneId: 'realtime',
+        knownPeerIds: ['bob-session', 'charlie-session'],
+        activePeerIds: ['bob-session', 'charlie-session'],
+        peerIdsWithNoReconnectableLanes: [],
+        readyPeerIds: ['bob-session', 'charlie-session'],
+        peers: []
+    });
+    const { runtime } = await loadConnectedMessageRuntime();
+
+    await runtime.send({
+        roomId: 'bb-group',
+        data: { text: 'hello ready peers' }
+    });
+
+    expect(facade.records.realtimeSends[0]?.[0]).toEqual(expect.objectContaining({
+        roomId: 'bb-group',
+        peerIds: ['bob-session', 'charlie-session'],
+        data: { text: 'hello ready peers' }
+    }));
+});
+
 it('subscribes before WebSocket sends and preserves message metadata', async () => {
     facade.behavior.wsMessageSend.mockResolvedValue({
         transport: 'ws',

--- a/packages/tests/shared-test/recipe-matrix.test.ts
+++ b/packages/tests/shared-test/recipe-matrix.test.ts
@@ -186,6 +186,13 @@ describe('black-box runner recipe matrix', () => {
         });
     });
 
+    it('gives the scope-isolation auth preflight a realistic deadline', () => {
+        const { entries } = readMatrix();
+        const scopeIsolation = entries.find((entry) => entry.id === 'api-v1-scope-isolation');
+
+        expect(scopeIsolation?.requires?.livePreflight?.timeoutMs).toBe(10_000);
+    });
+
     it('includes gated live-provider baselines for soak, traffic, and parallel RTC patterns', () => {
         const { entries } = readMatrix();
         const byProfile = (profile: string) => entries.filter((entry) => entry.profiles.includes(profile));

--- a/packages/tests/shared-web/director/browser-director-relay-runtime.test.ts
+++ b/packages/tests/shared-web/director/browser-director-relay-runtime.test.ts
@@ -366,6 +366,7 @@ describe('Rallar director relay', () => {
             appointedAtEpochMs: 1,
             heartbeatTtlMs: 60_000
         }));
+        mockRtcNoRoute();
         const enqueuedWsTypeIds: string[] = [];
         mocks.webSocketQueueBox.enqueueOutboxIfAbsent.mockImplementation(
             async (message) => {
@@ -405,6 +406,7 @@ describe('Rallar director relay', () => {
             appointedAtEpochMs: 1,
             heartbeatTtlMs: 60_000
         }));
+        mockRtcNoRoute();
         const relay = createRallarFacade().director.createRelay<DirectorMove, DirectorAcknowledgement>({
             roomId: 'room-1',
             laneId: 'director',
@@ -598,6 +600,17 @@ function resetDirectorRtcDoubles(): void {
         mocks.ctx.middleware.rtcRxStreamer
     );
     mocks.rtcRxStreamer.removeInboxMessageCallback.mockReturnValue(true);
+}
+
+function mockRtcNoRoute(): void {
+    mocks.rtcRxStreamer.enqueueOutboxIfAbsent.mockImplementation(
+        async (message) => ({
+            status: 'no-route',
+            message,
+            entries: [],
+            reason: `No outbound transport route for message ${message.id.msgId}`
+        })
+    );
 }
 
 function resetDirectorWsDoubles(): void {

--- a/packages/tests/shared-web/messages/browser-rallar-message-sender.test.ts
+++ b/packages/tests/shared-web/messages/browser-rallar-message-sender.test.ts
@@ -412,7 +412,6 @@ describe('Rallar message send', () => {
         });
 
         expect(result.status).toBe('enqueued');
-        expect(rtcRxStreamer.enqueueOutboxIfAbsent).toHaveBeenCalledOnce();
     });
 
     it('wakes the queue-box engine when RTC send queues durable outbox work', async () => {

--- a/packages/tests/shared-web/messages/browser-rallar-message-sender.test.ts
+++ b/packages/tests/shared-web/messages/browser-rallar-message-sender.test.ts
@@ -392,6 +392,29 @@ describe('Rallar message send', () => {
         });
     });
 
+    it('delegates RTC routing when the room cache is temporarily absent', async () => {
+        const { createRallarFacade } = await import(
+            '@shared-web/browser/rallar.ts'
+        );
+
+        const result = await createRallarFacade().messages.rtc.send({
+            roomRef: {
+                applicationId: 'app-1',
+                workspaceId: 'workspace-1',
+                groupId: 'room-1'
+            },
+            nextHopPeerIds: ['peer-1'],
+            typeId: 'chat.message.v1',
+            resourceId: 'msg-cache-lag',
+            payload: {
+                text: 'route through the transport runtime'
+            }
+        });
+
+        expect(result.status).toBe('enqueued');
+        expect(rtcRxStreamer.enqueueOutboxIfAbsent).toHaveBeenCalledOnce();
+    });
+
     it('wakes the queue-box engine when RTC send queues durable outbox work', async () => {
         const { createRallarFacade } = await import(
             '@shared-web/browser/rallar.ts'

--- a/packages/tests/shared-web/messages/browser-typed-message-channels.test.ts
+++ b/packages/tests/shared-web/messages/browser-typed-message-channels.test.ts
@@ -196,6 +196,7 @@ describe('Rallar typed message channel', () => {
         const { createRallarFacade } = await import(
             '@shared-web/browser/rallar.ts'
         );
+        mockRtcNoRoute();
         mockGroupSnapshot(createGroupSnapshot('room-1', ['session-1']));
         const facade = createRallarFacade();
         const channel = facade.messages.channel<ChatMessage>({
@@ -255,6 +256,7 @@ describe('Rallar typed message channel', () => {
         const { createRallarFacade } = await import(
             '@shared-web/browser/rallar.ts'
         );
+        mockRtcNoRoute();
         mockGroupSnapshot(createGroupSnapshot('room-1', ['session-1']));
         const facade = createRallarFacade();
         const channel = facade.messages.room<ChatMessage>({
@@ -398,6 +400,16 @@ function resetMiddlewareDoublesToDefaults(): void {
     vi.mocked(webSocketQueueBox.removeAnyInboxMessageCallback).mockReset();
     vi.mocked(webSocketQueueBox.socket.onWebsocketCallbacksDo).mockReset();
     vi.mocked(webSocketQueueBox.socket.removeWebsocketCallbackById).mockReset();
+}
+
+function mockRtcNoRoute(): void {
+    vi.mocked(mocks.ctx.middleware.rtcRxStreamer.enqueueOutboxIfAbsent)
+        .mockImplementation(async (message) => ({
+            status: 'no-route',
+            message,
+            entries: [],
+            reason: `No outbound transport route for message ${message.id.msgId}`
+        }));
 }
 
 function mockGroupSnapshot(snapshot: GroupSnapshot): void {

--- a/packages/tests/shared-web/rooms/room-session.test.ts
+++ b/packages/tests/shared-web/rooms/room-session.test.ts
@@ -48,7 +48,7 @@ it('reports a structured validation issue when no room session can be resolved',
     });
 });
 
-it('refreshes a bound room with one tokenless durable point read', async () => {
+it('refreshes a bound room and its current topology', async () => {
     const { createRallarFacade } = await import('@shared-web/browser/rallar.ts');
     configureApiClient({ apiBaseUrl: 'https://api.example.test' });
     const observed = createRoomSnapshot('room-1', ['session-1']);
@@ -65,25 +65,42 @@ it('refreshes a bound room with one tokenless durable point read', async () => {
     };
     seedRoomSnapshots([observed]);
     const fetchMock = vi.fn(async (
-        _input: RequestInfo | URL,
+        input: RequestInfo | URL,
         _init?: RequestInit
-    ) => new Response(JSON.stringify(current), {
-        status: 200,
-        headers: {
-            'cache-control': 'no-store',
-            'content-type': 'application/json',
-            'rallar-state-source': 'durable',
-            'rallar-group-revision': String(current.causalRevision.groupRevision),
-            'rallar-presence-revision': String(current.causalRevision.presenceRevision)
+    ) => {
+        if (String(input).endsWith('/topology')) {
+            return new Response(JSON.stringify({
+                groupRef: current.group,
+                overlayId: '["app-1","workspace-1","room-1"]',
+                snapshot: null,
+                config: null,
+                pending: null
+            }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' }
+            });
         }
-    }));
+        return new Response(JSON.stringify(current), {
+            status: 200,
+            headers: {
+                'cache-control': 'no-store',
+                'content-type': 'application/json',
+                'rallar-state-source': 'durable',
+                'rallar-group-revision': String(current.causalRevision.groupRevision),
+                'rallar-presence-revision': String(current.causalRevision.presenceRevision)
+            }
+        });
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     const refreshed = await createRallarFacade().rooms.session(observed.group).refresh();
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
         'https://api.example.test/api/state/apps/app-1/workspaces/workspace-1/groups/room-1'
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+        'https://api.example.test/api/state/apps/app-1/workspaces/workspace-1/groups/room-1/topology'
     );
     const request = fetchMock.mock.calls[0]?.[1];
     const headers = new Headers(request?.headers);

--- a/packages/tests/shared-web/rooms/room-session.test.ts
+++ b/packages/tests/shared-web/rooms/room-session.test.ts
@@ -64,11 +64,17 @@ it('refreshes a bound room and its current topology', async () => {
         }
     };
     seedRoomSnapshots([observed]);
+    let groupReadObserved = false;
+    let topologyReadObserved = false;
     const fetchMock = vi.fn(async (
         input: RequestInfo | URL,
         _init?: RequestInit
     ) => {
         if (String(input).endsWith('/topology')) {
+            if (!groupReadObserved) {
+                throw new Error('Topology was read before the current group snapshot.');
+            }
+            topologyReadObserved = true;
             return new Response(JSON.stringify({
                 groupRef: current.group,
                 overlayId: '["app-1","workspace-1","room-1"]',
@@ -80,6 +86,7 @@ it('refreshes a bound room and its current topology', async () => {
                 headers: { 'content-type': 'application/json' }
             });
         }
+        groupReadObserved = true;
         return new Response(JSON.stringify(current), {
             status: 200,
             headers: {
@@ -95,7 +102,8 @@ it('refreshes a bound room and its current topology', async () => {
 
     const refreshed = await createRallarFacade().rooms.session(observed.group).refresh();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(groupReadObserved).toBe(true);
+    expect(topologyReadObserved).toBe(true);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
         'https://api.example.test/api/state/apps/app-1/workspaces/workspace-1/groups/room-1'
     );

--- a/packages/tests/shared/al-inbound-message-runtime.test.ts
+++ b/packages/tests/shared/al-inbound-message-runtime.test.ts
@@ -10,11 +10,13 @@ import {
     planALMessageHandling,
     QueueBoxUtilities,
     type ALControlAcceptance,
+    type ALInboundAdmissionStore,
     type ALInboundRuntimeStores,
     type ALMessage,
     type ALMessageHandlingPlan,
     type ResourceEntry
 } from '@shared/mod.ts';
+import { ALAdmissionBackendConflictError } from '@shared/alm/ALAdmissionBackendConflictError.ts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('ALInboundMessageRuntime', () => {
@@ -177,6 +179,36 @@ describe('ALInboundMessageRuntime', () => {
         expect(rejectedFirstCommit).toBe(true);
         expect(dispatchedTexts).toEqual(['one', 'two']);
         expect(forwardedIds).toEqual([seq2.id.msgId, seq1.id.msgId]);
+    });
+
+    it('retries complete control-message admission after backend conflicts', async () => {
+        vi.useFakeTimers();
+        const stores = createInMemoryALInboundRuntimeStores();
+        const baseAdmission = requireInboundAdmissionStore(stores);
+        let attempts = 0;
+        const wrappedStores = replaceInboundAdmissionStore(stores, {
+            acceptControlMessage: async (msg) => {
+                attempts += 1;
+                if (attempts < 4) {
+                    throw new ALAdmissionBackendConflictError(
+                        'simulated inbound control conflict'
+                    );
+                }
+                return await baseAdmission.acceptControlMessage(msg);
+            }
+        });
+        const { runtime, controlAcceptances } = createInboundHarness(wrappedStores);
+
+        const pending = runtime.handleIncomingMessage(
+            newALAckControlMessage('peer-2', 'self', 'missing-msg', 'delivered'),
+            'peer-2'
+        );
+        void pending.catch(() => undefined);
+        await vi.runAllTimersAsync();
+
+        await expect(pending).resolves.toBeUndefined();
+        expect(attempts).toBe(4);
+        expect(controlAcceptances).toHaveLength(1);
     });
 
     it('retries buffered release when a downstream ack updates the sender version', async () => {
@@ -706,6 +738,57 @@ function createPersistentInboundStores(
             orderingTrackTtlMs: 5 * 60_000,
             supersedenceTrackTtlMs: 5 * 60_000
         })
+    };
+}
+
+function requireInboundAdmissionStore(
+    stores: ALInboundRuntimeStores
+): ALInboundAdmissionStore {
+    if (!stores.admissionStore) {
+        throw new Error('Expected inbound admission store');
+    }
+    return stores.admissionStore;
+}
+
+function replaceInboundAdmissionStore(
+    stores: ALInboundRuntimeStores,
+    overrides: Partial<ALInboundAdmissionStore>
+): ALInboundRuntimeStores {
+    const base = requireInboundAdmissionStore(stores);
+    return {
+        ...stores,
+        admissionStore: {
+            ready: async () => await base.ready(),
+            readIncomingMessage: async (msg, fromPeerId, planner) =>
+                await base.readIncomingMessage(msg, fromPeerId, planner),
+            readBufferedRelease: async (trackKey, seq) =>
+                await base.readBufferedRelease(trackKey, seq),
+            planStoredEntry: async (msg, planner) =>
+                await base.planStoredEntry(msg, planner),
+            acceptControlMessage: async (msg) =>
+                await base.acceptControlMessage(msg),
+            commitMutations: async (request) =>
+                await base.commitMutations(request),
+            commitBundle: async (bundle) => await base.commitBundle(bundle),
+            claimReadyEffects: async (workerId, maxCount, leaseMs, nowMs) =>
+                await base.claimReadyEffects(workerId, maxCount, leaseMs, nowMs),
+            completeEffect: async (effectId, workerId) =>
+                await base.completeEffect(effectId, workerId),
+            rescheduleEffect: async (
+                effectId,
+                workerId,
+                retryAtMs,
+                lastError
+            ) => await base.rescheduleEffect(
+                effectId,
+                workerId,
+                retryAtMs,
+                lastError
+            ),
+            peekNextEffectReadyAt: async (nowMs) =>
+                await base.peekNextEffectReadyAt(nowMs),
+            ...overrides
+        }
     };
 }
 

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -8,6 +8,30 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTestGroup } from '../create-test-group.ts';
 
 describe('WebRtcGroupManager', () => {
+    it('connects group-active peers before the independent client cache observes them', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcQBoxHarness('self');
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service as never,
+            groupCache,
+            clientCache,
+            undefined,
+            { overlayTransitionGraceMs: 0 }
+        );
+
+        await manager.acceptGroupUpdate(
+            createGroupSnapshot('group-1', 1, ['self', 'peer-a'])
+        );
+
+        expect(rtcQBox.ensurePeerConnectionStarted).toHaveBeenCalledWith('peer-a');
+        expect(manager.state()).toMatchObject({
+            desiredPeerIds: ['peer-a'],
+            onlinePeerIds: ['peer-a'],
+            connectablePeerIds: ['peer-a']
+        });
+    });
+
     it('reconciles desired groups against online clients and connection state', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -29,6 +29,11 @@ const CONTROL_WS_URL = 'ws://127.0.0.1:5180/control';
 type TransportUnderTest = 'realtime' | 'messages.rtc';
 type AgentPrefix = 'A' | 'B' | 'C';
 type DeliveryMode = 'direct' | 'multicast' | 'broadcast';
+type ConnectedAgent = Readonly<{ commandId: string; sessionId: string; }>;
+type ConnectedAgentTrio = Readonly<{
+    connections: readonly [ConnectedAgent, ConnectedAgent, ConnectedAgent];
+    readinessStartedAtMs: number;
+}>;
 
 type RestoredSession = Readonly<{
     clientId: string;
@@ -377,6 +382,7 @@ async function setupGroupMembership(
 ): Promise<readonly string[]> {
     const groupSegment = pathSegment(input.groupId);
     const createCommandId = `group-create-${input.suffix}`;
+    const createRequestId = `rtc-b06-create-${input.suffix}`;
     const joinCommandIds: string[] = [];
 
     await input.control.executeOk({
@@ -386,7 +392,9 @@ async function setupGroupMembership(
         command: {
             kind: 'http.request',
             request: {
-                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${pathSegment(workspaceId)}/groups`,
+                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
+                    pathSegment(workspaceId)
+                }/groups/requests/${pathSegment(createRequestId)}`,
                 method: 'POST',
                 body: {
                     groupId: input.groupId,
@@ -403,7 +411,8 @@ async function setupGroupMembership(
                 }
             },
             response: {
-                body: 'json'
+                body: 'json',
+                acceptedStatusCodes: [201]
             },
             timeoutMs: 10_000
         },
@@ -411,6 +420,8 @@ async function setupGroupMembership(
 
     for (const member of input.members) {
         const commandId = `group-join-${member.agentId}-${input.suffix}`;
+        const requestId =
+            `rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`;
         joinCommandIds.push(commandId);
         await input.control.executeOk({
             runId: input.runId,
@@ -421,14 +432,17 @@ async function setupGroupMembership(
                 request: {
                     path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
                         pathSegment(workspaceId)
-                    }/groups/${groupSegment}/members/{auth.clientId}`,
+                    }/groups/${groupSegment}/members/{auth.clientId}/requests/${
+                        pathSegment(requestId)
+                    }`,
                     method: 'PUT',
                     body: {
                         status: 'active'
                     }
                 },
                 response: {
-                    body: 'json'
+                    body: 'json',
+                    acceptedStatusCodes: [200]
                 },
                 timeoutMs: 10_000
             }
@@ -631,7 +645,7 @@ async function connectAgent(
         groupId: string;
         suffix: string;
     }>
-): Promise<Readonly<{ commandId: string; sessionId: string; }>> {
+): Promise<ConnectedAgent> {
     const commandId = `connect-${input.agent.prefix.toLowerCase()}-${input.transport.replace('.', '-')}-${input.suffix}`;
     const result = await input.control.executeOk({
         runId: input.runId,
@@ -659,6 +673,55 @@ async function connectAgent(
     return {
         commandId,
         sessionId: input.control.requireSessionId(result, commandId)
+    };
+}
+
+async function connectAgentTrio(
+    input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
+        transport: TransportUnderTest;
+        groupId: string;
+        suffix: string;
+    }>
+): Promise<ConnectedAgentTrio> {
+    const connected: ConnectedAgent[] = [];
+    for (const agent of input.agents.slice(0, 2)) {
+        connected.push(
+            await connectAgent({ ...input, agent })
+        );
+    }
+
+    const firstPairReadinessStartedAtMs = performance.now();
+    await Promise.all([
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.agents[0],
+            expectedPeerIds: [connected[1]!.sessionId],
+            suffix: `${input.suffix}-initial-pair`,
+            startedAtMs: firstPairReadinessStartedAtMs
+        }),
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.agents[1],
+            expectedPeerIds: [connected[0]!.sessionId],
+            suffix: `${input.suffix}-initial-pair`,
+            startedAtMs: firstPairReadinessStartedAtMs
+        })
+    ]);
+
+    const readinessStartedAtMs = performance.now();
+    connected.push(
+        await connectAgent({ ...input, agent: input.agents[2] })
+    );
+    return {
+        connections: [connected[0]!, connected[1]!, connected[2]!],
+        readinessStartedAtMs
     };
 }
 
@@ -732,9 +795,15 @@ async function runDeliveryMatrix(
         timings: readonly LiveRtcPerformanceTiming[];
     }>
 > {
-    const connectResults = await Promise.all(
-        input.agents.map((agent) => connectAgent({ ...input, agent }))
-    );
+    const connected = await connectAgentTrio({
+        control: input.control,
+        runId: input.runId,
+        agents: input.agents,
+        transport: input.transport,
+        groupId: input.groupId,
+        suffix: input.suffix
+    });
+    const connectResults = connected.connections;
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
         B: connectResults[1].sessionId,
@@ -744,7 +813,7 @@ async function runDeliveryMatrix(
 
     const [agentA, agentB, agentC] = input.agents;
     const transportSuffix = `${input.transport.replace('.', '-')}-${input.suffix}`;
-    const readinessStartedAtMs = performance.now();
+    const readinessStartedAtMs = connected.readinessStartedAtMs;
     const readinessDurationMs = await input.control.waitForPeerReadiness({
         runId: input.runId,
         agent: agentA,
@@ -936,9 +1005,15 @@ async function runAllDeliveryPermutations(
     }>
 > {
     const slug = transportSlug(input.transport);
-    const connectResults = await Promise.all(
-        input.agents.map((agent) => connectAgent({ ...input, agent }))
-    );
+    const connected = await connectAgentTrio({
+        control: input.control,
+        runId: input.runId,
+        agents: input.agents,
+        transport: input.transport,
+        groupId: input.groupId,
+        suffix: input.suffix
+    });
+    const connectResults = connected.connections;
     const sessions: Readonly<Record<AgentPrefix, string>> = {
         A: connectResults[0].sessionId,
         B: connectResults[1].sessionId,
@@ -947,7 +1022,7 @@ async function runAllDeliveryPermutations(
     expect(new Set(Object.values(sessions)).size).toBe(3);
 
     const readinessSuffix = `${slug}-${input.suffix}-all`;
-    const readinessStartedAtMs = performance.now();
+    const readinessStartedAtMs = connected.readinessStartedAtMs;
     const readinessDurations = await Promise.all(
         input.agents.map((agent) =>
             input.control.waitForPeerReadiness({
@@ -1248,6 +1323,64 @@ async function closeAndResetAgents(
     return commandIds;
 }
 
+async function closeAndResetSettledAgentTrio(
+    input: Readonly<{
+        control: LiveRtcControlClient;
+        runId: string;
+        agents: readonly [
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent,
+            LiveRtcControlClient.Agent
+        ];
+        sessions: Readonly<Record<AgentPrefix, string>>;
+        suffix: string;
+    }>
+): Promise<readonly string[]> {
+    const commandIds: string[] = [];
+    const closeAndReset = async (
+        agent: LiveRtcControlClient.Agent
+    ): Promise<void> => {
+        const closeCommandId = `close-${agent.prefix.toLowerCase()}-${input.suffix}`;
+        const resetCommandId = `reset-${agent.prefix.toLowerCase()}-${input.suffix}`;
+        commandIds.push(closeCommandId, resetCommandId);
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: closeCommandId,
+            command: { kind: 'close' },
+            timeoutMs: 45_000
+        });
+        await input.control.executeOk({
+            runId: input.runId,
+            agentId: agent.agentId,
+            commandId: resetCommandId,
+            command: { kind: 'reset' },
+            timeoutMs: 30_000
+        });
+    };
+
+    await closeAndReset(input.agents[2]);
+    await Promise.all(input.agents.slice(0, 2).map((agent) =>
+        input.control.waitForPeerAbsence({
+            runId: input.runId,
+            agent,
+            departedPeerIds: [input.sessions.C],
+            suffix: `${input.suffix}-retire-c`
+        })
+    ));
+
+    await closeAndReset(input.agents[1]);
+    await input.control.waitForPeerAbsence({
+        runId: input.runId,
+        agent: input.agents[0],
+        departedPeerIds: [input.sessions.B],
+        suffix: `${input.suffix}-retire-b`
+    });
+
+    await closeAndReset(input.agents[0]);
+    return commandIds;
+}
+
 async function writeAttemptEvidence(input: Readonly<{
     context: LiveRtcPerformanceAttemptContext | null;
     producerExitStatus: number;
@@ -1384,15 +1517,28 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 return agents;
             };
             const retireAgents = async (
-                agents: readonly LiveRtcControlClient.Agent[],
-                closeSuffix: string
+                agents: readonly [
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent,
+                    LiveRtcControlClient.Agent
+                ],
+                closeSuffix: string,
+                sessions?: Readonly<Record<AgentPrefix, string>>
             ): Promise<readonly string[]> => {
-                const retiredCommandIds = await closeAndResetAgents({
-                    control,
-                    runId,
-                    agents,
-                    suffix: closeSuffix
-                });
+                const retiredCommandIds = sessions
+                    ? await closeAndResetSettledAgentTrio({
+                        control,
+                        runId,
+                        agents,
+                        sessions,
+                        suffix: closeSuffix
+                    })
+                    : await closeAndResetAgents({
+                        control,
+                        runId,
+                        agents,
+                        suffix: closeSuffix
+                    });
                 await closeAgentContexts(agents);
                 for (const agent of agents) {
                     const index = openHandles.findIndex((candidate) => candidate.agentId === agent.agentId);
@@ -1439,22 +1585,12 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 commandIds.push(
                     ...await retireAgents(
                         realtimeAgents,
-                        `${suffix}-after-realtime`
+                        `${suffix}-after-realtime`,
+                        realtime.sessions
                     )
                 );
 
                 const messageAgents = await openAgents('live-messages');
-                commandIds.push(
-                    ...await setupGroupMembership({
-                        control,
-                        runId,
-                        owner: messageAgents[0],
-                        members: messageAgents,
-                        groupId,
-                        suffix: `${suffix}-messages`
-                    })
-                );
-
                 const messages = await runDeliveryMatrix({
                     control,
                     runId,
@@ -1628,15 +1764,28 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             return agents;
         };
         const retireAgents = async (
-            agents: readonly LiveRtcControlClient.Agent[],
-            closeSuffix: string
+            agents: readonly [
+                LiveRtcControlClient.Agent,
+                LiveRtcControlClient.Agent,
+                LiveRtcControlClient.Agent
+            ],
+            closeSuffix: string,
+            sessions?: Readonly<Record<AgentPrefix, string>>
         ): Promise<readonly string[]> => {
-            const retired = await closeAndResetAgents({
-                control,
-                runId,
-                agents,
-                suffix: closeSuffix
-            });
+            const retired = sessions
+                ? await closeAndResetSettledAgentTrio({
+                    control,
+                    runId,
+                    agents,
+                    sessions,
+                    suffix: closeSuffix
+                })
+                : await closeAndResetAgents({
+                    control,
+                    runId,
+                    agents,
+                    suffix: closeSuffix
+                });
             await closeAgentContexts(agents);
             for (const agent of agents) {
                 const index = openHandles.findIndex(
@@ -1688,7 +1837,8 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             diagnostics.push(realtimeDiagnostics.checkpoint);
             commandIds.push(...await retireAgents(
                 realtimeAgents,
-                `${suffix}-after-realtime-all`
+                `${suffix}-after-realtime-all`,
+                realtime.sessions
             ));
 
             const wsAgents = await openAgents('live-all-ws');
@@ -1702,14 +1852,6 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             commandIds.push(...await retireAgents(wsAgents, `${suffix}-after-ws-all`));
 
             const messageAgents = await openAgents('live-all-messages');
-            commandIds.push(...await setupGroupMembership({
-                control,
-                runId,
-                owner: messageAgents[0],
-                members: messageAgents,
-                groupId,
-                suffix: `${suffix}-messages`
-            }));
             const messages = await runAllDeliveryPermutations({
                 control,
                 runId,
@@ -1961,18 +2103,18 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 groupId,
                 suffix
             }));
-            const connected = await Promise.all(
-                agents.map((agent) => connectAgent({
-                    control,
-                    runId,
-                    agent,
-                    transport: 'messages.rtc',
-                    groupId,
-                    suffix: `${suffix}-initial`
-                }))
-            );
+            const initialConnection = await connectAgentTrio({
+                control,
+                runId,
+                agents,
+                transport: 'messages.rtc',
+                groupId,
+                suffix: `${suffix}-initial`
+            });
+            const connected = initialConnection.connections;
             commandIds.push(...connected.map((connection) => connection.commandId));
-            const initialReadinessStartedAtMs = performance.now();
+            const initialReadinessStartedAtMs =
+                initialConnection.readinessStartedAtMs;
             await Promise.all(agents.map((agent, agentIndex) =>
                 control.waitForPeerReadiness({
                     runId,


### PR DESCRIPTION
## Goal

Restore the in-memory three-browser RTC lifecycle needed to capture RTC-B06 evidence. This repairs the convergence defects exposed by the live matrix without pinning a moving `main` revision.

## Changes

- Retry the complete inbound control-message admission transaction when the durable backend reports an optimistic conflict.
- Make a bound room refresh read through the current server topology after accepting the fresh group snapshot.
- Treat sessions in accepted active group presence as connectable while the independently ordered client cache catches up; an explicit session-scoped offline observation remains a fence.
- Remove the sender-side room-cache `no-route` precheck and let the outbound RTC runtime make the authoritative routing decision.
- Update the architecture note and coupled fallback doubles to describe and test the actual boundaries.

## Acceptance

- The live three-browser memory matrix completes realtime and `messages.rtc` direct, multicast, and broadcast delivery, NACK and stale-send probes, and artifact assertions.
- Backend conflicts retry the complete control-message admission operation and do not leak from the message callback.
- Repeated room refreshes can discover and adopt topology that becomes current after initial connection.
- A fresh group presence snapshot can start an RTC dial before the client collection observes the same session.
- RTC route/no-route remains owned by the outbound runtime, including when the room-state cache temporarily lags.

## Test design evidence

- RED: the inbound control regression failed on the first of three simulated backend conflicts. GREEN: the operation completes on attempt four and reports one acceptance.
- RED: bound room refresh made one request when group plus topology were required. GREEN: it makes the exact group request followed by the exact topology request.
- RED: a group-active peer absent from the independent client cache produced zero dial attempts. GREEN: the peer is desired, connectable, and dialed.
- RED: an explicit RTC route was rejected by the stale room-cache precheck. GREEN: the outbound runtime receives the message and owns the result.
- The four coupled fallback tests now explicitly return `no-route` from their outbound-runtime doubles instead of depending on sender internals.

## Construction and registration timeline

1. API/runtime composition supplies the selected inbound admission stores to `WsQueueBoxServerService` and the browser RTC services.
2. `WsQueueBoxServerService.createInboundRuntime`, `WsQueueBoxClientService`, and `WebRtcRxStreamerService` construct `ALInboundMessageRuntime` with their concrete delivery effects.
3. WebSocket/RTC callbacks invoke the concrete `handleIncomingMessage` entry; browser state composition binds `rooms.session(...).refresh()` to `BrowserRallarRooms.refreshRoom`.
4. Browser communication composition constructs the message sender with the concrete outbound RTC streamer; there is no second route owner in the sender.

## Runtime invocation timeline

1. A control message enters `ALInboundMessageRuntime.handleIncomingMessage`.
2. `acceptControlMessageWithRetry` re-enters `ALInboundAdmissionStore.acceptControlMessage` after `ALAdmissionBackendConflictError`.
3. The admission policy parses ACK/NACK/repair state, reads current control facts, and derives the next accepted state.
4. The backend collector applies its optimistic write set; a runtime-state guard conflict restarts the complete operation.
5. The exact control state and any durable effect are committed, then the effect drain and registered control callback run after commit.
6. During browser readiness, `rooms.session(...).refresh()` accepts the exact group point read, reads through current topology, adopts the overlay, and triggers `WebRtcGroupManager` reconciliation.
7. The manager combines independently converging client and group presence, computes the dial plan, and starts the peer connection.
8. `messages.rtc.send` passes the message to the outbound runtime, which resolves explicit or overlay next hops and returns the canonical route status.

The manual cold trace reached all five mutation landmarks (operation entry, policy, first optimistic guard, durable result, and after-commit effect) with no search escape or ambiguous business-interface pivot. Named backend transaction and durable-effect drain edges remain legitimate deferred boundaries. The navigation analyzer also reported no findings for the modified runtime roots.

## Validation

- `npm run test:rallar:full-stack:memory:live-rtc-3` — 1 passed, 2 intentionally skipped; full primary matrix passed in 1.5 minutes.
- Focused convergence suites — 59/59 passed.
- `npx vitest run --config vitest.config.ts packages/tests/shared-web` — 108 files, 524 tests passed.
- Group formation/churn and manager suites — 30/30 passed.
- `npm run check --workspace packages/shared-rtc-bench` — TypeScript passed, 42 files/392 tests passed, and all Deno entry checks passed.
- `npm run typecheck` — all workspaces and 965 typed test files passed.
- Shared-web browser bundle budget check passed.
- Changed repository style, repository structure, navigation details, and `git diff --check` passed.

## Risk and rollback

Bound room refresh now performs one additional best-effort topology GET for a locally joined room. The public API is unchanged. Removing the sender precheck shifts no-route ownership to the existing outbound runtime, which already returns the canonical status used by fallbacks. Roll back by reverting this PR as one unit.

## Follow-up

- After this PR and #380 merge, initialize and capture a fresh RTC-B06 E3-memory attempt from then-current `main`.
- The passing live run also logged repeated RTC RTT AppInbox idempotency conflicts. They did not affect matrix acceptance and are intentionally not folded into this convergence repair.
