### PR TITLE
fix(shared-rtc-bench): finalize failed RTC-B06 observations

### DIFF
--- a/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-failure-accounting.ts
+++ b/packages/shared-rtc-bench/baseline/acceptance/rtc-baseline-failure-accounting.ts
@@ -477,6 +477,31 @@ export function createRtcBaselineNotRunArtifact(
     };
 }
 
+function createRtcBaselineBlockedCohortFailures(
+    manifest: RtcBaselineCaptureManifestDto,
+    blockedSampleIds: ReadonlySet<string>,
+    causalFailureId: string
+): RtcBaselineFailureArtifact[] {
+    return manifest.expectedCohorts.flatMap((identity) => {
+        const blockedMemberSampleIds = identity.memberSampleIds.filter((sampleId) => blockedSampleIds.has(sampleId));
+        return blockedMemberSampleIds.length === 0
+            ? []
+            : [
+                createRtcBaselineFailureArtifact(
+                    { kind: 'cohort', identity },
+                    [
+                        rtcBaselineIssue(
+                            '$.identity.memberSampleIds',
+                            'cohort-members-unavailable',
+                            'Cohort assertion cannot run after a member sample failed or was causally not run.'
+                        )
+                    ],
+                    { causalFailureId, blockedMemberSampleIds }
+                )
+            ];
+    });
+}
+
 export function buildRtcBaselineFailureSequence(
     input: RtcBaselineFailureSequenceInput
 ): (RtcBaselineFailureArtifact | RtcBaselineNotRunArtifact)[] {
@@ -490,10 +515,14 @@ export function buildRtcBaselineFailureSequence(
         (identity) => identity.workloadId === ownerIdentity.workloadId
     );
     const ownerIndex = identities.findIndex((identity) => rtcBaselineSampleIdentityEquals(identity, ownerIdentity));
+    const notRunIdentities = identities.slice(ownerIndex + 1);
+    const blockedSampleIds = new Set([
+        ownerIdentity.sampleId,
+        ...notRunIdentities.map((identity) => identity.sampleId)
+    ]);
     return [
         failure,
-        ...identities
-            .slice(ownerIndex + 1)
-            .map((identity) => createRtcBaselineNotRunArtifact(identity, failureId))
+        ...notRunIdentities.map((identity) => createRtcBaselineNotRunArtifact(identity, failureId)),
+        ...createRtcBaselineBlockedCohortFailures(input.manifest, blockedSampleIds, failureId)
     ];
 }

--- a/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-artifact-projection.ts
+++ b/packages/shared-rtc-bench/baseline/evidence/rtc-baseline-artifact-projection.ts
@@ -172,6 +172,13 @@ export function createRtcBaselineArtifactProjector(
                 issues: failure.issues
             });
         }
+        else {
+            cohortOutcomes.push({
+                identity: failure.identity,
+                outcome: 'failed',
+                issues: failure.issues
+            });
+        }
         return successful();
     }
 

