### PR TITLE
feat(rtc): carry the member policy on the group and bound in-flight setups per group

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -4688,6 +4688,7 @@ components:
         - formationElectorate
         - acceptedLayoutIdentity
         - transportState
+        - memberPolicy
       discriminator:
         propertyName: status
       oneOf:
@@ -4811,6 +4812,28 @@ components:
         transportState:
           type: string
           enum: [flowing, halted]
+        memberPolicy:
+          $ref: '#/components/schemas/GroupMemberPolicy'
+
+    GroupMemberPolicy:
+      type: object
+      description: >-
+        The member tier of the lifecycle policy (product decision 26), resolved
+        at creation and carried on every group read and delta so each member's
+        browser bounds its own concurrent RTC setups from the snapshot it
+        already holds. A group created without a policy carries the default
+        preset's values.
+      required:
+        - maxConcurrentEdgeSetups
+        - transports
+      properties:
+        maxConcurrentEdgeSetups:
+          type: integer
+          format: int64
+          minimum: 1
+        transports:
+          type: string
+          enum: [rtc-and-ws, ws-only, rtc-preferred]
 
     GroupLayoutIdentity:
       type: object

--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -4818,11 +4818,8 @@ components:
     GroupMemberPolicy:
       type: object
       description: >-
-        The member tier of the lifecycle policy (product decision 26), resolved
-        at creation and carried on every group read and delta so each member's
-        browser bounds its own concurrent RTC setups from the snapshot it
-        already holds. A group created without a policy carries the default
-        preset's values.
+        The member tier of the group's lifecycle policy, resolved once at
+        creation (product decision 26).
       required:
         - maxConcurrentEdgeSetups
         - transports
@@ -4831,6 +4828,7 @@ components:
           type: integer
           format: int64
           minimum: 1
+          maximum: 256
         transports:
           type: string
           enum: [rtc-and-ws, ws-only, rtc-preferred]

--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -69,6 +69,9 @@ response and in every WS delta envelope:
 - `formationAttemptCount` — incremented by failure; activation and reset clear the series.
 - `transportState` — flowing or halted independently of lifecycle stage.
 - `acceptedLayoutIdentity` — the last accepted layout; reconfiguration preserves it until replacement.
+- `memberPolicy` — the member tier of the lifecycle policy (`maxConcurrentEdgeSetups`, `transports`)
+  resolved at creation; a group created without a policy carries the default preset's values. The
+  browser bounds its own concurrent RTC setups per group from this field.
 - `lastFormationOutcome` — `null` until the criterion first decides, then the recorded decision:
   `{ outcome: 'activated' | 'activated-degraded' | 'below-floor', observedRate, atEpochMs,
   formationEpoch }`. Operator activation records nothing; only criterion-commanded transitions do.

--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -69,9 +69,8 @@ response and in every WS delta envelope:
 - `formationAttemptCount` — incremented by failure; activation and reset clear the series.
 - `transportState` — flowing or halted independently of lifecycle stage.
 - `acceptedLayoutIdentity` — the last accepted layout; reconfiguration preserves it until replacement.
-- `memberPolicy` — the member tier of the lifecycle policy (`maxConcurrentEdgeSetups`, `transports`)
-  resolved at creation; a group created without a policy carries the default preset's values. The
-  browser bounds its own concurrent RTC setups per group from this field.
+- `memberPolicy` — the member tier of the lifecycle policy (`maxConcurrentEdgeSetups`, `transports`),
+  resolved once at creation; the browser bounds its own concurrent RTC setups per group from it.
 - `lastFormationOutcome` — `null` until the criterion first decides, then the recorded decision:
   `{ outcome: 'activated' | 'activated-degraded' | 'below-floor', observedRate, atEpochMs,
   formationEpoch }`. Operator activation records nothing; only criterion-commanded transitions do.

--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -139,9 +139,9 @@ and initiator choices plus six policy sections. Every field is required once nor
 | `topology`      | `replanning`, `reconfigureLanding`, `debounceWindowMs`, `maxReplanWaitMs`                              |
 | `data`          | `preActivationAppData`: `'allowed'` \| `'blocked-until-active'`                                        |
 
-Two fields are carried but enforced by nothing in v1: `establishment.transports` and
-`establishment.maxConcurrentEdgeSetups` are normalized, clamped, and persisted, and no server path
-reads them. Establishment pacing is whatever the browser's existing dial budget provides.
+`establishment.maxConcurrentEdgeSetups` reaches the browser as `Group.memberPolicy`, where each
+member bounds the RTC setups it starts per group (product decision 18). `establishment.transports`
+is carried the same way but read by nothing yet, and no server path reads either field.
 
 ### Presets
 
@@ -783,8 +783,9 @@ writing this document:
   is a `GroupMember` rank field, its join plumbing, and switching the `match` preset back.
 - **A policy-update surface.** The document is written once at creation; per-field mutability
   declarations land with the first update surface.
-- **Enforcement of `establishment.transports` and `establishment.maxConcurrentEdgeSetups`.** Both
-  are recorded and unread; establishment pacing is the browser dial budget.
+- **Enforcement of `establishment.transports`.** It rides `Group.memberPolicy` and is read by
+  nothing. The in-flight bound is enforced by the browser for the setups it starts; setups accepted
+  from a peer's signaling are not paced.
 - **A pending-admission TTL.** Parked rows persist until granted, declined, withdrawn, or governed.
 - **General automatic plan/connect policy evaluation.** Durable initial retry intent is implemented;
   immediate, timed and presence trigger policies remain separate work.

