### PR TITLE
fix(shared-rtc-bench): fingerprint sandboxed macOS hosts

### DIFF
--- a/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-adapters.ts
+++ b/packages/shared-rtc-bench/baseline/runtime/rtc-baseline-deno-adapters.ts
@@ -45,7 +45,15 @@ export interface DenoRtcBaselineAdapters {
     };
 }
 
-const allowedExecutables = new Set(['git', 'node', 'npm', 'deno', 'uname', 'sysctl']);
+const allowedExecutables = new Set([
+    'git',
+    'node',
+    'npm',
+    'deno',
+    'uname',
+    'sysctl',
+    'system_profiler'
+]);
 const decoder = new TextDecoder();
 
 function cleanMessage(value: string) {
@@ -54,6 +62,30 @@ function cleanMessage(value: string) {
 
 function bytesToHex(bytes: Uint8Array) {
     return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function readDarwinCpuModel(run: ProcessPort['run']) {
+    const cpu = await run({
+        executable: 'sysctl',
+        arguments: ['-n', 'machdep.cpu.brand_string']
+    });
+    const sysctlCpuModel = cpu.ok ? cpu.value.stdout.trim() : '';
+    if (sysctlCpuModel.length > 0) {
+        return sysctlCpuModel;
+    }
+    const hardware = await run({
+        executable: 'system_profiler',
+        arguments: ['SPHardwareDataType', '-detailLevel', 'mini']
+    });
+    if (!hardware.ok) {
+        throw new Error(hardware.issues[0]!.message);
+    }
+    const profilerCpuModel = /^\s*(?:Chip|Processor Name)\s*:\s*(.+)$/m
+        .exec(hardware.value.stdout)?.[1]?.trim() ?? '';
+    if (profilerCpuModel.length === 0) {
+        throw new Error('macOS CPU model is unavailable.');
+    }
+    return profilerCpuModel;
 }
 
 export function createDenoRtcBaselineAdapters(
@@ -192,14 +224,7 @@ export function createDenoRtcBaselineAdapters(
                     }
                 }
                 else {
-                    const cpu = await run({
-                        executable: 'sysctl',
-                        arguments: ['-n', 'machdep.cpu.brand_string']
-                    });
-                    if (!cpu.ok) {
-                        throw new Error(cpu.issues[0]!.message);
-                    }
-                    cpuModel = cpu.value.stdout.trim();
+                    cpuModel = await readDarwinCpuModel(run);
                 }
                 return {
                     deno: runtime.version.deno,

--- a/packages/shared-rtc-bench/tests/baseline/runtime/rtc-performance-baseline-deno-adapters.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/runtime/rtc-performance-baseline-deno-adapters.test.ts
@@ -495,16 +495,22 @@ describe('RTC baseline Deno adapters', () => {
         const adapters = createDenoRtcBaselineAdapters(double.runtime);
         expect(
             await Promise.all([
-                adapters.freshWorker.run({ executable: 'deno', arguments: ['run', 'worker.ts'] }),
-                adapters.freshWorker.run({ executable: 'node', arguments: ['worker.mjs'] })
+                adapters.freshWorker.run({
+                    executable: 'deno',
+                    arguments: ['run', 'worker-entrypoint']
+                }),
+                adapters.freshWorker.run({
+                    executable: 'node',
+                    arguments: ['worker-entrypoint']
+                })
             ])
         ).toEqual([
             { ok: true, value: { exitStatus: 0, stdout: 'output\n', stderr: '' } },
             { ok: true, value: { exitStatus: 0, stdout: 'output\n', stderr: '' } }
         ]);
         expect(double.calls.filter((call) => call.startsWith('run:'))).toEqual([
-            'run:deno:run,worker.ts',
-            'run:node:worker.mjs'
+            'run:deno:run,worker-entrypoint',
+            'run:node:worker-entrypoint'
         ]);
     });
 });

--- a/packages/shared-rtc-bench/tests/baseline/runtime/rtc-performance-baseline-deno-adapters.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/runtime/rtc-performance-baseline-deno-adapters.test.ts
@@ -137,6 +137,67 @@ describe('RTC baseline Deno adapters', () => {
             'run:sysctl:-n,machdep.cpu.brand_string'
         ]);
     });
