### PR TITLE
fix(rtc): elect canonical RTT reporter

### DIFF
--- a/docs/rallar-rtc-rtt-reporting.md
+++ b/docs/rallar-rtc-rtt-reporting.md
@@ -79,6 +79,10 @@ running RTT heartbeat work.
 `WebRtcGroupManager.rttReportingPeerIds(...)` selects at most K peers for the
 local session with the shared deterministic reporting policy:
 
+- Each unordered session pair has exactly one reporter: the endpoint with the
+  lexically smaller session id. The other endpoint can keep the RTC lane open,
+  but does not run the pair's RTT heartbeat or publish a competing version
+  stream.
 - Server-published overlay `nextHopSessionIds` are preferred and sorted
   deterministically. Browser-local provisional star overlays are used for RTC
   connection bootstrap, but not as authoritative RTT reporting eligibility.
@@ -124,20 +128,24 @@ The RTT topic rejects a report with one of these policy reasons:
 - `invalid-rtt`: `rttMs` is missing, non-finite, zero, or negative.
 - `self-pair`: `sessionIdFrom` and `sessionIdTo` are the same session.
 - `sender-mismatch`: the AL sender does not match `sessionIdFrom`.
+- `non-canonical-reporter`: `sessionIdFrom` is not the lexically smaller
+  endpoint that owns reporting for the unordered pair.
 - `no-shared-active-group`: the endpoints are not both active members of any
   candidate scoped group.
 - `not-reporting-edge`: the pair is not in the group's eligible reporting
-  graph, using overlay next hops when a snapshot exists and deterministic
-  bootstrap selection otherwise.
+  graph under overlay next-hop or deterministic bootstrap selection.
 - `over-degree`: accepting the pair would put either endpoint over the
   reporting degree limit across accepted latest RTT pairs.
 
 Accepted measurements use latest-pair semantics. The key is an unordered
-session pair, newer versions win, and current runtime-state rows expire under
-the RTC-RTT retention policy. A stale or duplicate version is a no-op: it does
-not write measurement, receipt, endpoint admission, or topology work. The
-mutation guards the pair and both endpoint-admission rows so concurrent reports
-cannot exceed the reporting degree.
+session pair. Canonical reporter ownership gives that pair one heartbeat
+version stream, so independently initialized counters from the two endpoints
+cannot contend for the same pair and version. Newer versions win, and current
+runtime-state rows expire under the RTC-RTT retention policy. A stale or
+duplicate version is a no-op: it does not write measurement, receipt, endpoint
+admission, or topology work. The mutation guards the pair and both
+endpoint-admission rows so concurrent reports cannot exceed the reporting
+degree.
 
 ## How RTT Affects Topology
 
@@ -240,8 +248,8 @@ diagnostics before treating it as a production shape.
 
 ## Source Map
 
-- `packages/shared/rtc/rtt-reporting-policy.ts`: shared degree normalization
-  and deterministic RTT reporting peer selection.
+- `packages/shared/rtc/rtt-reporting-policy.ts`: shared canonical reporter,
+  degree normalization, and deterministic RTT reporting peer selection.
 - `packages/shared/services/WebRtcHeartbeatService.ts`: ping/pong heartbeat and
   RTT calculation.
 - `packages/shared/services/WebRtcRxStreamerService.ts`: per-peer heartbeat

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-authority.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-authority.ts
@@ -1,3 +1,5 @@
+import { isRtcRttCanonicalReporter } from '@shared/rtc/rtt-reporting-policy.ts';
+
 import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
