### PR TITLE
Precompute Admin prune persistence before transactions

### DIFF
--- a/apps/api-v1/test/admin-operations/persistence/admin-prune-cutoff-and-expiry.test.ts
+++ b/apps/api-v1/test/admin-operations/persistence/admin-prune-cutoff-and-expiry.test.ts
@@ -56,18 +56,13 @@ Deno.test('prune progress renews physical and JSON aggregate expiry together', a
             expireAtEpochMs: now + 120_000
         };
         const successor = toAdminPruneAggregateEntry(renewed);
+        const progressWrite = {
+            expectedAggregate: currentEntry.resource,
+            aggregateSuccessor: successor,
+            aggregateSuccessorExpiryAtIsoTimestamp: successor.audit.expiryTs.toString()
+        };
         await sql.begin(async (transaction) => {
-            await new PSqlAdminPruneRepository(sql).writeProgress(transaction, {
-                kind: 'page',
-                jobId: current.jobId,
-                category: 'runtime-state',
-                rowIds: [],
-                deletedRows: 0,
-                next: null,
-                expectedAggregate: currentEntry.resource,
-                aggregateSuccessor: successor,
-                finishedAtEpochMs: now + 1
-            });
+            await new PSqlAdminPruneRepository(sql).writeProgress(transaction, progressWrite);
         });
         const [stored] = await sql<{ ris_resource: string; expire_epoch_ms: string | number; }[]>`
       select ris_resource, floor(extract(epoch from expire_ts) * 1000)::bigint as expire_epoch_ms

--- a/apps/api-v1/test/admin-operations/persistence/admin-prune-pages.test.ts
+++ b/apps/api-v1/test/admin-operations/persistence/admin-prune-pages.test.ts
@@ -6,12 +6,14 @@ import {
 import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
 import { PSqlAdminPruneRepository } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
 import { toAdminPruneOutbox, type AdminPrunePageWork } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
+import { toAdminPrunePageDelete } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import {
     advanceAdminPruneAggregate,
     createAdminPruneAggregate,
     toAdminPruneAggregateEntry,
     toAdminPruneAggregateKey
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-progress.ts';
+import { computeAppOutboxInsert } from '@shared-server/rallar-system/app-outbox/app-outbox-insert.ts';
 import assert from 'node:assert/strict';
 import { createResourceEntry, readPGliteDatabaseEpochMs, withPGliteSql } from '../../db/pglite-auth-test-harness.ts';
 
@@ -55,8 +57,9 @@ Deno.test('admin prune PSQL repository reads and deletes one deterministic page'
             pageIndex: 0,
             appData: null
         };
+        const deletion = toAdminPrunePageDelete(work, read.rowIds);
         await sql.begin(async (transaction) => {
-            assert.equal(await repository.deletePage(transaction, work, read.rowIds), 2);
+            assert.equal(await repository.deletePage(transaction, deletion), 2);
         });
         const [remaining] = await sql<{ count: string | number; }[]>`
       select count(*) as count from runtime_state_store where expire_at_ts <= ${new Date(now)}
@@ -135,12 +138,13 @@ Deno.test('admin prune successor outbox rejects an identical active identity', a
             },
             'server-1'
         );
+        const outboxWrite = computeAppOutboxInsert(entry);
         await createPSqlResourceInboxRepository(sql).entries.write(entry);
 
         await assert.rejects(
             () =>
                 sql.begin(async (transaction) => {
-                    await new PSqlAdminPruneRepository(sql).writeOutbox(transaction, entry);
+                    await new PSqlAdminPruneRepository(sql).writeOutbox(transaction, outboxWrite);
                 }),
             Error
         );
