### PR TITLE
Add computed AppInbox transaction writes

### DIFF
--- a/packages/shared-server/queuebox/postgres/resource-inbox-reservation-write.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-reservation-write.ts
@@ -1,0 +1,29 @@
+import type { EntityStatus, Key } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
+
+export interface ResourceInboxReservationFinish {
+    readonly key: Key;
+    readonly expectedAttempts: number;
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+    readonly completedAt: Date;
+}
+
+export async function writeResourceInboxReservationFinish(
+    transaction: PSqlSql,
+    computed: ResourceInboxReservationFinish
+): Promise<boolean> {
+    const rows = await transaction<readonly { ri_row_id: bigint; }[]>`
+        update resource_inbox
+        set ri_status = ${computed.status}, end_ts = ${computed.completedAt}, next_ts = null
+        where ri_topic_id = ${computed.key.topicId}
+          and ri_resource_id = ${computed.key.resourceId}
+          and fk_ext_bank_id = ${computed.key.contextId}
+          and ri_status = 'RESERVED'
+          and ri_attempts = ${computed.expectedAttempts}
+          and expire_ts > (now() at time zone 'UTC')
+        returning ri_row_id
+    `;
+
+    return rows.length === 1;
+}

--- a/packages/shared-server/queuebox/postgres/resource-inbox-result-replacement.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-result-replacement.ts
@@ -1,0 +1,80 @@
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
+import {
+    toPgTimestamp,
+    toSystemDate,
+    type ResourceInboxResultsRow
+} from './resource-inbox-row-codec.ts';
+
+export interface ResourceInboxResultReplacement {
+    readonly resourceId: string;
+    readonly topicId: string;
+    readonly resource: string;
+    readonly typeId: string;
+    readonly status: ResourceEntry['status'];
+    readonly contextId: string;
+    readonly systemDate: string;
+    readonly createdBy: string;
+    readonly createdAt: string;
+    readonly expiresAt: string;
+}
+
+export function computeResourceInboxResultReplacement(
+    entry: ResourceEntry
+): ResourceInboxResultReplacement {
+    return {
+        resourceId: entry.key.resourceId,
+        topicId: entry.key.topicId,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        status: entry.status,
+        contextId: entry.key.contextId,
+        systemDate: toSystemDate(entry),
+        createdBy: entry.audit.createdBy,
+        createdAt: toPgTimestamp(entry.audit.createdTs),
+        expiresAt: toPgTimestamp(entry.audit.expiryTs)
+    };
+}
+
+export async function writeResourceInboxResultReplacement(
+    transaction: PSqlSql,
+    computed: ResourceInboxResultReplacement
+): Promise<ResourceInboxResultsRow> {
+    const rows = await transaction<readonly ResourceInboxResultsRow[]>`
+        insert into resource_inbox_results (ris_resource_id,
+                                            ris_topic_id,
+                                            ris_resource,
+                                            ris_type_id,
+                                            ris_status,
+                                            fk_ext_bank_id,
+                                            system_date,
+                                            created_by,
+                                            created_ts,
+                                            expire_ts)
+        values (${computed.resourceId},
+                ${computed.topicId},
+                ${computed.resource},
+                ${computed.typeId},
+                ${computed.status},
+                ${computed.contextId},
+                ${computed.systemDate},
+                ${computed.createdBy},
+                ${computed.createdAt},
+                ${computed.expiresAt})
+        on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
+            do update set ris_resource = excluded.ris_resource,
+                          ris_type_id  = excluded.ris_type_id,
+                          ris_status   = excluded.ris_status,
+                          system_date  = excluded.system_date,
+                          created_by   = excluded.created_by,
+                          created_ts   = excluded.created_ts,
+                          expire_ts    = excluded.expire_ts
+        returning *
+    `;
+
+    if (rows.length !== 1 || rows[0] === undefined) {
+        throw new Error('Resource inbox result replacement expected exactly one row');
+    }
+    return rows[0];
+}

