### PR TITLE
fix(rtc-bench): wait for authoritative room readiness

### DIFF
--- a/packages/tests/rallar-black-box/live-rtc-browser-agents.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-browser-agents.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { openLiveRtcBrowserAgent, type OpenLiveRtcBrowserAgentInput } from '../../../tests/playwright/rallar-black-box/live-rtc-browser-agents.ts';
+import {
+    closeLiveRtcBrowserAgentContexts,
+    openLiveRtcBrowserAgent,
+    type OpenLiveRtcBrowserAgentInput
+} from '../../../tests/playwright/rallar-black-box/live-rtc-browser-agents.ts';
 
 const agentInput: OpenLiveRtcBrowserAgentInput = {
     config: { spaBaseUrl: 'http://localhost', apiBaseUrl: 'http://localhost', controlWsUrl: 'ws://localhost', register: false },
@@ -36,5 +40,26 @@ describe('live RTC browser agent startup', () => {
 
         await expect(openLiveRtcBrowserAgent(browser, agentInput)).rejects.toBe(startupFailure);
         expect(allocatedContexts).toBe(0);
+    });
+    it('settles every owned context even when one close fails, so evidence finalization can continue', async () => {
+        const closed: string[] = [];
+        await closeLiveRtcBrowserAgentContexts([
+            {
+                context: {
+                    close: async () => {
+                        closed.push('A');
+                        throw new Error('close-failed');
+                    }
+                }
+            },
+            {
+                context: {
+                    close: async () => {
+                        closed.push('B');
+                    }
+                }
+            }
+        ]);
+        expect(closed.sort()).toEqual(['A', 'B']);
     });
 });

--- a/packages/tests/rallar-black-box/live-rtc-browser-agents.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-browser-agents.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { openLiveRtcBrowserAgent, type OpenLiveRtcBrowserAgentInput } from '../../../tests/playwright/rallar-black-box/live-rtc-browser-agents.ts';
+
+const agentInput: OpenLiveRtcBrowserAgentInput = {
+    config: { spaBaseUrl: 'http://localhost', apiBaseUrl: 'http://localhost', controlWsUrl: 'ws://localhost', register: false },
+    prefix: 'A',
+    auth: { kind: 'login', username: 'test-user', password: 'test-password' },
+    runId: 'startup-run',
+    agentId: 'agent-a',
+    actor: 'actor-a',
+    connection: 'connection-a',
+    groupId: 'startup-room'
+};
+
+describe('live RTC browser agent startup', () => {
+    it.each([false, true])('releases its context and preserves startup failure when cleanup fails=%s', async (cleanupFails) => {
+        let allocatedContexts = 0;
+        const startupFailure = new Error('page-start-failed');
+        const browser = {
+            newContext: async () => {
+                allocatedContexts++;
+                return {
+                    newPage: async () => {
+                        throw startupFailure;
+                    },
+                    close: async () => {
+                        allocatedContexts--;
+                        if (cleanupFails) {
+                            throw new Error('cleanup-failed');
+                        }
+                    }
+                };
+            }
+        };
+
+        await expect(openLiveRtcBrowserAgent(browser, agentInput)).rejects.toBe(startupFailure);
+        expect(allocatedContexts).toBe(0);
+    });
+});

--- a/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
@@ -1,0 +1,195 @@
+import { request, type APIRequestContext, type Page } from '@playwright/test';
+import { createServer, type Server } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LiveRtcControlClient } from '../../../tests/playwright/rallar-black-box/live-rtc-control-client.ts';
+import { normalizeJson } from '../../../tests/playwright/rallar-black-box/live-rtc-evidence-json.ts';
+
+interface ControlResult {
+    commandId: string;
+    ok: boolean;
+    result: { value: { rallar: { rtcStatus: { readyPeerIds: string[]; }; }; }; };
+}
+
+describe('live RTC control client', () => {
+    let server: Server;
+    let api: APIRequestContext;
+    let control: LiveRtcControlClient;
+    let nowMs: number;
+    const evaluate = vi.fn<Page['evaluate']>();
+    const agent = { agentId: 'agent-a', prefix: 'A' as const, page: { evaluate } };
+
+    beforeEach(async () => {
+        nowMs = 100;
+        const results: ControlResult[] = [];
+        server = createServer(async (incoming, response) => {
+            if (incoming.method === 'POST') {
+                const chunks: Buffer[] = [];
+                for await (const chunk of incoming) {
+                    chunks.push(Buffer.from(chunk));
+                }
+                const command = normalizeJson(JSON.parse(Buffer.concat(chunks).toString()));
+                if (!command || typeof command !== 'object' || !('commandId' in command) || typeof command.commandId !== 'string') {
+                    response.writeHead(400).end();
+                    return;
+                }
+                results.push({
+                    commandId: command.commandId,
+                    ok: true,
+                    result: { value: { rallar: { rtcStatus: { readyPeerIds: ['session-b', 'session-c'] } } } }
+                });
+                response.writeHead(202).end('{}');
+                return;
+            }
+            response.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ results }));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+            throw new Error('Expected a local control HTTP port.');
+        }
+        api = await request.newContext();
+        control = new LiveRtcControlClient({
+            request: api,
+            baseUrl: `http://127.0.0.1:${address.port}`,
+            monotonicNow: () => nowMs,
+            epochNow: () => 0
+        });
+        evaluate.mockImplementation(async (callback, argument) => {
+            if (typeof callback !== 'function') {
+                throw new Error('Expected a browser callback.');
+            }
+            return callback(argument);
+        });
+    });
+
+    afterEach(async () => {
+        await api.dispose();
+        await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        evaluate.mockReset();
+    });
+
+    it('waits for refreshed room membership and includes refresh time in readiness', async () => {
+        const refresh = Promise.withResolvers<void>();
+        let roomMembers = ['session-a'];
+        let refreshStarted = false;
+        let completed = false;
+        vi.stubGlobal('window', {
+            __blackBoxRallar: {
+                refreshRoom: async () => {
+                    refreshStarted = true;
+                    await refresh.promise;
+                    roomMembers = ['session-a', 'session-b', 'session-c'];
+                    nowMs = 350;
+                }
+            }
+        });
+
+        const readiness = control.waitForPeerReadiness({
+            runId: 'run-readiness',
+            agent,
+            expectedPeerIds: ['session-b', 'session-c'],
+            suffix: 'delivery',
+            startedAtMs: 100
+        }).then((durationMs) => {
+            completed = true;
+            return durationMs;
+        });
+        try {
+            await vi.waitFor(() => expect(refreshStarted).toBe(true));
+            expect(completed).toBe(false);
+            expect(roomMembers).toEqual(['session-a']);
+        }
+        finally {
+            refresh.resolve();
+        }
+        expect(await readiness).toBe(250);
+        expect(roomMembers).toEqual(['session-a', 'session-b', 'session-c']);
+    });
+
+    it('rejects readiness when authoritative room refresh fails', async () => {
+        vi.stubGlobal('window', {
+            __blackBoxRallar: {
+                refreshRoom: async () => {
+                    throw new Error('room refresh unavailable');
+                }
+            }
+        });
+
+        await expect(control.waitForPeerReadiness({
+            runId: 'run-readiness',
+            agent,
+            expectedPeerIds: ['session-b'],
+            suffix: 'delivery',
+            startedAtMs: 100
+        })).rejects.toThrow('room refresh unavailable');
+    });
+
+    it('rejects readiness when the browser runtime is missing', async () => {
+        vi.stubGlobal('window', {});
+
+        await expect(control.waitForPeerReadiness({
+            runId: 'run-readiness',
+            agent,
+            expectedPeerIds: ['session-b'],
+            suffix: 'delivery',
+            startedAtMs: 100
+        })).rejects.toThrow('room refresh');
+    });
+
+    it('does not report readiness after room refresh exhausts the shared deadline', async () => {
+        vi.stubGlobal('window', {
+            __blackBoxRallar: {
+                refreshRoom: async () => {
+                    nowMs = 60_101;
+                }
+            }
+        });
+
+        await expect(control.waitForPeerReadiness({
+            runId: 'run-readiness',
+            agent,
+            expectedPeerIds: ['session-b'],
+            suffix: 'delivery',
+            startedAtMs: 100
+        })).rejects.toThrow('readiness deadline');
+    });
+
+    it('reads the sent message identity from the RTC send-result envelope, not the command ID', () => {
+        expect(control.requireSentMessageId({
+            commandId: 'nack-probe-command',
+            ok: true,
+            result: { value: { message: { transport: 'rtc', status: 'sent', message: { id: { msgId: 'wire-message' } } } } }
+        })).toBe('wire-message');
+        expect(() => control.requireSentMessageId({ commandId: 'nack-probe-command', ok: true }))
+            .toThrow('message ID');
+    });
+
+    it('attaches received-NACK proof with the message and peer identities', async () => {
+        let artifact = '';
+        await control.recordReceivedNack({
+            testInfo: {
+                attach: async (_name, options) => {
+                    artifact = String(options?.body);
+                }
+            },
+            runId: 'run-nack',
+            agentId: 'agent-a',
+            messageId: 'wire-message',
+            senderSessionId: 'session-a',
+            targetSessionId: 'session-b',
+            frames: ['received-wire-frame']
+        });
+        expect(JSON.parse(artifact)).toEqual({
+            observation: 'received-protocol-nack',
+            runId: 'run-nack',
+            agentId: 'agent-a',
+            messageId: 'wire-message',
+            senderSessionId: 'session-a',
+            targetSessionId: 'session-b',
+            frames: ['received-wire-frame']
+        });
+    });
+});

--- a/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-performance-evidence.test.ts
@@ -2,11 +2,11 @@ import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { countUnexpectedLiveRtcDeliveries } from '../../../tests/playwright/rallar-black-box/live-rtc-control-client.ts';
 import {
     buildLiveRtcAgentDiagnostics,
     buildLiveRtcExternalAttempt,
     buildLiveRtcRetentionCohort,
-    countUnexpectedLiveRtcDeliveries,
     liveRtcRetentionStateReturned,
     loadLiveRtcPerformanceAttempt,
     writeLiveRtcPerformanceEvidence,
@@ -189,6 +189,65 @@ function agentDiagnostics(agentId: 'agent-a' | 'agent-b' | 'agent-c') {
     } as const;
 }
 