--- a/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-performance-baseline-evidence-failure.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/acceptance/rtc-performance-baseline-evidence-failure.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { createRtcBaselineEvidenceAcceptance } from '../../../baseline/acceptance/rtc-baseline-evidence-acceptance.ts';
 import {
@@ -104,6 +104,24 @@ const causalIssue = {
     code: 'causal-not-run',
     message: 'Not run after the first workload correctness failure.'
 };
+const blockedCohortFailureRow = [
+    'failure',
+    'failure-cohort-cohort',
+    cohortOwner,
+    'failed',
+    null,
+    [
+        {
+            path: '$.identity.memberSampleIds',
+            code: 'cohort-members-unavailable',
+            message: 'Cohort assertion cannot run after a member sample failed or was causally not run.'
+        }
+    ],
+    {
+        causalFailureId: 'failure-sample-external-sample',
+        blockedMemberSampleIds: ['external-sample']
+    }
+];
 const malformedIssue = {
     path: '$.raw-result',
     code: 'invalid-json',
@@ -232,10 +250,7 @@ describe('RTC baseline failure accounting', () => {
         };
         expect(createRtcBaselineAcceptedWorkerSampleIdentity(worker, 1)).toEqual(identities[1]);
 
-        const run = vi
-            .fn<() => Promise<{ durationMs: number; }>>()
-            .mockResolvedValueOnce({ durationMs: -1 })
-            .mockResolvedValue({ durationMs: 2 });
+        const run = async () => ({ durationMs: -1 });
         const samples = await runRtcBaselineAcceptedWorkerSamples({
             worker,
             run,
@@ -256,7 +271,6 @@ describe('RTC baseline failure accounting', () => {
             })
         });
 
-        expect(run).toHaveBeenCalledTimes(1);
         expect(samples.map((sample) => [sample.identity, sample.outcome, sample.issues])).toEqual([
             [
                 identities[0],
@@ -350,6 +364,99 @@ describe('RTC baseline failure accounting', () => {
             ]
         ]);
     });
+
+    it('accounts for a predeclared cohort blocked by an earlier external failure', async () => {
+        const retentionIdentity = {
+            ...externalOwner,
+            sampleId: 'external-retention-sample',
+            caseId: 'retention-100',
+            inputKey: 'e3-memory-retention-100',
+            outerOrdinal: 2
+        } as const;
+        const retentionCohortOwner = {
+            cohortId: 'cohort',
+            workloadId: 'RTC-B06' as const,
+            memberSampleIds: [retentionIdentity.sampleId]
+        };
+        const b06Manifest = {
+            ...externalManifest,
+            outerAttempts: [
+                externalManifest.outerAttempts[1]!,
+                {
+                    ...externalManifest.outerAttempts[1]!,
+                    caseId: retentionIdentity.caseId,
+                    inputKey: retentionIdentity.inputKey,
+                    outerOrdinal: retentionIdentity.outerOrdinal,
+                    sampleIds: [retentionIdentity.sampleId]
+                }
+            ],
+            expectedCohorts: [retentionCohortOwner]
+        };
+        const { service, writes } = recordingAcceptance({
+            readManifest: async () => ({ ok: true, value: b06Manifest })
+        });
+        const result = await service.recordExternalAttempt({
+            ...externalInput,
+            producerExitStatus: 9
+        });
+        const failureId = 'failure-sample-external-sample';
+
+        expect(result).toEqual({
+            ok: false,
+            issues: [
+                {
+                    path: '$.producerExitStatus',
+                    code: 'producer-exit-status',
+                    message: 'Producer exited with status 9.'
+                }
+            ]
+        });
+        expect(persistedRows(writes)).toEqual([
+            [
+                'failure',
+                failureId,
+                externalOwner,
+                'failed',
+                null,
+                [
+                    {
+                        path: '$.producerExitStatus',
+                        code: 'producer-exit-status',
+                        message: 'Producer exited with status 9.'
+                    }
+                ],
+                { producerExitStatus: 9 }
+            ],
+            [
+                'not-run',
+                failureId,
+                retentionIdentity,
+                'not-run',
+                failureId,
+                [causalIssue],
+                null
+            ],
+            [
+                'failure',
+                'failure-cohort-cohort',
+                retentionCohortOwner,
+                'failed',
+                null,
+                [
+                    {
+                        path: '$.identity.memberSampleIds',
+                        code: 'cohort-members-unavailable',
+                        message: 'Cohort assertion cannot run after a member sample failed or was causally not run.'
+                    }
+                ],
+                {
+                    causalFailureId: failureId,
+                    blockedMemberSampleIds: [retentionIdentity.sampleId]
+                }
+            ]
+        ]);
+    });
+
     it('persists a valid prefix, invalid worker failure, and complete later-outer remainder', async () => {
         const { service, writes } = recordingAcceptance({
             readManifest: async () => ({
@@ -399,7 +506,7 @@ describe('RTC baseline failure accounting', () => {
     it.each(
         [
             ['browser', 'failure-sample-browser-sample', browserOwner, null],
-            ['external', 'failure-sample-external-sample', externalOwner, null],
+            ['external', 'failure-sample-external-sample', externalOwner, blockedCohortFailureRow],
             ['cohort', 'failure-cohort-cohort', cohortOwner, null]
         ] as const
     )(
@@ -432,12 +539,12 @@ describe('RTC baseline failure accounting', () => {
 
     it.each(
         [
-            ['capture', 'failure-sample-rtc-b01-case-input-retained-001-001', identities[0]],
-            ['browser', 'failure-sample-browser-sample', browserOwner],
-            ['external', 'failure-sample-external-sample', externalOwner],
-            ['cohort', 'failure-cohort-cohort', cohortOwner]
+            ['capture', 'failure-sample-rtc-b01-case-input-retained-001-001', identities[0], null],
+            ['browser', 'failure-sample-browser-sample', browserOwner, null],
+            ['external', 'failure-sample-external-sample', externalOwner, blockedCohortFailureRow],
+            ['cohort', 'failure-cohort-cohort', cohortOwner, null]
         ] as const
-    )('persists the exact %s reconciliation owner', async (kind, failureId, identity) => {
+    )('persists the exact %s reconciliation owner', async (kind, failureId, identity, remainder) => {
         const { service, writes } = recordingAcceptance({
             readManifest: async () => ({ ok: true, value: manifestForOperation(kind) }),
             reconcileAcceptedOperation: async () => [reconciliationIssue]
@@ -447,14 +554,16 @@ describe('RTC baseline failure accounting', () => {
             issues: [reconciliationIssue]
         });
         expect(persistedRows(writes)).toEqual([
-            ['failure', failureId, identity, 'failed', null, [reconciliationIssue], null]
+            ['failure', failureId, identity, 'failed', null, [reconciliationIssue], null],
+            ...(remainder ? [remainder] : [])
         ]);
     });
 
     it('rejects initialization reconciliation before store mutation', async () => {
-        const initializeStore = vi.fn();
         const service = acceptance({
-            initializeStore,
+            initializeStore: async () => {
+                throw new Error('Initialization must not run before reconciliation succeeds.');
+            },
             reconcileAcceptedOperation: async () => [reconciliationIssue]
         });
         expect(
@@ -466,6 +575,5 @@ describe('RTC baseline failure accounting', () => {
             ok: false,
             issues: [reconciliationIssue]
         });
-        expect(initializeStore).not.toHaveBeenCalled();
     });
 });

--- a/packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-artifact-projection.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/evidence/rtc-baseline-artifact-projection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createRtcBaselineArtifactProjector } from '../../../baseline/evidence/rtc-baseline-artifact-projection.ts';
+
+describe('RTC baseline artifact projection', () => {
+    it('projects a cohort failure into both direct and derived accounting', async () => {
+        const identity = {
+            cohortId: 'rtc-b06-e3-memory-retention',
+            workloadId: 'RTC-B06' as const,
+            memberSampleIds: ['rtc-b06-retention-member']
+        };
+        const issues = [
+            {
+                path: '$.identity.memberSampleIds',
+                code: 'cohort-members-unavailable',
+                message: 'Cohort assertion cannot run after a member sample failed or was causally not run.'
+            }
+        ];
+        const projector = createRtcBaselineArtifactProjector({
+            environmentId: 'E3-memory',
+            environmentObservation: null,
+            conflictingSampleCode: 'conflicting-sample',
+            conflictingSampleMessage: () => 'conflicting sample',
+            sha256: async () => 'a'.repeat(64)
+        });
+
+        await expect(
+            projector.appendFailureOutcome({ identity, outcome: 'failed', issues })
+        ).resolves.toEqual({ ok: true, value: undefined });
+        expect(projector.getProjection()).toMatchObject({
+            cohortOutcomes: [{ identity, outcome: 'failed', issues }],
+            failures: [{ identity, outcome: 'failed', issues }]
+        });
+    });
+});


### PR DESCRIPTION
## Outcome

Failed RTC-B06 observations can now finalize and publish complete evidence instead of being lost to a secondary missing-cohort accounting error. The measured workload failure remains failed; this change only makes that failure durable and reviewable.

## Why

RTC-B06 run 33308919074 observed a real messages.rtc multicast timeout. The controller recorded the failed sample and later not-run samples, but omitted the predeclared retention cohort. Finalization then rejected the observation and only source-commit.txt survived.

## Changes

- account every predeclared cohort blocked by a failed or causally not-run member
- project cohort failure artifacts into both direct and derived outcome accounting
- add focused acceptance and projector regression coverage
- replace two implementation-shaped mock-call assertions exposed by the changed-file coupling gate with semantic failure traps

## Validation

- npm run check --workspace=packages/shared-rtc-bench: 45 files, 411 tests, TypeScript and Deno checks pass
- npx vitest run packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts: 19 tests pass
- npm run check:repo-structure: pass
- npm run check:repo-style:changed: no new findings
- check-test-structure-coupling changed range: zero current candidates, registry current
- manual CLI regression: a producer exit 9 finalizes a failed E3-memory observation with the blocked RTC-B06 cohort accounted

## Review judgment

The failure-accounting module remains one coherent artifact-accounting protocol despite advisory size/export prompts; splitting its shared failure vocabulary would add navigation hops. No production legacy, compatibility path, or public API change is introduced.