--- a/packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts
@@ -1,11 +1,15 @@
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import {
-    ResourceInboxResultsRow,
     toPgTimestamp,
     toResultsDomain,
-    toSystemDate
+    toSystemDate,
+    type ResourceInboxResultsRow
 } from '@shared-server/queuebox/postgres/resource-inbox-row-codec.ts';
 import type { Key, ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import {
+    computeResourceInboxResultReplacement,
+    writeResourceInboxResultReplacement
+} from './resource-inbox-result-replacement.ts';
 
 export class ResourceInboxResultsRepository {
     private readonly sql: PSqlSql;
@@ -21,13 +25,9 @@ export class ResourceInboxResultsRepository {
     async begin<T>(
         fn: (repo: ResourceInboxResultsRepository) => Promise<T>
     ): Promise<T> {
-        const newVar = await this.sql.begin<T>(
-            async (sql: PSqlSql) => {
-                return await fn(new ResourceInboxResultsRepository(sql));
-            }
+        return await this.sql.begin(
+            async (sql) => await fn(new ResourceInboxResultsRepository(sql))
         );
-
-        return newVar as T;
     }
 
     async writeIfAbsentOrReplaceExpired(
@@ -83,45 +83,11 @@ export class ResourceInboxResultsRepository {
     }
 
     async replace(entry: ResourceEntry): Promise<ResourceEntry> {
-        const systemDate = toSystemDate(entry);
-
-        const rows = await this.sql<ResourceInboxResultsRow[]>`
-            insert into resource_inbox_results (ris_resource_id,
-                                                ris_topic_id,
-                                                ris_resource,
-                                                ris_type_id,
-                                                ris_status,
-                                                fk_ext_bank_id,
-                                                system_date,
-                                                created_by,
-                                                created_ts,
-                                                expire_ts)
-            values (${entry.key.resourceId},
-                    ${entry.key.topicId},
-                    ${entry.resource},
-                    ${entry.typeId},
-                    ${entry.status},
-                    ${entry.key.contextId},
-                    ${systemDate},
-                    ${entry.audit.createdBy},
-                    ${toPgTimestamp(entry.audit.createdTs)},
-                    ${toPgTimestamp(entry.audit.expiryTs)})
-            on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
-                do update set ris_resource = excluded.ris_resource,
-                              ris_type_id  = excluded.ris_type_id,
-                              ris_status   = excluded.ris_status,
-                              system_date  = excluded.system_date,
-                              created_by   = excluded.created_by,
-                              created_ts   = excluded.created_ts,
-                              expire_ts    = excluded.expire_ts
-            returning *
-        `;
-
-        if (rows.length !== 1) {
-            throw new Error('Replace failed: expected exactly one row');
-        }
-
-        return toResultsDomain(rows[0]);
+        const row = await writeResourceInboxResultReplacement(
+            this.sql,
+            computeResourceInboxResultReplacement(entry)
+        );
+        return toResultsDomain(row);
     }
 
     async findAnyByKey(key: Key): Promise<ResourceEntry | null> {

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
@@ -1,0 +1,156 @@
+import { Temporal } from '@js-temporal/polyfill';
+import {
+    EntityStatus,
+    toResourceEntryWithUpdatedResource,
+    type ResourceEntry
+} from '@shared/queuebox/ResourceEntry.ts';
+import type { ResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import {
+    computeResourceInboxResultReplacement,
+    type ResourceInboxResultReplacement
+} from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
+import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
+import { AppInboxReservationConflictError } from '../app-inbox-contracts.ts';
+import { encodeAppInboxResult } from '../app-inbox-registration-codecs.ts';
+
+export interface AppInboxCompletionValidationIssue {
+    readonly path: string;
+    readonly message: string;
+    readonly cause: TypeError;
+}
+
+export interface AppInboxCompletionFacts {
+    readonly entry: ResourceEntry;
+    readonly completedAtEpochMs: number;
+}
+
+export interface AppInboxCompletionInput<Result> extends AppInboxCompletionFacts {
+    readonly durableResult: Result;
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+}
+
+export interface AppInboxCompletionValidationFacts extends AppInboxCompletionFacts {
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+}
+
+export interface AppInboxCompletionComputed<Result> {
+    readonly durableResult: Result;
+    readonly encodedResult: JsonWireValue;
+    readonly resultReplacement: ResourceInboxResultReplacement;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly reservationConflict: AppInboxReservationConflictError;
+    readonly finalizedEntry: ResourceEntry;
+}
+
+export function computeAppInboxCompletion<Result>(
+    input: AppInboxCompletionInput<Result>
+): AppInboxCompletionComputed<Result> {
+    const encodedResult = encodeAppInboxResult(input.durableResult, 'AppInbox completion result');
+    return {
+        durableResult: input.durableResult,
+        encodedResult,
+        resultReplacement: computeResourceInboxResultReplacement(
+            toResourceEntryWithUpdatedResource(input.entry, input.status, encodedResult)
+        ),
+        reservationFinish: {
+            key: input.entry.key,
+            expectedAttempts: input.entry.dequeueAudit.attempts,
+            status: input.status,
+            completedAt: new Date(input.completedAtEpochMs)
+        },
+        reservationConflict: new AppInboxReservationConflictError(input.entry.key),
+        finalizedEntry: {
+            ...input.entry,
+            status: input.status,
+            dequeueAudit: {
+                ...input.entry.dequeueAudit,
+                endTs: Temporal.Instant.fromEpochMilliseconds(input.completedAtEpochMs),
+                nextTs: undefined
+            }
+        }
+    };
+}
+
+export function validateAppInboxCompletion<Result>(
+    input: AppInboxCompletionInput<Result>,
+    computed: AppInboxCompletionComputed<Result>
+): readonly AppInboxCompletionValidationIssue[] {
+    const issues = validateAppInboxCompletionFacts(input);
+    if (computed.durableResult !== input.durableResult) {
+        issues.push(toAppInboxCompletionValidationIssue('computed.durableResult', 'must be the computed result'));
+    }
+    if (
+        !hasSameResourceInboxKey(computed.reservationFinish.key, input.entry.key) ||
+        computed.reservationFinish.expectedAttempts !== input.entry.dequeueAudit.attempts ||
+        computed.reservationFinish.status !== input.status ||
+        computed.reservationFinish.completedAt.getTime() !== input.completedAtEpochMs
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.reservationFinish',
+            'must match the reserved entry and completion facts'
+        ));
+    }
+    if (
+        computed.resultReplacement.resourceId !== input.entry.key.resourceId ||
+        computed.resultReplacement.topicId !== input.entry.key.topicId ||
+        computed.resultReplacement.contextId !== input.entry.key.contextId ||
+        computed.resultReplacement.status !== input.status
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.resultReplacement',
+            'must target the reserved entry with the computed status'
+        ));
+    }
+    if (
+        !hasSameResourceInboxKey(computed.finalizedEntry.key, input.entry.key) ||
+        computed.finalizedEntry.status !== input.status ||
+        computed.finalizedEntry.dequeueAudit.endTs?.epochMilliseconds !== input.completedAtEpochMs ||
+        computed.finalizedEntry.dequeueAudit.nextTs !== undefined
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.finalizedEntry',
+            'must describe the completed reservation'
+        ));
+    }
+    return issues;
+}
+
+export function validateAppInboxCompletionFacts(
+    input: AppInboxCompletionValidationFacts
+): AppInboxCompletionValidationIssue[] {
+    const issues: AppInboxCompletionValidationIssue[] = [];
+    if (!Number.isSafeInteger(input.completedAtEpochMs) || Math.abs(input.completedAtEpochMs) > 8.64e15) {
+        issues.push(
+            toAppInboxCompletionValidationIssue('completedAtEpochMs', 'must be a valid epoch millisecond timestamp')
+        );
+    }
+    if (!Number.isSafeInteger(input.entry.dequeueAudit.attempts) || input.entry.dequeueAudit.attempts < 1) {
+        issues.push(
+            toAppInboxCompletionValidationIssue('entry.dequeueAudit.attempts', 'must identify a reserved attempt')
+        );
+    }
+    if (input.entry.status !== EntityStatus.RESERVED) {
+        issues.push(toAppInboxCompletionValidationIssue('entry.status', 'must be RESERVED'));
+    }
+    if (input.status !== EntityStatus.COMPLETED && input.status !== EntityStatus.FAILED) {
+        issues.push(toAppInboxCompletionValidationIssue('status', 'must be COMPLETED or FAILED'));
+    }
+    return issues;
+}
+
+function hasSameResourceInboxKey(
+    left: ResourceEntry['key'],
+    right: ResourceEntry['key']
+): boolean {
+    return left.topicId === right.topicId &&
+        left.resourceId === right.resourceId &&
+        left.contextId === right.contextId;
+}
+
+function toAppInboxCompletionValidationIssue(
+    path: string,
+    reason: string
+): AppInboxCompletionValidationIssue {
+    const message = `AppInbox ${path} ${reason}`;
+    return { path, message, cause: new TypeError(message) };
+}

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.ts
@@ -16,12 +16,12 @@ import {
 import { AppInboxCommandIdentityError, validateAppInboxCommandIdentity } from '../app-inbox-command-identity.ts';
 import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../app-inbox-contracts.ts';
 import { classifyAppInboxError, type AppInboxErrorClassification } from '../app-inbox-error-classification.ts';
-import { encodeAppInboxFailure } from '../app-inbox-failure.ts';
 import type { AppInboxOptions } from '../app-inbox-options.ts';
 import type { AppInboxResultRepository } from '../app-inbox-persistence-ports.ts';
 import { toAppInboxAttemptTimingDetails, toAppInboxTimingDetails } from './app-inbox-attempt-timing.ts';
+import { computeAppInboxCompletion, validateAppInboxCompletion } from './app-inbox-completion-computation.ts';
 import type { AppInboxHandlerRegistration } from './app-inbox-handler-registration.ts';
-import { AppInboxTransactionWriter, toFinalizedResourceEntry } from './app-inbox-transaction-writer.ts';
+import { AppInboxTransactionWriter } from './app-inbox-transaction-writer.ts';
 
 interface AppInboxExecutionAttempt<Command, Result> {
     readonly registration: AppInboxHandlerRegistration<Command, Result>;
@@ -200,16 +200,19 @@ export class AppInboxHandlerExecutor {
             entry: input.entry,
             encodeResult: input.registration.encodeResult
         };
-        await this.transactionWriter.writeTerminalFailure(
-            terminalContext,
-            encodeAppInboxFailure(input.classification.result)
-        );
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(terminalContext),
+            durableResult: input.classification.result,
+            status: EntityStatus.FAILED
+        } as const;
+        const computed = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        await this.transactionWriter.writeComputedTerminalFailure(terminalContext, computed);
         throw new ResourceInboxFinalizedByHandlerError(
-            toFinalizedResourceEntry(
-                terminalContext,
-                EntityStatus.FAILED,
-                this.nowEpochMs()
-            ),
+            computed.finalizedEntry,
             input.error
         );
     }

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
@@ -7,6 +7,8 @@ import {
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
 import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
+import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import { writeResourceInboxResultReplacement } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
 import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
 import type { RallarTimingDetails, RallarTimingSink } from '../../observability/timing.ts';
 import { timeRallarAsync } from '../../observability/timing.ts';
@@ -17,6 +19,7 @@ import {
     type AppInboxMessageContext
 } from '../app-inbox-contracts.ts';
 import { toAppInboxAttemptTimingDetails } from './app-inbox-attempt-timing.ts';
+import type { AppInboxCompletionComputed, AppInboxCompletionFacts } from './app-inbox-completion-computation.ts';
 
 export type AppInboxHandlerFinalization =
     | Readonly<{ state: 'pending'; }>
@@ -32,6 +35,20 @@ export interface AppInboxMutationTransactionResult<DurableResult, AfterCommitRes
 }
 
 export interface AppInboxMutationTransactionWriter {
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
+
+    writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result>;
+
+    writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
+
     writeMutation<Result>(
         context: AppInboxMessageContext<Result>,
         write: (transaction: PSqlSql) => Promise<Result>
@@ -76,12 +93,37 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         this.config = config;
     }
 
-    begin<Result>(context: AppInboxMessageContext<Result>): void {
+    begin(context: AppInboxExecutionMetadata): void {
         this.finalizationByContext.set(context, { state: 'pending' });
     }
 
-    read<Result>(context: AppInboxMessageContext<Result>): AppInboxHandlerFinalization {
+    read(context: AppInboxExecutionMetadata): AppInboxHandlerFinalization {
         return this.finalizationByContext.get(context) ?? { state: 'pending' };
+    }
+
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        return {
+            entry: context.entry,
+            completedAtEpochMs: this.nowEpochMs()
+        };
+    }
+
+    async writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result> {
+        await this.writeComputedFinalizedMutation(context, computed, write);
+        return computed.durableResult;
+    }
+
+    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
+        const afterCommitResult = await this.writeComputedFinalizedMutation(context, computed, write);
+        return { durableResult: computed.durableResult, afterCommitResult };
     }
 
     async writeMutation<Result>(
@@ -175,7 +217,37 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         });
     }
 
