### PR TITLE
fix(shared-rtc-bench): support retryable local observations

### DIFF
--- a/packages/shared-rtc-bench/baseline/contracts/rtc-baseline-id.ts
+++ b/packages/shared-rtc-bench/baseline/contracts/rtc-baseline-id.ts
@@ -4,6 +4,7 @@ const dateScopedRtcBaselineIdPattern =
     /^\d{8}-[0-9a-f]{12}-e(?:1-local|2-browser|3-memory|4-pg|5-remote)(?:-repeat-01)?$/;
 const observationRtcBaselineIdPattern =
     /^(\d{8}T\d{6}Z)-[0-9a-f]{12}-e(?:1-local|2-browser|3-memory|4-pg|5-remote)-gh([1-9]\d*)-a([1-9]\d*)(?:-repeat-01)?$/;
+const localObservationRtcBaselineIdPattern = /^(\d{8}T\d{9}Z)-[0-9a-f]{12}-e(?:3-memory|4-pg)-local(?:-repeat-01)?$/;
 const fullCommitPattern = /^[0-9a-f]{40}$/;
 export interface RtcBaselineObservationIdInputDto {
     readonly startedAt: string;
@@ -13,15 +14,41 @@ export interface RtcBaselineObservationIdInputDto {
     readonly githubRunAttempt: number;
 }
 
+export interface RtcBaselineLocalObservationIdInputDto {
+    readonly startedAt: string;
+    readonly sourceCommit: string;
+    readonly environmentId: 'E3-memory' | 'E4-pg';
+}
+
 export function isRtcBaselineId(baselineId: string) {
     if (dateScopedRtcBaselineIdPattern.test(baselineId)) {
         return true;
+    }
+    const localMatch = localObservationRtcBaselineIdPattern.exec(baselineId);
+    if (localMatch !== null) {
+        return isCanonicalLocalUtcTimestamp(localMatch[1]!);
     }
     const match = observationRtcBaselineIdPattern.exec(baselineId);
     return match !== null &&
         isCanonicalUtcTimestamp(match[1]!) &&
         isPositiveSafeInteger(match[2]!) &&
         isPositiveSafeInteger(match[3]!);
+}
+
+export function createRtcBaselineLocalObservationId(
+    observation: RtcBaselineLocalObservationIdInputDto
+): RtcBaselineResult<string> {
+    const issues = validateRtcBaselineSourceIdentity(observation);
+    if (issues.length > 0) {
+        return { ok: false, issues };
+    }
+    const compactTimestamp = compactRtcBaselineLocalTimestamp(observation.startedAt);
+    return {
+        ok: true,
+        value: `${compactTimestamp}-${
+            observation.sourceCommit.slice(0, 12)
+        }-${observation.environmentId.toLowerCase()}-local`
+    };
 }
 
 export function isRtcBrowserBaselineId(baselineId: string) {
@@ -35,7 +62,7 @@ export function createRtcBaselineObservationId(
     if (issues.length > 0) {
         return { ok: false, issues };
     }
-    const compactTimestamp = observation.startedAt.slice(0, 19).replaceAll('-', '').replaceAll(':', '') + 'Z';
+    const compactTimestamp = compactRtcBaselineTimestamp(observation.startedAt);
     return {
         ok: true,
         value: `${compactTimestamp}-${
@@ -68,14 +95,19 @@ function isCanonicalUtcTimestamp(compactTimestamp: string) {
     return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === isoTimestamp;
 }
 
+function isCanonicalLocalUtcTimestamp(compactTimestamp: string) {
+    const isoTimestamp = `${compactTimestamp.slice(0, 4)}-${compactTimestamp.slice(4, 6)}-${
+        compactTimestamp.slice(6, 8)
+    }T${compactTimestamp.slice(9, 11)}:${compactTimestamp.slice(11, 13)}:${compactTimestamp.slice(13, 15)}.${
+        compactTimestamp.slice(15, 18)
+    }Z`;
+    const timestamp = Date.parse(isoTimestamp);
+    return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === isoTimestamp;
+}
+
 function validateRtcBaselineObservationIdInput(observation: RtcBaselineObservationIdInputDto) {
     return [
-        ...(!isCanonicalIsoTimestamp(observation.startedAt)
-            ? [issue('$.startedAt', 'invalid-started-at', 'Started time must be a canonical UTC timestamp.')]
-            : []),
-        ...(!fullCommitPattern.test(observation.sourceCommit)
-            ? [issue('$.sourceCommit', 'invalid-source-commit', 'Source commit must be one full lowercase Git OID.')]
-            : []),
+        ...validateRtcBaselineSourceIdentity(observation),
         ...(!isPositiveSafeInteger(observation.githubRunId)
             ? [issue('$.githubRunId', 'invalid-run-id', 'GitHub run ID must be a positive safe integer.')]
             : []),
@@ -87,6 +119,27 @@ function validateRtcBaselineObservationIdInput(observation: RtcBaselineObservati
             )]
             : [])
     ];
+}
+
+function validateRtcBaselineSourceIdentity(
+    observation: Pick<RtcBaselineObservationIdInputDto, 'startedAt' | 'sourceCommit'>
+) {
+    return [
+        ...(!isCanonicalIsoTimestamp(observation.startedAt)
+            ? [issue('$.startedAt', 'invalid-started-at', 'Started time must be a canonical UTC timestamp.')]
+            : []),
+        ...(!fullCommitPattern.test(observation.sourceCommit)
+            ? [issue('$.sourceCommit', 'invalid-source-commit', 'Source commit must be one full lowercase Git OID.')]
+            : [])
+    ];
+}
+
+function compactRtcBaselineTimestamp(startedAt: string) {
+    return startedAt.slice(0, 19).replaceAll('-', '').replaceAll(':', '') + 'Z';
+}
+
+function compactRtcBaselineLocalTimestamp(startedAt: string) {
+    return startedAt.slice(0, 23).replaceAll('-', '').replaceAll(':', '').replace('.', '') + 'Z';
 }
 
 function isCanonicalIsoTimestamp(isoTimestamp: string) {

--- a/packages/shared-rtc-bench/tests/baseline/contracts/rtc-baseline-id.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/contracts/rtc-baseline-id.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseRtcBaselineCommand } from '../../../baseline/command/rtc-baseline-cli-grammar.ts';
-import { createRtcBaselineObservationId, createRtcBaselineRepeatId } from '../../../baseline/contracts/rtc-baseline-id.ts';
+import { createRtcBaselineLocalObservationId, createRtcBaselineObservationId, createRtcBaselineRepeatId } from '../../../baseline/contracts/rtc-baseline-id.ts';
 import { validateRtcBaselineId } from '../../../baseline/contracts/rtc-baseline-validation.ts';
 
 const observationId = '20260827T031500Z-eaf526518c70-e2-browser-gh123456789-a2';
+const localObservationId = '20260830T081500417Z-eaf526518c70-e3-memory-local';
 
 describe('RTC baseline identity', () => {
     it('creates the canonical identity from exact observation provenance', () => {
@@ -25,6 +26,21 @@ describe('RTC baseline identity', () => {
             value: `${observationId}-repeat-01`
         });
         expect(createRtcBaselineRepeatId(`${observationId}-repeat-01`)).toMatchObject({ ok: false });
+    });
+
+    it('creates a timestamped local identity that can be retried without falsifying provenance', () => {
+        expect(
+            createRtcBaselineLocalObservationId({
+                startedAt: '2026-08-30T08:15:00.417Z',
+                sourceCommit: 'eaf526518c70e3b396dad91c008125a622b38b00',
+                environmentId: 'E3-memory'
+            })
+        ).toEqual({ ok: true, value: localObservationId });
+        expect(validateRtcBaselineId(localObservationId)).toEqual([]);
+        expect(createRtcBaselineRepeatId(localObservationId)).toEqual({
+            ok: true,
+            value: `${localObservationId}-repeat-01`
+        });
     });
 
     it.each([
@@ -79,12 +95,34 @@ describe('RTC baseline identity', () => {
         });
     });
 
+    it('accepts one timestamped local observation identity across command parsing', () => {
+        expect(
+            parseRtcBaselineCommand([
+                'initialize',
+                `--baseline-id=${localObservationId}`,
+                '--workloads=RTC-B06',
+                '--environment=E3-memory'
+            ])
+        ).toMatchObject({
+            ok: true,
+            value: {
+                baselineId: localObservationId,
+                workloadIds: ['RTC-B06'],
+                environmentId: 'E3-memory'
+            }
+        });
+    });
+
     it.each([
         '20260827T031500-eaf526518c70-e2-browser-gh123456789-a2',
         '20260230T031500Z-eaf526518c70-e2-browser-gh123456789-a2',
         '20260827T031500Z-eaf526518c70-e2-browser-gh0-a2',
         '20260827T031500Z-eaf526518c70-e2-browser-gh123456789-a0',
-        '20260827T031500Z-eaf526518c70-e2-browser-gh123456789-a2-repeat-02'
+        '20260827T031500Z-eaf526518c70-e2-browser-gh123456789-a2-repeat-02',
+        '20260830T081500417-eaf526518c70-e3-memory-local',
+        '20260230T081500417Z-eaf526518c70-e3-memory-local',
+        '20260830T081500417Z-eaf526518c70-e2-browser-local',
+        '20260830T081500417Z-eaf526518c70-e3-memory-local-repeat-02'
     ])('rejects malformed stream identity %s', (invalidObservationId) => {
         expect(validateRtcBaselineId(invalidObservationId)).toEqual([
             {

--- a/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts';
 
 const temporaryDirectories: string[] = [];
-const baselineId = '20260829-0123456789ab-e3-memory';
+const baselineId = '20260829T081500417Z-0123456789ab-e3-memory-local';
 const e3DefaultLocator = {
     workloadId: 'RTC-B06',
     caseId: 'default',

--- a/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
@@ -541,7 +541,7 @@ export class LiveRtcControlClient {
 
 const FIVE_MEBIBYTES = 5 * 1024 * 1024;
 const LIVE_RTC_BASELINE_ID =
-    /^\d{8}-[0-9a-f]{12}-e(?:3-memory|4-pg)(?:-repeat-01)?$/u;
+    /^(?:\d{8}-[0-9a-f]{12}-e(?:3-memory|4-pg)|\d{8}T\d{9}Z-[0-9a-f]{12}-e(?:3-memory|4-pg)-local)(?:-repeat-01)?$/u;
 const attemptIdentityFields = [
     'workloadId',
     'caseId',


### PR DESCRIPTION
## Summary
- add canonical millisecond timestamped local observation IDs for E3-memory and E4-pg
- preserve existing date-scoped and GitHub-run identity forms plus controlled repeats
- allow the B06 producer to consume the new canonical local IDs

## Why
A failed local initialization reserves the only date-scoped ID for that commit/environment/day. The new form records truthful per-attempt provenance instead of reusing an ID, inventing a date, or impersonating a GitHub run.

## Validation
- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check` (42 files, 398 tests; TypeScript and Deno checks pass)
- focused B06 owner tests (3 files, 25 tests)
- `npm run check:repo-style:changed -- origin/main`
- `git diff --check`