+    it('falls back to the macOS hardware profiler when sysctl is unavailable', async () => {
+        const double = createRuntimeDouble();
+        double.runtime.command = async (executable, arguments_) => {
+            double.calls.push(`run:${executable}:${arguments_.join(',')}`);
+            if (executable === 'uname') {
+                return {
+                    code: 0,
+                    stdout: new TextEncoder().encode('24.6.0\n'),
+                    stderr: new Uint8Array()
+                };
+            }
+            if (executable === 'sysctl') {
+                return {
+                    code: 1,
+                    stdout: new Uint8Array(),
+                    stderr: new TextEncoder().encode('Operation not permitted')
+                };
+            }
+            return {
+                code: 0,
+                stdout: new TextEncoder().encode(
+                    'Hardware:\n\n    Hardware Overview:\n\n      Chip: Apple M2 Max\n'
+                ),
+                stderr: new Uint8Array()
+            };
+        };
+        const adapters = createDenoRtcBaselineAdapters(double.runtime);
+
+        expect((await adapters.runtimeHost.read()).cpuModel).toBe('Apple M2 Max');
+        expect(double.calls.filter((call) => call.startsWith('run:'))).toEqual([
+            'run:uname:-r',
+            'run:sysctl:-n,machdep.cpu.brand_string',
+            'run:system_profiler:SPHardwareDataType,-detailLevel,mini'
+        ]);
+    });
+    it('uses Intel profiler output when sysctl is empty and fails closed without a CPU model', async () => {
+        const double = createRuntimeDouble();
+        double.runtime.command = async (executable, arguments_) => {
+            double.calls.push(`run:${executable}:${arguments_.join(',')}`);
+            const stdout = executable === 'uname'
+                ? '24.6.0\n'
+                : executable === 'system_profiler'
+                    ? '      Processor Name: 8-Core Intel Core i9\n'
+                    : '\n';
+            return {
+                code: 0,
+                stdout: new TextEncoder().encode(stdout),
+                stderr: new Uint8Array()
+            };
+        };
+        const adapters = createDenoRtcBaselineAdapters(double.runtime);
+
+        expect((await adapters.runtimeHost.read()).cpuModel).toBe('8-Core Intel Core i9');
+
+        double.runtime.command = async (executable) => ({
+            code: 0,
+            stdout: new TextEncoder().encode(executable === 'uname' ? '24.6.0\n' : '\n'),
+            stderr: new Uint8Array()
+        });
+        await expect(adapters.runtimeHost.read()).rejects.toThrow('macOS CPU model is unavailable.');
+    });
     it('reads branch and detached Git facts and preserves typed command failures', async () => {
         const double = createRuntimeDouble();
         const adapters = createDenoRtcBaselineAdapters(double.runtime);
@@ -365,6 +426,10 @@ describe('RTC baseline Deno adapters', () => {
                 adapters.process.run({
                     executable: 'sysctl',
                     arguments: ['-n', 'machdep.cpu.brand_string']
+                }),
+                adapters.process.run({
+                    executable: 'system_profiler',
+                    arguments: ['SPHardwareDataType', '-detailLevel', 'mini']
                 })
             ])
         ).toEqual([
@@ -373,7 +438,8 @@ describe('RTC baseline Deno adapters', () => {
             { ok: true, value: { exitStatus: 0, stdout: 'output\n', stderr: '' } },
             { ok: true, value: { exitStatus: 0, stdout: 'output\n', stderr: '' } },
             { ok: true, value: { exitStatus: 0, stdout: '24.6.0\n', stderr: '' } },
-            { ok: true, value: { exitStatus: 0, stdout: 'Apple M4\n', stderr: '' } }
+            { ok: true, value: { exitStatus: 0, stdout: 'Apple M4\n', stderr: '' } },
+            { ok: true, value: { exitStatus: 0, stdout: 'output\n', stderr: '' } }
         ]);
     });
     it('persists actual runtime versions and redacted secret environment presence', async () => {


### PR DESCRIPTION
## Summary
- keep `sysctl` as the preferred macOS CPU fingerprint source
- fall back to `system_profiler` when sandbox policy denies or empties `sysctl`
- fail closed when neither source yields a CPU model
- cover Apple Silicon, Intel, empty-output, and allowlist behavior

## Why
RTC-B06 E3-memory observation initialization correctly failed closed in the managed local sandbox because `sysctl` is denied. `system_profiler` remains available and reports the same truthful hardware identity, so this bounded fallback lets the capture proceed without weakening provenance.

## Validation
- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check`
- focused B06 owner tests (21 passed)
- `npm run check:repo-style:changed -- origin/main WORKTREE`
- `git diff --check`