-    private ensurePending<Result>(context: AppInboxMessageContext<Result>): void {
+    async writeComputedTerminalFailure<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>
+    ): Promise<void> {
+        await this.writeComputedFinalizedMutation(context, computed, async () => {});
+    }
+
+    private async writeComputedFinalizedMutation<DurableResult, WriteResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<WriteResult>
+    ): Promise<WriteResult> {
+        this.ensurePending(context);
+        const result = await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
+            const writeResult = await write(transaction);
+            await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
+            const completed = await writeResourceInboxReservationFinish(transaction, computed.reservationFinish);
+            if (!completed) {
+                throw computed.reservationConflict;
+            }
+            return writeResult;
+        });
+        this.finalizationByContext.set(context, {
+            state: 'transaction-finalized',
+            status: computed.reservationFinish.status,
+            result: computed.encodedResult
+        });
+        return result;
+    }
+
+    private ensurePending(context: AppInboxExecutionMetadata): void {
         const current = this.finalizationByContext.get(context);
         if (current?.state === 'transaction-finalized') {
             throw new Error('App inbox handler context is already finalized');
@@ -185,8 +257,8 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         }
     }
 
-    private async inTransaction<ReturnResult, Result>(
-        context: AppInboxMessageContext<Result>,
+    private async inTransaction<ReturnResult>(
+        context: AppInboxExecutionMetadata,
         details: RallarTimingDetails,
         write: (
             transaction: PSqlSql,

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
@@ -1,0 +1,125 @@
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    validateAppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
+import { AppInboxTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
+import { EntityStatus, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+import { createAtomicHarness } from '../test-support/app-inbox-transaction-test-runtime.ts';
+
+describe('AppInbox successful completion computation', () => {
+    it('validates captured completion facts without inspecting the durable result', () => {
+        const harness = createAtomicHarness();
+        let propertyReads = 0;
+        const facts = {
+            ...new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' })
+                .readCompletionFacts(harness.context),
+            completedAtEpochMs: Number.NaN,
+            status: EntityStatus.COMPLETED,
+            get durableResult() {
+                propertyReads += 1;
+                return { status: 'accepted' };
+            }
+        } as const;
+
+        const issues = validateAppInboxCompletionFacts(facts);
+
+        expect(issues.map((issue) => issue.path)).toEqual(['completedAtEpochMs']);
+        expect(propertyReads).toBe(0);
+    });
+
+    it('rejects completion data for a different reservation', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const durableResult = { status: 'accepted', revision: 2 } as const;
+        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        const candidate = {
+            ...computed,
+            reservationFinish: {
+                ...computed.reservationFinish,
+                expectedAttempts: computed.reservationFinish.expectedAttempts + 1
+            }
+        };
+
+        const issues = validateAppInboxCompletion(input, candidate);
+
+        expect(issues.map((issue) => issue.path)).toEqual(['computed.reservationFinish']);
+        expect(harness.database.beginCalls).toBe(0);
+    });
+
+    it('validates reservation identity by value rather than object identity', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const input = {
+            ...writer.readCompletionFacts(harness.context),
+            status: EntityStatus.COMPLETED,
+            durableResult: { status: 'accepted' }
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const copied = {
+            ...computed,
+            reservationFinish: {
+                ...computed.reservationFinish,
+                key: { ...computed.reservationFinish.key }
+            },
+            finalizedEntry: {
+                ...computed.finalizedEntry,
+                key: { ...computed.finalizedEntry.key }
+            }
+        };
+
+        expect(validateAppInboxCompletion(input, copied)).toEqual([]);
+    });
+
+    it('captures completion facts in read and consumes the exact result in write', async () => {
+        const harness = createAtomicHarness();
+        let clockReads = 0;
+        let readAllowed = true;
+        const nowEpochMs = () => {
+            if (!readAllowed) {
+                throw new Error('Completion facts were read after compute');
+            }
+            clockReads += 1;
+            return Date.parse('2026-07-22T12:00:01.000Z');
+        };
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1', nowEpochMs });
+        const facts = writer.readCompletionFacts(harness.context);
+        const durableResult = { status: 'accepted', revision: 2 } as const;
+        const input = { ...facts, status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
+        readAllowed = false;
+
+        const result = await writer.writeComputedMutation(harness.context, computed, async () => {
+            harness.database.writeMutation('group-1', { revision: 2 });
+        });
+
+        expect(result).toBe(durableResult);
+        expect(clockReads).toBe(1);
+        expect(harness.database.beginCalls).toBe(1);
+        const key = toKeyAsString(harness.entry.key);
+        expect(harness.database.state.results.get(key)?.resource).toBe(JSON.stringify(durableResult));
+        expect(harness.database.state.inbox.get(key)?.status).toBe(EntityStatus.COMPLETED);
+    });
+
+    it('keeps private after-commit data separate from the computed durable result', async () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const durableResult = { status: 'accepted' } as const;
+        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
+        const afterCommitResult = { wakeQueue: true };
+
+        const result = await writer.writeComputedMutationWithAfterCommitResult(
+            harness.context,
+            computed,
+            async () => afterCommitResult
+        );
+
+        expect(result).toEqual({ durableResult, afterCommitResult });
+        expect(harness.database.state.results.get(toKeyAsString(harness.entry.key))?.resource).toBe(JSON.stringify(durableResult));
+    });
+});

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -19,8 +19,15 @@ import type {
 import { decodeAuthMutationIntent } from '@shared-server/rallar-system/auth/mutation/decode-auth-mutation-intent.ts';
 
 import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
-import type { AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxExecutionMetadata,
+    AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type {
     AppInboxMutationTransactionResult,
     AppInboxMutationTransactionWriter
@@ -194,6 +201,26 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
     constructor(actions: string[], transaction: PSqlSql) {
         this.actions = actions;
         this.transaction = transaction;
+    }
+
+    readCompletionFacts(_context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        throw new Error('Computed transaction path must not run');
+    }
+
+    async writeComputedMutation<Result>(
+        _context: AppInboxExecutionMetadata,
+        _computed: AppInboxCompletionComputed<Result>,
+        _write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result> {
+        throw new Error('Computed transaction path must not run');
+    }
+
+    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        _context: AppInboxExecutionMetadata,
+        _computed: AppInboxCompletionComputed<DurableResult>,
+        _write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
+        throw new Error('Computed after-commit transaction path must not run');
     }
 
     async writeMutation<Result>(

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
-import { type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxExecutionMetadata,
+    AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     AppInboxTransactionWriter,
     type AppInboxMutationTransactionResult,
@@ -31,6 +38,17 @@ type DurableResult = Readonly<{ status: 'durable'; }>;
 type AfterCommitResult = Readonly<{ committedSnapshot: GroupSnapshot | undefined; }>;
 type TransactionResult = AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>;
 type ExpectedTransactionWriter = {
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
+    writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result>;
+    writeComputedMutationWithAfterCommitResult<Durable, AfterCommit>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Durable>,
+        write: (transaction: PSqlSql) => Promise<AfterCommit>
+    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
     writeMutation<Result>(
         context: AppInboxMessageContext<Result>,
         write: (transaction: PSqlSql) => Promise<Result>

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -3,8 +3,16 @@ import { describe, expect, it } from 'vitest';
 
 import type { PSqlParameter, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
-import { AppInboxType, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import {
+    AppInboxType,
+    type AppInboxExecutionMetadata,
+    type AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupMutationPreparation } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import { GroupStateInboxHandler } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
@@ -121,6 +129,19 @@ describe('group-state AppInbox transaction result boundary', () => {
     it('persists an inactive presence result once without active mutation effects', async () => {
         const actions: string[] = [];
         const transactionWriter: AppInboxMutationTransactionWriter = {
+            readCompletionFacts: (_context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
+                throw new Error('Inactive presence must not read computed completion facts');
+            },
+            writeComputedMutation: async <Result>(
+                _context: AppInboxExecutionMetadata,
+                _computed: AppInboxCompletionComputed<Result>,
+                _write: (transaction: PSqlSql) => Promise<void>
+            ): Promise<Result> => {
+                throw new Error('Inactive presence must not use computed mutation transaction');
+            },
+            writeComputedMutationWithAfterCommitResult: async () => {
+                throw new Error('Inactive presence must not use computed after-commit transaction');
+            },
             writeMutation: async (_context, write) => {
                 actions.push('inactive-transaction');
                 return await write(createUnusedTransaction());


### PR DESCRIPTION
## Goal

Introduce the small, explicit AppInbox persistence boundary needed to migrate domain services to `read → compute → validate → write(computed)` without carrying PR #403's generic validator framework or unrelated domain rewrites.

## Changes

- compute terminal AppInbox result encoding, persistence values, reservation finish values, and finalized queue entry before transaction entry
- add `writeComputedMutation*` entry points that execute only the supplied persistence callback and prepared AppInbox writes
- keep ResourceInbox SQL under one queue persistence owner; the existing repository delegates to that owner instead of duplicating SQL
- migrate terminal failure finalization to the strict path
- validate operation-owned completion fields with direct pure checks and value-based queue identity

## Review assessment

- Navigability: direct handler → completion compute/validate → transaction writer → two queue SQL adapters; navigation checker reports no findings
- Readability: named operation records, no recursive object walker, Proxy hardening framework, Node runtime introspection, or hidden retry
- Maintainability: one result-upsert SQL owner; no copied SQL; strict methods are additive only to keep the approved stacked migration reviewable
- Temporary stack constraint: the callback-returning writer methods remain until all eleven domain callers migrate in child PRs, then they will be deleted. They are not the final architecture.

## Validation

- `npx tsc -p packages/shared-server/tsconfig.json --noEmit --pretty false`
- focused AppInbox and result-replacement tests: 4 files, 43 tests passed
- `npm run check:repo-style:changed -- e09fd15a`: pass, no new findings
- scoped navigation-details: pass, zero findings
- `npm run check:repo-structure`: pass; two inherited findings in `packages/shared/api` belong to the parent PR structure change, not this slice
- dprint and `git diff --check`: pass (dprint cache write warning is host sandbox-only)

## Risk and rollback

The new strict methods are additive; only terminal failures use them in this PR. Rollback is the single commit in this PR. Successful domain mutations continue on the existing path until their reviewed child slices migrate.