--- a/packages/shared-rtc-bench/diagnostics/rtc-room-graph-no-rtt-bench.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtc-room-graph-no-rtt-bench.ts
@@ -1,4 +1,6 @@
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 type BenchResult = Readonly<{
@@ -110,7 +112,7 @@ function createGroupSnapshot(groupId: string, memberSessionIds: readonly string[
             formationElectorate: [],
             acceptedLayoutIdentity: null,
             transportState: 'flowing',
-            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+            memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
         },
         members: memberSessionIds.map((sessionId) => ({
             applicationId,

--- a/packages/shared-rtc-bench/diagnostics/rtc-room-graph-no-rtt-bench.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtc-room-graph-no-rtt-bench.ts
@@ -109,7 +109,8 @@ function createGroupSnapshot(groupId: string, memberSessionIds: readonly string[
             establishmentStartedAtEpochMs: null,
             formationElectorate: [],
             acceptedLayoutIdentity: null,
-            transportState: 'flowing'
+            transportState: 'flowing',
+            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
         },
         members: memberSessionIds.map((sessionId) => ({
             applicationId,

--- a/packages/shared-rtc-bench/diagnostics/rtc-rtt-group-scan-bench.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtc-rtt-group-scan-bench.ts
@@ -214,7 +214,8 @@ function createGroupSnapshot(groupId: string, memberSessionIds: readonly string[
             establishmentStartedAtEpochMs: null,
             formationElectorate: [],
             acceptedLayoutIdentity: null,
-            transportState: 'flowing'
+            transportState: 'flowing',
+            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
         },
         members: memberSessionIds.map((sessionId) => ({
             applicationId,

--- a/packages/shared-rtc-bench/diagnostics/rtc-rtt-group-scan-bench.ts
+++ b/packages/shared-rtc-bench/diagnostics/rtc-rtt-group-scan-bench.ts
@@ -1,4 +1,6 @@
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import {
     configureGroupStateSnapshotRepository,
@@ -215,7 +217,7 @@ function createGroupSnapshot(groupId: string, memberSessionIds: readonly string[
             formationElectorate: [],
             acceptedLayoutIdentity: null,
             transportState: 'flowing',
-            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+            memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
         },
         members: memberSessionIds.map((sessionId) => ({
             applicationId,

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
@@ -1,5 +1,7 @@
 import { dirname } from 'node:path';
 
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { ReadableKeyedValues } from '@shared/cache/RepositoryInterfaces.ts';
@@ -318,7 +320,7 @@ function createGroupSnapshotGroup(input: CreateGroupSnapshotInput): GroupSnapsho
         formationElectorate: [],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
-        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+        memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-cache-fallback-bench.ts
@@ -317,7 +317,8 @@ function createGroupSnapshotGroup(input: CreateGroupSnapshotInput): GroupSnapsho
         establishmentStartedAtEpochMs: null,
         formationElectorate: [],
         acceptedLayoutIdentity: null,
-        transportState: 'flowing'
+        transportState: 'flowing',
+        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
@@ -288,7 +288,8 @@ function createGroupSnapshotGroup(
             version: 1,
             state: 'active'
         },
-        transportState: 'flowing'
+        transportState: 'flowing',
+        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-peer-owners-bench.ts
@@ -2,6 +2,8 @@ import { dirname } from 'node:path';
 
 import type { ClientInfo, OverlayInfo } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import { WebRtcConnectionService } from '@shared/services/web-rtc-connection-service.ts';
@@ -289,7 +291,7 @@ function createGroupSnapshotGroup(
             state: 'active'
         },
         transportState: 'flowing',
-        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+        memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
@@ -1,6 +1,8 @@
 import { dirname } from 'node:path';
 
 import type { ClientInfo } from '@shared/api/api-config.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import type { ReadableKeyedValues } from '@shared/cache/RepositoryInterfaces.ts';
@@ -331,7 +333,7 @@ function createGroupSnapshotGroup(
         formationElectorate: [],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
-        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+        memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
+++ b/packages/shared-rtc-bench/workloads/group-coordination/webrtc-group-manager-state-bench.ts
@@ -330,7 +330,8 @@ function createGroupSnapshotGroup(
         establishmentStartedAtEpochMs: null,
         formationElectorate: [],
         acceptedLayoutIdentity: null,
-        transportState: 'flowing'
+        transportState: 'flowing',
+        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
     };
 }
 

--- a/packages/shared-rtc-bench/workloads/topology/create-deterministic-rtc-topology-group-snapshot.ts
+++ b/packages/shared-rtc-bench/workloads/topology/create-deterministic-rtc-topology-group-snapshot.ts
@@ -1,3 +1,5 @@
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { AuditStamp, GroupMember, GroupPresenceSession, GroupSnapshot } from '@shared/api/group-types.ts';
 
 export function createDeterministicRtcTopologyGroupSnapshot(
@@ -51,7 +53,7 @@ export function createDeterministicRtcTopologyGroupSnapshot(
             formationElectorate: [],
             acceptedLayoutIdentity: null,
             transportState: 'flowing',
-            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+            memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
         },
         members: memberSessionIds.map((sessionId): GroupMember => ({
             applicationId,

--- a/packages/shared-rtc-bench/workloads/topology/create-deterministic-rtc-topology-group-snapshot.ts
+++ b/packages/shared-rtc-bench/workloads/topology/create-deterministic-rtc-topology-group-snapshot.ts
@@ -50,7 +50,8 @@ export function createDeterministicRtcTopologyGroupSnapshot(
             establishmentStartedAtEpochMs: null,
             formationElectorate: [],
             acceptedLayoutIdentity: null,
-            transportState: 'flowing'
+            transportState: 'flowing',
+            memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
         },
         members: memberSessionIds.map((sessionId): GroupMember => ({
             applicationId,

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/create-initial-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/create-initial-group-mutation.ts
@@ -1,3 +1,5 @@
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { AuditStamp, Group, GroupMember, GroupPresenceSummary } from '@shared/api/group-types.ts';
 
 import type { GroupMutationCommand, GroupMutationFacts, GroupMutationRead } from '../group-mutation-contracts.ts';
@@ -44,7 +46,8 @@ export function createInitialGroup({
         establishmentStartedAtEpochMs: null,
         formationElectorate: [command.input.createdByPrincipalId],
         acceptedLayoutIdentity: null,
-        transportState: 'flowing'
+        transportState: 'flowing',
+        memberPolicy: toGroupMemberPolicy(command.input.lifecyclePolicy ?? createDefaultGroupLifecyclePolicy())
     };
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/create-initial-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/create-initial-group-mutation.ts
@@ -15,6 +15,7 @@ export function createInitialGroup({
     audit,
     snapshotVersion
 }: CreateInitialGroupInput): Group {
+    const lifecyclePolicy = command.input.lifecyclePolicy ?? createDefaultGroupLifecyclePolicy();
     return {
         ...command.aggregateRef,
         slug: command.input.slug,
@@ -39,7 +40,7 @@ export function createInitialGroup({
         expiresAtEpochMs: command.input.expiresAtEpochMs,
         emptySinceEpochMs: null,
         purgeAfterEpochMs: command.input.purgeAfterEpochMs,
-        lifecycleState: command.input.lifecyclePolicy?.formation === 'phased' ? 'forming' : 'active',
+        lifecycleState: lifecyclePolicy.formation === 'phased' ? 'forming' : 'active',
         formationEpoch: 0,
         formationAttemptCount: 0,
         lastFormationOutcome: null,
@@ -47,7 +48,7 @@ export function createInitialGroup({
         formationElectorate: [command.input.createdByPrincipalId],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
-        memberPolicy: toGroupMemberPolicy(command.input.lifecyclePolicy ?? createDefaultGroupLifecyclePolicy())
+        memberPolicy: toGroupMemberPolicy(lifecyclePolicy)
     };
 }
 

--- a/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-lifecycle-policy-input-shape.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/command-validation/validate-group-lifecycle-policy-input-shape.ts
@@ -1,4 +1,7 @@
-import { GROUP_LIFECYCLE_POLICY_PRESET_NAMES } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import {
+    GROUP_ESTABLISHMENT_TRANSPORTS,
+    GROUP_LIFECYCLE_POLICY_PRESET_NAMES
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 
 import { isGroupInputRecord, validateGroupInputJson } from './group-input-validation-issues.ts';
 
@@ -29,7 +32,7 @@ const POLICY_FIELDS: readonly PolicyShapeField[] = [
         key: 'establishment',
         kind: 'object',
         fields: [
-            { key: 'transports', kind: 'enum', values: ['rtc-and-ws', 'ws-only', 'rtc-preferred'] },
+            { key: 'transports', kind: 'enum', values: GROUP_ESTABLISHMENT_TRANSPORTS },
             { key: 'maxConcurrentEdgeSetups', kind: 'number' },
             { key: 'planTrigger', kind: 'trigger' },
             { key: 'connectTrigger', kind: 'trigger' }

--- a/packages/shared-server/rallar-system/group-state/persistence/decode-stored-group-lifecycle-policy.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/decode-stored-group-lifecycle-policy.ts
@@ -1,3 +1,4 @@
+import { GROUP_ESTABLISHMENT_TRANSPORTS } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupLifecyclePolicy, GroupStageTrigger } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import {
     MAX_GROUP_ADMISSION_MEMBER_COUNT,
@@ -134,7 +135,7 @@ function decodeEstablishmentPolicy(value: JsonWireValue): GroupLifecyclePolicy['
     return {
         transports: requireOneOf(
             establishment.transports,
-            ['rtc-and-ws', 'ws-only', 'rtc-preferred'] as const,
+            GROUP_ESTABLISHMENT_TRANSPORTS,
             'Group lifecycle establishment transports'
         ),
         maxConcurrentEdgeSetups: requireBoundedInteger({

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -2,7 +2,12 @@ import {
     GROUP_LAYOUT_IDENTITY_KEYS,
     GROUP_LAYOUT_IDENTITY_STATES
 } from '@shared/api/group-lifecycle/group-layout-identity.ts';
-import { GROUP_LIFECYCLE_STATES, GROUP_TRANSPORT_STATES } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import {
+    GROUP_ESTABLISHMENT_TRANSPORTS,
+    GROUP_LIFECYCLE_STATES,
+    GROUP_MEMBER_POLICY_KEYS,
+    GROUP_TRANSPORT_STATES
+} from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { AuditStamp, Group, GroupMember, GroupRef, GroupStateCausalRevision } from '@shared/api/group-types.ts';
 import type { MutationActor } from '@shared/api/mutation-actor.ts';
 
@@ -51,7 +56,8 @@ const STORED_GROUP_KEYS = [
     'establishmentStartedAtEpochMs',
     'formationElectorate',
     'acceptedLayoutIdentity',
-    'transportState'
+    'transportState',
+    'memberPolicy'
 ] as const;
 
 const FORMATION_OUTCOME_KEYS = ['outcome', 'observedRate', 'atEpochMs', 'formationEpoch'] as const;
@@ -168,6 +174,18 @@ export function validateStoredGroup(group: unknown, ref: GroupRef): asserts grou
         );
     }
     requireOneOf(value.transportState, GROUP_TRANSPORT_STATES, 'Stored group transportState');
+    const memberPolicy = requireRecord(value.memberPolicy, 'Stored group memberPolicy');
+    assertExactKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
+    assertRequiredKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
+    requirePositiveSafeInteger(
+        memberPolicy.maxConcurrentEdgeSetups,
+        'Stored group memberPolicy maxConcurrentEdgeSetups'
+    );
+    requireOneOf(
+        memberPolicy.transports,
+        GROUP_ESTABLISHMENT_TRANSPORTS,
+        'Stored group memberPolicy transports'
+    );
 }
 
 export function validateStoredMember(

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -175,11 +175,7 @@ export function validateStoredGroup(group: unknown, ref: GroupRef): asserts grou
         );
     }
     requireOneOf(value.transportState, GROUP_TRANSPORT_STATES, 'Stored group transportState');
-    validateStoredGroupMemberPolicy(value.memberPolicy);
-}
-
-function validateStoredGroupMemberPolicy(value: unknown): void {
-    const memberPolicy = requireRecord(value, 'Stored group memberPolicy');
+    const memberPolicy = requireRecord(value.memberPolicy, 'Stored group memberPolicy');
     assertExactKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     assertRequiredKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     requirePositiveSafeInteger(

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -8,6 +8,7 @@ import {
     GROUP_MEMBER_POLICY_KEYS,
     GROUP_TRANSPORT_STATES
 } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import { MAX_GROUP_CONCURRENT_EDGE_SETUPS } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { AuditStamp, Group, GroupMember, GroupRef, GroupStateCausalRevision } from '@shared/api/group-types.ts';
 import type { MutationActor } from '@shared/api/mutation-actor.ts';
 
@@ -174,13 +175,20 @@ export function validateStoredGroup(group: unknown, ref: GroupRef): asserts grou
         );
     }
     requireOneOf(value.transportState, GROUP_TRANSPORT_STATES, 'Stored group transportState');
-    const memberPolicy = requireRecord(value.memberPolicy, 'Stored group memberPolicy');
+    validateStoredGroupMemberPolicy(value.memberPolicy);
+}
+
+function validateStoredGroupMemberPolicy(value: unknown): void {
+    const memberPolicy = requireRecord(value, 'Stored group memberPolicy');
     assertExactKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     assertRequiredKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     requirePositiveSafeInteger(
         memberPolicy.maxConcurrentEdgeSetups,
         'Stored group memberPolicy maxConcurrentEdgeSetups'
     );
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        throw new TypeError('Stored group memberPolicy maxConcurrentEdgeSetups exceeds the policy bound');
+    }
     requireOneOf(
         memberPolicy.transports,
         GROUP_ESTABLISHMENT_TRANSPORTS,

--- a/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/validate-persisted-group.ts
@@ -79,6 +79,8 @@ const STORED_MEMBER_KEYS = [
     'invitationExpiresAtEpochMs'
 ] as const;
 
+type StoredGroupRecord = Readonly<Record<string, unknown>>;
+
 export function validateStoredGroup(group: unknown, ref: GroupRef): asserts group is Group {
     const value = requireRecord(group, 'Stored group value');
     assertExactKeys(value, STORED_GROUP_KEYS, 'Stored group value');
@@ -175,7 +177,10 @@ export function validateStoredGroup(group: unknown, ref: GroupRef): asserts grou
         );
     }
     requireOneOf(value.transportState, GROUP_TRANSPORT_STATES, 'Stored group transportState');
-    const memberPolicy = requireRecord(value.memberPolicy, 'Stored group memberPolicy');
+    validateStoredGroupMemberPolicy(requireRecord(value.memberPolicy, 'Stored group memberPolicy'));
+}
+
+function validateStoredGroupMemberPolicy(memberPolicy: StoredGroupRecord): void {
     assertExactKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     assertRequiredKeys(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'Stored group memberPolicy');
     requirePositiveSafeInteger(
@@ -271,7 +276,7 @@ export function validateScopedValue(
 }
 
 export function validateScopedRecord(
-    value: Readonly<Record<string, unknown>>,
+    value: StoredGroupRecord,
     ref: GroupRef,
     label: string
 ): void {

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-policy.json
@@ -180,7 +180,16 @@
         }
       },
       "expect": {
-        "status": 201
+        "status": 201,
+        "body": {
+          "group": {
+            "groupId": "{policyGroupId}",
+            "memberPolicy": {
+              "maxConcurrentEdgeSetups": 32,
+              "transports": "rtc-and-ws"
+            }
+          }
+        }
       }
     },
     {
@@ -208,7 +217,11 @@
           "group": {
             "groupId": "{plainGroupId}",
             "lifecycleState": "active",
-            "formationEpoch": 0
+            "formationEpoch": 0,
+            "memberPolicy": {
+              "maxConcurrentEdgeSetups": 64,
+              "transports": "rtc-and-ws"
+            }
           }
         }
       }
@@ -241,7 +254,11 @@
           "group": {
             "groupId": "{optimisticGroupId}",
             "lifecycleState": "active",
-            "formationEpoch": 0
+            "formationEpoch": 0,
+            "memberPolicy": {
+              "maxConcurrentEdgeSetups": 64,
+              "transports": "rtc-and-ws"
+            }
           }
         }
       }

--- a/packages/shared-web/browser/connection/browser-transport-runtime.ts
+++ b/packages/shared-web/browser/connection/browser-transport-runtime.ts
@@ -113,6 +113,7 @@ export class BrowserTransportRuntime implements BrowserTransportRuntimePort {
     ): void {
         runShutdownStep(() => middleware.heartbeat?.stop());
         runShutdownStep(() => middleware.rtcRxStreamer.dispose());
+        runShutdownStep(() => middleware.webRtcGroupManager.stopReconcileWakes());
         runShutdownStep(() => {
             for (const peerId of middleware.webRtcConnectionService.knownPeerIds()) {
                 middleware.webRtcConnectionService.disconnectPeer(peerId);

--- a/packages/shared-web/browser/connection/initialise-browser-middleware.ts
+++ b/packages/shared-web/browser/connection/initialise-browser-middleware.ts
@@ -372,6 +372,7 @@ function createBrowserRtcGroupManager(
                 rtcRxStreamer.setRttReportingPeerIds(rttReportingPeerIds)
         }
     );
+    webRtcGroupManager.startReconcileWakes();
     rtcRxStreamer.setRttReportingPeerIds(
         webRtcGroupManager.rttReportingPeerIds({ degreeLimit: input.options.rttReportingDegreeLimit })
     );

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -8,6 +8,7 @@ import {
     GROUP_MEMBER_POLICY_KEYS,
     GROUP_TRANSPORT_STATES
 } from './group-lifecycle/group-lifecycle-policy.ts';
+import { MAX_GROUP_CONCURRENT_EDGE_SETUPS } from './group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupEvent, GroupRef, GroupSnapshot } from './group-types.ts';
 import type { RallarOverlayTopologySnapshot } from './overlay-topology.ts';
 import type { StateEventPage } from './state-event-types.ts';
@@ -504,17 +505,7 @@ export function validateAuthoritativeGroupSnapshot(
         GROUP_TRANSPORT_STATES,
         'GroupSnapshot.group.transportState'
     );
-    const memberPolicy = record(group.memberPolicy, 'GroupSnapshot.group.memberPolicy');
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
-    positiveInteger(
-        memberPolicy.maxConcurrentEdgeSetups,
-        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
-    );
-    enumValue(
-        memberPolicy.transports,
-        GROUP_ESTABLISHMENT_TRANSPORTS,
-        'GroupSnapshot.group.memberPolicy.transports'
-    );
+    validateGroupSnapshotMemberPolicy(group.memberPolicy);
     const members = array(snapshot.members, 'GroupSnapshot.members');
     const memberIds = new Set<string>();
     const activeMemberIds = new Set<string>();
@@ -1037,6 +1028,23 @@ function causalRevision(
         groupRevision: causal.groupRevision,
         presenceRevision: causal.presenceRevision
     };
+}
+
+function validateGroupSnapshotMemberPolicy(value: unknown): void {
+    const memberPolicy = record(value, 'GroupSnapshot.group.memberPolicy');
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
+    positiveInteger(
+        memberPolicy.maxConcurrentEdgeSetups,
+        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
+    );
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        fail('GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound');
+    }
+    enumValue(
+        memberPolicy.transports,
+        GROUP_ESTABLISHMENT_TRANSPORTS,
+        'GroupSnapshot.group.memberPolicy.transports'
+    );
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -380,6 +380,24 @@ export function validateAuthoritativeClientSnapshot(
     }
 }
 
+type ValidatedRecord = Readonly<Record<string, unknown>>;
+
+function validateGroupSnapshotMemberPolicy(memberPolicy: ValidatedRecord): void {
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
+    positiveInteger(
+        memberPolicy.maxConcurrentEdgeSetups,
+        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
+    );
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        fail('GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound');
+    }
+    enumValue(
+        memberPolicy.transports,
+        GROUP_ESTABLISHMENT_TRANSPORTS,
+        'GroupSnapshot.group.memberPolicy.transports'
+    );
+}
+
 export function validateAuthoritativeGroupSnapshot(
     value: unknown,
     scope?: StateScope
@@ -505,20 +523,7 @@ export function validateAuthoritativeGroupSnapshot(
         GROUP_TRANSPORT_STATES,
         'GroupSnapshot.group.transportState'
     );
-    const memberPolicy = record(group.memberPolicy, 'GroupSnapshot.group.memberPolicy');
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
-    positiveInteger(
-        memberPolicy.maxConcurrentEdgeSetups,
-        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
-    );
-    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
-        fail('GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound');
-    }
-    enumValue(
-        memberPolicy.transports,
-        GROUP_ESTABLISHMENT_TRANSPORTS,
-        'GroupSnapshot.group.memberPolicy.transports'
-    );
+    validateGroupSnapshotMemberPolicy(record(group.memberPolicy, 'GroupSnapshot.group.memberPolicy'));
     const members = array(snapshot.members, 'GroupSnapshot.members');
     const memberIds = new Set<string>();
     const activeMemberIds = new Set<string>();
@@ -706,7 +711,7 @@ function assertCanonicalTopologyIdentifiers(values: readonly string[], label: st
 }
 
 function validateActiveTopologyGraph(
-    nextHops: Readonly<Record<string, unknown>>,
+    nextHops: ValidatedRecord,
     activeSessionIds: ReadonlySet<string>,
     degreeLimit: number
 ): void {

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -2,7 +2,12 @@ import { toScopedOverlayId } from './api-type-utils.ts';
 import type { ClientEvent, ClientSnapshot } from './client-types.ts';
 import { toClientSnapshotLastSeenAtEpochMs } from './group-client-views.ts';
 import { GROUP_LAYOUT_IDENTITY_KEYS, GROUP_LAYOUT_IDENTITY_STATES } from './group-lifecycle/group-layout-identity.ts';
-import { GROUP_LIFECYCLE_STATES, GROUP_TRANSPORT_STATES } from './group-lifecycle/group-lifecycle-policy.ts';
+import {
+    GROUP_ESTABLISHMENT_TRANSPORTS,
+    GROUP_LIFECYCLE_STATES,
+    GROUP_MEMBER_POLICY_KEYS,
+    GROUP_TRANSPORT_STATES
+} from './group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupEvent, GroupRef, GroupSnapshot } from './group-types.ts';
 import type { RallarOverlayTopologySnapshot } from './overlay-topology.ts';
 import type { StateEventPage } from './state-event-types.ts';
@@ -97,7 +102,8 @@ const GROUP_KEYS = [
     'establishmentStartedAtEpochMs',
     'formationElectorate',
     'acceptedLayoutIdentity',
-    'transportState'
+    'transportState',
+    'memberPolicy'
 ];
 const GROUP_MEMBER_KEYS = [
     'applicationId',
@@ -497,6 +503,17 @@ export function validateAuthoritativeGroupSnapshot(
         group.transportState,
         GROUP_TRANSPORT_STATES,
         'GroupSnapshot.group.transportState'
+    );
+    const memberPolicy = record(group.memberPolicy, 'GroupSnapshot.group.memberPolicy');
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
+    positiveInteger(
+        memberPolicy.maxConcurrentEdgeSetups,
+        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
+    );
+    enumValue(
+        memberPolicy.transports,
+        GROUP_ESTABLISHMENT_TRANSPORTS,
+        'GroupSnapshot.group.memberPolicy.transports'
     );
     const members = array(snapshot.members, 'GroupSnapshot.members');
     const memberIds = new Set<string>();

--- a/packages/shared/api/authoritative-state-validation.ts
+++ b/packages/shared/api/authoritative-state-validation.ts
@@ -505,7 +505,20 @@ export function validateAuthoritativeGroupSnapshot(
         GROUP_TRANSPORT_STATES,
         'GroupSnapshot.group.transportState'
     );
-    validateGroupSnapshotMemberPolicy(group.memberPolicy);
+    const memberPolicy = record(group.memberPolicy, 'GroupSnapshot.group.memberPolicy');
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
+    positiveInteger(
+        memberPolicy.maxConcurrentEdgeSetups,
+        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
+    );
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        fail('GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound');
+    }
+    enumValue(
+        memberPolicy.transports,
+        GROUP_ESTABLISHMENT_TRANSPORTS,
+        'GroupSnapshot.group.memberPolicy.transports'
+    );
     const members = array(snapshot.members, 'GroupSnapshot.members');
     const memberIds = new Set<string>();
     const activeMemberIds = new Set<string>();
@@ -1028,23 +1041,6 @@ function causalRevision(
         groupRevision: causal.groupRevision,
         presenceRevision: causal.presenceRevision
     };
-}
-
-function validateGroupSnapshotMemberPolicy(value: unknown): void {
-    const memberPolicy = record(value, 'GroupSnapshot.group.memberPolicy');
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, 'GroupSnapshot.group.memberPolicy');
-    positiveInteger(
-        memberPolicy.maxConcurrentEdgeSetups,
-        'GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups'
-    );
-    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
-        fail('GroupSnapshot.group.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound');
-    }
-    enumValue(
-        memberPolicy.transports,
-        GROUP_ESTABLISHMENT_TRANSPORTS,
-        'GroupSnapshot.group.memberPolicy.transports'
-    );
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
@@ -54,6 +54,29 @@ export type GroupEstablishmentTransports =
     | 'ws-only'
     | 'rtc-preferred';
 
+/** The runtime registry the validators check against. */
+export const GROUP_ESTABLISHMENT_TRANSPORTS = [
+    'rtc-and-ws',
+    'ws-only',
+    'rtc-preferred'
+] as const satisfies readonly GroupEstablishmentTransports[];
+
+/**
+ * The member tier of the policy (product decision 26), copied onto the group
+ * at creation so every member's browser bounds its own RTC setups from the
+ * snapshot it already holds (implementation decision I13). Declared at group
+ * scope, executed per member; write-once like the policy it comes from.
+ */
+export type GroupMemberPolicy = Readonly<{
+    maxConcurrentEdgeSetups: number;
+    transports: GroupEstablishmentTransports;
+}>;
+
+export const GROUP_MEMBER_POLICY_KEYS = [
+    'maxConcurrentEdgeSetups',
+    'transports'
+] as const satisfies readonly (keyof GroupMemberPolicy)[];
+
 /**
  * Who may issue the eight application-facing group-authority commands. One
  * policy governs all of them (product decision 12), and the field lives on the

--- a/packages/shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts
@@ -10,6 +10,7 @@ import type {
     GroupLifecyclePolicy,
     GroupLifecyclePolicyInput,
     GroupManagerPolicy,
+    GroupMemberPolicy,
     GroupStageTrigger,
     GroupTopologyPolicy
 } from './group-lifecycle-policy.ts';
@@ -46,6 +47,14 @@ export function toNormalizedGroupLifecyclePolicy(
         admission: toAdmissionPolicy(base.admission, input.admission),
         topology: toTopologyPolicy(base.topology, input.topology),
         data: toDataPolicy(base.data, input.data)
+    };
+}
+
+/** The member tier a group carries (product decision 26): the normalized policy's establishment values, nothing more. */
+export function toGroupMemberPolicy(policy: GroupLifecyclePolicy): GroupMemberPolicy {
+    return {
+        maxConcurrentEdgeSetups: policy.establishment.maxConcurrentEdgeSetups,
+        transports: policy.establishment.transports
     };
 }
 

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -7,6 +7,7 @@ import {
     GROUP_MEMBER_POLICY_KEYS,
     GROUP_TRANSPORT_STATES
 } from './group-lifecycle/group-lifecycle-policy.ts';
+import { MAX_GROUP_CONCURRENT_EDGE_SETUPS } from './group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { Group, GroupEvent, GroupMember, GroupPresenceSession, GroupStateCausalRevision } from './group-types.ts';
 import type { StateScope } from './state-types.ts';
 
@@ -251,11 +252,18 @@ function validateDeltaGroup(
         enumValue(accepted.state, GROUP_LAYOUT_IDENTITY_STATES, `${label}.acceptedLayoutIdentity.state`);
     }
     enumValue(group.transportState, GROUP_TRANSPORT_STATES, `${label}.transportState`);
-    const memberPolicy = record(group.memberPolicy, `${label}.memberPolicy`);
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, `${label}.memberPolicy`);
-    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.memberPolicy.maxConcurrentEdgeSetups`);
-    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.memberPolicy.transports`);
+    validateDeltaGroupMemberPolicy(group.memberPolicy, `${label}.memberPolicy`);
     return { activeMemberCount: group.activeMemberCount, status: group.status };
+}
+
+function validateDeltaGroupMemberPolicy(value: unknown, label: string): void {
+    const memberPolicy = record(value, label);
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, label);
+    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.maxConcurrentEdgeSetups`);
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        fail(`${label}.maxConcurrentEdgeSetups exceeds the policy bound`);
+    }
+    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.transports`);
 }
 
 function validateGroupLifecycle(group: Record<string, unknown>, label: string): void {

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -161,6 +161,8 @@ export function validateGroupStateDeltaEnvelope(
     }
 }
 
+type DeltaRecord = Record<string, unknown>;
+
 function validateDeltaGroup(
     value: unknown,
     ref: Readonly<{ applicationId: string; workspaceId: string; groupId: string; }>,
@@ -252,17 +254,20 @@ function validateDeltaGroup(
         enumValue(accepted.state, GROUP_LAYOUT_IDENTITY_STATES, `${label}.acceptedLayoutIdentity.state`);
     }
     enumValue(group.transportState, GROUP_TRANSPORT_STATES, `${label}.transportState`);
-    const memberPolicy = record(group.memberPolicy, `${label}.memberPolicy`);
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, `${label}.memberPolicy`);
-    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.memberPolicy.maxConcurrentEdgeSetups`);
-    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
-        fail(`${label}.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound`);
-    }
-    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.memberPolicy.transports`);
+    validateDeltaGroupMemberPolicy(record(group.memberPolicy, `${label}.memberPolicy`), `${label}.memberPolicy`);
     return { activeMemberCount: group.activeMemberCount, status: group.status };
 }
 
-function validateGroupLifecycle(group: Record<string, unknown>, label: string): void {
+function validateDeltaGroupMemberPolicy(memberPolicy: DeltaRecord, label: string): void {
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, label);
+    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.maxConcurrentEdgeSetups`);
+    if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
+        fail(`${label}.maxConcurrentEdgeSetups exceeds the policy bound`);
+    }
+    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.transports`);
+}
+
+function validateGroupLifecycle(group: DeltaRecord, label: string): void {
     if (group.status === 'active' && (group.archived !== null || group.deleted !== null)) {
         fail(`${label} lifecycle is invalid`);
     }

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -252,18 +252,14 @@ function validateDeltaGroup(
         enumValue(accepted.state, GROUP_LAYOUT_IDENTITY_STATES, `${label}.acceptedLayoutIdentity.state`);
     }
     enumValue(group.transportState, GROUP_TRANSPORT_STATES, `${label}.transportState`);
-    validateDeltaGroupMemberPolicy(group.memberPolicy, `${label}.memberPolicy`);
-    return { activeMemberCount: group.activeMemberCount, status: group.status };
-}
-
-function validateDeltaGroupMemberPolicy(value: unknown, label: string): void {
-    const memberPolicy = record(value, label);
-    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, label);
-    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.maxConcurrentEdgeSetups`);
+    const memberPolicy = record(group.memberPolicy, `${label}.memberPolicy`);
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, `${label}.memberPolicy`);
+    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.memberPolicy.maxConcurrentEdgeSetups`);
     if (memberPolicy.maxConcurrentEdgeSetups > MAX_GROUP_CONCURRENT_EDGE_SETUPS) {
-        fail(`${label}.maxConcurrentEdgeSetups exceeds the policy bound`);
+        fail(`${label}.memberPolicy.maxConcurrentEdgeSetups exceeds the policy bound`);
     }
-    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.transports`);
+    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.memberPolicy.transports`);
+    return { activeMemberCount: group.activeMemberCount, status: group.status };
 }
 
 function validateGroupLifecycle(group: Record<string, unknown>, label: string): void {

--- a/packages/shared/api/group-state-delta.ts
+++ b/packages/shared/api/group-state-delta.ts
@@ -1,7 +1,12 @@
 import { validateAuthoritativeGroupEvent } from './authoritative-state-validation.ts';
 import { compareGroupCausalRevision } from './group-client-views.ts';
 import { GROUP_LAYOUT_IDENTITY_KEYS, GROUP_LAYOUT_IDENTITY_STATES } from './group-lifecycle/group-layout-identity.ts';
-import { GROUP_LIFECYCLE_STATES, GROUP_TRANSPORT_STATES } from './group-lifecycle/group-lifecycle-policy.ts';
+import {
+    GROUP_ESTABLISHMENT_TRANSPORTS,
+    GROUP_LIFECYCLE_STATES,
+    GROUP_MEMBER_POLICY_KEYS,
+    GROUP_TRANSPORT_STATES
+} from './group-lifecycle/group-lifecycle-policy.ts';
 import type { Group, GroupEvent, GroupMember, GroupPresenceSession, GroupStateCausalRevision } from './group-types.ts';
 import type { StateScope } from './state-types.ts';
 
@@ -78,7 +83,8 @@ const GROUP_KEYS = [
     'establishmentStartedAtEpochMs',
     'formationElectorate',
     'acceptedLayoutIdentity',
-    'transportState'
+    'transportState',
+    'memberPolicy'
 ];
 const GROUP_MEMBER_KEYS = [
     'applicationId',
@@ -245,6 +251,10 @@ function validateDeltaGroup(
         enumValue(accepted.state, GROUP_LAYOUT_IDENTITY_STATES, `${label}.acceptedLayoutIdentity.state`);
     }
     enumValue(group.transportState, GROUP_TRANSPORT_STATES, `${label}.transportState`);
+    const memberPolicy = record(group.memberPolicy, `${label}.memberPolicy`);
+    exact(memberPolicy, GROUP_MEMBER_POLICY_KEYS, `${label}.memberPolicy`);
+    positiveInteger(memberPolicy.maxConcurrentEdgeSetups, `${label}.memberPolicy.maxConcurrentEdgeSetups`);
+    enumValue(memberPolicy.transports, GROUP_ESTABLISHMENT_TRANSPORTS, `${label}.memberPolicy.transports`);
     return { activeMemberCount: group.activeMemberCount, status: group.status };
 }
 

--- a/packages/shared/api/group-types.ts
+++ b/packages/shared/api/group-types.ts
@@ -118,12 +118,7 @@ type GroupBase =
          */
         transportState: GroupTransportState;
 
-        /**
-         * The member-tier policy values resolved at creation (product decision
-         * 26, implementation decision I13): the in-flight setup bound each
-         * member enforces on itself, and the declared transports. A group
-         * created without a policy carries the default preset's values.
-         */
+        /** Resolved once at creation and never rewritten, like the policy it comes from. */
         memberPolicy: GroupMemberPolicy;
     }>;
 

--- a/packages/shared/api/group-types.ts
+++ b/packages/shared/api/group-types.ts
@@ -3,6 +3,7 @@ import type { GroupLayoutIdentity } from './group-lifecycle/group-layout-identit
 import type {
     GroupFormationOutcome,
     GroupLifecycleState,
+    GroupMemberPolicy,
     GroupTransportState
 } from './group-lifecycle/group-lifecycle-policy.ts';
 import type { MutationActor } from './mutation-actor.ts';
@@ -116,6 +117,14 @@ type GroupBase =
          * Creation is always `flowing`.
          */
         transportState: GroupTransportState;
+
+        /**
+         * The member-tier policy values resolved at creation (product decision
+         * 26, implementation decision I13): the in-flight setup bound each
+         * member enforces on itself, and the declared transports. A group
+         * created without a policy carries the default preset's values.
+         */
+        memberPolicy: GroupMemberPolicy;
     }>;
 
 export type Group =

--- a/packages/shared/services/web-rtc-group-manager.ts
+++ b/packages/shared/services/web-rtc-group-manager.ts
@@ -11,6 +11,10 @@ import {
     type AnyClientPresence,
     type AnyGroupPresence
 } from '../api/group-client-views.ts';
+import {
+    computeInFlightDialAdmission,
+    type InFlightDialAdmission
+} from '../api/group-lifecycle/compute-in-flight-dial-admission.ts';
 import type { GroupRef } from '../api/group-types.ts';
 import type { ReadableKeyedValues } from '../cache/RepositoryInterfaces.ts';
 import {
@@ -37,9 +41,8 @@ import {
     readOverlayForGroup
 } from './webrtc-group-overlay-reading.ts';
 import {
+    computeInFlightSetupCounts,
     computeOutboundDialPlan,
-    computePacedOutboundDialPlan,
-    type GroupSetupBudget,
     type OutboundDialPlan
 } from './webrtc-outbound-dial-plan.ts';
 
@@ -54,6 +57,11 @@ export type {
 export const DEFAULT_WEBRTC_MAX_PEER_CONNECTIONS = 10;
 export const MIN_WEBRTC_MAX_PEER_CONNECTIONS = 5;
 export const DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS = 15_000;
+
+interface WaitingDials {
+    readonly pacedCount: number;
+    readonly deferredCount: number;
+}
 
 interface RttReportingGroupPair {
     readonly group: WebRtcGroupService;
@@ -73,7 +81,9 @@ export namespace WebRtcGroupManager {
     export interface PeerOwnership {
         readonly groupsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
         readonly dialAllowedPeerIds: ReadonlySet<PeerId>;
-        readonly setupBudgetsByGroupId: ReadonlyMap<GroupId, GroupSetupBudget>;
+        /** The same ownership by the scoped group key, which the bound is keyed on. */
+        readonly groupKeysByPeerId: ReadonlyMap<PeerId, readonly string[]>;
+        readonly maxConcurrentEdgeSetupsByGroupKey: ReadonlyMap<string, number>;
     }
 }
 
@@ -86,7 +96,8 @@ export class WebRtcGroupManager {
     private reconcileInFlight: Promise<void> | undefined;
     private reconcileRequested = false;
     private reconcilePassRunning = false;
-    private pacedPeerCount = 0;
+    private scheduledWake: Promise<void> | undefined;
+    private waitingDialCount = 0;
     private retainedOrder = 0;
     private readonly diagnostics = emptyGroupManagerDiagnostics();
 
@@ -108,27 +119,30 @@ export class WebRtcGroupManager {
         this.plannedOverlayCache = repositories.plannedOverlayCache;
         this.acceptedOverlayCache = repositories.acceptedOverlayCache;
         this.options = options;
-        // Every setup ending frees a slot under the in-flight bound (product
-        // decision 18), so the ending itself wakes the next reconcile.
-        rtcQBox.onRtcPeerLifecycleDo(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID, {
-            onCreated: () => {},
-            onDeleted: () => this.wakeAfterSetupEnded(),
-            onEstablished: () => this.wakeAfterSetupEnded(),
-            onConnectTimeout: () => this.wakeAfterSetupEnded()
-        });
-    }
-
-    /** Settles once the reconcile pass a lifecycle wake or an update started has finished. */
-    whenReconciled(): Promise<void> {
-        return this.reconcileInFlight ?? Promise.resolve();
     }
 
     /**
-     * Shutdown tears peers down while their groups still want them; without
-     * this, every teardown would wake a reconcile that dials them again.
+     * Every setup ending frees a slot under the in-flight bound (product
+     * decision 18), so an ending re-plans the dials that wait for one. The
+     * composition root starts this once the service and manager exist; shutdown
+     * stops it before tearing peers down, because shutdown removes peers their
+     * groups still want and every removal would otherwise dial them back.
      */
+    startReconcileWakes(): void {
+        this.rtcQBox.onRtcPeerLifecycleDo(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID, {
+            onCreated: () => {},
+            onDeleted: () => this.wakeAfterSetupEnded(),
+            onEstablished: () => this.wakeAfterSetupEnded()
+        });
+    }
+
     stopReconcileWakes(): void {
         this.rtcQBox.removeRtcPeerLifecycleById(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID);
+    }
+
+    /** Settles after the reconcile that a pending setup-ending wake or an in-flight update will run. */
+    whenReconciled(): Promise<void> {
+        return this.scheduledWake ?? this.reconcileInFlight ?? Promise.resolve();
     }
 
     readDiagnostics(): WebRtcGroupManagerDiagnostics {
@@ -235,33 +249,27 @@ export class WebRtcGroupManager {
 
     private computePeerOwnership(): WebRtcGroupManager.PeerOwnership {
         const owners = new Map<PeerId, GroupId[]>();
+        const groupKeysByPeerId = new Map<PeerId, string[]>();
         const dialAllowedPeerIds = new Set<PeerId>();
-        const setupBudgetsByGroupId = new Map<GroupId, GroupSetupBudget>();
+        const maxConcurrentEdgeSetupsByGroupKey = new Map<string, number>();
 
         for (const group of this.groupsByKey.values()) {
+            const snapshot = group.readGroup();
+            if (!snapshot) {
+                continue;
+            }
+            maxConcurrentEdgeSetupsByGroupKey.set(group.groupKey, snapshot.group.memberPolicy.maxConcurrentEdgeSetups);
             const groupPresentPeerIds = new Set(group.targetPeerIds());
-            const desiredPeerIds = this.targetPeerIdsForGroup(group);
-            for (const peerId of desiredPeerIds) {
-                let groupIds = owners.get(peerId);
-                if (!groupIds) {
-                    groupIds = [];
-                    owners.set(peerId, groupIds);
-                }
-                groupIds.push(group.groupRef.groupId);
+            for (const peerId of this.dialPeerIdsForSnapshot(snapshot, group.groupRef)) {
+                owners.set(peerId, [...(owners.get(peerId) ?? []), group.groupRef.groupId]);
+                groupKeysByPeerId.set(peerId, [...(groupKeysByPeerId.get(peerId) ?? []), group.groupKey]);
                 if (groupPresentPeerIds.has(peerId)) {
                     dialAllowedPeerIds.add(peerId);
                 }
             }
-            const snapshot = group.readGroup();
-            if (snapshot) {
-                setupBudgetsByGroupId.set(group.groupRef.groupId, {
-                    desiredPeerIds: new Set(desiredPeerIds),
-                    maxConcurrentEdgeSetups: snapshot.group.memberPolicy.maxConcurrentEdgeSetups
-                });
-            }
         }
 
-        return { groupsByPeerId: owners, dialAllowedPeerIds, setupBudgetsByGroupId };
+        return { groupsByPeerId: owners, dialAllowedPeerIds, groupKeysByPeerId, maxConcurrentEdgeSetupsByGroupKey };
     }
 
     ownerGroupsOfPeer(peerId: PeerId): readonly GroupId[] {
@@ -363,59 +371,63 @@ export class WebRtcGroupManager {
     }
 
     private wakeAfterSetupEnded(): void {
-        // A pass ends setups itself while it evicts and sweeps, and an ending
-        // only frees a slot somebody is waiting for while a paced dial exists;
-        // anything else is already covered by the next presence or layout trigger.
-        if (this.reconcilePassRunning || this.pacedPeerCount === 0) {
+        if (this.waitingDialCount === 0) {
             return;
         }
-        this.reconcileAllGroups().catch((caught) => {
-            console.error('Failed to reconcile groups after a setup ended', toError(caught));
-        });
+        if (this.reconcilePassRunning) {
+            // The pass ended a setup after its own dial loop; the drain loop
+            // re-plans once more instead of a wake landing mid-pass.
+            this.reconcileRequested = true;
+            return;
+        }
+        if (this.scheduledWake) {
+            return;
+        }
+        // Deferred past the notification that raised it, so every observer sees
+        // the ending before the dials it releases.
+        this.scheduledWake = Promise.resolve()
+            .then(() => {
+                this.scheduledWake = undefined;
+                return this.reconcileAllGroups();
+            })
+            .catch((caught) => {
+                console.error('Failed to reconcile groups after a setup ended', toError(caught));
+            });
     }
 
     private async drainReconcileRequests(): Promise<void> {
-        while (this.reconcileRequested) {
-            this.reconcileRequested = false;
-            this.runReconcilePass();
-            if (this.reconcileRequested) {
-                this.diagnostics.reconcileCoalescedRerunCount += 1;
-            }
-        }
-    }
-
-    private runReconcilePass(): void {
         this.reconcilePassRunning = true;
         try {
-            this.runReconcilePassNow();
+            while (this.reconcileRequested) {
+                this.reconcileRequested = false;
+                this.runReconcilePass();
+                if (this.reconcileRequested) {
+                    this.diagnostics.reconcileCoalescedRerunCount += 1;
+                }
+            }
         }
         finally {
             this.reconcilePassRunning = false;
         }
     }
 
-    private runReconcilePassNow(): void {
+    private runReconcilePass(): void {
         this.diagnostics.reconcileRunCount += 1;
-        const peerOwners = this.peerOwners();
-        const desiredPeerIds = new Set(peerOwners.keys());
-        const groupPresentDesiredPeerIds = this.readPeerOwnership().dialAllowedPeerIds;
+        const ownership = this.readPeerOwnership();
+        const desiredPeerIds = new Set(ownership.groupsByPeerId.keys());
         const peerIdsWithNoReconnectableLanes = new Set(
             this.rtcQBox.peerIdsWithNoReconnectableLanes()
         );
-        const knownPeerIds = new Set(this.rtcQBox.knownPeerIds());
         this.removeRetainedDesiredPeers(desiredPeerIds);
         this.diagnostics.lastDesiredPeerCount = desiredPeerIds.size;
 
-        const connectablePeerIds = Array.from(desiredPeerIds).filter(
-            (peerId) => groupPresentDesiredPeerIds.has(peerId)
-        );
-
         const dialPlan = computeOutboundDialPlan({
             maxPeerConnections: this.maxPeerConnections(),
-            knownPeerIds,
+            knownPeerIds: new Set(this.rtcQBox.knownPeerIds()),
+            livePeerIds: new Set(this.rtcQBox.activePeerIds()),
             desiredPeerIds,
-            connectablePeerIds: connectablePeerIds.filter(
-                (peerId) => !peerIdsWithNoReconnectableLanes.has(peerId)
+            connectablePeerIds: Array.from(desiredPeerIds).filter(
+                (peerId) => ownership.dialAllowedPeerIds.has(peerId) && !peerIdsWithNoReconnectableLanes.has(peerId)
             ),
             serverDesiredPeerIds: computeServerDesiredPeerIds(
                 this.acceptedOverlayCache,
@@ -423,17 +435,10 @@ export class WebRtcGroupManager {
                 this.rtcQBox.input.sessionId
             )
         });
-        this.diagnostics.connectDeferredBudgetCount += dialPlan.deferredPeerIds.length;
-        const pacedDialPlan = computePacedOutboundDialPlan({
-            peersToConnect: dialPlan.peersToConnect,
-            knownPeerIds,
-            inFlightPeerIds: new Set(this.rtcQBox.inFlightPeerIds()),
-            ownerGroupIdsByPeerId: peerOwners,
-            groupSetupBudgets: this.readPeerOwnership().setupBudgetsByGroupId
-        });
-        this.diagnostics.connectDeferredPacingCount += pacedDialPlan.pacedPeerIds.length;
-        this.pacedPeerCount = pacedDialPlan.pacedPeerIds.length;
-        this.connectDesiredPeers(pacedDialPlan.peersToConnect, peerOwners);
+        const waiting = this.connectDesiredPeers(dialPlan, ownership);
+        this.diagnostics.connectDeferredBudgetCount += waiting.deferredCount;
+        this.diagnostics.connectDeferredPacingCount += waiting.pacedCount;
+        this.waitingDialCount = waiting.deferredCount + waiting.pacedCount;
 
         const reconciledKnownPeerIds = new Set(this.rtcQBox.knownPeerIds());
         this.removeUnknownRetainedPeers(reconciledKnownPeerIds);
@@ -447,29 +452,87 @@ export class WebRtcGroupManager {
         });
     }
 
+    /**
+     * Spends the connection budget and the in-flight bound as dials start, on
+     * what each ensure actually did: a paced peer holds no slot, and a dial
+     * that started nothing frees its slot for the next candidate at once.
+     */
     private connectDesiredPeers(
-        peersToConnect: readonly PeerId[],
-        peerOwners: ReadonlyMap<PeerId, readonly GroupId[]>
-    ): void {
-        for (const peerId of peersToConnect) {
-            const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
-            if (isPeerSetupStarted(connected)) {
-                this.diagnostics.connectAttemptCount += 1;
+        dialPlan: OutboundDialPlan,
+        ownership: WebRtcGroupManager.PeerOwnership
+    ): WaitingDials {
+        const inFlightSetupCounts = computeInFlightSetupCounts(
+            this.rtcQBox.inFlightPeerIds(),
+            ownership.groupKeysByPeerId
+        );
+        for (const peerId of dialPlan.livePeerIds) {
+            this.ensureDesiredPeer(peerId, ownership);
+        }
+
+        let newDialBudget = dialPlan.newDialBudget;
+        let pacedCount = 0;
+        let deferredCount = 0;
+        const dials = [
+            ...dialPlan.deadKnownPeerIds.map((peerId) => ({ peerId, onNewConnectionSlot: false })),
+            ...dialPlan.candidatePeerIds.map((peerId) => ({ peerId, onNewConnectionSlot: true }))
+        ];
+        for (const dial of dials) {
+            if (dial.onNewConnectionSlot && newDialBudget === 0) {
+                deferredCount += 1;
+                continue;
             }
-            if (connected.left) {
-                this.diagnostics.connectFailureCount += 1;
-                const error = connected.left.kind === 'self' ||
-                        connected.left.kind === 'dial-denied'
-                    ? undefined
-                    : connected.left.error;
-                console.error(
-                    `Failed to connect peer ${peerId}. Owners=${
-                        JSON.stringify(peerOwners.get(peerId) ?? [])
-                    }. Cause=${connected.left.kind}`,
-                    error
-                );
+            if (this.resolveDialAdmission(dial.peerId, inFlightSetupCounts, ownership) === 'wait') {
+                pacedCount += 1;
+                continue;
+            }
+            if (this.ensureDesiredPeer(dial.peerId, ownership) !== 'setup-started') {
+                continue;
+            }
+            if (dial.onNewConnectionSlot) {
+                newDialBudget -= 1;
+            }
+            for (const groupKey of requireOwnerGroupKeys(ownership, dial.peerId)) {
+                inFlightSetupCounts.set(groupKey, (inFlightSetupCounts.get(groupKey) ?? 0) + 1);
             }
         }
+        return { pacedCount, deferredCount };
+    }
+
+    private resolveDialAdmission(
+        peerId: PeerId,
+        inFlightSetupCounts: ReadonlyMap<string, number>,
+        ownership: WebRtcGroupManager.PeerOwnership
+    ): InFlightDialAdmission {
+        const owningGroupBudgets = requireOwnerGroupKeys(ownership, peerId).map((groupKey) => ({
+            inFlightSetupCount: inFlightSetupCounts.get(groupKey) ?? 0,
+            maxConcurrentEdgeSetups: requireGroupSetupBound(ownership, groupKey)
+        }));
+        return computeInFlightDialAdmission({ owningGroupBudgets });
+    }
+
+    private ensureDesiredPeer(
+        peerId: PeerId,
+        ownership: WebRtcGroupManager.PeerOwnership
+    ): WebRtcConnectionService.PeerConnectionEnsureOutcome | undefined {
+        const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
+        if (isPeerSetupStarted(connected)) {
+            this.diagnostics.connectAttemptCount += 1;
+        }
+        if (connected.left) {
+            this.diagnostics.connectFailureCount += 1;
+            const error = connected.left.kind === 'self' ||
+                    connected.left.kind === 'dial-denied'
+                ? undefined
+                : connected.left.error;
+            console.error(
+                `Failed to connect peer ${peerId}. Owners=${
+                    JSON.stringify(ownership.groupsByPeerId.get(peerId) ?? [])
+                }. Cause=${connected.left.kind}`,
+                error
+            );
+            return undefined;
+        }
+        return connected.right?.outcome;
     }
 
     private evictRetainedPeers(
@@ -575,21 +638,15 @@ export class WebRtcGroupManager {
 
     private targetPeerIdsForGroup(group: WebRtcGroupService): readonly PeerId[] {
         const snapshot = group.readGroup();
-        if (!snapshot) {
-            return [];
-        }
+        return snapshot ? this.dialPeerIdsForSnapshot(snapshot, group.groupRef) : [];
+    }
 
+    private dialPeerIdsForSnapshot(snapshot: AnyGroupPresence, groupRef: GroupRef): readonly PeerId[] {
         return selectGroupDialPeerIds({
             lifecycleState: snapshot.group.lifecycleState,
             localSessionId: this.rtcQBox.input.sessionId,
-            planned: readOverlayForGroup(
-                this.plannedOverlayCache,
-                group.groupRef
-            ),
-            accepted: readOverlayForGroup(
-                this.acceptedOverlayCache,
-                group.groupRef
-            )
+            planned: readOverlayForGroup(this.plannedOverlayCache, groupRef),
+            accepted: readOverlayForGroup(this.acceptedOverlayCache, groupRef)
         });
     }
 
@@ -805,4 +862,26 @@ export class WebRtcGroupManager {
     private now(): number {
         return this.options.now?.() ?? Date.now();
     }
+}
+
+function requireOwnerGroupKeys(
+    ownership: WebRtcGroupManager.PeerOwnership,
+    peerId: PeerId
+): readonly string[] {
+    const groupKeys = ownership.groupKeysByPeerId.get(peerId);
+    if (!groupKeys) {
+        throw new Error(`Desired peer ${peerId} has no owning group`);
+    }
+    return groupKeys;
+}
+
+function requireGroupSetupBound(
+    ownership: WebRtcGroupManager.PeerOwnership,
+    groupKey: string
+): number {
+    const bound = ownership.maxConcurrentEdgeSetupsByGroupKey.get(groupKey);
+    if (bound === undefined) {
+        throw new Error(`Owning group ${groupKey} has no in-flight bound`);
+    }
+    return bound;
 }

--- a/packages/shared/services/web-rtc-group-manager.ts
+++ b/packages/shared/services/web-rtc-group-manager.ts
@@ -38,7 +38,7 @@ import {
     readOverlayForGroup
 } from './webrtc-group-overlay-reading.ts';
 import { computeOutboundDialPlan } from './webrtc-outbound-dial-plan.ts';
-import { WebRtcOutboundDialing } from './webrtc-outbound-dialing.ts';
+import { WebRtcOutboundDialing, type OutboundDialsStarted } from './webrtc-outbound-dialing.ts';
 
 export type {
     WebRtcGroupManagerDeleteOptions,
@@ -119,6 +119,8 @@ export class WebRtcGroupManager {
 
     stopReconcileWakes(): void {
         this.rtcQBox.removeRtcPeerLifecycleById(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID);
+        // A wake already on the microtask queue finds nothing waiting and stands down.
+        this.waitingDialCount = 0;
     }
 
     /** Settles after the reconcile that a pending setup-ending wake or an in-flight update will run. */
@@ -352,16 +354,9 @@ export class WebRtcGroupManager {
     }
 
     private wakeAfterSetupEnded(): void {
-        if (this.waitingDialCount === 0) {
-            return;
-        }
-        if (this.reconcilePassRunning) {
-            // The pass ended a setup after its own dial loop; the drain loop
-            // re-plans once more instead of a wake landing mid-pass.
-            this.reconcileRequested = true;
-            return;
-        }
-        if (this.scheduledWake) {
+        // A pass runs synchronously, so an ending observed while it runs is one
+        // the pass caused itself and already accounted for.
+        if (this.waitingDialCount === 0 || this.reconcilePassRunning || this.scheduledWake) {
             return;
         }
         // Deferred past the notification that raised it, so every observer sees
@@ -369,6 +364,9 @@ export class WebRtcGroupManager {
         this.scheduledWake = Promise.resolve()
             .then(() => {
                 this.scheduledWake = undefined;
+                if (this.waitingDialCount === 0) {
+                    return;
+                }
                 return this.reconcileAllGroups();
             })
             .catch((caught) => {
@@ -416,12 +414,9 @@ export class WebRtcGroupManager {
                 this.rtcQBox.input.sessionId
             )
         });
-        const started = new WebRtcOutboundDialing({ rtcQBox: this.rtcQBox, dialPlan, ownership }).start();
-        this.diagnostics.connectAttemptCount += started.attemptCount;
-        this.diagnostics.connectFailureCount += started.failureCount;
-        this.diagnostics.connectDeferredBudgetCount += started.deferredCount;
-        this.diagnostics.connectDeferredPacingCount += started.pacedCount;
-        this.waitingDialCount = started.deferredCount + started.pacedCount;
+        this.recordDialsStarted(
+            new WebRtcOutboundDialing({ rtcQBox: this.rtcQBox, dialPlan, ownership }).start()
+        );
 
         const reconciledKnownPeerIds = new Set(this.rtcQBox.knownPeerIds());
         this.removeUnknownRetainedPeers(reconciledKnownPeerIds);
@@ -433,6 +428,14 @@ export class WebRtcGroupManager {
             desiredPeerIds: [...desiredPeerIds],
             rttReportingPeerIds: this.rttReportingPeerIds({ degreeLimit: this.options.rttReportingDegreeLimit })
         });
+    }
+
+    private recordDialsStarted(started: OutboundDialsStarted): void {
+        this.diagnostics.connectAttemptCount += started.attemptCount;
+        this.diagnostics.connectFailureCount += started.failureCount;
+        this.diagnostics.connectDeferredBudgetCount += started.deferredCount;
+        this.diagnostics.connectDeferredPacingCount += started.pacedCount;
+        this.waitingDialCount = started.deferredCount + started.pacedCount;
     }
 
     private evictRetainedPeers(

--- a/packages/shared/services/web-rtc-group-manager.ts
+++ b/packages/shared/services/web-rtc-group-manager.ts
@@ -11,10 +11,6 @@ import {
     type AnyClientPresence,
     type AnyGroupPresence
 } from '../api/group-client-views.ts';
-import {
-    computeInFlightDialAdmission,
-    type InFlightDialAdmission
-} from '../api/group-lifecycle/compute-in-flight-dial-admission.ts';
 import type { GroupRef } from '../api/group-types.ts';
 import type { ReadableKeyedValues } from '../cache/RepositoryInterfaces.ts';
 import {
@@ -22,7 +18,7 @@ import {
     normalizeRttReportingDegreeLimit,
     selectRttReportingPeers
 } from '../rtc/rtt-reporting-policy.ts';
-import { isPeerSetupStarted, type WebRtcConnectionService } from './web-rtc-connection-service.ts';
+import type { WebRtcConnectionService } from './web-rtc-connection-service.ts';
 import { WebRtcGroupService } from './web-rtc-group-service.ts';
 import { selectGroupDialPeerIds } from './webrtc-group-dial-policy.ts';
 import {
@@ -33,6 +29,7 @@ import {
     type WebRtcGroupManagerDiagnostics,
     type WebRtcGroupManagerOptions,
     type WebRtcGroupManagerState,
+    type WebRtcPeerOwnership,
     type WebRtcRttReportingPeerOptions
 } from './webrtc-group-manager-contracts.ts';
 import {
@@ -40,11 +37,8 @@ import {
     computeServerDesiredPeerIds,
     readOverlayForGroup
 } from './webrtc-group-overlay-reading.ts';
-import {
-    computeInFlightSetupCounts,
-    computeOutboundDialPlan,
-    type OutboundDialPlan
-} from './webrtc-outbound-dial-plan.ts';
+import { computeOutboundDialPlan } from './webrtc-outbound-dial-plan.ts';
+import { WebRtcOutboundDialing } from './webrtc-outbound-dialing.ts';
 
 export type {
     WebRtcGroupManagerDeleteOptions,
@@ -57,11 +51,6 @@ export type {
 export const DEFAULT_WEBRTC_MAX_PEER_CONNECTIONS = 10;
 export const MIN_WEBRTC_MAX_PEER_CONNECTIONS = 5;
 export const DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS = 15_000;
-
-interface WaitingDials {
-    readonly pacedCount: number;
-    readonly deferredCount: number;
-}
 
 interface RttReportingGroupPair {
     readonly group: WebRtcGroupService;
@@ -77,14 +66,6 @@ export namespace WebRtcGroupManager {
         readonly plannedOverlayCache?: ReadableKeyedValues<string, OverlayInfo>;
         readonly acceptedOverlayCache?: ReadableKeyedValues<string, OverlayInfo>;
     }
-
-    export interface PeerOwnership {
-        readonly groupsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
-        readonly dialAllowedPeerIds: ReadonlySet<PeerId>;
-        /** The same ownership by the scoped group key, which the bound is keyed on. */
-        readonly groupKeysByPeerId: ReadonlyMap<PeerId, readonly string[]>;
-        readonly maxConcurrentEdgeSetupsByGroupKey: ReadonlyMap<string, number>;
-    }
 }
 
 export class WebRtcGroupManager {
@@ -92,7 +73,7 @@ export class WebRtcGroupManager {
 
     private readonly groupsByKey = new Map<string, WebRtcGroupService>();
     private readonly retainedPeerConnections = new Map<PeerId, RetainedPeerConnection>();
-    private peerOwnershipCache: WebRtcGroupManager.PeerOwnership | undefined;
+    private peerOwnershipCache: WebRtcPeerOwnership | undefined;
     private reconcileInFlight: Promise<void> | undefined;
     private reconcileRequested = false;
     private reconcilePassRunning = false;
@@ -239,7 +220,7 @@ export class WebRtcGroupManager {
         return clonePeerOwners(this.readPeerOwnership().groupsByPeerId);
     }
 
-    private readPeerOwnership(): WebRtcGroupManager.PeerOwnership {
+    private readPeerOwnership(): WebRtcPeerOwnership {
         if (!this.peerOwnershipCache) {
             this.peerOwnershipCache = this.computePeerOwnership();
         }
@@ -247,7 +228,7 @@ export class WebRtcGroupManager {
         return this.peerOwnershipCache;
     }
 
-    private computePeerOwnership(): WebRtcGroupManager.PeerOwnership {
+    private computePeerOwnership(): WebRtcPeerOwnership {
         const owners = new Map<PeerId, GroupId[]>();
         const groupKeysByPeerId = new Map<PeerId, string[]>();
         const dialAllowedPeerIds = new Set<PeerId>();
@@ -435,10 +416,12 @@ export class WebRtcGroupManager {
                 this.rtcQBox.input.sessionId
             )
         });
-        const waiting = this.connectDesiredPeers(dialPlan, ownership);
-        this.diagnostics.connectDeferredBudgetCount += waiting.deferredCount;
-        this.diagnostics.connectDeferredPacingCount += waiting.pacedCount;
-        this.waitingDialCount = waiting.deferredCount + waiting.pacedCount;
+        const started = new WebRtcOutboundDialing({ rtcQBox: this.rtcQBox, dialPlan, ownership }).start();
+        this.diagnostics.connectAttemptCount += started.attemptCount;
+        this.diagnostics.connectFailureCount += started.failureCount;
+        this.diagnostics.connectDeferredBudgetCount += started.deferredCount;
+        this.diagnostics.connectDeferredPacingCount += started.pacedCount;
+        this.waitingDialCount = started.deferredCount + started.pacedCount;
 
         const reconciledKnownPeerIds = new Set(this.rtcQBox.knownPeerIds());
         this.removeUnknownRetainedPeers(reconciledKnownPeerIds);
@@ -450,89 +433,6 @@ export class WebRtcGroupManager {
             desiredPeerIds: [...desiredPeerIds],
             rttReportingPeerIds: this.rttReportingPeerIds({ degreeLimit: this.options.rttReportingDegreeLimit })
         });
-    }
-
-    /**
-     * Spends the connection budget and the in-flight bound as dials start, on
-     * what each ensure actually did: a paced peer holds no slot, and a dial
-     * that started nothing frees its slot for the next candidate at once.
-     */
-    private connectDesiredPeers(
-        dialPlan: OutboundDialPlan,
-        ownership: WebRtcGroupManager.PeerOwnership
-    ): WaitingDials {
-        const inFlightSetupCounts = computeInFlightSetupCounts(
-            this.rtcQBox.inFlightPeerIds(),
-            ownership.groupKeysByPeerId
-        );
-        for (const peerId of dialPlan.livePeerIds) {
-            this.ensureDesiredPeer(peerId, ownership);
-        }
-
-        let newDialBudget = dialPlan.newDialBudget;
-        let pacedCount = 0;
-        let deferredCount = 0;
-        const dials = [
-            ...dialPlan.deadKnownPeerIds.map((peerId) => ({ peerId, onNewConnectionSlot: false })),
-            ...dialPlan.candidatePeerIds.map((peerId) => ({ peerId, onNewConnectionSlot: true }))
-        ];
-        for (const dial of dials) {
-            if (dial.onNewConnectionSlot && newDialBudget === 0) {
-                deferredCount += 1;
-                continue;
-            }
-            if (this.resolveDialAdmission(dial.peerId, inFlightSetupCounts, ownership) === 'wait') {
-                pacedCount += 1;
-                continue;
-            }
-            if (this.ensureDesiredPeer(dial.peerId, ownership) !== 'setup-started') {
-                continue;
-            }
-            if (dial.onNewConnectionSlot) {
-                newDialBudget -= 1;
-            }
-            for (const groupKey of requireOwnerGroupKeys(ownership, dial.peerId)) {
-                inFlightSetupCounts.set(groupKey, (inFlightSetupCounts.get(groupKey) ?? 0) + 1);
-            }
-        }
-        return { pacedCount, deferredCount };
-    }
-
-    private resolveDialAdmission(
-        peerId: PeerId,
-        inFlightSetupCounts: ReadonlyMap<string, number>,
-        ownership: WebRtcGroupManager.PeerOwnership
-    ): InFlightDialAdmission {
-        const owningGroupBudgets = requireOwnerGroupKeys(ownership, peerId).map((groupKey) => ({
-            inFlightSetupCount: inFlightSetupCounts.get(groupKey) ?? 0,
-            maxConcurrentEdgeSetups: requireGroupSetupBound(ownership, groupKey)
-        }));
-        return computeInFlightDialAdmission({ owningGroupBudgets });
-    }
-
-    private ensureDesiredPeer(
-        peerId: PeerId,
-        ownership: WebRtcGroupManager.PeerOwnership
-    ): WebRtcConnectionService.PeerConnectionEnsureOutcome | undefined {
-        const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
-        if (isPeerSetupStarted(connected)) {
-            this.diagnostics.connectAttemptCount += 1;
-        }
-        if (connected.left) {
-            this.diagnostics.connectFailureCount += 1;
-            const error = connected.left.kind === 'self' ||
-                    connected.left.kind === 'dial-denied'
-                ? undefined
-                : connected.left.error;
-            console.error(
-                `Failed to connect peer ${peerId}. Owners=${
-                    JSON.stringify(ownership.groupsByPeerId.get(peerId) ?? [])
-                }. Cause=${connected.left.kind}`,
-                error
-            );
-            return undefined;
-        }
-        return connected.right?.outcome;
     }
 
     private evictRetainedPeers(
@@ -862,26 +762,4 @@ export class WebRtcGroupManager {
     private now(): number {
         return this.options.now?.() ?? Date.now();
     }
-}
-
-function requireOwnerGroupKeys(
-    ownership: WebRtcGroupManager.PeerOwnership,
-    peerId: PeerId
-): readonly string[] {
-    const groupKeys = ownership.groupKeysByPeerId.get(peerId);
-    if (!groupKeys) {
-        throw new Error(`Desired peer ${peerId} has no owning group`);
-    }
-    return groupKeys;
-}
-
-function requireGroupSetupBound(
-    ownership: WebRtcGroupManager.PeerOwnership,
-    groupKey: string
-): number {
-    const bound = ownership.maxConcurrentEdgeSetupsByGroupKey.get(groupKey);
-    if (bound === undefined) {
-        throw new Error(`Owning group ${groupKey} has no in-flight bound`);
-    }
-    return bound;
 }

--- a/packages/shared/services/web-rtc-group-manager.ts
+++ b/packages/shared/services/web-rtc-group-manager.ts
@@ -36,7 +36,12 @@ import {
     computeServerDesiredPeerIds,
     readOverlayForGroup
 } from './webrtc-group-overlay-reading.ts';
-import { computeOutboundDialPlan, type OutboundDialPlan } from './webrtc-outbound-dial-plan.ts';
+import {
+    computeOutboundDialPlan,
+    computePacedOutboundDialPlan,
+    type GroupSetupBudget,
+    type OutboundDialPlan
+} from './webrtc-outbound-dial-plan.ts';
 
 export type {
     WebRtcGroupManagerDeleteOptions,
@@ -68,15 +73,20 @@ export namespace WebRtcGroupManager {
     export interface PeerOwnership {
         readonly groupsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
         readonly dialAllowedPeerIds: ReadonlySet<PeerId>;
+        readonly setupBudgetsByGroupId: ReadonlyMap<GroupId, GroupSetupBudget>;
     }
 }
 
 export class WebRtcGroupManager {
+    private static readonly SETUP_COMPLETION_CALLBACK_ID = 'webrtc-group-manager:setup-completion';
+
     private readonly groupsByKey = new Map<string, WebRtcGroupService>();
     private readonly retainedPeerConnections = new Map<PeerId, RetainedPeerConnection>();
     private peerOwnershipCache: WebRtcGroupManager.PeerOwnership | undefined;
     private reconcileInFlight: Promise<void> | undefined;
     private reconcileRequested = false;
+    private reconcilePassRunning = false;
+    private pacedPeerCount = 0;
     private retainedOrder = 0;
     private readonly diagnostics = emptyGroupManagerDiagnostics();
 
@@ -98,6 +108,27 @@ export class WebRtcGroupManager {
         this.plannedOverlayCache = repositories.plannedOverlayCache;
         this.acceptedOverlayCache = repositories.acceptedOverlayCache;
         this.options = options;
+        // Every setup ending frees a slot under the in-flight bound (product
+        // decision 18), so the ending itself wakes the next reconcile.
+        rtcQBox.onRtcPeerLifecycleDo(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID, {
+            onCreated: () => {},
+            onDeleted: () => this.wakeAfterSetupEnded(),
+            onEstablished: () => this.wakeAfterSetupEnded(),
+            onConnectTimeout: () => this.wakeAfterSetupEnded()
+        });
+    }
+
+    /** Settles once the reconcile pass a lifecycle wake or an update started has finished. */
+    whenReconciled(): Promise<void> {
+        return this.reconcileInFlight ?? Promise.resolve();
+    }
+
+    /**
+     * Shutdown tears peers down while their groups still want them; without
+     * this, every teardown would wake a reconcile that dials them again.
+     */
+    stopReconcileWakes(): void {
+        this.rtcQBox.removeRtcPeerLifecycleById(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID);
     }
 
     readDiagnostics(): WebRtcGroupManagerDiagnostics {
@@ -205,10 +236,12 @@ export class WebRtcGroupManager {
     private computePeerOwnership(): WebRtcGroupManager.PeerOwnership {
         const owners = new Map<PeerId, GroupId[]>();
         const dialAllowedPeerIds = new Set<PeerId>();
+        const setupBudgetsByGroupId = new Map<GroupId, GroupSetupBudget>();
 
         for (const group of this.groupsByKey.values()) {
             const groupPresentPeerIds = new Set(group.targetPeerIds());
-            for (const peerId of this.targetPeerIdsForGroup(group)) {
+            const desiredPeerIds = this.targetPeerIdsForGroup(group);
+            for (const peerId of desiredPeerIds) {
                 let groupIds = owners.get(peerId);
                 if (!groupIds) {
                     groupIds = [];
@@ -219,9 +252,16 @@ export class WebRtcGroupManager {
                     dialAllowedPeerIds.add(peerId);
                 }
             }
+            const snapshot = group.readGroup();
+            if (snapshot) {
+                setupBudgetsByGroupId.set(group.groupRef.groupId, {
+                    desiredPeerIds: new Set(desiredPeerIds),
+                    maxConcurrentEdgeSetups: snapshot.group.memberPolicy.maxConcurrentEdgeSetups
+                });
+            }
         }
 
-        return { groupsByPeerId: owners, dialAllowedPeerIds };
+        return { groupsByPeerId: owners, dialAllowedPeerIds, setupBudgetsByGroupId };
     }
 
     ownerGroupsOfPeer(peerId: PeerId): readonly GroupId[] {
@@ -322,6 +362,18 @@ export class WebRtcGroupManager {
         }
     }
 
+    private wakeAfterSetupEnded(): void {
+        // A pass ends setups itself while it evicts and sweeps, and an ending
+        // only frees a slot somebody is waiting for while a paced dial exists;
+        // anything else is already covered by the next presence or layout trigger.
+        if (this.reconcilePassRunning || this.pacedPeerCount === 0) {
+            return;
+        }
+        this.reconcileAllGroups().catch((caught) => {
+            console.error('Failed to reconcile groups after a setup ended', toError(caught));
+        });
+    }
+
     private async drainReconcileRequests(): Promise<void> {
         while (this.reconcileRequested) {
             this.reconcileRequested = false;
@@ -333,6 +385,16 @@ export class WebRtcGroupManager {
     }
 
     private runReconcilePass(): void {
+        this.reconcilePassRunning = true;
+        try {
+            this.runReconcilePassNow();
+        }
+        finally {
+            this.reconcilePassRunning = false;
+        }
+    }
+
+    private runReconcilePassNow(): void {
         this.diagnostics.reconcileRunCount += 1;
         const peerOwners = this.peerOwners();
         const desiredPeerIds = new Set(peerOwners.keys());
@@ -362,7 +424,16 @@ export class WebRtcGroupManager {
             )
         });
         this.diagnostics.connectDeferredBudgetCount += dialPlan.deferredPeerIds.length;
-        this.connectDesiredPeers(dialPlan, peerOwners);
+        const pacedDialPlan = computePacedOutboundDialPlan({
+            peersToConnect: dialPlan.peersToConnect,
+            knownPeerIds,
+            inFlightPeerIds: new Set(this.rtcQBox.inFlightPeerIds()),
+            ownerGroupIdsByPeerId: peerOwners,
+            groupSetupBudgets: this.readPeerOwnership().setupBudgetsByGroupId
+        });
+        this.diagnostics.connectDeferredPacingCount += pacedDialPlan.pacedPeerIds.length;
+        this.pacedPeerCount = pacedDialPlan.pacedPeerIds.length;
+        this.connectDesiredPeers(pacedDialPlan.peersToConnect, peerOwners);
 
         const reconciledKnownPeerIds = new Set(this.rtcQBox.knownPeerIds());
         this.removeUnknownRetainedPeers(reconciledKnownPeerIds);
@@ -377,10 +448,10 @@ export class WebRtcGroupManager {
     }
 
     private connectDesiredPeers(
-        dialPlan: OutboundDialPlan,
+        peersToConnect: readonly PeerId[],
         peerOwners: ReadonlyMap<PeerId, readonly GroupId[]>
     ): void {
-        for (const peerId of dialPlan.peersToConnect) {
+        for (const peerId of peersToConnect) {
             const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
             if (isPeerSetupStarted(connected)) {
                 this.diagnostics.connectAttemptCount += 1;

--- a/packages/shared/services/webrtc-group-manager-contracts.ts
+++ b/packages/shared/services/webrtc-group-manager-contracts.ts
@@ -68,6 +68,7 @@ export interface MutableWebRtcGroupManagerDiagnostics {
     connectAttemptCount: number;
     connectFailureCount: number;
     connectDeferredBudgetCount: number;
+    connectDeferredPacingCount: number;
     disconnectCount: number;
     retainedCreatedCount: number;
     retainedExpiredCount: number;
@@ -85,6 +86,7 @@ export function emptyGroupManagerDiagnostics(): MutableWebRtcGroupManagerDiagnos
         connectAttemptCount: 0,
         connectFailureCount: 0,
         connectDeferredBudgetCount: 0,
+        connectDeferredPacingCount: 0,
         disconnectCount: 0,
         retainedCreatedCount: 0,
         retainedExpiredCount: 0,

--- a/packages/shared/services/webrtc-group-manager-contracts.ts
+++ b/packages/shared/services/webrtc-group-manager-contracts.ts
@@ -37,6 +37,15 @@ export interface WebRtcRttReportingPeerOptions {
  * two reasons. Eviction order is defined across reasons: expired entries
  * first, then oldest `retainedOrder` regardless of reason.
  */
+/** Which groups want each desired peer, and each group's in-flight setup bound (product decision 18). */
+export interface WebRtcPeerOwnership {
+    readonly groupsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
+    readonly dialAllowedPeerIds: ReadonlySet<PeerId>;
+    /** The same ownership by the scoped group key, which the bound is keyed on. */
+    readonly groupKeysByPeerId: ReadonlyMap<PeerId, readonly string[]>;
+    readonly maxConcurrentEdgeSetupsByGroupKey: ReadonlyMap<string, number>;
+}
+
 export type RetainedPeerConnectionReason = 'left-group' | 'overlay-transition' | 'commanded';
 
 export interface RetainedPeerConnection {

--- a/packages/shared/services/webrtc-outbound-dial-plan.ts
+++ b/packages/shared/services/webrtc-outbound-dial-plan.ts
@@ -1,4 +1,5 @@
-import type { PeerId } from '../api/api-config.ts';
+import type { GroupId, PeerId } from '../api/api-config.ts';
+import { computeInFlightDialAdmission } from '../api/group-lifecycle/compute-in-flight-dial-admission.ts';
 
 export type OutboundDialPlanInput = Readonly<{
     maxPeerConnections: number;
@@ -11,6 +12,24 @@ export type OutboundDialPlanInput = Readonly<{
 export type OutboundDialPlan = Readonly<{
     peersToConnect: readonly PeerId[];
     deferredPeerIds: readonly PeerId[];
+}>;
+
+export interface GroupSetupBudget {
+    readonly desiredPeerIds: ReadonlySet<PeerId>;
+    readonly maxConcurrentEdgeSetups: number;
+}
+
+export interface PacedOutboundDialPlanInput {
+    readonly peersToConnect: readonly PeerId[];
+    readonly knownPeerIds: ReadonlySet<PeerId>;
+    readonly inFlightPeerIds: ReadonlySet<PeerId>;
+    readonly ownerGroupIdsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
+    readonly groupSetupBudgets: ReadonlyMap<GroupId, GroupSetupBudget>;
+}
+
+export type PacedOutboundDialPlan = Readonly<{
+    peersToConnect: readonly PeerId[];
+    pacedPeerIds: readonly PeerId[];
 }>;
 
 /**
@@ -52,4 +71,48 @@ export function computeOutboundDialPlan(
         ],
         deferredPeerIds: serverFirstCandidates.slice(newDialBudget)
     };
+}
+
+/**
+ * The in-flight bound (product decision 18) over a budgeted dial plan. A known
+ * peer passes untouched because its ensure starts nothing. A new dial is
+ * admitted only while every owning group is below its bound, counting the
+ * setups already in flight for that group plus the dials admitted earlier in
+ * this pass; a paced peer waits for the next reconcile, which a setup ending
+ * wakes.
+ */
+export function computePacedOutboundDialPlan(
+    input: PacedOutboundDialPlanInput
+): PacedOutboundDialPlan {
+    const inFlightSetupCountByGroupId = new Map<GroupId, number>();
+    for (const [groupId, budget] of input.groupSetupBudgets) {
+        const inFlightSetupCount = Array.from(input.inFlightPeerIds)
+            .filter((peerId) => budget.desiredPeerIds.has(peerId))
+            .length;
+        inFlightSetupCountByGroupId.set(groupId, inFlightSetupCount);
+    }
+
+    const peersToConnect: PeerId[] = [];
+    const pacedPeerIds: PeerId[] = [];
+    for (const peerId of input.peersToConnect) {
+        if (input.knownPeerIds.has(peerId)) {
+            peersToConnect.push(peerId);
+            continue;
+        }
+        const ownerGroupIds = input.ownerGroupIdsByPeerId.get(peerId) ?? [];
+        const owningGroupBudgets = ownerGroupIds.map((groupId) => ({
+            inFlightSetupCount: inFlightSetupCountByGroupId.get(groupId) ?? 0,
+            maxConcurrentEdgeSetups: input.groupSetupBudgets.get(groupId)?.maxConcurrentEdgeSetups ?? 0
+        }));
+        if (computeInFlightDialAdmission({ owningGroupBudgets }) === 'wait') {
+            pacedPeerIds.push(peerId);
+            continue;
+        }
+        peersToConnect.push(peerId);
+        for (const groupId of ownerGroupIds) {
+            inFlightSetupCountByGroupId.set(groupId, (inFlightSetupCountByGroupId.get(groupId) ?? 0) + 1);
+        }
+    }
+
+    return { peersToConnect, pacedPeerIds };
 }

--- a/packages/shared/services/webrtc-outbound-dial-plan.ts
+++ b/packages/shared/services/webrtc-outbound-dial-plan.ts
@@ -1,118 +1,68 @@
-import type { GroupId, PeerId } from '../api/api-config.ts';
-import { computeInFlightDialAdmission } from '../api/group-lifecycle/compute-in-flight-dial-admission.ts';
+import type { PeerId } from '../api/api-config.ts';
 
 export type OutboundDialPlanInput = Readonly<{
     maxPeerConnections: number;
     knownPeerIds: ReadonlySet<PeerId>;
+    /** Known peers whose native connection is still connecting or connected. */
+    livePeerIds: ReadonlySet<PeerId>;
     desiredPeerIds: ReadonlySet<PeerId>;
     connectablePeerIds: readonly PeerId[];
     serverDesiredPeerIds: ReadonlySet<PeerId>;
 }>;
 
 export type OutboundDialPlan = Readonly<{
-    peersToConnect: readonly PeerId[];
-    deferredPeerIds: readonly PeerId[];
-}>;
-
-export interface GroupSetupBudget {
-    readonly desiredPeerIds: ReadonlySet<PeerId>;
-    readonly maxConcurrentEdgeSetups: number;
-}
-
-export interface PacedOutboundDialPlanInput {
-    readonly peersToConnect: readonly PeerId[];
-    readonly knownPeerIds: ReadonlySet<PeerId>;
-    readonly inFlightPeerIds: ReadonlySet<PeerId>;
-    readonly ownerGroupIdsByPeerId: ReadonlyMap<PeerId, readonly GroupId[]>;
-    readonly groupSetupBudgets: ReadonlyMap<GroupId, GroupSetupBudget>;
-}
-
-export type PacedOutboundDialPlan = Readonly<{
-    peersToConnect: readonly PeerId[];
-    pacedPeerIds: readonly PeerId[];
+    /** Their ensure starts nothing, so neither the budget nor the bound applies. */
+    livePeerIds: readonly PeerId[];
+    /** Known peers whose connection died: their ensure starts a new setup under the bound, on a connection slot they already hold. */
+    deadKnownPeerIds: readonly PeerId[];
+    /** New dials, server-overlay-desired first; only `newDialBudget` of them fit the connection budget. */
+    candidatePeerIds: readonly PeerId[];
+    newDialBudget: number;
 }>;
 
 /**
- * Bounds outbound dialing to the same peer-connection budget inbound
- * admission uses. Peers with an existing connection are always ensured (an
- * ensure is idempotent, not a new dial); new dials are admitted
- * server-overlay-desired peers first, then bootstrap-desired peers, until
- * desired connections reach the budget. Only desired known connections count
- * against the budget: retained (grace) connections are governed by the
- * retained-eviction pass, which trims the overflow in the same reconcile —
- * counting them here would let a full retained set starve required dials
- * that the eviction pass would never unblock. Deferred peers are retried by
- * later reconciles as slots free up.
+ * Orders outbound dialing under the same peer-connection budget inbound
+ * admission uses. Only desired known connections count against the budget:
+ * retained (grace) connections are governed by the retained-eviction pass,
+ * which trims the overflow in the same reconcile — counting them here would let
+ * a full retained set starve required dials that the eviction pass would never
+ * unblock. The dial loop spends the budget and the in-flight bound as it goes,
+ * so a paced peer never holds a slot a later candidate could use, and a dial
+ * that starts nothing frees its slot at once.
  */
 export function computeOutboundDialPlan(
     input: OutboundDialPlanInput
 ): OutboundDialPlan {
-    const alreadyKnown = input.connectablePeerIds
-        .filter((peerId) => input.knownPeerIds.has(peerId));
-    const newCandidates = input.connectablePeerIds
-        .filter((peerId) => !input.knownPeerIds.has(peerId));
-    const serverFirstCandidates = [
-        ...newCandidates.filter((peerId) => input.serverDesiredPeerIds.has(peerId)),
-        ...newCandidates.filter((peerId) => !input.serverDesiredPeerIds.has(peerId))
-    ];
-
+    const known = input.connectablePeerIds.filter((peerId) => input.knownPeerIds.has(peerId));
+    const newCandidates = input.connectablePeerIds.filter((peerId) => !input.knownPeerIds.has(peerId));
     const desiredKnownCount = Array.from(input.knownPeerIds)
         .filter((peerId) => input.desiredPeerIds.has(peerId))
         .length;
-    const newDialBudget = Math.max(
-        0,
-        input.maxPeerConnections - desiredKnownCount
-    );
 
     return {
-        peersToConnect: [
-            ...alreadyKnown,
-            ...serverFirstCandidates.slice(0, newDialBudget)
+        livePeerIds: known.filter((peerId) => input.livePeerIds.has(peerId)),
+        deadKnownPeerIds: known.filter((peerId) => !input.livePeerIds.has(peerId)),
+        candidatePeerIds: [
+            ...newCandidates.filter((peerId) => input.serverDesiredPeerIds.has(peerId)),
+            ...newCandidates.filter((peerId) => !input.serverDesiredPeerIds.has(peerId))
         ],
-        deferredPeerIds: serverFirstCandidates.slice(newDialBudget)
+        newDialBudget: Math.max(0, input.maxPeerConnections - desiredKnownCount)
     };
 }
 
 /**
- * The in-flight bound (product decision 18) over a budgeted dial plan. A known
- * peer passes untouched because its ensure starts nothing. A new dial is
- * admitted only while every owning group is below its bound, counting the
- * setups already in flight for that group plus the dials admitted earlier in
- * this pass; a paced peer waits for the next reconcile, which a setup ending
- * wakes.
+ * Setups in flight per owning group (product decision 18): a shared peer is
+ * one connection charged to every group that wants it.
  */
-export function computePacedOutboundDialPlan(
-    input: PacedOutboundDialPlanInput
-): PacedOutboundDialPlan {
-    const inFlightSetupCountByGroupId = new Map<GroupId, number>();
-    for (const [groupId, budget] of input.groupSetupBudgets) {
-        const inFlightSetupCount = Array.from(input.inFlightPeerIds)
-            .filter((peerId) => budget.desiredPeerIds.has(peerId))
-            .length;
-        inFlightSetupCountByGroupId.set(groupId, inFlightSetupCount);
-    }
-
-    const peersToConnect: PeerId[] = [];
-    const pacedPeerIds: PeerId[] = [];
-    for (const peerId of input.peersToConnect) {
-        if (input.knownPeerIds.has(peerId)) {
-            peersToConnect.push(peerId);
-            continue;
-        }
-        const ownerGroupIds = input.ownerGroupIdsByPeerId.get(peerId) ?? [];
-        const owningGroupBudgets = ownerGroupIds.map((groupId) => ({
-            inFlightSetupCount: inFlightSetupCountByGroupId.get(groupId) ?? 0,
-            maxConcurrentEdgeSetups: input.groupSetupBudgets.get(groupId)?.maxConcurrentEdgeSetups ?? 0
-        }));
-        if (computeInFlightDialAdmission({ owningGroupBudgets }) === 'wait') {
-            pacedPeerIds.push(peerId);
-            continue;
-        }
-        peersToConnect.push(peerId);
-        for (const groupId of ownerGroupIds) {
-            inFlightSetupCountByGroupId.set(groupId, (inFlightSetupCountByGroupId.get(groupId) ?? 0) + 1);
+export function computeInFlightSetupCounts(
+    inFlightPeerIds: readonly PeerId[],
+    ownerGroupKeysByPeerId: ReadonlyMap<PeerId, readonly string[]>
+): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const peerId of inFlightPeerIds) {
+        for (const groupKey of ownerGroupKeysByPeerId.get(peerId) ?? []) {
+            counts.set(groupKey, (counts.get(groupKey) ?? 0) + 1);
         }
     }
-
-    return { peersToConnect, pacedPeerIds };
+    return counts;
 }

--- a/packages/shared/services/webrtc-outbound-dialing.ts
+++ b/packages/shared/services/webrtc-outbound-dialing.ts
@@ -1,0 +1,132 @@
+import type { PeerId } from '../api/api-config.ts';
+import {
+    computeInFlightDialAdmission,
+    type InFlightDialAdmission
+} from '../api/group-lifecycle/compute-in-flight-dial-admission.ts';
+import { isPeerSetupStarted, type WebRtcConnectionService } from './web-rtc-connection-service.ts';
+import type { WebRtcPeerOwnership } from './webrtc-group-manager-contracts.ts';
+import { computeInFlightSetupCounts, type OutboundDialPlan } from './webrtc-outbound-dial-plan.ts';
+
+export interface OutboundDialingInput {
+    readonly rtcQBox: WebRtcConnectionService;
+    readonly dialPlan: OutboundDialPlan;
+    readonly ownership: WebRtcPeerOwnership;
+}
+
+export interface OutboundDialsStarted {
+    readonly attemptCount: number;
+    readonly failureCount: number;
+    /** Desired peers that waited for a connection-budget slot. */
+    readonly deferredCount: number;
+    /** Desired peers that waited for an owner's in-flight slot (product decision 18). */
+    readonly pacedCount: number;
+}
+
+type DialSlot = 'existing-connection' | 'new-connection';
+
+/**
+ * One reconcile pass's dials. Spends the connection budget and the in-flight
+ * bound as dials start, on what each ensure actually did: a paced peer holds
+ * no slot, and a dial that started nothing frees its slot for the next
+ * candidate at once.
+ */
+export class WebRtcOutboundDialing {
+    private readonly rtcQBox: WebRtcConnectionService;
+    private readonly dialPlan: OutboundDialPlan;
+    private readonly ownership: WebRtcPeerOwnership;
+    private readonly inFlightSetupCounts: Map<string, number>;
+    private newDialBudget: number;
+    private readonly started = { attemptCount: 0, failureCount: 0, deferredCount: 0, pacedCount: 0 };
+
+    constructor(input: OutboundDialingInput) {
+        this.rtcQBox = input.rtcQBox;
+        this.dialPlan = input.dialPlan;
+        this.ownership = input.ownership;
+        this.inFlightSetupCounts = computeInFlightSetupCounts(
+            input.rtcQBox.inFlightPeerIds(),
+            input.ownership.groupKeysByPeerId
+        );
+        this.newDialBudget = input.dialPlan.newDialBudget;
+    }
+
+    start(): OutboundDialsStarted {
+        for (const peerId of this.dialPlan.livePeerIds) {
+            this.ensureDesiredPeer(peerId);
+        }
+        for (const peerId of this.dialPlan.deadKnownPeerIds) {
+            this.startDial(peerId, 'existing-connection');
+        }
+        for (const peerId of this.dialPlan.candidatePeerIds) {
+            this.startDial(peerId, 'new-connection');
+        }
+        return { ...this.started };
+    }
+
+    private startDial(peerId: PeerId, slot: DialSlot): void {
+        if (slot === 'new-connection' && this.newDialBudget === 0) {
+            this.started.deferredCount += 1;
+            return;
+        }
+        if (this.resolveDialAdmission(peerId) === 'wait') {
+            this.started.pacedCount += 1;
+            return;
+        }
+        if (this.ensureDesiredPeer(peerId) !== 'setup-started') {
+            return;
+        }
+        if (slot === 'new-connection') {
+            this.newDialBudget -= 1;
+        }
+        for (const groupKey of requireOwnerGroupKeys(this.ownership, peerId)) {
+            this.inFlightSetupCounts.set(groupKey, (this.inFlightSetupCounts.get(groupKey) ?? 0) + 1);
+        }
+    }
+
+    private resolveDialAdmission(peerId: PeerId): InFlightDialAdmission {
+        const owningGroupBudgets = requireOwnerGroupKeys(this.ownership, peerId).map((groupKey) => ({
+            inFlightSetupCount: this.inFlightSetupCounts.get(groupKey) ?? 0,
+            maxConcurrentEdgeSetups: requireGroupSetupBound(this.ownership, groupKey)
+        }));
+        return computeInFlightDialAdmission({ owningGroupBudgets });
+    }
+
+    private ensureDesiredPeer(
+        peerId: PeerId
+    ): WebRtcConnectionService.PeerConnectionEnsureOutcome | undefined {
+        const connected = this.rtcQBox.ensurePeerConnectionStarted(peerId);
+        if (isPeerSetupStarted(connected)) {
+            this.started.attemptCount += 1;
+        }
+        if (connected.left) {
+            this.started.failureCount += 1;
+            const error = connected.left.kind === 'self' ||
+                    connected.left.kind === 'dial-denied'
+                ? undefined
+                : connected.left.error;
+            console.error(
+                `Failed to connect peer ${peerId}. Owners=${
+                    JSON.stringify(this.ownership.groupsByPeerId.get(peerId) ?? [])
+                }. Cause=${connected.left.kind}`,
+                error
+            );
+            return undefined;
+        }
+        return connected.right?.outcome;
+    }
+}
+
+function requireOwnerGroupKeys(ownership: WebRtcPeerOwnership, peerId: PeerId): readonly string[] {
+    const groupKeys = ownership.groupKeysByPeerId.get(peerId);
+    if (!groupKeys) {
+        throw new Error(`Desired peer ${peerId} has no owning group`);
+    }
+    return groupKeys;
+}
+
+function requireGroupSetupBound(ownership: WebRtcPeerOwnership, groupKey: string): number {
+    const bound = ownership.maxConcurrentEdgeSetupsByGroupKey.get(groupKey);
+    if (bound === undefined) {
+        throw new Error(`Owning group ${groupKey} has no in-flight bound`);
+    }
+    return bound;
+}

--- a/packages/shared/services/webrtc-outbound-dialing.ts
+++ b/packages/shared/services/webrtc-outbound-dialing.ts
@@ -77,15 +77,15 @@ export class WebRtcOutboundDialing {
         if (slot === 'new-connection') {
             this.newDialBudget -= 1;
         }
-        for (const groupKey of requireOwnerGroupKeys(this.ownership, peerId)) {
+        for (const groupKey of getOwnerGroupKeys(this.ownership, peerId)) {
             this.inFlightSetupCounts.set(groupKey, (this.inFlightSetupCounts.get(groupKey) ?? 0) + 1);
         }
     }
 
     private resolveDialAdmission(peerId: PeerId): InFlightDialAdmission {
-        const owningGroupBudgets = requireOwnerGroupKeys(this.ownership, peerId).map((groupKey) => ({
+        const owningGroupBudgets = getOwnerGroupKeys(this.ownership, peerId).map((groupKey) => ({
             inFlightSetupCount: this.inFlightSetupCounts.get(groupKey) ?? 0,
-            maxConcurrentEdgeSetups: requireGroupSetupBound(this.ownership, groupKey)
+            maxConcurrentEdgeSetups: getGroupSetupBound(this.ownership, groupKey)
         }));
         return computeInFlightDialAdmission({ owningGroupBudgets });
     }
@@ -99,23 +99,21 @@ export class WebRtcOutboundDialing {
         }
         if (connected.left) {
             this.started.failureCount += 1;
-            const error = connected.left.kind === 'self' ||
-                    connected.left.kind === 'dial-denied'
-                ? undefined
-                : connected.left.error;
-            console.error(
-                `Failed to connect peer ${peerId}. Owners=${
-                    JSON.stringify(this.ownership.groupsByPeerId.get(peerId) ?? [])
-                }. Cause=${connected.left.kind}`,
-                error
-            );
+            if (connected.left.kind !== 'self' && connected.left.kind !== 'dial-denied') {
+                console.error(
+                    `Failed to connect peer ${peerId}. Owners=${
+                        JSON.stringify(this.ownership.groupsByPeerId.get(peerId) ?? [])
+                    }. Cause=${connected.left.kind}`,
+                    connected.left.error
+                );
+            }
             return undefined;
         }
         return connected.right?.outcome;
     }
 }
 
-function requireOwnerGroupKeys(ownership: WebRtcPeerOwnership, peerId: PeerId): readonly string[] {
+function getOwnerGroupKeys(ownership: WebRtcPeerOwnership, peerId: PeerId): readonly string[] {
     const groupKeys = ownership.groupKeysByPeerId.get(peerId);
     if (!groupKeys) {
         throw new Error(`Desired peer ${peerId} has no owning group`);
@@ -123,7 +121,7 @@ function requireOwnerGroupKeys(ownership: WebRtcPeerOwnership, peerId: PeerId): 
     return groupKeys;
 }
 
-function requireGroupSetupBound(ownership: WebRtcPeerOwnership, groupKey: string): number {
+function getGroupSetupBound(ownership: WebRtcPeerOwnership, groupKey: string): number {
     const bound = ownership.maxConcurrentEdgeSetupsByGroupKey.get(groupKey);
     if (bound === undefined) {
         throw new Error(`Owning group ${groupKey} has no in-flight bound`);

--- a/packages/tests/create-test-group.ts
+++ b/packages/tests/create-test-group.ts
@@ -49,7 +49,8 @@ export function createTestGroup(overrides: Partial<Group> = {}): Group {
         establishmentStartedAtEpochMs: null,
         formationElectorate: ['alice'],
         acceptedLayoutIdentity: null,
-        transportState: 'flowing'
+        transportState: 'flowing',
+        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
     };
 
     // `Group` correlates `status` with `archived`/`deleted`, and a spread of

--- a/packages/tests/create-test-group.ts
+++ b/packages/tests/create-test-group.ts
@@ -1,3 +1,5 @@
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { AuditStamp, Group } from '@shared/api/group-types.ts';
 
 /**
@@ -50,7 +52,7 @@ export function createTestGroup(overrides: Partial<Group> = {}): Group {
         formationElectorate: ['alice'],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
-        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' }
+        memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
     };
 
     // `Group` correlates `status` with `archived`/`deleted`, and a spread of

--- a/packages/tests/shared-server/performance/state-write/state-write-performance-topology-reasons.test.ts
+++ b/packages/tests/shared-server/performance/state-write/state-write-performance-topology-reasons.test.ts
@@ -87,6 +87,13 @@ describe('API-v1 state-write topology regression reasons', { timeout: 30_000 }, 
             []
         );
 
+        const memberPolicyOptions = parseBenchmarkOptions([
+            '--regression-reason-profile=member-policy-row-width'
+        ]);
+        const memberPolicyReasons = selectStateWriteRegressionReasons(memberPolicyOptions.regressionReasonProfile, []);
+        expect(memberPolicyReasons).toHaveLength(12);
+        expect(memberPolicyReasons.every((entry) => entry.reason.includes('memberPolicy'))).toBe(true);
+
         const groupTopologyOptions = parseBenchmarkOptions([
             '--regression-reasons-file=tmp/perf/topology-reasons.json'
         ]);

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -32,7 +32,7 @@ const EXPECTED_CREATE_GROUP_DURABLE_JSON = '{"status":"created","result":{"snaps
     '"traceId":null,"requestId":"create-transaction-boundary-room"},' +
     '"archived":null,"deleted":null,"expiresAtEpochMs":null,' +
     '"emptySinceEpochMs":null,"purgeAfterEpochMs":null,' +
-    '"lifecycleState":"active","formationEpoch":0,"formationAttemptCount":0,"lastFormationOutcome":null,"establishmentStartedAtEpochMs":null,"formationElectorate":["owner"],"acceptedLayoutIdentity":null,"transportState":"flowing"},"members":[' +
+    '"lifecycleState":"active","formationEpoch":0,"formationAttemptCount":0,"lastFormationOutcome":null,"establishmentStartedAtEpochMs":null,"formationElectorate":["owner"],"acceptedLayoutIdentity":null,"transportState":"flowing","memberPolicy":{"maxConcurrentEdgeSetups":64,"transports":"rtc-and-ws"}},"members":[' +
     '{"applicationId":"ar-eye-hunter","workspaceId":"default",' +
     '"groupId":"transaction-boundary-room","principalId":"owner","role":"owner",' +
     '"status":"active","joined":{"atEpochMs":1785628800000,' +

--- a/packages/tests/shared-web/api-middleware-test-double.ts
+++ b/packages/tests/shared-web/api-middleware-test-double.ts
@@ -40,6 +40,7 @@ export function createDefaultApiMiddlewareTestDouble(
             ),
             rtcRxStreamer: createRtcRxStreamerDouble(middlewareOverrides.rtcRxStreamer),
             webRtcGroupManager: toServiceTestDouble<RallarBrowserMiddleware['webRtcGroupManager']>({
+                startReconcileWakes: vi.fn(),
                 stopReconcileWakes: vi.fn(),
                 ...middlewareOverrides.webRtcGroupManager
             }),

--- a/packages/tests/shared-web/api-middleware-test-double.ts
+++ b/packages/tests/shared-web/api-middleware-test-double.ts
@@ -40,6 +40,7 @@ export function createDefaultApiMiddlewareTestDouble(
             ),
             rtcRxStreamer: createRtcRxStreamerDouble(middlewareOverrides.rtcRxStreamer),
             webRtcGroupManager: toServiceTestDouble<RallarBrowserMiddleware['webRtcGroupManager']>({
+                stopReconcileWakes: vi.fn(),
                 ...middlewareOverrides.webRtcGroupManager
             }),
             webRtcOverlayMulticastManager: toServiceTestDouble<RallarBrowserMiddleware['webRtcOverlayMulticastManager']>({

--- a/packages/tests/shared-web/connection/browser-transport-cleanup.test.ts
+++ b/packages/tests/shared-web/connection/browser-transport-cleanup.test.ts
@@ -272,6 +272,9 @@ describe('Browser transport cleanup', () => {
         vi.mocked(middleware.middleware.rtcRxStreamer.dispose).mockImplementation(() => {
             effects.push('rtc-disposed');
         });
+        vi.mocked(middleware.middleware.webRtcGroupManager.stopReconcileWakes).mockImplementation(() => {
+            effects.push('reconcile-wakes-stopped');
+        });
         vi.mocked(middleware.middleware.webRtcConnectionService.knownPeerIds).mockReturnValue(['peer-1']);
         vi.mocked(middleware.middleware.webRtcConnectionService.disconnectPeer).mockImplementation(() => {
             effects.push('rtc-peer');
@@ -328,6 +331,7 @@ describe('Browser transport cleanup', () => {
             'state-cache-detached',
             'heartbeat',
             'rtc-disposed',
+            'reconcile-wakes-stopped',
             'rtc-peer',
             'media',
             'multicast',

--- a/packages/tests/shared/group-key-allowlists-cross-check.test.ts
+++ b/packages/tests/shared/group-key-allowlists-cross-check.test.ts
@@ -39,6 +39,21 @@ describe('group key allowlists against keyof Group', () => {
         expect(() => validatePersistedGroup(group, ref)).not.toThrow();
     });
 
+    it('rejects an unregistered member policy key in every list', () => {
+        const group = JSON.parse(JSON.stringify(createTestGroup(ref)));
+        group.memberPolicy.retries = 3;
+        expect(() => validatePersistedGroup(group, ref))
+            .toThrow('Stored group memberPolicy has unexpected key: retries');
+        const snapshot = JSON.parse(JSON.stringify(createGroupSnapshotFixture({ ...ref, sessionIds: ['alice'] })));
+        snapshot.group.memberPolicy.retries = 3;
+        expect(() => validateAuthoritativeGroupSnapshot(snapshot, ref))
+            .toThrow('GroupSnapshot.group.memberPolicy has unexpected retries');
+        const envelope = JSON.parse(JSON.stringify(createDeltaEnvelopeFixture({ audienceSessionIds: ['alice-session'] })));
+        envelope.group.memberPolicy.retries = 3;
+        expect(() => validateGroupStateDeltaEnvelope(envelope))
+            .toThrow('memberPolicy has unexpected retries');
+    });
+
     it('rejects a group missing a registered key in every list', () => {
         const { transportState: omitted, ...withoutTransport } = JSON.parse(
             JSON.stringify(createTestGroup(ref))

--- a/packages/tests/shared/group-lifecycle-policy.test.ts
+++ b/packages/tests/shared/group-lifecycle-policy.test.ts
@@ -10,6 +10,7 @@ import {
     MAX_GROUP_STAGE_TRIGGER_DELAY_MS,
     MAX_GROUP_TOPOLOGY_DEBOUNCE_WINDOW_MS,
     MAX_GROUP_TOPOLOGY_REPLAN_WAIT_MS,
+    toGroupMemberPolicy,
     toNormalizedGroupLifecyclePolicy
 } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import { validateGroupLifecyclePolicy } from '@shared/api/group-lifecycle/validate-group-lifecycle-policy.ts';
@@ -72,6 +73,24 @@ describe('group lifecycle policy defaults', () => {
 
         expect(managed.establishment.planTrigger).toEqual({ kind: 'manual' });
         expect(managed.establishment.connectTrigger).toEqual({ kind: 'immediate' });
+    });
+});
+
+describe('group member policy', () => {
+    it('carries exactly the establishment values of the resolved policy', () => {
+        expect(toGroupMemberPolicy(resolveGroupLifecyclePolicyPreset('match'))).toEqual({
+            maxConcurrentEdgeSetups: 16,
+            transports: 'rtc-preferred'
+        });
+        expect(toGroupMemberPolicy(toNormalizedGroupLifecyclePolicy({ establishment: { maxConcurrentEdgeSetups: 3 } })))
+            .toEqual({ maxConcurrentEdgeSetups: 3, transports: 'rtc-and-ws' });
+    });
+
+    it('gives a group created without a policy the default preset values', () => {
+        expect(toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())).toEqual({
+            maxConcurrentEdgeSetups: 64,
+            transports: 'rtc-and-ws'
+        });
     });
 });
 

--- a/packages/tests/shared/simulated-rtc-connection-service.ts
+++ b/packages/tests/shared/simulated-rtc-connection-service.ts
@@ -1,7 +1,11 @@
 import { onTestFinished } from 'vitest';
 
 import { WebRtcConnectionService } from '@shared/services/web-rtc-connection-service.ts';
-import { installNativeRtcRuntime, NativeRtcRuntime } from './native-rtc-connection-fixture.ts';
+import {
+    installNativeRtcRuntime,
+    NativeRtcRuntime,
+    SimulatedNativeRtcPeerConnection
+} from './native-rtc-connection-fixture.ts';
 
 let nativeRuntime: NativeRtcRuntime | undefined;
 
@@ -20,9 +24,15 @@ function installSimulationNativeRuntime(): void {
 export interface SimulatedRtcConnections {
     readonly service: WebRtcConnectionService;
     markReconnectable(peerId: string): boolean;
+    /** Completes a started setup the way the native connection would: its setup ends established. */
+    establish(peerId: string): void;
 }
 
-/** Real peer ownership and dial results with simulated native transport readiness. */
+/**
+ * Real peer ownership and dial results with simulated native transport
+ * readiness. A dial starts a setup that stays in flight until the test
+ * establishes it, which is what lets pacing tests observe the bound.
+ */
 export function createSimulatedRtcConnections(
     sessionId: string,
     connect: (peerId: string) => boolean = () => true
@@ -60,6 +70,13 @@ export function createSimulatedRtcConnections(
     service.peerIdsWithNoReconnectableLanes = () => [...connectedPeerIds];
     return {
         service,
-        markReconnectable: (peerId) => connectedPeerIds.delete(peerId)
+        markReconnectable: (peerId) => connectedPeerIds.delete(peerId),
+        establish: (peerId) => {
+            const native = service.readPeer(peerId)?.connection.status.pc;
+            if (!(native instanceof SimulatedNativeRtcPeerConnection)) {
+                throw new Error(`No simulated native connection for ${peerId}`);
+            }
+            native.setConnected();
+        }
     };
 }

--- a/packages/tests/shared/simulated-rtc-connection-service.ts
+++ b/packages/tests/shared/simulated-rtc-connection-service.ts
@@ -2,6 +2,7 @@ import { onTestFinished } from 'vitest';
 
 import { WebRtcConnectionService } from '@shared/services/web-rtc-connection-service.ts';
 import {
+    createNativeRtcConnectionFixture,
     installNativeRtcRuntime,
     NativeRtcRuntime,
     SimulatedNativeRtcPeerConnection
@@ -9,9 +10,9 @@ import {
 
 let nativeRuntime: NativeRtcRuntime | undefined;
 
-function installSimulationNativeRuntime(): void {
+function installSimulationNativeRuntime(): NativeRtcRuntime {
     if (nativeRuntime) {
-        return;
+        return nativeRuntime;
     }
     const runtime = installNativeRtcRuntime();
     nativeRuntime = runtime;
@@ -19,33 +20,36 @@ function installSimulationNativeRuntime(): void {
         runtime.dispose();
         nativeRuntime = undefined;
     });
+    return runtime;
 }
 
 export interface SimulatedRtcConnections {
     readonly service: WebRtcConnectionService;
     markReconnectable(peerId: string): boolean;
-    /** Completes a started setup the way the native connection would: its setup ends established. */
-    establish(peerId: string): void;
+    /** The simulated native connection behind a started setup; `setConnected()` establishes it. */
+    nativePeer(peerId: string): SimulatedNativeRtcPeerConnection;
 }
 
 /**
- * Real peer ownership and dial results with simulated native transport
- * readiness. A dial starts a setup that stays in flight until the test
- * establishes it, which is what lets pacing tests observe the bound.
+ * Real peer ownership and dial results over the native connection fixture,
+ * with simulated lane readiness. A dial starts a setup that stays in flight
+ * until the test establishes its native connection, which is what lets pacing
+ * tests observe the bound.
  */
 export function createSimulatedRtcConnections(
     sessionId: string,
     connect: (peerId: string) => boolean = () => true
 ): SimulatedRtcConnections {
-    installSimulationNativeRuntime();
+    const runtime = installSimulationNativeRuntime();
     const connectedPeerIds = new Set<string>();
-    const service = new WebRtcConnectionService({ send: async () => undefined, connect: async () => undefined }, {
+    const fixture = createNativeRtcConnectionFixture({
         sessionId,
         token: 'fixture-token',
         iceCandidates: { iceServers: [], expiresAtEpochMs: 60_000 },
         dataChannelName: 'test',
         rtcSignalingTopicId: 'rtc'
-    });
+    }, runtime);
+    const { service } = fixture;
     service.onRtcPeerLifecycleDo('simulated-native-transport', {
         onCreated: (peer) => {
             for (const channel of peer.channels.values()) {
@@ -66,17 +70,12 @@ export function createSimulatedRtcConnections(
             connectedPeerIds.delete(peer.peerId);
         }
     });
-    // Group scenarios control lane readiness independently of the complete native peer fixture.
-    service.peerIdsWithNoReconnectableLanes = () => [...connectedPeerIds];
+    // Group scenarios control lane readiness independently of the complete native
+    // peer fixture; like the real predicate, only a live peer can report its lanes.
+    service.peerIdsWithNoReconnectableLanes = () => service.activePeerIds().filter((peerId) => connectedPeerIds.has(peerId));
     return {
         service,
         markReconnectable: (peerId) => connectedPeerIds.delete(peerId),
-        establish: (peerId) => {
-            const native = service.readPeer(peerId)?.connection.status.pc;
-            if (!(native instanceof SimulatedNativeRtcPeerConnection)) {
-                throw new Error(`No simulated native connection for ${peerId}`);
-            }
-            native.setConnected();
-        }
+        nativePeer: fixture.nativePeer
     };
 }

--- a/packages/tests/shared/simulated-rtc-connection-service.ts
+++ b/packages/tests/shared/simulated-rtc-connection-service.ts
@@ -41,7 +41,6 @@ export function createSimulatedRtcConnections(
     connect: (peerId: string) => boolean = () => true
 ): SimulatedRtcConnections {
     const runtime = installSimulationNativeRuntime();
-    const connectedPeerIds = new Set<string>();
     const fixture = createNativeRtcConnectionFixture({
         sessionId,
         token: 'fixture-token',
@@ -50,6 +49,22 @@ export function createSimulatedRtcConnections(
         rtcSignalingTopicId: 'rtc'
     }, runtime);
     const { service } = fixture;
+    const connectedPeerIds = installSimulatedLaneTransport(service, connect);
+    // Group scenarios control lane readiness independently of the complete native
+    // peer fixture; like the real predicate, only a live peer can report its lanes.
+    service.peerIdsWithNoReconnectableLanes = () => service.activePeerIds().filter((peerId) => connectedPeerIds.has(peerId));
+    return {
+        service,
+        markReconnectable: (peerId) => connectedPeerIds.delete(peerId),
+        nativePeer: fixture.nativePeer
+    };
+}
+
+function installSimulatedLaneTransport(
+    service: WebRtcConnectionService,
+    connect: (peerId: string) => boolean
+): Set<string> {
+    const connectedPeerIds = new Set<string>();
     service.onRtcPeerLifecycleDo('simulated-native-transport', {
         onCreated: (peer) => {
             for (const channel of peer.channels.values()) {
@@ -70,12 +85,5 @@ export function createSimulatedRtcConnections(
             connectedPeerIds.delete(peer.peerId);
         }
     });
-    // Group scenarios control lane readiness independently of the complete native
-    // peer fixture; like the real predicate, only a live peer can report its lanes.
-    service.peerIdsWithNoReconnectableLanes = () => service.activePeerIds().filter((peerId) => connectedPeerIds.has(peerId));
-    return {
-        service,
-        markReconnectable: (peerId) => connectedPeerIds.delete(peerId),
-        nativePeer: fixture.nativePeer
-    };
+    return connectedPeerIds;
 }

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -8,6 +8,8 @@ import {
 import type { ClientInfo, OverlayInfo } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 // dprint-ignore
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type {
     AuditStamp,
     Group,
@@ -20,6 +22,7 @@ import type { WebRtcConnectionService } from '@shared/services/web-rtc-connectio
 import { WebRtcGroupManager } from '@shared/services/web-rtc-group-manager.ts';
 import type { WebRtcGroupPeerSelection } from '@shared/services/webrtc-group-manager-contracts.ts';
 import { createTestGroup } from '../create-test-group.ts';
+import type { SimulatedNativeRtcPeerConnection } from './native-rtc-connection-fixture.ts';
 import { createSimulatedRtcConnections } from './simulated-rtc-connection-service.ts';
 
 interface GroupSnapshotFixture {
@@ -36,7 +39,7 @@ interface RtcConnectionHarness {
     knownPeerIds(): string[];
     peerIdsWithNoReconnectableLanes(): string[];
     markReconnectable(peerId: string): boolean;
-    establish(peerId: string): void;
+    nativePeer(peerId: string): SimulatedNativeRtcPeerConnection;
 }
 
 describe('WebRtcGroupManager', () => {
@@ -924,6 +927,7 @@ describe('WebRtcGroupManager', () => {
             { groupCache, clientCache, acceptedOverlayCache },
             { overlayTransitionGraceMs: 0 }
         );
+        manager.startReconcileWakes();
         const peerIds = ['peer-a', 'peer-b', 'peer-c', 'peer-d', 'peer-e'];
         for (const peerId of peerIds) {
             clientCache.set(peerId, createClientInfo(peerId, true));
@@ -944,14 +948,14 @@ describe('WebRtcGroupManager', () => {
         expect(rtcQBox.service.inFlightPeerIds()).toEqual(['peer-a', 'peer-b']);
         expect(manager.readDiagnostics()).toMatchObject({ connectAttemptCount: 2, connectDeferredPacingCount: 3 });
 
-        rtcQBox.establish('peer-a');
+        rtcQBox.nativePeer('peer-a').setConnected();
         await manager.whenReconciled();
 
         expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-c']);
         expect(rtcQBox.service.inFlightPeerIds()).toEqual(['peer-b', 'peer-c']);
 
-        rtcQBox.establish('peer-b');
-        rtcQBox.establish('peer-c');
+        rtcQBox.nativePeer('peer-b').setConnected();
+        rtcQBox.nativePeer('peer-c').setConnected();
         await manager.whenReconciled();
 
         expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-c', 'peer-d', 'peer-e']);
@@ -959,6 +963,83 @@ describe('WebRtcGroupManager', () => {
     });
 
     it('wakes a reconcile when a setup ends by removal while a paced dial is waiting', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        manager.startReconcileWakes();
+        for (const peerId of ['peer-a', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-a', 'peer-b'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1, connectAttemptCount: 1 });
+        const lifecycle: string[] = [];
+        rtcQBox.service.onRtcPeerLifecycleDo('observer-after-manager', {
+            onCreated: (peer) => {
+                lifecycle.push(`created:${peer.peerId}`);
+            },
+            onDeleted: (peer) => {
+                lifecycle.push(`deleted:${peer.peerId}`);
+            }
+        });
+
+        rtcQBox.service.disconnectPeer('peer-a');
+        expect(lifecycle).toEqual(['deleted:peer-a']);
+        await manager.whenReconciled();
+
+        // The wake ran after the deletion notice completed, so a later observer
+        // never sees the re-dial before the ending that released it.
+        expect(lifecycle).toEqual(['deleted:peer-a', 'created:peer-a']);
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a']);
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 2, connectAttemptCount: 2 });
+        manager.stopReconcileWakes();
+    });
+
+    it('frees a pacing slot at once when an admitted dial starts nothing', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        rtcQBox.service.setOutboundDialPolicy(({ peerId }) => peerId !== 'peer-denied');
+        for (const peerId of ['peer-denied', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-denied', 'peer-b'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-b']);
+        expect(manager.readDiagnostics()).toMatchObject({ connectFailureCount: 1, connectDeferredPacingCount: 0 });
+    });
+
+    it('charges a known peer whose connection died as the new setup its re-dial starts', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
         const rtcQBox = createRtcConnectionHarness('self');
@@ -981,14 +1062,52 @@ describe('WebRtcGroupManager', () => {
                 maxConcurrentEdgeSetups: 1
             })
         );
-        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1, connectAttemptCount: 1 });
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a']);
+        rtcQBox.nativePeer('peer-a').connectionState = 'failed';
+        expect(rtcQBox.service.inFlightPeerIds()).toEqual([]);
 
-        rtcQBox.service.disconnectPeer('peer-a');
-        await manager.whenReconciled();
+        await manager.ensureAllGroupsConnected();
 
         expect(rtcQBox.knownPeerIds()).toEqual(['peer-a']);
-        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 2, connectAttemptCount: 2 });
-        manager.stopReconcileWakes();
+        expect(rtcQBox.service.inFlightPeerIds()).toEqual(['peer-a']);
+        expect(manager.readDiagnostics()).toMatchObject({ connectAttemptCount: 2, connectDeferredPacingCount: 2 });
+    });
+
+    it('never lets a paced peer hold a connection-budget slot an idle group could use', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { maxPeerConnections: 5, overlayTransitionGraceMs: 0 }
+        );
+        const idlePeerIds = ['peer-k1', 'peer-k2', 'peer-k3', 'peer-c'];
+        for (const peerId of ['peer-s', 'peer-a', ...idlePeerIds]) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-saturated',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-s', 'peer-a'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-s']);
+
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({ groupId: 'group-idle', membershipVersion: 1, memberSessionIds: ['self', ...idlePeerIds] })
+        );
+
+        // Four connection slots remain; the paced peer-a consumes none of them.
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-s', ...idlePeerIds]);
+        expect(manager.readDiagnostics()).toMatchObject({ connectDeferredBudgetCount: 0 });
     });
 
     it('does not wake a reconcile for a setup ending while no dial is waiting, nor after wakes stop', async () => {
@@ -1001,6 +1120,7 @@ describe('WebRtcGroupManager', () => {
             { groupCache, clientCache, acceptedOverlayCache },
             { overlayTransitionGraceMs: 0 }
         );
+        manager.startReconcileWakes();
         for (const peerId of ['peer-a', 'peer-b']) {
             clientCache.set(peerId, createClientInfo(peerId, true));
         }
@@ -1011,7 +1131,7 @@ describe('WebRtcGroupManager', () => {
         );
         expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1, connectDeferredPacingCount: 0 });
 
-        rtcQBox.establish('peer-a');
+        rtcQBox.nativePeer('peer-a').setConnected();
         await manager.whenReconciled();
         expect(manager.readDiagnostics().reconcileRunCount).toBe(1);
 
@@ -1024,7 +1144,7 @@ describe('WebRtcGroupManager', () => {
             })
         );
         manager.stopReconcileWakes();
-        rtcQBox.establish('peer-b');
+        rtcQBox.nativePeer('peer-b').setConnected();
         await manager.whenReconciled();
 
         expect(manager.readDiagnostics().reconcileRunCount).toBe(2);
@@ -1040,6 +1160,7 @@ describe('WebRtcGroupManager', () => {
             { groupCache, clientCache, acceptedOverlayCache },
             { overlayTransitionGraceMs: 0 }
         );
+        manager.startReconcileWakes();
         for (const peerId of ['peer-a', 'peer-shared', 'peer-b']) {
             clientCache.set(peerId, createClientInfo(peerId, true));
         }
@@ -1060,11 +1181,8 @@ describe('WebRtcGroupManager', () => {
         await acceptActiveLayoutGroup(manager, acceptedOverlayCache, idle);
 
         expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
-        // The shared peer waited in both passes: once behind the saturated group alone,
-        // once again when the idle group arrived and still found that owner at its bound.
-        expect(manager.readDiagnostics()).toMatchObject({ connectDeferredPacingCount: 2 });
 
-        rtcQBox.establish('peer-a');
+        rtcQBox.nativePeer('peer-a').setConnected();
         await manager.whenReconciled();
 
         expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-shared']);
@@ -1174,7 +1292,7 @@ function createRtcConnectionHarness(
         knownPeerIds: () => [...service.knownPeerIds()],
         peerIdsWithNoReconnectableLanes: () => [...service.peerIdsWithNoReconnectableLanes()],
         markReconnectable: simulation.markReconnectable,
-        establish: simulation.establish
+        nativePeer: simulation.nativePeer
     };
 }
 
@@ -1224,7 +1342,12 @@ function createGroupSnapshot(
         formationElectorate: [...fixture.memberSessionIds],
         ...(fixture.maxConcurrentEdgeSetups === undefined
             ? {}
-            : { memberPolicy: { maxConcurrentEdgeSetups: fixture.maxConcurrentEdgeSetups, transports: 'rtc-and-ws' as const } }),
+            : {
+                memberPolicy: {
+                    ...toGroupMemberPolicy(createDefaultGroupLifecyclePolicy()),
+                    maxConcurrentEdgeSetups: fixture.maxConcurrentEdgeSetups
+                }
+            }),
         acceptedLayoutIdentity: {
             groupRevision: fixture.membershipVersion,
             presenceRevision: fixture.membershipVersion,

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -28,6 +28,7 @@ interface GroupSnapshotFixture {
     readonly memberSessionIds: readonly string[];
     readonly applicationId?: string;
     readonly workspaceId?: string;
+    readonly maxConcurrentEdgeSetups?: number;
 }
 
 interface RtcConnectionHarness {
@@ -35,6 +36,7 @@ interface RtcConnectionHarness {
     knownPeerIds(): string[];
     peerIdsWithNoReconnectableLanes(): string[];
     markReconnectable(peerId: string): boolean;
+    establish(peerId: string): void;
 }
 
 describe('WebRtcGroupManager', () => {
@@ -799,6 +801,7 @@ describe('WebRtcGroupManager', () => {
             connectAttemptCount: 0,
             connectFailureCount: 0,
             connectDeferredBudgetCount: 0,
+            connectDeferredPacingCount: 0,
             disconnectCount: 0,
             retainedCreatedCount: 0,
             retainedExpiredCount: 0,
@@ -911,6 +914,162 @@ describe('WebRtcGroupManager', () => {
         expect(manager.readDiagnostics().connectDeferredBudgetCount).toBe(0);
     });
 
+    it('bounds in-flight setups per group and dials paced peers as setups complete', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        const peerIds = ['peer-a', 'peer-b', 'peer-c', 'peer-d', 'peer-e'];
+        for (const peerId of peerIds) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', ...peerIds],
+                maxConcurrentEdgeSetups: 2
+            })
+        );
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+        expect(rtcQBox.service.inFlightPeerIds()).toEqual(['peer-a', 'peer-b']);
+        expect(manager.readDiagnostics()).toMatchObject({ connectAttemptCount: 2, connectDeferredPacingCount: 3 });
+
+        rtcQBox.establish('peer-a');
+        await manager.whenReconciled();
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-c']);
+        expect(rtcQBox.service.inFlightPeerIds()).toEqual(['peer-b', 'peer-c']);
+
+        rtcQBox.establish('peer-b');
+        rtcQBox.establish('peer-c');
+        await manager.whenReconciled();
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-c', 'peer-d', 'peer-e']);
+        expect(manager.readDiagnostics()).toMatchObject({ connectAttemptCount: 5 });
+    });
+
+    it('wakes a reconcile when a setup ends by removal while a paced dial is waiting', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        for (const peerId of ['peer-a', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-a', 'peer-b'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1, connectAttemptCount: 1 });
+
+        rtcQBox.service.disconnectPeer('peer-a');
+        await manager.whenReconciled();
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a']);
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 2, connectAttemptCount: 2 });
+        manager.stopReconcileWakes();
+    });
+
+    it('does not wake a reconcile for a setup ending while no dial is waiting, nor after wakes stop', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        for (const peerId of ['peer-a', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({ groupId: 'group-1', membershipVersion: 1, memberSessionIds: ['self', 'peer-a', 'peer-b'] })
+        );
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1, connectDeferredPacingCount: 0 });
+
+        rtcQBox.establish('peer-a');
+        await manager.whenReconciled();
+        expect(manager.readDiagnostics().reconcileRunCount).toBe(1);
+
+        await manager.acceptGroupUpdate(
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 2,
+                memberSessionIds: ['self', 'peer-a', 'peer-b'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        manager.stopReconcileWakes();
+        rtcQBox.establish('peer-b');
+        await manager.whenReconciled();
+
+        expect(manager.readDiagnostics().reconcileRunCount).toBe(2);
+    });
+
+    it('charges a peer wanted by two groups to both and waits while either owner is at its bound', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        for (const peerId of ['peer-a', 'peer-shared', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        const saturated = createGroupSnapshot({
+            groupId: 'group-saturated',
+            membershipVersion: 1,
+            memberSessionIds: ['self', 'peer-a', 'peer-shared'],
+            maxConcurrentEdgeSetups: 1
+        });
+        const idle = createGroupSnapshot({
+            groupId: 'group-idle',
+            membershipVersion: 1,
+            memberSessionIds: ['self', 'peer-shared', 'peer-b'],
+            maxConcurrentEdgeSetups: 5
+        });
+
+        await acceptActiveLayoutGroup(manager, acceptedOverlayCache, saturated);
+        await acceptActiveLayoutGroup(manager, acceptedOverlayCache, idle);
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+        // The shared peer waited in both passes: once behind the saturated group alone,
+        // once again when the idle group arrived and still found that owner at its bound.
+        expect(manager.readDiagnostics()).toMatchObject({ connectDeferredPacingCount: 2 });
+
+        rtcQBox.establish('peer-a');
+        await manager.whenReconciled();
+
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b', 'peer-shared']);
+    });
+
     it('counts connect failures in diagnostics', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();
@@ -1014,7 +1173,8 @@ function createRtcConnectionHarness(
         service,
         knownPeerIds: () => [...service.knownPeerIds()],
         peerIdsWithNoReconnectableLanes: () => [...service.peerIdsWithNoReconnectableLanes()],
-        markReconnectable: simulation.markReconnectable
+        markReconnectable: simulation.markReconnectable,
+        establish: simulation.establish
     };
 }
 
@@ -1062,6 +1222,9 @@ function createGroupSnapshot(
         rosterVersion: fixture.membershipVersion,
         presenceVersion: fixture.membershipVersion,
         formationElectorate: [...fixture.memberSessionIds],
+        ...(fixture.maxConcurrentEdgeSetups === undefined
+            ? {}
+            : { memberPolicy: { maxConcurrentEdgeSetups: fixture.maxConcurrentEdgeSetups, transports: 'rtc-and-ws' as const } }),
         acceptedLayoutIdentity: {
             groupRevision: fixture.membershipVersion,
             presenceRevision: fixture.membershipVersion,

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -1009,6 +1009,87 @@ describe('WebRtcGroupManager', () => {
         manager.stopReconcileWakes();
     });
 
+    it('stands down a wake scheduled before the wakes stop', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        const rtcQBox = createRtcConnectionHarness('self');
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        manager.startReconcileWakes();
+        for (const peerId of ['peer-a', 'peer-b']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-a', 'peer-b'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-a']);
+
+        // The removal schedules the wake; shutdown stops the wakes before it runs.
+        rtcQBox.service.disconnectPeer('peer-a');
+        manager.stopReconcileWakes();
+        await manager.whenReconciled();
+
+        expect(rtcQBox.knownPeerIds()).toEqual([]);
+        expect(manager.readDiagnostics()).toMatchObject({ reconcileRunCount: 1 });
+    });
+
+    it('does not re-run a pass for an ending its own dial caused', async () => {
+        const groupCache = new LatestRepository<string, GroupSnapshot>();
+        const clientCache = new LatestRepository<string, ClientInfo>();
+        // peer-a's lane refuses on every dial, which resets and removes its native
+        // connection inside the pass; with peer-c paced, a latch on that removal
+        // would re-run the pass forever.
+        const rtcQBox = createRtcConnectionHarness('self', [], (peerId) => {
+            if (peerId === 'peer-a') {
+                throw new Error('lane refused');
+            }
+            return true;
+        });
+        const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+        const manager = new WebRtcGroupManager(
+            rtcQBox.service,
+            { groupCache, clientCache, acceptedOverlayCache },
+            { overlayTransitionGraceMs: 0 }
+        );
+        manager.startReconcileWakes();
+        for (const peerId of ['peer-a', 'peer-b', 'peer-c']) {
+            clientCache.set(peerId, createClientInfo(peerId, true));
+        }
+        await acceptActiveLayoutGroup(
+            manager,
+            acceptedOverlayCache,
+            createGroupSnapshot({
+                groupId: 'group-1',
+                membershipVersion: 1,
+                memberSessionIds: ['self', 'peer-a', 'peer-b', 'peer-c'],
+                maxConcurrentEdgeSetups: 1
+            })
+        );
+        expect(rtcQBox.knownPeerIds()).toEqual(['peer-b']);
+
+        await manager.ensureAllGroupsConnected();
+        await manager.whenReconciled();
+
+        // Pass two paces both peer-a and peer-c behind peer-b's setup.
+        expect(manager.readDiagnostics()).toMatchObject({
+            reconcileRunCount: 2,
+            reconcileCoalescedRerunCount: 0,
+            connectDeferredPacingCount: 3
+        });
+        manager.stopReconcileWakes();
+    });
+
     it('frees a pacing slot at once when an admitted dial starts nothing', async () => {
         const groupCache = new LatestRepository<string, GroupSnapshot>();
         const clientCache = new LatestRepository<string, ClientInfo>();

--- a/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
+++ b/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
@@ -1,4 +1,4 @@
-import { computeOutboundDialPlan } from '@shared/services/webrtc-outbound-dial-plan.ts';
+import { computeOutboundDialPlan, computePacedOutboundDialPlan } from '@shared/services/webrtc-outbound-dial-plan.ts';
 import { describe, expect, it } from 'vitest';
 
 describe('computeOutboundDialPlan', () => {
@@ -78,5 +78,85 @@ describe('computeOutboundDialPlan', () => {
 
         expect(plan.peersToConnect).toEqual(['peer-a', 'peer-b']);
         expect(plan.deferredPeerIds).toEqual(['peer-c']);
+    });
+});
+
+describe('computePacedOutboundDialPlan', () => {
+    it('admits new dials until each owning group reaches its in-flight bound and paces the rest', () => {
+        const paced = computePacedOutboundDialPlan({
+            peersToConnect: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
+            knownPeerIds: new Set(),
+            inFlightPeerIds: new Set(),
+            ownerGroupIdsByPeerId: new Map([
+                ['peer-a', ['group-1']],
+                ['peer-b', ['group-1']],
+                ['peer-c', ['group-1']],
+                ['peer-d', ['group-1']]
+            ]),
+            groupSetupBudgets: new Map([
+                ['group-1', { desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c', 'peer-d']), maxConcurrentEdgeSetups: 2 }]
+            ])
+        });
+
+        expect(paced.peersToConnect).toEqual(['peer-a', 'peer-b']);
+        expect(paced.pacedPeerIds).toEqual(['peer-c', 'peer-d']);
+    });
+
+    it('charges setups already in flight to their owners before admitting new dials', () => {
+        const paced = computePacedOutboundDialPlan({
+            peersToConnect: ['peer-in-flight', 'peer-new-1', 'peer-new-2'],
+            knownPeerIds: new Set(['peer-in-flight']),
+            inFlightPeerIds: new Set(['peer-in-flight']),
+            ownerGroupIdsByPeerId: new Map([
+                ['peer-in-flight', ['group-1']],
+                ['peer-new-1', ['group-1']],
+                ['peer-new-2', ['group-1']]
+            ]),
+            groupSetupBudgets: new Map([
+                ['group-1', { desiredPeerIds: new Set(['peer-in-flight', 'peer-new-1', 'peer-new-2']), maxConcurrentEdgeSetups: 2 }]
+            ])
+        });
+
+        expect(paced.peersToConnect).toEqual(['peer-in-flight', 'peer-new-1']);
+        expect(paced.pacedPeerIds).toEqual(['peer-new-2']);
+    });
+
+    it('lets a peer shared by two groups start only when every owner has a free slot', () => {
+        const paced = computePacedOutboundDialPlan({
+            peersToConnect: ['peer-a', 'peer-shared', 'peer-b'],
+            knownPeerIds: new Set(),
+            inFlightPeerIds: new Set(),
+            ownerGroupIdsByPeerId: new Map([
+                ['peer-a', ['group-saturated']],
+                ['peer-shared', ['group-saturated', 'group-idle']],
+                ['peer-b', ['group-idle']]
+            ]),
+            groupSetupBudgets: new Map([
+                ['group-saturated', { desiredPeerIds: new Set(['peer-a', 'peer-shared']), maxConcurrentEdgeSetups: 1 }],
+                ['group-idle', { desiredPeerIds: new Set(['peer-shared', 'peer-b']), maxConcurrentEdgeSetups: 5 }]
+            ])
+        });
+
+        expect(paced.peersToConnect).toEqual(['peer-a', 'peer-b']);
+        expect(paced.pacedPeerIds).toEqual(['peer-shared']);
+    });
+
+    it('never paces a peer whose setup already exists, established or not', () => {
+        const paced = computePacedOutboundDialPlan({
+            peersToConnect: ['peer-established', 'peer-in-flight', 'peer-new'],
+            knownPeerIds: new Set(['peer-established', 'peer-in-flight']),
+            inFlightPeerIds: new Set(['peer-in-flight']),
+            ownerGroupIdsByPeerId: new Map([
+                ['peer-established', ['group-1']],
+                ['peer-in-flight', ['group-1']],
+                ['peer-new', ['group-1']]
+            ]),
+            groupSetupBudgets: new Map([
+                ['group-1', { desiredPeerIds: new Set(['peer-established', 'peer-in-flight', 'peer-new']), maxConcurrentEdgeSetups: 1 }]
+            ])
+        });
+
+        expect(paced.peersToConnect).toEqual(['peer-established', 'peer-in-flight']);
+        expect(paced.pacedPeerIds).toEqual(['peer-new']);
     });
 });

--- a/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
+++ b/packages/tests/shared/webrtc-outbound-dial-plan.test.ts
@@ -1,8 +1,8 @@
-import { computeOutboundDialPlan, computePacedOutboundDialPlan } from '@shared/services/webrtc-outbound-dial-plan.ts';
+import { computeInFlightSetupCounts, computeOutboundDialPlan } from '@shared/services/webrtc-outbound-dial-plan.ts';
 import { describe, expect, it } from 'vitest';
 
 describe('computeOutboundDialPlan', () => {
-    it('caps new dials at the connection budget and defers the rest', () => {
+    it('leaves the connection budget to new dials after the desired known peers', () => {
         const connectablePeerIds = Array.from(
             { length: 49 },
             (_, index) => `peer-${index}`
@@ -11,32 +11,39 @@ describe('computeOutboundDialPlan', () => {
         const plan = computeOutboundDialPlan({
             maxPeerConnections: 10,
             knownPeerIds: new Set(),
+            livePeerIds: new Set(),
             desiredPeerIds: new Set(connectablePeerIds),
             connectablePeerIds,
             serverDesiredPeerIds: new Set()
         });
 
-        expect(plan.peersToConnect).toHaveLength(10);
-        expect(plan.deferredPeerIds).toHaveLength(39);
+        expect(plan.livePeerIds).toEqual([]);
+        expect(plan.deadKnownPeerIds).toEqual([]);
+        expect(plan.candidatePeerIds).toEqual(connectablePeerIds);
+        expect(plan.newDialBudget).toBe(10);
     });
 
-    it('always ensures known desired peers and only budgets new dials', () => {
+    it('separates live known peers, dead known peers and new candidates, budgeting only the new ones', () => {
         const plan = computeOutboundDialPlan({
             maxPeerConnections: 3,
             knownPeerIds: new Set(['peer-a', 'peer-b']),
+            livePeerIds: new Set(['peer-a']),
             desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c', 'peer-d']),
             connectablePeerIds: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
             serverDesiredPeerIds: new Set()
         });
 
-        expect(plan.peersToConnect).toEqual(['peer-a', 'peer-b', 'peer-c']);
-        expect(plan.deferredPeerIds).toEqual(['peer-d']);
+        expect(plan.livePeerIds).toEqual(['peer-a']);
+        expect(plan.deadKnownPeerIds).toEqual(['peer-b']);
+        expect(plan.candidatePeerIds).toEqual(['peer-c', 'peer-d']);
+        expect(plan.newDialBudget).toBe(1);
     });
 
-    it('prioritizes server-overlay-desired peers over bootstrap peers', () => {
+    it('orders server-overlay-desired candidates before bootstrap candidates', () => {
         const plan = computeOutboundDialPlan({
             maxPeerConnections: 2,
             knownPeerIds: new Set(),
+            livePeerIds: new Set(),
             desiredPeerIds: new Set(['peer-boot-1', 'peer-server-1', 'peer-boot-2', 'peer-server-2']),
             connectablePeerIds: [
                 'peer-boot-1',
@@ -47,116 +54,37 @@ describe('computeOutboundDialPlan', () => {
             serverDesiredPeerIds: new Set(['peer-server-1', 'peer-server-2'])
         });
 
-        expect(plan.peersToConnect).toEqual(['peer-server-1', 'peer-server-2']);
-        expect(plan.deferredPeerIds).toEqual(['peer-boot-1', 'peer-boot-2']);
+        expect(plan.candidatePeerIds).toEqual(['peer-server-1', 'peer-server-2', 'peer-boot-1', 'peer-boot-2']);
+        expect(plan.newDialBudget).toBe(2);
     });
 
-    it('excludes retained non-desired connections from the dial budget', () => {
-        // Four retained (known, no longer desired) connections must not starve
-        // the dial of a newly desired peer: the retained-eviction pass owns
-        // trimming that overflow.
-        const plan = computeOutboundDialPlan({
-            maxPeerConnections: 5,
-            knownPeerIds: new Set(['old-a', 'old-b', 'old-c', 'old-d', 'old-e']),
-            desiredPeerIds: new Set(['peer-new']),
-            connectablePeerIds: ['peer-new'],
-            serverDesiredPeerIds: new Set()
-        });
-
-        expect(plan.peersToConnect).toEqual(['peer-new']);
-        expect(plan.deferredPeerIds).toEqual([]);
-    });
-
-    it('defers everything when desired connections already fill the budget', () => {
+    it('does not count retained undesired known peers against the budget', () => {
         const plan = computeOutboundDialPlan({
             maxPeerConnections: 2,
-            knownPeerIds: new Set(['peer-a', 'peer-b']),
-            desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c']),
-            connectablePeerIds: ['peer-a', 'peer-b', 'peer-c'],
+            knownPeerIds: new Set(['retained-1', 'retained-2', 'peer-a']),
+            livePeerIds: new Set(['retained-1', 'retained-2', 'peer-a']),
+            desiredPeerIds: new Set(['peer-a', 'peer-b']),
+            connectablePeerIds: ['peer-a', 'peer-b'],
             serverDesiredPeerIds: new Set()
         });
 
-        expect(plan.peersToConnect).toEqual(['peer-a', 'peer-b']);
-        expect(plan.deferredPeerIds).toEqual(['peer-c']);
+        expect(plan.livePeerIds).toEqual(['peer-a']);
+        expect(plan.candidatePeerIds).toEqual(['peer-b']);
+        expect(plan.newDialBudget).toBe(1);
     });
 });
 
-describe('computePacedOutboundDialPlan', () => {
-    it('admits new dials until each owning group reaches its in-flight bound and paces the rest', () => {
-        const paced = computePacedOutboundDialPlan({
-            peersToConnect: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
-            knownPeerIds: new Set(),
-            inFlightPeerIds: new Set(),
-            ownerGroupIdsByPeerId: new Map([
+describe('computeInFlightSetupCounts', () => {
+    it('charges every in-flight setup to each group that wants the peer', () => {
+        const counts = computeInFlightSetupCounts(
+            ['peer-shared', 'peer-a', 'peer-unowned'],
+            new Map([
+                ['peer-shared', ['group-1', 'group-2']],
                 ['peer-a', ['group-1']],
-                ['peer-b', ['group-1']],
-                ['peer-c', ['group-1']],
-                ['peer-d', ['group-1']]
-            ]),
-            groupSetupBudgets: new Map([
-                ['group-1', { desiredPeerIds: new Set(['peer-a', 'peer-b', 'peer-c', 'peer-d']), maxConcurrentEdgeSetups: 2 }]
+                ['peer-b', ['group-2']]
             ])
-        });
+        );
 
-        expect(paced.peersToConnect).toEqual(['peer-a', 'peer-b']);
-        expect(paced.pacedPeerIds).toEqual(['peer-c', 'peer-d']);
-    });
-
-    it('charges setups already in flight to their owners before admitting new dials', () => {
-        const paced = computePacedOutboundDialPlan({
-            peersToConnect: ['peer-in-flight', 'peer-new-1', 'peer-new-2'],
-            knownPeerIds: new Set(['peer-in-flight']),
-            inFlightPeerIds: new Set(['peer-in-flight']),
-            ownerGroupIdsByPeerId: new Map([
-                ['peer-in-flight', ['group-1']],
-                ['peer-new-1', ['group-1']],
-                ['peer-new-2', ['group-1']]
-            ]),
-            groupSetupBudgets: new Map([
-                ['group-1', { desiredPeerIds: new Set(['peer-in-flight', 'peer-new-1', 'peer-new-2']), maxConcurrentEdgeSetups: 2 }]
-            ])
-        });
-
-        expect(paced.peersToConnect).toEqual(['peer-in-flight', 'peer-new-1']);
-        expect(paced.pacedPeerIds).toEqual(['peer-new-2']);
-    });
-
-    it('lets a peer shared by two groups start only when every owner has a free slot', () => {
-        const paced = computePacedOutboundDialPlan({
-            peersToConnect: ['peer-a', 'peer-shared', 'peer-b'],
-            knownPeerIds: new Set(),
-            inFlightPeerIds: new Set(),
-            ownerGroupIdsByPeerId: new Map([
-                ['peer-a', ['group-saturated']],
-                ['peer-shared', ['group-saturated', 'group-idle']],
-                ['peer-b', ['group-idle']]
-            ]),
-            groupSetupBudgets: new Map([
-                ['group-saturated', { desiredPeerIds: new Set(['peer-a', 'peer-shared']), maxConcurrentEdgeSetups: 1 }],
-                ['group-idle', { desiredPeerIds: new Set(['peer-shared', 'peer-b']), maxConcurrentEdgeSetups: 5 }]
-            ])
-        });
-
-        expect(paced.peersToConnect).toEqual(['peer-a', 'peer-b']);
-        expect(paced.pacedPeerIds).toEqual(['peer-shared']);
-    });
-
-    it('never paces a peer whose setup already exists, established or not', () => {
-        const paced = computePacedOutboundDialPlan({
-            peersToConnect: ['peer-established', 'peer-in-flight', 'peer-new'],
-            knownPeerIds: new Set(['peer-established', 'peer-in-flight']),
-            inFlightPeerIds: new Set(['peer-in-flight']),
-            ownerGroupIdsByPeerId: new Map([
-                ['peer-established', ['group-1']],
-                ['peer-in-flight', ['group-1']],
-                ['peer-new', ['group-1']]
-            ]),
-            groupSetupBudgets: new Map([
-                ['group-1', { desiredPeerIds: new Set(['peer-established', 'peer-in-flight', 'peer-new']), maxConcurrentEdgeSetups: 1 }]
-            ])
-        });
-
-        expect(paced.peersToConnect).toEqual(['peer-established', 'peer-in-flight']);
-        expect(paced.pacedPeerIds).toEqual(['peer-new']);
+        expect([...counts.entries()]).toEqual([['group-1', 2], ['group-2', 1]]);
     });
 });

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -2330,19 +2330,46 @@ What 9b lands:
   preset when the request carries no policy, so every group read, delta and hydration carries the
   bound each member enforces on itself. Last in wire order (I4); no persisted-row migration
   because the key lists are exact and the cutover is clean-database, as every earlier aggregate
-  field was.
-- **`computePacedOutboundDialPlan`**, the pure in-flight dial plan over the budgeted plan: known
-  peers pass because their ensure starts nothing; a new dial is admitted only while every owning
-  group is below its bound, counting setups already in flight for that group plus the dials
-  admitted earlier in the same pass; a paced peer waits. Product decision 18's shared-peer rule
-  falls out of `computeInFlightDialAdmission` unchanged.
-- **Wake-on-completion**: the manager registers one lifecycle observer on the connection service
-  and re-reconciles when a setup ends by establishment, timeout or removal — but only while a
-  paced dial is waiting, and never for the endings a pass causes itself. The browser transport
-  shutdown stops the wakes before it tears peers down, because shutdown removes peers their groups
-  still want; without that, every teardown would dial them back.
-- **The completable harness dial**: the simulated connection harness now exposes `establish`, so
-  browser tests drive a setup from in flight to established and observe the bound release.
+  field was. The three validators enforce the normalizer's cap (256) and the OpenAPI schema
+  carries the same maximum, so no row or wire value can exceed what a policy can express.
+- **The dial plan and the dial walk.** `computeOutboundDialPlan` stays the pure ordering and
+  budget: known peers split by native liveness, new candidates server-first, and the connection
+  budget left after the peers already held. `WebRtcOutboundDialing` spends that budget and the
+  in-flight bound at dial time, against what each ensure actually did: an owner is charged only
+  when the ensure reports `setup-started`, a peer paced under product decision 18 holds no
+  connection-budget slot, a dial that starts nothing frees its slot for the next candidate at
+  once, and a known peer whose native connection died is charged as the new setup its re-dial
+  starts. Bounds are keyed by the scoped group key, so two groups sharing a bare id cannot share
+  a bound.
+- **Wake-on-completion** with an explicit lifecycle: the browser composition root calls
+  `startReconcileWakes()` once the service and manager exist, and transport shutdown calls
+  `stopReconcileWakes()` before it tears peers down, because shutdown removes peers their groups
+  still want. A wake runs on a microtask after the lifecycle notice that raised it, so every
+  observer sees the ending before the dials it releases; an ending the pass's own dial loop causes
+  sets the drain latch instead. `whenReconciled()` covers a scheduled wake. Nothing wakes while no
+  dial is waiting.
+- **The harness composes over the native fixture** and exposes `nativePeer(peerId)`: a test
+  establishes a setup with `setConnected()` on the simulated native connection, the path the
+  browser runtime takes. Only a live peer reports lane readiness there, as in the real predicate,
+  which is what lets a dead-but-known peer be re-dialed and charged.
+
+**Review correction (2026-09-02).** The first 9b head paced in the plan (`computePacedOutboundDialPlan`)
+and charged admissions before any ensure ran, so a denied or failed dial kept the slot it never
+used, a paced peer consumed a connection-budget slot, and a wake could re-dial a peer inside the
+deletion notice that freed it, ahead of other observers. The nine-angle review also found the
+bound keyed by bare group id, the wake observer registered in the constructor with no matching
+stop for non-browser owners, and the validators accepting any positive integer while the
+normalizer clamps to 256. All of it is folded into the shape above. Two consequences are
+accepted rather than fixed: a group created without a policy copies the default preset's member
+tier at creation, so a later preset change does not re-aim existing groups (the rule every other
+creation-time policy value already follows); and the member-policy checks stay inline in each
+validator because the changed-style gate counts an `unknown`-typed helper parameter as boundary
+widening.
+
+**Open for 9c.** Inbound setups are not paced: `acceptPeerIfAbsent` starts a setup for any
+signaled peer regardless of the bound, so a member's in-flight count can exceed its bound by the
+offers it accepts; the bound governs what this member starts. RTT-driven peer selection should
+decide whether the acceptor pays for those setups or whether the initiator's bound is enough.
 
 Refreshed next two slices. 9b is this PR. The 6/20/50 sweep manifests (`pacing-sweep`) follow as
 their own PR once 9b's live-RTC evidence exists; Slice 10a is the outcome after that.

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -2,7 +2,8 @@
 
 Status: **implementation in progress — Slices 1–8 are merged, the last through PR #396 on
 2026-09-01. Slice 9a, the truthful RTC lifecycle signals, is in delivery on
-`codex/group-activation-rtc-lifecycle-signals`; Slice 9b is the next outcome. Re-baselined
+`codex/group-activation-rtc-lifecycle-signals` (PR #404), and Slice 9b, the wire path and the
+per-group in-flight bound, is stacked on it on `codex/group-activation-in-flight-bound`. Re-baselined
 against product decisions 1–42. The product decisions are settled;
 the implementation decisions record current reasoning, while ownership, decomposition, file and
 symbol inventories, dependencies and gates must be refreshed against the actual delivery head before
@@ -2310,6 +2311,41 @@ native runtime. The sandboxed unit run reports six files that bind ports or `/tm
 unsandboxed and are environment evidence, not slice evidence. Seventeen pre-existing unformatted
 files on `main` are untouched and outside this closure, as is the legacy scan's vocabulary hit on
 the benches' pre-existing CLI default parameter.
+
+### Slice 9b start checkpoint — the wire path and the per-group in-flight bound (2026-09-02)
+
+Stacked on 9a's reviewed head. The Slice 0 material-change review found nothing new on `main`
+beyond 9a's own base. Ownership recovery confirmed the "five-list edit" I13 predicted, and it is
+exactly five: the persisted group validator's key list, the authoritative snapshot validator's,
+the delta envelope validator's, the OpenAPI `Group` required block, and the compile-complete test
+fixture — the aggregate cross-check test drives one `Group` through the first three, so a list
+that drifts fails there before any recipe runs. Six benchmark and diagnostic workloads build a
+`Group` literal by hand and joined the closure as compile errors, which is the fixture's design
+working as intended.
+
+What 9b lands:
+
+- **`Group.memberPolicy`** (I13, product decision 26): `{ maxConcurrentEdgeSetups, transports }`,
+  resolved by `toGroupMemberPolicy` from the normalized policy at creation and from the default
+  preset when the request carries no policy, so every group read, delta and hydration carries the
+  bound each member enforces on itself. Last in wire order (I4); no persisted-row migration
+  because the key lists are exact and the cutover is clean-database, as every earlier aggregate
+  field was.
+- **`computePacedOutboundDialPlan`**, the pure in-flight dial plan over the budgeted plan: known
+  peers pass because their ensure starts nothing; a new dial is admitted only while every owning
+  group is below its bound, counting setups already in flight for that group plus the dials
+  admitted earlier in the same pass; a paced peer waits. Product decision 18's shared-peer rule
+  falls out of `computeInFlightDialAdmission` unchanged.
+- **Wake-on-completion**: the manager registers one lifecycle observer on the connection service
+  and re-reconciles when a setup ends by establishment, timeout or removal — but only while a
+  paced dial is waiting, and never for the endings a pass causes itself. The browser transport
+  shutdown stops the wakes before it tears peers down, because shutdown removes peers their groups
+  still want; without that, every teardown would dial them back.
+- **The completable harness dial**: the simulated connection harness now exposes `establish`, so
+  browser tests drive a setup from in flight to established and observe the bound release.
+
+Refreshed next two slices. 9b is this PR. The 6/20/50 sweep manifests (`pacing-sweep`) follow as
+their own PR once 9b's live-RTC evidence exists; Slice 10a is the outcome after that.
 
 ## Slice 10 — Replanning modes and landing go live
 

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -2371,6 +2371,19 @@ signaled peer regardless of the bound, so a member's in-flight count can exceed 
 offers it accepts; the bound governs what this member starts. RTT-driven peer selection should
 decide whether the acceptor pays for those setups or whether the initiator's bound is enough.
 
+**Validation (2026-09-02, final head).** Baseline: dprint, `check:repo-style:changed` (no new
+findings), test-structure coupling, `check:retained-legacy` (four candidates, all the pre-existing
+`fallback` identifiers of two benches that only gained a policy import), `check:repo-structure`,
+the governed test typecheck, `typecheck`, `build`, `test:deno`, and `test:unit` unsandboxed with
+two failures: the headless bundle boundary (216.6 KiB against the 216 KiB ceiling, below) and one
+IndexedDB AL store test whose 30 ms real-timer wait lost under full-suite load; it passes three of
+three alone and the slice touches no AL code. The shared-web trio, the browser bundle budget and
+the API-v1 black-box in-memory profile, medium-scale profile and full-stack suite pass. The
+live-RTC three-browser matrix fails identically on pristine `main` on this machine today, so it
+is environmental and not slice evidence. Two items wait on the maintainer: the headless bundle
+ceiling, which this slice does not touch, and the state-write A-B-B-A comparison, blocked while a
+foreign perf-bench container from another worktree holds the pinned port.
+
 Refreshed next two slices. 9b is this PR. The 6/20/50 sweep manifests (`pacing-sweep`) follow as
 their own PR once 9b's live-RTC evidence exists; Slice 10a is the outcome after that.
 

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -2362,9 +2362,9 @@ stop for non-browser owners, and the validators accepting any positive integer w
 normalizer clamps to 256. All of it is folded into the shape above. Two consequences are
 accepted rather than fixed: a group created without a policy copies the default preset's member
 tier at creation, so a later preset change does not re-aim existing groups (the rule every other
-creation-time policy value already follows); and the member-policy checks stay inline in each
-validator because the changed-style gate counts an `unknown`-typed helper parameter as boundary
-widening.
+creation-time policy value already follows); and each validator's member-policy helper takes the
+already-narrowed record under one named record type per file, because the changed-style gate
+counts every `unknown` spelling a file gains and an `unknown`-typed helper parameter is one.
 
 **Open for 9c.** Inbound setups are not paced: `acceptPeerIfAbsent` starts a setup for any
 signaled peer regardless of the bound, so a member's in-flight count can exceed its bound by the

--- a/scripts/perf/group-list-fanout-bench.ts
+++ b/scripts/perf/group-list-fanout-bench.ts
@@ -16,6 +16,8 @@ import {
     assertRuntimeStateExpectedRevision,
     assertRuntimeStateUpsertExpectedRevision
 } from '@shared-server/runtime-state/runtime-state-repository.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { AuditStamp, Group, GroupMember, GroupPresenceSession } from '@shared/api/group-types.ts';
 
 const GROUPS = Number(
@@ -157,7 +159,7 @@ function createGroup(groupId: string, ownerPrincipalId: string): Group {
         formationElectorate: [ownerPrincipalId],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
-        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' },
+        memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy()),
         snapshotVersion: 1,
         metadataVersion: 1,
         rosterVersion: 1,

--- a/scripts/perf/group-list-fanout-bench.ts
+++ b/scripts/perf/group-list-fanout-bench.ts
@@ -157,6 +157,7 @@ function createGroup(groupId: string, ownerPrincipalId: string): Group {
         formationElectorate: [ownerPrincipalId],
         acceptedLayoutIdentity: null,
         transportState: 'flowing',
+        memberPolicy: { maxConcurrentEdgeSetups: 64, transports: 'rtc-and-ws' },
         snapshotVersion: 1,
         metadataVersion: 1,
         rosterVersion: 1,

--- a/scripts/perf/runtime-validation-bench.ts
+++ b/scripts/perf/runtime-validation-bench.ts
@@ -22,6 +22,8 @@ import type {
 import { newALBroadcastMessage, newALEventRoute } from '@shared/al-contracts/al-contract.ts';
 import { AppTopics } from '@shared/api/api-config.ts';
 import type { AuditStamp as ClientAuditStamp, ClientSnapshot } from '@shared/api/client-types.ts';
+import { createDefaultGroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import { toGroupMemberPolicy } from '@shared/api/group-lifecycle/to-normalized-group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import { ObservableLatestRepository } from '@shared/cache/ObservableLatestRepository.ts';
@@ -675,7 +677,8 @@ function makeGroupSnapshot(
                 (_, index) => `principal-${index}`
             ),
             acceptedLayoutIdentity: null,
-            transportState: 'flowing'
+            transportState: 'flowing',
+            memberPolicy: toGroupMemberPolicy(createDefaultGroupLifecyclePolicy())
         },
         members: Array.from({ length: memberCount }, (_, index) => ({
             ...ref,

--- a/scripts/perf/state-write/api-v1-state-write-benchmark-options.ts
+++ b/scripts/perf/state-write/api-v1-state-write-benchmark-options.ts
@@ -2,6 +2,7 @@ import { normalize } from 'node:path';
 
 import {
     GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE,
+    MEMBER_POLICY_ROW_WIDTH_REGRESSION_REASON_PROFILE,
     PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE,
     RTC_TOPOLOGY_REGRESSION_REASON_PROFILE
 } from './api-v1-state-write-regression-reasons.ts';
@@ -30,7 +31,8 @@ export interface StateWriteBenchmarkOptions {
     readonly regressionReasonProfile?:
         | typeof RTC_TOPOLOGY_REGRESSION_REASON_PROFILE
         | typeof GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE
-        | typeof PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE;
+        | typeof PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE
+        | typeof MEMBER_POLICY_ROW_WIDTH_REGRESSION_REASON_PROFILE;
 }
 
 export function parseBenchmarkOptions(args: readonly string[]): StateWriteBenchmarkOptions {
@@ -49,7 +51,8 @@ export function parseBenchmarkOptions(args: readonly string[]): StateWriteBenchm
         regressionReasonProfile !== undefined &&
         regressionReasonProfile !== RTC_TOPOLOGY_REGRESSION_REASON_PROFILE &&
         regressionReasonProfile !== GROUP_FORMATION_DAMPING_REGRESSION_REASON_PROFILE &&
-        regressionReasonProfile !== PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE
+        regressionReasonProfile !== PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE &&
+        regressionReasonProfile !== MEMBER_POLICY_ROW_WIDTH_REGRESSION_REASON_PROFILE
     ) {
         throw new Error(
             `Unsupported state-write regression reason profile: ${regressionReasonProfile}`

--- a/scripts/perf/state-write/api-v1-state-write-regression-reasons.ts
+++ b/scripts/perf/state-write/api-v1-state-write-regression-reasons.ts
@@ -64,6 +64,28 @@ export const PLANNED_LAYOUT_PROMOTION_REASONS = (['uncontended', 'shared', 'hot'
 
 export const PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE = 'planned-layout-promotion' as const;
 
+const MEMBER_POLICY_ROW_WIDTH_REASON = 'Slice 9b widens every persisted group row by one required field ' +
+    '(memberPolicy: the member tier\'s maxConcurrentEdgeSetups and transports), ' +
+    'growing serialized bytes and row work on all group writes; the bench dials ' +
+    'no RTC peers and its mix issues no lifecycle operations, so the residue is ' +
+    'row width plus the documented contention drift.';
+
+export const MEMBER_POLICY_ROW_WIDTH_REASONS = (['uncontended', 'shared', 'hot'] as const).flatMap(
+    (workload) =>
+        [
+            'sql.statements',
+            'sql.rowsRead',
+            'sql.serializedResultBytes',
+            'postgres.transactionDurationMs'
+        ].map((metric) => ({
+            workload,
+            metric,
+            reason: MEMBER_POLICY_ROW_WIDTH_REASON
+        }))
+);
+
+export const MEMBER_POLICY_ROW_WIDTH_REGRESSION_REASON_PROFILE = 'member-policy-row-width' as const;
+
 export function selectStateWriteRegressionReasons(
     profile: string | undefined,
     precommittedReasons: readonly StateWriteBenchmarkRegressionReason[]
@@ -82,6 +104,9 @@ export function selectStateWriteRegressionReasons(
     }
     if (profile === PLANNED_LAYOUT_PROMOTION_REGRESSION_REASON_PROFILE) {
         return PLANNED_LAYOUT_PROMOTION_REASONS;
+    }
+    if (profile === MEMBER_POLICY_ROW_WIDTH_REGRESSION_REASON_PROFILE) {
+        return MEMBER_POLICY_ROW_WIDTH_REASONS;
     }
     throw new Error('State-write regression reason selection is inconsistent');
 }


### PR DESCRIPTION
## Goal

Slice 9b of the [group activation implementation plan](playground/rtc-design/2026-08-22-group-activation-implementation-plan.md), stacked on #404: carry the member tier of the lifecycle policy on every group (implementation decision I13, product decision 26) and have each member's browser bound the RTC setups it starts per group, with wake-on-completion (product decision 18).

## Changes

- `Group.memberPolicy` (`maxConcurrentEdgeSetups`, `transports`): resolved by `toGroupMemberPolicy` from the normalized policy at creation, and from the default preset when the request carries no policy. Added last in wire order to the persisted, authoritative-snapshot and delta validators, which also enforce the normalizer's cap (256), the OpenAPI `Group` schema (new `GroupMemberPolicy`, `maximum: 256`), the compile-complete test fixture and the seven benchmark/diagnostic `Group` literals that now derive the default from the translation. `GROUP_ESTABLISHMENT_TRANSPORTS` becomes a runtime registry and replaces the two inline transport lists in shared-server.
- `computeOutboundDialPlan` stays the pure ordering and budget: known peers split by native liveness, new candidates server-first, and the connection budget left after the peers already held.
- `WebRtcOutboundDialing` (new) spends that budget and the in-flight bound at dial time, against what each ensure actually did: an owner is charged only when the ensure reports `setup-started`, a paced peer holds no connection-budget slot, a dial that starts nothing frees its slot for the next candidate at once, and a known peer whose native connection died is charged as the new setup its re-dial starts. Bounds are keyed by the scoped group key.
- `WebRtcGroupManager`: reads each group's bound from its snapshot into `WebRtcPeerOwnership`, hands the plan to the dialer, counts `connectDeferredPacingCount`, and owns the wake lifecycle: `startReconcileWakes()` is called by the browser composition root once the service and manager exist, `stopReconcileWakes()` by transport shutdown before it tears peers down. A wake runs on a microtask after the lifecycle notice that raised it, so every observer sees the ending before the dials it releases; an ending the running pass causes sets the drain latch instead. `whenReconciled()` covers a scheduled wake.
- Test harness: the simulated RTC connection service composes over the native fixture and exposes `nativePeer(peerId)`; a test establishes a setup with `setConnected()`, the path the browser runtime takes.
- Recipe: the lifecycle-policy recipe asserts `memberPolicy` on the plain (64 / rtc-and-ws), optimistic (64) and managed (32) groups.
- Docs: the group formation architecture field list and open items, and the plan's Slice 9b checkpoint with the review correction record.

## Review correction

The nine-angle review of the first head found: owners charged before any ensure ran (a denied or failed dial kept its slot), a paced peer consuming a connection-budget slot, the bound keyed by bare group id, the wake observer registered in the constructor with no matching stop for non-browser owners and re-dialing inside the deletion notice that freed it, and validators accepting any positive integer while the normalizer clamps to 256. All are resolved in `e6057d29a` and `1f3c22294`. Two consequences are accepted rather than changed: a group created without a policy copies the default preset's member tier at creation (a later preset change does not re-aim existing groups, the rule every creation-time policy value follows), and each validator's member-policy helper takes the already-narrowed record under one named record type per file, because the changed-style gate counts every `unknown` spelling a file gains. The scoped re-review of the correction added: a wake already scheduled when `stopReconcileWakes()` runs now stands down, an ending observed during a running pass is ignored because a pass is synchronous and already accounted for it (the previous in-pass latch could loop on a deterministic synchronous dial failure), and policy outcomes (`self`, `dial-denied`) are no longer logged as errors. One item is carried to 9c as an open question: setups accepted from a peer's signaling are not paced, so a member's in-flight count can exceed its bound by the offers it accepts.

## Acceptance

- A group with `maxConcurrentEdgeSetups: 2` and five desired peers dials two; establishing one dials the third without any other trigger; establishing the rest dials all five.
- A peer wanted by a saturated group and an idle group waits until the saturated owner frees a slot.
- A dial the outbound policy denies frees its slot at once for the next candidate.
- A paced peer never holds a connection-budget slot an idle group could use.
- A known peer whose native connection died is re-dialed through the bound and charged.
- A setup ending by removal wakes a reconcile after the deletion notice completes, only while a paced dial is waiting; after `stopReconcileWakes()` no wake fires.
- A group created with the managed preset reads `memberPolicy.maxConcurrentEdgeSetups: 32` over HTTP; a group created without a policy reads 64.
- An unregistered key inside `memberPolicy`, or a bound above 256, is rejected by all three validators.

## Validation

Passed locally on the final head: dprint, `check:repo-style:changed` (no new findings), `check-test-structure-coupling --changed`, `check:repo-structure`, `check:retained-legacy` (four candidates, all pre-existing `fallback` identifiers in two benches that only gained a policy import), the governed test typecheck, `typecheck`, `build`, `test:deno`, the shared-web public API snapshots and bundle boundaries, the browser bundle budget, the API-v1 black-box in-memory profile, the Postgres medium-scale profile and `test:full-stack`.

`test:unit` (unsandboxed, 9013 tests) has two failures: the headless bundle boundary (decision below) and `al-indexeddb-runtime-stores.test.ts` "does not repair from IndexedDB when an acknowledgement is accepted while timeout is claimed", whose 30 ms real-timer wait lost under full-suite load; it passes three of three in isolation and this branch touches no AL or IndexedDB code.

Not slice evidence: the live-RTC three-browser matrix fails identically ("RTC peer establishment timed out", ready peers empty) on pristine `main` on this machine today. Blocked: the state-write A-B-B-A comparison (profile `member-policy-row-width`) needs the pinned perf-bench port, which a `rallar-perf-bench-postgres` container from another worktree still holds; it was not removed.

**Decision needed:** the headless agent bundle measures 216.7 KiB Brotli against the maintainer-approved strict ceiling of 216 KiB in `headless-bundle-boundary.test.ts`. The growth is the member-policy validation and the dial pacing the headless agent legitimately runs. The ceiling has not been changed.

## Risk and rollback

`Group` gains a required field, so a database whose group rows predate this change fails exact-key validation on read, the same clean-database cutover every earlier aggregate field used; no data-rewrite migration is provided. The browser dial change only delays new dials while a group is at its bound and re-runs on setup endings; the default preset's bound (64) exceeds the connection budget (10), so groups without a policy behave as before. Rollback is a revert of the branch.

## Follow-up

The 6/20/50 `pacing-sweep` Hetzner manifests follow as their own PR once the live-RTC evidence exists. No GitHub Issues were created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
