### PR TITLE
fix(shared-rtc-bench): expose RTC-B06 producer failures

### DIFF
--- a/packages/shared-rtc-bench/README.md
+++ b/packages/shared-rtc-bench/README.md
@@ -91,7 +91,9 @@ env -u DATABASE_URL -u RALLAR_ICE_MODE \
 `index-entry.jsonl`. Tooling failure before initialization creates no ZIP.
 After initialization, complete failed evidence can be archived with outcome
 `failed` and `acceptedMetrics: false`; malformed or unaccounted evidence is
-rejected rather than published.
+rejected rather than published. A failed RTC-B06 producer also replays its
+captured stdout and stderr into the workflow log with the exact attempt
+identity; successful producer output remains quiet.
 
 Repository observations are append-only:
 

--- a/packages/shared-rtc-bench/baseline/command/rtc-baseline-cli.ts
+++ b/packages/shared-rtc-bench/baseline/command/rtc-baseline-cli.ts
@@ -190,6 +190,12 @@ function defaultRuntime() {
         async command(executable: string, arguments_: readonly string[]) {
             return new deno.Command(executable, { args: [...arguments_] }).output();
         },
+        writeStdout: async (bytes: Uint8Array) => {
+            await deno.stdout.write(bytes);
+        },
+        writeStderr: async (bytes: Uint8Array) => {
+            await deno.stderr.write(bytes);
+        },
         now: () => new Date(),
         performanceNow: () => performance.now(),
         systemMemoryInfo: () => deno.systemMemoryInfo(),
@@ -213,7 +219,8 @@ function createDefaultRtcBaselineCliComposition(): RtcBaselineCliComposition {
     const liveRtcObservation = createRtcB06ObservationDenoRuntime({
         runtime,
         adapters,
-        envelope
+        envelope,
+        producerOutput: runtime
     });
     return {
         envelope,

--- a/packages/shared-rtc-bench/baseline/observation/rtc-b06-observation-deno-runtime.ts
+++ b/packages/shared-rtc-bench/baseline/observation/rtc-b06-observation-deno-runtime.ts
@@ -21,6 +21,7 @@ const inheritedConfiguration = [
     'RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK',
     'RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES'
 ];
+const encoder = new TextEncoder();
 
 export interface RtcB06LiveProducerCommandInput {
     readonly baselineId: string;
@@ -36,6 +37,12 @@ export interface RtcB06ObservationDenoRuntimeInput {
     readonly runtime: RtcBaselineDenoPort;
     readonly adapters: DenoRtcBaselineAdapters;
     readonly envelope: RtcBaselineEnvelope;
+    readonly producerOutput: RtcB06ProducerOutput;
+}
+
+export interface RtcB06ProducerOutput {
+    writeStdout(bytes: Uint8Array): Promise<void>;
+    writeStderr(bytes: Uint8Array): Promise<void>;
 }
 
 export function createRtcB06ObservationDenoRuntime(
@@ -45,14 +52,7 @@ export function createRtcB06ObservationDenoRuntime(
         envelope: input.envelope,
         preflight: () => preflight(input.runtime),
         readSource: () => readRtcPerformanceObservationSource(input.adapters),
-        runLiveRtcProducer: async ({ baselineId, attempt }) => {
-            const command = createRtcB06LiveProducerCommand({ baselineId, attempt });
-            const output = await input.runtime.command(
-                command.executable,
-                command.arguments
-            );
-            return { exitStatus: output.code };
-        },
+        runLiveRtcProducer: (producer) => runRtcB06LiveProducer(input.runtime, input.producerOutput, producer),
         readFinalizedArtifacts: (baselineId) =>
             readRtcPerformanceObservationFinalizedArtifacts(input.runtime, baselineId),
         createArchive: createVerifiedRtcPerformanceObservationArchive,
@@ -60,6 +60,28 @@ export function createRtcB06ObservationDenoRuntime(
             writeRtcPerformanceObservationOutput(input.runtime, outputDirectory, archive),
         nowUtc: () => input.runtime.now().toISOString()
     };
+}
+
+export async function runRtcB06LiveProducer(
+    runtime: Pick<RtcBaselineDenoPort, 'command'>,
+    producerOutput: RtcB06ProducerOutput,
+    input: RtcB06LiveProducerCommandInput
+) {
+    const command = createRtcB06LiveProducerCommand(input);
+    const output = await runtime.command(command.executable, command.arguments);
+    if (output.code !== 0) {
+        const attempt = input.attempt;
+        await producerOutput.writeStderr(encoder.encode(
+            `RTC-B06 producer failed for ${attempt.caseId}/${attempt.intendedPhase}/${attempt.outerOrdinal} with exit status ${output.code}.\n`
+        ));
+        if (output.stdout.length > 0) {
+            await producerOutput.writeStdout(output.stdout);
+        }
+        if (output.stderr.length > 0) {
+            await producerOutput.writeStderr(output.stderr);
+        }
+    }
+    return { exitStatus: output.code };
 }
 
 export function createRtcB06LiveProducerCommand(

--- a/packages/shared-rtc-bench/tests/baseline/observation/rtc-b06-observation-deno-runtime.test.ts
+++ b/packages/shared-rtc-bench/tests/baseline/observation/rtc-b06-observation-deno-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createRtcB06LiveProducerCommand } from '../../../baseline/observation/rtc-b06-observation-deno-runtime.ts';
+import { createRtcB06LiveProducerCommand, runRtcB06LiveProducer } from '../../../baseline/observation/rtc-b06-observation-deno-runtime.ts';
 
 const baselineId = '20260830T100000Z-c0cadb8216cf-e3-memory-gh987654321-a3';
 
@@ -35,6 +35,61 @@ const commonArguments = [
 ];
 
 describe('RTC-B06 observation Deno runtime', () => {
+    it('publishes captured producer output when the live matrix fails', async () => {
+        const stdout: string[] = [];
+        const stderr: string[] = [];
+        const result = await runRtcB06LiveProducer(
+            {
+                command: async () => ({
+                    code: 1,
+                    stdout: new TextEncoder().encode('playwright failure\n'),
+                    stderr: new TextEncoder().encode('receiver timed out\n')
+                })
+            },
+            {
+                writeStdout: async (bytes) => {
+                    stdout.push(new TextDecoder().decode(bytes));
+                },
+                writeStderr: async (bytes) => {
+                    stderr.push(new TextDecoder().decode(bytes));
+                }
+            },
+            { baselineId, attempt: attempt('default') }
+        );
+
+        expect(result).toEqual({ exitStatus: 1 });
+        expect(stdout).toEqual(['playwright failure\n']);
+        expect(stderr).toEqual([
+            'RTC-B06 producer failed for default/retained/2 with exit status 1.\n',
+            'receiver timed out\n'
+        ]);
+    });
+
+    it('does not publish captured producer output from a successful matrix', async () => {
+        const writes: Uint8Array[] = [];
+        const result = await runRtcB06LiveProducer(
+            {
+                command: async () => ({
+                    code: 0,
+                    stdout: new TextEncoder().encode('normal output\n'),
+                    stderr: new Uint8Array()
+                })
+            },
+            {
+                writeStdout: async (bytes) => {
+                    writes.push(bytes);
+                },
+                writeStderr: async (bytes) => {
+                    writes.push(bytes);
+                }
+            },
+            { baselineId, attempt: attempt('default') }
+        );
+
+        expect(result).toEqual({ exitStatus: 0 });
+        expect(writes).toEqual([]);
+    });
+
     it('starts the default E3 producer with database and scenario inheritance removed', () => {
         expect(createRtcB06LiveProducerCommand({ baselineId, attempt: attempt('default') }))
             .toEqual({


### PR DESCRIPTION
## Summary
- replay failed RTC-B06 producer stdout/stderr into the observation workflow log
- label the failure with its exact case, phase, ordinal, and exit status
- keep successful producer output suppressed
- document and test the failure-diagnostic contract

## Evidence
- `npm --workspace @ar-eye-hunter/shared-rtc-bench run check`
- `npm run check:repo-style:changed -- origin/main`
- `npm run check:repo-structure -- --base origin/main`
- `npm run check:test-structure-coupling -- --files packages/shared-rtc-bench/tests/baseline/observation/rtc-b06-observation-deno-runtime.test.ts`
- `npx dprint check` for the three touched TypeScript files
- `git diff --check`

Discovered while reconciling RTC-B06 observation run 33316148662 and archive PR #392: the durable failure recorded exit status 1, but the wrapper discarded the underlying Playwright diagnostics.
