### PR TITLE
Fix RTC-B06 observation controller environment

### DIFF
--- a/.github/workflows/rtc-b06-performance-observation.yml
+++ b/.github/workflows/rtc-b06-performance-observation.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Capture RTC-B06 E3-memory observation
         run: |
           env -u DATABASE_URL -u RALLAR_ICE_MODE \
-            -u RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS \
-            -u RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK \
-            -u RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES \
+            RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=1 \
+            RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=1 \
+            RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES=100 \
             npm run perf:rtc-baseline -- observe-live-rtc \
             --source-ref=main \
             --github-run-id="$GITHUB_RUN_ID" \

--- a/packages/shared-rtc-bench/README.md
+++ b/packages/shared-rtc-bench/README.md
@@ -76,9 +76,9 @@ The corresponding RTC-B06 E3 command is:
 
 ```bash
 env -u DATABASE_URL -u RALLAR_ICE_MODE \
-  -u RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS \
-  -u RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK \
-  -u RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES \
+  RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=1 \
+  RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=1 \
+  RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES=100 \
   npm run perf:rtc-baseline -- observe-live-rtc \
   --source-ref=main \
   --github-run-id=1 \

--- a/packages/tests/repo/pull-request-delivery/pull-request-workflow.test.ts
+++ b/packages/tests/repo/pull-request-delivery/pull-request-workflow.test.ts
@@ -86,8 +86,6 @@ describe('pull-request release workflow', () => {
         });
         expect(capture['timeout-minutes']).toBe(360);
         expect(observe.run).toContain('observe-live-rtc');
-        expect(observe.run).toContain('env -u DATABASE_URL -u RALLAR_ICE_MODE');
-        expect(observe.run).not.toContain('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=1');
         expect(upload).toMatchObject({
             if: '${{ always() }}',
             uses: 'actions/upload-artifact@v7',

--- a/packages/tests/repo/pull-request-delivery/rtc-b06-observation-workflow-environment.test.ts
+++ b/packages/tests/repo/pull-request-delivery/rtc-b06-observation-workflow-environment.test.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const fixtureRoots: string[] = [];
+
+afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+describe('RTC-B06 observation workflow environment', () => {
+    it('starts the controller with complete catalog values and a memory-only producer boundary', () => {
+        const fixtureRoot = createEnvironmentCaptureFixture();
+        const capture = readCaptureCommand();
+        const result = spawnSync('bash', ['-euo', 'pipefail', '-c', capture], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                PATH: `${fixtureRoot}/bin:${process.env.PATH ?? ''}`,
+                DATABASE_URL: 'postgres://inherited.invalid/database',
+                RALLAR_ICE_MODE: 'inherited-ice-mode',
+                RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS: 'inherited-all-scenarios',
+                RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK: 'inherited-retention-soak',
+                RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES: '999',
+                RTC_B06_ENVIRONMENT_RECORD: `${fixtureRoot}/environment.json`,
+                RTC_OBSERVATION_OUTPUT: `${fixtureRoot}/output`,
+                GITHUB_RUN_ID: '123456789',
+                GITHUB_RUN_ATTEMPT: '2',
+                GITHUB_SERVER_URL: 'https://github.com',
+                GITHUB_REPOSITORY: 'example/repository'
+            }
+        });
+
+        expect(result).toMatchObject({ status: 0, stderr: '' });
+        expect(
+            JSON.parse(readFileSync(`${fixtureRoot}/environment.json`, 'utf8'))
+        ).toEqual({
+            DATABASE_URL: null,
+            RALLAR_ICE_MODE: null,
+            RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS: '1',
+            RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK: '1',
+            RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES: '100'
+        });
+    });
+});
+
+function readCaptureCommand(): string {
+    const workflowPath = path.join(
+        repoRoot,
+        '.github/workflows/rtc-b06-performance-observation.yml'
+    );
+    const workflow = load(readFileSync(workflowPath, 'utf8')) as {
+        jobs: {
+            capture: {
+                steps: Array<{ name?: string; run?: string; }>;
+            };
+        };
+    };
+    const capture = workflow.jobs.capture.steps.find(
+        ({ name }) => name === 'Capture RTC-B06 E3-memory observation'
+    )?.run;
+    if (capture === undefined) {
+        throw new Error('RTC-B06 capture command is missing.');
+    }
+    return capture;
+}
+
+function createEnvironmentCaptureFixture(): string {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'rtc-b06-workflow-environment-'));
+    const fakeNpmPath = path.join(fixtureRoot, 'bin', 'npm');
+    fixtureRoots.push(fixtureRoot);
+    mkdirSync(path.dirname(fakeNpmPath));
+    writeFileSync(
+        fakeNpmPath,
+        `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs');
+const names = [
+    'DATABASE_URL',
+    'RALLAR_ICE_MODE',
+    'RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS',
+    'RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK',
+    'RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES'
+];
+writeFileSync(
+    process.env.RTC_B06_ENVIRONMENT_RECORD,
+    JSON.stringify(Object.fromEntries(names.map((name) => [name, process.env[name] ?? null])))
+);
+`
+    );
+    chmodSync(fakeNpmPath, 0o755);
+    return fixtureRoot;
+}


### PR DESCRIPTION
## Goal

Restore RTC-B06 E3-memory observation capture after run 33306000819 failed during controller initialization because required catalog environment values were unset.

## Changes

- Start the RTC-B06 controller with the governed all-scenarios and retention values required to resolve the complete attempt catalog.
- Continue clearing inherited database and ICE settings so the observation remains E3-memory.
- Keep per-case producer isolation unchanged; the controller still clears and reapplies case flags at the producer boundary.
- Add a semantic workflow-shell test that executes the real capture command and records the environment received by the controller.
- Update the package-owned local command and remove obsolete source-text assertions.

## Acceptance

- The controller receives `RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS=1`, `RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=1`, and `RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES=100`.
- `DATABASE_URL` and `RALLAR_ICE_MODE` are absent.
- The real workflow shell command passes the semantic environment regression test.
- RTC package, test typecheck, repository structure, changed-style, formatting, and structure-coupling checks pass.

## Validation

- `npx vitest run packages/tests/repo/pull-request-delivery/pull-request-workflow.test.ts packages/tests/repo/pull-request-delivery/rtc-b06-observation-workflow-environment.test.ts`
- `npm run typecheck:tests`
- `npm run check --workspace=packages/shared-rtc-bench`
- `npm run check:test-structure-coupling -- --files packages/tests/repo/pull-request-delivery/pull-request-workflow.test.ts packages/tests/repo/pull-request-delivery/rtc-b06-observation-workflow-environment.test.ts`
- `npm run check:repo-style:changed -- 2a62150d1e1b585ab41668e8495dcd8ac4219425`
- `npm run check:repo-structure -- --base 2a62150d1e1b585ab41668e8495dcd8ac4219425`
- `npx dprint check .github/workflows/rtc-b06-performance-observation.yml packages/shared-rtc-bench/README.md packages/tests/repo/pull-request-delivery/pull-request-workflow.test.ts packages/tests/repo/pull-request-delivery/rtc-b06-observation-workflow-environment.test.ts`
- `git diff --check`

## Risk and rollback

Risk is limited to the manual RTC-B06 observation workflow and its documented local equivalent. Rolling back this commit restores the prior behavior, which deterministically fails before browser capture; no product runtime or observation archive format changes.

## Follow-up

After merge, dispatch the RTC-B06 workflow again from then-current `main`, verify the finalized observation, and let the workflow publish the append-only observation PR.