### PR TITLE
Gate high-confidence transaction write purity

### DIFF
--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -204,6 +204,9 @@ checker does not substitute for following production symbols.
   validation, sorting, candidate/event/outbox construction, arbitrary helpers,
   and other precomputable work before transaction entry. Deterministic work is
   non-waivable even when cheap or under deadline pressure.
+- Run `npm run check:transaction-writes` for authored package or API mutation
+  paths. Treat its lexical findings as blocking; helper provenance and SQL
+  semantics remain required human review boundaries.
 - Treat transaction timing and value provenance as separate facts. A value
   desired only for a transaction winner is not thereby database-derived. Only
   actual database-returned facts justify inside-transaction refinement. One

--- a/.agents/skills/rallar-testing/SKILL.md
+++ b/.agents/skills/rallar-testing/SKILL.md
@@ -62,6 +62,9 @@ compute, validate, and write. Prove through transaction and redelivery behavior
 that the handler and persistence helper do not own an inner retry loop. Prove that
 inside-transaction refinement starts from actual database-returned facts, and
 keep human review responsible for PostgreSQL semantics.
+Run `npm run check:transaction-writes` for affected authored package or API
+mutation paths. The check supplements semantic tests; helper provenance and
+PostgreSQL business semantics remain human review boundaries.
 
 For both phases, the same explicit input produces the same result. They perform
 no repository reads, clocks, randomness, mutable dependency lookups, or hidden

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "test:rallar-code-writing": "vitest run packages/tests/repo/rallar-code-writing packages/tests/repo/repo-code-style-authority-integrity.test.ts packages/tests/repo/repo-code-style-review-evidence-integrity.test.ts",
     "check:adaptive-agent-evaluation": "node .agents/evaluations/adaptive-agent-execution/v1/validate-result.mjs",
     "check:repo-structure": "node scripts/repo-structure-check.mjs",
+    "check:transaction-writes": "node scripts/transaction-write-check/check-transaction-writes.mjs",
+    "test:transaction-writes": "vitest run packages/tests/repo/transaction-write-check",
     "test:repo-structure": "vitest run packages/tests/repo/repo-structure-check",
     "check:governance-gate": "node scripts/governance-gate.mjs",
     "test:governance-gate": "vitest run packages/tests/repo/governance-gate",

--- a/packages/tests/repo/governance-gate/governance-gate-command.test.ts
+++ b/packages/tests/repo/governance-gate/governance-gate-command.test.ts
@@ -12,7 +12,8 @@ const fixtureRoots: string[] = [];
 const requiredPhaseCommands = {
     'check:repo-structure': ['repo-structure', 0],
     'check:repo-style': ['repo-style', 0],
-    'check:retained-legacy': ['retained-legacy', 0]
+    'check:retained-legacy': ['retained-legacy', 0],
+    'check:transaction-writes': ['transaction-writes', 0]
 } as const;
 
 afterEach(() => {
@@ -33,12 +34,14 @@ describe('governance gate command', () => {
             'PASS: governance gate repo-style',
             'retained-legacy fixture success',
             'PASS: governance gate retained-legacy',
-            'PASS: governance gate (3 phases)'
+            'PASS: governance gate transaction-writes',
+            'PASS: governance gate (4 phases)'
         ]);
         expect(readExecutedPhases(fixtureRoot).sort()).toEqual([
             'repo-structure',
             'repo-style',
-            'retained-legacy'
+            'retained-legacy',
+            'transaction-writes'
         ]);
     });
 