+const defaultTimings: LiveRtcPerformanceRawEvidence['timings'] = [
+    {
+        kind: 'peer-ready',
+        transport: 'realtime',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 12
+    },
+    {
+        kind: 'direct-delivery',
+        transport: 'realtime',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b'],
+        durationMs: 4
+    },
+    {
+        kind: 'multicast-delivery',
+        transport: 'realtime',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 5
+    },
+    {
+        kind: 'broadcast-delivery',
+        transport: 'realtime',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 6
+    },
+    {
+        kind: 'peer-ready',
+        transport: 'messages.rtc',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 13
+    },
+    {
+        kind: 'direct-delivery',
+        transport: 'messages.rtc',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b'],
+        durationMs: 7
+    },
+    {
+        kind: 'multicast-delivery',
+        transport: 'messages.rtc',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 8
+    },
+    {
+        kind: 'broadcast-delivery',
+        transport: 'messages.rtc',
+        senderAgentId: 'agent-a',
+        receiverAgentIds: ['agent-b', 'agent-c'],
+        durationMs: 9
+    }
+];
+
 function defaultRawEvidence(
     overrides: Partial<LiveRtcPerformanceRawEvidence> = {}
 ): LiveRtcPerformanceRawEvidence {
@@ -223,64 +282,7 @@ function defaultRawEvidence(
             playwright: '1.55.0',
             chromium: '140.0.0.0'
         },
-        timings: [
-            {
-                kind: 'peer-ready',
-                transport: 'realtime',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 12
-            },
-            {
-                kind: 'direct-delivery',
-                transport: 'realtime',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b'],
-                durationMs: 4
-            },
-            {
-                kind: 'multicast-delivery',
-                transport: 'realtime',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 5
-            },
-            {
-                kind: 'broadcast-delivery',
-                transport: 'realtime',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 6
-            },
-            {
-                kind: 'peer-ready',
-                transport: 'messages.rtc',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 13
-            },
-            {
-                kind: 'direct-delivery',
-                transport: 'messages.rtc',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b'],
-                durationMs: 7
-            },
-            {
-                kind: 'multicast-delivery',
-                transport: 'messages.rtc',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 8
-            },
-            {
-                kind: 'broadcast-delivery',
-                transport: 'messages.rtc',
-                senderAgentId: 'agent-a',
-                receiverAgentIds: ['agent-b', 'agent-c'],
-                durationMs: 9
-            }
-        ],
+        timings: defaultTimings,
         diagnostics: [
             {
                 label: 'realtime-final',
@@ -303,46 +305,22 @@ function defaultRawEvidence(
     };
 }
 
+interface RetentionEvidenceInput {
+    environmentId?: 'E3-memory' | 'E4-pg';
+    inputKey?: 'e3-memory-retention-100' | 'e4-pg-retention-100';
+    outerOrdinal: number;
+    cycle0HeapBytes: number;
+    finalHeapBytes: number;
+    stateReturned?: boolean;
+}
+
 function retentionRawEvidence(
-    input: Readonly<{
-        environmentId?: 'E3-memory' | 'E4-pg';
-        inputKey?: 'e3-memory-retention-100' | 'e4-pg-retention-100';
-        outerOrdinal: number;
-        cycle0HeapBytes: number;
-        finalHeapBytes: number;
-        stateReturned?: boolean;
-    }>
+    input: RetentionEvidenceInput
 ): LiveRtcPerformanceRawEvidence {
     const environmentId = input.environmentId ?? 'E3-memory';
     const inputKey = input.inputKey ?? 'e3-memory-retention-100';
     const stateReturned = input.stateReturned ?? true;
-    const checkpoints = Array.from({ length: 11 }, (_, index) => {
-        const cycle = index * 10;
-        const progress = cycle / 100;
-        return {
-            cycle,
-            postGcHeapBytes: Math.round(
-                input.cycle0HeapBytes +
-                    (input.finalHeapBytes - input.cycle0HeapBytes) * progress
-            ),
-            agents: [
-                agentDiagnostics('agent-a'),
-                agentDiagnostics('agent-b'),
-                {
-                    ...agentDiagnostics('agent-c'),
-                    laneStates: cycle === 100 && !stateReturned
-                        ? [{
-                            peerId: 'agent-b',
-                            laneId: 'json',
-                            isOpen: false,
-                            isReconnectable: true
-                        }]
-                        : agentDiagnostics('agent-c').laneStates,
-                    connectionTimerActive: cycle === 100 && !stateReturned
-                }
-            ]
-        } as const;
-    });
+    const checkpoints = toRetentionCheckpoints(input);
     return {
         ...defaultRawEvidence(),
         identity: {
@@ -388,6 +366,36 @@ function retentionRawEvidence(
             reconnectPassed: true
         }
     };
+}
+
+function toRetentionCheckpoints(input: RetentionEvidenceInput) {
+    return Array.from({ length: 11 }, (_, index) => {
+        const cycle = index * 10;
+        const progress = cycle / 100;
+        return {
+            cycle,
+            postGcHeapBytes: Math.round(
+                input.cycle0HeapBytes +
+                    (input.finalHeapBytes - input.cycle0HeapBytes) * progress
+            ),
+            agents: [
+                agentDiagnostics('agent-a'),
+                agentDiagnostics('agent-b'),
+                {
+                    ...agentDiagnostics('agent-c'),
+                    laneStates: cycle === 100 && input.stateReturned === false
+                        ? [{
+                            peerId: 'agent-b',
+                            laneId: 'json',
+                            isOpen: false,
+                            isReconnectable: true
+                        }]
+                        : agentDiagnostics('agent-c').laneStates,
+                    connectionTimerActive: cycle === 100 && input.stateReturned === false
+                }
+            ]
+        } as const;
+    });
 }
 
 function retentionAttempt(

--- a/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-three-browser-script-gates.test.ts
@@ -2,16 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-type PackageManifest = Readonly<{
-    scripts?: Readonly<Record<string, string>>;
-}>;
-
 const repoRoot = process.cwd();
-const packageJson = JSON.parse(
-    fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
-) as PackageManifest;
-const liveMatrixSpec =
-    'tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts';
+const scripts = readPackageScripts();
+const liveMatrixSpec = 'tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts';
 
 const REQUIRED_LIVE_RTC_GATE_ENV = [
     'RALLAR_BLACK_BOX_FULL_STACK=1',
@@ -42,7 +35,7 @@ describe('live three-browser RTC npm script gates', () => {
         apiBaseUrl,
         spaBaseUrl
     ) => {
-        const script = packageJson.scripts?.[scriptName] ?? '';
+        const script = scripts[scriptName] ?? '';
 
         expect(script).toContain(apiBaseUrl);
         expect(script).toContain(spaBaseUrl);
@@ -58,13 +51,13 @@ describe('live three-browser RTC npm script gates', () => {
     });
 
     it('keeps exhaustive and retention selectors owned by the invoking attempt', () => {
-        const memory = packageJson.scripts?.[
+        const memory = scripts[
             'test:rallar:full-stack:memory:live-rtc-3'
         ] ?? '';
-        const postgres = packageJson.scripts?.[
+        const postgres = scripts[
             'test:rallar:full-stack:postgres:live-rtc-3'
         ] ?? '';
-        const postgresAll = packageJson.scripts?.[
+        const postgresAll = scripts[
             'test:rallar:full-stack:postgres:live-rtc-3:all'
         ] ?? '';
 
@@ -75,48 +68,12 @@ describe('live three-browser RTC npm script gates', () => {
         expect(postgres).not.toContain('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK=');
     });
 
-    it('uses cryptographically secure live run and session identities', () => {
-        const source = fs.readFileSync(path.join(repoRoot, liveMatrixSpec), 'utf8');
-
-        expect(source).not.toContain('Math.random()');
-        expect(source).toContain('crypto.randomUUID()');
-    });
-
-    it('uses the current idempotent group mutation request routes', () => {
-        const source = fs.readFileSync(path.join(repoRoot, liveMatrixSpec), 'utf8');
-
-        expect(source).toMatch(
-            /groups\/requests\/\$\{pathSegment\(createRequestId\)\}/u
-        );
-        expect(source).toMatch(
-            /members\/\{auth\.clientId\}\/requests\/\$\{\s*pathSegment\(requestId\)\s*\}/u
-        );
-        expect(source).toContain('`rtc-b06-create-${input.suffix}`');
-        expect(source).toContain(
-            '`rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`'
-        );
-        expect(source).toContain('acceptedStatusCodes: [201]');
-        expect(source.match(/setupGroupMembership\(\{/gu)).toHaveLength(3);
-        expect(source).toMatch(
-            /for \(const agent of input\.agents\.slice\(0, 2\)\) \{\s*connected\.push\(\s*await connectAgent/u
-        );
-        expect(source).toContain('`${input.suffix}-initial-pair`');
-        expect(source).toContain('readinessStartedAtMs');
-        expect(source.match(/connectAgentTrio\(\{/gu)).toHaveLength(3);
-        expect(source).not.toMatch(
-            /input\.agents\.map\(\(agent\) => connectAgent/u
-        );
-        expect(source).toContain('departedPeerIds: [input.sessions.C]');
-        expect(source).toContain('departedPeerIds: [input.sessions.B]');
-        expect(source.match(/realtime\.sessions/gu)).toHaveLength(2);
-    });
-
     it('keeps benchmark ownership out of application and reusable product sources', () => {
         const productRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')];
         const forbiddenImports: string[] = [];
 
         for (const root of productRoots) {
-            for (const file of sourceFiles(root)) {
+            for (const file of readSourceFiles(root)) {
                 if (
                     file.includes(`${path.sep}shared-rtc-bench${path.sep}`) ||
                     file.includes(`${path.sep}tests${path.sep}`)
@@ -138,12 +95,30 @@ describe('live three-browser RTC npm script gates', () => {
     });
 });
 
-function sourceFiles(root: string): string[] {
+function readPackageScripts(): Readonly<Record<string, string>> {
+    const manifest: unknown = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    if (
+        typeof manifest !== 'object' || manifest === null || !('scripts' in manifest) ||
+        typeof manifest.scripts !== 'object' || manifest.scripts === null
+    ) {
+        throw new Error('Package manifest must define scripts.');
+    }
+    const scripts: Record<string, string> = {};
+    for (const [name, command] of Object.entries(manifest.scripts)) {
+        if (typeof command !== 'string') {
+            throw new Error(`Package script ${name} must be a string.`);
+        }
+        scripts[name] = command;
+    }
+    return scripts;
+}
+
+function readSourceFiles(root: string): string[] {
     const files: string[] = [];
     for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
         const absolutePath = path.join(root, entry.name);
         if (entry.isDirectory()) {
-            files.push(...sourceFiles(absolutePath));
+            files.push(...readSourceFiles(absolutePath));
         }
         else if (entry.isFile() && /\.(?:c|m)?(?:j|t)sx?$/.test(entry.name)) {
             files.push(absolutePath);

--- a/packages/tests/rallar-black-box/live-rtc-wire-observation.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-wire-observation.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { hasLiveRtcNotYetInSyncNack, installLiveRtcWireObservation } from '../../../tests/playwright/rallar-black-box/live-rtc-wire-observation.ts';
+
+describe('live RTC wire observation', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('captures incoming frames only during the probe, including newly received channels', () => {
+        class NativePeerConnection extends EventTarget {
+            createDataChannel(): EventTarget {
+                return new EventTarget();
+            }
+        }
+        vi.stubGlobal('window', { RTCPeerConnection: NativePeerConnection });
+        installLiveRtcWireObservation();
+        const peer = new window.RTCPeerConnection();
+        const outgoing = peer.createDataChannel('application');
+        const observation = window.__liveRtcWireObservation;
+        if (!observation) {
+            throw new Error('Wire observer was not installed.');
+        }
+        outgoing.dispatchEvent(new MessageEvent('message', { data: 'before-probe' }));
+        expect(observation.read()).toEqual([]);
+
+        observation.start();
+        outgoing.dispatchEvent(new MessageEvent('message', { data: 'existing-channel-frame' }));
+        const incoming = new EventTarget();
+        peer.dispatchEvent(Object.assign(new Event('datachannel'), { channel: incoming }));
+        incoming.dispatchEvent(new MessageEvent('message', { data: 'incoming-channel-frame' }));
+        expect(observation.read()).toEqual(['existing-channel-frame', 'incoming-channel-frame']);
+        observation.stop();
+        incoming.dispatchEvent(new MessageEvent('message', { data: 'after-probe' }));
+        expect(observation.read()).toEqual([]);
+
+        incoming.dispatchEvent(new Event('close'));
+        observation.start();
+        incoming.dispatchEvent(new MessageEvent('message', { data: 'closed-channel-frame' }));
+        expect(observation.read()).toEqual([]);
+        observation.stop();
+    });
+
+    it('fails explicitly when the bounded capture overflows', () => {
+        class NativePeerConnection extends EventTarget {
+            createDataChannel(): EventTarget {
+                return new EventTarget();
+            }
+        }
+        vi.stubGlobal('window', { RTCPeerConnection: NativePeerConnection });
+        installLiveRtcWireObservation();
+        const channel = new window.RTCPeerConnection().createDataChannel('application');
+        window.__liveRtcWireObservation?.start();
+        for (let i = 0; i < 1_001; i++) {
+            channel.dispatchEvent(new MessageEvent('message', { data: 'frame' }));
+        }
+        expect(() => window.__liveRtcWireObservation?.read()).toThrow('frame limit');
+        window.__liveRtcWireObservation?.stop();
+    });
+});
+
+describe('received not-yet-in-sync NACK proof', () => {
+    const probe = { messageId: 'sent-message', senderSessionId: 'session-a', targetSessionId: 'session-b' };
+    const nack = { msgId: 'sent-message', reason: 'not-yet-in-sync', fromPeerId: 'session-b', toPeerId: 'session-a' };
+    const frame = JSON.stringify({ payload: { typeId: 'al.control.nack.v1', resource: JSON.stringify(nack) } });
+
+    it('accepts only the received protocol NACK matching message and both sessions', () => {
+        expect(hasLiveRtcNotYetInSyncNack({ ...probe, frames: [frame] })).toBe(true);
+    });
+
+    it.each([
+        { ...probe, messageId: 'another-message' },
+        { ...probe, senderSessionId: 'another-sender' },
+        { ...probe, targetSessionId: 'another-target' }
+    ])('rejects unrelated identity %#', (identity) => {
+        expect(hasLiveRtcNotYetInSyncNack({ ...identity, frames: [frame] })).toBe(false);
+    });
+
+    it.each([
+        'not JSON',
+        JSON.stringify({ commandId: 'nack-not-yet-in-sync-command', ok: false, error: { message: 'unrelated failure' } }),
+        JSON.stringify({ minSnapshotVersion: 9_999_999, message: { id: { msgId: 'sent-message' } } }),
+        JSON.stringify({ payload: { typeId: 'manual.type', resource: JSON.stringify(nack) } }),
+        JSON.stringify({ payload: { typeId: 'al.control.nack.v1', resource: 'invalid resource' } }),
+        JSON.stringify({ payload: { typeId: 'al.control.nack.v1', resource: JSON.stringify({ ...nack, reason: 'unauthorized' }) } })
+    ])('rejects malformed, echoed, or different protocol evidence %#', (unrelated) => {
+        expect(hasLiveRtcNotYetInSyncNack({ ...probe, frames: [unrelated] })).toBe(false);
+    });
+});

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -1487,7 +1487,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                         command: { kind: 'close' },
                         timeoutMs: 15_000
                     }).catch(() => undefined);
-                    await handle.context.close();
+                    await closeLiveRtcBrowserAgentContexts([handle]);
                 }));
                 await writeAttemptEvidence({
                     context: evidenceContext,
@@ -1828,7 +1828,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     command: { kind: 'close' },
                     timeoutMs: 15_000
                 }).catch(() => undefined);
-                await handle.context.close();
+                await closeLiveRtcBrowserAgentContexts([handle]);
             }));
             await writeAttemptEvidence({
                 context: evidenceContext,
@@ -2033,7 +2033,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     command: { kind: 'close' },
                     timeoutMs: 15_000
                 }).catch(() => undefined);
-                await agent.context.close();
+                await closeLiveRtcBrowserAgentContexts([agent]);
             }));
             await writeAttemptEvidence({
                 context: evidenceContext,

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -1,15 +1,14 @@
-import {
-    expect,
-    test,
-    type Browser,
-    type BrowserContext,
-    type Page
-} from '@playwright/test';
+import { expect, test, type Browser, type Page, type TestInfo } from '@playwright/test';
 import { openTab } from './full-stack-helpers.ts';
+import {
+    closeLiveRtcBrowserAgentContexts,
+    openLiveRtcBrowserAgent,
+    type LiveRtcBrowserAgentAuth
+} from './live-rtc-browser-agents.ts';
+import { LiveRtcControlClient } from './live-rtc-control-client.ts';
 import {
     buildLiveRtcExternalAttempt,
     captureLiveRtcPostGcHeap,
-    LiveRtcControlClient,
     liveRtcRetentionStateReturned,
     loadLiveRtcPerformanceAttempt,
     writeLiveRtcPerformanceEvidence,
@@ -20,6 +19,7 @@ import {
     type LiveRtcPerformanceTiming,
     type LiveRtcRetentionCheckpoint
 } from './live-rtc-performance-evidence.ts';
+import { hasLiveRtcNotYetInSyncNack } from './live-rtc-wire-observation.ts';
 
 const SPA_BASE_URL = envValue('VITE_RALLAR_SPA_BASE_URL') ??
     'http://localhost:5176';
@@ -34,25 +34,6 @@ type ConnectedAgentTrio = Readonly<{
     connections: readonly [ConnectedAgent, ConnectedAgent, ConnectedAgent];
     readinessStartedAtMs: number;
 }>;
-
-type RestoredSession = Readonly<{
-    clientId: string;
-    accessToken: string;
-    username: string;
-    sessionId: string;
-    expiresAtEpochMs: number;
-}>;
-
-type AgentAuth =
-    | Readonly<{
-        kind: 'login';
-        username: string;
-        password: string;
-    }>
-    | Readonly<{
-        kind: 'restore';
-        session: RestoredSession;
-    }>;
 
 const apiBaseUrl = envValue('VITE_RALLAR_API_BASE_URL');
 const roomSeed = firstEnvValue('VITE_RALLAR_ROOM_ID', 'VITE_RALLAR_GROUP_ID');
@@ -74,9 +55,9 @@ const liveAllScenariosEnabled = booleanEnv(
 const liveRetentionSoakEnabled = booleanEnv(
     'RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK'
 );
-const agentAAuth = resolveAgentAuth('A');
-const agentBAuth = resolveAgentAuth('B');
-const agentCAuth = resolveAgentAuth('C');
+const agentAAuth = resolveLiveRtcBrowserAgentAuth('A');
+const agentBAuth = resolveLiveRtcBrowserAgentAuth('B');
+const agentCAuth = resolveLiveRtcBrowserAgentAuth('C');
 const hasThreeAgentConfig = Boolean(
     fullStackEnabled &&
         liveMatrixEnabled &&
@@ -119,7 +100,7 @@ function numberEnv(key: string): number | undefined {
     return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function resolveAgentAuth(prefix: AgentPrefix): AgentAuth | undefined {
+function resolveLiveRtcBrowserAgentAuth(prefix: AgentPrefix): LiveRtcBrowserAgentAuth | undefined {
     const genericUsername = prefix === 'A' ? ['VITE_RALLAR_USERNAME'] : [];
     const genericPassword = prefix === 'A' ? ['VITE_RALLAR_PASSWORD'] : [];
     const username = firstEnvValue(
@@ -182,7 +163,7 @@ function transportSlug(transport: TransportUnderTest): string {
     return transport.replace('.', '-');
 }
 
-function agentAuth(prefix: AgentPrefix): AgentAuth {
+function agentAuth(prefix: AgentPrefix): LiveRtcBrowserAgentAuth {
     const auth = prefix === 'A'
         ? agentAAuth
         : prefix === 'B'
@@ -226,13 +207,15 @@ function rallarConnectConfig(
     };
 }
 
-function sendPayload(input: Readonly<{
-    transport: TransportUnderTest;
-    groupId: string;
-    targetSessionIds?: readonly string[];
-    payload: object;
-    minSnapshotVersion?: number;
-}>): object {
+function sendPayload(
+    input: Readonly<{
+        transport: TransportUnderTest;
+        groupId: string;
+        targetSessionIds?: readonly string[];
+        payload: object;
+        minSnapshotVersion?: number;
+    }>
+): object {
     if (input.transport === 'messages.rtc') {
         return {
             roomId: input.groupId,
@@ -256,74 +239,6 @@ function sendPayload(input: Readonly<{
     };
 }
 
-async function openAgent(
-    browser: Browser,
-    input: Readonly<{
-        prefix: AgentPrefix;
-        auth: AgentAuth;
-        runId: string;
-        agentId: string;
-        actor: string;
-        connection: string;
-        groupId: string;
-    }>
-): Promise<LiveRtcControlClient.Agent> {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    if (input.auth.kind === 'restore') {
-        await page.addInitScript((session) => {
-            window.localStorage.setItem('auth.session', JSON.stringify(session));
-        }, input.auth.session);
-    }
-
-    const query = new URLSearchParams({
-        mode: 'control',
-        provider: 'browser-rallar',
-        autoConnect: '1',
-        tab: 'local-workbench',
-        controlUrl: CONTROL_WS_URL,
-        runId: input.runId,
-        agentId: input.agentId,
-        apiBaseUrl: apiBaseUrl ?? '',
-        roomId: input.groupId,
-        actor: input.actor,
-        sessionId: input.agentId,
-        transport: 'realtime',
-        statsIntervalMs: '2000',
-        rallarLeaveRoomOnClose: '0',
-        ...(booleanEnv('VITE_RALLAR_REGISTER') ? { rallarRegister: '1' } : {}),
-        ...(input.auth.kind === 'restore' ? { rallarRestoreSession: '1' } : {}),
-        ...(input.auth.kind === 'login'
-            ? {
-                rallarUsername: input.auth.username,
-                rallarPassword: input.auth.password
-            }
-            : {})
-    });
-
-    await page.goto(`${SPA_BASE_URL}/?${query.toString()}`);
-
-    if (input.auth.kind === 'login') {
-        await expect(page.getByRole('heading', { name: 'Rallar Server Login' }))
-            .toBeVisible();
-        await page.getByRole('button', { name: 'Sign in' }).click();
-    }
-
-    await openTab(page, 'local-workbench', 'black-box-runner');
-    await expect(page.locator('#panel-local-workbench .control-panel'))
-        .toContainText('registered', { timeout: 30_000 });
-
-    return {
-        context,
-        page,
-        prefix: input.prefix,
-        agentId: input.agentId,
-        actor: input.actor,
-        connection: input.connection
-    };
-}
-
 async function openAgentTrio(
     browser: Browser,
     input: Readonly<{
@@ -340,19 +255,31 @@ async function openAgentTrio(
     ]
 > {
     const handles: LiveRtcControlClient.Agent[] = [];
-    for (const prefix of ['A', 'B', 'C'] as const) {
-        const agentName = `${input.label}-${prefix.toLowerCase()}-${input.suffix}`;
-        handles.push(
-            await openAgent(browser, {
-                prefix,
-                auth: agentAuth(prefix),
-                runId: input.runId,
-                agentId: agentName,
-                actor: actorFor(prefix, input.suffix),
-                connection: agentName,
-                groupId: input.groupId
-            })
-        );
+    try {
+        for (const prefix of ['A', 'B', 'C'] as const) {
+            const agentName = `${input.label}-${prefix.toLowerCase()}-${input.suffix}`;
+            handles.push(
+                await openLiveRtcBrowserAgent(browser, {
+                    config: {
+                        spaBaseUrl: SPA_BASE_URL,
+                        controlWsUrl: CONTROL_WS_URL,
+                        apiBaseUrl: apiBaseUrl ?? '',
+                        register: booleanEnv('VITE_RALLAR_REGISTER')
+                    },
+                    prefix,
+                    auth: agentAuth(prefix),
+                    runId: input.runId,
+                    agentId: agentName,
+                    actor: actorFor(prefix, input.suffix),
+                    connection: agentName,
+                    groupId: input.groupId
+                })
+            );
+        }
+    }
+    catch (error) {
+        await closeLiveRtcBrowserAgentContexts(handles);
+        throw error;
     }
 
     return handles as [
@@ -362,66 +289,25 @@ async function openAgentTrio(
     ];
 }
 
-async function closeAgentContexts(
-    agents: readonly LiveRtcControlClient.Agent[]
-): Promise<void> {
-    await Promise.all(
-        agents.map((agent) => agent.context.close().catch(() => undefined))
-    );
+interface SetupGroupMembershipInput {
+    readonly control: LiveRtcControlClient;
+    readonly runId: string;
+    readonly owner: LiveRtcControlClient.Agent;
+    readonly members: readonly LiveRtcControlClient.Agent[];
+    readonly groupId: string;
+    readonly suffix: string;
 }
 
 async function setupGroupMembership(
-    input: Readonly<{
-        control: LiveRtcControlClient;
-        runId: string;
-        owner: LiveRtcControlClient.Agent;
-        members: readonly LiveRtcControlClient.Agent[];
-        groupId: string;
-        suffix: string;
-    }>
+    input: SetupGroupMembershipInput
 ): Promise<readonly string[]> {
     const groupSegment = pathSegment(input.groupId);
-    const createCommandId = `group-create-${input.suffix}`;
-    const createRequestId = `rtc-b06-create-${input.suffix}`;
+    const createCommandId = await createMatrixRoom(input);
     const joinCommandIds: string[] = [];
-
-    await input.control.executeOk({
-        runId: input.runId,
-        agentId: input.owner.agentId,
-        commandId: createCommandId,
-        command: {
-            kind: 'http.request',
-            request: {
-                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
-                    pathSegment(workspaceId)
-                }/groups/requests/${pathSegment(createRequestId)}`,
-                method: 'POST',
-                body: {
-                    groupId: input.groupId,
-                    displayName: input.groupId,
-                    description: 'Created by rallar-black-box live three-browser matrix',
-                    kind: 'room',
-                    joinMode: 'open',
-                    createdByPrincipalId: '{auth.clientId}',
-                    metadata: {
-                        source: 'rallar-black-box',
-                        matrix: 'live-three-browser',
-                        suffix: input.suffix
-                    }
-                }
-            },
-            response: {
-                body: 'json',
-                acceptedStatusCodes: [201]
-            },
-            timeoutMs: 10_000
-        },
-    });
 
     for (const member of input.members) {
         const commandId = `group-join-${member.agentId}-${input.suffix}`;
-        const requestId =
-            `rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`;
+        const requestId = `rtc-b06-member-${member.prefix.toLowerCase()}-${input.suffix}`;
         joinCommandIds.push(commandId);
         await input.control.executeOk({
             runId: input.runId,
@@ -432,9 +318,7 @@ async function setupGroupMembership(
                 request: {
                     path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
                         pathSegment(workspaceId)
-                    }/groups/${groupSegment}/members/{auth.clientId}/requests/${
-                        pathSegment(requestId)
-                    }`,
+                    }/groups/${groupSegment}/members/{auth.clientId}/requests/${pathSegment(requestId)}`,
                     method: 'PUT',
                     body: {
                         status: 'active'
@@ -523,39 +407,41 @@ async function configureAgentForServerCommands(
         command: {
             kind: 'configure',
             config: {
-            runId: input.runId,
-            agentId: input.agent.agentId,
-            apiBaseUrl,
-            actor: input.agent.actor,
-            sessionId: input.agent.agentId,
-            roomId: input.groupId,
-            control: {
-                mode: 'live-all-scenarios',
-                providerMode: 'browser-rallar'
-            },
-            defaults: {
-                connection: input.agent.connection,
-                providerMode: 'browser-rallar'
-            },
-            rallar: {
+                runId: input.runId,
+                agentId: input.agent.agentId,
                 apiBaseUrl,
-                restoreSession: true,
-                leaveRoomOnClose: false
-            }
+                actor: input.agent.actor,
+                sessionId: input.agent.agentId,
+                roomId: input.groupId,
+                control: {
+                    mode: 'live-all-scenarios',
+                    providerMode: 'browser-rallar'
+                },
+                defaults: {
+                    connection: input.agent.connection,
+                    providerMode: 'browser-rallar'
+                },
+                rallar: {
+                    apiBaseUrl,
+                    restoreSession: true,
+                    leaveRoomOnClose: false
+                }
             }
         }
     });
     return commandId;
 }
 
+interface WebSocketMatrixInput {
+    readonly control: LiveRtcControlClient;
+    readonly runId: string;
+    readonly agents: readonly LiveRtcControlClient.Agent[];
+    readonly groupId: string;
+    readonly suffix: string;
+}
+
 async function runWebSocketOpenSendCloseMatrix(
-    input: Readonly<{
-        control: LiveRtcControlClient;
-        runId: string;
-        agents: readonly LiveRtcControlClient.Agent[];
-        groupId: string;
-        suffix: string;
-    }>
+    input: WebSocketMatrixInput
 ): Promise<readonly string[]> {
     const commandIds: string[] = [];
     for (const agent of input.agents) {
@@ -586,39 +472,7 @@ async function runWebSocketOpenSendCloseMatrix(
             command: {
                 kind: 'ws.send',
                 connection,
-                data: {
-                id: {
-                    v: 2,
-                    msgId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
-                    ts: 0,
-                    senderId: '{auth.sessionId}',
-                    sessionId: '{auth.sessionId}',
-                    traceId: `ws-${input.suffix}`
-                },
-                route: {
-                    topicId: 'app.black-box.live-three-browser.ws',
-                    resourceId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
-                    contextId: `${applicationId}:${workspaceId}:${input.groupId}`
-                },
-                targets: {
-                    mode: 'unicast',
-                    toPeerId: '{auth.sessionId}'
-                },
-                delivery: {
-                    reliability: 'best-effort',
-                    ack: 'none'
-                },
-                payload: {
-                    typeId: 'app.black-box.live-three-browser.ws',
-                    contentType: 'application/json',
-                    resource: JSON.stringify({
-                        matrixId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
-                        agentId: agent.agentId,
-                        groupId: input.groupId,
-                        runId: input.runId
-                    })
-                }
-            }
+                data: toWebSocketMatrixPayload(input, agent)
             }
         });
         await input.control.executeOk({
@@ -646,26 +500,28 @@ async function connectAgent(
         suffix: string;
     }>
 ): Promise<ConnectedAgent> {
-    const commandId = `connect-${input.agent.prefix.toLowerCase()}-${input.transport.replace('.', '-')}-${input.suffix}`;
+    const commandId = `connect-${input.agent.prefix.toLowerCase()}-${
+        input.transport.replace('.', '-')
+    }-${input.suffix}`;
     const result = await input.control.executeOk({
         runId: input.runId,
         agentId: input.agent.agentId,
         commandId,
         command: {
-        kind: 'rtc.connect',
-        connection: `${input.agent.connection}-${input.transport.replace('.', '-')}`,
-        actor: input.agent.actor,
-        roomId: input.groupId,
-        applicationId,
-        workspaceId,
-        roomRef: {
+            kind: 'rtc.connect',
+            connection: `${input.agent.connection}-${input.transport.replace('.', '-')}`,
+            actor: input.agent.actor,
+            roomId: input.groupId,
             applicationId,
             workspaceId,
-            groupId: input.groupId
-        },
-        transport: input.transport,
-        rallar: rallarConnectConfig(input.transport),
-        timeoutMs: 45_000
+            roomRef: {
+                applicationId,
+                workspaceId,
+                groupId: input.groupId
+            },
+            transport: input.transport,
+            rallar: rallarConnectConfig(input.transport),
+            timeoutMs: 45_000
         },
         timeoutMs: 60_000
     });
@@ -774,424 +630,285 @@ async function sendMatrixPayload(
     return commandId;
 }
 
-async function runDeliveryMatrix(
-    input: Readonly<{
-        control: LiveRtcControlClient;
-        runId: string;
-        agents: readonly [
-            LiveRtcControlClient.Agent,
-            LiveRtcControlClient.Agent,
-            LiveRtcControlClient.Agent
-        ];
-        transport: TransportUnderTest;
-        groupId: string;
-        suffix: string;
-    }>
-): Promise<
-    Readonly<{
-        commandIds: readonly string[];
-        sessions: Readonly<Record<AgentPrefix, string>>;
-        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
-        timings: readonly LiveRtcPerformanceTiming[];
-    }>
-> {
-    const connected = await connectAgentTrio({
-        control: input.control,
-        runId: input.runId,
-        agents: input.agents,
-        transport: input.transport,
-        groupId: input.groupId,
-        suffix: input.suffix
-    });
-    const connectResults = connected.connections;
-    const sessions: Readonly<Record<AgentPrefix, string>> = {
-        A: connectResults[0].sessionId,
-        B: connectResults[1].sessionId,
-        C: connectResults[2].sessionId
-    };
-    expect(new Set(Object.values(sessions)).size).toBe(3);
+interface DeliveryMatrixInput {
+    control: LiveRtcControlClient;
+    runId: string;
+    agents: readonly [LiveRtcControlClient.Agent, LiveRtcControlClient.Agent, LiveRtcControlClient.Agent];
+    transport: TransportUnderTest;
+    groupId: string;
+    suffix: string;
+}
 
+interface DeliveryMatrixResult {
+    commandIds: readonly string[];
+    sessions: Readonly<Record<AgentPrefix, string>>;
+    scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+    timings: readonly LiveRtcPerformanceTiming[];
+}
+
+interface MatrixDeliveryInput extends DeliveryMatrixInput {
+    sessions: Readonly<Record<AgentPrefix, string>>;
+    sender: LiveRtcControlClient.Agent;
+    receivers: readonly LiveRtcControlClient.Agent[];
+    deliveryMode: DeliveryMode;
+    matrixId: string;
+}
+
+interface MatrixDeliveryResult {
+    commandId: string;
+    scenario: LiveRtcControlClient.DeliveryScenario;
+    timing: LiveRtcPerformanceTiming;
+}
+
+async function runDeliveryMatrix(input: DeliveryMatrixInput): Promise<DeliveryMatrixResult> {
+    const connected = await connectAgentTrio(input);
+    const sessions = toAgentSessions(connected.connections);
     const [agentA, agentB, agentC] = input.agents;
-    const transportSuffix = `${input.transport.replace('.', '-')}-${input.suffix}`;
-    const readinessStartedAtMs = connected.readinessStartedAtMs;
     const readinessDurationMs = await input.control.waitForPeerReadiness({
         runId: input.runId,
         agent: agentA,
         expectedPeerIds: [sessions.B, sessions.C],
-        suffix: transportSuffix,
-        startedAtMs: readinessStartedAtMs
+        suffix: transportSlug(input.transport) + '-' + input.suffix,
+        startedAtMs: connected.readinessStartedAtMs
     });
-    const timings: LiveRtcPerformanceTiming[] = [{
-        kind: 'peer-ready',
-        transport: input.transport,
-        senderAgentId: agentA.agentId,
-        receiverAgentIds: [agentB.agentId, agentC.agentId],
-        durationMs: readinessDurationMs
-    }];
-
-    const directMatrixId = `direct-${input.transport}-${input.suffix}`;
-    const multicastMatrixId = `multicast-${input.transport}-${input.suffix}`;
-    const broadcastMatrixId = `broadcast-${input.transport}-${input.suffix}`;
-    const directStartedAtMs = performance.now();
-    const sendDirect = await sendMatrixPayload({
-        ...input,
-        sender: agentA,
+    const delivery = { ...input, sessions, sender: agentA };
+    const direct = await observeMatrixDelivery({
+        ...delivery,
+        receivers: [agentB],
         deliveryMode: 'direct',
-        targetSessionIds: [sessions.B],
-        matrixId: directMatrixId
+        matrixId: 'direct-' + input.transport + '-' + input.suffix
     });
-    const directDurationMs = await input.control.waitForMessage({
-        runId: input.runId,
-        agentId: agentB.agentId,
-        transport: input.transport,
-        matrixId: directMatrixId,
-        deliveryMode: 'direct',
-        startedAtMs: directStartedAtMs
-    });
-    timings.push({
-        kind: 'direct-delivery',
-        transport: input.transport,
-        senderAgentId: agentA.agentId,
-        receiverAgentIds: [agentB.agentId],
-        durationMs: directDurationMs
-    });
-    await openTab(agentB.page, 'manual-rallar', 'black-box-runner');
-    await expect(
-        agentB.page.locator('#panel-manual-rallar .received-inbox-panel')
-    )
-        .toContainText(directMatrixId, { timeout: 30_000 });
-
-    const multicastStartedAtMs = performance.now();
-    const sendMulticast = await sendMatrixPayload({
-        ...input,
-        sender: agentA,
+    await expectMatrixInboxMessage(agentB.page, direct.scenario.matrixId);
+    const multicast = await observeMatrixDelivery({
+        ...delivery,
+        receivers: [agentB, agentC],
         deliveryMode: 'multicast',
-        targetSessionIds: [sessions.B, sessions.C],
-        matrixId: multicastMatrixId
+        matrixId: 'multicast-' + input.transport + '-' + input.suffix
     });
-    const multicastDurations = await Promise.all([
-        input.control.waitForMessage({
-            runId: input.runId,
-            agentId: agentB.agentId,
-            transport: input.transport,
-            matrixId: multicastMatrixId,
-            deliveryMode: 'multicast',
-            startedAtMs: multicastStartedAtMs
-        }),
-        input.control.waitForMessage({
-            runId: input.runId,
-            agentId: agentC.agentId,
-            transport: input.transport,
-            matrixId: multicastMatrixId,
-            deliveryMode: 'multicast',
-            startedAtMs: multicastStartedAtMs
-        })
-    ]);
-    timings.push({
-        kind: 'multicast-delivery',
-        transport: input.transport,
-        senderAgentId: agentA.agentId,
-        receiverAgentIds: [agentB.agentId, agentC.agentId],
-        durationMs: Math.max(...multicastDurations)
-    });
-
-    const broadcastStartedAtMs = performance.now();
-    const sendBroadcast = await sendMatrixPayload({
-        ...input,
-        sender: agentA,
+    const broadcast = await observeMatrixDelivery({
+        ...delivery,
+        receivers: [agentB, agentC],
         deliveryMode: 'broadcast',
-        matrixId: broadcastMatrixId
+        matrixId: 'broadcast-' + input.transport + '-' + input.suffix
     });
-    const broadcastDurations = await Promise.all([
-        input.control.waitForMessage({
-            runId: input.runId,
-            agentId: agentB.agentId,
-            transport: input.transport,
-            matrixId: broadcastMatrixId,
-            deliveryMode: 'broadcast',
-            startedAtMs: broadcastStartedAtMs
-        }),
-        input.control.waitForMessage({
-            runId: input.runId,
-            agentId: agentC.agentId,
-            transport: input.transport,
-            matrixId: broadcastMatrixId,
-            deliveryMode: 'broadcast',
-            startedAtMs: broadcastStartedAtMs
-        })
-    ]);
-    timings.push({
-        kind: 'broadcast-delivery',
-        transport: input.transport,
-        senderAgentId: agentA.agentId,
-        receiverAgentIds: [agentB.agentId, agentC.agentId],
-        durationMs: Math.max(...broadcastDurations)
-    });
-    await openTab(agentC.page, 'manual-rallar', 'black-box-runner');
-    await expect(
-        agentC.page.locator('#panel-manual-rallar .received-inbox-panel')
-    )
-        .toContainText(broadcastMatrixId, { timeout: 30_000 });
-
+    await expectMatrixInboxMessage(agentC.page, broadcast.scenario.matrixId);
     if (input.transport === 'realtime') {
-        const healthA = await input.control.executeOk({
+        const health = await input.control.executeOk({
             runId: input.runId,
             agentId: agentA.agentId,
-            commandId: `health-a-${input.suffix}`,
+            commandId: 'health-a-' + input.suffix,
             command: { kind: 'health' }
         });
-        expect(input.control.readyPeerIds(healthA)).toEqual(
-            expect.arrayContaining([sessions.B, sessions.C])
-        );
+        expect(input.control.readyPeerIds(health)).toEqual(expect.arrayContaining([sessions.B, sessions.C]));
     }
-
+    const deliveries = [direct, multicast, broadcast];
     return {
         commandIds: [
-            ...connectResults.map((result) => result.commandId),
-            sendDirect,
-            sendMulticast,
-            sendBroadcast
+            ...connected.connections.map((result) => result.commandId),
+            ...deliveries.map((result) => result.commandId)
         ],
         sessions,
-        scenarios: [
-            {
-                matrixId: directMatrixId,
-                transport: input.transport,
-                deliveryMode: 'direct',
-                senderAgentId: agentA.agentId,
-                expectedAgentIds: [agentB.agentId],
-                allowedAgentIds: [agentB.agentId]
-            },
-            {
-                matrixId: multicastMatrixId,
-                transport: input.transport,
-                deliveryMode: 'multicast',
-                senderAgentId: agentA.agentId,
-                expectedAgentIds: [agentB.agentId, agentC.agentId],
-                allowedAgentIds: [agentB.agentId, agentC.agentId]
-            },
-            {
-                matrixId: broadcastMatrixId,
-                transport: input.transport,
-                deliveryMode: 'broadcast',
-                senderAgentId: agentA.agentId,
-                expectedAgentIds: [agentB.agentId, agentC.agentId],
-                allowedAgentIds: input.agents.map((agent) => agent.agentId)
-            }
-        ],
-        timings
-    };
-}
-
-async function runAllDeliveryPermutations(
-    input: Readonly<{
-        control: LiveRtcControlClient;
-        runId: string;
-        agents: readonly [
-            LiveRtcControlClient.Agent,
-            LiveRtcControlClient.Agent,
-            LiveRtcControlClient.Agent
-        ];
-        transport: TransportUnderTest;
-        groupId: string;
-        suffix: string;
-    }>
-): Promise<
-    Readonly<{
-        commandIds: readonly string[];
-        sessions: Readonly<Record<AgentPrefix, string>>;
-        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
-        timings: readonly LiveRtcPerformanceTiming[];
-    }>
-> {
-    const slug = transportSlug(input.transport);
-    const connected = await connectAgentTrio({
-        control: input.control,
-        runId: input.runId,
-        agents: input.agents,
-        transport: input.transport,
-        groupId: input.groupId,
-        suffix: input.suffix
-    });
-    const connectResults = connected.connections;
-    const sessions: Readonly<Record<AgentPrefix, string>> = {
-        A: connectResults[0].sessionId,
-        B: connectResults[1].sessionId,
-        C: connectResults[2].sessionId
-    };
-    expect(new Set(Object.values(sessions)).size).toBe(3);
-
-    const readinessSuffix = `${slug}-${input.suffix}-all`;
-    const readinessStartedAtMs = connected.readinessStartedAtMs;
-    const readinessDurations = await Promise.all(
-        input.agents.map((agent) =>
-            input.control.waitForPeerReadiness({
-                runId: input.runId,
-                agent,
-                expectedPeerIds: input.agents
-                    .filter((candidate) => candidate.agentId !== agent.agentId)
-                    .map((candidate) => sessions[candidate.prefix]),
-                suffix: readinessSuffix,
-                startedAtMs: readinessStartedAtMs
-            })
-        )
-    );
-
-    const commandIds = connectResults.map((result) => result.commandId);
-    const scenarios: LiveRtcControlClient.DeliveryScenario[] = [];
-    const timings: LiveRtcPerformanceTiming[] = input.agents.map(
-        (agent, index) => ({
+        scenarios: deliveries.map((result) => result.scenario),
+        timings: [{
             kind: 'peer-ready',
             transport: input.transport,
-            senderAgentId: agent.agentId,
-            receiverAgentIds: input.agents
-                .filter((candidate) => candidate.agentId !== agent.agentId)
-                .map((candidate) => candidate.agentId),
-            durationMs: readinessDurations[index]!
-        })
-    );
-
-    for (const sender of input.agents) {
-        const receivers = input.agents.filter(
-            (agent) => agent.agentId !== sender.agentId
-        );
-
-        for (const receiver of receivers) {
-            const matrixId =
-                `${slug}-direct-${sender.prefix.toLowerCase()}-to-${receiver.prefix.toLowerCase()}-${input.suffix}`;
-            const startedAtMs = performance.now();
-            commandIds.push(
-                await sendMatrixPayload({
-                    ...input,
-                    sender,
-                    deliveryMode: 'direct',
-                    targetSessionIds: [sessions[receiver.prefix]],
-                    matrixId
-                })
-            );
-            const durationMs = await input.control.waitForMessage({
-                runId: input.runId,
-                agentId: receiver.agentId,
-                transport: input.transport,
-                matrixId,
-                deliveryMode: 'direct',
-                startedAtMs
-            });
-            timings.push({
-                kind: 'direct-delivery',
-                transport: input.transport,
-                senderAgentId: sender.agentId,
-                receiverAgentIds: [receiver.agentId],
-                durationMs
-            });
-            scenarios.push({
-                matrixId,
-                transport: input.transport,
-                deliveryMode: 'direct',
-                senderAgentId: sender.agentId,
-                expectedAgentIds: [receiver.agentId],
-                allowedAgentIds: [receiver.agentId]
-            });
-        }
-
-        const multicastMatrixId = `${slug}-multicast-${sender.prefix.toLowerCase()}-${input.suffix}`;
-        const multicastStartedAtMs = performance.now();
-        commandIds.push(
-            await sendMatrixPayload({
-                ...input,
-                sender,
-                deliveryMode: 'multicast',
-                targetSessionIds: receivers.map((receiver) => sessions[receiver.prefix]),
-                matrixId: multicastMatrixId
-            })
-        );
-        const multicastDurations = await Promise.all(
-            receivers.map((receiver) =>
-                input.control.waitForMessage({
-                    runId: input.runId,
-                    agentId: receiver.agentId,
-                    transport: input.transport,
-                    matrixId: multicastMatrixId,
-                    deliveryMode: 'multicast',
-                    startedAtMs: multicastStartedAtMs
-                })
-            )
-        );
-        timings.push({
-            kind: 'multicast-delivery',
-            transport: input.transport,
-            senderAgentId: sender.agentId,
-            receiverAgentIds: receivers.map((receiver) => receiver.agentId),
-            durationMs: Math.max(...multicastDurations)
-        });
-        scenarios.push({
-            matrixId: multicastMatrixId,
-            transport: input.transport,
-            deliveryMode: 'multicast',
-            senderAgentId: sender.agentId,
-            expectedAgentIds: receivers.map((receiver) => receiver.agentId),
-            allowedAgentIds: receivers.map((receiver) => receiver.agentId)
-        });
-
-        const broadcastMatrixId = `${slug}-broadcast-${sender.prefix.toLowerCase()}-${input.suffix}`;
-        const broadcastStartedAtMs = performance.now();
-        commandIds.push(
-            await sendMatrixPayload({
-                ...input,
-                sender,
-                deliveryMode: 'broadcast',
-                matrixId: broadcastMatrixId
-            })
-        );
-        const broadcastDurations = await Promise.all(
-            receivers.map((receiver) =>
-                input.control.waitForMessage({
-                    runId: input.runId,
-                    agentId: receiver.agentId,
-                    transport: input.transport,
-                    matrixId: broadcastMatrixId,
-                    deliveryMode: 'broadcast',
-                    startedAtMs: broadcastStartedAtMs
-                })
-            )
-        );
-        timings.push({
-            kind: 'broadcast-delivery',
-            transport: input.transport,
-            senderAgentId: sender.agentId,
-            receiverAgentIds: receivers.map((receiver) => receiver.agentId),
-            durationMs: Math.max(...broadcastDurations)
-        });
-        scenarios.push({
-            matrixId: broadcastMatrixId,
-            transport: input.transport,
-            deliveryMode: 'broadcast',
-            senderAgentId: sender.agentId,
-            expectedAgentIds: receivers.map((receiver) => receiver.agentId),
-            allowedAgentIds: input.agents.map((agent) => agent.agentId)
-        });
-    }
-
-    return {
-        commandIds,
-        sessions,
-        scenarios,
-        timings
+            senderAgentId: agentA.agentId,
+            receiverAgentIds: [agentB.agentId, agentC.agentId],
+            durationMs: readinessDurationMs
+        }, ...deliveries.map((result) => result.timing)]
     };
 }
 
-async function runNackProbe(
-    input: Readonly<{
-        control: LiveRtcControlClient;
-        runId: string;
-        agent: LiveRtcControlClient.Agent;
-        groupId: string;
-        suffix: string;
-        targetSessionId: string;
-    }>
-): Promise<string> {
+async function runAllDeliveryPermutations(input: DeliveryMatrixInput): Promise<DeliveryMatrixResult> {
+    const connected = await connectAgentTrio(input);
+    const sessions = toAgentSessions(connected.connections);
+    const readinessDurations = await Promise.all(input.agents.map((agent) =>
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent,
+            expectedPeerIds: input.agents.filter((candidate) => candidate.agentId !== agent.agentId)
+                .map((candidate) => sessions[candidate.prefix]),
+            suffix: transportSlug(input.transport) + '-' + input.suffix + '-all',
+            startedAtMs: connected.readinessStartedAtMs
+        })
+    ));
+    const timings: LiveRtcPerformanceTiming[] = input.agents.map((agent, index) => ({
+        kind: 'peer-ready',
+        transport: input.transport,
+        senderAgentId: agent.agentId,
+        receiverAgentIds: input.agents.filter((candidate) => candidate.agentId !== agent.agentId).map((candidate) =>
+            candidate.agentId
+        ),
+        durationMs: readinessDurations[index]!
+    }));
+    const deliveries: MatrixDeliveryResult[] = [];
+    for (const sender of input.agents) {
+        deliveries.push(
+            ...await observeSenderPermutations({
+                ...input,
+                sessions,
+                sender,
+                receivers: input.agents.filter((agent) => agent.agentId !== sender.agentId)
+            })
+        );
+    }
+    return {
+        commandIds: [
+            ...connected.connections.map((result) => result.commandId),
+            ...deliveries.map((result) => result.commandId)
+        ],
+        sessions,
+        scenarios: deliveries.map((result) => result.scenario),
+        timings: [...timings, ...deliveries.map((result) => result.timing)]
+    };
+}
+
+async function observeSenderPermutations(
+    input: Omit<MatrixDeliveryInput, 'deliveryMode' | 'matrixId'>
+): Promise<MatrixDeliveryResult[]> {
+    const slug = transportSlug(input.transport);
+    const sender = input.sender.prefix.toLowerCase();
+    const deliveries: MatrixDeliveryResult[] = [];
+    for (const receiver of input.receivers) {
+        deliveries.push(
+            await observeMatrixDelivery({
+                ...input,
+                receivers: [receiver],
+                deliveryMode: 'direct',
+                matrixId: slug + '-direct-' + sender + '-to-' + receiver.prefix.toLowerCase() + '-' + input.suffix
+            })
+        );
+    }
+    deliveries.push(
+        await observeMatrixDelivery({
+            ...input,
+            deliveryMode: 'multicast',
+            matrixId: slug + '-multicast-' + sender + '-' + input.suffix
+        })
+    );
+    deliveries.push(
+        await observeMatrixDelivery({
+            ...input,
+            deliveryMode: 'broadcast',
+            matrixId: slug + '-broadcast-' + sender + '-' + input.suffix
+        })
+    );
+    return deliveries;
+}
+
+async function observeMatrixDelivery(input: MatrixDeliveryInput): Promise<MatrixDeliveryResult> {
+    const startedAtMs = performance.now();
+    const commandId = await sendMatrixPayload({
+        ...input,
+        targetSessionIds: input.deliveryMode === 'broadcast'
+            ? undefined
+            : input.receivers.map((receiver) => input.sessions[receiver.prefix])
+    });
+    const durations = await Promise.all(input.receivers.map((receiver) =>
+        input.control.waitForMessage({
+            runId: input.runId,
+            agentId: receiver.agentId,
+            transport: input.transport,
+            matrixId: input.matrixId,
+            deliveryMode: input.deliveryMode,
+            startedAtMs
+        })
+    ));
+    const receiverAgentIds = input.receivers.map((receiver) => receiver.agentId);
+    return {
+        commandId,
+        scenario: {
+            matrixId: input.matrixId,
+            transport: input.transport,
+            deliveryMode: input.deliveryMode,
+            senderAgentId: input.sender.agentId,
+            expectedAgentIds: receiverAgentIds,
+            allowedAgentIds: input.deliveryMode === 'broadcast'
+                ? input.agents.map((agent) => agent.agentId)
+                : receiverAgentIds
+        },
+        timing: {
+            kind: input.deliveryMode === 'direct'
+                ? 'direct-delivery'
+                : input.deliveryMode === 'multicast'
+                ? 'multicast-delivery'
+                : 'broadcast-delivery',
+            transport: input.transport,
+            senderAgentId: input.sender.agentId,
+            receiverAgentIds,
+            durationMs: Math.max(...durations)
+        }
+    };
+}
+
+function toAgentSessions(
+    connections: ConnectedAgentTrio['connections']
+): Readonly<Record<AgentPrefix, string>> {
+    const sessions = { A: connections[0].sessionId, B: connections[1].sessionId, C: connections[2].sessionId };
+    expect(new Set(Object.values(sessions)).size).toBe(3);
+    return sessions;
+}
+
+async function expectMatrixInboxMessage(page: Page, matrixId: string): Promise<void> {
+    await openTab(page, 'manual-rallar', 'black-box-runner');
+    await expect(page.locator('#panel-manual-rallar .received-inbox-panel')).toContainText(matrixId, {
+        timeout: 30_000
+    });
+}
+
+interface NackProbeInput {
+    readonly testInfo: TestInfo;
+    readonly control: LiveRtcControlClient;
+    readonly runId: string;
+    readonly agent: LiveRtcControlClient.Agent;
+    readonly groupId: string;
+    readonly suffix: string;
+    readonly targetSessionId: string;
+    readonly senderSessionId: string;
+}
+
+async function runNackProbe(input: NackProbeInput): Promise<string> {
+    await input.agent.page.evaluate(() => {
+        if (!window.__liveRtcWireObservation) {
+            throw new Error('RTC wire observer is missing.');
+        }
+        window.__liveRtcWireObservation.start();
+    });
     const commandId = `nack-not-yet-in-sync-${input.suffix}`;
-    const result = await input.control.executeResult({
+    try {
+        const result = await sendNackProbe(input, commandId);
+        const messageId = input.control.requireSentMessageId(result);
+        const identity = { messageId, senderSessionId: input.senderSessionId, targetSessionId: input.targetSessionId };
+        let frames: readonly string[] = [];
+        await expect.poll(async () => {
+            const received = await input.agent.page.evaluate(() => {
+                if (!window.__liveRtcWireObservation) {
+                    throw new Error('RTC wire observer is missing.');
+                }
+                return window.__liveRtcWireObservation.read();
+            });
+            frames = received.filter((frame) => hasLiveRtcNotYetInSyncNack({ ...identity, frames: [frame] }));
+            return frames.length > 0;
+        }, { timeout: 15_000, message: 'Expected a received not-yet-in-sync NACK for the probe message.' }).toBe(true);
+        await input.control.recordReceivedNack({
+            ...identity,
+            frames,
+            testInfo: input.testInfo,
+            runId: input.runId,
+            agentId: input.agent.agentId
+        });
+        return commandId;
+    }
+    finally {
+        await input.agent.page.evaluate(() => window.__liveRtcWireObservation?.stop()).catch(() => undefined);
+    }
+}
+
+async function sendNackProbe(
+    input: NackProbeInput,
+    commandId: string
+): Promise<LiveRtcControlClient.Result> {
+    return await input.control.executeOk({
         runId: input.runId,
         agentId: input.agent.agentId,
         commandId,
@@ -1225,18 +942,6 @@ async function runNackProbe(
         },
         timeoutMs: 60_000
     });
-    const run = await input.control.fetchRun(input.runId);
-    const evidence = JSON.stringify({
-        result,
-        events: run.events?.filter((event) => event.agentId === input.agent.agentId)
-            .slice(-12)
-    }).toLowerCase();
-    expect(
-        evidence.includes('not-yet-in-sync') ||
-            evidence.includes('nack') ||
-            (result.ok === true && evidence.includes('minsnapshotversion'))
-    ).toBe(true);
-    return commandId;
 }
 
 async function expectClosedTransportFailure(
@@ -1249,8 +954,7 @@ async function expectClosedTransportFailure(
         targetSessionId: string;
     }>
 ): Promise<readonly string[]> {
-    const closeCommandId =
-        `close-before-stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
+    const closeCommandId = `close-before-stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
     await input.control.executeOk({
         runId: input.runId,
         agentId: input.agent.agentId,
@@ -1259,8 +963,7 @@ async function expectClosedTransportFailure(
         timeoutMs: 45_000
     });
 
-    const staleSendCommandId =
-        `stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
+    const staleSendCommandId = `stale-send-${input.agent.prefix.toLowerCase()}-${input.suffix}`;
     const staleResult = await input.control.executeResult({
         runId: input.runId,
         agentId: input.agent.agentId,
@@ -1360,14 +1063,16 @@ async function closeAndResetSettledAgentTrio(
     };
 
     await closeAndReset(input.agents[2]);
-    await Promise.all(input.agents.slice(0, 2).map((agent) =>
-        input.control.waitForPeerAbsence({
-            runId: input.runId,
-            agent,
-            departedPeerIds: [input.sessions.C],
-            suffix: `${input.suffix}-retire-c`
-        })
-    ));
+    await Promise.all(
+        input.agents.slice(0, 2).map((agent) =>
+            input.control.waitForPeerAbsence({
+                runId: input.runId,
+                agent,
+                departedPeerIds: [input.sessions.C],
+                suffix: `${input.suffix}-retire-c`
+            })
+        )
+    );
 
     await closeAndReset(input.agents[1]);
     await input.control.waitForPeerAbsence({
@@ -1381,20 +1086,121 @@ async function closeAndResetSettledAgentTrio(
     return commandIds;
 }
 
-async function writeAttemptEvidence(input: Readonly<{
-    context: LiveRtcPerformanceAttemptContext | null;
-    producerExitStatus: number;
-    timings: readonly LiveRtcPerformanceTiming[];
-    diagnostics: readonly LiveRtcDiagnosticsCheckpoint[];
-    retention: LiveRtcPerformanceRawEvidence['retention'];
-    assertions: LiveRtcPerformanceRawEvidence['assertions'];
-}>): Promise<void> {
+interface WriteAttemptEvidenceInput {
+    readonly context: LiveRtcPerformanceAttemptContext | null;
+    readonly producerExitStatus: number;
+    readonly timings: readonly LiveRtcPerformanceTiming[];
+    readonly diagnostics: readonly LiveRtcDiagnosticsCheckpoint[];
+    readonly retention: LiveRtcPerformanceRawEvidence['retention'];
+    readonly assertions: LiveRtcPerformanceRawEvidence['assertions'];
+}
+
+async function writeAttemptEvidence(input: WriteAttemptEvidenceInput): Promise<void> {
     if (!input.context) {
         return;
     }
+    const rawEvidence = toMatrixRawEvidence({ ...input, context: input.context });
+    const attempt = buildLiveRtcExternalAttempt({
+        locator: input.context.locator,
+        sampleIdentity: input.context.sampleIdentity,
+        producerExitStatus: input.producerExitStatus,
+        runtimeObservation: input.context.runtimeObservation,
+        rawEvidence
+    });
+    await writeLiveRtcPerformanceEvidence({
+        repoRoot: input.context.repoRoot,
+        baselineId: input.context.baselineId,
+        relativePath: input.context.locator.rawResultRelativePath,
+        evidence: attempt
+    });
+    await writeLiveRtcRetentionCohortIfComplete(input.context);
+}
+
+async function createMatrixRoom(input: SetupGroupMembershipInput): Promise<string> {
+    const createCommandId = `group-create-${input.suffix}`;
+    const createRequestId = `rtc-b06-create-${input.suffix}`;
+
+    await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.owner.agentId,
+        commandId: createCommandId,
+        command: {
+            kind: 'http.request',
+            request: {
+                path: `/api/state/apps/${pathSegment(applicationId)}/workspaces/${
+                    pathSegment(workspaceId)
+                }/groups/requests/${pathSegment(createRequestId)}`,
+                method: 'POST',
+                body: {
+                    groupId: input.groupId,
+                    displayName: input.groupId,
+                    description: 'Created by rallar-black-box live three-browser matrix',
+                    kind: 'room',
+                    joinMode: 'open',
+                    createdByPrincipalId: '{auth.clientId}',
+                    metadata: {
+                        source: 'rallar-black-box',
+                        matrix: 'live-three-browser',
+                        suffix: input.suffix
+                    }
+                }
+            },
+            response: {
+                body: 'json',
+                acceptedStatusCodes: [201]
+            },
+            timeoutMs: 10_000
+        }
+    });
+
+    return createCommandId;
+}
+
+function toWebSocketMatrixPayload(
+    input: WebSocketMatrixInput,
+    agent: LiveRtcControlClient.Agent
+): object {
+    return {
+        id: {
+            v: 2,
+            msgId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
+            ts: 0,
+            senderId: '{auth.sessionId}',
+            sessionId: '{auth.sessionId}',
+            traceId: `ws-${input.suffix}`
+        },
+        route: {
+            topicId: 'app.black-box.live-three-browser.ws',
+            resourceId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
+            contextId: `${applicationId}:${workspaceId}:${input.groupId}`
+        },
+        targets: {
+            mode: 'unicast',
+            toPeerId: '{auth.sessionId}'
+        },
+        delivery: {
+            reliability: 'best-effort',
+            ack: 'none'
+        },
+        payload: {
+            typeId: 'app.black-box.live-three-browser.ws',
+            contentType: 'application/json',
+            resource: JSON.stringify({
+                matrixId: `ws-${agent.prefix.toLowerCase()}-${input.suffix}`,
+                agentId: agent.agentId,
+                groupId: input.groupId,
+                runId: input.runId
+            })
+        }
+    };
+}
+
+function toMatrixRawEvidence(
+    input: WriteAttemptEvidenceInput & { context: LiveRtcPerformanceAttemptContext; }
+): LiveRtcPerformanceRawEvidence {
     const environmentId = input.context.locator.environmentId;
     const e4 = environmentId === 'E4-pg';
-    const rawEvidence: LiveRtcPerformanceRawEvidence = {
+    return {
         identity: {
             workloadId: 'RTC-B06',
             caseId: input.context.locator.caseId,
@@ -1414,12 +1220,9 @@ async function writeAttemptEvidence(input: Readonly<{
             databaseProvider: e4 ? 'postgres' : 'memory',
             databaseUrl: envValue('DATABASE_URL') ? 'present' : 'absent',
             iceMode: e4 ? 'local' : 'repository-default',
-            allScenariosRaw:
-                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS'),
-            retentionSoakRaw:
-                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK'),
-            retentionCyclesRaw:
-                rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES'),
+            allScenariosRaw: rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_ALL_SCENARIOS'),
+            retentionSoakRaw: rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_SOAK'),
+            retentionCyclesRaw: rawEnvironmentValue('RALLAR_BLACK_BOX_LIVE_RETENTION_CYCLES'),
             iceModeRaw: rawEnvironmentValue('RALLAR_ICE_MODE'),
             transports: ['realtime', 'messages.rtc']
         },
@@ -1433,20 +1236,6 @@ async function writeAttemptEvidence(input: Readonly<{
         retention: input.retention,
         assertions: input.assertions
     };
-    const attempt = buildLiveRtcExternalAttempt({
-        locator: input.context.locator,
-        sampleIdentity: input.context.sampleIdentity,
-        producerExitStatus: input.producerExitStatus,
-        runtimeObservation: input.context.runtimeObservation,
-        rawEvidence
-    });
-    await writeLiveRtcPerformanceEvidence({
-        repoRoot: input.context.repoRoot,
-        baselineId: input.context.baselineId,
-        relativePath: input.context.locator.rawResultRelativePath,
-        evidence: attempt
-    });
-    await writeLiveRtcRetentionCohortIfComplete(input.context);
 }
 
 test.describe('full-stack live three-browser RTC matrix', () => {
@@ -1479,6 +1268,8 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             const control = new LiveRtcControlClient({
                 request,
                 baseUrl: CONTROL_BASE_URL,
+                monotonicNow: () => performance.now(),
+                epochNow: Date.now,
                 diagnosticsOutDir: envValue(
                     'RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR'
                 )
@@ -1539,7 +1330,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                         agents,
                         suffix: closeSuffix
                     });
-                await closeAgentContexts(agents);
+                await closeLiveRtcBrowserAgentContexts(agents);
                 for (const agent of agents) {
                     const index = openHandles.findIndex((candidate) => candidate.agentId === agent.agentId);
                     if (index >= 0) {
@@ -1604,12 +1395,14 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 scenarios.push(...messages.scenarios);
                 commandIds.push(
                     await runNackProbe({
+                        testInfo,
                         control,
                         runId,
                         agent: messageAgents[0],
                         groupId,
                         suffix,
-                        targetSessionId: messages.sessions.B
+                        targetSessionId: messages.sessions.B,
+                        senderSessionId: messages.sessions.A
                     })
                 );
                 const messageDiagnostics = await control.captureDiagnostics({
@@ -1651,13 +1444,13 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                 await expect.poll(async () => {
                     const run = await control.fetchRun(runId);
                     const resultIds = new Set(
-                        (run.results ?? [])
+                        run.results
                             .filter((result) => result.ok === true)
                             .map((result) => result.commandId)
                     );
                     const topics = control.runtimeTopics(run);
                     return {
-                        agents: (run.agents ?? [])
+                        agents: run.agents
                             .filter((agent) => allHandles.some((handle) => handle.agentId === agent.agentId))
                             .length,
                         keyCommandsComplete: commandIds
@@ -1690,8 +1483,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     await control.executeResult({
                         runId,
                         agentId: handle.agentId,
-                        commandId:
-                            `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
+                        commandId: `best-effort-close-${handle.prefix.toLowerCase()}-${suffix}`,
                         command: { kind: 'close' },
                         timeoutMs: 15_000
                     }).catch(() => undefined);
@@ -1736,6 +1528,8 @@ test.describe('full-stack live three-browser RTC matrix', () => {
         const control = new LiveRtcControlClient({
             request,
             baseUrl: CONTROL_BASE_URL,
+            monotonicNow: () => performance.now(),
+            epochNow: Date.now,
             diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
         });
         const suffix = `live3-all-${Date.now()}-${crypto.randomUUID()}`;
@@ -1786,7 +1580,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     agents,
                     suffix: closeSuffix
                 });
-            await closeAgentContexts(agents);
+            await closeLiveRtcBrowserAgentContexts(agents);
             for (const agent of agents) {
                 const index = openHandles.findIndex(
                     (candidate) => candidate.agentId === agent.agentId
@@ -1800,21 +1594,25 @@ test.describe('full-stack live three-browser RTC matrix', () => {
 
         try {
             const realtimeAgents = await openAgents('live-all-realtime');
-            commandIds.push(...await setupGroupMembership({
-                control,
-                runId,
-                owner: realtimeAgents[0],
-                members: realtimeAgents,
-                groupId,
-                suffix
-            }));
-            commandIds.push(...await verifyGroupStateReadback({
-                control,
-                runId,
-                owner: realtimeAgents[0],
-                groupId,
-                suffix
-            }));
+            commandIds.push(
+                ...await setupGroupMembership({
+                    control,
+                    runId,
+                    owner: realtimeAgents[0],
+                    members: realtimeAgents,
+                    groupId,
+                    suffix
+                })
+            );
+            commandIds.push(
+                ...await verifyGroupStateReadback({
+                    control,
+                    runId,
+                    owner: realtimeAgents[0],
+                    groupId,
+                    suffix
+                })
+            );
             const realtime = await runAllDeliveryPermutations({
                 control,
                 runId,
@@ -1835,20 +1633,24 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             });
             commandIds.push(...realtimeDiagnostics.commandIds);
             diagnostics.push(realtimeDiagnostics.checkpoint);
-            commandIds.push(...await retireAgents(
-                realtimeAgents,
-                `${suffix}-after-realtime-all`,
-                realtime.sessions
-            ));
+            commandIds.push(
+                ...await retireAgents(
+                    realtimeAgents,
+                    `${suffix}-after-realtime-all`,
+                    realtime.sessions
+                )
+            );
 
             const wsAgents = await openAgents('live-all-ws');
-            commandIds.push(...await runWebSocketOpenSendCloseMatrix({
-                control,
-                runId,
-                agents: wsAgents,
-                groupId,
-                suffix
-            }));
+            commandIds.push(
+                ...await runWebSocketOpenSendCloseMatrix({
+                    control,
+                    runId,
+                    agents: wsAgents,
+                    groupId,
+                    suffix
+                })
+            );
             commandIds.push(...await retireAgents(wsAgents, `${suffix}-after-ws-all`));
 
             const messageAgents = await openAgents('live-all-messages');
@@ -1863,30 +1665,38 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             commandIds.push(...messages.commandIds);
             scenarios.push(...messages.scenarios);
             timings.push(...messages.timings);
-            commandIds.push(await runNackProbe({
-                control,
-                runId,
-                agent: messageAgents[0],
-                groupId,
-                suffix,
-                targetSessionId: messages.sessions.B
-            }));
-            commandIds.push(...await expectClosedTransportFailure({
-                control,
-                runId,
-                agent: messageAgents[2],
-                groupId,
-                suffix,
-                targetSessionId: messages.sessions.B
-            }));
-            await Promise.all(messageAgents.slice(0, 2).map((agent) =>
-                control.waitForPeerAbsence({
+            commandIds.push(
+                await runNackProbe({
+                    testInfo,
+                    control,
                     runId,
-                    agent,
-                    departedPeerIds: [messages.sessions.C],
-                    suffix: `${suffix}-reconnect-c`
+                    agent: messageAgents[0],
+                    groupId,
+                    suffix,
+                    targetSessionId: messages.sessions.B,
+                    senderSessionId: messages.sessions.A
                 })
-            ));
+            );
+            commandIds.push(
+                ...await expectClosedTransportFailure({
+                    control,
+                    runId,
+                    agent: messageAgents[2],
+                    groupId,
+                    suffix,
+                    targetSessionId: messages.sessions.B
+                })
+            );
+            await Promise.all(
+                messageAgents.slice(0, 2).map((agent) =>
+                    control.waitForPeerAbsence({
+                        runId,
+                        agent,
+                        departedPeerIds: [messages.sessions.C],
+                        suffix: `${suffix}-reconnect-c`
+                    })
+                )
+            );
             const reconnectStartedAtMs = performance.now();
             const reconnectC = await connectAgent({
                 control,
@@ -1927,17 +1737,19 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             });
             const reconnectMatrixId = `messages-rtc-reconnect-b-to-c-${suffix}`;
             const reconnectMessageStartedAtMs = performance.now();
-            commandIds.push(await sendMatrixPayload({
-                control,
-                runId,
-                sender: messageAgents[1],
-                transport: 'messages.rtc',
-                groupId,
-                suffix,
-                deliveryMode: 'direct',
-                targetSessionIds: [reconnectC.sessionId],
-                matrixId: reconnectMatrixId
-            }));
+            commandIds.push(
+                await sendMatrixPayload({
+                    control,
+                    runId,
+                    sender: messageAgents[1],
+                    transport: 'messages.rtc',
+                    groupId,
+                    suffix,
+                    deliveryMode: 'direct',
+                    targetSessionIds: [reconnectC.sessionId],
+                    matrixId: reconnectMatrixId
+                })
+            );
             await control.waitForMessage({
                 runId,
                 agentId: messageAgents[2].agentId,
@@ -1956,12 +1768,14 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             });
             commandIds.push(...messageDiagnostics.commandIds);
             diagnostics.push(messageDiagnostics.checkpoint);
-            commandIds.push(...await closeAndResetAgents({
-                control,
-                runId,
-                agents: messageAgents,
-                suffix: `${suffix}-final-all`
-            }));
+            commandIds.push(
+                ...await closeAndResetAgents({
+                    control,
+                    runId,
+                    agents: messageAgents,
+                    suffix: `${suffix}-final-all`
+                })
+            );
             unexpectedDeliveryCount = await control.unexpectedDeliveryCount({
                 runId,
                 scenarios
@@ -1973,12 +1787,12 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             await expect.poll(async () => {
                 const run = await control.fetchRun(runId);
                 const resultIds = new Set(
-                    (run.results ?? [])
+                    run.results
                         .filter((result) => result.ok === true)
                         .map((result) => result.commandId)
                 );
                 return {
-                    agents: (run.agents ?? []).filter((agent) =>
+                    agents: run.agents.filter((agent) =>
                         allHandles.some((handle) => handle.agentId === agent.agentId)
                     ).length,
                     keyCommandsComplete: commandIds
@@ -2054,6 +1868,8 @@ test.describe('full-stack live three-browser RTC matrix', () => {
         const control = new LiveRtcControlClient({
             request,
             baseUrl: CONTROL_BASE_URL,
+            monotonicNow: () => performance.now(),
+            epochNow: Date.now,
             diagnosticsOutDir: envValue('RALLAR_BLACK_BOX_RTC_DIAGNOSTICS_OUT_DIR')
         });
         const suffix = `live3-retention-${Date.now()}-${crypto.randomUUID()}`;
@@ -2095,14 +1911,16 @@ test.describe('full-stack live three-browser RTC matrix', () => {
         };
 
         try {
-            commandIds.push(...await setupGroupMembership({
-                control,
-                runId,
-                owner: agents[0],
-                members: agents,
-                groupId,
-                suffix
-            }));
+            commandIds.push(
+                ...await setupGroupMembership({
+                    control,
+                    runId,
+                    owner: agents[0],
+                    members: agents,
+                    groupId,
+                    suffix
+                })
+            );
             const initialConnection = await connectAgentTrio({
                 control,
                 runId,
@@ -2113,8 +1931,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             });
             const connected = initialConnection.connections;
             commandIds.push(...connected.map((connection) => connection.commandId));
-            const initialReadinessStartedAtMs =
-                initialConnection.readinessStartedAtMs;
+            const initialReadinessStartedAtMs = initialConnection.readinessStartedAtMs;
             await Promise.all(agents.map((agent, agentIndex) =>
                 control.waitForPeerReadiness({
                     runId,
@@ -2139,14 +1956,16 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     timeoutMs: 45_000
                 });
                 commandIds.push(closeCommandId);
-                await Promise.all(agents.slice(0, 2).map((agent) =>
-                    control.waitForPeerAbsence({
-                        runId,
-                        agent,
-                        departedPeerIds: [currentSessionId],
-                        suffix: `${suffix}-${cycle}`
-                    })
-                ));
+                await Promise.all(
+                    agents.slice(0, 2).map((agent) =>
+                        control.waitForPeerAbsence({
+                            runId,
+                            agent,
+                            departedPeerIds: [currentSessionId],
+                            suffix: `${suffix}-${cycle}`
+                        })
+                    )
+                );
                 const reconnectStartedAtMs = performance.now();
                 const reconnected = await connectAgent({
                     control,
@@ -2189,12 +2008,14 @@ test.describe('full-stack live three-browser RTC matrix', () => {
             }
             reconnectPassed = true;
             matrixPassed = true;
-            commandIds.push(...await closeAndResetAgents({
-                control,
-                runId,
-                agents,
-                suffix: `${suffix}-final`
-            }));
+            commandIds.push(
+                ...await closeAndResetAgents({
+                    control,
+                    runId,
+                    agents,
+                    suffix: `${suffix}-final`
+                })
+            );
             await control.expectArtifactBundle({ runId, commandIds });
             artifactBundlePassed = true;
         }

--- a/tests/playwright/rallar-black-box/live-rtc-browser-agents.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-browser-agents.ts
@@ -1,0 +1,125 @@
+import { expect, type BrowserContext } from '@playwright/test';
+
+import { openTab } from './full-stack-helpers.ts';
+import type { LiveRtcControlClient } from './live-rtc-control-client.ts';
+import { installLiveRtcWireObservation } from './live-rtc-wire-observation.ts';
+
+export interface LiveRtcBrowserAgentConfig {
+    readonly spaBaseUrl: string;
+    readonly controlWsUrl: string;
+    readonly apiBaseUrl: string;
+    readonly register: boolean;
+}
+
+export interface LiveRtcRestoredSession {
+    readonly clientId: string;
+    readonly accessToken: string;
+    readonly username: string;
+    readonly sessionId: string;
+    readonly expiresAtEpochMs: number;
+}
+
+export type LiveRtcBrowserAgentAuth =
+    | Readonly<{
+        kind: 'login';
+        username: string;
+        password: string;
+    }>
+    | Readonly<{
+        kind: 'restore';
+        session: LiveRtcRestoredSession;
+    }>;
+
+export interface OpenLiveRtcBrowserAgentInput {
+    readonly config: LiveRtcBrowserAgentConfig;
+    readonly prefix: LiveRtcControlClient.Agent['prefix'];
+    readonly auth: LiveRtcBrowserAgentAuth;
+    readonly runId: string;
+    readonly agentId: string;
+    readonly actor: string;
+    readonly connection: string;
+    readonly groupId: string;
+}
+
+export interface LiveRtcBrowserContextFactory {
+    newContext(): Promise<Pick<BrowserContext, 'newPage' | 'close'>>;
+}
+
+export async function openLiveRtcBrowserAgent(
+    browser: LiveRtcBrowserContextFactory,
+    input: OpenLiveRtcBrowserAgentInput
+): Promise<LiveRtcControlClient.Agent> {
+    const context = await browser.newContext();
+    try {
+        const page = await context.newPage();
+        await page.addInitScript(installLiveRtcWireObservation);
+
+        if (input.auth.kind === 'restore') {
+            await page.addInitScript((session) => {
+                window.localStorage.setItem('auth.session', JSON.stringify(session));
+            }, input.auth.session);
+        }
+
+        const query = toLiveRtcBrowserAgentQuery(input);
+
+        await page.goto(`${input.config.spaBaseUrl}/?${query.toString()}`);
+
+        if (input.auth.kind === 'login') {
+            await expect(page.getByRole('heading', { name: 'Rallar Server Login' }))
+                .toBeVisible();
+            await page.getByRole('button', { name: 'Sign in' }).click();
+        }
+
+        await openTab(page, 'local-workbench', 'black-box-runner');
+        await expect(page.locator('#panel-local-workbench .control-panel'))
+            .toContainText('registered', { timeout: 30_000 });
+
+        return {
+            context,
+            page,
+            prefix: input.prefix,
+            agentId: input.agentId,
+            actor: input.actor,
+            connection: input.connection
+        };
+    }
+    catch (error) {
+        await context.close().catch(() => undefined);
+        throw error;
+    }
+}
+
+export async function closeLiveRtcBrowserAgentContexts(
+    agents: readonly LiveRtcControlClient.Agent[]
+): Promise<void> {
+    await Promise.all(
+        agents.map((agent) => agent.context.close().catch(() => undefined))
+    );
+}
+
+function toLiveRtcBrowserAgentQuery(input: OpenLiveRtcBrowserAgentInput): URLSearchParams {
+    return new URLSearchParams({
+        mode: 'control',
+        provider: 'browser-rallar',
+        autoConnect: '1',
+        tab: 'local-workbench',
+        controlUrl: input.config.controlWsUrl,
+        runId: input.runId,
+        agentId: input.agentId,
+        apiBaseUrl: input.config.apiBaseUrl,
+        roomId: input.groupId,
+        actor: input.actor,
+        sessionId: input.agentId,
+        transport: 'realtime',
+        statsIntervalMs: '2000',
+        rallarLeaveRoomOnClose: '0',
+        ...(input.config.register ? { rallarRegister: '1' } : {}),
+        ...(input.auth.kind === 'restore' ? { rallarRestoreSession: '1' } : {}),
+        ...(input.auth.kind === 'login'
+            ? {
+                rallarUsername: input.auth.username,
+                rallarPassword: input.auth.password
+            }
+            : {})
+    });
+}

--- a/tests/playwright/rallar-black-box/live-rtc-browser-agents.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-browser-agents.ts
@@ -90,7 +90,7 @@ export async function openLiveRtcBrowserAgent(
 }
 
 export async function closeLiveRtcBrowserAgentContexts(
-    agents: readonly LiveRtcControlClient.Agent[]
+    agents: readonly Pick<LiveRtcControlClient.Agent, 'context'>[]
 ): Promise<void> {
     await Promise.all(
         agents.map((agent) => agent.context.close().catch(() => undefined))

--- a/tests/playwright/rallar-black-box/live-rtc-control-client.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-control-client.ts
@@ -1,0 +1,559 @@
+import { expect, type APIRequestContext, type BrowserContext, type Page, type TestInfo } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { RtcBaselineJson } from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-contracts.ts';
+
+import {
+    jsonRecord,
+    normalizeJson,
+    optionalJsonArray,
+    optionalString,
+    requiredBoolean,
+    requiredJsonRecord,
+    requiredString,
+    stringArrayValue,
+    stringValue
+} from './live-rtc-evidence-json.ts';
+import {
+    buildLiveRtcAgentDiagnostics,
+    type LiveRtcAgentDiagnostics,
+    type LiveRtcDiagnosticsCheckpoint
+} from './live-rtc-performance-evidence.ts';
+
+export namespace LiveRtcControlClient {
+    export interface Agent {
+        context: Pick<BrowserContext, 'close'>;
+        page: Page;
+        prefix: 'A' | 'B' | 'C';
+        agentId: string;
+        actor: string;
+        connection: string;
+    }
+
+    export interface Result {
+        agentId?: string;
+        commandId: string;
+        ok: boolean;
+        result?: Readonly<{ value?: RtcBaselineJson; }>;
+        error?: RtcBaselineJson;
+    }
+
+    export interface Event {
+        kind?: string;
+        agentId?: string;
+        payload?: RtcBaselineJson;
+    }
+
+    export interface RunSnapshot {
+        agents: readonly Readonly<{ agentId: string; }>[];
+        results: readonly Result[];
+        events: readonly Event[];
+    }
+
+    export interface DeliveryScenario {
+        matrixId: string;
+        transport: 'realtime' | 'messages.rtc';
+        deliveryMode: 'direct' | 'multicast' | 'broadcast';
+        senderAgentId: string;
+        expectedAgentIds: readonly string[];
+        allowedAgentIds: readonly string[];
+    }
+
+    export interface ExecuteInput {
+        runId: string;
+        agentId: string;
+        commandId: string;
+        command: object;
+        timeoutMs?: number;
+    }
+
+    export interface WaitForMessageInput {
+        runId: string;
+        agentId: string;
+        transport: 'realtime' | 'messages.rtc';
+        matrixId: string;
+        deliveryMode: string;
+        startedAtMs: number;
+    }
+
+    export interface WaitForPeerReadinessInput {
+        runId: string;
+        agent: Pick<Agent, 'agentId' | 'prefix'> & { page: Pick<Page, 'evaluate'>; };
+        expectedPeerIds: readonly string[];
+        suffix: string;
+        startedAtMs: number;
+    }
+
+    export interface WaitForPeerAbsenceInput {
+        runId: string;
+        agent: Agent;
+        departedPeerIds: readonly string[];
+        suffix: string;
+    }
+
+    export interface CaptureDiagnosticsInput {
+        testInfo: TestInfo;
+        runId: string;
+        agents: readonly Agent[];
+        label: string;
+        cycle: number | null;
+    }
+
+    export interface CapturedDiagnostics {
+        commandIds: readonly string[];
+        checkpoint: LiveRtcDiagnosticsCheckpoint;
+    }
+}
+
+export class LiveRtcControlClient {
+    readonly #request: APIRequestContext;
+    readonly #baseUrl: string;
+    readonly #diagnosticsOutDir: string | undefined;
+    readonly #monotonicNow: () => number;
+    readonly #epochNow: () => number;
+
+    constructor(
+        input: Readonly<{
+            request: APIRequestContext;
+            baseUrl: string;
+            diagnosticsOutDir?: string;
+            monotonicNow: () => number;
+            epochNow: () => number;
+        }>
+    ) {
+        this.#request = input.request;
+        this.#baseUrl = input.baseUrl;
+        this.#diagnosticsOutDir = input.diagnosticsOutDir;
+        this.#monotonicNow = input.monotonicNow;
+        this.#epochNow = input.epochNow;
+    }
+
+    async fetchRun(runId: string): Promise<LiveRtcControlClient.RunSnapshot> {
+        const response = await this.#request.get(
+            `${this.#baseUrl}/runs/${encodeURIComponent(runId)}`
+        );
+        expect(response.ok()).toBe(true);
+        return decodeControlRunSnapshot(normalizeJson(await response.json()));
+    }
+
+    async executeResult(
+        input: LiveRtcControlClient.ExecuteInput
+    ): Promise<LiveRtcControlClient.Result> {
+        const response = await this.#request.post(
+            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/agents/${
+                encodeURIComponent(input.agentId)
+            }/commands`,
+            {
+                data: {
+                    commandId: input.commandId,
+                    command: input.command
+                }
+            }
+        );
+        expect(
+            response.status(),
+            `Expected command ${input.commandId} for agent ${input.agentId} to enqueue: ${await response.text()}`
+        ).toBe(202);
+
+        let latest: LiveRtcControlClient.Result | undefined;
+        await expect.poll(async () => {
+            const run = await this.fetchRun(input.runId);
+            latest = run.results.find(
+                (result) => result.commandId === input.commandId
+            );
+            return Boolean(latest);
+        }, {
+            timeout: input.timeoutMs ?? 45_000
+        }).toBe(true);
+        if (!latest) {
+            throw new Error(`Command ${input.commandId} did not return a result.`);
+        }
+        return latest;
+    }
+
+    async executeOk(
+        input: LiveRtcControlClient.ExecuteInput
+    ): Promise<LiveRtcControlClient.Result> {
+        const result = await this.executeResult(input);
+        expect(
+            result.ok,
+            `Expected command ${input.commandId} for agent ${input.agentId} to succeed: ${JSON.stringify(result)}`
+        ).toBe(true);
+        return result;
+    }
+
+    resultValue(
+        result: LiveRtcControlClient.Result
+    ): { [key: string]: RtcBaselineJson; } {
+        return jsonRecord(result.result?.value) ?? {};
+    }
+
+    requireSessionId(
+        result: LiveRtcControlClient.Result,
+        commandId: string
+    ): string {
+        const sessionId = stringValue(this.resultValue(result).sessionId);
+        if (!sessionId) {
+            throw new Error(`Connect result ${commandId} did not include a sessionId.`);
+        }
+        return sessionId;
+    }
+
+    requireSentMessageId(result: LiveRtcControlClient.Result): string {
+        const sendResult = jsonRecord(this.resultValue(result).message);
+        const sentMessage = jsonRecord(sendResult?.message);
+        const messageId = stringValue(jsonRecord(sentMessage?.id)?.msgId);
+        if (!messageId) {
+            throw new Error('RTC send result did not include a message ID.');
+        }
+        return messageId;
+    }
+
+    readyPeerIds(result: LiveRtcControlClient.Result): readonly string[] {
+        return stringArrayValue(
+            jsonRecord(
+                jsonRecord(this.resultValue(result).rallar)?.rtcStatus
+            )?.readyPeerIds
+        );
+    }
+
+    runtimeTopics(run: LiveRtcControlClient.RunSnapshot): readonly string[] {
+        return run.events
+            .map((event) => stringValue(runtimeEventPayload(event).topic))
+            .filter((topic): topic is string => Boolean(topic));
+    }
+
+    async waitForMessage(
+        input: LiveRtcControlClient.WaitForMessageInput
+    ): Promise<number> {
+        await expect.poll(async () => {
+            const run = await this.fetchRun(input.runId);
+            return run.events.some((event) => isMessageFor(event, input));
+        }, {
+            message: `Expected ${input.agentId} to receive ${input.transport} ${input.deliveryMode} ${input.matrixId}`,
+            timeout: 60_000
+        }).toBe(true);
+        return this.#monotonicNow() - input.startedAtMs;
+    }
+
+    async waitForPeerReadiness(
+        input: LiveRtcControlClient.WaitForPeerReadinessInput
+    ): Promise<number> {
+        const deadlineMs = this.#monotonicNow() + 60_000;
+        let attempt = 0;
+        await expect.poll(async () => {
+            const result = await this.executeResult({
+                runId: input.runId,
+                agentId: input.agent.agentId,
+                commandId: `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
+                command: { kind: 'health' },
+                timeoutMs: 15_000
+            }).catch(() => undefined);
+            if (!result?.ok) {
+                return [];
+            }
+            return stringArrayValue(
+                jsonRecord(
+                    jsonRecord(this.resultValue(result).rallar)?.rtcStatus
+                )?.readyPeerIds
+            );
+        }, {
+            message: `Expected ${input.agent.agentId} to see ready peers ${
+                input.expectedPeerIds.join(', ')
+            } for ${input.suffix}`,
+            timeout: 60_000
+        }).toEqual(expect.arrayContaining([...input.expectedPeerIds]));
+        const timeoutMs = deadlineMs - this.#monotonicNow();
+        if (timeoutMs <= 0) {
+            throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);
+        }
+        await input.agent.page.evaluate(async (timeoutMs) => {
+            if (!('__blackBoxRallar' in window)) {
+                throw new Error('RTC room refresh requires the browser Rallar runtime.');
+            }
+            const runtime = window.__blackBoxRallar;
+            if (
+                !runtime || typeof runtime !== 'object' ||
+                !('refreshRoom' in runtime) || typeof runtime.refreshRoom !== 'function'
+            ) {
+                throw new Error('RTC room refresh requires the browser Rallar runtime.');
+            }
+            await runtime.refreshRoom({ timeoutMs });
+        }, timeoutMs);
+        const readyAtMs = this.#monotonicNow();
+        if (readyAtMs >= deadlineMs) {
+            throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);
+        }
+        return readyAtMs - input.startedAtMs;
+    }
+
+    async waitForPeerAbsence(
+        input: LiveRtcControlClient.WaitForPeerAbsenceInput
+    ): Promise<void> {
+        let attempt = 0;
+        await expect.poll(async () => {
+            const result = await this.executeResult({
+                runId: input.runId,
+                agentId: input.agent.agentId,
+                commandId: `health-absent-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
+                command: { kind: 'health' },
+                timeoutMs: 15_000
+            }).catch(() => undefined);
+            if (!result?.ok) {
+                return input.departedPeerIds;
+            }
+            const readyPeerIds = this.readyPeerIds(result);
+            return input.departedPeerIds.filter((peerId) => readyPeerIds.includes(peerId));
+        }, {
+            message: `Expected ${input.agent.agentId} to observe departed peers ${
+                input.departedPeerIds.join(', ')
+            } for ${input.suffix}`,
+            timeout: 60_000
+        }).toEqual([]);
+    }
+
+    async unexpectedDeliveryCount(
+        input: Readonly<{
+            runId: string;
+            scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+        }>
+    ): Promise<number> {
+        const run = await this.fetchRun(input.runId);
+        return countUnexpectedLiveRtcDeliveries({
+            events: run.events,
+            scenarios: input.scenarios
+        });
+    }
+
+    async expectArtifactBundle(
+        input: Readonly<{
+            runId: string;
+            commandIds: readonly string[];
+        }>
+    ): Promise<void> {
+        const response = await this.#request.get(
+            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/artifacts`
+        );
+        expect(response.ok()).toBe(true);
+        const bundle = requiredJsonRecord(
+            normalizeJson(await response.json()),
+            '$.artifactBundle'
+        );
+        const files = requiredJsonRecord(bundle.files, '$.artifactBundle.files');
+        const report = stringValue(files['report.json']) ?? '';
+        const events = stringValue(files['events.jsonl']) ?? '';
+        expect(report).toContain(input.commandIds[0]);
+        expect(events).toContain('rallar.browser');
+    }
+
+    async attachRunSummary(
+        input: Readonly<{
+            testInfo: TestInfo;
+            runId: string;
+        }>
+    ): Promise<void> {
+        const run = await this.fetchRun(input.runId);
+        const body = JSON.stringify(
+            {
+                runId: input.runId,
+                agents: run.agents.map((agent) => agent.agentId),
+                resultCount: run.results.length,
+                eventCount: run.events.length
+            },
+            null,
+            2
+        );
+        await input.testInfo.attach('live-rtc-three-browser-run-summary.json', {
+            body,
+            contentType: 'application/json'
+        });
+        await this.#writeDiagnosticsArtifact(
+            `live-rtc-three-browser-run-summary-${safeFileName(input.runId)}.json`,
+            body
+        );
+    }
+
+    async captureDiagnostics(
+        input: LiveRtcControlClient.CaptureDiagnosticsInput
+    ): Promise<LiveRtcControlClient.CapturedDiagnostics> {
+        const commandIds: string[] = [];
+        const agents: LiveRtcAgentDiagnostics[] = [];
+        for (const agent of input.agents) {
+            const commandId = `rtc-diagnostics-${agent.prefix.toLowerCase()}-${input.label}`;
+            commandIds.push(commandId);
+            const result = await this.executeOk({
+                runId: input.runId,
+                agentId: agent.agentId,
+                commandId,
+                command: {
+                    kind: 'health',
+                    includeRtcDiagnostics: true
+                },
+                timeoutMs: 30_000
+            });
+            agents.push(
+                buildLiveRtcAgentDiagnostics(agent.agentId, this.resultValue(result))
+            );
+        }
+        const checkpoint: LiveRtcDiagnosticsCheckpoint = {
+            label: input.label,
+            cycle: input.cycle,
+            agents
+        };
+        const body = JSON.stringify(
+            {
+                runId: input.runId,
+                capturedAtEpochMs: this.#epochNow(),
+                ...checkpoint
+            },
+            null,
+            2
+        );
+        await input.testInfo.attach(`live-rtc-diagnostics-${input.label}.json`, {
+            body,
+            contentType: 'application/json'
+        });
+        await this.#writeDiagnosticsArtifact(
+            `live-rtc-diagnostics-${safeFileName(input.label)}.json`,
+            body
+        );
+        return { commandIds, checkpoint };
+    }
+
+    async #writeDiagnosticsArtifact(fileName: string, body: string): Promise<void> {
+        if (!this.#diagnosticsOutDir) {
+            return;
+        }
+        await mkdir(this.#diagnosticsOutDir, { recursive: true });
+        await writeFile(resolve(this.#diagnosticsOutDir, fileName), body);
+    }
+
+    async recordReceivedNack(
+        input: Readonly<{
+            testInfo: Pick<TestInfo, 'attach'>;
+            runId: string;
+            agentId: string;
+            messageId: string;
+            senderSessionId: string;
+            targetSessionId: string;
+            frames: readonly string[];
+        }>
+    ): Promise<void> {
+        const { testInfo, ...evidence } = input;
+        const body = JSON.stringify({ observation: 'received-protocol-nack', ...evidence }, null, 2);
+        const fileName = `live-rtc-received-nack-${safeFileName(input.agentId)}.json`;
+        await testInfo.attach(fileName, { body, contentType: 'application/json' });
+        await this.#writeDiagnosticsArtifact(fileName, body);
+    }
+}
+
+function decodeControlRunSnapshot(
+    value: RtcBaselineJson
+): LiveRtcControlClient.RunSnapshot {
+    const run = requiredJsonRecord(value, '$.controlRun');
+    const agents = optionalJsonArray(run.agents, '$.controlRun.agents').map(
+        (entry, index) => {
+            const agent = requiredJsonRecord(entry, `$.controlRun.agents[${index}]`);
+            return {
+                agentId: requiredString(
+                    agent.agentId,
+                    `$.controlRun.agents[${index}].agentId`
+                )
+            };
+        }
+    );
+    const results = optionalJsonArray(run.results, '$.controlRun.results').map(
+        (entry, index) => {
+            const result = requiredJsonRecord(entry, `$.controlRun.results[${index}]`);
+            const resultEnvelope = result.result === undefined
+                ? null
+                : requiredJsonRecord(
+                    result.result,
+                    `$.controlRun.results[${index}].result`
+                );
+            return {
+                agentId: optionalString(
+                    result.agentId,
+                    `$.controlRun.results[${index}].agentId`
+                ),
+                commandId: requiredString(
+                    result.commandId,
+                    `$.controlRun.results[${index}].commandId`
+                ),
+                ok: requiredBoolean(
+                    result.ok,
+                    `$.controlRun.results[${index}].ok`
+                ),
+                ...(resultEnvelope ? { result: { value: resultEnvelope.value } } : {}),
+                ...(result.error !== undefined ? { error: result.error } : {})
+            };
+        }
+    );
+    const events = optionalJsonArray(run.events, '$.controlRun.events').map(
+        (entry, index) => {
+            const event = requiredJsonRecord(entry, `$.controlRun.events[${index}]`);
+            return {
+                kind: optionalString(event.kind, `$.controlRun.events[${index}].kind`),
+                agentId: optionalString(
+                    event.agentId,
+                    `$.controlRun.events[${index}].agentId`
+                ),
+                ...(event.payload !== undefined ? { payload: event.payload } : {})
+            };
+        }
+    );
+    return { agents, results, events };
+}
+
+function runtimeEventPayload(
+    event: LiveRtcControlClient.Event
+): { [key: string]: RtcBaselineJson; } {
+    const payload = jsonRecord(event.payload) ?? {};
+    return typeof payload.kind === 'string'
+        ? payload
+        : jsonRecord(payload.payload) ?? payload;
+}
+
+function messageData(
+    event: LiveRtcControlClient.Event
+): { [key: string]: RtcBaselineJson; } {
+    const runtimeEvent = runtimeEventPayload(event);
+    const runtimePayload = jsonRecord(runtimeEvent.payload) ?? {};
+    return jsonRecord(runtimePayload.data ?? runtimeEvent.data) ?? {};
+}
+
+export function countUnexpectedLiveRtcDeliveries(
+    input: Readonly<{
+        events: readonly LiveRtcControlClient.Event[];
+        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
+    }>
+): number {
+    const scenarioById = new Map(
+        input.scenarios.map((scenario) => [scenario.matrixId, scenario])
+    );
+    return input.events.filter((event) => {
+        const matrixId = stringValue(messageData(event).matrixId);
+        const scenario = matrixId ? scenarioById.get(matrixId) : undefined;
+        return scenario !== undefined &&
+            event.agentId !== undefined &&
+            !scenario.allowedAgentIds.includes(event.agentId);
+    }).length;
+}
+
+function isMessageFor(
+    event: LiveRtcControlClient.Event,
+    input: LiveRtcControlClient.WaitForMessageInput
+): boolean {
+    const runtimeEvent = runtimeEventPayload(event);
+    const data = messageData(event);
+    return event.agentId === input.agentId &&
+        runtimeEvent.kind === 'message' &&
+        runtimeEvent.transport === input.transport &&
+        data.matrixId === input.matrixId &&
+        data.deliveryMode === input.deliveryMode;
+}
+
+function safeFileName(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_.-]+/g, '-');
+}

--- a/tests/playwright/rallar-black-box/live-rtc-evidence-json.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-evidence-json.ts
@@ -1,0 +1,144 @@
+import type { RtcBaselineJson } from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-contracts.ts';
+
+export function jsonRecord(
+    value: RtcBaselineJson | undefined
+): { [key: string]: RtcBaselineJson; } | null {
+    return value !== undefined &&
+            typeof value === 'object' &&
+            value !== null &&
+            !Array.isArray(value)
+        ? value
+        : null;
+}
+
+export function exactStringArray(value: RtcBaselineJson | undefined): readonly string[] | null {
+    return Array.isArray(value) &&
+            value.every((entry): entry is string => typeof entry === 'string')
+        ? value
+        : null;
+}
+
+export function isFiniteNonnegativeNumber(
+    value: RtcBaselineJson | undefined
+): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+export function optionalJsonArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): readonly RtcBaselineJson[] {
+    return value === undefined ? [] : requiredJsonArray(value, path);
+}
+
+export function optionalString(
+    value: RtcBaselineJson | undefined,
+    path: string
+): string | undefined {
+    return value === undefined ? undefined : requiredString(value, path);
+}
+
+export function stringValue(value: RtcBaselineJson | undefined): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function numberValue(value: RtcBaselineJson | undefined): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function stringArrayValue(value: RtcBaselineJson | undefined): readonly string[] {
+    return Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+}
+
+export function requiredJsonRecord(
+    value: RtcBaselineJson | undefined,
+    path: string
+): { [key: string]: RtcBaselineJson; } {
+    const record = jsonRecord(value);
+    if (!record) {
+        throw new Error(`${path} must be a JSON object.`);
+    }
+    return record;
+}
+
+export function requiredJsonArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): readonly RtcBaselineJson[] {
+    if (!Array.isArray(value)) {
+        throw new Error(`${path} must be a JSON array.`);
+    }
+    return value;
+}
+
+export function requiredStringArray(
+    value: RtcBaselineJson | undefined,
+    path: string
+): string[] {
+    const values = exactStringArray(value);
+    if (!values) {
+        throw new Error(`${path} must contain only strings.`);
+    }
+    return [...values];
+}
+
+export function requiredString(value: RtcBaselineJson | undefined, field: string): string {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`${field} must be a nonempty string.`);
+    }
+    return value;
+}
+
+export function requiredBoolean(value: RtcBaselineJson | undefined, field: string): boolean {
+    if (typeof value !== 'boolean') {
+        throw new Error(`${field} must be boolean.`);
+    }
+    return value;
+}
+
+export function requiredNonnegativeNumber(
+    value: RtcBaselineJson | undefined,
+    field: string
+): number {
+    if (!isFiniteNonnegativeNumber(value)) {
+        throw new Error(`${field} must be a finite nonnegative number.`);
+    }
+    return value;
+}
+
+export function normalizeJson(value: RtcBaselineJson | object): RtcBaselineJson {
+    assertJsonValue(value, '$');
+    return JSON.parse(JSON.stringify(value)) as RtcBaselineJson;
+}
+
+function assertJsonValue(value: RtcBaselineJson | object, path: string): void {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+        return;
+    }
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw new Error(`${path} contains a non-finite number.`);
+        }
+        return;
+    }
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            if (!(index in value)) {
+                throw new Error(`${path}[${index}] is a sparse array entry.`);
+            }
+            assertJsonValue(value[index], `${path}[${index}]`);
+        }
+        return;
+    }
+    if (typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
+        throw new Error(`${path} is not a plain JSON value.`);
+    }
+    for (const [field, entry] of Object.entries(value)) {
+        if (entry === undefined) {
+            throw new Error(`${path}.${field} is undefined.`);
+        }
+        assertJsonValue(entry, `${path}.${field}`);
+    }
+}

--- a/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
@@ -1,5 +1,5 @@
-import { expect, type APIRequestContext, type BrowserContext, type Page, type TestInfo } from '@playwright/test';
-import { lstat, mkdir, open, readFile, realpath, writeFile } from 'node:fs/promises';
+import type { Page } from '@playwright/test';
+import { lstat, mkdir, open, readFile, realpath } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { deriveRtcBaselineExternalAttempts } from '../../../packages/shared-rtc-bench/baseline/catalog/rtc-baseline-workload-manifest.ts';
 import {
@@ -23,6 +23,20 @@ import type {
     RtcBaselineSampleDto,
     RtcBaselineSampleIdentityDto
 } from '../../../packages/shared-rtc-bench/baseline/contracts/rtc-baseline-contracts.ts';
+
+import {
+    exactStringArray,
+    isFiniteNonnegativeNumber,
+    jsonRecord,
+    normalizeJson,
+    numberValue,
+    requiredBoolean,
+    requiredJsonArray,
+    requiredJsonRecord,
+    requiredNonnegativeNumber,
+    requiredString,
+    requiredStringArray
+} from './live-rtc-evidence-json.ts';
 
 export interface LiveRtcPerformanceIdentity {
     workloadId: 'RTC-B06';
@@ -170,377 +184,6 @@ export interface LiveRtcPerformanceAttemptLocator extends RtcBaselineAttemptLoca
     environmentId: LiveRtcPerformanceIdentity['environmentId'];
 }
 
-export namespace LiveRtcControlClient {
-    export interface Agent {
-        context: BrowserContext;
-        page: Page;
-        prefix: 'A' | 'B' | 'C';
-        agentId: string;
-        actor: string;
-        connection: string;
-    }
-
-    export interface Result {
-        agentId?: string;
-        commandId?: string;
-        ok?: boolean;
-        result?: Readonly<{ value?: RtcBaselineJson; }>;
-        error?: RtcBaselineJson;
-    }
-
-    export interface Event {
-        kind?: string;
-        agentId?: string;
-        payload?: RtcBaselineJson;
-    }
-
-    export interface RunSnapshot {
-        agents?: readonly Readonly<{ agentId?: string; }>[];
-        results?: readonly Result[];
-        events?: readonly Event[];
-    }
-
-    export interface DeliveryScenario {
-        matrixId: string;
-        transport: 'realtime' | 'messages.rtc';
-        deliveryMode: 'direct' | 'multicast' | 'broadcast';
-        senderAgentId: string;
-        expectedAgentIds: readonly string[];
-        allowedAgentIds: readonly string[];
-    }
-
-    export interface ExecuteInput {
-        runId: string;
-        agentId: string;
-        commandId: string;
-        command: object;
-        timeoutMs?: number;
-    }
-
-    export interface WaitForMessageInput {
-        runId: string;
-        agentId: string;
-        transport: 'realtime' | 'messages.rtc';
-        matrixId: string;
-        deliveryMode: string;
-        startedAtMs: number;
-    }
-
-    export interface WaitForPeerReadinessInput {
-        runId: string;
-        agent: Agent;
-        expectedPeerIds: readonly string[];
-        suffix: string;
-        startedAtMs: number;
-    }
-
-    export interface WaitForPeerAbsenceInput {
-        runId: string;
-        agent: Agent;
-        departedPeerIds: readonly string[];
-        suffix: string;
-    }
-
-    export interface CaptureDiagnosticsInput {
-        testInfo: TestInfo;
-        runId: string;
-        agents: readonly Agent[];
-        label: string;
-        cycle: number | null;
-    }
-
-    export interface CapturedDiagnostics {
-        commandIds: readonly string[];
-        checkpoint: LiveRtcDiagnosticsCheckpoint;
-    }
-}
-
-export class LiveRtcControlClient {
-    readonly #request: APIRequestContext;
-    readonly #baseUrl: string;
-    readonly #diagnosticsOutDir: string | undefined;
-
-    constructor(
-        input: Readonly<{
-            request: APIRequestContext;
-            baseUrl: string;
-            diagnosticsOutDir?: string;
-        }>
-    ) {
-        this.#request = input.request;
-        this.#baseUrl = input.baseUrl;
-        this.#diagnosticsOutDir = input.diagnosticsOutDir;
-    }
-
-    async fetchRun(runId: string): Promise<LiveRtcControlClient.RunSnapshot> {
-        const response = await this.#request.get(
-            `${this.#baseUrl}/runs/${encodeURIComponent(runId)}`
-        );
-        expect(response.ok()).toBe(true);
-        return decodeControlRunSnapshot(normalizeJson(await response.json()));
-    }
-
-    async executeResult(
-        input: LiveRtcControlClient.ExecuteInput
-    ): Promise<LiveRtcControlClient.Result> {
-        const response = await this.#request.post(
-            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/agents/${
-                encodeURIComponent(input.agentId)
-            }/commands`,
-            {
-                data: {
-                    commandId: input.commandId,
-                    command: input.command
-                }
-            }
-        );
-        expect(
-            response.status(),
-            `Expected command ${input.commandId} for agent ${input.agentId} to enqueue: ${await response.text()}`
-        ).toBe(202);
-
-        let latest: LiveRtcControlClient.Result | undefined;
-        await expect.poll(async () => {
-            const run = await this.fetchRun(input.runId);
-            latest = run.results?.find(
-                (result) => result.commandId === input.commandId
-            );
-            return Boolean(latest);
-        }, {
-            timeout: input.timeoutMs ?? 45_000
-        }).toBe(true);
-        if (!latest) {
-            throw new Error(`Command ${input.commandId} did not return a result.`);
-        }
-        return latest;
-    }
-
-    async executeOk(
-        input: LiveRtcControlClient.ExecuteInput
-    ): Promise<LiveRtcControlClient.Result> {
-        const result = await this.executeResult(input);
-        expect(
-            result.ok,
-            `Expected command ${input.commandId} for agent ${input.agentId} to succeed: ${JSON.stringify(result)}`
-        ).toBe(true);
-        return result;
-    }
-
-    resultValue(
-        result: LiveRtcControlClient.Result
-    ): { [key: string]: RtcBaselineJson; } {
-        return jsonRecord(result.result?.value) ?? {};
-    }
-
-    requireSessionId(
-        result: LiveRtcControlClient.Result,
-        commandId: string
-    ): string {
-        const sessionId = stringValue(this.resultValue(result).sessionId);
-        if (!sessionId) {
-            throw new Error(`Connect result ${commandId} did not include a sessionId.`);
-        }
-        return sessionId;
-    }
-
-    readyPeerIds(result: LiveRtcControlClient.Result): readonly string[] {
-        return stringArrayValue(
-            jsonRecord(
-                jsonRecord(this.resultValue(result).rallar)?.rtcStatus
-            )?.readyPeerIds
-        );
-    }
-
-    runtimeTopics(run: LiveRtcControlClient.RunSnapshot): readonly string[] {
-        return (run.events ?? [])
-            .map((event) => stringValue(runtimeEventPayload(event).topic))
-            .filter((topic): topic is string => Boolean(topic));
-    }
-
-    async waitForMessage(
-        input: LiveRtcControlClient.WaitForMessageInput
-    ): Promise<number> {
-        await expect.poll(async () => {
-            const run = await this.fetchRun(input.runId);
-            return run.events?.some((event) => isMessageFor(event, input)) ?? false;
-        }, {
-            message: `Expected ${input.agentId} to receive ${input.transport} ${input.deliveryMode} ${input.matrixId}`,
-            timeout: 60_000
-        }).toBe(true);
-        return performance.now() - input.startedAtMs;
-    }
-
-    async waitForPeerReadiness(
-        input: LiveRtcControlClient.WaitForPeerReadinessInput
-    ): Promise<number> {
-        let attempt = 0;
-        await expect.poll(async () => {
-            const result = await this.executeResult({
-                runId: input.runId,
-                agentId: input.agent.agentId,
-                commandId: `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
-                command: { kind: 'health' },
-                timeoutMs: 15_000
-            }).catch(() => undefined);
-            if (!result?.ok) {
-                return [];
-            }
-            return stringArrayValue(
-                jsonRecord(
-                    jsonRecord(this.resultValue(result).rallar)?.rtcStatus
-                )?.readyPeerIds
-            );
-        }, {
-            message: `Expected ${input.agent.agentId} to see ready peers ${
-                input.expectedPeerIds.join(', ')
-            } for ${input.suffix}`,
-            timeout: 60_000
-        }).toEqual(expect.arrayContaining([...input.expectedPeerIds]));
-        return performance.now() - input.startedAtMs;
-    }
-
-    async waitForPeerAbsence(
-        input: LiveRtcControlClient.WaitForPeerAbsenceInput
-    ): Promise<void> {
-        let attempt = 0;
-        await expect.poll(async () => {
-            const result = await this.executeResult({
-                runId: input.runId,
-                agentId: input.agent.agentId,
-                commandId: `health-absent-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
-                command: { kind: 'health' },
-                timeoutMs: 15_000
-            }).catch(() => undefined);
-            if (!result?.ok) {
-                return input.departedPeerIds;
-            }
-            const readyPeerIds = this.readyPeerIds(result);
-            return input.departedPeerIds.filter((peerId) => readyPeerIds.includes(peerId));
-        }, {
-            message: `Expected ${input.agent.agentId} to observe departed peers ${
-                input.departedPeerIds.join(', ')
-            } for ${input.suffix}`,
-            timeout: 60_000
-        }).toEqual([]);
-    }
-
-    async unexpectedDeliveryCount(
-        input: Readonly<{
-            runId: string;
-            scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
-        }>
-    ): Promise<number> {
-        const run = await this.fetchRun(input.runId);
-        return countUnexpectedLiveRtcDeliveries({
-            events: run.events ?? [],
-            scenarios: input.scenarios
-        });
-    }
-
-    async expectArtifactBundle(
-        input: Readonly<{
-            runId: string;
-            commandIds: readonly string[];
-        }>
-    ): Promise<void> {
-        const response = await this.#request.get(
-            `${this.#baseUrl}/runs/${encodeURIComponent(input.runId)}/artifacts`
-        );
-        expect(response.ok()).toBe(true);
-        const bundle = requiredJsonRecord(
-            normalizeJson(await response.json()),
-            '$.artifactBundle'
-        );
-        const files = requiredJsonRecord(bundle.files, '$.artifactBundle.files');
-        const report = stringValue(files['report.json']) ?? '';
-        const events = stringValue(files['events.jsonl']) ?? '';
-        expect(report).toContain(input.commandIds[0]);
-        expect(events).toContain('rallar.browser');
-    }
-
-    async attachRunSummary(
-        input: Readonly<{
-            testInfo: TestInfo;
-            runId: string;
-        }>
-    ): Promise<void> {
-        const run = await this.fetchRun(input.runId);
-        const body = JSON.stringify(
-            {
-                runId: input.runId,
-                agents: run.agents?.map((agent) => agent.agentId),
-                resultCount: run.results?.length ?? 0,
-                eventCount: run.events?.length ?? 0
-            },
-            null,
-            2
-        );
-        await input.testInfo.attach('live-rtc-three-browser-run-summary.json', {
-            body,
-            contentType: 'application/json'
-        });
-        await this.#writeDiagnosticsArtifact(
-            `live-rtc-three-browser-run-summary-${safeFileName(input.runId)}.json`,
-            body
-        );
-    }
-
-    async captureDiagnostics(
-        input: LiveRtcControlClient.CaptureDiagnosticsInput
-    ): Promise<LiveRtcControlClient.CapturedDiagnostics> {
-        const commandIds: string[] = [];
-        const agents: LiveRtcAgentDiagnostics[] = [];
-        for (const agent of input.agents) {
-            const commandId = `rtc-diagnostics-${agent.prefix.toLowerCase()}-${input.label}`;
-            commandIds.push(commandId);
-            const result = await this.executeOk({
-                runId: input.runId,
-                agentId: agent.agentId,
-                commandId,
-                command: {
-                    kind: 'health',
-                    includeRtcDiagnostics: true
-                },
-                timeoutMs: 30_000
-            });
-            agents.push(
-                buildLiveRtcAgentDiagnostics(agent.agentId, this.resultValue(result))
-            );
-        }
-        const checkpoint: LiveRtcDiagnosticsCheckpoint = {
-            label: input.label,
-            cycle: input.cycle,
-            agents
-        };
-        const body = JSON.stringify(
-            {
-                runId: input.runId,
-                capturedAtEpochMs: Date.now(),
-                ...checkpoint
-            },
-            null,
-            2
-        );
-        await input.testInfo.attach(`live-rtc-diagnostics-${input.label}.json`, {
-            body,
-            contentType: 'application/json'
-        });
-        await this.#writeDiagnosticsArtifact(
-            `live-rtc-diagnostics-${safeFileName(input.label)}.json`,
-            body
-        );
-        return { commandIds, checkpoint };
-    }
-
-    async #writeDiagnosticsArtifact(fileName: string, body: string): Promise<void> {
-        if (!this.#diagnosticsOutDir) {
-            return;
-        }
-        await mkdir(this.#diagnosticsOutDir, { recursive: true });
-        await writeFile(resolve(this.#diagnosticsOutDir, fileName), body);
-    }
-}
-
 const FIVE_MEBIBYTES = 5 * 1024 * 1024;
 const LIVE_RTC_BASELINE_ID =
     /^(?:\d{8}-[0-9a-f]{12}-e(?:3-memory|4-pg)|\d{8}T\d{9}Z-[0-9a-f]{12}-e(?:3-memory|4-pg)-local|\d{8}T\d{6}Z-[0-9a-f]{12}-e(?:3-memory|4-pg)-gh[1-9][0-9]*-a[1-9][0-9]*)(?:-repeat-01)?$/u;
@@ -552,9 +195,17 @@ const attemptIdentityFields = [
     'outerOrdinal'
 ] as const;
 
-export async function loadLiveRtcPerformanceAttempt(
-    input: LoadLiveRtcPerformanceAttemptInput
-): Promise<LiveRtcPerformanceAttemptContext | null> {
+interface LiveRtcAttemptSelection {
+    baselineId: string;
+    caseId: string;
+    inputKey: string;
+    intendedPhase: string;
+    outerOrdinal: number;
+}
+
+function toLiveRtcAttemptSelection(
+    environment: Readonly<Record<string, string | undefined>>
+): LiveRtcAttemptSelection | null {
     const names = [
         'RALLAR_BLACK_BOX_RTC_BASELINE_ID',
         'RALLAR_BLACK_BOX_RTC_CASE_ID',
@@ -563,7 +214,7 @@ export async function loadLiveRtcPerformanceAttempt(
         'RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL'
     ] as const;
     const values = names.map((name) => {
-        const value = input.environment[name];
+        const value = environment[name];
         return value !== undefined && value.length > 0 ? value : undefined;
     });
     if (values.every((value) => value === undefined)) {
@@ -588,6 +239,17 @@ export async function loadLiveRtcPerformanceAttempt(
     if (!Number.isSafeInteger(outerOrdinal)) {
         throw new Error('RALLAR_BLACK_BOX_RTC_OUTER_ORDINAL must be a safe positive integer.');
     }
+    return { baselineId, caseId, inputKey, intendedPhase, outerOrdinal };
+}
+
+export async function loadLiveRtcPerformanceAttempt(
+    input: LoadLiveRtcPerformanceAttemptInput
+): Promise<LiveRtcPerformanceAttemptContext | null> {
+    const selection = toLiveRtcAttemptSelection(input.environment);
+    if (!selection) {
+        return null;
+    }
+    const { baselineId, caseId, inputKey, intendedPhase, outerOrdinal } = selection;
     const baselineRoot = resolve(
         input.repoRoot,
         'tmp',
@@ -608,12 +270,7 @@ export async function loadLiveRtcPerformanceAttempt(
         throw new Error('Live RTC evidence environment does not identify a predeclared attempt.');
     }
     const outerAttempt = manifest.outerAttempts.find(
-        (attempt) =>
-            attempt.workloadId === locator.workloadId &&
-            attempt.caseId === locator.caseId &&
-            attempt.inputKey === locator.inputKey &&
-            attempt.intendedPhase === locator.intendedPhase &&
-            attempt.outerOrdinal === locator.outerOrdinal
+        (attempt) => attemptIdentityFields.every((field) => attempt[field] === locator[field])
     );
     if (!outerAttempt || outerAttempt.sampleIds.length !== 1) {
         throw new Error('Live RTC evidence requires exactly one predeclared sample per attempt.');
@@ -976,6 +633,22 @@ function attemptIssues(input: BuildLiveRtcExternalAttemptInput): RtcBaselineIssu
             });
         }
     }
+    issues.push(...diagnosticCheckpointIssues(evidence));
+    if (evidence.identity.caseId === 'retention-100') {
+        issues.push(...retentionAttemptIssues(evidence));
+    }
+    else if (evidence.retention !== null) {
+        issues.push({
+            path: '$.rawEvidence.retention',
+            code: 'unexpected-retention-evidence',
+            message: 'Only the retention-100 case may contain retention checkpoints.'
+        });
+    }
+    return issues;
+}
+
+function diagnosticCheckpointIssues(evidence: LiveRtcPerformanceRawEvidence): RtcBaselineIssueDto[] {
+    const issues: RtcBaselineIssueDto[] = [];
     if (evidence.diagnostics.length === 0) {
         issues.push({
             path: '$.rawEvidence.diagnostics',
@@ -994,16 +667,6 @@ function attemptIssues(input: BuildLiveRtcExternalAttemptInput): RtcBaselineIssu
             path: '$.rawEvidence.diagnostics',
             code: 'incomplete-rtc-diagnostics',
             message: 'Every RTC diagnostics checkpoint must contain three distinct browser agents.'
-        });
-    }
-    if (evidence.identity.caseId === 'retention-100') {
-        issues.push(...retentionAttemptIssues(evidence));
-    }
-    else if (evidence.retention !== null) {
-        issues.push({
-            path: '$.rawEvidence.retention',
-            code: 'unexpected-retention-evidence',
-            message: 'Only the retention-100 case may contain retention checkpoints.'
         });
     }
     return issues;
@@ -1392,164 +1055,6 @@ function decodeLaneDiagnostics(
         : null;
 }
 
-function jsonRecord(
-    value: RtcBaselineJson | undefined
-): { [key: string]: RtcBaselineJson; } | null {
-    return value !== undefined &&
-            typeof value === 'object' &&
-            value !== null &&
-            !Array.isArray(value)
-        ? value
-        : null;
-}
-
-function exactStringArray(value: RtcBaselineJson | undefined): readonly string[] | null {
-    return Array.isArray(value) &&
-            value.every((entry): entry is string => typeof entry === 'string')
-        ? value
-        : null;
-}
-
-function isFiniteNonnegativeNumber(
-    value: RtcBaselineJson | undefined
-): value is number {
-    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
-}
-
-function decodeControlRunSnapshot(
-    value: RtcBaselineJson
-): LiveRtcControlClient.RunSnapshot {
-    const run = requiredJsonRecord(value, '$.controlRun');
-    const agents = optionalJsonArray(run.agents, '$.controlRun.agents').map(
-        (entry, index) => {
-            const agent = requiredJsonRecord(entry, `$.controlRun.agents[${index}]`);
-            return {
-                agentId: requiredString(
-                    agent.agentId,
-                    `$.controlRun.agents[${index}].agentId`
-                )
-            };
-        }
-    );
-    const results = optionalJsonArray(run.results, '$.controlRun.results').map(
-        (entry, index) => {
-            const result = requiredJsonRecord(entry, `$.controlRun.results[${index}]`);
-            const resultEnvelope = result.result === undefined
-                ? null
-                : requiredJsonRecord(
-                    result.result,
-                    `$.controlRun.results[${index}].result`
-                );
-            return {
-                agentId: optionalString(
-                    result.agentId,
-                    `$.controlRun.results[${index}].agentId`
-                ),
-                commandId: requiredString(
-                    result.commandId,
-                    `$.controlRun.results[${index}].commandId`
-                ),
-                ok: requiredBoolean(
-                    result.ok,
-                    `$.controlRun.results[${index}].ok`
-                ),
-                ...(resultEnvelope ? { result: { value: resultEnvelope.value } } : {}),
-                ...(result.error !== undefined ? { error: result.error } : {})
-            };
-        }
-    );
-    const events = optionalJsonArray(run.events, '$.controlRun.events').map(
-        (entry, index) => {
-            const event = requiredJsonRecord(entry, `$.controlRun.events[${index}]`);
-            return {
-                kind: optionalString(event.kind, `$.controlRun.events[${index}].kind`),
-                agentId: optionalString(
-                    event.agentId,
-                    `$.controlRun.events[${index}].agentId`
-                ),
-                ...(event.payload !== undefined ? { payload: event.payload } : {})
-            };
-        }
-    );
-    return { agents, results, events };
-}
-
-function optionalJsonArray(
-    value: RtcBaselineJson | undefined,
-    path: string
-): readonly RtcBaselineJson[] {
-    return value === undefined ? [] : requiredJsonArray(value, path);
-}
-
-function optionalString(
-    value: RtcBaselineJson | undefined,
-    path: string
-): string | undefined {
-    return value === undefined ? undefined : requiredString(value, path);
-}
-
-function stringValue(value: RtcBaselineJson | undefined): string | undefined {
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function numberValue(value: RtcBaselineJson | undefined): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
-function stringArrayValue(value: RtcBaselineJson | undefined): readonly string[] {
-    return Array.isArray(value)
-        ? value.filter((entry): entry is string => typeof entry === 'string')
-        : [];
-}
-
-function runtimeEventPayload(
-    event: LiveRtcControlClient.Event
-): { [key: string]: RtcBaselineJson; } {
-    const payload = jsonRecord(event.payload) ?? {};
-    return typeof payload.kind === 'string'
-        ? payload
-        : jsonRecord(payload.payload) ?? payload;
-}
-
-function messageData(
-    event: LiveRtcControlClient.Event
-): { [key: string]: RtcBaselineJson; } {
-    const runtimeEvent = runtimeEventPayload(event);
-    const runtimePayload = jsonRecord(runtimeEvent.payload) ?? {};
-    return jsonRecord(runtimePayload.data ?? runtimeEvent.data) ?? {};
-}
-
-export function countUnexpectedLiveRtcDeliveries(
-    input: Readonly<{
-        events: readonly LiveRtcControlClient.Event[];
-        scenarios: readonly LiveRtcControlClient.DeliveryScenario[];
-    }>
-): number {
-    const scenarioById = new Map(
-        input.scenarios.map((scenario) => [scenario.matrixId, scenario])
-    );
-    return input.events.filter((event) => {
-        const matrixId = stringValue(messageData(event).matrixId);
-        const scenario = matrixId ? scenarioById.get(matrixId) : undefined;
-        return scenario !== undefined &&
-            event.agentId !== undefined &&
-            !scenario.allowedAgentIds.includes(event.agentId);
-    }).length;
-}
-
-function isMessageFor(
-    event: LiveRtcControlClient.Event,
-    input: LiveRtcControlClient.WaitForMessageInput
-): boolean {
-    const runtimeEvent = runtimeEventPayload(event);
-    const data = messageData(event);
-    return event.agentId === input.agentId &&
-        runtimeEvent.kind === 'message' &&
-        runtimeEvent.transport === input.transport &&
-        data.matrixId === input.matrixId &&
-        data.deliveryMode === input.deliveryMode;
-}
-
 export function buildLiveRtcAgentDiagnostics(
     agentId: string,
     resultValue: RtcBaselineJson | object
@@ -1575,42 +1080,12 @@ export function buildLiveRtcAgentDiagnostics(
         '$.rallar.rtcDiagnostics.peers'
     );
     const peerRecords = peers.map((peer, index) => requiredJsonRecord(peer, `$.rallar.rtcDiagnostics.peers[${index}]`));
-    const laneStates = peerRecords.flatMap((peer) => {
-        const peerId = requiredString(peer.peerId, 'RTC diagnostic peerId');
-        const lanes = requiredJsonArray(peer.lanes, `RTC diagnostic lanes for ${peerId}`);
-        return lanes.map((laneValue, index) => {
-            const lane = requiredJsonRecord(
-                laneValue,
-                `RTC diagnostic lane ${index} for ${peerId}`
-            );
-            return {
-                peerId,
-                laneId: requiredString(lane.laneId, `RTC diagnostic laneId for ${peerId}`),
-                isOpen: requiredBoolean(lane.isOpen, `RTC diagnostic isOpen for ${peerId}`),
-                isReconnectable: requiredBoolean(
-                    lane.isReconnectable,
-                    `RTC diagnostic isReconnectable for ${peerId}`
-                )
-            };
-        });
-    }).sort(compareLaneStates);
-    const connectionTimerActive = peerRecords.some((peer) => {
-        const connection = requiredJsonRecord(
-            peer.connection,
-            'RTC diagnostic peer connection'
-        );
-        const connectionDiagnostics = jsonRecord(peer.connectionDiagnostics);
-        return connection.disconnectPending === true ||
-            connection.reconnecting === true ||
-            connectionDiagnostics?.hasReconnectTimer === true ||
-            (numberValue(connectionDiagnostics?.reconnectAttemptsInFlight) ?? 0) !== 0;
-    });
     return {
         agentId,
         settledPeerIds,
         readyPeerIds,
-        laneStates,
-        connectionTimerActive,
+        laneStates: toLiveRtcLaneStates(peerRecords),
+        connectionTimerActive: hasLiveRtcConnectionTimer(peerRecords),
         peerCount: requiredNonnegativeNumber(diagnostics.peerCount, 'RTC peerCount'),
         connectedPeerCount: requiredNonnegativeNumber(
             diagnostics.connectedPeerCount,
@@ -1630,107 +1105,52 @@ export function buildLiveRtcAgentDiagnostics(
     };
 }
 
+function toLiveRtcLaneStates(
+    peerRecords: readonly { [key: string]: RtcBaselineJson; }[]
+): LiveRtcLaneDiagnostics[] {
+    return peerRecords.flatMap((peer) => {
+        const peerId = requiredString(peer.peerId, 'RTC diagnostic peerId');
+        const lanes = requiredJsonArray(peer.lanes, `RTC diagnostic lanes for ${peerId}`);
+        return lanes.map((laneValue, index) => {
+            const lane = requiredJsonRecord(
+                laneValue,
+                `RTC diagnostic lane ${index} for ${peerId}`
+            );
+            return {
+                peerId,
+                laneId: requiredString(lane.laneId, `RTC diagnostic laneId for ${peerId}`),
+                isOpen: requiredBoolean(lane.isOpen, `RTC diagnostic isOpen for ${peerId}`),
+                isReconnectable: requiredBoolean(
+                    lane.isReconnectable,
+                    `RTC diagnostic isReconnectable for ${peerId}`
+                )
+            };
+        });
+    }).sort(compareLaneStates);
+}
+
+function hasLiveRtcConnectionTimer(
+    peerRecords: readonly { [key: string]: RtcBaselineJson; }[]
+): boolean {
+    return peerRecords.some((peer) => {
+        const connection = requiredJsonRecord(
+            peer.connection,
+            'RTC diagnostic peer connection'
+        );
+        const connectionDiagnostics = jsonRecord(peer.connectionDiagnostics);
+        return connection.disconnectPending === true ||
+            connection.reconnecting === true ||
+            connectionDiagnostics?.hasReconnectTimer === true ||
+            (numberValue(connectionDiagnostics?.reconnectAttemptsInFlight) ?? 0) !== 0;
+    });
+}
+
 function compareLaneStates(
     left: LiveRtcLaneDiagnostics,
     right: LiveRtcLaneDiagnostics
 ): number {
     return left.peerId.localeCompare(right.peerId) ||
         left.laneId.localeCompare(right.laneId);
-}
-
-function requiredJsonRecord(
-    value: RtcBaselineJson | undefined,
-    path: string
-): { [key: string]: RtcBaselineJson; } {
-    const record = jsonRecord(value);
-    if (!record) {
-        throw new Error(`${path} must be a JSON object.`);
-    }
-    return record;
-}
-
-function requiredJsonArray(
-    value: RtcBaselineJson | undefined,
-    path: string
-): readonly RtcBaselineJson[] {
-    if (!Array.isArray(value)) {
-        throw new Error(`${path} must be a JSON array.`);
-    }
-    return value;
-}
-
-function requiredStringArray(
-    value: RtcBaselineJson | undefined,
-    path: string
-): string[] {
-    const values = exactStringArray(value);
-    if (!values) {
-        throw new Error(`${path} must contain only strings.`);
-    }
-    return [...values];
-}
-
-function requiredString(value: RtcBaselineJson | undefined, field: string): string {
-    if (typeof value !== 'string' || value.length === 0) {
-        throw new Error(`${field} must be a nonempty string.`);
-    }
-    return value;
-}
-
-function requiredBoolean(value: RtcBaselineJson | undefined, field: string): boolean {
-    if (typeof value !== 'boolean') {
-        throw new Error(`${field} must be boolean.`);
-    }
-    return value;
-}
-
-function requiredNonnegativeNumber(
-    value: RtcBaselineJson | undefined,
-    field: string
-): number {
-    if (!isFiniteNonnegativeNumber(value)) {
-        throw new Error(`${field} must be a finite nonnegative number.`);
-    }
-    return value;
-}
-
-function safeFileName(value: string): string {
-    return value.replace(/[^a-zA-Z0-9_.-]+/g, '-');
-}
-
-function normalizeJson(value: RtcBaselineJson | object): RtcBaselineJson {
-    assertJsonValue(value, '$');
-    return JSON.parse(JSON.stringify(value)) as RtcBaselineJson;
-}
-
-function assertJsonValue(value: RtcBaselineJson | object, path: string): void {
-    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-        return;
-    }
-    if (typeof value === 'number') {
-        if (!Number.isFinite(value)) {
-            throw new Error(`${path} contains a non-finite number.`);
-        }
-        return;
-    }
-    if (Array.isArray(value)) {
-        for (let index = 0; index < value.length; index += 1) {
-            if (!(index in value)) {
-                throw new Error(`${path}[${index}] is a sparse array entry.`);
-            }
-            assertJsonValue(value[index], `${path}[${index}]`);
-        }
-        return;
-    }
-    if (typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
-        throw new Error(`${path} is not a plain JSON value.`);
-    }
-    for (const [field, entry] of Object.entries(value)) {
-        if (entry === undefined) {
-            throw new Error(`${path}.${field} is undefined.`);
-        }
-        assertJsonValue(entry, `${path}.${field}`);
-    }
 }
 
 async function createConfinedDirectories(

--- a/tests/playwright/rallar-black-box/live-rtc-wire-observation.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-wire-observation.ts
@@ -1,0 +1,97 @@
+import { jsonRecord, normalizeJson, stringValue } from './live-rtc-evidence-json.ts';
+
+export interface LiveRtcWireObservation {
+    start(): void;
+    read(): readonly string[];
+    stop(): void;
+}
+
+declare global {
+    interface Window {
+        __liveRtcWireObservation?: LiveRtcWireObservation;
+    }
+}
+
+/** Serialized by Playwright before app startup; contains no imported runtime dependencies. */
+export function installLiveRtcWireObservation(): void {
+    const channels = new Set<RTCDataChannel>();
+    const frames: string[] = [];
+    let active = false;
+    const receive = (event: MessageEvent) => {
+        if (typeof event.data === 'string' && frames.length <= 1_000) {
+            frames.push(event.data);
+        }
+    };
+    const track = (channel: RTCDataChannel) => {
+        channels.add(channel);
+        if (active) {
+            channel.addEventListener('message', receive);
+        }
+        channel.addEventListener('close', () => {
+            channels.delete(channel);
+            channel.removeEventListener('message', receive);
+        }, { once: true });
+    };
+    const NativePeerConnection = window.RTCPeerConnection;
+    window.RTCPeerConnection = class extends NativePeerConnection {
+        constructor(configuration?: RTCConfiguration) {
+            super(configuration);
+            this.addEventListener('datachannel', (event) => track(event.channel));
+        }
+        override createDataChannel(label: string, options?: RTCDataChannelInit): RTCDataChannel {
+            const channel = super.createDataChannel(label, options);
+            track(channel);
+            return channel;
+        }
+    };
+    window.__liveRtcWireObservation = {
+        start: () => {
+            frames.length = 0;
+            active = true;
+            channels.forEach((channel) => channel.addEventListener('message', receive));
+        },
+        read: () => {
+            if (frames.length > 1_000) {
+                throw new Error('RTC wire observation exceeded its frame limit.');
+            }
+            return [...frames];
+        },
+        stop: () => {
+            active = false;
+            channels.forEach((channel) => channel.removeEventListener('message', receive));
+            frames.length = 0;
+        }
+    };
+}
+
+export function hasLiveRtcNotYetInSyncNack(
+    input: Readonly<{
+        frames: readonly string[];
+        messageId: string;
+        senderSessionId: string;
+        targetSessionId: string;
+    }>
+): boolean {
+    return input.frames.some((frame) => {
+        let message;
+        try {
+            message = jsonRecord(normalizeJson(JSON.parse(frame)));
+        }
+        catch {
+            return false;
+        }
+        const payload = jsonRecord(message?.payload);
+        const resource = stringValue(payload?.resource);
+        if (payload?.typeId !== 'al.control.nack.v1' || !resource) {
+            return false;
+        }
+        try {
+            const nack = jsonRecord(normalizeJson(JSON.parse(resource)));
+            return nack?.msgId === input.messageId && nack.reason === 'not-yet-in-sync' &&
+                nack.fromPeerId === input.targetSessionId && nack.toPeerId === input.senderSessionId;
+        }
+        catch {
+            return false;
+        }
+    });
+}


### PR DESCRIPTION
## Goal

Make RTC-B06 measurements wait for authoritative room membership after transport readiness, so measured sends do not race the room cache.

## Changes

- Refresh the exact configured room after RTC peer readiness, inside the shared readiness deadline and measured duration. Propagate refresh failure; preserve production routing and membership safeguards.
- Separate browser-agent lifecycle, control commands, evidence decoding, and artifact construction into directly owned harness modules. Consolidate the duplicated delivery matrix without reducing sender/receiver permutations.
- Close allocated browser contexts on startup failure, including earlier agents in a partially opened trio.
- Replace the self-fulfilling NACK text search with a bounded, probe-only native data-channel observer. Require a received protocol NACK matching the sent message and both peer identities; record the matched evidence. Production message subscriptions and control handling are unchanged.

- Remove obsolete helper-call-count and crypto source-text assertions from the script gates. Retain the script configuration and benchmark import-boundary checks, with semantic readiness, startup cleanup, and NACK/evidence coverage.

## Acceptance

- [x] Room-refresh completion and elapsed cost are covered by focused regressions, including refresh failure and exhausted deadline.
- [x] Startup cleanup, send-result identity, and protocol evidence rejection have focused coverage.
- [x] Independent review completed with no remaining harness findings; all changed files and remediation support files reviewed in full.
- [ ] Final real-browser matrix passes: blocked by the confirmed existing RTC snapshot-version/NACK gap in #399.
- [x] Branch Release Gate passes.

## Validation

- Branch Release Gate passed after the test correction: 8,415 unit tests passed (9 skipped), followed by the Deno/browser suite, all deployable app builds, Postgres integration, API black-box recipes, topology replay, full-stack smoke, and presence-expiry checks.
- The test-only CI correction passes **48 tests across 6 files**, covering script gates, control readiness, browser lifecycle, wire observation, evidence, and browser bundle boundaries. This was checked from a clean snapshot of the publication candidate, excluding unfinished local production work.
- The Rallar Black Box application typecheck passes.
- `npm run typecheck:tests`: **973 files enforced, 0 known debt, 0 errors**. Explicit Playwright harness `tsc --noEmit` passes.
- Shared RTC benchmark package check passed: 413 tests plus TypeScript and Deno checks.
- Rallar Black Box build passed.
- Three independent default browser matrix repetitions passed with no retries before the stricter NACK observer was added. Those runs support the readiness correction but do not prove NACK receipt.
- The final native-observer full-scenario run **failed**: no correlated `not-yet-in-sync` NACK was received. Independent execution of the real message builder/policy confirms `minSnapshotVersion: 9999999` still permits local delivery without a NACK. Earlier invalid observer attempts were diagnosed and removed; none is accepted B06 evidence.
- Repository structure/style and changed-range test structure-coupling checks passed, with **0 current coupling candidates**.
- Retention soak and fresh remote B06 capture were not rerun after discovering the blocking production gap. No E4 or B07 run was dispatched.

## Risk and rollback

Harness-only change: no production routing, persisted format, deployment workflow, or public API changes. Wire receipt is not a claim of downstream control acceptance. Packet listeners are attached only during the unmeasured NACK probe and cleared in `finally`; capture overflow fails explicitly. Revert this PR to roll back the harness change.

## Follow-up

Keep this PR draft until the production snapshot-version/NACK correction tracked in [#399](https://github.com/intact-software-systems/ar-eye-hunter/issues/399) is completed and the real-browser matrix is rerun. That production correction is in progress locally and is not included in this test-only CI update. Do not silently weaken the browser assertion. After the authorized correction and merge, take a fresh RTC-B06 observation from then-current main and assess the evidence without retrying failed measurements into passes. E4 remains conditional on a database-backed candidate; B07 remains held.
