### PR TITLE
Make topology config mutation phases explicit

### DIFF
--- a/apps/api-v1/test/db/pglite-topology-retry.test.ts
+++ b/apps/api-v1/test/db/pglite-topology-retry.test.ts
@@ -10,7 +10,6 @@ import { type IssuedAuthSession } from '@shared-server/rallar-system/auth/persis
 import { createGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { requireRecord } from '@shared-server/rallar-system/protocol/exact-object-decoding.ts';
-import { decodeJsonWireValue, hashMutationCommand } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import type { GroupTopologyConfigMutationCommand } from '@shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts';
 import { GroupTopologyConfigRepository } from '@shared-server/rallar-system/topology/config/persistence/group-topology-config-repository.ts';
 import { toTopologyAppInboxCommand } from '@shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts';
@@ -500,11 +499,6 @@ Deno.test(
                 'tree'
             );
             const mutation = service.configMutation;
-            const preparation = await mutation.prepare({
-                command,
-                commandHash: await hashMutationCommand(decodeJsonWireValue(command, 'Topology mutation command')),
-                capturedAtEpochMs: 1_000
-            });
             pauseFirstRead = true;
             const firstReadPromise = mutation.read(command);
             await observed.promise;
@@ -525,16 +519,11 @@ Deno.test(
             release.resolve();
             const firstRead = await firstReadPromise;
             const firstComputed = mutation.compute(
-                preparation,
+                command,
                 firstRead,
                 1
             );
-            mutation.validate(
-                preparation,
-                firstRead,
-                1,
-                firstComputed
-            );
+            mutation.validate({ command, read: firstRead, attemptCount: 1, computed: firstComputed });
             assert.equal(firstComputed.outcome, 'write');
             if (firstComputed.outcome !== 'write') {
                 throw new Error('Expected topology write');
@@ -544,13 +533,15 @@ Deno.test(
                 /conditional write conflict/
             );
             const retryRead = await mutation.read(command);
+            const retryComputed = mutation.compute(command, retryRead, 2);
             assert.throws(
                 () =>
-                    mutation.compute(
-                        preparation,
-                        retryRead,
-                        2
-                    ),
+                    mutation.validate({
+                        command,
+                        read: retryRead,
+                        attemptCount: 2,
+                        computed: retryComputed
+                    }),
                 (error) => error instanceof Error && 'status' in error && error.status === 403
             );
             assert.equal(await topology.findConfig(groupRef), undefined);

--- a/apps/api-v1/test/db/pglite-topology-test-runtime.ts
+++ b/apps/api-v1/test/db/pglite-topology-test-runtime.ts
@@ -124,6 +124,8 @@ export function topologyConfigCommand(
         aggregateRef: groupRef,
         commandId: requestId,
         requestId,
+        commandHash: `sha256:${'a'.repeat(64)}`,
+        capturedAtEpochMs: 1_000,
         input: {
             config: { topologyKind },
             updatedByPrincipalId: 'owner',
@@ -143,6 +145,8 @@ export function topologyOverrideCommand(
         aggregateRef: groupRef,
         commandId: requestId,
         requestId,
+        commandHash: `sha256:${'a'.repeat(64)}`,
+        capturedAtEpochMs: 1_000,
         input: {
             config: { topologyKind },
             updatedByPrincipalId: 'owner',
@@ -221,7 +225,7 @@ async function createPGliteTopologyWorkSetup(sql: PGliteSql, commandId: string):
     );
     const topologyManagement = createGroupTopologyRuntimeOwners({
         findGroupSnapshotByRef: () => groupSnapshot,
-        readCurrentGroupSnapshot: async () => groupSnapshot,
+        readCurrentGroupSnapshot: () => Promise.resolve(groupSnapshot),
         readRttMeasurements: () => [],
         topologyService: new RallarRtcTopologyService({ now: () => nowEpochMs }),
         topologySnapshotRepository

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts
@@ -2,8 +2,10 @@ import type { GroupTopologyConfigMutationReceipt } from '@shared/api/graph-topol
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import type { GroupStateRepository } from '../../group-state/persistence/group-state-repository.ts';
 import type { RtcTopologyOutboxWriter } from '../mutation/rtc-topology-outbox-writer.ts';
-import { resolveOverrideExpiresAtEpochMs } from './group-topology-config.ts';
-import type { GroupTopologyServerOptions } from './group-topology-config.ts';
+import {
+    computeOverrideExpiresAtEpochMs,
+    type GroupTopologyServerOptions
+} from './group-topology-config.ts';
 import { computeTopologyConfigMutation } from './mutation/compute-topology-config-mutation.ts';
 import type * as mutationContracts from './mutation/group-topology-config-mutation-contracts.ts';
 import { readTopologyConfigMutation } from './mutation/read-topology-config-mutation.ts';
@@ -24,14 +26,18 @@ export interface GroupTopologyConfigMutationServiceDependencies {
     readonly outboxWriter: RtcTopologyOutboxWriter;
 }
 
-export interface GroupTopologyConfigMutationPreparation {
-    readonly command: mutationContracts.GroupTopologyConfigMutationCommand;
-    readonly stableFacts: mutationContracts.GroupTopologyConfigMutationStableFacts;
-}
-
 export interface GroupTopologyConfigMutationAttemptRead {
     readonly state: Awaited<ReturnType<typeof readTopologyConfigMutation>>;
     readonly policyNowEpochMs: number;
+    readonly isPlatformAdmin: boolean;
+    readonly serverDefaults: GroupTopologyServerOptions;
+}
+
+export interface GroupTopologyConfigMutationValidation {
+    readonly command: mutationContracts.GroupTopologyConfigMutationCommand;
+    readonly read: GroupTopologyConfigMutationAttemptRead;
+    readonly attemptCount: number;
+    readonly computed: mutationContracts.GroupTopologyConfigMutationComputed;
 }
 
 export class GroupTopologyConfigMutationService {
@@ -39,27 +45,6 @@ export class GroupTopologyConfigMutationService {
 
     constructor(dependencies: GroupTopologyConfigMutationServiceDependencies) {
         this.dependencies = dependencies;
-    }
-
-    async prepare(input: {
-        readonly command: mutationContracts.GroupTopologyConfigMutationCommand;
-        readonly commandHash: string;
-        readonly capturedAtEpochMs: number;
-    }): Promise<GroupTopologyConfigMutationPreparation> {
-        return {
-            command: input.command,
-            stableFacts: {
-                requestedAtEpochMs: input.capturedAtEpochMs,
-                commandHash: input.commandHash,
-                resolvedOverrideExpiresAtEpochMs: input.command.operation === 'putOverride'
-                    ? resolveOverrideExpiresAtEpochMs({
-                        nowEpochMs: input.capturedAtEpochMs,
-                        ttlMs: input.command.input.ttlMs ?? undefined,
-                        expiresAtEpochMs: input.command.input.expiresAtEpochMs ?? undefined
-                    })
-                    : null
-            }
-        };
     }
 
     async read(
@@ -71,56 +56,55 @@ export class GroupTopologyConfigMutationService {
                 this.dependencies.groupStateRepository,
                 command
             ),
-            policyNowEpochMs: this.dependencies.nowEpochMs()
+            policyNowEpochMs: this.dependencies.nowEpochMs(),
+            isPlatformAdmin: this.dependencies.isPlatformAdmin(
+                command.input.updatedByPrincipalId
+            ),
+            serverDefaults: { ...(this.dependencies.serverDefaults ?? {}) }
         };
     }
 
     compute(
-        preparation: GroupTopologyConfigMutationPreparation,
+        command: mutationContracts.GroupTopologyConfigMutationCommand,
         read: GroupTopologyConfigMutationAttemptRead,
         attemptCount: number
     ): mutationContracts.GroupTopologyConfigMutationComputed {
         const idempotency = probeTopologyConfigMutationIdempotency(
-            preparation.command,
+            command,
             read.state,
-            preparation.stableFacts.commandHash
+            command.commandHash
         );
         if (idempotency.outcome !== 'miss') {
             return idempotency;
         }
         return computeTopologyConfigMutation({
-            command: preparation.command,
+            command,
             read: read.state,
-            facts: this.toFacts(preparation, read, attemptCount),
-            serverDefaults: this.dependencies.serverDefaults ?? {}
+            facts: toTopologyConfigMutationFacts(command, read, attemptCount),
+            serverDefaults: read.serverDefaults
         });
     }
 
-    validate(
-        preparation: GroupTopologyConfigMutationPreparation,
-        read: GroupTopologyConfigMutationAttemptRead,
-        attemptCount: number,
-        computed: mutationContracts.GroupTopologyConfigMutationComputed
-    ): void {
+    validate(validation: GroupTopologyConfigMutationValidation): void {
+        const { command, read, attemptCount, computed } = validation;
         if (computed.outcome === 'replay' || computed.outcome === 'idempotency-conflict') {
             validateTopologyConfigMutationIdempotency({
-                command: preparation.command,
+                command,
                 read: read.state,
-                commandHash: preparation.stableFacts.commandHash,
+                commandHash: command.commandHash,
                 authorityFacts: {
-                    isPlatformAdmin: this.dependencies.isPlatformAdmin(
-                        preparation.command.input.updatedByPrincipalId
-                    )
+                    isPlatformAdmin: read.isPlatformAdmin,
+                    policyNowEpochMs: read.policyNowEpochMs
                 },
                 computed
             });
             return;
         }
         validateTopologyConfigMutation({
-            command: preparation.command,
+            command,
             read: read.state,
-            facts: this.toFacts(preparation, read, attemptCount),
-            serverDefaults: this.dependencies.serverDefaults ?? {},
+            facts: toTopologyConfigMutationFacts(command, read, attemptCount),
+            serverDefaults: read.serverDefaults,
             computed
         });
     }
@@ -135,19 +119,23 @@ export class GroupTopologyConfigMutationService {
             outboxWriter: this.dependencies.outboxWriter
         });
     }
+}
 
-    private toFacts(
-        preparation: GroupTopologyConfigMutationPreparation,
-        read: GroupTopologyConfigMutationAttemptRead,
-        attemptCount: number
-    ): mutationContracts.GroupTopologyConfigMutationFacts {
-        return {
-            ...preparation.stableFacts,
-            isPlatformAdmin: this.dependencies.isPlatformAdmin(
-                preparation.command.input.updatedByPrincipalId
-            ),
-            policyNowEpochMs: read.policyNowEpochMs,
-            attemptCount
-        };
-    }
+function toTopologyConfigMutationFacts(
+    command: mutationContracts.GroupTopologyConfigMutationCommand,
+    read: GroupTopologyConfigMutationAttemptRead,
+    attemptCount: number
+): mutationContracts.GroupTopologyConfigMutationFacts {
+    return {
+        resolvedOverrideExpiresAtEpochMs: command.operation === 'putOverride'
+            ? computeOverrideExpiresAtEpochMs({
+                nowEpochMs: command.capturedAtEpochMs,
+                ttlMs: command.input.ttlMs ?? undefined,
+                expiresAtEpochMs: command.input.expiresAtEpochMs ?? undefined
+            })
+            : null,
+        isPlatformAdmin: read.isPlatformAdmin,
+        policyNowEpochMs: read.policyNowEpochMs,
+        attemptCount
+    };
 }

--- a/packages/shared-server/rallar-system/topology/config/group-topology-config.ts
+++ b/packages/shared-server/rallar-system/topology/config/group-topology-config.ts
@@ -181,9 +181,7 @@ function toSetTopologyConfigPatch(
 export function resolveOverrideExpiresAtEpochMs(
     input: ResolveOverrideExpiresAtEpochMsInput
 ): number {
-    const maxExpiresAtEpochMs = input.nowEpochMs + MAX_GROUP_TOPOLOGY_OVERRIDE_TTL_MS;
-    const requestedExpiresAtEpochMs = input.expiresAtEpochMs ??
-        input.nowEpochMs + (input.ttlMs ?? DEFAULT_GROUP_TOPOLOGY_OVERRIDE_TTL_MS);
+    const requestedExpiresAtEpochMs = computeOverrideExpiresAtEpochMs(input);
     if (
         !Number.isFinite(requestedExpiresAtEpochMs) ||
         requestedExpiresAtEpochMs <= input.nowEpochMs
@@ -200,7 +198,18 @@ export function resolveOverrideExpiresAtEpochMs(
             }
         ]);
     }
-    return Math.min(requestedExpiresAtEpochMs, maxExpiresAtEpochMs);
+    return requestedExpiresAtEpochMs;
+}
+
+export function computeOverrideExpiresAtEpochMs(
+    input: ResolveOverrideExpiresAtEpochMsInput
+): number {
+    const requestedExpiresAtEpochMs = input.expiresAtEpochMs ??
+        input.nowEpochMs + (input.ttlMs ?? DEFAULT_GROUP_TOPOLOGY_OVERRIDE_TTL_MS);
+    return Math.min(
+        requestedExpiresAtEpochMs,
+        input.nowEpochMs + MAX_GROUP_TOPOLOGY_OVERRIDE_TTL_MS
+    );
 }
 
 function throwIfIssues(issues: readonly GroupTopologyValidationIssue[]): void {

--- a/packages/shared-server/rallar-system/topology/config/mutation/compute-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/compute-topology-config-mutation.ts
@@ -6,7 +6,7 @@ import type {
 } from '@shared/api/graph-topology-management-types.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RuntimeStateEntryValue } from '../../../../runtime-state/runtime-state-json-store.ts';
-import { readDefaultGroupTopologyConfig, resolveGroupTopologyConfig } from '../group-topology-config.ts';
+import { readDefaultGroupTopologyConfig } from '../group-topology-config.ts';
 import type {
     GroupTopologyConfigGeneration,
     GroupTopologyConfigMutationComputed,
@@ -19,19 +19,14 @@ import {
     createTopologyConfigNoOpReceipt,
     createTopologyConfigWriteResult
 } from './topology-config-mutation-receipt.ts';
-import {
-    requireTopologyConfigPatch,
-    validateTopologyConfigMutationInput
-} from './validate-topology-config-mutation-input.ts';
 
 export function computeTopologyConfigMutation(
     topologyMutation: TopologyConfigMutationInput
 ): GroupTopologyConfigMutationComputed {
-    validateTopologyConfigMutationInput(topologyMutation);
     const idempotency = probeTopologyConfigMutationIdempotency(
         topologyMutation.command,
         topologyMutation.read,
-        topologyMutation.facts.commandHash
+        topologyMutation.command.commandHash
     );
     if (idempotency.outcome !== 'miss') {
         return idempotency;
@@ -60,25 +55,17 @@ function computePutConfig(
         config: applyGroupTopologyConfigPatch({
             fallback: readDefaultGroupTopologyConfig(topologyMutation.serverDefaults),
             current: current?.value.config,
-            patch: requireTopologyConfigPatch(command)
+            patch: command.input.config ?? {}
         }),
         version: nextTopologyConfigVersion(current?.value.version, generation),
-        createdAtEpochMs: current?.value.createdAtEpochMs ?? facts.requestedAtEpochMs,
+        createdAtEpochMs: current?.value.createdAtEpochMs ?? command.capturedAtEpochMs,
         updatedAtEpochMs: Math.max(
-            facts.requestedAtEpochMs,
-            current?.value.updatedAtEpochMs ?? facts.requestedAtEpochMs
+            command.capturedAtEpochMs,
+            current?.value.updatedAtEpochMs ?? command.capturedAtEpochMs
         ),
         updatedByPrincipalId: command.input.updatedByPrincipalId,
         requestId: command.requestId
     };
-    resolveGroupTopologyConfig({ serverOptions: topologyMutation.serverDefaults, durable: config });
-    if (read.override) {
-        resolveGroupTopologyConfig({
-            serverOptions: topologyMutation.serverDefaults,
-            durable: config,
-            temporary: read.override.value
-        });
-    }
     return createTopologyConfigWriteResult({
         command,
         read,
@@ -101,32 +88,24 @@ function computePutOverride(
     const { command, read, facts } = topologyMutation;
     const current = read.override;
     const generation = read.overrideGeneration;
-    if (facts.resolvedOverrideExpiresAtEpochMs === null) {
-        throw new TypeError('Topology override expiry fact is required');
-    }
     const override: StoredGroupTopologyOverride = {
         groupRef: copyGroupRef(command.aggregateRef),
         config: applyGroupTopologyConfigPatch({
             fallback: read.config?.value.config ??
                 readDefaultGroupTopologyConfig(topologyMutation.serverDefaults),
             current: current?.value.config,
-            patch: requireTopologyConfigPatch(command)
+            patch: command.input.config ?? {}
         }),
         version: nextTopologyConfigVersion(current?.value.version, generation),
-        createdAtEpochMs: current?.value.createdAtEpochMs ?? facts.requestedAtEpochMs,
+        createdAtEpochMs: current?.value.createdAtEpochMs ?? command.capturedAtEpochMs,
         updatedAtEpochMs: Math.max(
-            facts.requestedAtEpochMs,
-            current?.value.updatedAtEpochMs ?? facts.requestedAtEpochMs
+            command.capturedAtEpochMs,
+            current?.value.updatedAtEpochMs ?? command.capturedAtEpochMs
         ),
         updatedByPrincipalId: command.input.updatedByPrincipalId,
         requestId: command.requestId,
-        expiresAtEpochMs: facts.resolvedOverrideExpiresAtEpochMs
+        expiresAtEpochMs: facts.resolvedOverrideExpiresAtEpochMs ?? command.capturedAtEpochMs
     };
-    resolveGroupTopologyConfig({
-        serverOptions: topologyMutation.serverDefaults,
-        durable: read.config?.value,
-        temporary: override
-    });
     return createTopologyConfigWriteResult({
         command,
         read,
@@ -155,11 +134,6 @@ function computeDelete(
         return computeAbsentDelete(topologyMutation, target, generation);
     }
 
-    resolveGroupTopologyConfig({
-        serverOptions: topologyMutation.serverDefaults,
-        durable: target === 'config' ? undefined : topologyMutation.read.config?.value,
-        temporary: target === 'override' ? undefined : topologyMutation.read.override?.value
-    });
     const guard: TopologyConfigWriteGuard = target === 'config'
         ? {
             target: 'config',
@@ -199,7 +173,6 @@ function computeAbsentDelete(
     }
     const idempotency = createTopologyConfigMutationRecord(
         topologyMutation.command,
-        topologyMutation.facts,
         receipt
     );
     if (idempotency === null) {

--- a/packages/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts
@@ -11,18 +11,22 @@ import type * as persistence from '../../../group-state/persistence/group-state-
 import type { ComputedRtcTopologyOutbox } from '../../mutation/rtc-topology-outbox-entry.ts';
 import type { GroupTopologyServerOptions } from '../group-topology-config.ts';
 
-export type GroupTopologyConfigMutationCommand = Readonly<{
-    operation: GroupTopologyConfigMutationOperation;
-    aggregateRef: GroupRef;
-    commandId: string;
-    requestId: string | null;
-    input: Readonly<{
-        config: GroupTopologyConfigPatch | null;
-        updatedByPrincipalId: string;
-        ttlMs: number | null;
-        expiresAtEpochMs: number | null;
-    }>;
-}>;
+export interface GroupTopologyConfigMutationCommandInput {
+    readonly config: GroupTopologyConfigPatch | null;
+    readonly updatedByPrincipalId: string;
+    readonly ttlMs: number | null;
+    readonly expiresAtEpochMs: number | null;
+}
+
+export interface GroupTopologyConfigMutationCommand {
+    readonly operation: GroupTopologyConfigMutationOperation;
+    readonly aggregateRef: GroupRef;
+    readonly commandId: string;
+    readonly requestId: string | null;
+    readonly commandHash: string;
+    readonly capturedAtEpochMs: number;
+    readonly input: GroupTopologyConfigMutationCommandInput;
+}
 
 export interface GroupTopologyConfigMutationRecord {
     readonly groupRef: GroupRef;
@@ -62,13 +66,8 @@ export interface GroupTopologyConfigMutationRead {
 
 type TopologyConfigInvariantGenerationEntry = RuntimeStateEntryValue<GroupTopologyConfigInvariantGeneration>;
 
-export interface GroupTopologyConfigMutationStableFacts {
-    readonly requestedAtEpochMs: number;
-    readonly commandHash: string;
+export interface GroupTopologyConfigMutationFacts {
     readonly resolvedOverrideExpiresAtEpochMs: number | null;
-}
-
-export interface GroupTopologyConfigMutationFacts extends GroupTopologyConfigMutationStableFacts {
     readonly isPlatformAdmin: boolean;
     readonly policyNowEpochMs: number;
     readonly attemptCount: number;

--- a/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-idempotency.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-idempotency.ts
@@ -4,17 +4,13 @@ import type {
     GroupTopologyConfigMutationRead
 } from './group-topology-config-mutation-contracts.ts';
 import { resultFromTopologyConfigReceipt } from './topology-config-mutation-receipt.ts';
-import {
-    requireTopologyConfigRequestId,
-    validateTopologyConfigIdempotencyInput
-} from './validate-topology-config-mutation-input.ts';
-import { validateGroupTopologyConfigMutationRecord } from './validate-topology-config-records.ts';
+import { validateTopologyConfigIdempotencyInput } from './validate-topology-config-mutation-input.ts';
 
 export interface ValidateTopologyConfigMutationIdempotencyInput {
     readonly command: GroupTopologyConfigMutationCommand;
     readonly read: GroupTopologyConfigMutationRead;
     readonly commandHash: string;
-    readonly authorityFacts: Readonly<{ isPlatformAdmin: boolean; }>;
+    readonly authorityFacts: Readonly<{ isPlatformAdmin: boolean; policyNowEpochMs: number; }>;
     readonly computed: Exclude<GroupTopologyConfigMutationComputed, { outcome: 'write' | 'claim' | 'no-op'; }>;
 }
 
@@ -30,20 +26,12 @@ export function probeTopologyConfigMutationIdempotency(
         return { outcome: 'miss' };
     }
     const record = read.idempotency.value;
-    const requestId = requireTopologyConfigRequestId(command);
-    validateGroupTopologyConfigMutationRecord(record, {
-        groupRef: command.aggregateRef,
-        requestId
-    });
     if (record.commandHash !== commandHash) {
         return {
             outcome: 'idempotency-conflict',
             existingCommandHash: record.commandHash,
             receivedCommandHash: commandHash
         };
-    }
-    if (record.receipt.operation !== command.operation) {
-        throw new TypeError('Topology config receipt operation differs from command');
     }
     return {
         outcome: 'replay',
@@ -60,6 +48,12 @@ export function validateTopologyConfigMutationIdempotency(
         idempotencyValidation.read,
         idempotencyValidation.authorityFacts
     );
+    if (
+        idempotencyValidation.read.idempotency?.value.receipt.operation !==
+            idempotencyValidation.command.operation
+    ) {
+        throw new TypeError('Topology config receipt operation differs from command');
+    }
     const canonical = probeTopologyConfigMutationIdempotency(
         idempotencyValidation.command,
         idempotencyValidation.read,

--- a/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
@@ -87,7 +87,6 @@ export function createTopologyConfigWriteResult(
         receipt,
         idempotency: createTopologyConfigMutationRecord(
             topologyWrite.command,
-            topologyWrite.facts,
             receipt
         ),
         outbox,
@@ -116,7 +115,6 @@ export function createTopologyConfigNoOpReceipt(
 
 export function createTopologyConfigMutationRecord(
     command: GroupTopologyConfigMutationCommand,
-    facts: GroupTopologyConfigMutationFacts,
     receipt: GroupTopologyConfigMutationReceipt
 ): GroupTopologyConfigMutationRecord | null {
     return command.requestId === null
@@ -124,7 +122,7 @@ export function createTopologyConfigMutationRecord(
         : {
             groupRef: copyGroupRef(command.aggregateRef),
             requestId: command.requestId,
-            commandHash: facts.commandHash,
+            commandHash: command.commandHash,
             receipt
         };
 }
@@ -181,7 +179,7 @@ function createTopologyConfigOutbox(
     return {
         aggregateRef: copyGroupRef(topologyWrite.command.aggregateRef),
         commandId: topologyWrite.command.commandId,
-        createdAtEpochMs: topologyWrite.facts.requestedAtEpochMs,
+        createdAtEpochMs: topologyWrite.command.capturedAtEpochMs,
         acceptedCausalRevision: acceptedCausalRevision.causalRevision,
         groupSnapshot: topologyWrite.read.groupSnapshot,
         effectKind: 'rtc-topology-recompute',
@@ -225,7 +223,7 @@ function createTopologyConfigReceipt(
     return {
         commandId: receiptFields.command.commandId,
         requestId: receiptFields.command.requestId,
-        commandHash: receiptFields.facts.commandHash,
+        commandHash: receiptFields.command.commandHash,
         operation: receiptFields.command.operation,
         outcome: receiptFields.outcome,
         attemptCount: receiptFields.facts.attemptCount,

--- a/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation-input.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation-input.ts
@@ -30,7 +30,7 @@ export function validateTopologyConfigMutationInput(
 ): void {
     validateTopologyConfigCommand(topologyMutation.command);
     validateTopologyConfigRead(topologyMutation.read, topologyMutation.command);
-    validateTopologyConfigFacts(topologyMutation.facts);
+    validateTopologyConfigFacts(topologyMutation.command, topologyMutation.facts);
     validateTopologyConfigAuthority(
         topologyMutation.read.groupSnapshot,
         topologyMutation.command,
@@ -41,13 +41,14 @@ export function validateTopologyConfigMutationInput(
 export function validateTopologyConfigIdempotencyInput(
     command: GroupTopologyConfigMutationCommand,
     read: GroupTopologyConfigMutationRead,
-    authorityFacts: Readonly<{ isPlatformAdmin: boolean; }>
+    authorityFacts: Readonly<{ isPlatformAdmin: boolean; policyNowEpochMs: number; }>
 ): void {
     validateTopologyConfigCommand(command);
     validateTopologyConfigRead(read, command);
     if (typeof authorityFacts.isPlatformAdmin !== 'boolean') {
         throw new TypeError('Topology config admin fact is invalid');
     }
+    validateTopologyStorageRevision(authorityFacts.policyNowEpochMs, 'Topology config policy time');
     validateTopologyConfigAuthority(read.groupSnapshot, command, authorityFacts);
 }
 
@@ -70,7 +71,7 @@ export function requireTopologyConfigRequestId(
 }
 
 function validateTopologyConfigCommand(command: GroupTopologyConfigMutationCommand): void {
-    if (!command || typeof command !== 'object' || 'commandHash' in command) {
+    if (!command || typeof command !== 'object') {
         throw new TypeError('Topology config command is invalid');
     }
     if (!['putConfig', 'deleteConfig', 'putOverride', 'deleteOverride'].includes(command.operation)) {
@@ -78,6 +79,10 @@ function validateTopologyConfigCommand(command: GroupTopologyConfigMutationComma
     }
     validateTopologyGroupRef(command.aggregateRef, 'Topology config command groupRef');
     requireTopologyString(command.commandId, 'Topology config commandId');
+    if (!/^sha256:[0-9a-f]{64}$/.test(command.commandHash)) {
+        throw new TypeError('Topology config command hash is invalid');
+    }
+    validateTopologyStorageRevision(command.capturedAtEpochMs, 'Topology config captured time');
     if (command.requestId !== null) {
         requireTopologyString(command.requestId, 'Topology config requestId');
     }
@@ -165,15 +170,20 @@ function validateTopologyConfigReadGenerations(
     }
 }
 
-function validateTopologyConfigFacts(facts: GroupTopologyConfigMutationFacts): void {
-    validateTopologyStorageRevision(facts.requestedAtEpochMs, 'request fact time');
+function validateTopologyConfigFacts(
+    command: GroupTopologyConfigMutationCommand,
+    facts: GroupTopologyConfigMutationFacts
+): void {
     validateTopologyStorageRevision(facts.policyNowEpochMs, 'policy fact time');
     validateTopologyPositiveInteger(facts.attemptCount, 'attempt fact count');
-    if (!/^sha256:[0-9a-f]{64}$/.test(facts.commandHash)) {
-        throw new TypeError('Topology config command hash is invalid');
-    }
     if (typeof facts.isPlatformAdmin !== 'boolean') {
         throw new TypeError('Topology config admin fact is invalid');
+    }
+    if (command.operation === 'putOverride' && facts.resolvedOverrideExpiresAtEpochMs === null) {
+        throw new TypeError('Topology override expiry fact is required');
+    }
+    if (command.operation !== 'putOverride' && facts.resolvedOverrideExpiresAtEpochMs !== null) {
+        throw new TypeError('Topology override expiry fact differs from operation');
     }
     if (facts.resolvedOverrideExpiresAtEpochMs !== null) {
         validateTopologyStorageRevision(facts.resolvedOverrideExpiresAtEpochMs, 'override expiry fact');

--- a/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation.ts
@@ -1,11 +1,19 @@
 import { toRtcTopologyEntryResourceId } from '../../mutation/rtc-topology-outbox-entry.ts';
+import { resolveGroupTopologyConfig } from '../group-topology-config.ts';
 import { computeTopologyConfigMutation } from './compute-topology-config-mutation.ts';
 import type {
     GroupTopologyConfigMutationComputed,
     TopologyConfigMutationInput
 } from './group-topology-config-mutation-contracts.ts';
-import { requireTopologyConfigRequestId } from './validate-topology-config-mutation-input.ts';
-import { validateGroupTopologyConfigMutationRecord } from './validate-topology-config-records.ts';
+import {
+    requireTopologyConfigRequestId,
+    validateTopologyConfigMutationInput
+} from './validate-topology-config-mutation-input.ts';
+import {
+    validateGroupTopologyConfigMutationRecord,
+    validateStoredGroupTopologyConfig,
+    validateStoredGroupTopologyOverride
+} from './validate-topology-config-records.ts';
 
 export interface ValidateTopologyConfigMutationInput extends TopologyConfigMutationInput {
     readonly computed: GroupTopologyConfigMutationComputed;
@@ -14,6 +22,7 @@ export interface ValidateTopologyConfigMutationInput extends TopologyConfigMutat
 export function validateTopologyConfigMutation(
     topologyValidation: ValidateTopologyConfigMutationInput
 ): void {
+    validateTopologyConfigMutationInput(topologyValidation);
     const computed = topologyValidation.computed;
     const canonical = computeTopologyConfigMutation(topologyValidation);
     if (JSON.stringify(computed) !== JSON.stringify(canonical)) {
@@ -25,12 +34,45 @@ export function validateTopologyConfigMutation(
     if (computed.outcome === 'write' || computed.outcome === 'claim') {
         validateWrittenOrClaimedTopologyConfigMutation({ ...topologyValidation, computed });
     }
+    if (computed.outcome === 'write') {
+        validateTopologyConfigWrite(topologyValidation, computed);
+    }
     if (
         computed.outcome === 'write' &&
         computed.receipt.outboxIds[0] !== toRtcTopologyEntryResourceId(computed.outbox)
     ) {
         throw new TypeError('Topology config receipt outbox differs from intent');
     }
+}
+
+function validateTopologyConfigWrite(
+    topologyValidation: ValidateTopologyConfigMutationInput,
+    computed: Extract<GroupTopologyConfigMutationComputed, { outcome: 'write'; }>
+): void {
+    const guard = computed.guard;
+    if (guard.operation === 'delete') {
+        resolveGroupTopologyConfig({
+            serverOptions: topologyValidation.serverDefaults,
+            durable: guard.target === 'config' ? undefined : topologyValidation.read.config?.value,
+            temporary: guard.target === 'override' ? undefined : topologyValidation.read.override?.value
+        });
+        return;
+    }
+    if (guard.target === 'config') {
+        validateStoredGroupTopologyConfig(guard.value, topologyValidation.command.aggregateRef);
+        resolveGroupTopologyConfig({
+            serverOptions: topologyValidation.serverDefaults,
+            durable: guard.value,
+            temporary: topologyValidation.read.override?.value
+        });
+        return;
+    }
+    validateStoredGroupTopologyOverride(guard.value, topologyValidation.command.aggregateRef);
+    resolveGroupTopologyConfig({
+        serverOptions: topologyValidation.serverDefaults,
+        durable: topologyValidation.read.config?.value,
+        temporary: guard.value
+    });
 }
 
 function validateWrittenOrClaimedTopologyConfigMutation(
@@ -40,8 +82,8 @@ function validateWrittenOrClaimedTopologyConfigMutation(
             computed: Extract<GroupTopologyConfigMutationComputed, { outcome: 'write' | 'claim'; }>;
         }>
 ): void {
-    if (topologyValidation.computed.receipt.commandHash !== topologyValidation.facts.commandHash) {
-        throw new TypeError('Topology config receipt hash differs from facts');
+    if (topologyValidation.computed.receipt.commandHash !== topologyValidation.command.commandHash) {
+        throw new TypeError('Topology config receipt hash differs from command');
     }
     if (topologyValidation.computed.idempotency !== null) {
         validateGroupTopologyConfigMutationRecord(topologyValidation.computed.idempotency, {

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts
@@ -370,6 +370,8 @@ function topologyConfigMutationCommand(
         aggregateRef: command.groupRef,
         commandId: command.requestId,
         requestId: command.requestId,
+        commandHash: command.commandHash,
+        capturedAtEpochMs: command.capturedAtEpochMs,
         input: {
             config,
             updatedByPrincipalId: command.actor.principalId,

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -36,10 +36,7 @@ export interface TopologyAppInboxHandlerDependencies {
 }
 
 export interface TopologyAppInboxMutationOwners {
-    readonly configMutationService: Pick<
-        GroupTopologyConfigMutationService,
-        'prepare' | 'read' | 'compute' | 'validate' | 'write'
-    >;
+    readonly configMutationService: Pick<GroupTopologyConfigMutationService, 'read' | 'compute' | 'validate' | 'write'>;
     readonly reconfigureMutation: Pick<GroupTopologyReconfigureMutation, 'read' | 'compute' | 'validate' | 'write'>;
 }
 
@@ -179,15 +176,11 @@ export class TopologyAppInboxHandler {
                 owners.reconfigureMutation
             );
         }
-        const preparation = await owners.configMutationService.prepare({
-            command: toTopologyConfigMutationCommand(authority.command),
-            commandHash: authority.command.commandHash,
-            capturedAtEpochMs: authority.command.capturedAtEpochMs
-        });
-        const read = await owners.configMutationService.read(preparation.command);
+        const command = toTopologyConfigMutationCommand(authority.command);
+        const read = await owners.configMutationService.read(command);
         const attemptCount = context.entry.dequeueAudit.attempts;
-        const computed = owners.configMutationService.compute(preparation, read, attemptCount);
-        owners.configMutationService.validate(preparation, read, attemptCount, computed);
+        const computed = owners.configMutationService.compute(command, read, attemptCount);
+        owners.configMutationService.validate({ command, read, attemptCount, computed });
         if (computed.outcome === 'idempotency-conflict') {
             throw new GroupTopologyConfigIdempotencyConflictError(
                 computed.existingCommandHash,

--- a/packages/tests/shared-server/rallar-system/topology/config/group-topology-config-resolution.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/group-topology-config-resolution.test.ts
@@ -2,6 +2,7 @@ import type { PutGroupTopologyConfigRequest, PutGroupTopologyOverrideRequest } f
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
+    computeOverrideExpiresAtEpochMs,
     DEFAULT_GROUP_TOPOLOGY_OVERRIDE_TTL_MS,
     GroupTopologyConfigValidationError,
     MAX_GROUP_TOPOLOGY_OVERRIDE_TTL_MS,
@@ -89,6 +90,7 @@ describe('group topology config resolution', () => {
     });
 
     it('defaults override expiry to 15 minutes, caps it at 24 hours, and rejects elapsed values', () => {
+        expect(computeOverrideExpiresAtEpochMs({ nowEpochMs: 1_000, ttlMs: 0 })).toBe(1_000);
         expect(resolveOverrideExpiresAtEpochMs({ nowEpochMs: 1_000 })).toBe(
             1_000 + DEFAULT_GROUP_TOPOLOGY_OVERRIDE_TTL_MS
         );

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-compute.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-compute.test.ts
@@ -1,7 +1,6 @@
 import { computeTopologyConfigMutation } from '@shared-server/rallar-system/topology/config/mutation/compute-topology-config-mutation.ts';
 import { validateTopologyConfigMutation } from '@shared-server/rallar-system/topology/config/mutation/validate-topology-config-mutation.ts';
 import { validateGroupTopologyConfigMutationRecord } from '@shared-server/rallar-system/topology/config/mutation/validate-topology-config-records.ts';
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
     createTopologyConfigMutationTestInput,
@@ -81,53 +80,6 @@ describe('group topology config mutation compute', () => {
         }
         expect(override.result.override.config.degreeLimit).toBe(4);
     });
-
-    it('keeps pure topology config phases ambient-free and orchestration visible', () => {
-        const mutationSource = readProductionSource(
-            'topology/config/mutation/compute-topology-config-mutation.ts'
-        );
-        for (
-            const forbidden of [
-                'Date.now',
-                'Temporal.Now',
-                'Math.random',
-                'randomUUID',
-                '.begin(',
-                'hashMutationCommand',
-                'publisher',
-                'topologyService'
-            ]
-        ) {
-            expect(mutationSource, forbidden).not.toContain(forbidden);
-        }
-
-        const writerSource = readProductionSource(
-            'topology/config/mutation/write-topology-config-mutation.ts'
-        );
-        const appInboxSource = readProductionSource('topology/inbox/topology-app-inbox-handler.ts');
-        const read = appInboxSource.indexOf('const read = await owners.configMutationService.read');
-        const compute = appInboxSource.indexOf(
-            'const computed = owners.configMutationService.compute',
-            read
-        );
-        const validate = appInboxSource.indexOf('owners.configMutationService.validate', compute);
-        const transaction = appInboxSource.indexOf(
-            'const result = await this.dependencies.transactionWriter.writeMutation',
-            validate
-        );
-        const write = appInboxSource.indexOf('configMutationService.write(', transaction);
-        expect(read).toBeGreaterThan(-1);
-        expect(read).toBeLessThan(compute);
-        expect(compute).toBeLessThan(validate);
-        expect(validate).toBeLessThan(transaction);
-        expect(transaction).toBeLessThan(write);
-        const writeHelper = writerSource.indexOf('export async function writeTopologyConfigMutation');
-        expect(writeHelper).toBeGreaterThan(-1);
-        const writer = writerSource.slice(writeHelper);
-        expect(writerSource).toContain('readonly transaction: PSqlSql');
-        expect(writer).not.toContain('.begin(');
-        expect(appInboxSource.slice(read, write)).not.toContain('.begin(');
-    });
 });
 
 type DeterministicMutationInput = ReturnType<typeof deterministicMutationInput>;
@@ -141,6 +93,8 @@ function deterministicMutationInput() {
             aggregateRef: createTopologyTestGroupRef(),
             commandId: 'config-command-1',
             requestId: 'config-command-1',
+            commandHash: `sha256:${'a'.repeat(64)}`,
+            capturedAtEpochMs: 1_000,
             input: {
                 config: { topologyKind: 'tree' as const, degreeLimit: 4 },
                 updatedByPrincipalId: 'owner',
@@ -159,9 +113,7 @@ function deterministicMutationInput() {
             groupAuthorityGuard: createTopologyTestAuthorityGuard(40)
         },
         facts: {
-            requestedAtEpochMs: 1_000,
             policyNowEpochMs: 1_000,
-            commandHash: `sha256:${'a'.repeat(64)}`,
             attemptCount: 1,
             isPlatformAdmin: false,
             resolvedOverrideExpiresAtEpochMs: null,
@@ -176,19 +128,12 @@ function validateMutationRecord(input: DeterministicMutationInput, receipt: Writ
         {
             groupRef: input.command.aggregateRef,
             requestId: input.command.requestId,
-            commandHash: input.facts.commandHash,
+            commandHash: input.command.commandHash,
             receipt
         },
         {
             groupRef: input.command.aggregateRef,
             requestId: input.command.requestId
         }
-    );
-}
-
-function readProductionSource(relativePath: string): string {
-    return readFileSync(
-        new URL(`../../../../../../shared-server/rallar-system/${relativePath}`, import.meta.url),
-        'utf8'
     );
 }

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-idempotency.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-idempotency.test.ts
@@ -21,17 +21,20 @@ describe('topology config mutation idempotency', () => {
         const replay = probeTopologyConfigMutationIdempotency(
             mutation.command,
             read,
-            mutation.facts.commandHash
+            mutation.command.commandHash
         );
 
         expect(replay).toMatchObject({ outcome: 'replay', receipt: accepted.receipt });
+        if (replay.outcome !== 'replay') {
+            throw new Error('Expected topology config replay');
+        }
         expect(() =>
             validateTopologyConfigMutationIdempotency({
                 command: mutation.command,
                 read,
-                commandHash: mutation.facts.commandHash,
-                authorityFacts: { isPlatformAdmin: false },
-                computed: replay as never
+                commandHash: mutation.command.commandHash,
+                authorityFacts: { isPlatformAdmin: false, policyNowEpochMs: 1_000 },
+                computed: replay
             })
         ).not.toThrow();
     });
@@ -50,7 +53,7 @@ describe('topology config mutation idempotency', () => {
 
         expect(conflict).toEqual({
             outcome: 'idempotency-conflict',
-            existingCommandHash: mutation.facts.commandHash,
+            existingCommandHash: mutation.command.commandHash,
             receivedCommandHash: `sha256:${'d'.repeat(64)}`
         });
     });
@@ -64,10 +67,13 @@ describe('topology config mutation idempotency', () => {
         if (accepted.outcome !== 'write') {
             throw new Error('Expected topology config write');
         }
+        if (mutation.command.requestId === null) {
+            throw new Error('Expected topology config request id');
+        }
         const corruptRecord = {
             groupRef: mutation.command.aggregateRef,
-            requestId: mutation.command.requestId!,
-            commandHash: mutation.facts.commandHash,
+            requestId: mutation.command.requestId,
+            commandHash: mutation.command.commandHash,
             receipt: {
                 ...accepted.receipt,
                 operation: 'putOverride' as const,
@@ -77,9 +83,26 @@ describe('topology config mutation idempotency', () => {
         };
         const read = { ...mutation.read, idempotency: runtimeEntry(corruptRecord) };
 
-        expect(() => probeTopologyConfigMutationIdempotency(mutation.command, read, mutation.facts.commandHash)).toThrow(
-            'Topology config receipt operation differs from command'
+        const replay = probeTopologyConfigMutationIdempotency(
+            mutation.command,
+            read,
+            mutation.command.commandHash
         );
+        if (replay.outcome === 'miss') {
+            throw new Error('Expected topology config replay');
+        }
+        expect(() =>
+            validateTopologyConfigMutationIdempotency({
+                command: mutation.command,
+                read,
+                commandHash: mutation.command.commandHash,
+                authorityFacts: {
+                    isPlatformAdmin: mutation.facts.isPlatformAdmin,
+                    policyNowEpochMs: mutation.facts.policyNowEpochMs
+                },
+                computed: replay
+            })
+        ).toThrow('Topology config receipt operation differs from command');
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-test-fixtures.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-test-fixtures.ts
@@ -32,6 +32,8 @@ export function createTopologyConfigMutationTestInput(
         aggregateRef: groupRef,
         commandId: commandId ?? `command-${operation}`,
         requestId,
+        commandHash: `sha256:${'c'.repeat(64)}`,
+        capturedAtEpochMs: 1_000,
         input: {
             config: settings.config ?? { topologyKind: 'tree' },
             updatedByPrincipalId: 'owner',
@@ -40,9 +42,7 @@ export function createTopologyConfigMutationTestInput(
         }
     };
     const facts: GroupTopologyConfigMutationFacts = {
-        requestedAtEpochMs: 1_000,
         policyNowEpochMs: 1_000,
-        commandHash: `sha256:${'c'.repeat(64)}`,
         attemptCount: 1,
         isPlatformAdmin: false,
         resolvedOverrideExpiresAtEpochMs: operation === 'putOverride' ? 6_000 : null

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-transaction.test.ts
@@ -1,106 +1,75 @@
 import { createTestGroupStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
-import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { GroupTopologyConfigMutationService } from '@shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts';
-import type { GroupTopologyConfigMutationCommand } from '@shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts';
 import { GroupTopologyConfigRepository } from '@shared-server/rallar-system/topology/config/persistence/group-topology-config-repository.ts';
 import { RtcTopologyOutboxWriter } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-writer.ts';
 
 import { FakeRuntimeStateRepository } from '../../../../runtime-state/test-support/fake-runtime-state-repository.ts';
+import {
+    createTopologyConfigMutationTestInput,
+    deepFreezeTopologyTestValue
+} from './group-topology-config-mutation-test-fixtures.ts';
 
-const GROUP_REF = {
-    applicationId: 'topology-app',
-    workspaceId: 'topology-workspace',
-    groupId: 'topology-room'
-} as const;
-
-describe('group topology config mutation transaction shell', () => {
-    it('exposes transaction-bound writes without a service-local retry lane or DB lock', () => {
-        const source = readFileSync(
-            new URL(
-                '../../../../../../shared-server/rallar-system/topology/config/mutation/write-topology-config-mutation.ts',
-                import.meta.url
-            ),
-            'utf8'
-        );
-
-        expect(source).not.toMatch(/createInProcessMutationLane|configMutationLane/);
-        expect(source).not.toMatch(/waitForRuntimeStateWriteRetry/);
-        expect(source).not.toMatch(/\bfor\s*\([^)]*attempt/);
-        expect(source).not.toMatch(/\.begin\s*\(/);
-        expect(source).not.toMatch(/for\s+update|pg_advisory|row lock/i);
-        expect(source).toContain('writeTopologyConfigMutation(');
-        expect(source).toContain('transaction: PSqlSql');
-    });
-
-    it('materializes only first-winner time facts before an override attempt', async () => {
+describe('group topology config mutation phases', () => {
+    it('computes override expiry from explicit command and read facts without a prepare phase', () => {
         const service = createService();
-        const preparation = await service.prepare({
-            command: command('putOverride', {
-                config: { topologyKind: 'tree' },
-                ttlMs: 5_000,
-                expiresAtEpochMs: null
-            }),
-            commandHash: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            capturedAtEpochMs: 10_000
+        const mutation = createTopologyConfigMutationTestInput({ operation: 'putOverride' });
+        const command = {
+            ...mutation.command,
+            commandHash: `sha256:${'a'.repeat(64)}`,
+            capturedAtEpochMs: 10_000,
+            input: { ...mutation.command.input, ttlMs: 5_000 }
+        };
+        const read = deepFreezeTopologyTestValue({
+            state: mutation.read,
+            policyNowEpochMs: 10_000,
+            isPlatformAdmin: false,
+            serverDefaults: {}
         });
+        const computed = service.compute(command, read, 1);
 
-        expect(preparation.stableFacts).toEqual({
-            requestedAtEpochMs: 10_000,
-            commandHash: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            resolvedOverrideExpiresAtEpochMs: 15_000
+        expect(computed).toMatchObject({
+            outcome: 'write',
+            receipt: {
+                commandHash: command.commandHash,
+                acceptedCreatedAtEpochMs: 10_000,
+                acceptedUpdatedAtEpochMs: 10_000,
+                acceptedExpiresAtEpochMs: 15_000
+            }
         });
-        expect(preparation.stableFacts).not.toHaveProperty('deleteTarget');
+        expect(() => service.validate({ command, read, attemptCount: 1, computed })).not.toThrow();
     });
 
-    it.each(['deleteConfig', 'deleteOverride'] as const)(
-        'does not capture mutable state while preparing %s',
-        async (operation) => {
-            const service = createService();
-            const preparation = await service.prepare({
-                command: command(operation, {
-                    config: null,
-                    ttlMs: null,
-                    expiresAtEpochMs: null
-                }),
-                commandHash: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-                capturedAtEpochMs: 20_000
-            });
+    it('keeps compute and validate repeatable after explicit read facts are captured', () => {
+        const isPlatformAdmin = vi.fn(() => false);
+        const service = createService(isPlatformAdmin);
+        const mutation = createTopologyConfigMutationTestInput();
+        const read = deepFreezeTopologyTestValue({
+            state: mutation.read,
+            policyNowEpochMs: 1_000,
+            isPlatformAdmin: false,
+            serverDefaults: {}
+        });
 
-            expect(preparation.stableFacts).toEqual({
-                requestedAtEpochMs: 20_000,
-                commandHash: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-                resolvedOverrideExpiresAtEpochMs: null
-            });
-        }
-    );
+        const first = service.compute(mutation.command, read, 1);
+        const second = service.compute(mutation.command, read, 1);
+
+        expect(second).toEqual(first);
+        expect(() => service.validate({ command: mutation.command, read, attemptCount: 1, computed: first })).not.toThrow();
+        expect(() => service.validate({ command: mutation.command, read, attemptCount: 1, computed: second })).not.toThrow();
+        expect(isPlatformAdmin).not.toHaveBeenCalled();
+    });
 });
 
-function createService(): GroupTopologyConfigMutationService {
+function createService(isPlatformAdmin: (principalId: string) => boolean = () => false): GroupTopologyConfigMutationService {
     const runtimeRepository = new FakeRuntimeStateRepository();
     return new GroupTopologyConfigMutationService({
         configRepository: new GroupTopologyConfigRepository(runtimeRepository),
         groupStateRepository: createTestGroupStateRepository(runtimeRepository),
         nowEpochMs: () => 20_000,
-        isPlatformAdmin: () => false,
+        isPlatformAdmin,
         outboxWriter: new RtcTopologyOutboxWriter({ recordWrite: () => undefined })
     });
-}
-
-function command(
-    operation: GroupTopologyConfigMutationCommand['operation'],
-    input: Omit<GroupTopologyConfigMutationCommand['input'], 'updatedByPrincipalId'>
-): GroupTopologyConfigMutationCommand {
-    return {
-        operation,
-        aggregateRef: GROUP_REF,
-        commandId: `${operation}-command`,
-        requestId: `${operation}-request`,
-        input: {
-            ...input,
-            updatedByPrincipalId: 'owner'
-        }
-    };
 }

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-transaction.test.ts
@@ -1,5 +1,5 @@
 import { createTestGroupStateRepository } from '@shared-test/shared-server/create-test-state-repositories.ts';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { GroupTopologyConfigMutationService } from '@shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts';
@@ -43,7 +43,9 @@ describe('group topology config mutation phases', () => {
     });
 
     it('keeps compute and validate repeatable after explicit read facts are captured', () => {
-        const isPlatformAdmin = vi.fn(() => false);
+        const isPlatformAdmin = () => {
+            throw new Error('Compute and validate must use the captured authority fact');
+        };
         const service = createService(isPlatformAdmin);
         const mutation = createTopologyConfigMutationTestInput();
         const read = deepFreezeTopologyTestValue({
@@ -59,7 +61,6 @@ describe('group topology config mutation phases', () => {
         expect(second).toEqual(first);
         expect(() => service.validate({ command: mutation.command, read, attemptCount: 1, computed: first })).not.toThrow();
         expect(() => service.validate({ command: mutation.command, read, attemptCount: 1, computed: second })).not.toThrow();
-        expect(isPlatformAdmin).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-validation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-validation.test.ts
@@ -30,13 +30,13 @@ describe('topology config mutation validation', () => {
             durableDegreeLimit: 3,
             overrideDegreeLimit: 5
         });
+        const input = {
+            ...mutation,
+            serverDefaults: { degreeLimit: 3, meshParamK: 2 }
+        };
+        const computed = computeTopologyConfigMutation(input);
 
-        expect(() =>
-            computeTopologyConfigMutation({
-                ...mutation,
-                serverDefaults: { degreeLimit: 3, meshParamK: 2 }
-            })
-        ).toThrow(GroupTopologyConfigValidationError);
+        expect(() => validateTopologyConfigMutation({ ...input, computed })).toThrow(GroupTopologyConfigValidationError);
     });
 
     it('revalidates lifecycle authority at explicit attempt time', () => {
@@ -45,14 +45,14 @@ describe('topology config mutation validation', () => {
             ...mutation.read.groupSnapshot,
             group: { ...mutation.read.groupSnapshot.group, expiresAtEpochMs: 1_500 }
         };
+        const input = {
+            ...mutation,
+            read: { ...mutation.read, groupSnapshot: expired },
+            facts: { ...mutation.facts, isPlatformAdmin: true, policyNowEpochMs: 2_000 }
+        };
+        const computed = computeTopologyConfigMutation(input);
 
-        expect(() =>
-            computeTopologyConfigMutation({
-                ...mutation,
-                read: { ...mutation.read, groupSnapshot: expired },
-                facts: { ...mutation.facts, isPlatformAdmin: true, policyNowEpochMs: 2_000 }
-            })
-        ).toThrow(expect.objectContaining({ status: 403 }));
+        expect(() => validateTopologyConfigMutation({ ...input, computed })).toThrow(expect.objectContaining({ status: 403 }));
     });
 
     it('denies expired and terminal lifecycle mutations to platform admins', () => {
@@ -84,13 +84,13 @@ describe('topology config mutation validation', () => {
                 [terminal, 'group-deleted']
             ] as const
         ) {
-            expect(() =>
-                computeTopologyConfigMutation({
-                    ...mutation,
-                    read: { ...mutation.read, groupSnapshot },
-                    facts: { ...mutation.facts, isPlatformAdmin: true, policyNowEpochMs: 2_000 }
-                })
-            ).toThrow(
+            const input = {
+                ...mutation,
+                read: { ...mutation.read, groupSnapshot },
+                facts: { ...mutation.facts, isPlatformAdmin: true, policyNowEpochMs: 2_000 }
+            };
+            const computed = computeTopologyConfigMutation(input);
+            expect(() => validateTopologyConfigMutation({ ...input, computed })).toThrow(
                 expect.objectContaining({
                     status: 403,
                     denial: expect.objectContaining({ code: denialCode })
@@ -105,11 +105,24 @@ describe('topology config mutation validation', () => {
             commandId: 'elapsed-stable-expiry',
             requestId: 'elapsed-stable-expiry'
         });
-        expect(() =>
-            computeTopologyConfigMutation({
-                ...mutation,
-                facts: { ...mutation.facts, policyNowEpochMs: 7_000 }
-            })
-        ).toThrow(GroupTopologyConfigValidationError);
+        const input = {
+            ...mutation,
+            facts: { ...mutation.facts, policyNowEpochMs: 7_000 }
+        };
+        const computed = computeTopologyConfigMutation(input);
+        expect(() => validateTopologyConfigMutation({ ...input, computed })).toThrow(GroupTopologyConfigValidationError);
+    });
+
+    it('rejects a missing computed override expiry during validation', () => {
+        const mutation = createTopologyConfigMutationTestInput({ operation: 'putOverride' });
+        const input = {
+            ...mutation,
+            facts: { ...mutation.facts, resolvedOverrideExpiresAtEpochMs: null }
+        };
+        const computed = computeTopologyConfigMutation(input);
+
+        expect(() => validateTopologyConfigMutation({ ...input, computed })).toThrow(
+            'Topology override expiry fact is required'
+        );
     });
 });

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -26,8 +26,6 @@ import { createAuthenticatedTopologyEnqueue } from '@shared-server/rallar-system
 
 import { toTopologyAppInboxCommand } from '@shared-server/rallar-system/topology/inbox/topology-app-inbox-command.ts';
 
-import { toTopologyConfigMutationResult } from '@shared-server/rallar-system/topology/config/mutation/to-topology-config-mutation-result.ts';
-
 import type { TopologyAppInboxCommand } from '@shared-server/rallar-system/topology/inbox/topology-app-inbox-contracts.ts';
 import {
     decodeTopologyAppInboxResult,
@@ -39,21 +37,13 @@ import {
 import type { GroupTopologyConfigMutationComputed } from '@shared-server/rallar-system/topology/config/mutation/group-topology-config-mutation-contracts.ts';
 import type { GroupTopologyConfigMutationReceipt } from '@shared/api/graph-topology-management-types.ts';
 
-import type {
-    GroupTopologyConfigMutationAttemptRead,
-    GroupTopologyConfigMutationPreparation
-} from '@shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts';
+import type { GroupTopologyConfigMutationAttemptRead } from '@shared-server/rallar-system/topology/config/group-topology-config-mutation-service.ts';
 
 import type {
     GroupTopologyReconfigureComputed,
     GroupTopologyReconfigureRead
 } from '@shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-contracts.ts';
 import { createTestGroup } from '../../../../create-test-group.ts';
-
-vi.mock(
-    '@shared-server/rallar-system/topology/config/mutation/to-topology-config-mutation-result.ts',
-    () => ({ toTopologyConfigMutationResult: vi.fn() })
-);
 
 const NOW_EPOCH_MS = 1_000;
 const GROUP_REF: GroupRef = {
@@ -99,10 +89,6 @@ describe('TopologyAppInboxHandler', () => {
         const expected = { receipt: computed.receipt, config: computed.result.config };
         const owners = {
             configMutationService: {
-                prepare: vi.fn(async () => {
-                    phases.push('prepare');
-                    return configPreparation();
-                }),
                 read: vi.fn(async () => {
                     phases.push('read');
                     return configRead();
@@ -121,9 +107,6 @@ describe('TopologyAppInboxHandler', () => {
             },
             reconfigureMutation: unusedReconfigureMutation()
         } satisfies TopologyAppInboxMutationOwners;
-        vi.mocked(toTopologyConfigMutationResult).mockImplementationOnce(
-            () => (phases.push('result'), expected)
-        );
         const wakeQueue = vi.fn(() => phases.push('wake'));
         const handler = new TopologyAppInboxHandler({
             groupStateService: sessionReader(phases),
@@ -138,16 +121,14 @@ describe('TopologyAppInboxHandler', () => {
                 }
             }
         });
-        await expect(handler.processMutation(context, owners)).resolves.toBe(expected);
+        await expect(handler.processMutation(context, owners)).resolves.toEqual(expected);
         expect(phases).toEqual([
             'verify-authority',
-            'prepare',
             'read',
             'compute',
             'validate',
             'transaction',
             'write',
-            'result',
             'commit',
             'wake'
         ]);
@@ -165,7 +146,6 @@ describe('TopologyAppInboxHandler', () => {
         };
         const owners = {
             configMutationService: {
-                prepare: vi.fn(async () => configPreparation()),
                 read: vi.fn(async () => configRead()),
                 compute: vi.fn(
                     () =>
@@ -359,28 +339,6 @@ async function persistedSession(): Promise<PersistedAuthSession> {
     };
 }
 
-function configPreparation(): GroupTopologyConfigMutationPreparation {
-    return {
-        command: {
-            operation: 'putConfig',
-            aggregateRef: GROUP_REF,
-            commandId: 'handler-request',
-            requestId: 'handler-request',
-            input: {
-                config: { topologyKind: 'tree' },
-                updatedByPrincipalId: 'owner',
-                ttlMs: null,
-                expiresAtEpochMs: null
-            }
-        },
-        stableFacts: {
-            requestedAtEpochMs: NOW_EPOCH_MS,
-            commandHash: `sha256:${'a'.repeat(64)}`,
-            resolvedOverrideExpiresAtEpochMs: null
-        }
-    };
-}
-
 function configRead(): GroupTopologyConfigMutationAttemptRead {
     return {
         state: {
@@ -393,7 +351,9 @@ function configRead(): GroupTopologyConfigMutationAttemptRead {
             groupSnapshot: groupSnapshot(),
             groupAuthorityGuard: groupAuthorityGuard()
         },
-        policyNowEpochMs: NOW_EPOCH_MS
+        policyNowEpochMs: NOW_EPOCH_MS,
+        isPlatformAdmin: false,
+        serverDefaults: {}
     };
 }
 
@@ -454,7 +414,6 @@ function reconfigureComputed(): GroupTopologyReconfigureComputed {
 
 function unusedConfigMutationService(): TopologyAppInboxMutationOwners['configMutationService'] {
     return {
-        prepare: async () => await Promise.reject(new Error('Unexpected config prepare')),
         read: async () => await Promise.reject(new Error('Unexpected config read')),
         compute: () => {
             throw new Error('Unexpected config compute');

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
@@ -346,14 +346,9 @@ describe('topology AppInbox transaction and idempotency', () => {
         const command = await topologyCommand('collision-request', 5);
         const mutationCommand = toTopologyConfigMutationCommand(command);
         const mutation = management.mutationOwners.configMutationService;
-        const preparation = await mutation.prepare({
-            command: mutationCommand,
-            commandHash: command.commandHash,
-            capturedAtEpochMs: command.capturedAtEpochMs
-        });
         const read = await mutation.read(mutationCommand);
-        const computed = mutation.compute(preparation, read, 1);
-        mutation.validate(preparation, read, 1, computed);
+        const computed = mutation.compute(mutationCommand, read, 1);
+        mutation.validate({ command: mutationCommand, read, attemptCount: 1, computed });
         expect(computed.outcome).toBe('write');
         if (computed.outcome !== 'write') {
             throw new Error('Expected a topology config write');


### PR DESCRIPTION
## Goal

Make topology-config AppInbox mutations follow the direct `read → compute → validate → write(transaction, computed)` model without an extra preparation phase, hidden compute/validate dependencies, or an inner retry loop.

## Changes

- Removes `GroupTopologyConfigMutationService.prepare` and its preparation/stable-facts contracts without a compatibility wrapper.
- Carries immutable command hash and capture time on the command that owns them.
- Captures policy time, platform-admin result, and server defaults in the explicit read result.
- Keeps compute and validate deterministic from command/read/attempt inputs; authorization, lifecycle, persisted-record, and effective-config rejection now occurs in validate.
- Centralizes non-validating override-expiry arithmetic in one pure function; validation remains separate.
- Moves idempotency command/receipt validation out of replay computation and into validate.
- Removes brittle source-grep tests and the mocked result builder; semantic handler, pure-phase, retry-redelivery, collision, and PGlite tests remain.

## Acceptance

- Config handler has no `prepare` phase and exposes read/compute/validate/write directly.
- Repeating compute or validate with the same explicit inputs produces the same result and performs no repository read, clock read, admin lookup, or hidden effect.
- Invalid lifecycle, config, expiry, and replay relationships are computed as candidate data and rejected by validate before transaction entry.
- A write conflict exits one attempt; QueueBox redelivery rereads, recomputes, and revalidates. No handler-local retry loop is added.
- Existing transaction, idempotency, rollback, result, and topology behavior is preserved.

## Validation

- `npx vitest run packages/tests/shared-server/rallar-system/topology --silent`: 60 files passed, 3 skipped; 512 tests passed, 5 skipped.
- Installed Deno 2.9.5 PGlite topology retry/authority test: 3 passed, 0 failed.
- `npx tsc -p packages/shared-server/tsconfig.json --noEmit --pretty false`: passed.
- `npm run typecheck:tests`: 1,019 files enforced, 0 errors.
- API-v1 `deno task check`, focused Deno check, and focused Deno lint: passed.
- Changed-range repository style: passed with no new findings.
- Repository structure, dprint, and diff checks: passed.
- Scoped navigation reports one pre-existing high-confidence registration-indirection finding in untouched `topology-inbox-service.ts`; this PR neither changes nor worsens it. The direct changed path is command decode → read → compute → validate → AppInbox transaction → write → commit → wake.

## Risk and rollback

The internal mutation command and service signatures change atomically across verified consumers. There is no external product API or persisted wire-format change. Roll back this PR as one commit if a downstream internal consumer was missed.

## Follow-up

A separate stacked PR will make topology-config persistence operation-specific and SQL-ready before transaction entry. This PR deliberately does not mix that database adapter change into the phase/control-flow review.