@@ -38,6 +40,7 @@ export interface VerifyRtcRttAppInboxAuthorityInput {
 export async function createRtcRttDurableEnqueue(
     input: CreateRtcRttDurableEnqueueInput
 ): Promise<AppInboxEnqueueInput> {
+    requireCanonicalRtcRttSender(input.request);
     const session = await input.groupStateService.readIssuedAuthSession(input.request.alSenderId);
     if (!session || session.expiresAtEpochMs <= input.nowEpochMs()) {
         throw new GroupMutationAuthorizationError(
@@ -81,6 +84,16 @@ export async function createRtcRttDurableEnqueue(
         data: encodeAppInboxCommand(command, 'RTC RTT AppInbox command'),
         authority: decodeJsonWireValue(authority, 'RTC RTT AppInbox authority')
     };
+}
+
+function requireCanonicalRtcRttSender(request: CreateRtcRttAppInboxEnqueueInput): void {
+    validateRtcRttMeasurement(request.rtt);
+    if (
+        request.alSenderId !== request.rtt.sessionIdFrom ||
+        !isRtcRttCanonicalReporter(request.rtt.sessionIdFrom, request.rtt.sessionIdTo)
+    ) {
+        throw new GroupMutationAuthorizationError('RTC RTT sender must own the canonical reporting endpoint.');
+    }
 }
 
 export function decodeRtcRttAppInboxAuthority(

--- a/packages/shared-server/rallar-system/rtc-rtt/policy/rtc-rtt-measurement-policy.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/policy/rtc-rtt-measurement-policy.ts
@@ -4,13 +4,14 @@ import { readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import { pairKey } from '@shared/repository/rtt-repository.ts';
-import { selectRttReportingPeers } from '@shared/rtc/rtt-reporting-policy.ts';
+import { isRtcRttCanonicalReporter, selectRttReportingPeers } from '@shared/rtc/rtt-reporting-policy.ts';
 
 export type RtcRttAcceptanceReason =
     | 'accepted'
     | 'invalid-rtt'
     | 'self-pair'
     | 'sender-mismatch'
+    | 'non-canonical-reporter'
     | 'not-reporting-edge'
     | 'no-shared-active-group'
     | 'over-degree';
@@ -63,6 +64,10 @@ export function evaluateRtcRttMeasurement(input: {
 
     if (input.alSenderId !== rtt.sessionIdFrom) {
         return rejected('sender-mismatch');
+    }
+
+    if (!isRtcRttCanonicalReporter(rtt.sessionIdFrom, rtt.sessionIdTo)) {
+        return rejected('non-canonical-reporter');
     }
 
     const sharedActiveGroups = input.candidateGroups.filter(
@@ -155,6 +160,15 @@ interface IsReportingPairForGroupInput {
 }
 
 function isReportingPairForGroup(input: IsReportingPairForGroupInput): boolean {
+    if (
+        !isRtcRttCanonicalReporter(
+            input.rtt.sessionIdFrom,
+            input.rtt.sessionIdTo
+        )
+    ) {
+        return false;
+    }
+
     const activePeerSessionIds = readGroupMemberSessionIds(input.group);
     const groupKey = toWebRtcGroupKey(input.group.group);
     const fromSelection = selectRttReportingPeers({

--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -553,6 +553,8 @@ Stable operators:
 - `coalesce`: return the first non-empty value, skipping missing optional paths
 - `add` and `max`: combine a non-empty array of finite numeric values
 - `equals`: compare exactly two evaluated values
+- `lexicallyBefore`: compare exactly two strings by deterministic JavaScript
+  code-unit ordering
 - `if`: evaluate a condition and exactly one of the required `then` or `else` branches
 - `jsonStringify` and `jsonParse`
 - `urlEncode`

--- a/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
+++ b/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
@@ -1,44 +1,54 @@
 import type { JsonSchemaValidationIssue } from '../../rallar-bb-test/schema.ts';
+import { directSafeOutputTransformSpec } from '../scenario-transform/safe-output-transform.ts';
 import { validateBlackBoxRunnerScenarioRecipe } from '../schema.ts';
-type JsonRecord = Record<string, unknown>;
+import {
+    toConnectionPreflight,
+    type ConnectionPreflightStep,
+    type ConnectionSelection
+} from './to-connection-preflight.ts';
+
+interface JsonRecord {
+    [key: string]: unknown;
+}
+
 export type BlackBoxRunnerPreflightProfile = 'compat' | 'strict';
 export type BlackBoxRunnerPreflightSeverity = 'error' | 'warning';
-export type BlackBoxRunnerEnvRequirement = Readonly<{
-    variableName: string;
-    envName: string;
-    required: boolean;
-    secret: boolean;
-    hasValue: boolean;
-    hasDefault: boolean;
-    hasFallback: boolean;
-    source: 'env' | 'default' | 'fallback' | 'missing' | 'unset';
-}>;
+export interface BlackBoxRunnerEnvRequirement {
+    readonly variableName: string;
+    readonly envName: string;
+    readonly required: boolean;
+    readonly secret: boolean;
+    readonly hasValue: boolean;
+    readonly hasDefault: boolean;
+    readonly hasFallback: boolean;
+    readonly source: 'env' | 'default' | 'fallback' | 'missing' | 'unset';
+}
 
-export type BlackBoxRunnerPreflightIssue = Readonly<{
-    severity: BlackBoxRunnerPreflightSeverity;
-    code: string;
-    message: string;
-    path?: string;
-}>;
+export interface BlackBoxRunnerPreflightIssue {
+    readonly severity: BlackBoxRunnerPreflightSeverity;
+    readonly code: string;
+    readonly message: string;
+    readonly path?: string;
+}
 
-export type BlackBoxRunnerPreflightOperation = Readonly<{
-    name: string;
-    transport: string;
-    action?: string;
-    connection?: string;
-    provider?: string;
-    path?: string;
-    group?: string;
-    groupCount?: number;
-    interactionExecutionNumber?: number;
-    repeatIndex?: number;
-}>;
+export interface BlackBoxRunnerPreflightOperation {
+    readonly name: string;
+    readonly transport: string;
+    readonly action?: string;
+    readonly connection?: string;
+    readonly provider?: string;
+    readonly path?: string;
+    readonly group?: string;
+    readonly groupCount?: number;
+    readonly interactionExecutionNumber?: number;
+    readonly repeatIndex?: number;
+}
 
-export type BlackBoxRunnerPlanPreflight = Readonly<{
-    schemaVersion: 1;
-    ok: boolean;
-    profile: BlackBoxRunnerPreflightProfile;
-    summary: Readonly<{
+export interface BlackBoxRunnerPlanPreflight {
+    readonly schemaVersion: 1;
+    readonly ok: boolean;
+    readonly profile: BlackBoxRunnerPreflightProfile;
+    readonly summary: Readonly<{
         generatedOperationCount: number;
         topLevelOperationCount: number;
         parallelGroupCount: number;
@@ -48,60 +58,78 @@ export type BlackBoxRunnerPlanPreflight = Readonly<{
         postRunAssertionCount: number;
         includeCount: number;
     }>;
-    includes: Readonly<{
+    readonly includes: Readonly<{
         resolved: readonly JsonRecord[];
     }>;
-    providerModes: readonly string[];
-    liveServiceRequirements: readonly string[];
-    env: Readonly<{
+    readonly providerModes: readonly string[];
+    readonly liveServiceRequirements: readonly string[];
+    readonly env: Readonly<{
         required: readonly BlackBoxRunnerEnvRequirement[];
         missing: readonly BlackBoxRunnerEnvRequirement[];
     }>;
-    connections: Readonly<{
+    readonly connections: Readonly<{
         defined: readonly string[];
         referenced: readonly string[];
         missing: readonly string[];
     }>;
-    stepReferences: Readonly<{
+    readonly stepReferences: Readonly<{
         defined: readonly string[];
         referenced: readonly Readonly<{ name: string; path: string; }>[];
         missing: readonly Readonly<{ name: string; path: string; }>[];
     }>;
-    outputs: Readonly<{
+    readonly outputs: Readonly<{
         produced: readonly string[];
         consumed: readonly string[];
         missingConsumed: readonly string[];
     }>;
-    redactions: Readonly<{
+    readonly redactions: Readonly<{
         sources: readonly Readonly<{ kind: 'variable' | 'output'; name: string; redactAs?: string; }>[];
     }>;
-    trafficPlan?: Readonly<{
+    readonly trafficPlan?: Readonly<{
         enabled: boolean;
         replay: boolean;
         seed?: number;
         decisionCount: number;
         stepCount: number;
     }>;
-    operations: readonly BlackBoxRunnerPreflightOperation[];
-    issues: readonly BlackBoxRunnerPreflightIssue[];
-}>;
+    readonly operations: readonly BlackBoxRunnerPreflightOperation[];
+    readonly issues: readonly BlackBoxRunnerPreflightIssue[];
+}
 
-export type BlackBoxRunnerPreflightInput = Readonly<{
-    rawConfig: JsonRecord;
-    expandedConfig?: JsonRecord;
-    executableInteractions?: readonly unknown[];
-    envRequirements?: readonly BlackBoxRunnerEnvRequirement[];
-    trafficPlanArtifact?: JsonRecord;
-    profile?: BlackBoxRunnerPreflightProfile;
-    expansionError?: unknown;
-}>;
+export interface BlackBoxRunnerPreflightInput {
+    readonly rawConfig: JsonRecord;
+    readonly expandedConfig?: JsonRecord;
+    readonly executableInteractions?: readonly unknown[];
+    readonly envRequirements?: readonly BlackBoxRunnerEnvRequirement[];
+    readonly trafficPlanArtifact?: JsonRecord;
+    readonly profile?: BlackBoxRunnerPreflightProfile;
+    readonly expansionError?: unknown;
+}
 
-type Redaction = {
+interface Redaction {
     name: string;
     value: string;
-};
+}
 
-const TRANSPORT_KEYS = ['HTTP', 'MQ', 'WS', 'RTC', 'WEBRTC', 'ASSERT', 'SET', 'PARALLEL'] as const;
+export interface BlackBoxRunnerPreflightVariables {
+    readonly variables: JsonRecord;
+    readonly redactions: Redaction[];
+}
+
+interface PreflightReferenceChecks {
+    readonly missingEnv: readonly BlackBoxRunnerEnvRequirement[];
+    readonly connections: BlackBoxRunnerPlanPreflight['connections'];
+    readonly steps: BlackBoxRunnerPlanPreflight['stepReferences'];
+    readonly outputs: BlackBoxRunnerPlanPreflight['outputs'];
+}
+
+interface PreflightSizeInput {
+    readonly config: BlackBoxRunnerPreflightInput;
+    readonly operations: readonly BlackBoxRunnerPreflightOperation[];
+    readonly includeCount: number;
+}
+
+const TRANSPORT_KEYS = ['HTTP', 'MQ', 'WS', 'RTC', 'WEBRTC', 'CRDT', 'ASSERT', 'SET', 'PARALLEL'] as const;
 const RESERVED_PLACEHOLDER_ROOTS = new Set([
     'loop',
     'traffic',
@@ -112,6 +140,52 @@ const RESERVED_PLACEHOLDER_ROOTS = new Set([
     'resultsByName',
     'process'
 ]);
+
+const TRANSFORM_KEYS = new Set([
+    'path',
+    'from',
+    'outputPath',
+    'template',
+    'concat',
+    'coalesce',
+    'jsonStringify',
+    'jsonParse',
+    'urlEncode',
+    'number',
+    'string',
+    'boolean',
+    'uuid',
+    'timestamp',
+    'op',
+    'operator',
+    'type',
+    'value',
+    'input',
+    'values',
+    'format',
+    'secret',
+    'redact',
+    'redactAs',
+    'transform'
+]);
+const TRANSFORM_OPERATOR_KEYS = [
+    'path',
+    'from',
+    'outputPath',
+    'template',
+    'concat',
+    'coalesce',
+    'jsonStringify',
+    'jsonParse',
+    'urlEncode',
+    'number',
+    'string',
+    'boolean',
+    'uuid',
+    'timestamp',
+    'op',
+    'operator'
+];
 
 export function collectBlackBoxRunnerEnvRequirements(
     config: JsonRecord,
@@ -159,7 +233,7 @@ export function resolveBlackBoxRunnerVariablesForPreflight(
     rawVariables: JsonRecord = {},
     environment: Record<string, string | undefined> = {},
     secretVariables: unknown = []
-): { variables: JsonRecord; redactions: Redaction[]; } {
+): BlackBoxRunnerPreflightVariables {
     const secrets = toSecretNameSet(secretVariables);
     const variables: JsonRecord = {};
     const redactions: Redaction[] = [];
@@ -206,83 +280,33 @@ export function explainBlackBoxRunnerPlan(input: BlackBoxRunnerPreflightInput): 
     const expandedConfig = input.expandedConfig ?? rawConfig;
     const executableInteractions = input.executableInteractions ?? [];
     const operations = flattenExecutableOperations(executableInteractions);
-    const schemaValidation = validateBlackBoxRunnerScenarioRecipe(rawConfig);
     const envRequirements = input.envRequirements ?? collectBlackBoxRunnerEnvRequirements(rawConfig);
     const missingEnv = envRequirements.filter((requirement) =>
         requirement.required && requirement.source === 'missing'
     );
-    const connectionSummary = connectionPreflight(rawConfig, operations);
+    const connectionSummary = toConnectionPreflight(
+        Object.keys(asRecord(rawConfig.connections)),
+        toConnectionPreflightSteps(executableInteractions, stopsOnFailure(asRecord(expandedConfig.execution)))
+    );
     const stepReferences = stepReferencePreflight(rawConfig);
     const outputSummary = outputPreflight(rawConfig, expandedConfig, operations);
     const redactions = redactionPreflight(rawConfig);
     const includes = includePreflight(expandedConfig);
-    const strictIssues = profile === 'strict'
-        ? strictProfileIssues(rawConfig, operations)
-        : [];
-    const schemaIssues = schemaValidation.ok
-        ? []
-        : schemaValidation.errors.map(schemaIssueToPreflightIssue);
-    const expansionIssue = input.expansionError === undefined
-        ? []
-        : [{
-            severity: 'error' as const,
-            code: 'PLAN_EXPANSION_FAILED',
-            message: errorMessage(input.expansionError)
-        }];
     const issues = [
-        ...schemaIssues,
-        ...missingEnv.map((requirement) => ({
-            severity: 'error' as const,
-            code: 'MISSING_ENV',
-            message:
-                `Missing required environment variable ${requirement.envName} for variable ${requirement.variableName}.`,
-            path: `variables.${requirement.variableName}`
-        })),
-        ...connectionSummary.missing.map((connection) => ({
-            severity: 'error' as const,
-            code: 'MISSING_CONNECTION',
-            message: `Step references missing connection ${connection}.`,
-            path: 'connections'
-        })),
-        ...stepReferences.missing.map((reference) => ({
-            severity: 'error' as const,
-            code: 'MISSING_STEP_REFERENCE',
-            message: `Recipe references missing step ${reference.name}.`,
-            path: reference.path
-        })),
-        ...outputSummary.missingConsumed.map((output) => ({
-            severity: 'warning' as const,
-            code: 'MISSING_OUTPUT_REFERENCE',
-            message: `Placeholder references ${output}, but no earlier output with that name is produced.`,
-            path: 'steps'
-        })),
-        ...strictIssues,
-        ...expansionIssue
+        ...validateRecipeShape(input, operations),
+        ...validatePreflightReferences({
+            missingEnv,
+            connections: connectionSummary,
+            steps: stepReferences,
+            outputs: outputSummary
+        })
     ];
-    const parallelGroupCount = operations.filter((operation) => operation.transport === 'PARALLEL').length === 0
-        ? 0
-        : operations
-            .filter((operation) => operation.transport === 'PARALLEL')
-            .reduce((sum, operation) => sum + (operation.groupCount ?? 0), 0);
-    const estimatedArtifactJsonBytes = JSON.stringify({
-        executableInteractions,
-        trafficPlan: input.trafficPlanArtifact
-    }).length;
 
     return {
         schemaVersion: 1,
         ok: issues.every((issue) => issue.severity !== 'error'),
         profile,
-        summary: {
-            generatedOperationCount: operations.length,
-            topLevelOperationCount: executableInteractions.length,
-            parallelGroupCount,
-            estimatedArtifactResultRecords: operations.length,
-            estimatedArtifactEventRecords: Math.max(operations.length, operations.length * 2),
-            estimatedArtifactJsonBytes,
-            postRunAssertionCount: postRunAssertionCount(rawConfig),
-            includeCount: includes.resolved.length
-        },
+        summary: toPreflightSize({ config: input, operations, includeCount: includes.resolved.length }),
         includes,
         providerModes: providerModes(rawConfig, operations),
         liveServiceRequirements: liveServiceRequirements(rawConfig, operations, input.trafficPlanArtifact),
@@ -298,6 +322,69 @@ export function explainBlackBoxRunnerPlan(input: BlackBoxRunnerPreflightInput): 
         operations,
         issues
     };
+}
+
+function validatePreflightReferences(checks: PreflightReferenceChecks): readonly BlackBoxRunnerPreflightIssue[] {
+    return [
+        ...checks.missingEnv.map((requirement) => ({
+            severity: 'error' as const,
+            code: 'MISSING_ENV',
+            message:
+                `Missing required environment variable ${requirement.envName} for variable ${requirement.variableName}.`,
+            path: `variables.${requirement.variableName}`
+        })),
+        ...checks.connections.missing.map((connection) => ({
+            severity: 'error' as const,
+            code: 'MISSING_CONNECTION',
+            message: `Step references missing connection ${connection}.`,
+            path: 'connections'
+        })),
+        ...checks.steps.missing.map((reference) => ({
+            severity: 'error' as const,
+            code: 'MISSING_STEP_REFERENCE',
+            message: `Recipe references missing step ${reference.name}.`,
+            path: reference.path
+        })),
+        ...checks.outputs.missingConsumed.map((output) => ({
+            severity: 'warning' as const,
+            code: 'MISSING_OUTPUT_REFERENCE',
+            message: `Placeholder references ${output}, but no earlier output with that name is produced.`,
+            path: 'steps'
+        }))
+    ];
+}
+
+function toPreflightSize(input: PreflightSizeInput): BlackBoxRunnerPlanPreflight['summary'] {
+    return {
+        generatedOperationCount: input.operations.length,
+        topLevelOperationCount: input.config.executableInteractions?.length ?? 0,
+        parallelGroupCount: input.operations
+            .filter((operation) => operation.transport === 'PARALLEL')
+            .reduce((sum, operation) => sum + (operation.groupCount ?? 0), 0),
+        estimatedArtifactResultRecords: input.operations.length,
+        estimatedArtifactEventRecords: input.operations.length * 2,
+        estimatedArtifactJsonBytes: JSON.stringify({
+            executableInteractions: input.config.executableInteractions ?? [],
+            trafficPlan: input.config.trafficPlanArtifact
+        }).length,
+        postRunAssertionCount: postRunAssertionCount(input.config.rawConfig),
+        includeCount: input.includeCount
+    };
+}
+
+function validateRecipeShape(
+    input: BlackBoxRunnerPreflightInput,
+    operations: readonly BlackBoxRunnerPreflightOperation[]
+): readonly BlackBoxRunnerPreflightIssue[] {
+    const schema = validateBlackBoxRunnerScenarioRecipe(input.rawConfig);
+    const issues: BlackBoxRunnerPreflightIssue[] = schema.ok ? [] : schema.errors.map(schemaIssueToPreflightIssue);
+    if (input.profile === 'strict') {
+        issues.push(...strictProfileIssues(input.rawConfig, operations));
+    }
+    if (input.expansionError !== undefined) {
+        issues.push({ severity: 'error', code: 'PLAN_EXPANSION_FAILED', message: errorMessage(input.expansionError) });
+    }
+    return issues;
 }
 
 function schemaIssueToPreflightIssue(issue: JsonSchemaValidationIssue): BlackBoxRunnerPreflightIssue {
@@ -441,25 +528,6 @@ function stringValue(value: unknown): string | undefined {
 function numberValue(value: unknown): number | undefined {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function connectionPreflight(
-    rawConfig: JsonRecord,
-    operations: readonly BlackBoxRunnerPreflightOperation[]
-): BlackBoxRunnerPlanPreflight['connections'] {
-    const defined = uniqueValues(Object.keys(asRecord(rawConfig.connections)));
-    const referenced = uniqueValues(
-        operations
-            .map((operation) => operation.connection)
-            .filter((connection): connection is string => Boolean(connection))
-    );
-    const definedSet = new Set(defined);
-
-    return {
-        defined,
-        referenced,
-        missing: referenced.filter((connection) => !definedSet.has(connection))
-    };
 }
 
 function stepReferencePreflight(rawConfig: JsonRecord): BlackBoxRunnerPlanPreflight['stepReferences'] {
@@ -635,55 +703,10 @@ function transformPathRoots(...values: readonly unknown[]): readonly string[] {
 }
 
 function isTransformOnlySpec(record: JsonRecord): boolean {
-    const transformKeys = new Set([
-        'path',
-        'from',
-        'outputPath',
-        'template',
-        'concat',
-        'coalesce',
-        'jsonStringify',
-        'jsonParse',
-        'urlEncode',
-        'number',
-        'string',
-        'boolean',
-        'uuid',
-        'timestamp',
-        'op',
-        'operator',
-        'type',
-        'value',
-        'input',
-        'values',
-        'format',
-        'secret',
-        'redact',
-        'redactAs',
-        'transform'
-    ]);
-    const operatorKeys = [
-        'path',
-        'from',
-        'outputPath',
-        'template',
-        'concat',
-        'coalesce',
-        'jsonStringify',
-        'jsonParse',
-        'urlEncode',
-        'number',
-        'string',
-        'boolean',
-        'uuid',
-        'timestamp',
-        'op',
-        'operator'
-    ];
     const keys = Object.keys(record);
     return keys.length > 0 &&
-        operatorKeys.some((key) => record[key] !== undefined) &&
-        keys.every((key) => transformKeys.has(key));
+        TRANSFORM_OPERATOR_KEYS.some((key) => record[key] !== undefined) &&
+        keys.every((key) => TRANSFORM_KEYS.has(key));
 }
 
 function redactionPreflight(rawConfig: JsonRecord): BlackBoxRunnerPlanPreflight['redactions'] {
@@ -799,7 +822,9 @@ function liveServiceRequirements(
     return uniqueValues(requirements);
 }
 
-function trafficPlanPreflight(artifact: JsonRecord | undefined): BlackBoxRunnerPlanPreflight['trafficPlan'] {
+function trafficPlanPreflight(
+    artifact: JsonRecord | undefined
+): BlackBoxRunnerPlanPreflight['trafficPlan'] {
     if (!artifact) {
         return undefined;
     }
@@ -868,88 +893,84 @@ function strictProfileIssues(
     rawConfig: JsonRecord,
     operations: readonly BlackBoxRunnerPreflightOperation[]
 ): readonly BlackBoxRunnerPreflightIssue[] {
-    const issues: BlackBoxRunnerPreflightIssue[] = [];
     const steps = Array.isArray(rawConfig.steps) ? rawConfig.steps.map(asRecord) : [];
-
-    steps.forEach((step, index) => {
-        const type = String(step.type || '').toLowerCase();
-        const request = asRecord(step.request);
-        const expect = asRecord(step.expect || step.response);
-        const path = `steps[${index}]`;
-
-        if (type.length > 0 && !isKnownStepType(type)) {
-            issues.push({
-                severity: 'error',
-                code: 'STRICT_UNKNOWN_STEP_TYPE',
-                message: `Unknown strict step type ${type}.`,
-                path: `${path}.type`
-            });
-        }
-
-        if (type.startsWith('set') || type.startsWith('derive')) {
-            const output = step.output ?? request.output;
-            const stateWriteEvidence = step.stateWriteEvidence ?? request.stateWriteEvidence;
-            if (output === 'stateWriteEvidence' && !isRecord(stateWriteEvidence)) {
-                issues.push({
-                    severity: 'error',
-                    code: 'STRICT_STATE_WRITE_EVIDENCE_SOURCE',
-                    message: 'Strict stateWriteEvidence must come from the persisted-state collector.',
-                    path
-                });
-            }
-            if (typeof output !== 'string') {
-                issues.push({
-                    severity: 'error',
-                    code: 'STRICT_SET_OUTPUT',
-                    message: 'Strict set steps require output.',
-                    path
-                });
-            }
-            if (
-                step.value === undefined &&
-                request.value === undefined &&
-                step.transform === undefined &&
-                request.transform === undefined &&
-                step.derive === undefined &&
-                request.derive === undefined &&
-                stateWriteEvidence === undefined
-            ) {
-                issues.push({
-                    severity: 'error',
-                    code: 'STRICT_SET_VALUE',
-                    message: 'Strict set steps require value, request.value, transform, or request.transform.',
-                    path
-                });
-            }
-        }
-
-        if (type.startsWith('assert')) {
-            const hasExpected = expect.body !== undefined ||
-                expect.expect !== undefined || expect.expected !== undefined ||
-                Array.isArray(expect.anyOf) || Array.isArray(expect.comparators);
-            if (!hasExpected) {
-                issues.push({
-                    severity: 'error',
-                    code: 'STRICT_ASSERT_EXPECTED',
-                    message: 'Strict assert steps need an expected value or expect.comparators.',
-                    path
-                });
-            }
-        }
-    });
-
-    operations
-        .filter((operation) => operation.transport === 'HTTP' && !operation.path)
-        .forEach((operation) => {
-            issues.push({
+    return [
+        ...steps.flatMap((step, index) => validateStrictStep(step, `steps[${index}]`)),
+        ...operations
+            .filter((operation) => operation.transport === 'HTTP' && !operation.path)
+            .map((operation): BlackBoxRunnerPreflightIssue => ({
                 severity: 'error',
                 code: 'STRICT_HTTP_TARGET',
                 message:
                     `Strict HTTP operation ${operation.name} requires request.path, request.url, or connection.url.`,
                 path: operation.name
-            });
-        });
+            }))
+    ];
+}
 
+function validateStrictStep(step: JsonRecord, path: string): readonly BlackBoxRunnerPreflightIssue[] {
+    const type = String(step.type || '').toLowerCase();
+    const issues: BlackBoxRunnerPreflightIssue[] = [];
+    if (type.length > 0 && !isKnownStepType(type)) {
+        issues.push({
+            severity: 'error',
+            code: 'STRICT_UNKNOWN_STEP_TYPE',
+            message: `Unknown strict step type ${type}.`,
+            path: `${path}.type`
+        });
+    }
+    if (type.startsWith('set') || type.startsWith('derive')) {
+        issues.push(...validateStrictSet(step, path));
+    }
+    if (type.startsWith('assert')) {
+        const expected = asRecord(step.expect || step.response);
+        const hasExpected = expected.body !== undefined || expected.expect !== undefined ||
+            expected.expected !== undefined || Array.isArray(expected.anyOf) || Array.isArray(expected.comparators);
+        if (!hasExpected) {
+            issues.push({
+                severity: 'error',
+                code: 'STRICT_ASSERT_EXPECTED',
+                message: 'Strict assert steps need an expected value or expect.comparators.',
+                path
+            });
+        }
+    }
+    return issues;
+}
+
+function validateStrictSet(step: JsonRecord, path: string): readonly BlackBoxRunnerPreflightIssue[] {
+    const request = asRecord(step.request);
+    const output = step.output ?? request.output;
+    const stateWriteEvidence = step.stateWriteEvidence ?? request.stateWriteEvidence;
+    const issues: BlackBoxRunnerPreflightIssue[] = [];
+    if (output === 'stateWriteEvidence' && !isRecord(stateWriteEvidence)) {
+        issues.push({
+            severity: 'error',
+            code: 'STRICT_STATE_WRITE_EVIDENCE_SOURCE',
+            message: 'Strict stateWriteEvidence must come from the persisted-state collector.',
+            path
+        });
+    }
+    if (typeof output !== 'string') {
+        issues.push({
+            severity: 'error',
+            code: 'STRICT_SET_OUTPUT',
+            message: 'Strict set steps require output.',
+            path
+        });
+    }
+    if (
+        step.value === undefined && request.value === undefined &&
+        step.transform === undefined && request.transform === undefined &&
+        step.derive === undefined && request.derive === undefined && stateWriteEvidence === undefined
+    ) {
+        issues.push({
+            severity: 'error',
+            code: 'STRICT_SET_VALUE',
+            message: 'Strict set steps require value, request.value, transform, or request.transform.',
+            path
+        });
+    }
     return issues;
 }
 
@@ -989,4 +1010,67 @@ function isKnownStepType(type: string): boolean {
 
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+}
+
+function toConnectionPreflightSteps(
+    interactions: NonNullable<BlackBoxRunnerPreflightInput['executableInteractions']>,
+    failureStops: boolean
+): ConnectionPreflightStep[] {
+    return interactions.map((interaction) => {
+        const request = executableRequest(interaction);
+        const transport = transportKey(interaction);
+        const groups = transport === 'PARALLEL' && Array.isArray(request.groups) ? request.groups : [];
+        const output = stringValue(request.output);
+        const writtenOutputs = [...Object.keys(asRecord(request.outputs)), ...(output ? [output] : [])];
+        const writesAllOutputs = writtenOutputs.some((name) => /[{}]/.test(name)) ||
+            (request.outputs !== undefined && !isRecord(request.outputs));
+        const selectionCanBeTrusted = failureStops && stopsOnFailure(request) && !writesAllOutputs;
+        return {
+            connection: stringValue(request.connection),
+            writtenOutputs,
+            writesAllOutputs,
+            selection: transport === 'SET' && selectionCanBeTrusted ? toBoundedConnectionSelection(request) : undefined,
+            groups: groups.map((group) => {
+                const steps = asRecord(group).steps;
+                return toConnectionPreflightSteps(
+                    Array.isArray(steps) ? steps : [],
+                    stopsOnFailure(request)
+                );
+            })
+        };
+    });
+}
+
+function toBoundedConnectionSelection(request: JsonRecord): ConnectionSelection | undefined {
+    const output = stringValue(request.output);
+    if (!output || Object.hasOwn(asRecord(request.outputs), output)) {
+        return undefined;
+    }
+    if (request.transform === undefined && request.outputPath) {
+        return undefined;
+    }
+    const transform = asRecord(request.transform === undefined ? request.derive : request.transform);
+    if (Object.keys(transform).length !== 1 || transform.if === undefined) {
+        return undefined;
+    }
+    const branches = asRecord(transform.if);
+    if (branches.condition === undefined) {
+        return undefined;
+    }
+    const whenTrue = toLiteralConnection(asRecord(branches.then));
+    const whenFalse = toLiteralConnection(asRecord(branches.else));
+    return whenTrue && whenFalse ? { output, connections: [...new Set([whenTrue, whenFalse])] } : undefined;
+}
+
+function toLiteralConnection(branch: JsonRecord): string | undefined {
+    if (directSafeOutputTransformSpec(branch) !== undefined) {
+        return undefined;
+    }
+    const connection = branch.connection;
+    return typeof connection === 'string' && connection.length > 0 && !/[{}]/.test(connection) ? connection : undefined;
+}
+
+function stopsOnFailure(request: JsonRecord): boolean {
+    return (request.failFast === undefined || request.failFast === true) &&
+        (request.nonBlockingFailure === undefined || request.nonBlockingFailure === false);
 }

--- a/packages/shared-test/black-box-runner/preflight/to-connection-preflight.ts
+++ b/packages/shared-test/black-box-runner/preflight/to-connection-preflight.ts
@@ -1,0 +1,130 @@
+export interface ConnectionPreflight {
+    readonly defined: readonly string[];
+    readonly referenced: readonly string[];
+    readonly missing: readonly string[];
+}
+
+export interface ConnectionSelection {
+    readonly output: string;
+    readonly connections: readonly string[];
+}
+
+export interface ConnectionPreflightStep {
+    readonly connection: string | undefined;
+    readonly writtenOutputs: readonly string[];
+    readonly writesAllOutputs: boolean;
+    readonly selection: ConnectionSelection | undefined;
+    readonly groups: readonly (readonly ConnectionPreflightStep[])[];
+}
+
+interface ConnectionWalk {
+    readonly outputs: Map<string, readonly string[]>;
+    readonly uncertainOutputs: ReadonlySet<string>;
+    readonly allOutputsUncertain: boolean;
+    readonly referenced: Set<string>;
+}
+
+interface OutputWrites {
+    readonly names: readonly string[];
+    readonly anyOutput: boolean;
+}
+
+const RESERVED_ROOTS = new Set([
+    'variables',
+    'outputs',
+    'results',
+    'resultsList',
+    'resultsByName',
+    'runnerRunId',
+    'correlation'
+]);
+
+export function toConnectionPreflight(
+    definedConnectionNames: readonly string[],
+    steps: readonly ConnectionPreflightStep[]
+): ConnectionPreflight {
+    const walk: ConnectionWalk = {
+        outputs: new Map(),
+        uncertainOutputs: new Set(),
+        allOutputsUncertain: false,
+        referenced: new Set()
+    };
+    collectConnectionReferences(steps, walk);
+    const defined = [...new Set(definedConnectionNames)].sort();
+    const definedSet = new Set(defined);
+    const referenced = [...walk.referenced].sort();
+    return { defined, referenced, missing: referenced.filter((name) => /[{}]/.test(name) || !definedSet.has(name)) };
+}
+
+function collectConnectionReferences(steps: readonly ConnectionPreflightStep[], walk: ConnectionWalk): void {
+    for (const step of steps) {
+        if (step.connection) {
+            for (const connection of resolvePossibleConnections(step.connection, walk.outputs)) {
+                walk.referenced.add(connection);
+            }
+        }
+        collectParallelConnections(step.groups, walk);
+        if (step.writesAllOutputs) {
+            walk.outputs.clear();
+        }
+        for (const name of step.writtenOutputs) {
+            walk.outputs.delete(name);
+        }
+        if (step.selection && !walk.allOutputsUncertain && !walk.uncertainOutputs.has(step.selection.output)) {
+            walk.outputs.set(step.selection.output, step.selection.connections);
+        }
+    }
+}
+
+function collectParallelConnections(
+    groups: readonly (readonly ConnectionPreflightStep[])[],
+    walk: ConnectionWalk
+): void {
+    const groupWrites = groups.map(collectWrittenOutputs);
+    groups.forEach((steps, index) => {
+        const siblingWrites = groupWrites.filter((_writes, sibling) => sibling !== index);
+        const uncertainOutputs = new Set([
+            ...walk.uncertainOutputs,
+            ...siblingWrites.flatMap((writes) => writes.names)
+        ]);
+        const allOutputsUncertain = walk.allOutputsUncertain || siblingWrites.some((writes) => writes.anyOutput);
+        const outputs = new Map(allOutputsUncertain ? [] : walk.outputs);
+        for (const name of uncertainOutputs) {
+            outputs.delete(name);
+        }
+        collectConnectionReferences(steps, {
+            outputs,
+            uncertainOutputs,
+            allOutputsUncertain,
+            referenced: walk.referenced
+        });
+    });
+    // All groups share runtime outputs. Their writes have no single known post-join owner.
+    if (groupWrites.some((writes) => writes.anyOutput)) {
+        walk.outputs.clear();
+    }
+    for (const name of groupWrites.flatMap((writes) => writes.names)) {
+        walk.outputs.delete(name);
+    }
+}
+
+function collectWrittenOutputs(steps: readonly ConnectionPreflightStep[]): OutputWrites {
+    const nested = steps.flatMap((step) => step.groups.map(collectWrittenOutputs));
+    return {
+        names: [
+            ...new Set([...steps.flatMap((step) => step.writtenOutputs), ...nested.flatMap((writes) => writes.names)])
+        ],
+        anyOutput: steps.some((step) => step.writesAllOutputs) || nested.some((writes) => writes.anyOutput)
+    };
+}
+
+function resolvePossibleConnections(
+    connection: string,
+    outputs: ReadonlyMap<string, readonly string[]>
+): readonly string[] {
+    const placeholder = /^\{([A-Za-z_][A-Za-z0-9_-]*)\.connection\}$/.exec(connection);
+    if (!placeholder || RESERVED_ROOTS.has(placeholder[1])) {
+        return [connection];
+    }
+    return outputs.get(placeholder[1]) ?? [connection];
+}

--- a/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform.ts
+++ b/packages/shared-test/black-box-runner/scenario-transform/safe-output-transform.ts
@@ -103,6 +103,8 @@ export function evaluateSafeOutputTransform(
             return evaluateNumericTransform({ spec, input, details });
         case 'equals':
             return evaluateEqualsTransform(spec, input, details);
+        case 'lexicallyBefore':
+            return evaluateLexicallyBeforeTransform(spec, input, details);
         case 'if':
             return evaluateIfTransform(spec, input, details);
         case 'jsonStringify':
@@ -212,6 +214,22 @@ function evaluateEqualsTransform(
         evaluateTransformValue(values[0], input),
         evaluateTransformValue(values[1], input)
     );
+}
+
+function evaluateLexicallyBeforeTransform(
+    spec: Record<string, any>,
+    input: SafeOutputTransformEvaluationInput,
+    details: SafeOutputTransformDetails
+): boolean {
+    const values = transformValues(spec, 'lexicallyBefore')
+        .map((value) => evaluateTransformValue(value, input));
+    if (values.length !== 2 || values.some((value) => typeof value !== 'string')) {
+        return rejectSafeOutputTransform(
+            'Lexically-before transform requires exactly two string values.',
+            { ...details, input: values }
+        );
+    }
+    return values[0] < values[1];
 }
 
 function evaluateIfTransform(

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-criterion.json
@@ -55,6 +55,10 @@
     "wsAlice": {
       "type": "ws",
       "timeoutMs": 10000
+    },
+    "wsBob": {
+      "type": "ws",
+      "timeoutMs": 10000
     }
   },
   "steps": [
@@ -786,11 +790,84 @@
       }
     },
     {
+      "name": "createBobWsTicket",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/ws-ticket/requests/bb-formation-criterion-bob-ws-{runId}",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "outputs": {
+          "bobWsTicket": {
+            "path": "body.ticket",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveBobWsUrl",
+      "type": "set",
+      "output": "bobWsUrl",
+      "secret": true,
+      "redactAs": "bobWsUrl",
+      "transform": {
+        "concat": [
+          { "path": "variables.rallarWsBaseUrl" },
+          "/api/ws/",
+          { "path": "outputs.bobSessionId" },
+          "?ticket=",
+          { "urlEncode": { "path": "outputs.bobWsTicket" } }
+        ]
+      }
+    },
+    {
+      "name": "openBobWs",
+      "type": "ws.open",
+      "connection": "wsBob",
+      "request": {
+        "url": "{bobWsUrl}",
+        "timeoutMs": 10000
+      }
+    },
+    {
       "name": "deriveRttCreatedAt",
       "type": "set",
       "output": "rttCreatedAtEpochMs",
       "transform": {
         "timestamp": true
+      }
+    },
+    {
+      "name": "deriveRttReporter",
+      "type": "set",
+      "output": "rttReporter",
+      "transform": {
+        "if": {
+          "condition": {
+            "operator": "lexicallyBefore",
+            "values": [
+              { "path": "outputs.aliceSessionId" },
+              { "path": "outputs.bobSessionId" }
+            ]
+          },
+          "then": {
+            "connection": "wsAlice",
+            "sessionIdFrom": { "path": "outputs.aliceSessionId" },
+            "sessionIdTo": { "path": "outputs.bobSessionId" }
+          },
+          "else": {
+            "connection": "wsBob",
+            "sessionIdFrom": { "path": "outputs.bobSessionId" },
+            "sessionIdTo": { "path": "outputs.aliceSessionId" }
+          }
+        }
       }
     },
     {
@@ -801,11 +878,11 @@
         "concat": [
           "{\"sessionIdFrom\":\"",
           {
-            "path": "outputs.aliceSessionId"
+            "path": "outputs.rttReporter.sessionIdFrom"
           },
           "\",\"sessionIdTo\":\"",
           {
-            "path": "outputs.bobSessionId"
+            "path": "outputs.rttReporter.sessionIdTo"
           },
           "\",\"rttMs\":42,\"createdAtEpochMs\":",
           {
@@ -818,15 +895,15 @@
     {
       "name": "reportTheObservedEdge",
       "type": "ws.send",
-      "connection": "wsAlice",
+      "connection": "{rttReporter.connection}",
       "request": {
         "send": {
           "id": {
             "v": 2,
             "msgId": "rtt-report-{runId}",
             "ts": 0,
-            "senderId": "{aliceSessionId}",
-            "sessionId": "{aliceSessionId}"
+            "senderId": "{rttReporter.sessionIdFrom}",
+            "sessionId": "{rttReporter.sessionIdFrom}"
           },
           "route": {
             "topicId": "rtt",
@@ -882,6 +959,15 @@
       "name": "closeAliceWs",
       "type": "ws.close",
       "connection": "wsAlice",
+      "request": {
+        "code": 1000,
+        "reason": "formation criterion ws checks done"
+      }
+    },
+    {
+      "name": "closeBobWs",
+      "type": "ws.close",
+      "connection": "wsBob",
       "request": {
         "code": 1000,
         "reason": "formation criterion ws checks done"

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-large.json
@@ -459,6 +459,32 @@
     "report-rtt-pair": {
       "steps": [
         {
+          "name": "deriveRtt{i}x{j}Reporter",
+          "type": "set",
+          "output": "rtt{i}x{j}Reporter",
+          "transform": {
+            "if": {
+              "condition": {
+                "operator": "lexicallyBefore",
+                "values": [
+                  { "path": "outputs.client{i}SessionId" },
+                  { "path": "outputs.client{j}SessionId" }
+                ]
+              },
+              "then": {
+                "connection": "ws-client-{i}",
+                "sessionIdFrom": { "path": "outputs.client{i}SessionId" },
+                "sessionIdTo": { "path": "outputs.client{j}SessionId" }
+              },
+              "else": {
+                "connection": "ws-client-{j}",
+                "sessionIdFrom": { "path": "outputs.client{j}SessionId" },
+                "sessionIdTo": { "path": "outputs.client{i}SessionId" }
+              }
+            }
+          }
+        },
+        {
           "name": "deriveRtt{i}x{j}Resource",
           "type": "set",
           "output": "rtt{i}x{j}Resource",
@@ -466,11 +492,11 @@
             "concat": [
               "{\"sessionIdFrom\":\"",
               {
-                "path": "outputs.client{i}SessionId"
+                "path": "outputs.rtt{i}x{j}Reporter.sessionIdFrom"
               },
               "\",\"sessionIdTo\":\"",
               {
-                "path": "outputs.client{j}SessionId"
+                "path": "outputs.rtt{i}x{j}Reporter.sessionIdTo"
               },
               "\",\"rttMs\":42,\"createdAtEpochMs\":",
               {
@@ -483,15 +509,15 @@
         {
           "name": "reportRtt{i}x{j}",
           "type": "ws.send",
-          "connection": "ws-client-{i}",
+          "connection": "{rtt{i}x{j}Reporter.connection}",
           "request": {
             "send": {
               "id": {
                 "v": 2,
                 "msgId": "rtt-managed-burst-large-{i}x{j}-{runId}",
                 "ts": 0,
-                "senderId": "{client{i}SessionId}",
-                "sessionId": "{client{i}SessionId}"
+                "senderId": "{rtt{i}x{j}Reporter.sessionIdFrom}",
+                "sessionId": "{rtt{i}x{j}Reporter.sessionIdFrom}"
               },
               "route": {
                 "topicId": "rtt",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-formation-managed-burst-medium.json
@@ -339,6 +339,32 @@
     "report-rtt-pair": {
       "steps": [
         {
+          "name": "deriveRtt{i}x{j}Reporter",
+          "type": "set",
+          "output": "rtt{i}x{j}Reporter",
+          "transform": {
+            "if": {
+              "condition": {
+                "operator": "lexicallyBefore",
+                "values": [
+                  { "path": "outputs.client{i}SessionId" },
+                  { "path": "outputs.client{j}SessionId" }
+                ]
+              },
+              "then": {
+                "connection": "ws-client-{i}",
+                "sessionIdFrom": { "path": "outputs.client{i}SessionId" },
+                "sessionIdTo": { "path": "outputs.client{j}SessionId" }
+              },
+              "else": {
+                "connection": "ws-client-{j}",
+                "sessionIdFrom": { "path": "outputs.client{j}SessionId" },
+                "sessionIdTo": { "path": "outputs.client{i}SessionId" }
+              }
+            }
+          }
+        },
+        {
           "name": "deriveRtt{i}x{j}Resource",
           "type": "set",
           "output": "rtt{i}x{j}Resource",
@@ -346,11 +372,11 @@
             "concat": [
               "{\"sessionIdFrom\":\"",
               {
-                "path": "outputs.client{i}SessionId"
+                "path": "outputs.rtt{i}x{j}Reporter.sessionIdFrom"
               },
               "\",\"sessionIdTo\":\"",
               {
-                "path": "outputs.client{j}SessionId"
+                "path": "outputs.rtt{i}x{j}Reporter.sessionIdTo"
               },
               "\",\"rttMs\":42,\"createdAtEpochMs\":",
               {
@@ -363,15 +389,15 @@
         {
           "name": "reportRtt{i}x{j}",
           "type": "ws.send",
-          "connection": "ws-client-{i}",
+          "connection": "{rtt{i}x{j}Reporter.connection}",
           "request": {
             "send": {
               "id": {
                 "v": 2,
                 "msgId": "rtt-managed-burst-medium-{i}x{j}-{runId}",
                 "ts": 0,
-                "senderId": "{client{i}SessionId}",
-                "sessionId": "{client{i}SessionId}"
+                "senderId": "{rtt{i}x{j}Reporter.sessionIdFrom}",
+                "sessionId": "{rtt{i}x{j}Reporter.sessionIdFrom}"
               },
               "route": {
                 "topicId": "rtt",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-match-preset.json
@@ -870,6 +870,32 @@
       }
     },
     {
+      "name": "deriveArenaRttReporter",
+      "type": "set",
+      "output": "arenaRttReporter",
+      "transform": {
+        "if": {
+          "condition": {
+            "operator": "lexicallyBefore",
+            "values": [
+              { "path": "outputs.carolSessionId" },
+              { "path": "outputs.danSessionId" }
+            ]
+          },
+          "then": {
+            "connection": "wsCarol",
+            "sessionIdFrom": { "path": "outputs.carolSessionId" },
+            "sessionIdTo": { "path": "outputs.danSessionId" }
+          },
+          "else": {
+            "connection": "wsDan",
+            "sessionIdFrom": { "path": "outputs.danSessionId" },
+            "sessionIdTo": { "path": "outputs.carolSessionId" }
+          }
+        }
+      }
+    },
+    {
       "name": "deriveArenaRttResource",
       "type": "set",
       "output": "arenaRttResource",
@@ -877,11 +903,11 @@
         "concat": [
           "{\"sessionIdFrom\":\"",
           {
-            "path": "outputs.carolSessionId"
+            "path": "outputs.arenaRttReporter.sessionIdFrom"
           },
           "\",\"sessionIdTo\":\"",
           {
-            "path": "outputs.danSessionId"
+            "path": "outputs.arenaRttReporter.sessionIdTo"
           },
           "\",\"rttMs\":21,\"createdAtEpochMs\":",
           {
@@ -894,15 +920,15 @@
     {
       "name": "reportTheArenaEdge",
       "type": "ws.send",
-      "connection": "wsCarol",
+      "connection": "{arenaRttReporter.connection}",
       "request": {
         "send": {
           "id": {
             "v": 2,
             "msgId": "match-arena-rtt-{runId}",
             "ts": 0,
-            "senderId": "{carolSessionId}",
-            "sessionId": "{carolSessionId}"
+            "senderId": "{arenaRttReporter.sessionIdFrom}",
+            "sessionId": "{arenaRttReporter.sessionIdFrom}"
           },
           "route": {
             "topicId": "rtt",

--- a/packages/shared/rtc/rtt-reporting-policy.ts
+++ b/packages/shared/rtc/rtt-reporting-policy.ts
@@ -26,6 +26,13 @@ export function normalizeRttReportingDegreeLimit(
         : DEFAULT_RTT_REPORTING_DEGREE_LIMIT;
 }
 
+export function isRtcRttCanonicalReporter(
+    localSessionId: string,
+    peerSessionId: string
+): boolean {
+    return localSessionId < peerSessionId;
+}
+
 export function selectRttReportingPeers(
     input: RttReportingPeerSelectionInput
 ): RttReportingPeerSelection {

--- a/packages/shared/services/WebRtcGroupManager.ts
+++ b/packages/shared/services/WebRtcGroupManager.ts
@@ -7,7 +7,11 @@ import {
 } from '../api/group-client-views.ts';
 import type { GroupRef } from '../api/group-types.ts';
 import { ReadableKeyedValues } from '../cache/RepositoryInterfaces.ts';
-import { normalizeRttReportingDegreeLimit, selectRttReportingPeers } from '../rtc/rtt-reporting-policy.ts';
+import {
+    isRtcRttCanonicalReporter,
+    normalizeRttReportingDegreeLimit,
+    selectRttReportingPeers
+} from '../rtc/rtt-reporting-policy.ts';
 import {
     clonePeerOwners,
     emptyGroupManagerDiagnostics,
@@ -508,7 +512,13 @@ export class WebRtcGroupManager {
             });
 
             for (const peerId of selection.selectedPeerIds) {
-                if (seen.has(peerId)) {
+                if (
+                    seen.has(peerId) ||
+                    !isRtcRttCanonicalReporter(
+                        this.rtcQBox.input.sessionId,
+                        peerId
+                    )
+                ) {
                     continue;
                 }
 

--- a/packages/shared/services/WebRtcHeartbeatService.ts
+++ b/packages/shared/services/WebRtcHeartbeatService.ts
@@ -76,7 +76,14 @@ export class WebRtcHeartbeatService {
         this.messageCallbackId = this.input.peerSessionId + '-heartbeat';
         this.input.channel.onRtcMessageDo(
             this.messageCallbackId,
-            { onMessage: (message) => this.receiveHeartbeatMessage(message) },
+            {
+                onMessage: async (value) => {
+                    const message = toHeartbeatMessage(value);
+                    if (message) {
+                        await this.receiveHeartbeatMessage(message);
+                    }
+                }
+            },
             pingMessageType
         );
     }
@@ -101,12 +108,7 @@ export class WebRtcHeartbeatService {
         }
     }
 
-    private async receiveHeartbeatMessage(value: unknown): Promise<void> {
-        const message = toHeartbeatMessage(value);
-        if (!message) {
-            return;
-        }
-
+    private async receiveHeartbeatMessage(message: PingPayload): Promise<void> {
         try {
             if (message.pingType === 'ping') {
                 await this.input.channel.sendAsJsonString(JSON.stringify(

--- a/packages/shared/services/WebRtcHeartbeatService.ts
+++ b/packages/shared/services/WebRtcHeartbeatService.ts
@@ -3,43 +3,43 @@ import { QRtcDataChannel } from '../webrtc/QRtcDataChannel.ts';
 export const defaultMaxMissedPings = 5;
 export const defaultPingFrequencyMsecs = 5000;
 
-type WebRtcHeartbeatServiceStatusDto = {
+interface WebRtcHeartbeatServiceStatusDto {
     pingInterval: ReturnType<typeof setInterval> | undefined;
     missedPings: number;
-    lastRttMsecs: number;
-};
+}
 
-const pingMessageType: string = 'ping';
+const pingMessageType = 'ping';
 
-type PingPayload = {
-    type: string;
-    pingType: 'ping' | 'pong';
-    ts: number;
-};
+interface PingPayload {
+    readonly type: 'ping';
+    readonly pingType: 'ping' | 'pong';
+    readonly ts: number;
+}
 
-export type WebRtcHeartbeatCallbacks = {
-    onHeartbeat: (result: PingResult) => Promise<void>;
-    onMissedHeartbeat: (peerId: string) => Promise<void>;
-};
+export interface WebRtcHeartbeatCallbacks {
+    readonly onHeartbeat: (result: PingResult) => Promise<void>;
+    readonly onMissedHeartbeat: (peerId: string) => Promise<void>;
+}
 
-export type PingResult = {
-    peerSessionId: string;
-    rttMsecs: number;
-    version: number;
-};
+export interface PingResult {
+    readonly peerSessionId: string;
+    readonly rttMsecs: number;
+    readonly version: number;
+}
 
-export type WebRtcHeartbeatServiceInputDto = {
-    sessionId: string;
-    peerSessionId: string;
-    channel: QRtcDataChannel;
-    maxMissedPings: number;
-    pingFrequencyMsecs: number;
-};
+export interface WebRtcHeartbeatServiceInputDto {
+    readonly sessionId: string;
+    readonly peerSessionId: string;
+    readonly channel: QRtcDataChannel;
+    readonly maxMissedPings: number;
+    readonly pingFrequencyMsecs: number;
+}
 
 export class WebRtcHeartbeatService {
     private readonly status: WebRtcHeartbeatServiceStatusDto;
 
     private messageCallbackId: string | undefined;
+    private reportingCallbacks: WebRtcHeartbeatCallbacks | undefined;
     private versionCounter = 1;
 
     public readonly input: WebRtcHeartbeatServiceInputDto;
@@ -50,26 +50,48 @@ export class WebRtcHeartbeatService {
         this.input = input;
         this.status = {
             pingInterval: undefined,
-            missedPings: 0,
-            lastRttMsecs: 0
+            missedPings: 0
         };
     }
 
     start(callbacks: WebRtcHeartbeatCallbacks): void {
         if (this.status.pingInterval) {
-            console.warn('Heartbeat already started');
             return;
         }
 
-        this.messageCallbackId = this.setupMessageHandler(this.input, callbacks);
-        this.status.pingInterval = this.startHeartbeat(this.input, callbacks);
+        this.startResponding();
+        this.reportingCallbacks = callbacks;
+        this.status.missedPings = 0;
+        this.status.pingInterval = setInterval(
+            () => this.writeHeartbeatPing(callbacks),
+            this.input.pingFrequencyMsecs
+        );
     }
 
-    stop(): void {
+    startResponding(): void {
+        if (this.messageCallbackId !== undefined) {
+            return;
+        }
+
+        this.messageCallbackId = this.input.peerSessionId + '-heartbeat';
+        this.input.channel.onRtcMessageDo(
+            this.messageCallbackId,
+            { onMessage: (message) => this.receiveHeartbeatMessage(message) },
+            pingMessageType
+        );
+    }
+
+    stopReporting(): void {
         if (this.status.pingInterval) {
             clearInterval(this.status.pingInterval);
             this.status.pingInterval = undefined;
         }
+        this.reportingCallbacks = undefined;
+        this.status.missedPings = 0;
+    }
+
+    stop(): void {
+        this.stopReporting();
 
         if (this.messageCallbackId) {
             this.input.channel.removeOnRtcMessageCallbackById(
@@ -79,98 +101,66 @@ export class WebRtcHeartbeatService {
         }
     }
 
-    private setupMessageHandler(
-        input: WebRtcHeartbeatServiceInputDto,
-        callbacks: WebRtcHeartbeatCallbacks
-    ): string {
-        const callbackId = input.peerSessionId + '-heartbeat';
-        input.channel.onRtcMessageDo(
-            callbackId,
+    private async receiveHeartbeatMessage(value: unknown): Promise<void> {
+        const message = toHeartbeatMessage(value);
+        if (!message) {
+            return;
+        }
+
+        try {
+            if (message.pingType === 'ping') {
+                await this.input.channel.sendAsJsonString(JSON.stringify(
+                    {
+                        type: pingMessageType,
+                        pingType: 'pong',
+                        ts: message.ts
+                    } satisfies PingPayload
+                ));
+            }
+            else if (this.reportingCallbacks) {
+                this.status.missedPings = 0;
+                const rttMsecs = Math.round(performance.now() - message.ts);
+                await this.reportingCallbacks.onHeartbeat({
+                    peerSessionId: this.input.peerSessionId,
+                    rttMsecs,
+                    version: ++this.versionCounter
+                });
+            }
+        }
+        catch (error) {
+            console.error('Failed to process RTC heartbeat message', error);
+        }
+    }
+
+    private async writeHeartbeatPing(callbacks: WebRtcHeartbeatCallbacks): Promise<void> {
+        if (!this.input.channel.isOpen()) {
+            this.stop();
+            return;
+        }
+        if (this.status.missedPings >= this.input.maxMissedPings) {
+            await callbacks.onMissedHeartbeat(this.input.peerSessionId);
+            return;
+        }
+
+        this.status.missedPings++;
+        await this.input.channel.sendAsJsonString(JSON.stringify(
             {
-                onMessage: async (data: unknown) => {
-                    try {
-                        const msg = data as PingPayload;
-
-                        switch (msg.pingType) {
-                            // Respond to incoming Pings from the remote peer
-                            case 'ping': {
-                                // Echo the exact timestamp back
-                                const value: PingPayload = {
-                                    type: pingMessageType,
-                                    pingType: 'pong',
-                                    ts: msg.ts
-                                };
-
-                                await input.channel.sendAsJsonString(
-                                    JSON.stringify(value)
-                                );
-
-                                break;
-                            }
-
-                            // Process incoming Pongs to calculate RTT
-                            case 'pong': {
-                                this.status.missedPings = 0; // Reset failure counter
-
-                                if (msg.ts) {
-                                    // RTT = Time right now minus the time the ping was sent
-                                    const rttMsecs = Math.round(performance.now() - msg.ts);
-
-                                    this.status.lastRttMsecs = rttMsecs;
-
-                                    console.log(`RTT to ${this.input.peerSessionId}: ${rttMsecs}ms`);
-
-                                    await callbacks.onHeartbeat(
-                                        {
-                                            peerSessionId: this.input.peerSessionId,
-                                            rttMsecs: rttMsecs,
-                                            version: ++this.versionCounter
-                                        }
-                                    );
-                                }
-                                break;
-                            }
-                        }
-                    }
-                    catch (e) {
-                        console.error('Failed to parse DataChannel message', e);
-                    }
-                }
-            },
-            pingMessageType
-        );
-        return callbackId;
+                type: pingMessageType,
+                pingType: 'ping',
+                ts: performance.now()
+            } satisfies PingPayload
+        ));
     }
+}
 
-    private startHeartbeat(
-        input: WebRtcHeartbeatServiceInputDto,
-        callbacks: WebRtcHeartbeatCallbacks
-    ): ReturnType<typeof setInterval> {
-        return setInterval(
-            async () => {
-                if (!input.channel.isOpen()) {
-                    console.log('DataChannel is closed, stopping heartbeat');
-                    this.stop();
-                    return;
-                }
-
-                if (this.status.missedPings >= this.input.maxMissedPings) {
-                    await callbacks.onMissedHeartbeat(input.peerSessionId);
-                    return;
-                }
-
-                this.status.missedPings++;
-
-                // Use performance.now() for sub-millisecond precision
-                const pingPayload: PingPayload = {
-                    type: pingMessageType,
-                    pingType: 'ping',
-                    ts: performance.now()
-                };
-
-                await input.channel.sendAsJsonString(JSON.stringify(pingPayload));
-            },
-            this.input.pingFrequencyMsecs
-        );
+function toHeartbeatMessage(value: unknown): PingPayload | undefined {
+    if (
+        typeof value !== 'object' || value === null ||
+        !('type' in value) || value.type !== 'ping' ||
+        !('pingType' in value) || (value.pingType !== 'ping' && value.pingType !== 'pong') ||
+        !('ts' in value) || typeof value.ts !== 'number' || !Number.isFinite(value.ts)
+    ) {
+        return undefined;
     }
+    return { type: 'ping', pingType: value.pingType, ts: value.ts };
 }

--- a/packages/shared/services/WebRtcHeartbeatService.ts
+++ b/packages/shared/services/WebRtcHeartbeatService.ts
@@ -78,9 +78,8 @@ export class WebRtcHeartbeatService {
             this.messageCallbackId,
             {
                 onMessage: async (value) => {
-                    const message = toHeartbeatMessage(value);
-                    if (message) {
-                        await this.receiveHeartbeatMessage(message);
+                    if (isHeartbeatMessage(value)) {
+                        await this.receiveHeartbeatMessage(value);
                     }
                 }
             },
@@ -155,14 +154,9 @@ export class WebRtcHeartbeatService {
     }
 }
 
-function toHeartbeatMessage(value: unknown): PingPayload | undefined {
-    if (
-        typeof value !== 'object' || value === null ||
-        !('type' in value) || value.type !== 'ping' ||
-        !('pingType' in value) || (value.pingType !== 'ping' && value.pingType !== 'pong') ||
-        !('ts' in value) || typeof value.ts !== 'number' || !Number.isFinite(value.ts)
-    ) {
-        return undefined;
-    }
-    return { type: 'ping', pingType: value.pingType, ts: value.ts };
+function isHeartbeatMessage(value: unknown): value is PingPayload {
+    return typeof value === 'object' && value !== null &&
+        'type' in value && value.type === 'ping' &&
+        'pingType' in value && (value.pingType === 'ping' || value.pingType === 'pong') &&
+        'ts' in value && typeof value.ts === 'number' && Number.isFinite(value.ts);
 }

--- a/packages/shared/services/WebRtcRxStreamerService.ts
+++ b/packages/shared/services/WebRtcRxStreamerService.ts
@@ -1,4 +1,8 @@
 import { ALMessage } from '../al-contracts/al-contract.ts';
+import {
+    decodePersistedALMessage,
+    decodePersistedALMessageValue
+} from '../al-contracts/al-message-persistence-validation.ts';
 import { ALMessageHandlingPlan } from '../al-contracts/al-policy.ts';
 import type { ALInboundRuntimeStores } from '../alm/ALInboundMessageRuntime.ts';
 import { ALInboundMessageRuntime } from '../alm/ALInboundMessageRuntime.ts';
@@ -21,24 +25,24 @@ import {
     WebRtcHeartbeatService
 } from './WebRtcHeartbeatService.ts';
 
-export type WebRtcRxStreamerServiceInputDto = {
-    sessionId: string;
-};
+export interface WebRtcRxStreamerServiceInputDto {
+    readonly sessionId: string;
+}
 
-type WebRtcRxStreamerServiceStatus = {
+interface WebRtcRxStreamerServiceStatus {
     localMediaStream: MediaStream | undefined;
     localAudioEnabled: boolean;
     localVideoEnabled: boolean;
     mediaPolicy: QRtcMediaPolicy | undefined;
-};
+}
 
-export type RttMeasurementCallbacks = {
-    onHeartbeat: (rtt: RttMeasurementInfo) => Promise<void>;
-};
+export interface RttMeasurementCallbacks {
+    readonly onHeartbeat: (rtt: RttMeasurementInfo) => Promise<void>;
+}
 
-export type WebRtcRxStreamerServiceOptions = Readonly<{
-    inboundStores?: ALInboundRuntimeStores;
-}>;
+export interface WebRtcRxStreamerServiceOptions {
+    readonly inboundStores?: ALInboundRuntimeStores;
+}
 
 export class WebRtcRxStreamerService {
     private static readonly ALL_IN = '*';
@@ -56,7 +60,7 @@ export class WebRtcRxStreamerService {
         (peerId: string, stream: MediaStream, event: RTCTrackEvent) => Promise<void>
     > = new Map();
 
-    private status: WebRtcRxStreamerServiceStatus = {
+    private readonly status: WebRtcRxStreamerServiceStatus = {
         localMediaStream: undefined,
         localAudioEnabled: false,
         localVideoEnabled: false,
@@ -90,7 +94,7 @@ export class WebRtcRxStreamerService {
                 planIncomingMessage: (msg, fromPeerId, runtime) => {
                     return this.multicast.planIncomingMessage(msg, fromPeerId, runtime);
                 },
-                readStoredEntry: (entry) => JSON.parse(entry.resource) as ALMessage,
+                readStoredEntry: (entry) => decodePersistedALMessage(entry.resource),
                 toInboxEntry: (msg) =>
                     QueueBoxUtilities.toResourceEntryFromMsg(
                         msg,
@@ -112,7 +116,6 @@ export class WebRtcRxStreamerService {
         );
     }
 
-    // callback from WebRtcConnectionService whenever a new connection
     addPeer(peerDto: QRtcPeerDto): void {
         if (this.peerDtoByPeerId.has(peerDto.peerId)) {
             console.warn(`Peer ${peerDto.peerId} already exists. Ignoring ...`);
@@ -120,7 +123,11 @@ export class WebRtcRxStreamerService {
         }
 
         this.peerDtoByPeerId.set(peerDto.peerId, peerDto);
+        this.registerPeerMessages(peerDto);
+        this.registerPeerMedia(peerDto);
+    }
 
+    private registerPeerMessages(peerDto: QRtcPeerDto): void {
         peerDto.channel
             .onRtcCallbacksDo(
                 this.toHeartbeatCallbackId(peerDto.peerId),
@@ -129,24 +136,16 @@ export class WebRtcRxStreamerService {
             .onRtcMessageDo(
                 this.toRtcChannelSubscriptionId(peerDto.peerId),
                 {
-                    onMessage: async (data) => {
-                        console.log(`From ${(peerDto.peerId)}: ${JSON.stringify(data)}`);
-
-                        const msg = data as ALMessage;
-
-                        if (msg.id.senderId !== peerDto.peerId) {
-                            console.warn(`Message from ${msg.id.senderId} does not match peerId ${(peerDto.peerId)}. `);
-                        }
-
-                        await this.inboundRuntime.handleIncomingMessage(msg, peerDto.peerId);
-                    }
+                    onMessage: (message) => this.receivePeerMessage(peerDto.peerId, message)
                 }
             );
 
-        for (const [id, cb] of this.onRtcMessageCallbacks.entries()) {
-            peerDto.channel.onRtcMessageDo(id, cb);
+        for (const [id, callback] of this.onRtcMessageCallbacks.entries()) {
+            peerDto.channel.onRtcMessageDo(id, callback);
         }
+    }
 
+    private registerPeerMedia(peerDto: QRtcPeerDto): void {
         if (this.status.mediaPolicy) {
             peerDto.connection.applyMediaPolicy(this.status.mediaPolicy);
         }
@@ -154,16 +153,7 @@ export class WebRtcRxStreamerService {
         peerDto.media
             .onRemoteStreamDo(
                 this.toRtcMediaSubscriptionId(peerDto.peerId),
-                async (stream, event) => {
-                    for (const cb of this.onRemoteStreamCallbacks.values()) {
-                        try {
-                            await cb(peerDto.peerId, stream, event);
-                        }
-                        catch (e) {
-                            console.error('Error calling onRemoteStream callback', e);
-                        }
-                    }
-                }
+                (stream, event) => this.publishRemoteStream(peerDto.peerId, stream, event)
             );
 
         if (this.status.localMediaStream) {
@@ -176,12 +166,31 @@ export class WebRtcRxStreamerService {
         }
     }
 
+    private async receivePeerMessage(peerId: PeerId, value: unknown): Promise<void> {
+        const message = decodePersistedALMessageValue(value);
+        if (message.id.senderId !== peerId) {
+            console.warn(`Message from ${message.id.senderId} does not match peerId ${peerId}.`);
+        }
+        await this.inboundRuntime.handleIncomingMessage(message, peerId);
+    }
+
+    private async publishRemoteStream(peerId: PeerId, stream: MediaStream, event: RTCTrackEvent): Promise<void> {
+        for (const callback of this.onRemoteStreamCallbacks.values()) {
+            try {
+                await callback(peerId, stream, event);
+            }
+            catch (error) {
+                console.error('Error calling onRemoteStream callback', error);
+            }
+        }
+    }
+
     removePeer(peerDto: QRtcPeerDto): void {
         this.peerDtoByPeerId.delete(peerDto.peerId);
 
         peerDto.media.removeOnRemoteStreamCallbackById(this.toRtcMediaSubscriptionId(peerDto.peerId));
         peerDto.channel.removeOnRtcMessageCallbackById(this.toRtcChannelSubscriptionId(peerDto.peerId));
-        peerDto.channel.removeOnRtcMessageCallbackById(this.toHeartbeatCallbackId(peerDto.peerId));
+        peerDto.channel.removeRtcCallbackById(this.toHeartbeatCallbackId(peerDto.peerId));
 
         const heartbeat = this.heartbeatByPeerId.get(peerDto.peerId);
 
@@ -201,17 +210,13 @@ export class WebRtcRxStreamerService {
         this.rttReportingPeerIds = new Set(peerIds);
         for (const [peerId, heartbeat] of this.heartbeatByPeerId.entries()) {
             if (!this.shouldReportRttForPeer(peerId)) {
-                heartbeat.stop();
-                this.heartbeatByPeerId.delete(peerId);
+                heartbeat.stopReporting();
             }
         }
 
         for (const peerId of peerIds) {
             const dto = this.peerDtoByPeerId.get(peerId);
-            if (
-                dto?.channel?.isOpen?.() &&
-                !this.heartbeatByPeerId.has(peerId)
-            ) {
+            if (dto?.channel.isOpen()) {
                 this.startRtcHeartbeats(peerId).catch((error) =>
                     console.error(`Failed to start RTT heartbeat for ${peerId}`, error)
                 );
@@ -256,67 +261,56 @@ export class WebRtcRxStreamerService {
     }
 
     private startRtcHeartbeats(peerId: string): Promise<void> {
-        if (!this.shouldReportRttForPeer(peerId)) {
-            return Promise.resolve();
-        }
-
-        console.log(`Data channel to ${peerId} opened. Starting heartbeat`);
-
-        {
-            const heartbeat = this.heartbeatByPeerId.get(peerId);
-            if (heartbeat) {
-                heartbeat.stop();
-            }
-        }
-
         const dto = this.peerDtoByPeerId.get(peerId);
-        if (!dto?.channel) {
-            console.warn(`No channel for peer ${peerId}. Ignoring heartbeat ...`);
+        if (!dto) {
             return Promise.resolve();
         }
 
-        const heartbeat = new WebRtcHeartbeatService(
-            {
+        let heartbeat = this.heartbeatByPeerId.get(peerId);
+        if (!heartbeat) {
+            heartbeat = new WebRtcHeartbeatService({
                 sessionId: this.input.sessionId,
                 peerSessionId: peerId,
                 channel: dto.channel,
                 maxMissedPings: defaultMaxMissedPings,
                 pingFrequencyMsecs: defaultPingFrequencyMsecs
-            }
-        );
+            });
+            this.heartbeatByPeerId.set(peerId, heartbeat);
+        }
+        heartbeat.startResponding();
+        if (this.shouldReportRttForPeer(peerId)) {
+            heartbeat.start(this.toRttMeasurementCallbacks(peerId));
+        }
+        return Promise.resolve();
+    }
 
-        const callbacks: WebRtcHeartbeatCallbacks = {
+    private toRttMeasurementCallbacks(peerId: string): WebRtcHeartbeatCallbacks {
+        return {
             onMissedHeartbeat: (peerId: string) => {
                 console.log(`Missed heartbeat from ${peerId}.`);
                 return Promise.resolve();
             },
-            onHeartbeat: (result: PingResult) => {
-                const previousVersion = this.rttVersionByPeerId.get(peerId) ?? 0;
-                const version = Math.max(previousVersion + 1, result.version);
-                this.rttVersionByPeerId.set(peerId, version);
-                const rtt: RttMeasurementInfo = {
-                    sessionIdFrom: this.input.sessionId,
-                    sessionIdTo: peerId,
-                    rttMs: result.rttMsecs,
-                    createdAtEpochMs: Date.now(),
-                    version
-                };
-                for (const [_, cb] of this.onRttMeasurementCallbacks.entries()) {
-                    cb.onHeartbeat(rtt)
-                        .catch(
-                            (e) => console.error('Error calling onRttMeasurementCallback', e)
-                        );
-                }
-
+            onHeartbeat: (result) => {
+                this.publishRttMeasurement(peerId, result);
                 return Promise.resolve();
             }
         };
+    }
 
-        heartbeat.start(callbacks);
-
-        this.heartbeatByPeerId.set(peerId, heartbeat);
-
-        return Promise.resolve();
+    private publishRttMeasurement(peerId: PeerId, result: PingResult): void {
+        const previousVersion = this.rttVersionByPeerId.get(peerId) ?? 0;
+        const version = Math.max(previousVersion + 1, result.version);
+        this.rttVersionByPeerId.set(peerId, version);
+        const rtt: RttMeasurementInfo = {
+            sessionIdFrom: this.input.sessionId,
+            sessionIdTo: peerId,
+            rttMs: result.rttMsecs,
+            createdAtEpochMs: Date.now(),
+            version
+        };
+        for (const callback of this.onRttMeasurementCallbacks.values()) {
+            callback.onHeartbeat(rtt).catch((error) => console.error('Error calling onRttMeasurementCallback', error));
+        }
     }
 
     private shouldReportRttForPeer(peerId: PeerId): boolean {
@@ -340,7 +334,7 @@ export class WebRtcRxStreamerService {
         entry: ResourceEntry,
         plan?: ALMessageHandlingPlan
     ): Promise<void> {
-        const message = JSON.parse(entry.resource) as ALMessage;
+        const message = decodePersistedALMessage(entry.resource);
 
         let exclusiveCallback;
         let wildcard = undefined;
@@ -376,10 +370,6 @@ export class WebRtcRxStreamerService {
             console.error('Error calling onMessage callback', e);
         }
     }
-
-    // --------------------------------------------------
-    // Callbacks
-    // --------------------------------------------------
 
     onAllInboxMessagesDo(callback: OnMessageCallback, forceUpdate: boolean = false): WebRtcRxStreamerService {
         if (!forceUpdate && this.onInboxMessageCallbacks.has(WebRtcRxStreamerService.ALL_IN)) {
@@ -437,10 +427,6 @@ export class WebRtcRxStreamerService {
         return this.onRttMeasurementCallbacks.delete(id);
     }
 
-    // --------------------------------------------------
-    // Queue management
-    // --------------------------------------------------
-
     async enqueueOutboxIfAbsent(msg: ALMessage): Promise<ALOutboundEnqueueResult> {
         return await this.multicast.enqueueIfAbsent(msg);
     }
@@ -456,20 +442,13 @@ export class WebRtcRxStreamerService {
         );
     }
 
-    // ---------------------------------------------------------------
-    // Media/remote stream callback registry and local media controls
-    // ---------------------------------------------------------------
-
     async setLocalMediaStream(stream: MediaStream): Promise<void> {
         this.status.localMediaStream = stream;
 
         for (const peer of this.peerDtoByPeerId.values()) {
-            if (peer?.media) {
-                await peer.media.setLocalMediaStream(stream);
-
-                peer.media.setLocalAudioEnabled(this.status.localAudioEnabled);
-                peer.media.setLocalVideoEnabled(this.status.localVideoEnabled);
-            }
+            await peer.media.setLocalMediaStream(stream);
+            peer.media.setLocalAudioEnabled(this.status.localAudioEnabled);
+            peer.media.setLocalVideoEnabled(this.status.localVideoEnabled);
         }
     }
 
@@ -477,7 +456,7 @@ export class WebRtcRxStreamerService {
         this.status.localAudioEnabled = enabled;
 
         for (const peer of this.peerDtoByPeerId.values()) {
-            peer.media?.setLocalAudioEnabled(enabled);
+            peer.media.setLocalAudioEnabled(enabled);
         }
     }
 
@@ -485,13 +464,13 @@ export class WebRtcRxStreamerService {
         this.status.localVideoEnabled = enabled;
 
         for (const peer of this.peerDtoByPeerId.values()) {
-            peer.media?.setLocalVideoEnabled(enabled);
+            peer.media.setLocalVideoEnabled(enabled);
         }
     }
 
     stopLocalMedia(kind: 'audio' | 'video' | 'all'): void {
         for (const peer of this.peerDtoByPeerId.values()) {
-            peer.media?.stopLocalMedia(kind);
+            peer.media.stopLocalMedia(kind);
         }
     }
 

--- a/packages/shared/services/WebRtcRxStreamerService.ts
+++ b/packages/shared/services/WebRtcRxStreamerService.ts
@@ -136,7 +136,10 @@ export class WebRtcRxStreamerService {
             .onRtcMessageDo(
                 this.toRtcChannelSubscriptionId(peerDto.peerId),
                 {
-                    onMessage: (message) => this.receivePeerMessage(peerDto.peerId, message)
+                    onMessage: async (value) => {
+                        const message = decodePersistedALMessageValue(value);
+                        await this.receivePeerMessage(peerDto.peerId, message);
+                    }
                 }
             );
 
@@ -166,8 +169,7 @@ export class WebRtcRxStreamerService {
         }
     }
 
-    private async receivePeerMessage(peerId: PeerId, value: unknown): Promise<void> {
-        const message = decodePersistedALMessageValue(value);
+    private async receivePeerMessage(peerId: PeerId, message: ALMessage): Promise<void> {
         if (message.id.senderId !== peerId) {
             console.warn(`Message from ${message.id.senderId} does not match peerId ${peerId}.`);
         }

--- a/packages/tests/shared-server/rallar-system/rtc-rtt/rtc-rtt-app-inbox.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-rtt/rtc-rtt-app-inbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { AppOutboxType } from '@shared-server/rallar-system/app-outbox/app-outbox-type.ts';
+import { GroupMutationAuthorizationError } from '@shared-server/rallar-system/group-state/group-mutation-authority.ts';
 import { RtcRttInboxService } from '@shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-inbox-service.ts';
 import { toRtcRttMutationReceiptId } from '@shared-server/rallar-system/rtc-rtt/mutation/rtc-rtt-mutation-identifiers.ts';
 import { RtcRttRepository } from '@shared-server/rallar-system/rtc-rtt/persistence/rtc-rtt-repository.ts';
@@ -11,7 +12,7 @@ import type { AuditStamp, GroupMember, GroupPresenceSession, GroupSnapshot } fro
 import { InboxQueueReader } from '@shared/services/InboxQueueReader.ts';
 
 import { createTestGroup } from '../../../create-test-group.ts';
-import { createAuthorityHarness, createResilience, SCOPE } from '../group-state/inbox/group-state-inbox-test-runtime.ts';
+import { createAuthorityHarness, createResilience, SCOPE, type AuthorityHarness } from '../group-state/inbox/group-state-inbox-test-runtime.ts';
 
 describe('durable RTC RTT refinement work', () => {
     it('preserves the accepted RTT observation in final topology work', async () => {
@@ -23,31 +24,7 @@ describe('durable RTC RTT refinement work', () => {
             createdAtEpochMs: harness.nowEpochMs,
             version: 1
         };
-        const group = createRttGroupSnapshot(harness.nowEpochMs);
-        const service = new RtcRttInboxService(
-            {
-                inboxQueueReader: harness.reader,
-                resourceInboxRepository: harness.queue,
-                resourceInboxResultsRepository: harness.results,
-                database: harness.database,
-                groupStateService: harness.groupStateService,
-                mutationDependencies: {
-                    repository: new RtcRttRepository(harness.runtimeRepository, {
-                        now: () => harness.nowEpochMs
-                    }),
-                    outboxWriter: new RtcTopologyOutboxWriter({ recordWrite: () => undefined }),
-                    readPolicyInputs: async () => ({
-                        candidateGroups: [group],
-                        overlaySnapshotsByGroupKey: new Map(),
-                        degreeLimit: 2
-                    })
-                }
-            },
-            {
-                serviceId: 'rtc-rtt-app-inbox-test',
-                options: { nowEpochMs: () => harness.nowEpochMs }
-            }
-        );
+        const service = createRttService(harness);
 
         await service.enqueue({
             rtt,
@@ -68,11 +45,83 @@ describe('durable RTC RTT refinement work', () => {
             rtt,
             refinementObservationId: toRtcRttMutationReceiptId(rtt)
         });
-        if (envelope.data.kind !== 'rtt-refresh') {
-            throw new Error('Expected canonical durable RTT refresh work');
+    });
+
+    it.each([
+        { rejectedFrom: 'bob-session', first: 'rejected' },
+        { rejectedFrom: 'bob-session', first: 'canonical' },
+        { rejectedFrom: 'alice-session', first: 'rejected' },
+        { rejectedFrom: 'alice-session', first: 'canonical' }
+    ])('keeps the pair/version slot available when $rejectedFrom reports as bob, $first first', async ({ rejectedFrom, first }) => {
+        const harness = await createAuthorityHarness(['alice', 'bob']);
+        const service = createRttService(harness);
+        const canonical = {
+            rtt: {
+                sessionIdFrom: 'alice-session',
+                sessionIdTo: 'bob-session',
+                rttMs: 12,
+                createdAtEpochMs: harness.nowEpochMs,
+                version: 1
+            },
+            alSenderId: 'alice-session',
+            capturedAtEpochMs: harness.nowEpochMs
+        };
+        const rejected = {
+            ...canonical,
+            alSenderId: 'bob-session',
+            rtt: {
+                ...canonical.rtt,
+                sessionIdFrom: rejectedFrom,
+                sessionIdTo: rejectedFrom === 'bob-session' ? 'alice-session' : 'bob-session'
+            }
+        };
+        if (first === 'canonical') {
+            await service.enqueue(canonical);
         }
+        const before = await harness.queueEntries();
+
+        await expect(service.enqueue(rejected)).rejects.toBeInstanceOf(GroupMutationAuthorizationError);
+        expect(await harness.queueEntries()).toEqual(before);
+        await service.enqueue(canonical);
+        await service.enqueue(canonical);
+        expect(await harness.queueEntries()).toHaveLength(1);
+
+        await harness.reader.dequeueInbox(InboxQueueReader.INBOX_DEQUEUE_TYPES, createResilience());
+        expect(harness.database.outboxEntries.size).toBe(1);
+        const entry = [...harness.database.outboxEntries.values()][0];
+        if (!entry) {
+            throw new Error('Expected accepted canonical RTT topology work');
+        }
+        const envelope = readRtcTopologyWorkEnvelope(
+            decodePersistedALMessage(entry.resource),
+            AppOutboxType.RTC_TOPOLOGY_RECOMPUTE
+        );
+        expect(envelope.data).toMatchObject({ kind: 'rtt-refresh', rtt: canonical.rtt });
     });
 });
+
+function createRttService(harness: AuthorityHarness): RtcRttInboxService {
+    const group = createRttGroupSnapshot(harness.nowEpochMs);
+    return new RtcRttInboxService(
+        {
+            inboxQueueReader: harness.reader,
+            resourceInboxRepository: harness.queue,
+            resourceInboxResultsRepository: harness.results,
+            database: harness.database,
+            groupStateService: harness.groupStateService,
+            mutationDependencies: {
+                repository: new RtcRttRepository(harness.runtimeRepository, { now: () => harness.nowEpochMs }),
+                outboxWriter: new RtcTopologyOutboxWriter({ recordWrite: () => undefined }),
+                readPolicyInputs: async () => ({
+                    candidateGroups: [group],
+                    overlaySnapshotsByGroupKey: new Map(),
+                    degreeLimit: 2
+                })
+            }
+        },
+        { serviceId: 'rtc-rtt-app-inbox-test', options: { nowEpochMs: () => harness.nowEpochMs } }
+    );
+}
 
 function createRttGroupSnapshot(nowEpochMs: number): GroupSnapshot {
     const groupRef = { ...SCOPE, groupId: 'rtc-room' };

--- a/packages/tests/shared-server/rallar-system/rtc-rtt/rtc-rtt-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/rtc-rtt/rtc-rtt-mutation.test.ts
@@ -154,6 +154,26 @@ describe('RTC RTT mutation phases', () => {
             computeAndValidateRttTwice(
                 deepFreeze({
                     ...base,
+                    command: {
+                        ...base.command,
+                        rtt: {
+                            ...rtt,
+                            sessionIdFrom: 'session-b',
+                            sessionIdTo: 'session-a'
+                        },
+                        alSenderId: 'session-b'
+                    },
+                    read: emptyRead
+                })
+            )
+        ).toMatchObject({
+            outcome: 'rejected',
+            reason: 'non-canonical-reporter'
+        });
+        expect(
+            computeAndValidateRttTwice(
+                deepFreeze({
+                    ...base,
                     read: {
                         ...emptyRead,
                         endpointAdmissions: [

--- a/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { readApiV1Recipe } from './api-v1-recipe-test-fixture.ts';
+
+interface RttRecipeStep {
+    readonly name?: string;
+}
+
+interface RttRecipeFragment {
+    readonly steps?: readonly RttRecipeStep[];
+}
+
+interface RttRecipe {
+    readonly steps?: readonly RttRecipeStep[];
+    readonly fragments?: Readonly<Record<string, RttRecipeFragment>>;
+}
+
+describe('API-v1 RTC RTT recipe semantics', () => {
+    it('orients every synthetic RTT report from the canonical session', () => {
+        const cases = [
+            {
+                recipePath: 'tests/api-v1/api-v1-group-formation-criterion.json',
+                reporterStepName: 'deriveRttReporter',
+                resourceStepName: 'deriveRttResource',
+                sendStepName: 'reportTheObservedEdge',
+                reporterOutput: 'rttReporter',
+                firstSessionPath: 'outputs.aliceSessionId',
+                secondSessionPath: 'outputs.bobSessionId',
+                firstConnection: 'wsAlice',
+                secondConnection: 'wsBob'
+            },
+            {
+                recipePath: 'tests/api-v1/api-v1-match-preset.json',
+                reporterStepName: 'deriveArenaRttReporter',
+                resourceStepName: 'deriveArenaRttResource',
+                sendStepName: 'reportTheArenaEdge',
+                reporterOutput: 'arenaRttReporter',
+                firstSessionPath: 'outputs.carolSessionId',
+                secondSessionPath: 'outputs.danSessionId',
+                firstConnection: 'wsCarol',
+                secondConnection: 'wsDan'
+            },
+            {
+                recipePath: 'tests/api-v1/api-v1-group-formation-managed-burst-medium.json',
+                fragmentName: 'report-rtt-pair',
+                reporterStepName: 'deriveRtt{i}x{j}Reporter',
+                resourceStepName: 'deriveRtt{i}x{j}Resource',
+                sendStepName: 'reportRtt{i}x{j}',
+                reporterOutput: 'rtt{i}x{j}Reporter',
+                firstSessionPath: 'outputs.client{i}SessionId',
+                secondSessionPath: 'outputs.client{j}SessionId',
+                firstConnection: 'ws-client-{i}',
+                secondConnection: 'ws-client-{j}'
+            },
+            {
+                recipePath: 'tests/api-v1/api-v1-group-formation-managed-burst-large.json',
+                fragmentName: 'report-rtt-pair',
+                reporterStepName: 'deriveRtt{i}x{j}Reporter',
+                resourceStepName: 'deriveRtt{i}x{j}Resource',
+                sendStepName: 'reportRtt{i}x{j}',
+                reporterOutput: 'rtt{i}x{j}Reporter',
+                firstSessionPath: 'outputs.client{i}SessionId',
+                secondSessionPath: 'outputs.client{j}SessionId',
+                firstConnection: 'ws-client-{i}',
+                secondConnection: 'ws-client-{j}'
+            }
+        ] as const;
+
+        for (const testCase of cases) {
+            const recipe = readApiV1Recipe(testCase.recipePath) as RttRecipe;
+            const steps = 'fragmentName' in testCase
+                ? recipe.fragments?.[testCase.fragmentName]?.steps ?? []
+                : recipe.steps ?? [];
+            const reporterStep = steps.find(
+                (step) => step.name === testCase.reporterStepName
+            );
+            const resourceStep = steps.find(
+                (step) => step.name === testCase.resourceStepName
+            );
+            const sendStep = steps.find(
+                (step) => step.name === testCase.sendStepName
+            );
+
+            expect(reporterStep, testCase.recipePath).toMatchObject({
+                type: 'set',
+                output: testCase.reporterOutput,
+                transform: {
+                    if: {
+                        condition: {
+                            operator: 'lexicallyBefore',
+                            values: [
+                                { path: testCase.firstSessionPath },
+                                { path: testCase.secondSessionPath }
+                            ]
+                        },
+                        then: {
+                            connection: testCase.firstConnection,
+                            sessionIdFrom: { path: testCase.firstSessionPath },
+                            sessionIdTo: { path: testCase.secondSessionPath }
+                        },
+                        else: {
+                            connection: testCase.secondConnection,
+                            sessionIdFrom: { path: testCase.secondSessionPath },
+                            sessionIdTo: { path: testCase.firstSessionPath }
+                        }
+                    }
+                }
+            });
+            expect(resourceStep, testCase.recipePath).toMatchObject({
+                type: 'set',
+                transform: {
+                    concat: expect.arrayContaining([
+                        { path: `outputs.${testCase.reporterOutput}.sessionIdFrom` },
+                        { path: `outputs.${testCase.reporterOutput}.sessionIdTo` }
+                    ])
+                }
+            });
+            expect(sendStep, testCase.recipePath).toMatchObject({
+                type: 'ws.send',
+                connection: `{${testCase.reporterOutput}.connection}`,
+                request: {
+                    send: {
+                        id: {
+                            senderId: `{${testCase.reporterOutput}.sessionIdFrom}`,
+                            sessionId: `{${testCase.reporterOutput}.sessionIdFrom}`
+                        }
+                    }
+                }
+            });
+        }
+    });
+});

--- a/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
@@ -1,132 +1,122 @@
-import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { WebSocketServer } from 'ws';
 
-import { readApiV1Recipe } from './api-v1-recipe-test-fixture.ts';
+import { executeBlackBox } from '@shared-test/black-box-runner/execute-black-box.ts';
+import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
+import { decodePersistedALMessage } from '@shared/al-contracts/al-message-persistence-validation.ts';
 
-interface RttRecipeStep {
-    readonly name?: string;
+interface RecipeInteraction {
+    readonly [name: string]: unknown;
+    readonly PARALLEL?: { readonly request: { readonly groups: readonly { readonly steps: readonly RecipeInteraction[]; }[]; }; };
 }
 
-interface RttRecipeFragment {
-    readonly steps?: readonly RttRecipeStep[];
+interface CapturedReport {
+    readonly connection: string;
+    readonly message: ALMessage;
 }
 
-interface RttRecipe {
-    readonly steps?: readonly RttRecipeStep[];
-    readonly fragments?: Readonly<Record<string, RttRecipeFragment>>;
-}
+const CLI = fileURLToPath(new URL('../../shared-test/black-box-runner/scenario-black-box.ts', import.meta.url));
+const RECIPE_ROOT = fileURLToPath(new URL('../../shared-test/black-box-runner/tests/api-v1/', import.meta.url));
+const CASES = [
+    {
+        recipe: 'api-v1-group-formation-criterion.json',
+        steps: ['deriveRttCreatedAt', 'deriveRttReporter', 'deriveRttResource', 'reportTheObservedEdge'],
+        sessions: ['aliceSessionId', 'bobSessionId'],
+        connections: ['wsAlice', 'wsBob']
+    },
+    {
+        recipe: 'api-v1-match-preset.json',
+        steps: ['captureArenaRttReportedAt', 'deriveArenaRttReporter', 'deriveArenaRttResource', 'reportTheArenaEdge'],
+        sessions: ['carolSessionId', 'danSessionId'],
+        connections: ['wsCarol', 'wsDan']
+    },
+    ...['medium', 'large'].map((size) => ({
+        recipe: `api-v1-group-formation-managed-burst-${size}.json`,
+        steps: ['captureRttReportedAt', 'deriveRtt1x2Reporter', 'deriveRtt1x2Resource', 'reportRtt1x2'],
+        sessions: ['client1SessionId', 'client2SessionId'],
+        connections: ['ws-client-1', 'ws-client-2']
+    }))
+];
 
-describe('API-v1 RTC RTT recipe semantics', () => {
-    it('orients every synthetic RTT report from the canonical session', () => {
-        const cases = [
-            {
-                recipePath: 'tests/api-v1/api-v1-group-formation-criterion.json',
-                reporterStepName: 'deriveRttReporter',
-                resourceStepName: 'deriveRttResource',
-                sendStepName: 'reportTheObservedEdge',
-                reporterOutput: 'rttReporter',
-                firstSessionPath: 'outputs.aliceSessionId',
-                secondSessionPath: 'outputs.bobSessionId',
-                firstConnection: 'wsAlice',
-                secondConnection: 'wsBob'
-            },
-            {
-                recipePath: 'tests/api-v1/api-v1-match-preset.json',
-                reporterStepName: 'deriveArenaRttReporter',
-                resourceStepName: 'deriveArenaRttResource',
-                sendStepName: 'reportTheArenaEdge',
-                reporterOutput: 'arenaRttReporter',
-                firstSessionPath: 'outputs.carolSessionId',
-                secondSessionPath: 'outputs.danSessionId',
-                firstConnection: 'wsCarol',
-                secondConnection: 'wsDan'
-            },
-            {
-                recipePath: 'tests/api-v1/api-v1-group-formation-managed-burst-medium.json',
-                fragmentName: 'report-rtt-pair',
-                reporterStepName: 'deriveRtt{i}x{j}Reporter',
-                resourceStepName: 'deriveRtt{i}x{j}Resource',
-                sendStepName: 'reportRtt{i}x{j}',
-                reporterOutput: 'rtt{i}x{j}Reporter',
-                firstSessionPath: 'outputs.client{i}SessionId',
-                secondSessionPath: 'outputs.client{j}SessionId',
-                firstConnection: 'ws-client-{i}',
-                secondConnection: 'ws-client-{j}'
-            },
-            {
-                recipePath: 'tests/api-v1/api-v1-group-formation-managed-burst-large.json',
-                fragmentName: 'report-rtt-pair',
-                reporterStepName: 'deriveRtt{i}x{j}Reporter',
-                resourceStepName: 'deriveRtt{i}x{j}Resource',
-                sendStepName: 'reportRtt{i}x{j}',
-                reporterOutput: 'rtt{i}x{j}Reporter',
-                firstSessionPath: 'outputs.client{i}SessionId',
-                secondSessionPath: 'outputs.client{j}SessionId',
-                firstConnection: 'ws-client-{i}',
-                secondConnection: 'ws-client-{j}'
+describe('API-v1 RTC RTT recipe execution', () => {
+    it.each(CASES)('strictly validates every expanded connection in $recipe', (testCase) => {
+        const report = runRecipeCli(testCase.recipe, ['--validate', '--strict']);
+        expect(report.status, report.stderr).toBe(0);
+        expect(JSON.parse(report.stdout)).toMatchObject({ ok: true, connections: { missing: [] } });
+    });
+
+    it.each(CASES)('sends from the canonical socket with either session order in $recipe', async (testCase) => {
+        const expansion = runRecipeCli(testCase.recipe, ['-e', 'dry']);
+        expect(expansion.status, expansion.stderr).toBe(0);
+        const compiled = flattenRecipeInteractions(JSON.parse(expansion.stdout));
+        const reportSteps = testCase.steps.map((name) => {
+            const operation = compiled.find((interaction) => Object.hasOwn(interaction, name));
+            if (!operation) {
+                throw new Error(`Missing authored RTT operation ${name}`);
             }
-        ] as const;
+            return operation;
+        });
+        const capture = new WebSocketServer({ port: 0, host: '127.0.0.1' });
+        const reports: CapturedReport[] = [];
+        capture.on('connection', (socket, request) => {
+            socket.on('message', (data) =>
+                reports.push({
+                    connection: request.url ?? '',
+                    message: decodePersistedALMessage(data.toString())
+                }));
+        });
+        await once(capture, 'listening');
+        const address = capture.address();
+        if (typeof address === 'string' || address === null) {
+            throw new Error('Expected local WebSocket listener');
+        }
 
-        for (const testCase of cases) {
-            const recipe = readApiV1Recipe(testCase.recipePath) as RttRecipe;
-            const steps = 'fragmentName' in testCase
-                ? recipe.fragments?.[testCase.fragmentName]?.steps ?? []
-                : recipe.steps ?? [];
-            const reporterStep = steps.find(
-                (step) => step.name === testCase.reporterStepName
-            );
-            const resourceStep = steps.find(
-                (step) => step.name === testCase.resourceStepName
-            );
-            const sendStep = steps.find(
-                (step) => step.name === testCase.sendStepName
-            );
-
-            expect(reporterStep, testCase.recipePath).toMatchObject({
-                type: 'set',
-                output: testCase.reporterOutput,
-                transform: {
-                    if: {
-                        condition: {
-                            operator: 'lexicallyBefore',
-                            values: [
-                                { path: testCase.firstSessionPath },
-                                { path: testCase.secondSessionPath }
-                            ]
-                        },
-                        then: {
-                            connection: testCase.firstConnection,
-                            sessionIdFrom: { path: testCase.firstSessionPath },
-                            sessionIdTo: { path: testCase.secondSessionPath }
-                        },
-                        else: {
-                            connection: testCase.secondConnection,
-                            sessionIdFrom: { path: testCase.secondSessionPath },
-                            sessionIdTo: { path: testCase.firstSessionPath }
-                        }
-                    }
-                }
-            });
-            expect(resourceStep, testCase.recipePath).toMatchObject({
-                type: 'set',
-                transform: {
-                    concat: expect.arrayContaining([
-                        { path: `outputs.${testCase.reporterOutput}.sessionIdFrom` },
-                        { path: `outputs.${testCase.reporterOutput}.sessionIdTo` }
-                    ])
-                }
-            });
-            expect(sendStep, testCase.recipePath).toMatchObject({
-                type: 'ws.send',
-                connection: `{${testCase.reporterOutput}.connection}`,
-                request: {
-                    send: {
-                        id: {
-                            senderId: `{${testCase.reporterOutput}.sessionIdFrom}`,
-                            sessionId: `{${testCase.reporterOutput}.sessionIdFrom}`
-                        }
-                    }
-                }
-            });
+        try {
+            for (const sessionIds of [['a-session', 'z-session'], ['z-session', 'a-session']]) {
+                reports.length = 0;
+                const setup = testCase.sessions.map((output, index) => ({
+                    SET: { request: { output, value: sessionIds[index] }, response: {} },
+                    [`seed-${output}`]: { type: 'set' }
+                }));
+                const opens = testCase.connections.map((connection) => ({
+                    WS: { request: { action: 'open', connection, url: `ws://127.0.0.1:${address.port}/${connection}` }, response: {} },
+                    [`open-${connection}`]: { type: 'ws.open' }
+                }));
+                const result = await executeBlackBox([...setup, ...opens, ...structuredClone(reportSteps)], 0, { failFast: true });
+                expect(result, JSON.stringify(result.results)).toMatchObject({ summary: { failure: 0 } });
+                await vi.waitFor(() => expect(reports).toHaveLength(1));
+                expect(reports[0].connection).toBe(`/${testCase.connections[sessionIds[0] === 'a-session' ? 0 : 1]}`);
+                expect(reports[0].message.id).toMatchObject({ senderId: 'a-session', sessionId: 'a-session' });
+                expect(JSON.parse(reports[0].message.payload.resource)).toMatchObject({
+                    sessionIdFrom: 'a-session',
+                    sessionIdTo: 'z-session',
+                    version: 1
+                });
+            }
+        }
+        finally {
+            for (const socket of capture.clients) {
+                socket.terminate();
+            }
+            await new Promise<void>((resolve, reject) => capture.close((error) => error ? reject(error) : resolve()));
         }
     });
 });
+
+function runRecipeCli(recipe: string, args: readonly string[]) {
+    return spawnSync('deno', ['run', '-A', CLI, '-w', RECIPE_ROOT, '-c', recipe, ...args], {
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        timeout: 30_000
+    });
+}
+
+function flattenRecipeInteractions(interactions: readonly RecipeInteraction[]): RecipeInteraction[] {
+    return interactions.flatMap((interaction) => [
+        interaction,
+        ...interaction.PARALLEL?.request.groups.flatMap((group) => flattenRecipeInteractions(group.steps)) ?? []
+    ]);
+}

--- a/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
+++ b/packages/tests/shared-test/api-v1-rtc-rtt-recipe-semantics.test.ts
@@ -4,14 +4,10 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { WebSocketServer } from 'ws';
 
+import { decodeJsonWireText, type JsonWireObject, type JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import { executeBlackBox } from '@shared-test/black-box-runner/execute-black-box.ts';
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { decodePersistedALMessage } from '@shared/al-contracts/al-message-persistence-validation.ts';
-
-interface RecipeInteraction {
-    readonly [name: string]: unknown;
-    readonly PARALLEL?: { readonly request: { readonly groups: readonly { readonly steps: readonly RecipeInteraction[]; }[]; }; };
-}
 
 interface CapturedReport {
     readonly connection: string;
@@ -42,16 +38,24 @@ const CASES = [
 ];
 
 describe('API-v1 RTC RTT recipe execution', () => {
+    it.each([
+        '[false]',
+        '[[]]',
+        '[{"PARALLEL":null}]'
+    ])('rejects malformed compiled interactions before selecting report operations: %s', (serialized) => {
+        expect(() => toFlatRecipeInteractions(decodeJsonWireText(serialized))).toThrow();
+    });
+
     it.each(CASES)('strictly validates every expanded connection in $recipe', (testCase) => {
         const report = runRecipeCli(testCase.recipe, ['--validate', '--strict']);
         expect(report.status, report.stderr).toBe(0);
-        expect(JSON.parse(report.stdout)).toMatchObject({ ok: true, connections: { missing: [] } });
+        expect(decodeJsonWireText(report.stdout)).toMatchObject({ ok: true, connections: { missing: [] } });
     });
 
     it.each(CASES)('sends from the canonical socket with either session order in $recipe', async (testCase) => {
         const expansion = runRecipeCli(testCase.recipe, ['-e', 'dry']);
         expect(expansion.status, expansion.stderr).toBe(0);
-        const compiled = flattenRecipeInteractions(JSON.parse(expansion.stdout));
+        const compiled = toFlatRecipeInteractions(decodeJsonWireText(expansion.stdout));
         const reportSteps = testCase.steps.map((name) => {
             const operation = compiled.find((interaction) => Object.hasOwn(interaction, name));
             if (!operation) {
@@ -90,7 +94,7 @@ describe('API-v1 RTC RTT recipe execution', () => {
                 await vi.waitFor(() => expect(reports).toHaveLength(1));
                 expect(reports[0].connection).toBe(`/${testCase.connections[sessionIds[0] === 'a-session' ? 0 : 1]}`);
                 expect(reports[0].message.id).toMatchObject({ senderId: 'a-session', sessionId: 'a-session' });
-                expect(JSON.parse(reports[0].message.payload.resource)).toMatchObject({
+                expect(decodeJsonWireText(reports[0].message.payload.resource)).toMatchObject({
                     sessionIdFrom: 'a-session',
                     sessionIdTo: 'z-session',
                     version: 1
@@ -106,17 +110,36 @@ describe('API-v1 RTC RTT recipe execution', () => {
     });
 });
 
+function toFlatRecipeInteractions(value: JsonWireValue | undefined): JsonWireObject[] {
+    return toRecipeObjects(value, 'compiled interactions').flatMap((interaction) => {
+        if (!Object.hasOwn(interaction, 'PARALLEL')) {
+            return [interaction];
+        }
+        const parallel = toRecipeObject(interaction.PARALLEL, 'PARALLEL');
+        const request = toRecipeObject(parallel.request, 'PARALLEL request');
+        const groups = toRecipeObjects(request.groups, 'PARALLEL groups');
+        return [interaction, ...groups.flatMap((group) => toFlatRecipeInteractions(group.steps))];
+    });
+}
+
+function toRecipeObjects(value: JsonWireValue | undefined, label: string): JsonWireObject[] {
+    if (!Array.isArray(value)) {
+        throw new Error(`Expected ${label} to be an array`);
+    }
+    return value.map((entry) => toRecipeObject(entry, label));
+}
+
+function toRecipeObject(value: JsonWireValue | undefined, label: string): JsonWireObject {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`Expected ${label} to be an object`);
+    }
+    return value as JsonWireObject;
+}
+
 function runRecipeCli(recipe: string, args: readonly string[]) {
     return spawnSync('deno', ['run', '-A', CLI, '-w', RECIPE_ROOT, '-c', recipe, ...args], {
         encoding: 'utf8',
         maxBuffer: 64 * 1024 * 1024,
         timeout: 30_000
     });
-}
-
-function flattenRecipeInteractions(interactions: readonly RecipeInteraction[]): RecipeInteraction[] {
-    return interactions.flatMap((interaction) => [
-        interaction,
-        ...interaction.PARALLEL?.request.groups.flatMap((group) => flattenRecipeInteractions(group.steps)) ?? []
-    ]);
 }

--- a/packages/tests/shared-test/black-box-runner-connection-preflight.test.ts
+++ b/packages/tests/shared-test/black-box-runner-connection-preflight.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+
+import { explainBlackBoxRunnerPlan, type BlackBoxRunnerPreflightInput } from '@shared-test/black-box-runner/preflight/plan-preflight.ts';
+
+describe('runtime-selected connection preflight', () => {
+    it('validates both literal branches of a preceding SET selection', () => {
+        const report = explainConnections([
+            selectConnection('wsAlice', 'wsBob'),
+            sendThrough('{reporter.connection}')
+        ]);
+        expect(report.connections).toEqual({
+            defined: ['wsAlice', 'wsBob'],
+            referenced: ['wsAlice', 'wsBob'],
+            missing: []
+        });
+        expect(report.issues.filter((issue) => issue.code === 'MISSING_CONNECTION')).toEqual([]);
+    });
+
+    it('rejects an undeclared connection in either conditional branch', () => {
+        for (const branches of [['wsMissing', 'wsBob'], ['wsAlice', 'wsMissing']]) {
+            const report = explainConnections([
+                selectConnection(branches[0], branches[1]),
+                sendThrough('{reporter.connection}')
+            ]);
+            expect(report.connections.missing).toEqual(['wsMissing']);
+        }
+    });
+
+    it('does not approve future, unbounded, or missing output paths', () => {
+        expect(
+            explainConnections([
+                sendThrough('{reporter.connection}'),
+                selectConnection('wsAlice', 'wsBob')
+            ]).connections.missing
+        ).toEqual(['{reporter.connection}']);
+        expect(
+            explainConnections([
+                selectConnection('wsAlice', { path: 'outputs.remoteConnection' }),
+                sendThrough('{reporter.connection}')
+            ]).connections.missing
+        ).toEqual(['{reporter.connection}']);
+        expect(
+            explainConnections([
+                selectConnection('wsAlice', 'wsBob'),
+                sendThrough('{reporter.typo}')
+            ]).connections.missing
+        ).toEqual(['{reporter.typo}']);
+    });
+
+    it('invalidates bounded output knowledge when a later request overwrites it', () => {
+        const report = explainConnections([
+            selectConnection('wsAlice', 'wsBob'),
+            { HTTP: { request: { output: 'reporter', path: 'https://example.invalid' } } },
+            sendThrough('{reporter.connection}')
+        ]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('does not mistake mixed transform keys for literal connection-bearing objects', () => {
+        const selection = selectConnection('wsAlice', 'wsBob');
+        Object.assign(selection.SET.request.transform.if.then, { path: 'outputs.remote' });
+        const report = explainConnections([selection, sendThrough('{reporter.connection}')]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('rejects dependencies on another parallel branch or an ambiguous post-join value', () => {
+        const report = explainConnections([{
+            PARALLEL: {
+                request: {
+                    groups: [
+                        { steps: [selectConnection('wsAlice', 'wsBob'), sendThrough('{reporter.connection}')] },
+                        { steps: [sendThrough('{reporter.connection}')] }
+                    ]
+                }
+            }
+        }, sendThrough('{reporter.connection}')]);
+        expect(report.connections.referenced).toEqual(['wsAlice', 'wsBob', '{reporter.connection}']);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it.each([false, true])('rejects sibling overwrites even with a branch-local selection: %s', (localSelection) => {
+        const report = explainConnections([
+            selectConnection('wsAlice', 'wsBob'),
+            {
+                PARALLEL: {
+                    request: {
+                        maxConcurrency: 1,
+                        groups: [
+                            { steps: [selectConnection('wsMissing', 'wsMissing')] },
+                            { steps: [...(localSelection ? [selectConnection('wsAlice', 'wsBob')] : []), sendThrough('{reporter.connection}')] }
+                        ]
+                    }
+                }
+            }
+        ]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('does not approve a direct output overwritten by a named extraction in the same SET', () => {
+        const selection = selectConnection('wsAlice', 'wsBob');
+        Object.assign(selection.SET.request, { outputs: { reporter: { transform: { path: 'outputs.remote' } } } });
+        expect(explainConnections([selection, sendThrough('{reporter.connection}')]).connections.missing)
+            .toEqual(['{reporter.connection}']);
+    });
+
+    it.each(['variables', 'outputs', 'results', 'resultsList', 'resultsByName', 'runnerRunId', 'correlation'])(
+        'does not shadow the reserved resolver root %s',
+        (name) => {
+            const selection = selectConnection('wsAlice', 'wsBob');
+            selection.SET.request.output = name;
+            expect(explainConnections([selection, sendThrough(`{${name}.connection}`)]).connections.missing)
+                .toEqual([`{${name}.connection}`]);
+        }
+    );
+
+    it('still rejects unknown static connection names', () => {
+        expect(explainConnections([sendThrough('wsMissing')]).connections.missing).toEqual(['wsMissing']);
+    });
+
+    it.each([
+        { output: '{target}', value: { connection: 'wsMissing' } },
+        { output: 'dummy', value: { connection: 'wsMissing' }, outputs: '{extractions}' }
+    ])('invalidates knowledge after an unresolved output write: %j', (request) => {
+        const report = explainConnections([
+            selectConnection('wsAlice', 'wsBob'),
+            { SET: { request } },
+            sendThrough('{reporter.connection}')
+        ]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('rejects branch-local knowledge when a sibling can write any output', () => {
+        const report = explainConnections([{
+            PARALLEL: {
+                request: {
+                    groups: [
+                        { steps: [{ SET: { request: { output: '{target}', value: {} } } }] },
+                        { steps: [selectConnection('wsAlice', 'wsBob'), sendThrough('{reporter.connection}')] }
+                    ]
+                }
+            }
+        }]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('does not approve derive branches subsequently replaced by outputPath extraction', () => {
+        const selection = selectConnection('wsAlice', 'wsBob');
+        const report = explainConnections([
+            { SET: { request: { output: 'reporter', derive: selection.SET.request.transform, outputPath: 'alternate' } } },
+            sendThrough('{reporter.connection}')
+        ]);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it('does not assume a selection succeeded when the run continues after failure', () => {
+        const report = explainConnections([selectConnection('wsAlice', 'wsBob'), sendThrough('{reporter.connection}')], false);
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+
+    it.each([true, '{continuePolicy}'])('does not assume a nonblocking selection succeeded: %s', (nonBlockingFailure) => {
+        const selection = selectConnection('wsAlice', 'wsBob');
+        Object.assign(selection.SET.request, { nonBlockingFailure });
+        expect(explainConnections([selection, sendThrough('{reporter.connection}')]).connections.missing)
+            .toEqual(['{reporter.connection}']);
+    });
+
+    it.each([{ failFast: false }, { nonBlockingFailure: true }, { failFast: '{continuePolicy}' }, { nonBlockingFailure: '{continuePolicy}' }])(
+        'honors parallel failure continuation: %j',
+        (policy) => {
+            const report = explainConnections([{
+                PARALLEL: {
+                    request: {
+                        ...policy,
+                        groups: [
+                            { steps: [selectConnection('wsAlice', 'wsBob'), sendThrough('{reporter.connection}')] }
+                        ]
+                    }
+                }
+            }]);
+            expect(report.connections.missing).toEqual(['{reporter.connection}']);
+        }
+    );
+
+    it('checks CRDT connection references as well as WebSocket references', () => {
+        const report = explainConnections([{ CRDT: { request: { connection: 'wsMissing', action: 'open' } } }]);
+        expect(report.connections.missing).toEqual(['wsMissing']);
+    });
+
+    it('does not turn an unresolved placeholder into a valid literal connection name', () => {
+        const report = explainBlackBoxRunnerPlan({
+            rawConfig: { connections: { '{reporter.connection}': { type: 'ws' } }, steps: [] },
+            executableInteractions: [sendThrough('{reporter.connection}')]
+        });
+        expect(report.connections.missing).toEqual(['{reporter.connection}']);
+    });
+});
+
+function explainConnections(executableInteractions: BlackBoxRunnerPreflightInput['executableInteractions'], failFast = true) {
+    return explainBlackBoxRunnerPlan({
+        rawConfig: { connections: { wsAlice: { type: 'ws' }, wsBob: { type: 'ws' } }, steps: [], execution: { failFast } },
+        executableInteractions,
+        profile: 'strict'
+    });
+}
+
+function selectConnection(first: string | { readonly path: string; }, second: string | { readonly path: string; }) {
+    return {
+        SET: {
+            request: {
+                output: 'reporter',
+                transform: {
+                    if: {
+                        condition: { operator: 'lexicallyBefore', values: [{ path: 'outputs.a' }, { path: 'outputs.b' }] },
+                        then: { connection: first },
+                        else: { connection: second }
+                    }
+                }
+            }
+        }
+    };
+}
+
+function sendThrough(connection: string) {
+    return { WS: { request: { action: 'send', connection } } };
+}

--- a/packages/tests/shared-test/scenario-black-box-config.test.ts
+++ b/packages/tests/shared-test/scenario-black-box-config.test.ts
@@ -744,6 +744,8 @@ describe('scenario-black-box CLI', () => {
                                 roomId: 'room-1'
                             },
                             payloadJson: '["room.join",true]',
+                            firstSessionId: 'session-a',
+                            secondSessionId: 'session-b',
                             fallback: 'fallback-value'
                         }
                     },
@@ -833,6 +835,20 @@ describe('scenario-black-box CLI', () => {
                                 { path: 'body.fallback' }
                             ]
                         },
+                        firstSessionReports: {
+                            operator: 'lexicallyBefore',
+                            values: [
+                                { path: 'body.firstSessionId' },
+                                { path: 'body.secondSessionId' }
+                            ]
+                        },
+                        secondSessionReports: {
+                            operator: 'lexicallyBefore',
+                            values: [
+                                { path: 'body.secondSessionId' },
+                                { path: 'body.firstSessionId' }
+                            ]
+                        },
                         templatedToken: {
                             template: 'token={result.actual.body.access_token}',
                             secret: true,
@@ -866,7 +882,9 @@ describe('scenario-black-box CLI', () => {
                         pendingRevision: '{pendingRevision}',
                         enabled: '{enabled}',
                         parsedPayload: '{parsedPayload}',
-                        fallbackValue: '{fallbackValue}'
+                        fallbackValue: '{fallbackValue}',
+                        firstSessionReports: '{firstSessionReports}',
+                        secondSessionReports: '{secondSessionReports}'
                     },
                     expect: {
                         body: {
@@ -879,7 +897,9 @@ describe('scenario-black-box CLI', () => {
                             pendingRevision: 47,
                             enabled: true,
                             parsedPayload: ['room.join', true],
-                            fallbackValue: 'fallback-value'
+                            fallbackValue: 'fallback-value',
+                            firstSessionReports: true,
+                            secondSessionReports: false
                         }
                     }
                 }
@@ -916,6 +936,8 @@ describe('scenario-black-box CLI', () => {
             parsedPayload: ['room.join', true],
             payloadJson: '{"roomId":"room-1"}',
             fallbackValue: 'fallback-value',
+            firstSessionReports: true,
+            secondSessionReports: false,
             templatedToken: 'token=<redacted:accessToken>'
         });
         expect(report.outputs.traceId).toMatch(/^trace-[0-9a-f-]{36}-\d+$/);

--- a/packages/tests/shared/rtc-rtt-reporting-policy.test.ts
+++ b/packages/tests/shared/rtc-rtt-reporting-policy.test.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_RTT_REPORTING_DEGREE_LIMIT, normalizeRttReportingDegreeLimit, selectRttReportingPeers } from '@shared/rtc/rtt-reporting-policy.ts';
+import {
+    DEFAULT_RTT_REPORTING_DEGREE_LIMIT,
+    isRtcRttCanonicalReporter,
+    normalizeRttReportingDegreeLimit,
+    selectRttReportingPeers
+} from '@shared/rtc/rtt-reporting-policy.ts';
 import { describe, expect, it } from 'vitest';
 
 describe('RTT reporting policy', () => {
@@ -8,6 +13,12 @@ describe('RTT reporting policy', () => {
         expect(normalizeRttReportingDegreeLimit(3, 5)).toBe(3);
         expect(normalizeRttReportingDegreeLimit(0, 5)).toBe(5);
         expect(normalizeRttReportingDegreeLimit(1.5, 5)).toBe(5);
+    });
+
+    it('assigns each unordered pair to the lexically first reporter', () => {
+        expect(isRtcRttCanonicalReporter('session-a', 'session-b')).toBe(true);
+        expect(isRtcRttCanonicalReporter('session-b', 'session-a')).toBe(false);
+        expect(isRtcRttCanonicalReporter('session-a', 'session-a')).toBe(false);
     });
 
     it('selects overlay next hops before bootstrap candidates', () => {

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -373,7 +373,7 @@ describe('WebRtcGroupManager', () => {
     it('selects at most the configured RTT reporting peers from bootstrap room peers', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -389,21 +389,54 @@ describe('WebRtcGroupManager', () => {
             createGroupSnapshot(
                 'group-1',
                 1,
-                ['self', 'peer-a', 'peer-b', 'peer-c', 'peer-d']
+                ['local', 'peer-a', 'peer-b', 'peer-c', 'peer-d']
             )
         );
 
         const selected = manager.rttReportingPeerIds({ degreeLimit: 2 });
 
         expect(selected).toHaveLength(2);
-        expect(selected).not.toContain('self');
+        expect(selected).not.toContain('local');
+    });
+
+    it('assigns an RTT pair to only the canonical browser reporter', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const sessionAManager = new WebRtcGroupManager(
+            createRtcQBoxHarness('session-a').service as never,
+            groupCache,
+            clientCache,
+            undefined,
+            { maxPeerConnections: 10, overlayTransitionGraceMs: 0 }
+        );
+        const sessionBManager = new WebRtcGroupManager(
+            createRtcQBoxHarness('session-b').service as never,
+            groupCache,
+            clientCache,
+            undefined,
+            { maxPeerConnections: 10, overlayTransitionGraceMs: 0 }
+        );
+        const group = createGroupSnapshot('group-1', 1, [
+            'session-a',
+            'session-b'
+        ]);
+        clientCache.set('session-a', createClientInfo('session-a', true));
+        clientCache.set('session-b', createClientInfo('session-b', true));
+
+        await sessionAManager.acceptGroupUpdate(group);
+        await sessionBManager.acceptGroupUpdate(group);
+
+        expect(sessionAManager.rttReportingPeerIds({ degreeLimit: 1 }))
+            .toEqual(['session-b']);
+        expect(sessionBManager.rttReportingPeerIds({ degreeLimit: 1 }))
+            .toEqual([]);
     });
 
     it('prefers overlay next hops for RTT reporting selection', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
         const overlayCache = new LatestRepository<string, OverlayInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -412,7 +445,7 @@ describe('WebRtcGroupManager', () => {
             { maxPeerConnections: 10, overlayTransitionGraceMs: 0 }
         );
         const group = createGroupSnapshot('group-1', 1, [
-            'self',
+            'local',
             'peer-a',
             'peer-b',
             'peer-c'
@@ -434,7 +467,7 @@ describe('WebRtcGroupManager', () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
         const overlayCache = new LatestRepository<string, OverlayInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -443,7 +476,7 @@ describe('WebRtcGroupManager', () => {
             { maxPeerConnections: 10, overlayTransitionGraceMs: 0 }
         );
         const group = createGroupSnapshot('group-1', 1, [
-            'self',
+            'local',
             'peer-a',
             'peer-b',
             'peer-c'
@@ -464,7 +497,7 @@ describe('WebRtcGroupManager', () => {
     it('uses server-compatible per-group bootstrap candidates for RTT reporting', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -486,23 +519,23 @@ describe('WebRtcGroupManager', () => {
         }
 
         await manager.acceptGroupUpdate(
-            createGroupSnapshot('group-1', 1, ['self', 'peer-a', 'peer-b', 'peer-c'])
+            createGroupSnapshot('group-1', 1, ['local', 'peer-a', 'peer-b', 'peer-c'])
         );
         await manager.acceptGroupUpdate(
-            createGroupSnapshot('group-2', 1, ['self', 'peer-ax', 'peer-bx', 'peer-cx'])
+            createGroupSnapshot('group-2', 1, ['local', 'peer-ax', 'peer-bx', 'peer-cx'])
         );
 
         const selected = manager.rttReportingPeerIds({ degreeLimit: 1 });
 
         expect(selected).toHaveLength(1);
         expect(selected).not.toContain('peer-cx');
-        expect(['peer-c', 'peer-bx']).toContain(selected[0]);
+        expect(['peer-b', 'peer-c', 'peer-bx']).toContain(selected[0]);
     });
 
     it('does not report RTT peers rejected by another shared active group', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -515,10 +548,10 @@ describe('WebRtcGroupManager', () => {
         }
 
         await manager.acceptGroupUpdate(
-            createGroupSnapshot('group-1', 1, ['self', 'peer-a', 'peer-b', 'peer-c'])
+            createGroupSnapshot('group-1', 1, ['local', 'peer-a', 'peer-b', 'peer-c'])
         );
         await manager.acceptGroupUpdate(
-            createGroupSnapshot('group-2', 1, ['self', 'peer-a', 'peer-b', 'peer-c'])
+            createGroupSnapshot('group-2', 1, ['local', 'peer-a', 'peer-b', 'peer-c'])
         );
 
         expect(manager.rttReportingPeerIds({ degreeLimit: 1 })).toEqual([]);
@@ -528,7 +561,7 @@ describe('WebRtcGroupManager', () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
         const overlayCache = new LatestRepository<string, OverlayInfo>();
-        const rtcQBox = createRtcQBoxHarness('self');
+        const rtcQBox = createRtcQBoxHarness('local');
         const manager = new WebRtcGroupManager(
             rtcQBox.service as never,
             groupCache,
@@ -536,7 +569,7 @@ describe('WebRtcGroupManager', () => {
             overlayCache
         );
         const group = createGroupSnapshot('group-1', 1, [
-            'self',
+            'local',
             'peer-a',
             'peer-b',
             'peer-c'

--- a/packages/tests/shared/webrtc-rtt-lifecycle.test.ts
+++ b/packages/tests/shared/webrtc-rtt-lifecycle.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
+import { LatestRepository } from '@shared/cache/LatestRepository.ts';
+import { WebRtcOverlayMulticastManager } from '@shared/multicast/WebRtcOverlayMulticastManager.ts';
+import { InMemoryQueueBox } from '@shared/queuebox/in-memory-queue-box.ts';
+import { WebRtcConnectionService, type QRtcPeerDto } from '@shared/services/WebRtcConnectionService.ts';
+import { WebRtcRxStreamerService } from '@shared/services/WebRtcRxStreamerService.ts';
+import { QRtcDataChannel } from '@shared/webrtc/QRtcDataChannel.ts';
+import { QRtcMediaChannel } from '@shared/webrtc/QRtcMediaChannel.ts';
+import { QRtcPeerConnection } from '@shared/webrtc/QRtcPeerConnection.ts';
+
+interface StreamingEndpoint {
+    readonly streamer: WebRtcRxStreamerService;
+    readonly peer: QRtcPeerDto;
+    readonly wire: LoopbackDataChannel;
+    readonly measurements: RttMeasurementInfo[];
+}
+
+describe('RTC single-reporter heartbeat lifecycle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'setTimeout', 'clearTimeout', 'performance', 'Date'] });
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps the non-reporting endpoint responsive without publishing a second RTT stream', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+
+        await vi.advanceTimersByTimeAsync(5_020);
+
+        expect(reporter.measurements).toEqual([{
+            sessionIdFrom: 'session-a',
+            sessionIdTo: 'session-b',
+            rttMs: 20,
+            createdAtEpochMs: expect.any(Number),
+            version: 2
+        }]);
+        expect(responder.measurements).toEqual([]);
+        expect(reporter.wire.sent.map((message) => JSON.parse(message).pingType)).toEqual(['ping']);
+        expect(responder.wire.sent.map((message) => JSON.parse(message).pingType)).toEqual(['pong']);
+        expect(reporter.peer.channel.isOpen()).toBe(true);
+        expect(responder.peer.channel.isOpen()).toBe(true);
+    });
+
+    it('continues answering remote pings after local reporting is disabled', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+        responder.streamer.setRttReportingPeerIds(['session-a']);
+        responder.streamer.setRttReportingPeerIds([]);
+
+        await vi.advanceTimersByTimeAsync(5_020);
+
+        expect(reporter.measurements.map((measurement) => measurement.rttMs)).toEqual([20]);
+        expect(responder.measurements).toEqual([]);
+        expect(responder.wire.sent.map((message) => JSON.parse(message).pingType)).toEqual(['pong']);
+    });
+
+    it('cleans up removed peers and resumes one monotonic stream after reconnect', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+        await vi.advanceTimersByTimeAsync(5_020);
+
+        responder.streamer.removePeer(responder.peer);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2]);
+
+        responder.streamer.addPeer(responder.peer);
+        responder.wire.open();
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2, 3]);
+        expect(responder.measurements).toEqual([]);
+
+        reporter.streamer.stopAllHeartbeats();
+        responder.streamer.stopAllHeartbeats();
+        const sentCount = reporter.wire.sent.length + responder.wire.sent.length;
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(reporter.wire.sent.length + responder.wire.sent.length).toBe(sentCount);
+    });
+
+    it('carries the reporting version across channel closure and peer replacement', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+        await vi.advanceTimersByTimeAsync(5_020);
+
+        reporter.wire.close();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2]);
+        reporter.peer.channel.connect(true);
+        reporter.wire.open();
+        await vi.advanceTimersByTimeAsync(5_020);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2, 3]);
+
+        reporter.streamer.removePeer(reporter.peer);
+        reporter.streamer.addPeer(reporter.peer);
+        reporter.wire.open();
+        await vi.advanceTimersByTimeAsync(5_020);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2, 3, 4]);
+        expect(responder.measurements).toEqual([]);
+    });
+
+    it('answers zero-origin pings but ignores malformed traffic and unsolicited passive pongs', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+        reporter.streamer.setRttReportingPeerIds([]);
+        for (
+            const message of [
+                { type: 'ping', pingType: 'invalid', ts: 0 },
+                { type: 'ping', pingType: 'ping', ts: '0' },
+                { type: 'ping', pingType: 'ping', ts: null },
+                { type: 'ping', pingType: 'pong', ts: 0 }
+            ]
+        ) {
+            reporter.wire.send(JSON.stringify(message));
+        }
+        await vi.advanceTimersByTimeAsync(20);
+        expect(responder.wire.sent).toEqual([]);
+        expect(responder.measurements).toEqual([]);
+
+        reporter.wire.send(JSON.stringify({ type: 'ping', pingType: 'ping', ts: 0 }));
+        await vi.advanceTimersByTimeAsync(20);
+        expect(responder.wire.sent.map((message) => JSON.parse(message))).toEqual([{ type: 'ping', pingType: 'pong', ts: 0 }]);
+        expect(reporter.measurements).toEqual([]);
+    });
+
+    it('resumes reporting without resetting versions or duplicating timers during refresh', async () => {
+        const reporter = createStreamingEndpoint('session-a', 'session-b');
+        const responder = createStreamingEndpoint('session-b', 'session-a');
+        openStreamingPair(reporter, responder);
+        await vi.advanceTimersByTimeAsync(5_020);
+        reporter.streamer.setRttReportingPeerIds([]);
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2]);
+
+        reporter.streamer.setRttReportingPeerIds(['session-b']);
+        reporter.streamer.setRttReportingPeerIds(['session-b']);
+        await vi.advanceTimersByTimeAsync(5_020);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2, 3]);
+
+        reporter.streamer.removePeer(reporter.peer);
+        reporter.wire.open();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(reporter.measurements.map((measurement) => measurement.version)).toEqual([2, 3]);
+    });
+});
+
+function createStreamingEndpoint(sessionId: string, peerSessionId: string): StreamingEndpoint {
+    const signaler = { send: async () => undefined, connect: async () => undefined };
+    const iceCandidates = { iceServers: [], expiresAtEpochMs: 60_000 };
+    const connection = new QRtcPeerConnection(signaler, {
+        sessionId,
+        peerSessionId,
+        token: 'test-token',
+        iceCandidates,
+        isPolite: false
+    });
+    const channel = new QRtcDataChannel(connection, { peerId: peerSessionId, dataChannelName: 'rtc-test' });
+    const wire = new LoopbackDataChannel();
+    vi.spyOn(connection, 'createDataChannel').mockReturnValue(wire);
+    const peer: QRtcPeerDto = {
+        peerId: peerSessionId,
+        connection,
+        channel,
+        channels: new Map([['reliable', channel]]),
+        media: new QRtcMediaChannel(connection, { peerId: peerSessionId })
+    };
+    const connectionService = new WebRtcConnectionService(signaler, {
+        sessionId,
+        token: 'test-token',
+        iceCandidates,
+        dataChannelName: 'rtc-test',
+        rtcSignalingTopicId: 'rtc-signaling'
+    });
+    const multicast = new WebRtcOverlayMulticastManager(
+        new InMemoryQueueBox(new Map()),
+        connectionService,
+        new LatestRepository(),
+        new LatestRepository(),
+        () => {
+            throw new Error('Heartbeat traffic must not enter multicast');
+        }
+    );
+    const streamer = new WebRtcRxStreamerService(new InMemoryQueueBox(new Map()), multicast, { sessionId });
+    const measurements: RttMeasurementInfo[] = [];
+    streamer.onRttMeasurementDo('observations', {
+        onHeartbeat: async (measurement) => {
+            measurements.push(measurement);
+        }
+    });
+    streamer.addPeer(peer);
+    channel.connect(true);
+    return { streamer, peer, wire, measurements };
+}
+
+function openStreamingPair(reporter: StreamingEndpoint, responder: StreamingEndpoint): void {
+    reporter.wire.remote = responder.wire;
+    responder.wire.remote = reporter.wire;
+    reporter.streamer.setRttReportingPeerIds(['session-b']);
+    responder.streamer.setRttReportingPeerIds([]);
+    reporter.wire.open();
+    responder.wire.open();
+}
+
+class LoopbackDataChannel extends EventTarget implements RTCDataChannel {
+    readonly label = 'rtc-test';
+    readonly id = 1;
+    readonly ordered = true;
+    readonly protocol = '';
+    readonly negotiated = false;
+    readonly maxPacketLifeTime = null;
+    readonly maxRetransmits = null;
+    readonly bufferedAmount = 0;
+    bufferedAmountLowThreshold = 0;
+    binaryType: BinaryType = 'arraybuffer';
+    readyState: RTCDataChannelState = 'connecting';
+    onopen: RTCDataChannel['onopen'] = null;
+    onclose: RTCDataChannel['onclose'] = null;
+    onclosing: RTCDataChannel['onclosing'] = null;
+    onerror: RTCDataChannel['onerror'] = null;
+    onmessage: RTCDataChannel['onmessage'] = null;
+    onbufferedamountlow: RTCDataChannel['onbufferedamountlow'] = null;
+    remote: LoopbackDataChannel | undefined;
+    readonly sent: string[] = [];
+
+    open(): void {
+        this.readyState = 'open';
+        this.onopen?.call(this, new Event('open'));
+    }
+
+    close(): void {
+        this.readyState = 'closed';
+        this.onclose?.call(this, new Event('close'));
+    }
+
+    send(data: string | Blob | ArrayBuffer | ArrayBufferView<ArrayBuffer>): void {
+        if (typeof data !== 'string' || !this.remote) {
+            throw new Error('The heartbeat wire requires a connected JSON string transport');
+        }
+        this.sent.push(data);
+        const remote = this.remote;
+        setTimeout(() => remote.onmessage?.call(remote, new MessageEvent('message', { data })), 10);
+    }
+}

--- a/packages/tests/shared/webrtc-rx-streamer-service.test.ts
+++ b/packages/tests/shared/webrtc-rx-streamer-service.test.ts
@@ -1,421 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LatestRepository } from '@shared/cache/LatestRepository.ts';
+import { WebRtcOverlayMulticastManager } from '@shared/multicast/WebRtcOverlayMulticastManager.ts';
 import { InMemoryQueueBox } from '@shared/queuebox/in-memory-queue-box.ts';
-import type { WebRtcHeartbeatServiceInputDto } from '@shared/services/WebRtcHeartbeatService.ts';
-import { WebRtcRxStreamerService, type RttMeasurementCallbacks } from '@shared/services/WebRtcRxStreamerService.ts';
-import type { OnQRtcMessageCallback } from '@shared/webrtc/QRtcClientCallbacks.ts';
-import type { QRtcMediaPolicy } from '@shared/webrtc/QRtcPeerConnection.ts';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebRtcConnectionService, type QRtcPeerDto } from '@shared/services/WebRtcConnectionService.ts';
+import { WebRtcRxStreamerService } from '@shared/services/WebRtcRxStreamerService.ts';
+import { QRtcDataChannel } from '@shared/webrtc/QRtcDataChannel.ts';
+import { QRtcMediaChannel } from '@shared/webrtc/QRtcMediaChannel.ts';
+import { QRtcPeerConnection, type QRtcOnRemoteStreamCallback } from '@shared/webrtc/QRtcPeerConnection.ts';
 
-const mockState = vi.hoisted(() => ({
-    heartbeats: [] as MockHeartbeatService[]
-}));
+interface MediaFixture {
+    readonly service: WebRtcRxStreamerService;
+    readonly peer: QRtcPeerDto;
+    readonly publishRemoteStream: QRtcOnRemoteStreamCallback;
+    readonly attachedStreams: MediaStream[];
+    readonly stoppedMediaKinds: string[];
+}
 
-vi.mock('@shared/services/WebRtcHeartbeatService.ts', () => {
-    class MockHeartbeatService {
-        public callbacks:
-            | {
-                onHeartbeat: (result: {
-                    peerSessionId: string;
-                    rttMsecs: number;
-                    version: number;
-                }) => Promise<void>;
-                onMissedHeartbeat: (peerId: string) => Promise<void>;
-            }
-            | undefined;
-        public readonly start = vi.fn((callbacks) => {
-            this.startCount += 1;
-            this.callbacks = callbacks;
+describe('WebRtcRxStreamerService media lifecycle', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('hydrates new peers with cached media settings and publishes remote streams', async () => {
+        const fixture = createMediaFixture();
+        const localStream = new EmptyMediaStream('local-1');
+        const policy = { maxVideoBitrateBps: 120_000, maxAudioBitrateBps: 48_000 };
+        const received: MediaStream[] = [];
+        fixture.service.onRemoteStreamDo('remote', async (_peerId, stream) => {
+            received.push(stream);
         });
-        public readonly stop = vi.fn(() => {
-            this.stopCount += 1;
-        });
-        public startCount = 0;
-        public stopCount = 0;
 
-        public readonly input: WebRtcHeartbeatServiceInputDto;
+        await fixture.service.setLocalMediaStream(localStream);
+        fixture.service.setLocalAudioEnabled(true);
+        fixture.service.setLocalVideoEnabled(false);
+        fixture.service.setMediaPolicy(policy);
+        fixture.service.addPeer(fixture.peer);
 
-        constructor(input: WebRtcHeartbeatServiceInputDto) {
-            this.input = input;
-            mockState.heartbeats.push(this);
-        }
-    }
-
-    return {
-        WebRtcHeartbeatService: MockHeartbeatService,
-        defaultMaxMissedPings: 5,
-        defaultPingFrequencyMsecs: 5_000
-    };
-});
-
-describe('WebRtcRxStreamerService', () => {
-    beforeEach(() => {
-        mockState.heartbeats.length = 0;
-        vi.restoreAllMocks();
+        await vi.waitFor(() => expect(fixture.peer.media.status.localVideoEnabled).toBe(false));
+        expect(fixture.peer.connection.status.mediaPolicy).toEqual(policy);
+        expect(fixture.attachedStreams).toEqual([localStream]);
+        expect(fixture.peer.media.status.localAudioEnabled).toBe(true);
+        const remoteStream = new EmptyMediaStream('remote-1');
+        await fixture.publishRemoteStream(remoteStream, new Event('track') as RTCTrackEvent);
+        expect(received).toEqual([remoteStream]);
     });
 
-    it('hydrates new peers with cached media state and relays remote stream and RTT events', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            {
-                sessionId: 'self'
-            }
-        );
-
-        const localStream = createMediaStream('local-1');
-        const policy = {
-            maxVideoBitrateBps: 120_000,
-            maxAudioBitrateBps: 48_000
-        };
-        const onRemoteStream = vi.fn(async () => {
-        });
-        const onRtcMessage = {
-            onMessage: vi.fn(async () => {
-            })
-        };
-        const onRttMeasurement = {
-            onHeartbeat: vi.fn(async () => {
-            })
-        };
-
-        await service.setLocalMediaStream(localStream);
-        service.setLocalAudioEnabled(true);
-        service.setLocalVideoEnabled(false);
-        service.setMediaPolicy(policy);
-        service.onRemoteStreamDo('remote', onRemoteStream);
-        service.onRtcMessageDo('tap', onRtcMessage);
-        service.onRttMeasurementDo('rtt', onRttMeasurement);
-
-        const peer = createPeerDto('peer-1');
-        service.addPeer(peer as never);
-
-        expect(mockState.heartbeats).toHaveLength(0);
-        expect(peer.connection.applyMediaPolicy).toHaveBeenCalledWith(policy);
-        expect(peer.media.setParameters).toHaveBeenCalledWith(localStream, true, false);
-        expect(peer.channel.onRtcCallbacksDo).toHaveBeenCalledWith(
-            'self-peer-1-rtc-datachannel-lifecycle',
-            expect.any(Object)
-        );
-        expect(peer.channel.onRtcMessageDo).toHaveBeenCalledWith(
-            'self-peer-1-rtc-inbox',
-            expect.any(Object)
-        );
-        expect(peer.channel.onRtcMessageDo).toHaveBeenCalledWith('tap', onRtcMessage);
-
-        const lifecycle = peer.channel.lifecycleCallbacks.get(
-            'self-peer-1-rtc-datachannel-lifecycle'
-        );
-        await lifecycle?.onOpen?.();
-
-        expect(mockState.heartbeats).toHaveLength(1);
-        expect(mockState.heartbeats[0].startCount).toBe(1);
-
-        const remoteStream = createMediaStream('remote-1');
-        const remoteEvent = createTrackEvent(remoteStream);
-        await peer.media.emitRemoteStream(remoteStream, remoteEvent);
-
-        expect(onRemoteStream).toHaveBeenCalledWith('peer-1', remoteStream, remoteEvent);
-
-        await mockState.heartbeats[0].callbacks?.onHeartbeat({
-            peerSessionId: 'peer-1',
-            rttMsecs: 42,
-            version: 3
+    it('updates existing peers and stops publishing their remote streams after removal', async () => {
+        const fixture = createMediaFixture();
+        fixture.service.addPeer(fixture.peer);
+        const localStream = new EmptyMediaStream('local-2');
+        const policy = { preferredVideoCodecs: ['video/VP8'] };
+        const received: MediaStream[] = [];
+        fixture.service.onRemoteStreamDo('remote', async (_peerId, stream) => {
+            received.push(stream);
         });
 
-        expect(onRttMeasurement.onHeartbeat).toHaveBeenCalledWith({
-            sessionIdFrom: 'self',
-            sessionIdTo: 'peer-1',
-            rttMs: 42,
-            createdAtEpochMs: expect.any(Number),
-            version: 3
-        });
+        await fixture.service.setLocalMediaStream(localStream);
+        fixture.service.setLocalAudioEnabled(true);
+        fixture.service.setLocalVideoEnabled(true);
+        fixture.service.stopLocalMedia('video');
+        fixture.service.setMediaPolicy(policy);
 
-        service.addPeer(peer as never);
-        expect(mockState.heartbeats).toHaveLength(1);
-    });
-
-    it('updates existing peers on media changes and tears down lifecycle wiring when removed', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            {
-                sessionId: 'self'
-            }
-        );
-
-        const peer = createPeerDto('peer-1');
-        service.addPeer(peer as never);
-
-        const lifecycle = peer.channel.lifecycleCallbacks.get(
-            'self-peer-1-rtc-datachannel-lifecycle'
-        );
-        expect(lifecycle).toBeDefined();
-        expect(mockState.heartbeats).toHaveLength(0);
-
-        const localStream = createMediaStream('local-2');
-        const policy = {
-            preferredVideoCodecs: ['video/VP8']
-        };
-
-        await service.setLocalMediaStream(localStream);
-        service.setLocalAudioEnabled(true);
-        service.setLocalVideoEnabled(true);
-        service.stopLocalMedia('video');
-        service.setMediaPolicy(policy);
-
-        expect(peer.media.localMediaStream).toBe(localStream);
-        expect(peer.media.localAudioEnabled).toBe(true);
-        expect(peer.media.localVideoEnabled).toBe(true);
-        expect(peer.media.stoppedMediaKinds).toContain('video');
-        expect(peer.connection.appliedMediaPolicy).toBe(policy);
-
-        await lifecycle?.onOpen?.();
-
-        expect(mockState.heartbeats).toHaveLength(1);
-        const firstHeartbeat = mockState.heartbeats[0];
-
-        await lifecycle?.onOpen?.();
-
-        expect(firstHeartbeat.stopCount).toBe(1);
-        expect(mockState.heartbeats).toHaveLength(2);
-
-        await lifecycle?.onClose?.();
-
-        expect(mockState.heartbeats[1].stopCount).toBe(1);
-
-        service.removePeer(peer as never);
-
-        expect(peer.media.removeOnRemoteStreamCallbackById).toHaveBeenCalledWith(
-            'self-peer-1-rtc-media-remote-stream'
-        );
-        expect(peer.channel.removeOnRtcMessageCallbackById).toHaveBeenCalledWith(
-            'self-peer-1-rtc-inbox'
-        );
-        expect(peer.channel.removeOnRtcMessageCallbackById).toHaveBeenCalledWith(
-            'self-peer-1-rtc-datachannel-lifecycle'
-        );
-    });
-
-    it('keeps RTT versions monotonic when a peer heartbeat restarts', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            { sessionId: 'self' }
-        );
-        const measurements: Parameters<RttMeasurementCallbacks['onHeartbeat']>[0][] = [];
-        const onHeartbeat: RttMeasurementCallbacks['onHeartbeat'] = async (measurement) => {
-            measurements.push(measurement);
-        };
-        service.onRttMeasurementDo('rtt', { onHeartbeat });
-
-        const peer = createPeerDto('peer-1');
-        service.addPeer(peer as never);
-        const lifecycle = peer.channel.lifecycleCallbacks.get(
-            'self-peer-1-rtc-datachannel-lifecycle'
-        );
-
-        await lifecycle?.onOpen?.();
-        await mockState.heartbeats[0].callbacks?.onHeartbeat({
-            peerSessionId: 'peer-1',
-            rttMsecs: 10,
-            version: 2
-        });
-        await lifecycle?.onOpen?.();
-        await mockState.heartbeats[1].callbacks?.onHeartbeat({
-            peerSessionId: 'peer-1',
-            rttMsecs: 11,
-            version: 2
-        });
-
-        expect(measurements.map((rtt) => rtt.version)).toEqual([2, 3]);
-    });
-
-    it('does not start RTT heartbeats for peers outside the reporting set', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            { sessionId: 'self' }
-        );
-        service.setRttReportingPeerIds(['peer-1']);
-
-        const peer1 = createPeerDto('peer-1');
-        const peer2 = createPeerDto('peer-2');
-        service.addPeer(peer1 as never);
-        service.addPeer(peer2 as never);
-
-        await peer1.channel.lifecycleCallbacks
-            .get('self-peer-1-rtc-datachannel-lifecycle')?.onOpen?.();
-        await peer2.channel.lifecycleCallbacks
-            .get('self-peer-2-rtc-datachannel-lifecycle')?.onOpen?.();
-
-        expect(mockState.heartbeats).toHaveLength(1);
-        expect((mockState.heartbeats[0].input as { peerSessionId: string; }).peerSessionId)
-            .toBe('peer-1');
-    });
-
-    it('stops RTT heartbeats when a peer leaves the reporting set', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            { sessionId: 'self' }
-        );
-        service.setRttReportingPeerIds(['peer-1']);
-
-        const peer = createPeerDto('peer-1');
-        service.addPeer(peer as never);
-        await peer.channel.lifecycleCallbacks
-            .get('self-peer-1-rtc-datachannel-lifecycle')?.onOpen?.();
-
-        service.setRttReportingPeerIds([]);
-
-        expect(mockState.heartbeats[0].stopCount).toBe(1);
-    });
-
-    it('starts RTT heartbeat for an already-open peer when it enters the reporting set', async () => {
-        const service = new WebRtcRxStreamerService(
-            new InMemoryQueueBox(new Map()),
-            createFakeMulticastManager() as never,
-            { sessionId: 'self' }
-        );
-        service.setRttReportingPeerIds([]);
-
-        const peer = createPeerDto('peer-1');
-        service.addPeer(peer as never);
-        await peer.channel.lifecycleCallbacks
-            .get('self-peer-1-rtc-datachannel-lifecycle')?.onOpen?.();
-
-        expect(mockState.heartbeats).toHaveLength(0);
-
-        service.setRttReportingPeerIds(['peer-1']);
-
-        expect(mockState.heartbeats).toHaveLength(1);
+        expect(fixture.attachedStreams).toEqual([localStream]);
+        expect(fixture.peer.media.status.localAudioEnabled).toBe(true);
+        expect(fixture.peer.media.status.localVideoEnabled).toBe(true);
+        expect(fixture.stoppedMediaKinds).toEqual(['video']);
+        expect(fixture.peer.connection.status.mediaPolicy).toEqual(policy);
+        fixture.service.removePeer(fixture.peer);
+        await fixture.publishRemoteStream(new EmptyMediaStream('removed-remote'), new Event('track') as RTCTrackEvent);
+        expect(received).toEqual([]);
     });
 });
 
-class FakeRtcChannel {
-    public readonly lifecycleCallbacks = new Map<string, {
-        onOpen?: () => Promise<void>;
-        onError?: () => Promise<void>;
-        onClose?: () => Promise<void>;
-    }>();
-    public readonly messageCallbacks = new Map<string, OnQRtcMessageCallback>();
-    public readonly onRtcCallbacksDo = vi.fn(
-        (
-            id: string,
-            callbacks: {
-                onOpen?: () => Promise<void>;
-                onError?: () => Promise<void>;
-                onClose?: () => Promise<void>;
-            }
-        ) => {
-            this.lifecycleCallbacks.set(id, callbacks);
-            return this;
-        }
-    );
-    public readonly onRtcMessageDo = vi.fn((id: string, callback: OnQRtcMessageCallback) => {
-        this.messageCallbacks.set(id, callback);
-        return this;
+function createMediaFixture(): MediaFixture {
+    const signaler = { send: async () => undefined, connect: async () => undefined };
+    const iceCandidates = { iceServers: [], expiresAtEpochMs: 60_000 };
+    const connection = new QRtcPeerConnection(signaler, {
+        sessionId: 'self',
+        peerSessionId: 'peer-1',
+        token: 'test-token',
+        iceCandidates,
+        isPolite: false
     });
-    public readonly removeOnRtcMessageCallbackById = vi.fn((id: string) => {
-        return this.messageCallbacks.delete(id) || this.lifecycleCallbacks.delete(id);
-    });
-    public readonly sendAsJsonString = vi.fn(async () => {
-    });
-    public readonly send = vi.fn(async () => {
-    });
-    public readonly isOpen = vi.fn(() => true);
-}
-
-class FakeRtcMedia {
-    public readonly remoteStreamCallbacks = new Map<string, RemoteStreamCallback>();
-    public localMediaStream: MediaStream | undefined;
-    public localAudioEnabled: boolean | undefined;
-    public localVideoEnabled: boolean | undefined;
-    public readonly stoppedMediaKinds: string[] = [];
-    public readonly onRemoteStreamDo = vi.fn(
-        (id: string, cb: RemoteStreamCallback) => {
-            this.remoteStreamCallbacks.set(id, cb);
-            return this;
-        }
-    );
-    public readonly removeOnRemoteStreamCallbackById = vi.fn((id: string) => {
-        return this.remoteStreamCallbacks.delete(id);
-    });
-    public readonly setParameters = vi.fn(async () => {
-    });
-    public readonly setLocalMediaStream = vi.fn(async (stream: MediaStream) => {
-        this.localMediaStream = stream;
-    });
-    public readonly setLocalAudioEnabled = vi.fn((enabled: boolean) => {
-        this.localAudioEnabled = enabled;
-    });
-    public readonly setLocalVideoEnabled = vi.fn((enabled: boolean) => {
-        this.localVideoEnabled = enabled;
-    });
-    public readonly stopLocalMedia = vi.fn((kind: string) => {
-        this.stoppedMediaKinds.push(kind);
-    });
-
-    async emitRemoteStream(stream: MediaStream, event: RTCTrackEvent): Promise<void> {
-        for (const callback of this.remoteStreamCallbacks.values()) {
-            await callback(stream, event);
-        }
+    const channel = new QRtcDataChannel(connection, { peerId: 'peer-1', dataChannelName: 'test' });
+    const media = new QRtcMediaChannel(connection, { peerId: 'peer-1' });
+    const subscription = vi.spyOn(connection, 'onRemoteStreamDo');
+    media.connect();
+    const publishRemoteStream = subscription.mock.calls[0]?.[1];
+    if (!publishRemoteStream) {
+        throw new Error('Expected media subscription on the peer event port');
     }
-}
-
-type MockHeartbeatService = {
-    readonly input: WebRtcHeartbeatServiceInputDto;
-    readonly start: ReturnType<typeof vi.fn>;
-    readonly stop: ReturnType<typeof vi.fn>;
-    readonly startCount: number;
-    readonly stopCount: number;
-    callbacks?:
-        | {
-            onHeartbeat: (result: {
-                peerSessionId: string;
-                rttMsecs: number;
-                version: number;
-            }) => Promise<void>;
-            onMissedHeartbeat: (peerId: string) => Promise<void>;
+    const attachedStreams: MediaStream[] = [];
+    const stoppedMediaKinds: string[] = [];
+    vi.spyOn(connection, 'setLocalMediaStream').mockImplementation(async (stream) => {
+        attachedStreams.push(stream);
+    });
+    vi.spyOn(connection, 'stopLocalMedia').mockImplementation((kind) => {
+        stoppedMediaKinds.push(kind);
+    });
+    const connectionService = new WebRtcConnectionService(signaler, {
+        sessionId: 'self',
+        token: 'test-token',
+        iceCandidates,
+        dataChannelName: 'test',
+        rtcSignalingTopicId: 'rtc-signaling'
+    });
+    const multicast = new WebRtcOverlayMulticastManager(
+        new InMemoryQueueBox(new Map()),
+        connectionService,
+        new LatestRepository(),
+        new LatestRepository(),
+        () => {
+            throw new Error('Media control must not construct multicast messages');
         }
-        | undefined;
-};
-
-type RemoteStreamCallback = (
-    stream: MediaStream,
-    event: RTCTrackEvent
-) => Promise<void>;
-
-function createPeerDto(peerId: string) {
-    const connection = {
-        appliedMediaPolicy: undefined as QRtcMediaPolicy | undefined,
-        applyMediaPolicy: vi.fn((policy: QRtcMediaPolicy) => {
-            connection.appliedMediaPolicy = policy;
-        })
-    };
+    );
+    const service = new WebRtcRxStreamerService(new InMemoryQueueBox(new Map()), multicast, { sessionId: 'self' });
+    service.setRttReportingPeerIds([]);
     return {
-        peerId,
-        channel: new FakeRtcChannel(),
-        media: new FakeRtcMedia(),
-        connection
+        service,
+        peer: { peerId: 'peer-1', connection, channel, channels: new Map([['reliable', channel]]), media },
+        publishRemoteStream,
+        attachedStreams,
+        stoppedMediaKinds
     };
 }
 
-function createFakeMulticastManager() {
-    return {
-        planIncomingMessage: vi.fn(),
-        enqueueIfAbsent: vi.fn(async () => []),
-        acceptControlMessage: vi.fn(async () => {
-        }),
-        forwardIfRequired: vi.fn(async () => [])
-    };
-}
+class EmptyMediaStream extends EventTarget implements MediaStream {
+    readonly active = true;
+    readonly id: string;
+    onaddtrack: MediaStream['onaddtrack'] = null;
+    onremovetrack: MediaStream['onremovetrack'] = null;
 
-function createMediaStream(id: string): MediaStream {
-    return { id } as MediaStream;
-}
+    constructor(id: string) {
+        super();
+        this.id = id;
+    }
 
-function createTrackEvent(stream: MediaStream): RTCTrackEvent {
-    const event = new Event('track') as RTCTrackEvent;
-    Object.defineProperty(event, 'streams', { value: [stream] });
-    return event;
+    getTracks(): MediaStreamTrack[] {
+        return [];
+    }
+    getAudioTracks(): MediaStreamTrack[] {
+        return [];
+    }
+    getVideoTracks(): MediaStreamTrack[] {
+        return [];
+    }
+    getTrackById(_id: string): null {
+        return null;
+    }
+    clone(): MediaStream {
+        return new EmptyMediaStream(this.id);
+    }
+    addTrack(_track: MediaStreamTrack): void {
+        throw new Error('This media fixture has no native tracks');
+    }
+    removeTrack(_track: MediaStreamTrack): void {
+        throw new Error('This media fixture has no native tracks');
+    }
 }


### PR DESCRIPTION
## Goal

Restore one canonical RTT publisher per unordered session pair without losing heartbeat replies or allowing competing reports to claim its durable identity.

## Changes

- Elect the lexically smaller session endpoint in browser selection, server acceptance, and authored synthetic recipes.
- Keep passive pong responders running on both endpoints; reporting can pause independently. Preserve monotonically increasing versions across reconnect/removal and remove lifecycle callbacks on teardown.
- Validate sender and canonical ownership before AppInbox enqueue, so reverse or spoofed reports cannot poison the canonical idempotency slot.
- Recognize bounded two-connection SET selections during preflight. Reject unresolved overwrites, parallel races, extraction overrides, reserved roots, and failure-continuing policies.
- Replace implementation-coupled assertions with real two-endpoint lifecycle tests, durable enqueue arrival-order tests, and actual compiled-recipe WebSocket execution.
- Normalize raw RTC values at channel callbacks before typed internal handlers. Retain the AL decoder and every heartbeat field check. Validate heartbeat payloads with a type guard instead of allocating a duplicate object.
- Decode compiled-recipe JSON using the existing JSON decoder, check recursive PARALLEL container shapes, and preserve complete executable operations. Remove the broad unknown dictionary; no style exemptions or checker changes are needed.

## Acceptance

- [x] One reporting endpoint still receives pongs from the passive endpoint.
- [x] Pausing, reconnecting, and removing peers preserve lifecycle ownership and version monotonicity.
- [x] Invalid senders leave the canonical durable slot available in either arrival order.
- [x] All four authored RTT recipes pass strict preflight and route through the canonical sender in either session ordering.
- [x] Malformed compiled interactions are rejected before report-operation selection.
- [x] Independent review found no remaining correctness blockers, including the boundary follow-up.
- [x] The three changed-style failures are resolved in code without exemptions.
- [x] State-write performance comparison for the server mutation changes.
- [x] Current Branch Release Gate.

## Validation

- Final full local unit suite: 8,396 tests passed, nine skipped; 996 files passed, four skipped. The previously failing headless bundle test now passes under its unchanged cap.
- Full local Deno test command and all three deployable app builds passed.
- Final boundary follow-up: 84 tests passed across 12 files in one focused run, covering heartbeat/lifecycle, channel delivery, AL decoding/inbound runtime, canonical selection, recipe execution, browser/headless bundle boundaries, and public API snapshots.
- Three new malformed compiled-recipe cases failed before the fix and passed afterward; the original changed-style gate reproduced all three failures before the fix and passes afterward.
- `npx tsc -p packages/shared/tsconfig.json --noEmit` and the shared-web equivalent: passed.
- `npm --workspace @ar-eye-hunter/shared-test run check`: TypeScript and Deno checks passed.
- `npm run typecheck:tests`: 970 test files, zero errors/debt.
- `npm run check:repo-structure -- --base <PR base>`, touched-file dprint, and `git diff --check`: passed.
- `node scripts/check-changed-repo-style.mjs <PR base> WORKTREE`: passed with no new findings.
- Committed-range test structure-coupling: passed with no current candidates. Retained-legacy registry: passed. The 16 heuristic legacy candidates remain resolved as active CLI profile/environment fallback and peer degree-default policies, not superseded implementations.
- Warning-only style review: the remaining heartbeat unknown is confined to its type guard; recipe callback nesting represents real test/socket lifecycle boundaries. Canonical public service import paths remain unchanged.
- Earlier server/runner validation remains applicable to unchanged production paths: 210 focused tests, shared-server typecheck, and the 100-client/five-group/three-API PostgreSQL gate passed with 2,757 successful operations and zero failures.
- The state-write baseline and candidate each used freshly migrated isolated databases, accepted 6,300 measured commands with zero exhausted retries or atomic-completion failures, and passed `compare-api-v1-state-write-results.mjs`. This follow-up changes no server mutation or production runner code; no performance-improvement claim is made.
- Native CI passed changed-style and structure-coupling checks, then exposed a headless bundle regression: 203.022 KiB against the existing 203 KiB cap. Replacing heartbeat reconstruction with an equivalent guard reduced it to 202.972 KiB with the cap unchanged. The guard received an independent correctness review; no runtime speedup is claimed.
- Additional local Node 24 validation: all 15 heartbeat, lifecycle, formation-churn, and headless bundle tests passed.
- Current Branch Release Gate passed in full: changed-style/coupling, typechecks, the full root suite (unit, Deno, browser, and in-memory full-stack), app builds, Deno app checks, PostgreSQL integration, API black-box recipes, topology replay, smoke tests, and repeated presence-expiry tests. Validation evidence publication and the final gate result passed. Medium-scale, formation-large, topology replay, and CodeQL workflows also passed.

## Risk and rollback

No persisted format, wire payload, canonical pair identity, or public export/signature changes in the boundary follow-up. Decoding remains inside async callbacks so rejected inputs retain channel-owned error handling; all heartbeat field checks and handler effects are preserved. Complete compiled operations are retained for real runner execution.

All changed human-authored files were reviewed in full and the boundary noncompliance was remediated. Any support file modified by remediation enters closure recursively; none additional were needed for this follow-up. Independent untouched code remains outside closure. Revert this PR to restore the previous reporting policy.

## Follow-up

None outside this PR. Native human review or an intentional authorized administrator merge remains.