@@ -164,23 +168,24 @@ Deno.test('admin prune PSQL progress CAS completes the aggregate result', async 
         await new ResourceInboxResultsRepository(sql).replace(aggregateEntry);
 
         const repository = new PSqlAdminPruneRepository(sql);
+        const page = {
+            kind: 'page',
+            jobId: 'job-aggregate',
+            category: 'runtime-state',
+            rowIds: ['1', '2'],
+            deletedRows: 2,
+            next: null
+        } as const;
+        const aggregateSuccessor = toAdminPruneAggregateEntry(
+            advanceAdminPruneAggregate(aggregate, page)
+        );
+        const progressWrite = {
+            expectedAggregate: aggregateEntry.resource,
+            aggregateSuccessor,
+            aggregateSuccessorExpiryAtIsoTimestamp: aggregateSuccessor.audit.expiryTs.toString()
+        };
         await sql.begin(async (transaction) => {
-            const page = {
-                kind: 'page',
-                jobId: 'job-aggregate',
-                category: 'runtime-state',
-                rowIds: ['1', '2'],
-                deletedRows: 2,
-                next: null
-            } as const;
-            await repository.writeProgress(transaction, {
-                ...page,
-                expectedAggregate: aggregateEntry.resource,
-                aggregateSuccessor: toAdminPruneAggregateEntry(
-                    advanceAdminPruneAggregate(aggregate, page)
-                ),
-                finishedAtEpochMs: now
-            });
+            await repository.writeProgress(transaction, progressWrite);
         });
 
         const result = await new ResourceInboxResultsRepository(sql).findAnyByKey(

--- a/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
@@ -4,16 +4,13 @@ import {
     type AdminPruneExpiredRequest
 } from '@shared/api/admin-operations-types.ts';
 import type { AuthSession } from '@shared/api/api-config.ts';
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { TryWithExhaustedError, TryWithPolicy, tryWithPolicy } from '@shared/resilience/TryWith.ts';
 import type { InboxQueueReader } from '@shared/services/inbox-queue-reader.ts';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 
-import { PSqlResourceInboxEntryRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-
-import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
 import type { AppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import { toUnavailableAppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import {
@@ -31,13 +28,12 @@ import { createAppInboxClientRuntime } from '../../app-inbox/client/create-app-i
 import { AppInboxHandlerRegistry } from '../../app-inbox/handler/app-inbox-handler-registry.ts';
 import { createAppInboxHandlerRuntime } from '../../app-inbox/handler/app-inbox-handler-runtime.ts';
 import { AppInboxTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
+import { writeAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
 import type { AdminExpiredDataPruner } from '../admin-expired-data-pruner.ts';
 import { toAdminPruneExpiredOptions } from '../admin-prune-options.ts';
-import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
+import { writeAdminPruneAggregate } from '../postgres/p-sql-admin-prune-repository.ts';
 import {
-    createAdminPruneAggregate,
     decodeAdminPruneAggregate,
-    toAdminPruneAggregateEntry,
     toAdminPruneAggregateKey,
     toAdminPruneCompletedResultForCommand
 } from '../prune/admin-prune-progress.ts';
@@ -47,7 +43,7 @@ import {
     type AdminPruneCommand
 } from './admin-prune-command-codec.ts';
 
-import { AppInboxType, type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import { AppInboxType, type AppInboxExecutionMetadata } from '../../app-inbox/app-inbox-contracts.ts';
 
 import { recordRallarTiming, timeRallarAsync, type RallarTimingSink } from '../../observability/timing.ts';
 import {
@@ -66,7 +62,13 @@ import {
     type AdminPruneIdempotencyIdentityInput,
     type AdminPruneTimingIdentity
 } from './admin-prune-inbox-identity.ts';
-import { throwOnAdminPruneValidationIssues, type AdminPruneValidationIssue } from './admin-prune-inbox-validation.ts';
+import { throwOnAdminPruneValidationIssues } from './admin-prune-inbox-validation.ts';
+import {
+    computeAdminPruneMutation,
+    validateAdminPruneMutation,
+    type AdminPruneComputed,
+    type AdminPruneRead
+} from './compute-admin-prune-mutation.ts';
 
 export interface AdminPruneAuthorityReaderInput {
     readonly requestedBy: string;
@@ -102,20 +104,6 @@ export interface AppAdminInboxServiceConfig {
     readonly pageSize: number;
     readonly timing?: RallarTimingSink;
     readonly appInbox: AppInboxOptions;
-}
-
-interface AdminPruneRead {
-    readonly command: AdminPruneCommand;
-    readonly expiredRows: Readonly<Record<AdminPruneExpiredCategory, number>>;
-    readonly authority: AdminPruneAuthority;
-    readonly nowEpochMs: number;
-}
-
-interface AdminPruneComputed {
-    readonly read: AdminPruneRead;
-    readonly result: AdminPruneEnqueueResult;
-    readonly outboxEntries: readonly ResourceEntry[];
-    readonly aggregateEntry: ResourceEntry | null;
 }
 
 export class AppAdminInboxService {
@@ -229,7 +217,7 @@ export class AppAdminInboxService {
 
     private async processCommand(
         value: AdminPruneCommand,
-        context: AppInboxMessageContext<AdminPruneEnqueueResult>
+        context: AppInboxExecutionMetadata
     ): Promise<AdminPruneEnqueueResult> {
         const command = decodeAdminPruneCommand(value);
         await assertAdminPruneQueueIdentity(command, context);
@@ -237,38 +225,35 @@ export class AppAdminInboxService {
         const read = await this.timeAdminPrunePhase(
             'read',
             command,
-            async () => await this.read(command)
+            async () => await this.read(command, context)
         );
-        const computed = await this.timeAdminPrunePhase('compute', command, () => Promise.resolve(this.compute(read)));
+        const computed = await this.timeAdminPrunePhase(
+            'compute',
+            command,
+            () => Promise.resolve(computeAdminPruneMutation(read))
+        );
         const issues = await this.timeAdminPrunePhase(
             'validate',
             command,
-            () => Promise.resolve(this.validate(computed))
+            () => Promise.resolve(validateAdminPruneMutation(read, computed))
         );
         throwOnAdminPruneValidationIssues(issues);
 
-        const result = await this.transactionWriter.writeMutation(context, async (transaction) => {
-            const outbox = new PSqlResourceInboxEntryRepository(transaction);
-            for (const entry of computed.outboxEntries) {
-                await outbox.write(entry);
-            }
-            if (computed.aggregateEntry !== null) {
-                const stored = await new ResourceInboxResultsRepository(
-                    transaction
-                ).writeIfAbsentOrReplaceExpired(computed.aggregateEntry);
-                if (stored.resource !== computed.aggregateEntry.resource) {
-                    throw new Error('Admin prune aggregate collides with an active job');
-                }
-            }
-            return computed.result;
-        });
+        const result = await this.transactionWriter.writeComputedMutation(
+            context,
+            computed.completion,
+            async (transaction) => await this.write(transaction, computed)
+        );
         if (!command.dryRun) {
             this.dependencies.wakeQueueEngine();
         }
         return result;
     }
 
-    private async read(command: AdminPruneCommand): Promise<AdminPruneRead> {
+    private async read(
+        command: AdminPruneCommand,
+        context: AppInboxExecutionMetadata
+    ): Promise<AdminPruneRead> {
         const nowEpochMs = this.config.appInbox.nowEpochMs?.() ?? Date.now();
         const countPairs = ADMIN_PRUNE_EXPIRED_CATEGORIES.map(async (category) => {
             const count = command.categories.includes(category)
@@ -293,79 +278,23 @@ export class AppAdminInboxService {
         for (const [category, count] of pairs) {
             expiredRows[category] = count;
         }
-        return { command, expiredRows, authority, nowEpochMs };
-    }
-
-    private compute(read: AdminPruneRead): AdminPruneComputed {
-        const command = read.command;
-        const results = command.categories.map((category) => ({
-            category,
-            expiredRows: read.expiredRows[category],
-            deletedRows: 0,
-            dryRun: command.dryRun
-        }));
         return {
-            read,
-            outboxEntries: createInitialAdminPrunePages(command, this.serviceId),
-            aggregateEntry: command.dryRun
-                ? null
-                : toAdminPruneAggregateEntry(
-                    createAdminPruneAggregate({
-                        jobId: command.jobId,
-                        generatedAtEpochMs: command.capturedAtEpochMs,
-                        expireAtEpochMs: command.expireAtEpochMs,
-                        serverId: this.serviceId,
-                        requestedBy: command.requestedBy,
-                        requestedSessionId: command.requestedSessionId,
-                        categories: command.categories,
-                        expiredRows: read.expiredRows
-                    })
-                ),
-            result: {
-                generatedAtEpochMs: command.capturedAtEpochMs,
-                serverId: this.serviceId,
-                warnings: [],
-                operation: 'maintenance.prune-expired',
-                status: command.dryRun ? 'dry-run' : 'queued',
-                changed: false,
-                jobId: command.jobId,
-                results
-            }
+            command,
+            expiredRows,
+            authority,
+            nowEpochMs,
+            serviceId: this.serviceId,
+            completionFacts: this.transactionWriter.readCompletionFacts(context)
         };
     }
 
-    private validate(computed: AdminPruneComputed): readonly AdminPruneValidationIssue[] {
-        const { command } = computed.read;
-        const issues: AdminPruneValidationIssue[] = [];
-        if (!computed.read.authority.allowed || command.expireAtEpochMs <= computed.read.nowEpochMs) {
-            issues.push({
-                code: 'admin-prune-authority-denied',
-                message: 'Admin prune current authority is denied',
-                status: 403
-            });
+    private async write(transaction: PSqlSql, computed: AdminPruneComputed): Promise<void> {
+        for (const outboxWrite of computed.outboxWrites) {
+            await writeAppOutboxInsert(transaction, outboxWrite);
         }
-        if (computed.result.jobId !== command.jobId) {
-            issues.push({
-                code: 'admin-prune-computed-identity-invalid',
-                message: 'Admin prune computed identity differs from command',
-                status: 400
-            });
+        if (computed.aggregateWrite !== null) {
+            await writeAdminPruneAggregate(transaction, computed.aggregateWrite);
         }
-        if (computed.outboxEntries.length !== (command.dryRun ? 0 : command.categories.length)) {
-            issues.push({
-                code: 'admin-prune-computed-category-count-invalid',
-                message: 'Admin prune computed category count is invalid',
-                status: 400
-            });
-        }
-        if ((computed.aggregateEntry === null) !== command.dryRun) {
-            issues.push({
-                code: 'admin-prune-aggregate-presence-invalid',
-                message: 'Admin prune aggregate presence is invalid',
-                status: 400
-            });
-        }
-        return issues;
     }
 
     private async toCallerResult(
@@ -455,31 +384,4 @@ function createWaitPolicy(label: string, options: AppInboxOptions): TryWithPolic
             options.waitMaxRetryIntervalMsecs ?? DEFAULT_APP_INBOX_WAIT_MAX_RETRY_INTERVAL_MSECS
         )
         .jitterRatio(options.waitJitterRatio ?? DEFAULT_APP_INBOX_WAIT_JITTER_RATIO);
-}
-
-function createInitialAdminPrunePages(
-    command: AdminPruneCommand,
-    serviceId: string
-): readonly ResourceEntry[] {
-    if (command.dryRun) {
-        return [];
-    }
-    return command.categories.map((category) =>
-        toAdminPruneOutbox(
-            {
-                kind: 'page',
-                jobId: command.jobId,
-                category,
-                requestedBy: command.requestedBy,
-                requestedSessionId: command.requestedSessionId,
-                capturedAtEpochMs: command.capturedAtEpochMs,
-                expireAtEpochMs: command.expireAtEpochMs,
-                pageSize: command.pageSize,
-                afterCursor: null,
-                pageIndex: 0,
-                appData: category === 'app-data' ? command.appData : null
-            },
-            serviceId
-        )
-    );
 }

--- a/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
@@ -1,0 +1,198 @@
+import type { AdminPruneExpiredCategory } from '@shared/api/admin-operations-types.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import {
+    toPgTimestamp,
+    toSystemDate
+} from '../../../queuebox/postgres/resource-inbox-row-codec.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed,
+    type AppInboxCompletionFacts
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import {
+    computeAppOutboxInsert,
+    type AppOutboxInsert
+} from '../../app-outbox/app-outbox-insert.ts';
+import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
+import {
+    createAdminPruneAggregate,
+    toAdminPruneAggregateEntry,
+    toAdminPruneAggregateKey
+} from '../prune/admin-prune-progress.ts';
+import type { AdminPruneCommand } from './admin-prune-command-codec.ts';
+import type { AdminPruneEnqueueResult } from './admin-prune-inbox-codec.ts';
+import type { AdminPruneValidationIssue } from './admin-prune-inbox-validation.ts';
+import type { AdminPruneAuthority } from './app-admin-inbox-service.ts';
+
+export interface AdminPruneRead {
+    readonly command: AdminPruneCommand;
+    readonly expiredRows: Readonly<Record<AdminPruneExpiredCategory, number>>;
+    readonly authority: AdminPruneAuthority;
+    readonly nowEpochMs: number;
+    readonly serviceId: string;
+    readonly completionFacts: AppInboxCompletionFacts;
+}
+
+export interface AdminPruneAggregateWrite {
+    readonly entry: Readonly<ResourceEntry>;
+    readonly systemDate: string;
+    readonly createdAt: string;
+    readonly expiresAt: string;
+}
+
+export interface AdminPruneComputed {
+    readonly result: AdminPruneEnqueueResult;
+    readonly outboxWrites: readonly AppOutboxInsert[];
+    readonly aggregateWrite: AdminPruneAggregateWrite | null;
+    readonly completion: AppInboxCompletionComputed<AdminPruneEnqueueResult>;
+}
+
+export function computeAdminPruneMutation(read: AdminPruneRead): AdminPruneComputed {
+    const command = read.command;
+    const result: AdminPruneEnqueueResult = {
+        generatedAtEpochMs: command.capturedAtEpochMs,
+        serverId: read.serviceId,
+        warnings: [],
+        operation: 'maintenance.prune-expired',
+        status: command.dryRun ? 'dry-run' : 'queued',
+        changed: false,
+        jobId: command.jobId,
+        results: command.categories.map((category) => ({
+            category,
+            expiredRows: read.expiredRows[category],
+            deletedRows: 0,
+            dryRun: command.dryRun
+        }))
+    };
+    return {
+        result,
+        outboxWrites: computeInitialAdminPrunePages(command, read.serviceId),
+        aggregateWrite: command.dryRun
+            ? null
+            : computeAdminPruneAggregateWrite(toAdminPruneAggregateEntry(createAdminPruneAggregate({
+                jobId: command.jobId,
+                generatedAtEpochMs: command.capturedAtEpochMs,
+                expireAtEpochMs: command.expireAtEpochMs,
+                serverId: read.serviceId,
+                requestedBy: command.requestedBy,
+                requestedSessionId: command.requestedSessionId,
+                categories: command.categories,
+                expiredRows: read.expiredRows
+            }))),
+        completion: computeAppInboxCompletion({
+            ...read.completionFacts,
+            durableResult: result,
+            status: EntityStatus.COMPLETED
+        })
+    };
+}
+
+export function validateAdminPruneMutation(
+    read: AdminPruneRead,
+    computed: AdminPruneComputed
+): readonly AdminPruneValidationIssue[] {
+    const issues: AdminPruneValidationIssue[] = [];
+    if (!read.authority.allowed || read.command.expireAtEpochMs <= read.nowEpochMs) {
+        issues.push({
+            code: 'admin-prune-authority-denied',
+            message: 'Admin prune current authority is denied',
+            status: 403
+        });
+    }
+    if (
+        computed.result.jobId !== read.command.jobId ||
+        computed.result.serverId !== read.serviceId ||
+        computed.result.status !== (read.command.dryRun ? 'dry-run' : 'queued')
+    ) {
+        issues.push({
+            code: 'admin-prune-computed-identity-invalid',
+            message: 'Admin prune computed identity differs from its read facts',
+            status: 400
+        });
+    }
+    if (computed.outboxWrites.length !== (read.command.dryRun ? 0 : read.command.categories.length)) {
+        issues.push({
+            code: 'admin-prune-computed-category-count-invalid',
+            message: 'Admin prune computed category count is invalid',
+            status: 400
+        });
+    }
+    if (!hasExpectedAggregateWrite(read, computed.aggregateWrite)) {
+        issues.push({
+            code: 'admin-prune-aggregate-presence-invalid',
+            message: 'Admin prune aggregate write differs from its command',
+            status: 400
+        });
+    }
+    issues.push(
+        ...validateAppInboxCompletion(
+            {
+                ...read.completionFacts,
+                durableResult: computed.result,
+                status: EntityStatus.COMPLETED
+            },
+            computed.completion
+        ).map((issue) => ({
+            code: 'admin-prune-completion-invalid',
+            message: issue.message,
+            status: 500
+        }))
+    );
+    return issues;
+}
+
+function computeInitialAdminPrunePages(
+    command: AdminPruneCommand,
+    serviceId: string
+): readonly AppOutboxInsert[] {
+    if (command.dryRun) {
+        return [];
+    }
+    return command.categories.map((category) =>
+        computeAppOutboxInsert(toAdminPruneOutbox({
+            kind: 'page',
+            jobId: command.jobId,
+            category,
+            requestedBy: command.requestedBy,
+            requestedSessionId: command.requestedSessionId,
+            capturedAtEpochMs: command.capturedAtEpochMs,
+            expireAtEpochMs: command.expireAtEpochMs,
+            pageSize: command.pageSize,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: category === 'app-data' ? command.appData : null
+        }, serviceId))
+    );
+}
+
+function computeAdminPruneAggregateWrite(entry: ResourceEntry): AdminPruneAggregateWrite {
+    const snapshot: Readonly<ResourceEntry> = {
+        ...entry,
+        key: { ...entry.key },
+        audit: { ...entry.audit },
+        dequeueAudit: { ...entry.dequeueAudit }
+    };
+    return {
+        entry: snapshot,
+        systemDate: toSystemDate(snapshot),
+        createdAt: toPgTimestamp(snapshot.audit.createdTs),
+        expiresAt: toPgTimestamp(snapshot.audit.expiryTs)
+    };
+}
+
+function hasExpectedAggregateWrite(
+    read: AdminPruneRead,
+    aggregateWrite: AdminPruneAggregateWrite | null
+): boolean {
+    if (read.command.dryRun) {
+        return aggregateWrite === null;
+    }
+    if (aggregateWrite === null) {
+        return false;
+    }
+    const expectedKey = toAdminPruneAggregateKey(read.command.jobId);
+    return aggregateWrite.entry.key.topicId === expectedKey.topicId &&
+        aggregateWrite.entry.key.resourceId === expectedKey.resourceId &&
+        aggregateWrite.entry.key.contextId === expectedKey.contextId;
+}

--- a/packages/shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts
+++ b/packages/shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts
@@ -1,13 +1,13 @@
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { PSqlResourceInboxEntryRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
+import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
-import type { AdminPrunePageWork } from '../prune/admin-prune-page-codec.ts';
+import { writeAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import type { AdminPruneAggregateWrite } from '../inbox/compute-admin-prune-mutation.ts';
 import type {
     AdminPruneCandidatePage,
-    AdminPrunePageComputed,
-    AdminPrunePageRepository
+    AdminPrunePageDelete,
+    AdminPrunePageRepository,
+    AdminPruneProgressWrite
 } from '../prune/admin-prune-page-worker.ts';
 import { decodeAdminPruneAggregate, toAdminPruneAggregateKey } from '../prune/admin-prune-progress.ts';
 
@@ -15,6 +15,14 @@ type RuntimeRow = Readonly<{ store_namespace: string; store_key: string; }>;
 type ResourceRow = Readonly<{ ri_row_id: number | string; }>;
 type ResultsRow = Readonly<{ ris_row_id: number | string; }>;
 type AppDataRow = Readonly<{ store_name: string; data_key: string; }>;
+
+class AdminPruneProgressConflictError extends Error {
+    readonly code = 'admin-prune-progress-conflict';
+
+    constructor() {
+        super('Admin prune aggregate changed before commit');
+    }
+}
 
 export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
     private readonly sql: PSqlSql;
@@ -38,13 +46,12 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
 
     async deletePage(
         transaction: PSqlSql,
-        command: AdminPrunePageWork,
-        rowIds: readonly string[]
+        deletion: AdminPrunePageDelete
     ): Promise<number> {
-        if (rowIds.length === 0) {
+        if (deletion.rowIds.length === 0) {
             return 0;
         }
-        return await deletePageRows(transaction, command, rowIds);
+        return await deletePageRows(transaction, deletion);
     }
 
     async readAggregate(jobId: string) {
@@ -61,20 +68,23 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
         return { aggregate, resource: current.resource };
     }
 
-    async writeOutbox(transaction: PSqlSql, entry: ResourceEntry): Promise<void> {
-        await new PSqlResourceInboxEntryRepository(transaction).write(entry);
+    async writeOutbox(
+        transaction: PSqlSql,
+        computed: Parameters<AdminPrunePageRepository['writeOutbox']>[1]
+    ): Promise<void> {
+        await writeAppOutboxInsert(transaction, computed);
     }
 
     async writeProgress(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed
+        computed: AdminPruneProgressWrite
     ): Promise<void> {
         const next = computed.aggregateSuccessor;
         const key = next.key;
         const rows = await transaction<{ ris_row_id: number | string; }[]>`
             update resource_inbox_results
             set ris_resource = ${next.resource}, ris_status = ${next.status},
-                expire_ts = ${next.audit.expiryTs.toString()}
+                expire_ts = ${computed.aggregateSuccessorExpiryAtIsoTimestamp}
             where ris_topic_id = ${key.topicId}
               and ris_resource_id = ${key.resourceId}
               and fk_ext_bank_id = ${key.contextId}
@@ -82,23 +92,71 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
             returning ris_row_id
         `;
         if (rows.length !== 1) {
-            throw Object.assign(new Error('Admin prune aggregate changed before commit'), {
-                code: 'admin-prune-progress-conflict'
-            });
+            throw new AdminPruneProgressConflictError();
         }
     }
 
     async finishReserved(
         transaction: PSqlSql,
-        entry: ResourceEntry,
-        finishedAtEpochMs: number
+        completion: Parameters<AdminPrunePageRepository['finishReserved']>[1]
     ): Promise<boolean> {
-        return await new PSqlResourceInboxFinalizationRepository(transaction).finishReserved(
-            entry.key,
-            entry.dequeueAudit.attempts,
-            EntityStatus.COMPLETED,
-            new Date(finishedAtEpochMs)
-        );
+        return await writeResourceInboxReservationFinish(transaction, completion);
+    }
+}
+
+export async function writeAdminPruneAggregate(
+    transaction: PSqlSql,
+    computed: AdminPruneAggregateWrite
+): Promise<void> {
+    const entry = computed.entry;
+    const rows = await transaction<readonly { ris_resource: string; }[]>`
+        insert into resource_inbox_results (ris_resource_id,
+                                            ris_topic_id,
+                                            ris_resource,
+                                            ris_type_id,
+                                            ris_status,
+                                            fk_ext_bank_id,
+                                            system_date,
+                                            created_by,
+                                            created_ts,
+                                            expire_ts)
+        values (${entry.key.resourceId},
+                ${entry.key.topicId},
+                ${entry.resource},
+                ${entry.typeId},
+                ${entry.status},
+                ${entry.key.contextId},
+                ${computed.systemDate},
+                ${entry.audit.createdBy},
+                ${computed.createdAt},
+                ${computed.expiresAt})
+        on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
+            do update set ris_resource = excluded.ris_resource,
+                          ris_type_id  = excluded.ris_type_id,
+                          ris_status   = excluded.ris_status,
+                          system_date  = excluded.system_date,
+                          created_by   = excluded.created_by,
+                          created_ts   = excluded.created_ts,
+                          expire_ts    = excluded.expire_ts
+        where resource_inbox_results.expire_ts <= (now() at time zone 'UTC')
+        returning ris_resource
+    `;
+    if (rows.length > 1) {
+        throw new Error('Admin prune aggregate write returned multiple rows');
+    }
+    const stored = rows[0] ?? (await transaction<readonly { ris_resource: string; }[]>`
+        select ris_resource
+        from resource_inbox_results
+        where ris_topic_id = ${entry.key.topicId}
+          and ris_resource_id = ${entry.key.resourceId}
+          and fk_ext_bank_id = ${entry.key.contextId}
+        limit 1
+    `)[0];
+    if (!stored) {
+        throw new Error('Admin prune aggregate conflict row was not found');
+    }
+    if (stored.ris_resource !== entry.resource) {
+        throw new Error('Admin prune aggregate collides with an active job');
     }
 }
 
@@ -184,21 +242,20 @@ async function readAppDataPage(
 
 async function deletePageRows(
     sql: PSqlSql,
-    command: AdminPrunePageWork,
-    rowIds: readonly string[]
+    deletion: AdminPrunePageDelete
 ): Promise<number> {
-    switch (command.category) {
+    switch (deletion.category) {
         case 'runtime-state': {
             return (await sql<RuntimeRow[]>`
                 with expired as (
                     select value::jsonb ->> 0 as store_namespace,
                            value::jsonb ->> 1 as store_key
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from runtime_state_store target using expired
                 where target.store_namespace = expired.store_namespace
                   and target.store_key = expired.store_key
-                  and expire_at_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_at_ts <= ${deletion.capturedAt}
                 returning target.store_namespace, target.store_key
             `).length;
         }
@@ -206,39 +263,36 @@ async function deletePageRows(
             return (await sql<ResourceRow[]>`
                 with expired as (
                     select value::bigint as ri_row_id
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from resource_inbox target using expired
                 where target.ri_row_id = expired.ri_row_id
-                  and expire_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_ts <= ${deletion.capturedAt}
                 returning target.ri_row_id
             `).length;
         case 'resource-inbox-results':
             return (await sql<ResultsRow[]>`
                 with expired as (
                     select value::bigint as ris_row_id
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from resource_inbox_results target using expired
                 where target.ris_row_id = expired.ris_row_id
-                  and expire_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_ts <= ${deletion.capturedAt}
                 returning target.ris_row_id
             `).length;
         case 'app-data': {
-            if (!command.appData) {
-                throw new TypeError('App-data prune requires namespace');
-            }
             return (await sql<AppDataRow[]>`
                 with expired as (
                     select value::jsonb ->> 0 as store_name,
                            value::jsonb ->> 1 as data_key
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from app_data_store target using expired
-                where target.app_namespace = ${command.appData.namespace}
+                where target.app_namespace = ${deletion.appData.namespace}
                   and target.store_name = expired.store_name
                   and target.data_key = expired.data_key
-                  and expire_at_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_at_ts <= ${deletion.capturedAt}
                 returning target.store_name, target.data_key
             `).length;
         }

--- a/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
+++ b/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
@@ -1,8 +1,13 @@
 import type { AdminPruneExpiredCategory } from '@shared/api/admin-operations-types.ts';
-import type { Key, ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
+import type { ResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import {
+    computeAppOutboxInsert,
+    type AppOutboxInsert
+} from '../../app-outbox/app-outbox-insert.ts';
 import { requireAdminPrunePageSize, type AdminPruneAppData } from '../inbox/admin-prune-command-codec.ts';
 import {
     decodeAdminPruneWork,
@@ -29,19 +34,39 @@ export type AdminPrunePageRead =
         expectedAggregate: string;
         authority: Readonly<{ allowed: boolean; code: string; }>;
         nowEpochMs: number;
+        serviceId: string;
     }>;
 
-export type AdminPrunePageComputed = Readonly<{
-    kind: 'page';
-    jobId: string;
-    category: AdminPruneExpiredCategory;
-    rowIds: readonly string[];
-    deletedRows: number;
-    next: AdminPrunePageWork | null;
+interface AdminPrunePageDeleteBase {
+    readonly rowIds: readonly string[];
+    readonly capturedAt: Date;
+}
+
+export type AdminPrunePageDelete =
+    | Readonly<AdminPrunePageDeleteBase & { category: 'runtime-state'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'resource-inbox'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'resource-inbox-results'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'app-data'; appData: AdminPruneAppData; }>;
+
+export type AdminPruneProgressWrite = Readonly<{
     expectedAggregate: string;
     aggregateSuccessor: ResourceEntry;
-    finishedAtEpochMs: number;
+    aggregateSuccessorExpiryAtIsoTimestamp: string;
 }>;
+
+export type AdminPrunePageComputed =
+    & AdminPruneProgressWrite
+    & Readonly<{
+        kind: 'page';
+        jobId: string;
+        category: AdminPruneExpiredCategory;
+        rowIds: readonly string[];
+        deletedRows: number;
+        deletion: AdminPrunePageDelete;
+        next: AdminPrunePageWork | null;
+        successorOutboxWrite: AppOutboxInsert | null;
+        reservationFinish: ResourceInboxReservationFinish;
+    }>;
 
 export type AdminPrunePageRepository = Readonly<{
     readPage(
@@ -62,18 +87,16 @@ export type AdminPrunePageRepository = Readonly<{
     >;
     deletePage(
         transaction: PSqlSql,
-        command: AdminPrunePageWork,
-        rowIds: readonly string[]
+        deletion: AdminPrunePageDelete
     ): Promise<number>;
-    writeOutbox(transaction: PSqlSql, entry: ResourceEntry): Promise<void>;
+    writeOutbox(transaction: PSqlSql, computed: AppOutboxInsert): Promise<void>;
     writeProgress(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed
+        computed: AdminPruneProgressWrite
     ): Promise<void>;
     finishReserved(
         transaction: PSqlSql,
-        entry: ResourceEntry,
-        finishedAtEpochMs: number
+        completion: ResourceInboxReservationFinish
     ): Promise<boolean>;
 }>;
 
@@ -133,7 +156,8 @@ export class AdminPrunePageWorker {
             aggregate: aggregateRead.aggregate,
             expectedAggregate: aggregateRead.resource,
             authority,
-            nowEpochMs
+            nowEpochMs,
+            serviceId: this.options.serviceId
         };
     }
 
@@ -168,28 +192,40 @@ export class AdminPrunePageWorker {
                 appData: command.appData
             }
             : null;
+        const deletion = toAdminPrunePageDelete(command, read.rowIds);
         const page = {
             kind: 'page',
             jobId: command.jobId,
             category: command.category,
-            rowIds: read.rowIds,
-            deletedRows: read.rowIds.length,
+            rowIds: deletion.rowIds,
+            deletedRows: deletion.rowIds.length,
+            deletion,
             next
         } as const;
         const aggregate = advanceAdminPruneAggregate(read.aggregate, page);
+        const aggregateSuccessor = toAdminPruneAggregateEntry(
+            {
+                ...aggregate,
+                expireAtEpochMs: Math.max(
+                    aggregate.expireAtEpochMs,
+                    resourceInboxRetryExpiryAtEpochMs(read.nowEpochMs)
+                )
+            }
+        );
         return {
             ...page,
+            successorOutboxWrite: next
+                ? computeAppOutboxInsert(toAdminPruneOutbox(next, read.serviceId))
+                : null,
             expectedAggregate: read.expectedAggregate,
-            aggregateSuccessor: toAdminPruneAggregateEntry(
-                {
-                    ...aggregate,
-                    expireAtEpochMs: Math.max(
-                        aggregate.expireAtEpochMs,
-                        resourceInboxRetryExpiryAtEpochMs(read.nowEpochMs)
-                    )
-                }
-            ),
-            finishedAtEpochMs: read.nowEpochMs
+            aggregateSuccessor,
+            aggregateSuccessorExpiryAtIsoTimestamp: aggregateSuccessor.audit.expiryTs.toString(),
+            reservationFinish: {
+                key: command.reservation.key,
+                expectedAttempts: command.reservation.dequeueAudit.attempts,
+                status: EntityStatus.COMPLETED,
+                completedAt: new Date(read.nowEpochMs)
+            }
         };
     }
 
@@ -213,32 +249,31 @@ export class AdminPrunePageWorker {
         ) {
             throw new TypeError('Admin prune computed aggregate differs from read predecessor');
         }
+        if (
+            computed.deletion.category !== command.category ||
+            computed.deletion.rowIds.length !== read.rowIds.length ||
+            computed.deletion.capturedAt.getTime() !== command.capturedAtEpochMs ||
+            (computed.next === null) !== (computed.successorOutboxWrite === null) ||
+            computed.reservationFinish.expectedAttempts !== command.reservation.dequeueAudit.attempts ||
+            computed.reservationFinish.completedAt.getTime() !== read.nowEpochMs
+        ) {
+            throw new TypeError('Admin prune computed persistence differs from read facts');
+        }
     }
 
     async write(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed,
-        entry: ResourceEntry
+        computed: AdminPrunePageComputed
     ): Promise<void> {
-        const command = decodeAdminPruneWork(entry);
         await this.options.repository.writeProgress(transaction, computed);
-        const deleted = await this.options.repository.deletePage(transaction, command, computed.rowIds);
+        const deleted = await this.options.repository.deletePage(transaction, computed.deletion);
         if (deleted !== computed.deletedRows) {
             throw new Error('Admin prune page changed before delete');
         }
-        if (computed.next) {
-            await this.options.repository.writeOutbox(
-                transaction,
-                toAdminPruneOutbox(computed.next, this.options.serviceId)
-            );
+        if (computed.successorOutboxWrite !== null) {
+            await this.options.repository.writeOutbox(transaction, computed.successorOutboxWrite);
         }
-        if (
-            !await this.options.repository.finishReserved(
-                transaction,
-                entry,
-                computed.finishedAtEpochMs
-            )
-        ) {
+        if (!await this.options.repository.finishReserved(transaction, computed.reservationFinish)) {
             throw new Error('Admin prune reservation changed before commit');
         }
     }
@@ -249,8 +284,29 @@ export class AdminPrunePageWorker {
         const computed = this.compute(command, read);
         this.validate(command, read, computed);
         await runInPSqlTransaction(this.options.database, async (transaction) => {
-            await this.write(transaction, computed, entry);
+            await this.write(transaction, computed);
         });
         this.options.wakeQueue?.();
+    }
+}
+
+export function toAdminPrunePageDelete(
+    command: AdminPrunePageWork,
+    rowIds: readonly string[]
+): AdminPrunePageDelete {
+    const base = {
+        rowIds: [...rowIds],
+        capturedAt: new Date(command.capturedAtEpochMs)
+    };
+    switch (command.category) {
+        case 'runtime-state':
+        case 'resource-inbox':
+        case 'resource-inbox-results':
+            return { ...base, category: command.category };
+        case 'app-data':
+            if (!command.appData) {
+                throw new TypeError('App-data prune requires namespace');
+            }
+            return { ...base, category: command.category, appData: command.appData };
     }
 }

--- a/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
+++ b/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
@@ -1,6 +1,7 @@
 import type { AdminPruneExpiredCategory } from '@shared/api/admin-operations-types.ts';
 import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
 import type { ResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
@@ -8,6 +9,7 @@ import {
     computeAppOutboxInsert,
     type AppOutboxInsert
 } from '../../app-outbox/app-outbox-insert.ts';
+import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import { requireAdminPrunePageSize, type AdminPruneAppData } from '../inbox/admin-prune-command-codec.ts';
 import {
     decodeAdminPruneWork,
@@ -18,7 +20,6 @@ import {
 import {
     advanceAdminPruneAggregate,
     toAdminPruneAggregateEntry,
-    toAdminPruneAggregateKey,
     type AdminPruneAggregate
 } from './admin-prune-progress.ts';
 
@@ -165,17 +166,6 @@ export class AdminPrunePageWorker {
         command: ReservedAdminPrunePageWork,
         read: AdminPrunePageRead
     ): AdminPrunePageComputed {
-        if (
-            !read.authority.allowed ||
-            command.expireAtEpochMs <= read.nowEpochMs ||
-            read.aggregate.requestedBy !== command.requestedBy ||
-            read.aggregate.requestedSessionId !== command.requestedSessionId
-        ) {
-            throw Object.assign(new Error('Admin prune current authority is denied'), {
-                code: 'admin-prune-authority-denied',
-                status: 403
-            });
-        }
         const cursor = read.rowIds.at(-1) ?? command.afterCursor;
         const next = read.hasMore && cursor !== null
             ? {
@@ -234,29 +224,22 @@ export class AdminPrunePageWorker {
         read: AdminPrunePageRead,
         computed: AdminPrunePageComputed
     ): void {
-        const aggregateKey = toAdminPruneAggregateKey(command.jobId);
-        if (computed.jobId !== command.jobId || computed.category !== command.category) {
-            throw new TypeError('Admin prune computed identity differs from command');
+        if (
+            !read.authority.allowed ||
+            command.expireAtEpochMs <= read.nowEpochMs ||
+            read.aggregate.requestedBy !== command.requestedBy ||
+            read.aggregate.requestedSessionId !== command.requestedSessionId
+        ) {
+            throw Object.assign(new Error('Admin prune current authority is denied'), {
+                code: 'admin-prune-authority-denied',
+                status: 403
+            });
         }
-        if (read.rowIds.length > command.pageSize || computed.deletedRows !== read.rowIds.length) {
+        if (read.rowIds.length > command.pageSize) {
             throw new TypeError('Admin prune computed page exceeds its command');
         }
-        if (
-            computed.expectedAggregate !== read.expectedAggregate ||
-            computed.aggregateSuccessor.key.topicId !== aggregateKey.topicId ||
-            computed.aggregateSuccessor.key.resourceId !== aggregateKey.resourceId ||
-            computed.aggregateSuccessor.key.contextId !== aggregateKey.contextId
-        ) {
-            throw new TypeError('Admin prune computed aggregate differs from read predecessor');
-        }
-        if (
-            computed.deletion.category !== command.category ||
-            computed.deletion.rowIds.length !== read.rowIds.length ||
-            computed.deletion.capturedAt.getTime() !== command.capturedAtEpochMs ||
-            (computed.next === null) !== (computed.successorOutboxWrite === null) ||
-            computed.reservationFinish.expectedAttempts !== command.reservation.dequeueAudit.attempts ||
-            computed.reservationFinish.completedAt.getTime() !== read.nowEpochMs
-        ) {
+        const expected = this.compute(command, read);
+        if (!jsonEquals(toAdminPrunePagePersistence(computed), toAdminPrunePagePersistence(expected))) {
             throw new TypeError('Admin prune computed persistence differs from read facts');
         }
     }
@@ -288,6 +271,96 @@ export class AdminPrunePageWorker {
         });
         this.options.wakeQueue?.();
     }
+}
+
+function toAdminPrunePagePersistence(computed: AdminPrunePageComputed): JsonWireValue {
+    return {
+        kind: computed.kind,
+        jobId: computed.jobId,
+        category: computed.category,
+        rowIds: computed.rowIds,
+        deletedRows: computed.deletedRows,
+        deletion: {
+            category: computed.deletion.category,
+            rowIds: computed.deletion.rowIds,
+            capturedAtEpochMs: computed.deletion.capturedAt.getTime(),
+            appData: computed.deletion.category === 'app-data' ? computed.deletion.appData : null
+        },
+        next: computed.next === null
+            ? null
+            : {
+                kind: computed.next.kind,
+                jobId: computed.next.jobId,
+                category: computed.next.category,
+                requestedBy: computed.next.requestedBy,
+                requestedSessionId: computed.next.requestedSessionId,
+                capturedAtEpochMs: computed.next.capturedAtEpochMs,
+                expireAtEpochMs: computed.next.expireAtEpochMs,
+                pageSize: computed.next.pageSize,
+                afterCursor: computed.next.afterCursor,
+                pageIndex: computed.next.pageIndex,
+                appData: computed.next.appData === null
+                    ? null
+                    : {
+                        namespace: computed.next.appData.namespace,
+                        storeName: computed.next.appData.storeName
+                    }
+            },
+        successorOutboxWrite: computed.successorOutboxWrite === null
+            ? null
+            : toAppOutboxPersistence(computed.successorOutboxWrite),
+        expectedAggregate: computed.expectedAggregate,
+        aggregateSuccessor: toResourceEntryPersistence(computed.aggregateSuccessor),
+        aggregateSuccessorExpiryAtIsoTimestamp: computed.aggregateSuccessorExpiryAtIsoTimestamp,
+        reservationFinish: {
+            key: computed.reservationFinish.key,
+            expectedAttempts: computed.reservationFinish.expectedAttempts,
+            status: computed.reservationFinish.status,
+            completedAtEpochMs: computed.reservationFinish.completedAt.getTime()
+        }
+    };
+}
+
+function toAppOutboxPersistence(computed: AppOutboxInsert): JsonWireValue {
+    return {
+        entry: toResourceEntryPersistence(computed.entry),
+        systemDate: computed.systemDate,
+        createdAt: computed.createdAt,
+        expiresAt: computed.expiresAt,
+        startedAt: computed.startedAt,
+        finishedAt: computed.finishedAt,
+        nextAt: computed.nextAt,
+        attempts: computed.attempts,
+        conflict: {
+            name: computed.conflict.name,
+            message: computed.conflict.message,
+            code: computed.conflict.code,
+            status: computed.conflict.status,
+            key: computed.conflict.key
+        }
+    };
+}
+
+function toResourceEntryPersistence(entry: Readonly<ResourceEntry>): JsonWireValue {
+    return {
+        key: entry.key,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        status: entry.status,
+        audit: {
+            date: entry.audit.date.toString(),
+            createdBy: entry.audit.createdBy,
+            createdTs: entry.audit.createdTs.toString(),
+            expiryTs: entry.audit.expiryTs.toString()
+        },
+        dequeueAudit: {
+            attempts: entry.dequeueAudit.attempts,
+            startTs: entry.dequeueAudit.startTs?.toString() ?? null,
+            endTs: entry.dequeueAudit.endTs?.toString() ?? null,
+            nextTs: entry.dequeueAudit.nextTs?.toString() ?? null
+        },
+        db: entry.db ?? null
+    };
 }
 
 export function toAdminPrunePageDelete(

--- a/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
+++ b/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
@@ -143,10 +143,11 @@ it.each([
         source: sources.appAdmin,
         owner: 'processCommand',
         calls: [
-            'this.read(command)',
-            'this.compute(read)',
-            'this.validate(computed)',
-            'this.transactionWriter.writeMutation(context'
+            'this.read(command, context)',
+            'computeAdminPruneMutation(read)',
+            'validateAdminPruneMutation(read, computed)',
+            'this.transactionWriter.writeComputedMutation(',
+            'this.write(transaction, computed)'
         ]
     },
     {

--- a/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
@@ -1,0 +1,128 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { describe, expect, it } from 'vitest';
+
+import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { createAdminPruneCommand } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
+import {
+    computeAdminPruneMutation,
+    validateAdminPruneMutation
+} from '@shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts';
+import { writeAdminPruneAggregate } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+describe('admin prune computation', () => {
+    it('computes persistence-ready domain and completion writes before the transaction', async () => {
+        const read = await createRead();
+
+        const computed = computeAdminPruneMutation(read);
+
+        expect(computed.result).toMatchObject({
+            status: 'queued',
+            serverId: 'admin-server',
+            jobId: 'prune-job'
+        });
+        expect(computed.outboxWrites).toEqual([
+            expect.objectContaining({
+                entry: expect.objectContaining({ typeId: 'APP_OUTBOX' }),
+                systemDate: expect.any(String),
+                createdAt: expect.any(String),
+                expiresAt: expect.any(String)
+            })
+        ]);
+        expect(computed.aggregateWrite).toEqual(expect.objectContaining({
+            entry: expect.objectContaining({ resource: expect.any(String) }),
+            systemDate: expect.any(String),
+            createdAt: expect.any(String),
+            expiresAt: expect.any(String)
+        }));
+        expect(computed.completion.durableResult).toBe(computed.result);
+        expect(computed.completion.reservationFinish.completedAt).toEqual(new Date(1_010));
+        expect(validateAdminPruneMutation(read, computed)).toEqual([]);
+    });
+
+    it('validates the supplied computation without replacing it', async () => {
+        const read = await createRead();
+        const computed = computeAdminPruneMutation(read);
+        const changed = {
+            ...computed,
+            result: { ...computed.result, jobId: 'another-job' }
+        };
+
+        const issues = validateAdminPruneMutation(read, changed);
+
+        expect(issues).toContainEqual(expect.objectContaining({
+            code: 'admin-prune-computed-identity-invalid',
+            status: 400
+        }));
+        expect(changed.result.jobId).toBe('another-job');
+    });
+
+    it('writes the prepared aggregate without formatting timestamps in the transaction', async () => {
+        const computed = computeAdminPruneMutation(await createRead());
+        const aggregateWrite = computed.aggregateWrite;
+        if (aggregateWrite === null) {
+            throw new Error('Expected a durable admin prune aggregate');
+        }
+        const transaction = ((parts: TemplateStringsArray) => {
+            const statement = parts.join(' ');
+            return Promise.resolve(
+                statement.includes('insert into resource_inbox_results')
+                    ? [{ ris_resource: aggregateWrite.entry.resource }]
+                    : []
+            );
+        }) as PSqlSql;
+        const originalToString = Temporal.Instant.prototype.toString;
+
+        Temporal.Instant.prototype.toString = rejectTimestampFormattingDuringWrite;
+        try {
+            await writeAdminPruneAggregate(transaction, aggregateWrite);
+        }
+        finally {
+            Temporal.Instant.prototype.toString = originalToString;
+        }
+    });
+});
+
+function rejectTimestampFormattingDuringWrite(): never {
+    throw new TypeError('Admin prune aggregate timestamp formatted inside write');
+}
+
+async function createRead() {
+    const command = await createAdminPruneCommand({
+        jobId: 'prune-job',
+        requestedBy: 'admin',
+        requestedSessionId: 'session',
+        capturedAtEpochMs: 1_000,
+        expireAtEpochMs: 100_000,
+        dryRun: false,
+        categories: ['runtime-state'],
+        appData: null,
+        pageSize: 25
+    });
+    const entry: ResourceEntry = {
+        key: { topicId: 'ADMIN_PRUNE_EXPIRED', resourceId: 'prune-job', contextId: 'admin' },
+        resource: '{}',
+        typeId: 'APP_INBOX',
+        status: EntityStatus.RESERVED,
+        audit: {
+            date: Temporal.PlainTime.from('12:00:00'),
+            createdBy: 'admin-server',
+            createdTs: Temporal.PlainDateTime.from('2026-08-07T12:00:00'),
+            expiryTs: Temporal.Instant.from('2026-08-07T13:00:00Z')
+        },
+        dequeueAudit: { attempts: 1 }
+    };
+    return {
+        command,
+        expiredRows: {
+            'runtime-state': 3,
+            'resource-inbox': 0,
+            'resource-inbox-results': 0,
+            'app-data': 0
+        },
+        authority: { allowed: true, code: 'allowed' },
+        nowEpochMs: 1_005,
+        serviceId: 'admin-server',
+        completionFacts: { entry, completedAtEpochMs: 1_010 }
+    };
+}

--- a/packages/tests/shared-server/rallar-system/admin-operations/app-admin-inbox-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/app-admin-inbox-service.test.ts
@@ -463,12 +463,12 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
             'transaction',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
         expect(harness.events.filter((event) => event === 'queue-wake')).toHaveLength(1);
@@ -493,6 +493,7 @@ describe('AppAdminInboxService initial prune command', () => {
             'count:runtime-state',
             'count:resource-inbox-results',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
@@ -501,7 +502,6 @@ describe('AppAdminInboxService initial prune command', () => {
             'page-write',
             'aggregate-write',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
         expect(harness.events.filter((event) => event === 'queue-wake')).toHaveLength(2);
@@ -562,6 +562,7 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
@@ -569,12 +570,12 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
             'transaction',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
     });

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-persistence-invariants.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-persistence-invariants.test.ts
@@ -6,7 +6,11 @@ import {
     toAdminPruneOutbox,
     type AdminPrunePageWork
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
-import { AdminPrunePageWorker, type AdminPrunePageComputed } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
+import {
+    AdminPrunePageWorker,
+    toAdminPrunePageDelete,
+    type AdminPruneProgressWrite
+} from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import {
     createAdminPruneAggregate,
     decodeAdminPruneAggregate,
@@ -29,8 +33,7 @@ describe('admin prune page persistence invariants', () => {
         const repository = new PSqlAdminPruneRepository((() => undefined) as never);
         const deleted = await repository.deletePage(
             transaction,
-            pageWork({ category: 'resource-inbox' }),
-            ['1', '2', '3']
+            toAdminPrunePageDelete(pageWork({ category: 'resource-inbox' }), ['1', '2', '3'])
         );
 
         expect(deleted).toBe(3);
@@ -77,7 +80,8 @@ describe('admin prune page persistence invariants', () => {
             aggregate,
             expectedAggregate: JSON.stringify(aggregate),
             authority: { allowed: true, code: 'allowed' },
-            nowEpochMs: NOW
+            nowEpochMs: NOW,
+            serviceId: 'server-1'
         } as const;
         const computed = service.compute(command, read);
 
@@ -133,16 +137,10 @@ describe('admin prune page persistence invariants', () => {
             revision: 1
         } as const;
         const successorEntry = toAdminPruneAggregateEntry(aggregateSuccessor);
-        const computed: AdminPrunePageComputed = {
-            kind: 'page',
-            jobId: aggregate.jobId,
-            category: 'runtime-state',
-            rowIds: [],
-            deletedRows: 0,
-            next: null,
+        const computed: AdminPruneProgressWrite = {
             expectedAggregate: JSON.stringify(aggregate),
             aggregateSuccessor: successorEntry,
-            finishedAtEpochMs: NOW
+            aggregateSuccessorExpiryAtIsoTimestamp: successorEntry.audit.expiryTs.toString()
         };
         const boundValues: Array<Parameters<PSqlSql>[0][number]> = [];
         const transaction = ((parts: TemplateStringsArray, ...values: Parameters<PSqlSql>[0]) => {
@@ -150,8 +148,15 @@ describe('admin prune page persistence invariants', () => {
             return Promise.resolve([{ ris_row_id: 1 }]);
         }) as never;
         const repository = new PSqlAdminPruneRepository((() => undefined) as never);
+        const originalToString = Temporal.Instant.prototype.toString;
 
-        await repository.writeProgress(transaction, computed);
+        Temporal.Instant.prototype.toString = rejectTimestampFormattingDuringWrite;
+        try {
+            await repository.writeProgress(transaction, computed);
+        }
+        finally {
+            Temporal.Instant.prototype.toString = originalToString;
+        }
 
         expect(boundValues).toContain(successorEntry.resource);
         expect(boundValues).toContain(successorEntry.status);
@@ -161,6 +166,10 @@ describe('admin prune page persistence invariants', () => {
         expect(boundValues).toContain(computed.expectedAggregate);
     });
 });
+
+function rejectTimestampFormattingDuringWrite(): never {
+    throw new TypeError('Admin prune progress timestamp formatted inside write');
+}
 
 function pageWork(
     overrides: Partial<AdminPrunePageWork> = {}

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-postgres.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-postgres.test.ts
@@ -4,6 +4,7 @@ import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import type { AdminPruneAppData } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
 import { PSqlAdminPruneRepository } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
 import type { AdminPrunePageWork } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
+import { toAdminPrunePageDelete } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 
 const postgresIt = process.env.RALLAR_POSTGRES_INTEGRATION === '1' ? it : it.skip;
 
@@ -169,7 +170,7 @@ async function deletePage(
 ): Promise<number> {
     const repository = new PSqlAdminPruneRepository(sql);
     return await sql.begin(async (transaction) => {
-        return await repository.deletePage(transaction, work, rowIds);
+        return await repository.deletePage(transaction, toAdminPrunePageDelete(work, rowIds));
     });
 }
 

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
@@ -97,6 +97,65 @@ describe('AdminPrunePageWorker', () => {
         expect(computed.next?.expireAtEpochMs).toBe(resourceInboxRetryExpiryAtEpochMs(NOW));
     });
 
+    it('rejects prepared persistence data that differs from the read facts', async () => {
+        const repository = new MemoryPruneRepository(['1', '2', '3']);
+        const work = new AdminPrunePageWorker({
+            database: repository.database,
+            repository,
+            serviceId: 'server-1',
+            pageSize: 2,
+            now: () => NOW,
+            readAuthority: () => Promise.resolve({ allowed: true, code: 'allowed' })
+        });
+        const entry = createReservedEntry({
+            kind: 'page',
+            jobId: 'prune-exact-validation',
+            category: 'runtime-state',
+            capturedAtEpochMs: NOW,
+            expireAtEpochMs: NOW + 60_000,
+            pageSize: 2,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: null
+        });
+        const command = decodeAdminPruneWork(entry);
+        const read = await work.read(command);
+        const computed = work.compute(command, read);
+        if (computed.successorOutboxWrite === null) {
+            throw new Error('Expected successor page work');
+        }
+        const alteredCandidates = [
+            {
+                ...computed,
+                deletion: { ...computed.deletion, rowIds: ['different', '2'] }
+            },
+            {
+                ...computed,
+                aggregateSuccessorExpiryAtIsoTimestamp: '2099-01-01T00:00:00Z'
+            },
+            {
+                ...computed,
+                reservationFinish: {
+                    ...computed.reservationFinish,
+                    key: { ...computed.reservationFinish.key, resourceId: 'different' }
+                }
+            },
+            {
+                ...computed,
+                successorOutboxWrite: {
+                    ...computed.successorOutboxWrite,
+                    entry: { ...computed.successorOutboxWrite.entry, resource: '{}' }
+                }
+            }
+        ];
+
+        for (const altered of alteredCandidates) {
+            expect(() => work.validate(command, read, altered)).toThrow(
+                'Admin prune computed persistence differs from read facts'
+            );
+        }
+    });
+
     it('excludes the currently executing resource-inbox row from its page', async () => {
         const repository = new MemoryPruneRepository(['10', '11', '12']);
         const work = new AdminPrunePageWorker({
@@ -186,6 +245,36 @@ describe('AdminPrunePageWorker', () => {
         expect(repository.finished).toEqual([]);
         expect(repository.progressWrites).toBe(0);
         expect(wakeCount).toBe(0);
+    });
+
+    it('computes denied work as data and rejects it during validation', async () => {
+        const repository = new MemoryPruneRepository(['1', '2', '3']);
+        const work = new AdminPrunePageWorker({
+            database: repository.database,
+            repository,
+            serviceId: 'server-1',
+            pageSize: 2,
+            now: () => NOW,
+            readAuthority: () => Promise.resolve({ allowed: false, code: 'session-revoked' })
+        });
+        const command = decodeAdminPruneWork(createReservedEntry({
+            kind: 'page',
+            jobId: 'prune-denied-validation',
+            category: 'runtime-state',
+            capturedAtEpochMs: NOW,
+            expireAtEpochMs: NOW + 60_000,
+            pageSize: 2,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: null
+        }));
+        const read = await work.read(command);
+
+        const computed = work.compute(command, read);
+
+        expect(() => work.validate(command, read, computed)).toThrow(
+            expect.objectContaining({ code: 'admin-prune-authority-denied', status: 403 })
+        );
     });
 
     it('rolls aggregate, deletion, successor, and reservation back on outbox collision', async () => {

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
+import type { ResourceInboxReservationFinish } from '@shared-server/queuebox/postgres/resource-inbox-reservation-write.ts';
 import { createAdminPruneCommand, decodeAdminPruneCommand } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
 import {
     ADMIN_PRUNE_APP_OUTBOX_TOPIC,
@@ -6,8 +7,13 @@ import {
     toAdminPruneOutbox,
     type AdminPrunePageWork
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
-import { AdminPrunePageWorker, type AdminPrunePageRepository } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
+import {
+    AdminPrunePageWorker,
+    type AdminPrunePageDelete,
+    type AdminPrunePageRepository
+} from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import { createAdminPruneAggregate, toAdminPruneAggregateEntry } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-progress.ts';
+import type { AppOutboxInsert } from '@shared-server/rallar-system/app-outbox/app-outbox-insert.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { describe, expect, it } from 'vitest';
@@ -82,7 +88,7 @@ describe('AdminPrunePageWorker', () => {
             }
         });
 
-        await work.write(repository.transaction, computed, entry);
+        await work.write(repository.transaction, computed);
 
         expect(repository.deleted).toEqual(['1', '2']);
         expect(repository.calls[0]).toBe('progress');
@@ -409,7 +415,7 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         }
     });
     readonly deleted: string[] = [];
-    readonly writtenEntries: ResourceEntry[] = [];
+    readonly writtenEntries: Array<Readonly<ResourceEntry>> = [];
     readonly finished: ResourceEntry['key'][] = [];
     readonly calls: string[] = [];
     lastExcludedResourceKey: ResourceEntry['key'] | null = null;
@@ -459,15 +465,15 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         return Promise.resolve({ aggregate, resource: entry.resource });
     }
 
-    deletePage(_transaction: never, _command: unknown, rowIds: readonly string[]) {
+    deletePage(_transaction: never, deletion: AdminPrunePageDelete) {
         this.calls.push('delete');
-        this.deleted.push(...rowIds);
-        return Promise.resolve(rowIds.length);
+        this.deleted.push(...deletion.rowIds);
+        return Promise.resolve(deletion.rowIds.length);
     }
 
-    writeOutbox(_transaction: never, entry: ResourceEntry) {
+    writeOutbox(_transaction: never, computed: AppOutboxInsert) {
         this.calls.push('outbox');
-        this.writtenEntries.push(entry);
+        this.writtenEntries.push(computed.entry);
         if (this.rejectOutbox) {
             throw new Error('Admin prune outbox collision');
         }
@@ -486,11 +492,11 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         return Promise.resolve();
     }
 
-    finishReserved(_transaction: never, entry: ResourceEntry) {
+    finishReserved(_transaction: never, completion: ResourceInboxReservationFinish) {
         if (this.loseReservation) {
             return Promise.resolve(false);
         }
-        this.finished.push(entry.key);
+        this.finished.push(completion.key);
         return Promise.resolve(true);
     }
 }

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-retry-lifetime.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-retry-lifetime.test.ts
@@ -56,7 +56,8 @@ describe('admin prune retry lifetime', () => {
             aggregate,
             expectedAggregate: JSON.stringify(aggregate),
             authority: { allowed: true, code: 'allowed' },
-            nowEpochMs: NOW
+            nowEpochMs: NOW,
+            serviceId: 'server-1'
         };
 
         const computed = service.compute(command, read);


### PR DESCRIPTION
## Summary

- move Admin AppInbox completion, initial outbox rows, and aggregate row materialization into the compute phase
- move page deletion parameters, successor outbox rows, progress timestamps, and reservation completion into the page compute phase
- keep transactions limited to prepared SQL operations and decisions based on returned database rows
- preserve outer AppInbox redelivery; no inner retry loop or additional prepare phase

## Deliberate exclusions

- no generic recursive or Proxy-based computed validator
- no recomputation from validate
- no unrelated admin runtime decoder changes
- no ResourceInbox middleware governance change
- no compatibility wrapper for the old write signatures

## Review assessment

The dataflow is directly visible as read -> compute -> validate -> write. The new operation-owned records add fields only for persisted values that previously required conversion inside the transaction. Database-outcome error checks remain in write rather than being carried as preconstructed Error data. Scoped navigation and structure checks report no findings.

## Validation

- Admin focused Vitest: 15 files passed, 1 PostgreSQL integration file skipped; 100 tests passed, 4 skipped
- shared-server TypeScript: pass
- governed test typecheck: 1019 files, zero errors
- headless bundle boundary: pass
- changed-range repository style: pass
- scoped navigation: pass with two legitimate named clock ports
- repository structure: pass
- dprint and git diff check: pass (sandbox prevented only dprint incremental cache persistence)

The environment did not provide the PostgreSQL integration variable, so the four native Admin page deletion cases remain for remote CI.