@@ -80,7 +83,8 @@ describe('governance gate command', () => {
         [
             ['repo-structure', 'check:repo-structure'],
             ['repo-style', 'check:repo-style'],
-            ['retained-legacy', 'check:retained-legacy']
+            ['retained-legacy', 'check:retained-legacy'],
+            ['transaction-writes', 'check:transaction-writes']
         ] as const
     )('attributes a non-zero %s result to its canonical command', (phase, command) => {
         const commands = { ...requiredPhaseCommands, [command]: [phase, 7] as const };

--- a/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
+++ b/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
@@ -40,6 +40,10 @@ const strictMutationPhaseGuidancePaths = [
     '.agents/skills/rallar-testing/SKILL.md',
     '.agents/skills/performance-analysis/SKILL.md'
 ] as const;
+const transactionWriteCheckGuidancePaths = [
+    '.agents/skills/rallar-code-writing/SKILL.md',
+    '.agents/skills/rallar-testing/SKILL.md'
+] as const;
 const canonicalSnapshotOrderingGuidancePaths = [
     canonicalServiceWritingPath,
     'docs/rallar-convergent-state-and-rtc-topology.md'
@@ -430,6 +434,17 @@ describe('authoritative mutation guidance integrity', () => {
                 'Adding another service mutation phase requires explicit human approval',
                 'One queue delivery performs one mutation attempt',
                 'A conflict exits that attempt; queue redelivery starts again from `read`'
+            ]);
+        }
+    );
+
+    it.each(transactionWriteCheckGuidancePaths)(
+        '%s publishes the transaction-write check without overstating its proof',
+        (filePath) => {
+            expectAllNormalized(readRepo(filePath), [
+                'npm run check:transaction-writes',
+                'helper provenance',
+                'human review'
             ]);
         }
     );

--- a/packages/tests/repo/transaction-write-check/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check/transaction-write-check.test.ts
@@ -1,0 +1,149 @@
+import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
+
+import { analyzeTransactionWrites } from '../../../../scripts/transaction-write-check/analyze-transaction-writes.mjs';
+
+describe('transaction write check', () => {
+    it('reports named precomputable helpers in transaction callbacks', () => {
+        const findings = analyzeFixture(`
+            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            declare const database: Sql;
+            declare const computed: { row: string };
+            function computeRow(): string { return JSON.stringify(computed); }
+            export async function execute(): Promise<void> {
+                await database.begin(async (transaction) => {
+                    const row = computeRow();
+                    await transaction.begin(async () => row);
+                });
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['computeRow']);
+    });
+
+    it('reports clocks, randomness, hashing, and sorting in transaction write functions', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            export async function writeMutation(transaction: PSqlSql, computed: string[]): Promise<void> {
+                const now = Date.now();
+                const id = crypto.randomUUID();
+                const sorted = computed.toSorted();
+                const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(id));
+                await transaction.query({ now, sorted, bytes });
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual([
+            'Date.now',
+            'crypto.randomUUID',
+            'toSorted',
+            'crypto.subtle.digest',
+            'TextEncoder'
+        ]);
+    });
+
+    it('allows executing computed writes and bounded database-result checks', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<{ rows: { id: number }[] }>; }
+            export async function writeMutation(
+                transaction: PSqlSql,
+                computed: readonly { sql: string }[]
+            ): Promise<number> {
+                for (const write of computed) await transaction.query(write.sql);
+                const result = await transaction.query('returning id');
+                const id = Number(result.rows[0].id);
+                if (!Number.isSafeInteger(id)) throw new Error('Invalid database id');
+                return id;
+            }
+        `);
+
+        expect(findings).toEqual([]);
+    });
+
+    it('recognizes IndexedDB readwrite and upgrade callbacks but excludes readonly work', () => {
+        const findings = analyzeFixture(`
+            declare const db: IDBDatabase;
+            declare const request: IDBOpenDBRequest;
+            export function read(): void {
+                const transaction = db.transaction('items', 'readonly');
+                JSON.stringify(transaction.objectStore('items'));
+            }
+            export function write(): void {
+                const transaction = db.transaction('items', 'readwrite');
+                const encoded = JSON.stringify({ value: 1 });
+                transaction.objectStore('items').put(encoded);
+            }
+            export function computedBeforeWrite(): void {
+                const encoded = JSON.stringify({ value: 1 });
+                const transaction = db.transaction('items', 'readwrite');
+                transaction.objectStore('items').put(encoded);
+            }
+            request.onupgradeneeded = () => {
+                const stores = ['items'].toSorted();
+                request.result.createObjectStore(stores[0]);
+            };
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual([
+            'JSON.stringify',
+            'toSorted'
+        ]);
+    });
+
+    it('reports transaction loops without rejecting ordinary computed-write iteration', () => {
+        const findings = analyzeFixture(`
+            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            declare const database: Sql;
+            export async function writeWithRetry(): Promise<void> {
+                for (let attempt = 0; attempt < 3; attempt += 1) {
+                    await database.begin(async () => undefined);
+                }
+            }
+        `);
+
+        expect(findings).toMatchObject([{
+            rule: 'transaction.inner-retry',
+            operation: 'database.begin'
+        }]);
+    });
+
+    it('exempts exact PostgreSQL ResourceInbox owners but not browser QueueBox writes', () => {
+        const project = new Project({ useInMemoryFileSystem: true });
+        const specialized = project.createSourceFile(
+            '/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts',
+            transactionSource('Date.now()')
+        );
+        const browser = project.createSourceFile(
+            '/packages/shared/queuebox/indexed-db-queue-box-write.ts',
+            `declare const db: IDBDatabase;
+             export function write(): void {
+                 const transaction = db.transaction('items', 'readwrite');
+                 transaction.objectStore('items').put(JSON.stringify({ value: 1 }));
+             }`
+        );
+
+        const findings = analyzeTransactionWrites(project, [specialized, browser]);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({
+            path: 'packages/shared/queuebox/indexed-db-queue-box-write.ts',
+            operation: 'JSON.stringify'
+        });
+    });
+});
+
+function analyzeFixture(source: string) {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile('/packages/domain/mutation.ts', source);
+    return analyzeTransactionWrites(project, [sourceFile]);
+}
+
+function transactionSource(work: string): string {
+    return `
+        interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+        declare const database: Sql;
+        export async function write(): Promise<void> {
+            await database.begin(async () => { ${work}; });
+        }
+    `;
+}

--- a/scripts/governance-gate/governance-gate-phases.mjs
+++ b/scripts/governance-gate/governance-gate-phases.mjs
@@ -10,7 +10,8 @@ export const governanceGatePhases = [
         phase: 'retained-legacy',
         command: 'check:retained-legacy',
         showSuccessfulOutput: true
-    }
+    },
+    { phase: 'transaction-writes', command: 'check:transaction-writes' }
 ];
 
 const forbiddenScriptPatterns = [

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -1,0 +1,31 @@
+# Transaction write check
+
+`npm run check:transaction-writes` checks authored `packages/**` and
+`apps/api-v1/src/**` execution paths for high-confidence work that must happen
+before a write-capable transaction starts.
+
+The checker reports:
+
+- `transaction.precomputable-work` for clocks, randomness, serialization,
+  hashing, sorting/canonicalization, and named compute/prepare builders reached
+  from a resolved transaction callback or transaction-write function;
+- `transaction.inner-retry` when a write transaction is opened from a
+  retry/attempt loop.
+
+It recognizes PostgreSQL/PGlite `begin` and `transaction` callbacks, the
+`runInPSqlTransaction` wrapper, IndexedDB `readwrite` transactions, IndexedDB
+upgrade callbacks, and callback identifiers that resolve to authored source.
+It inspects the lexical transaction body rather than expanding arbitrary helper
+graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
+their call site. Readonly IndexedDB transactions, tests, fixtures, generated/vendor code,
+`packages/shared-test/**`, and `packages/shared-rtc-bench/**` are excluded.
+Exact PostgreSQL ResourceInbox owners under
+`packages/shared-server/queuebox/postgres/**` are governed by their specialized
+SQL review and semantic tests instead.
+
+This is intentionally a narrow check. It does not attempt whole-program
+provenance, arbitrary helper-body expansion, SQL semantic proof, dynamic
+callback resolution, or an exception/fingerprint registry. Human review remains
+responsible for ambiguous helpers and database-result refinements. Extend the
+checker only with a focused failing fixture and a demonstrated production class
+of error.

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -1,0 +1,352 @@
+import { Node, SyntaxKind } from 'ts-morph';
+
+const PRECOMPUTABLE_CALLS = new Set([
+    'Date.now',
+    'JSON.parse',
+    'JSON.stringify',
+    'Math.random',
+    'crypto.getRandomValues',
+    'crypto.randomUUID',
+    'crypto.subtle.digest',
+    'structuredClone'
+]);
+
+const PRECOMPUTABLE_METHODS = new Set(['sort', 'toSorted']);
+const PRECOMPUTABLE_NAME = /^(?:compute|prepare|serialize|canonicalize|hash|encode)(?:$|[A-Z_])/u;
+const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
+const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
+const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
+
+export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
+    const findings = new Map();
+    const roots = [];
+
+    for (const sourceFile of sourceFiles) {
+        const path = sourcePath(sourceFile);
+        if (!isAnalyzedSource(path)) {
+            continue;
+        }
+        const specialized = path.startsWith(SPECIALIZED_RESOURCE_INBOX_ROOT);
+        for (const declaration of sourceFile.getDescendants().filter(isFunctionDeclaration)) {
+            if (!specialized && isTransactionWriteDeclaration(declaration)) {
+                roots.push(analysisRoot(declaration));
+            }
+        }
+        for (const assignment of sourceFile.getDescendantsOfKind(SyntaxKind.BinaryExpression)) {
+            if (!specialized && isUpgradeCallbackAssignment(assignment)) {
+                const callback = assignment.getRight();
+                if (Node.isArrowFunction(callback) || Node.isFunctionExpression(callback)) {
+                    roots.push(analysisRoot(callback));
+                }
+            }
+        }
+        for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+            const boundary = transactionBoundary(call);
+            if (!boundary) {
+                continue;
+            }
+            if (!specialized) {
+                reportTransactionLoop(call, findings);
+            }
+            if (specialized || boundary.kind === 'readonly') {
+                continue;
+            }
+            if (boundary.kind === 'indexed-db') {
+                const owner = call.getFirstAncestor(isFunctionDeclaration);
+                if (owner) {
+                    roots.push(analysisRoot(owner, call.getEnd()));
+                }
+                continue;
+            }
+            for (const callback of resolveCallbackBodies(boundary.callback, project)) {
+                roots.push(analysisRoot(callback));
+            }
+        }
+    }
+
+    const visited = new Set();
+    for (const root of roots) {
+        analyzeBody({
+            root: root.node,
+            start: root.start,
+            findings,
+            visited,
+            boundary: root.node
+        });
+    }
+    return [...findings.values()].sort(compareFindings);
+}
+
+function analyzeBody(input) {
+    const { root, start, findings, visited, boundary } = input;
+    const body = functionBody(root);
+    if (!body) {
+        return;
+    }
+    const identity = `${body.getSourceFile().getFilePath()}:${body.getStart()}:${start}`;
+    if (visited.has(identity)) {
+        return;
+    }
+    visited.add(identity);
+
+    for (const construct of body.getDescendantsOfKind(SyntaxKind.NewExpression)) {
+        if (construct.getStart() < start) {
+            continue;
+        }
+        const operation = construct.getExpression().getText();
+        if (operation === 'Date' || operation === 'TextEncoder') {
+            addFinding({
+                findings,
+                node: construct,
+                rule: 'transaction.precomputable-work',
+                operation,
+                boundary
+            });
+        }
+    }
+    for (const call of body.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+        if (call.getStart() < start) {
+            continue;
+        }
+        const operation = callOperation(call);
+        const precomputable = precomputableOperation(call, operation);
+        if (precomputable) {
+            addFinding({
+                findings,
+                node: call,
+                rule: 'transaction.precomputable-work',
+                operation: precomputable,
+                boundary
+            });
+        }
+    }
+}
+
+function analysisRoot(node, start = node.getStart()) {
+    return { node, start };
+}
+
+function precomputableOperation(call, operation) {
+    if (PRECOMPUTABLE_CALLS.has(operation) || operation.startsWith('Temporal.Now.')) {
+        return operation;
+    }
+    const expression = call.getExpression();
+    const name = Node.isPropertyAccessExpression(expression)
+        ? expression.getName()
+        : Node.isIdentifier(expression)
+        ? expression.getText()
+        : '';
+    if (PRECOMPUTABLE_METHODS.has(name)) {
+        return name;
+    }
+    if (
+        name === 'encode' &&
+        Node.isPropertyAccessExpression(expression) &&
+        Node.isNewExpression(expression.getExpression()) &&
+        expression.getExpression().getExpression().getText() === 'TextEncoder'
+    ) {
+        return undefined;
+    }
+    return PRECOMPUTABLE_NAME.test(name) ? name : undefined;
+}
+
+function transactionBoundary(call) {
+    const expression = call.getExpression();
+    if (Node.isIdentifier(expression) && expression.getText() === 'runInPSqlTransaction') {
+        return { kind: 'callback', callback: call.getArguments()[1] };
+    }
+    if (!Node.isPropertyAccessExpression(expression)) {
+        return undefined;
+    }
+    const method = expression.getName();
+    if (method === 'transaction') {
+        const mode = call.getArguments()[1]?.getText().replaceAll(/["']/gu, '');
+        if (mode === 'readonly') {
+            return { kind: 'readonly' };
+        }
+        if (mode === 'readwrite') {
+            return { kind: 'indexed-db' };
+        }
+        const callback = call.getArguments()[0];
+        if (isCallbackReference(callback) && looksLikeDatabaseReceiver(expression.getExpression())) {
+            return { kind: 'callback', callback };
+        }
+        return undefined;
+    }
+    if (method !== 'begin') {
+        return undefined;
+    }
+    const callback = call.getArguments()[0];
+    if (!isCallbackReference(callback) || !looksLikeDatabaseReceiver(expression.getExpression())) {
+        return undefined;
+    }
+    return { kind: 'callback', callback };
+}
+
+function looksLikeDatabaseReceiver(receiver) {
+    const typeText = receiver.getType().getText(receiver);
+    if (DATABASE_RECEIVER_TYPE.test(typeText)) {
+        return true;
+    }
+    const name = receiver.getText();
+    return /(?:database|repository|runtime|sql|pglite)/iu.test(name);
+}
+
+function reportTransactionLoop(call, findings) {
+    const loop = call.getFirstAncestor((ancestor) =>
+        Node.isForStatement(ancestor) ||
+        Node.isForInStatement(ancestor) ||
+        Node.isForOfStatement(ancestor) ||
+        Node.isWhileStatement(ancestor) ||
+        Node.isDoStatement(ancestor)
+    );
+    if (loop && isRetryLoop(loop)) {
+        addFinding({
+            findings,
+            node: call,
+            rule: 'transaction.inner-retry',
+            operation: callOperation(call),
+            boundary: call
+        });
+    }
+}
+
+function isTransactionWriteDeclaration(declaration) {
+    const name = declarationName(declaration);
+    if (!/^(?:write|commit|insert|update|delete|remove|put|finish)/u.test(name)) {
+        return false;
+    }
+    return declaration.getParameters().some((parameter) => {
+        const typeNode = parameter.getTypeNode();
+        return /^(?:transaction|tx|sql)$/iu.test(parameter.getName()) &&
+            typeNode !== undefined &&
+            !Node.isFunctionTypeNode(typeNode) &&
+            TRANSACTION_TYPE.test(typeNode.getText());
+    });
+}
+
+function isCallbackReference(node) {
+    return node !== undefined && (
+        Node.isArrowFunction(node) ||
+        Node.isFunctionExpression(node) ||
+        Node.isIdentifier(node)
+    );
+}
+
+function isRetryLoop(loop) {
+    const owner = loop.getFirstAncestor(isFunctionDeclaration);
+    return /(?:retry|attempt)/iu.test(loop.getText()) ||
+        (owner !== undefined && /(?:retry|attempt)/iu.test(declarationName(owner)));
+}
+
+function isUpgradeCallbackAssignment(assignment) {
+    if (assignment.getOperatorToken().getKind() !== SyntaxKind.EqualsToken) {
+        return false;
+    }
+    const left = assignment.getLeft();
+    return Node.isPropertyAccessExpression(left) && left.getName() === 'onupgradeneeded';
+}
+
+function resolveCallbackBodies(node, project) {
+    if (!node) {
+        return [];
+    }
+    if (Node.isArrowFunction(node) || Node.isFunctionExpression(node)) {
+        return [node];
+    }
+    if (!Node.isIdentifier(node)) {
+        return [];
+    }
+    return resolveDeclarations(node.getSymbol(), project);
+}
+
+function resolveDeclarations(symbol, project) {
+    if (!symbol) {
+        return [];
+    }
+    const resolved = symbol.isAlias() ? symbol.getAliasedSymbol() : symbol;
+    const bodies = [];
+    for (const declaration of resolved?.getDeclarations() ?? []) {
+        const source = sourcePath(declaration.getSourceFile());
+        if (!isAnalyzedSource(source) || !project.getSourceFile(declaration.getSourceFile().getFilePath())) {
+            continue;
+        }
+        if (isFunctionDeclaration(declaration)) {
+            bodies.push(declaration);
+            continue;
+        }
+        if (Node.isVariableDeclaration(declaration) || Node.isPropertyAssignment(declaration)) {
+            const initializer = declaration.getInitializer();
+            if (initializer && (Node.isArrowFunction(initializer) || Node.isFunctionExpression(initializer))) {
+                bodies.push(initializer);
+            }
+        }
+    }
+    return bodies;
+}
+
+function isFunctionDeclaration(node) {
+    return Node.isFunctionDeclaration(node) ||
+        Node.isMethodDeclaration(node) ||
+        Node.isArrowFunction(node) ||
+        Node.isFunctionExpression(node);
+}
+
+function functionBody(node) {
+    return typeof node.getBody === 'function' ? node.getBody() : undefined;
+}
+
+function declarationName(declaration) {
+    if (Node.isFunctionDeclaration(declaration) || Node.isMethodDeclaration(declaration)) {
+        return declaration.getName() ?? '';
+    }
+    const parent = declaration.getParent();
+    return Node.isVariableDeclaration(parent) ? parent.getName() : '';
+}
+
+function callOperation(call) {
+    return call.getExpression().getText().replaceAll(/\s+/gu, ' ');
+}
+
+function addFinding(input) {
+    const { findings, node, rule, operation, boundary } = input;
+    const sourceFile = node.getSourceFile();
+    const position = sourceFile.getLineAndColumnAtPos(node.getStart());
+    const finding = {
+        rule,
+        path: sourcePath(sourceFile),
+        line: position.line,
+        column: position.column,
+        operation,
+        boundary: boundaryLabel(boundary)
+    };
+    findings.set(`${finding.rule}:${finding.path}:${node.getStart()}`, finding);
+}
+
+function boundaryLabel(boundary) {
+    const sourceFile = boundary.getSourceFile();
+    const position = sourceFile.getLineAndColumnAtPos(boundary.getStart());
+    return `${sourcePath(sourceFile)}:${position.line}`;
+}
+
+function sourcePath(sourceFile) {
+    return sourceFile.getFilePath()
+        .replaceAll('\\', '/')
+        .replace(/^.*\/(packages|apps\/api-v1\/src)\//u, '$1/');
+}
+
+function isAnalyzedSource(path) {
+    return (path.startsWith('packages/') || path.startsWith('apps/api-v1/src/')) &&
+        !path.startsWith('packages/tests/') &&
+        !path.startsWith('packages/shared-test/') &&
+        !path.startsWith('packages/shared-rtc-bench/') &&
+        !/(?:^|\/)(?:generated|vendor|fixtures?|mocks?)(?:\/|$)/u.test(path) &&
+        !/\.(?:test|spec|d)\.ts$/u.test(path);
+}
+
+function compareFindings(left, right) {
+    return left.path.localeCompare(right.path) ||
+        left.line - right.line ||
+        left.column - right.column ||
+        left.operation.localeCompare(right.operation);
+}

--- a/scripts/transaction-write-check/check-transaction-writes.mjs
+++ b/scripts/transaction-write-check/check-transaction-writes.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { Project } from 'ts-morph';
+
+import { analyzeTransactionWrites } from './analyze-transaction-writes.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../..');
+const project = new Project({
+    tsConfigFilePath: path.join(repositoryRoot, 'tsconfig.json'),
+    skipAddingFilesFromTsConfig: true
+});
+
+project.addSourceFilesAtPaths([
+    path.join(repositoryRoot, 'packages/**/*.ts'),
+    path.join(repositoryRoot, 'apps/api-v1/src/**/*.ts'),
+    `!${path.join(repositoryRoot, 'packages/tests/**')}`,
+    `!${path.join(repositoryRoot, 'packages/shared-test/**')}`,
+    `!${path.join(repositoryRoot, 'packages/shared-rtc-bench/**')}`
+]);
+
+const findings = analyzeTransactionWrites(project);
+for (const finding of findings) {
+    console.error(
+        `${finding.path}:${finding.line}:${finding.column} ` +
+            `${finding.rule} ${finding.operation} (boundary ${finding.boundary})`
+    );
+}
+if (findings.length > 0) {
+    console.error(`FAIL: transaction write check (${findings.length} findings)`);
+    process.exitCode = 1;
+}
+else {
+    console.log('PASS: transaction write check');
+}


### PR DESCRIPTION
Stacked on #406.

## What changed
- add a focused 352-line transaction-write analyzer instead of restoring the archived 27-module/17,000-line implementation
- report high-confidence clocks, randomness, serialization, hashing, sorting/canonicalization, named compute/prepare builders, and retry-loop transaction openings
- recognize PostgreSQL/PGlite callbacks, `runInPSqlTransaction`, IndexedDB readwrite transactions, and IndexedDB upgrades
- exclude tests/generated code and exact PostgreSQL ResourceInbox owners; browser QueueBox remains strict
- inspect lexical transaction bodies and explicit transaction-write functions without claiming arbitrary helper-graph or SQL provenance proof
- add `check:transaction-writes` as the fourth governance-gate phase
- publish the command and its human-review boundary in code-writing and testing skills

## Why this shape
The archived checker generated hundreds of unresolved/fingerprint findings and required a complex exception registry. This replacement deliberately enforces only evidence with a low false-positive rate. Ambiguous helper provenance, database-result refinement, and PostgreSQL business semantics remain mandatory human review.

## Validation
- transaction checker tests: 6 passed
- production transaction scan: PASS, zero findings
- checker scoped style: PASS, zero findings
- governance command tests: 14 passed
- authoritative mutation guidance integrity: 40 passed
- full repo governance: 27 files, 431 tests passed
- governed test typecheck: 1,054 files, zero debt/errors
- complete governance gate: PASS, four phases

## Explicit exclusions
- no exception/fingerprint registry
- no fail-closed unresolved-provenance rule
- no arbitrary helper-closure expansion
- no changes to production mutation behavior in this PR
