### PR TITLE
Compute IndexedDB writes before transactions

### DIFF
--- a/packages/shared-web/browser/al-runtime/browser-al-runtime-cleanup.ts
+++ b/packages/shared-web/browser/al-runtime/browser-al-runtime-cleanup.ts
@@ -1,10 +1,11 @@
+import { decodeALAdmissionStoredValue } from '@shared/alm/al-admission-backend.ts';
+import { ALAdmissionCorruptionError, decodeALAdmissionValue } from '@shared/alm/al-admission-decoder.ts';
+import { decodeALAdmissionNumber } from '@shared/alm/al-admission-value-validation.ts';
 import { isIndexedDbALRuntimeStoreSupported } from '@shared/alm/al-runtime-stores.ts';
-import {
-    decodeALAdmissionStoredValue,
-    type ALAdmissionStoredValue
-} from '@shared/alm/al-admission-backend.ts';
-import { decodeALAdmissionValue } from '@shared/alm/al-admission-decoder.ts';
+import { ALAdmissionBackendConflictError } from '@shared/alm/ALAdmissionBackendConflictError.ts';
+import { AL_ADMISSION_REVISION_KEY } from '@shared/alm/indexed-db-admission-backend.ts';
 import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import { tryRunInIntervals } from '@shared/resilience/TryWith.ts';
 
 import {
@@ -16,11 +17,24 @@ import {
 
 export const BROWSER_AL_RUNTIME_EXPIRY_EVICTION_INTERVAL_MS = 60_000;
 
-interface BrowserALRuntimeCleanupScan {
-    readonly db: IDBDatabase;
-    readonly keyPrefixes: readonly string[];
-    readonly shouldDelete: (entry: ALAdmissionStoredValue) => boolean;
+interface BrowserALRuntimeCleanupRead {
+    readonly revision: number;
+    readonly rows: readonly Readonly<{ key: string; value: unknown; }>[];
 }
+
+interface BrowserALRuntimeCleanupComputed {
+    readonly deleteKeys: readonly string[];
+    readonly revisionWrite: Readonly<{
+        key: typeof AL_ADMISSION_REVISION_KEY;
+        value: number;
+        expireAtTimestamp: number;
+    }>;
+    readonly scanned: number;
+}
+
+type BrowserALRuntimeDeletionPolicy =
+    | Readonly<{ kind: 'all'; }>
+    | Readonly<{ kind: 'expired'; nowMs: number; }>;
 
 export type BrowserALRuntimeCleanupResult = Readonly<{
     dbName: string;
@@ -44,7 +58,7 @@ export async function deleteExpiredBrowserALRuntimeEntries(
 
     return await deleteBrowserALRuntimeEntriesMatching({
         keyPrefixes: options.keyPrefixes ?? [BROWSER_AL_RUNTIME_ENTRY_KEY_PREFIX],
-        shouldDelete: (entry) => isExpiredBrowserALRuntimeEntry(entry, nowMs)
+        deletionPolicy: { kind: 'expired', nowMs }
     });
 }
 
@@ -63,7 +77,7 @@ export async function deleteBrowserALRuntimeEntriesForSession(
 ): Promise<BrowserALRuntimeCleanupResult> {
     return await deleteBrowserALRuntimeEntriesMatching({
         keyPrefixes: toBrowserSessionALRuntimeEntryKeyPrefixes(sessionId),
-        shouldDelete: () => true
+        deletionPolicy: { kind: 'all' }
     });
 }
 
@@ -104,7 +118,7 @@ export async function initBrowserALRuntimeExpiryEviction(
 async function deleteBrowserALRuntimeEntriesMatching(
     options: Readonly<{
         keyPrefixes: readonly string[];
-        shouldDelete: (entry: ALAdmissionStoredValue) => boolean;
+        deletionPolicy: BrowserALRuntimeDeletionPolicy;
     }>
 ): Promise<BrowserALRuntimeCleanupResult> {
     const keyPrefixes = [...new Set(options.keyPrefixes)].filter((prefix) => prefix.length > 0);
@@ -123,73 +137,146 @@ async function deleteBrowserALRuntimeEntriesMatching(
     );
 
     try {
-        return await scanBrowserALRuntimeEntries({
-            db,
-            keyPrefixes,
-            shouldDelete: options.shouldDelete
-        });
+        const read = await readBrowserALRuntimeCleanup(db, keyPrefixes);
+        const computed = computeBrowserALRuntimeCleanup(read, options.deletionPolicy);
+        await writeBrowserALRuntimeCleanup(db, read.revision, computed);
+        return toBrowserALRuntimeCleanupResult(keyPrefixes, computed.scanned, computed.deleteKeys.length);
     }
     finally {
         db.close();
     }
 }
 
-function scanBrowserALRuntimeEntries(
-    input: BrowserALRuntimeCleanupScan
-): Promise<BrowserALRuntimeCleanupResult> {
-    return new Promise<BrowserALRuntimeCleanupResult>((resolve, reject) => {
-        const tx = input.db.transaction(BROWSER_AL_RUNTIME_STORE_NAME, 'readwrite');
-        const store = tx.objectStore(BROWSER_AL_RUNTIME_STORE_NAME);
+async function readBrowserALRuntimeCleanup(
+    db: IDBDatabase,
+    keyPrefixes: readonly string[]
+): Promise<BrowserALRuntimeCleanupRead> {
+    const transaction = db.transaction(BROWSER_AL_RUNTIME_STORE_NAME, 'readonly');
+    const store = transaction.objectStore(BROWSER_AL_RUNTIME_STORE_NAME);
+    const rowsPromise = readBrowserALRuntimeCleanupRows(store, keyPrefixes);
+    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
+    const completed = transactionDone(transaction);
+    const [rows, revisionValue] = await Promise.all([rowsPromise, revisionPromise]);
+    await completed;
+    return { rows, revision: decodeBrowserALRuntimeRevision(revisionValue) };
+}
+
+function readBrowserALRuntimeCleanupRows(
+    store: IDBObjectStore,
+    keyPrefixes: readonly string[]
+): Promise<readonly Readonly<{ key: string; value: unknown; }>[]> {
+    return new Promise((resolve, reject) => {
+        const rows: Readonly<{ key: string; value: unknown; }>[] = [];
         const request = store.openCursor();
-        let scanned = 0;
-        let deleted = 0;
-
-        tx.oncomplete = () =>
-            resolve(
-                toBrowserALRuntimeCleanupResult(input.keyPrefixes, scanned, deleted)
-            );
-        tx.onabort = () => reject(tx.error ?? new Error('Browser AL runtime cleanup aborted'));
-        tx.onerror = () => reject(tx.error ?? new Error('Browser AL runtime cleanup failed'));
-        request.onerror = () =>
-            reject(
-                request.error ?? new Error('Browser AL runtime cleanup cursor failed')
-            );
+        request.onerror = () => reject(request.error ?? new Error('Browser AL runtime cleanup cursor failed'));
         request.onsuccess = () => {
-            try {
-                const cursor = request.result;
-                if (!cursor) {
-                    return;
-                }
-                const key = cursor.primaryKey;
-                if (typeof key !== 'string') {
-                    throw new TypeError('Browser AL runtime cleanup row key must be a string');
-                }
-                if (!matchesAnyBrowserALRuntimePrefix(key, input.keyPrefixes)) {
-                    cursor.continue();
-                    return;
-                }
-
-                const entry = decodeALAdmissionValue(cursor.value, key, decodeALAdmissionStoredValue);
-                scanned += 1;
-                if (!input.shouldDelete(entry)) {
-                    cursor.continue();
-                    return;
-                }
-
-                deleted += 1;
-                const deleteRequest = cursor.delete();
-                deleteRequest.onerror = () =>
-                    reject(
-                        deleteRequest.error ??
-                            new Error('Browser AL runtime cleanup delete failed')
-                    );
-                deleteRequest.onsuccess = () => cursor.continue();
+            const cursor = request.result;
+            if (cursor === null) {
+                resolve(rows);
+                return;
             }
-            catch (error) {
-                reject(error);
-                tx.abort();
+            const key = cursor.primaryKey;
+            if (typeof key !== 'string') {
+                reject(new TypeError('Browser AL runtime cleanup row key must be a string'));
+                return;
+            }
+            if (matchesAnyBrowserALRuntimePrefix(key, keyPrefixes)) {
+                rows.push({ key, value: cursor.value });
+            }
+            cursor.continue();
+        };
+    });
+}
+
+function decodeBrowserALRuntimeRevision(value: unknown): number {
+    if (value === undefined) {
+        return 0;
+    }
+    const stored = decodeALAdmissionValue(value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionStoredValue);
+    return decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+}
+
+function computeBrowserALRuntimeCleanup(
+    read: BrowserALRuntimeCleanupRead,
+    deletionPolicy: BrowserALRuntimeDeletionPolicy
+): BrowserALRuntimeCleanupComputed {
+    const deleteKeys: string[] = [];
+    for (const row of read.rows) {
+        if (shouldDeleteBrowserALRuntimeEntry(row.key, row.value, deletionPolicy)) {
+            deleteKeys.push(row.key);
+        }
+    }
+    return {
+        deleteKeys,
+        revisionWrite: {
+            key: AL_ADMISSION_REVISION_KEY,
+            value: read.revision + 1,
+            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
+        },
+        scanned: read.rows.length
+    };
+}
+
+async function writeBrowserALRuntimeCleanup(
+    db: IDBDatabase,
+    expectedRevision: number,
+    computed: BrowserALRuntimeCleanupComputed
+): Promise<void> {
+    if (computed.deleteKeys.length === 0) {
+        return;
+    }
+    const committed = await new Promise<boolean>((resolve, reject) => {
+        const transaction = db.transaction(BROWSER_AL_RUNTIME_STORE_NAME, 'readwrite');
+        const store = transaction.objectStore(BROWSER_AL_RUNTIME_STORE_NAME);
+        const revisionRequest = store.get(AL_ADMISSION_REVISION_KEY);
+        let conflict = false;
+
+        transaction.oncomplete = () => resolve(true);
+        transaction.onabort = () => {
+            if (conflict) {
+                resolve(false);
+                return;
+            }
+            reject(transaction.error ?? new Error('Browser AL runtime cleanup aborted'));
+        };
+        transaction.onerror = () => {
+            if (!conflict) {
+                reject(transaction.error ?? new Error('Browser AL runtime cleanup failed'));
             }
         };
+        revisionRequest.onerror = () =>
+            reject(revisionRequest.error ?? new Error('Browser AL runtime cleanup revision read failed'));
+        revisionRequest.onsuccess = () => {
+            const storedRevision = revisionRequest.result as { readonly value?: unknown; } | undefined;
+            const actualRevision = storedRevision?.value ?? 0;
+            if (actualRevision !== expectedRevision) {
+                conflict = true;
+                transaction.abort();
+                return;
+            }
+            for (const key of computed.deleteKeys) {
+                store.delete(key);
+            }
+            store.put(computed.revisionWrite);
+        };
+    });
+    if (!committed) {
+        throw new ALAdmissionBackendConflictError('Browser AL runtime cleanup conflicted');
+    }
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error('Browser AL runtime cleanup request failed'));
+    });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error ?? new Error('Browser AL runtime cleanup read aborted'));
+        transaction.onerror = () => reject(transaction.error ?? new Error('Browser AL runtime cleanup read failed'));
     });
 }
 
@@ -211,12 +298,36 @@ function matchesAnyBrowserALRuntimePrefix(
     key: string,
     keyPrefixes: readonly string[]
 ): boolean {
-    return keyPrefixes.some((prefix) => key.startsWith(prefix));
+    for (const prefix of keyPrefixes) {
+        if (key.startsWith(prefix)) {
+            return true;
+        }
+    }
+    return false;
 }
 
-function isExpiredBrowserALRuntimeEntry(
-    entry: ALAdmissionStoredValue,
-    nowMs: number
+function shouldDeleteBrowserALRuntimeEntry(
+    key: string,
+    value: unknown,
+    policy: BrowserALRuntimeDeletionPolicy
 ): boolean {
-    return entry.expireAtTimestamp <= nowMs;
+    if (policy.kind === 'all') {
+        return true;
+    }
+    if (value === null || typeof value !== 'object') {
+        throw new ALAdmissionCorruptionError(key, new TypeError('Browser AL runtime cleanup row must be an object'));
+    }
+    const expireAtTimestamp = (value as { readonly expireAtTimestamp?: unknown; }).expireAtTimestamp;
+    if (
+        typeof expireAtTimestamp !== 'number' ||
+        !Number.isSafeInteger(expireAtTimestamp) ||
+        expireAtTimestamp < 0 ||
+        Object.is(expireAtTimestamp, -0)
+    ) {
+        throw new ALAdmissionCorruptionError(
+            key,
+            new TypeError('Browser AL runtime cleanup expiry must be a non-negative safe integer')
+        );
+    }
+    return expireAtTimestamp <= policy.nowMs;
 }

--- a/packages/shared/alm/indexed-db-admission-backend.ts
+++ b/packages/shared/alm/indexed-db-admission-backend.ts
@@ -9,6 +9,13 @@ import {
 } from './al-admission-backend.ts';
 import { ALAdmissionCorruptionError, decodeALAdmissionValue, type ALAdmissionDecoder } from './al-admission-decoder.ts';
 import { decodeALAdmissionNumber } from './al-admission-value-validation.ts';
+import { ALAdmissionBackendConflictError } from './ALAdmissionBackendConflictError.ts';
+
+export const AL_ADMISSION_REVISION_KEY = '__rallar_al_admission_revision__';
+
+type IndexedDbAdmissionMutation =
+    | Readonly<{ kind: 'set'; stored: ALAdmissionStoredValue; }>
+    | Readonly<{ kind: 'remove'; key: string; }>;
 
 export class IndexedDbAdmissionBackend implements ALAdmissionBackend {
     private dbPromise?: Promise<IDBDatabase>;
@@ -32,44 +39,75 @@ export class IndexedDbAdmissionBackend implements ALAdmissionBackend {
     }
 
     async read<V>(key: string, decode: ALAdmissionDecoder<V>): Promise<V | undefined> {
-        return await this.write((transaction) => transaction.read(key, decode));
+        const db = await this.openDb();
+        const snapshot = await readIndexedDbAdmissionSnapshot(db, this.storeName, key);
+        if (snapshot.stored === undefined) {
+            return undefined;
+        }
+        const observed = decodeAdmissionValue(snapshot.stored, key, decode, this.nowMs());
+        if (!observed.expired) {
+            return observed.value;
+        }
+        await removeExpiredIndexedDbAdmissionValues({
+            db,
+            storeName: this.storeName,
+            expectedRevision: snapshot.revision,
+            keys: [key]
+        });
+        return undefined;
     }
 
     async list<V>(prefix: string, decode: ALAdmissionDecoder<V>): Promise<readonly ALAdmissionBackendEntry<V>[]> {
-        return await this.write((transaction) => transaction.list(prefix, decode));
+        const db = await this.openDb();
+        const snapshot = await listIndexedDbAdmissionSnapshot(db, this.storeName, prefix);
+        const entries: ALAdmissionBackendEntry<V>[] = [];
+        const expiredKeys: string[] = [];
+        const nowMs = this.nowMs();
+        for (const row of snapshot.stored) {
+            if (row.key === AL_ADMISSION_REVISION_KEY) {
+                continue;
+            }
+            const observed = decodeAdmissionValue(row, row.key, decode, nowMs);
+            if (observed.expired) {
+                expiredKeys.push(row.key);
+            }
+            else {
+                entries.push({ key: row.key, value: observed.value });
+            }
+        }
+        if (expiredKeys.length > 0) {
+            await removeExpiredIndexedDbAdmissionValues({
+                db,
+                storeName: this.storeName,
+                expectedRevision: snapshot.revision,
+                keys: expiredKeys
+            });
+        }
+        return entries;
     }
 
     async write<T>(fn: (tx: ALAdmissionWriteContext) => Promise<T>): Promise<T> {
         const db = await this.openDb();
-        const tx = db.transaction(this.storeName, 'readwrite');
-        const store = tx.objectStore(this.storeName);
-
-        const completed = transactionDone(tx);
-        // Observe early native failures while the callback is still awaiting other work.
-        // The original completion promise is awaited below, so failures are not suppressed.
-        void completed.catch(() => undefined);
-        const activity = new IndexedDbAdmissionTransactionActivity(store);
-        const context = new IndexedDbAdmissionWriteContext(store, activity, this.nowMs);
-
-        try {
-            const result = await fn(context);
-            activity.release();
-            await completed;
-            return result;
+        const expectedRevision = await readIndexedDbAdmissionRevision(db, this.storeName);
+        const buffer = new IndexedDbAdmissionWriteBuffer(db, this.storeName, this.nowMs);
+        const result = await fn(buffer);
+        const mutations = buffer.mutations();
+        const revisionWrite: ALAdmissionStoredValue = {
+            key: AL_ADMISSION_REVISION_KEY,
+            value: expectedRevision + 1,
+            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
+        };
+        const committed = await writeIndexedDbAdmissionMutations({
+            db,
+            storeName: this.storeName,
+            expectedRevision,
+            mutations,
+            revisionWrite
+        });
+        if (!committed) {
+            throw new ALAdmissionBackendConflictError('IndexedDB AL admission write conflicted');
         }
-        catch (error) {
-            try {
-                tx.abort();
-            }
-            catch {
-                // A failed request may already have aborted the transaction.
-            }
-            await completed.catch(() => undefined);
-            throw error;
-        }
-        finally {
-            activity.release();
-        }
+        return result;
     }
 
     private async openDb(): Promise<IDBDatabase> {
@@ -93,129 +131,282 @@ export class IndexedDbAdmissionBackend implements ALAdmissionBackend {
     }
 }
 
-/** Decodes raw object-store records before exposing them within one native transaction. */
-class IndexedDbAdmissionWriteContext implements ALAdmissionWriteContext {
-    private readonly store: IDBObjectStore;
-    private readonly activity: IndexedDbAdmissionTransactionActivity;
+class IndexedDbAdmissionWriteBuffer implements ALAdmissionWriteContext {
+    private readonly pending = new Map<string, ALAdmissionStoredValue | undefined>();
+    private readonly db: IDBDatabase;
+    private readonly storeName: string;
     private readonly nowMs: () => number;
 
-    constructor(store: IDBObjectStore, activity: IndexedDbAdmissionTransactionActivity, nowMs: () => number) {
-        this.store = store;
-        this.activity = activity;
+    constructor(db: IDBDatabase, storeName: string, nowMs: () => number) {
+        this.db = db;
+        this.storeName = storeName;
         this.nowMs = nowMs;
     }
 
     async read<V>(key: string, decode: ALAdmissionDecoder<V>): Promise<V | undefined> {
-        await this.activity.enter();
-        const value = await requestToPromise<unknown>(this.store.get(key));
-        if (value === undefined) {
+        if (!this.pending.has(key)) {
+            const stored = await readIndexedDbAdmissionStoredValue(this.db, this.storeName, key);
+            if (stored === undefined) {
+                return undefined;
+            }
+            const observed = decodeAdmissionValue(stored, key, decode, this.nowMs());
+            return observed.expired ? undefined : observed.value;
+        }
+        const stored = this.pending.get(key);
+        if (stored === undefined) {
             return undefined;
         }
-        const stored = decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue);
-        const decoded = decodeALAdmissionValue(stored.value, key, decode);
-        if (stored.expireAtTimestamp <= this.nowMs()) {
-            this.store.delete(key);
-            return undefined;
-        }
-        return decoded;
+        const observed = decodeAdmissionValue(stored, key, decode, this.nowMs());
+        return observed.expired ? undefined : observed.value;
     }
 
     async list<V>(prefix: string, decode: ALAdmissionDecoder<V>): Promise<readonly ALAdmissionBackendEntry<V>[]> {
-        await this.activity.enter();
-        const values: ALAdmissionBackendEntry<V>[] = [];
-        await cursorEach(this.store, (cursor) => {
-            const key = cursor.primaryKey;
-            if (typeof key !== 'string') {
-                throw new ALAdmissionCorruptionError(String(key), new TypeError('Admission row key must be a string'));
+        const values = new Map<string, V>();
+        const storedEntries = await listIndexedDbAdmissionStoredValues(this.db, this.storeName, prefix);
+        const nowMs = this.nowMs();
+        for (const stored of storedEntries) {
+            if (stored.key === AL_ADMISSION_REVISION_KEY || this.pending.has(stored.key)) {
+                continue;
             }
+            const observed = decodeAdmissionValue(stored, stored.key, decode, nowMs);
+            if (!observed.expired) {
+                values.set(stored.key, observed.value);
+            }
+        }
+        for (const [key, stored] of this.pending) {
             if (!key.startsWith(prefix)) {
-                return;
+                continue;
             }
-            const stored = decodeALAdmissionValue(cursor.value, key, decodeALAdmissionStoredValue);
-            const decoded = decodeALAdmissionValue(stored.value, key, decode);
-            if (stored.expireAtTimestamp <= this.nowMs()) {
-                cursor.delete();
-                return;
+            if (stored === undefined) {
+                values.delete(key);
+                continue;
             }
-            values.push({ key, value: decoded });
-        });
-        return values;
+            const observed = decodeAdmissionValue(stored, key, decode, nowMs);
+            if (observed.expired) {
+                values.delete(key);
+            }
+            else {
+                values.set(key, observed.value);
+            }
+        }
+        return [...values].map(([key, value]) => ({ key, value }));
     }
 
     async set<V>(key: string, value: V, expireAtTimestamp = NEVER_EXPIRE_AT_TIMESTAMP): Promise<void> {
-        await this.activity.enter();
-        await requestToPromise(this.store.put(
-            {
-                key,
-                value,
-                expireAtTimestamp: decodeALAdmissionNumber(expireAtTimestamp)
-            } satisfies ALAdmissionStoredValue
-        ));
+        this.pending.set(key, {
+            key,
+            value,
+            expireAtTimestamp: decodeALAdmissionNumber(expireAtTimestamp)
+        });
     }
 
     async remove(key: string): Promise<void> {
-        await this.activity.enter();
-        await requestToPromise(this.store.delete(key));
+        this.pending.set(key, undefined);
+    }
+
+    mutations(): readonly IndexedDbAdmissionMutation[] {
+        return [...this.pending].map(([key, stored]) =>
+            stored === undefined ? { kind: 'remove', key } : { kind: 'set', stored }
+        );
     }
 }
 
-namespace IndexedDbAdmissionTransactionActivity {
-    export interface Activation {
-        readonly resolve: () => void;
-        readonly reject: (error: Error) => void;
-    }
+function decodeAdmissionValue<V>(
+    stored: ALAdmissionStoredValue,
+    key: string,
+    decode: ALAdmissionDecoder<V>,
+    nowMs: number
+): Readonly<{ value: V; expired: boolean; }> {
+    const canonical = decodeALAdmissionValue(stored, key, decodeALAdmissionStoredValue);
+    const value = decodeALAdmissionValue(canonical.value, key, decode);
+    return { value, expired: canonical.expireAtTimestamp <= nowMs };
 }
 
-/**
- * An async callback may outlive the native transaction's active event task.
- * Keep it open until the callback settles, and resume each request from an
- * IndexedDB success event: being open alone does not make a transaction active.
- */
-class IndexedDbAdmissionTransactionActivity {
-    private readonly store: IDBObjectStore;
-    private held = true;
-    private failure?: Error;
-    private readonly pending: IndexedDbAdmissionTransactionActivity.Activation[] = [];
+interface IndexedDbAdmissionReadSnapshot {
+    readonly revision: number;
+    readonly stored: ALAdmissionStoredValue | undefined;
+}
 
-    constructor(store: IDBObjectStore) {
-        this.store = store;
-        this.requestKeepAlive();
+interface IndexedDbAdmissionListSnapshot {
+    readonly revision: number;
+    readonly stored: readonly ALAdmissionStoredValue[];
+}
+
+async function readIndexedDbAdmissionSnapshot(
+    db: IDBDatabase,
+    storeName: string,
+    key: string
+): Promise<IndexedDbAdmissionReadSnapshot> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const store = transaction.objectStore(storeName);
+    const completed = transactionDone(transaction);
+    const valuePromise = requestToPromise<unknown>(store.get(key));
+    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
+    const [value, revisionValue] = await Promise.all([valuePromise, revisionPromise]);
+    await completed;
+    return {
+        revision: decodeIndexedDbAdmissionRevision(revisionValue),
+        stored: value === undefined
+            ? undefined
+            : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue)
+    };
+}
+
+async function listIndexedDbAdmissionSnapshot(
+    db: IDBDatabase,
+    storeName: string,
+    prefix: string
+): Promise<IndexedDbAdmissionListSnapshot> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const store = transaction.objectStore(storeName);
+    const completed = transactionDone(transaction);
+    const valuesPromise = collectIndexedDbAdmissionStoredValues(store, prefix);
+    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
+    const [stored, revisionValue] = await Promise.all([valuesPromise, revisionPromise]);
+    await completed;
+    return { revision: decodeIndexedDbAdmissionRevision(revisionValue), stored };
+}
+
+function decodeIndexedDbAdmissionRevision(value: unknown): number {
+    if (value === undefined) {
+        return 0;
     }
+    const stored = decodeALAdmissionValue(value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionStoredValue);
+    return decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+}
 
-    async enter(): Promise<void> {
-        if (!this.held) {
-            throw this.failure ?? new Error('Admission transaction is closed');
+async function collectIndexedDbAdmissionStoredValues(
+    store: IDBObjectStore,
+    prefix: string
+): Promise<readonly ALAdmissionStoredValue[]> {
+    const values: ALAdmissionStoredValue[] = [];
+    await cursorEach(store, (cursor) => {
+        const key = cursor.primaryKey;
+        if (typeof key !== 'string') {
+            throw new ALAdmissionCorruptionError(String(key), new TypeError('Admission row key must be a string'));
         }
-        await new Promise<void>((resolve, reject) => this.pending.push({ resolve, reject }));
-    }
+        if (key.startsWith(prefix)) {
+            values.push(decodeALAdmissionValue(cursor.value, key, decodeALAdmissionStoredValue));
+        }
+    });
+    return values;
+}
 
-    release(): void {
-        this.held = false;
-    }
+interface RemoveExpiredIndexedDbAdmissionValuesInput {
+    readonly db: IDBDatabase;
+    readonly expectedRevision: number;
+    readonly keys: readonly string[];
+    readonly storeName: string;
+}
 
-    private requestKeepAlive(): void {
-        const request = this.store.getKey('');
-        request.onsuccess = () => {
-            for (const activation of this.pending.splice(0)) {
-                activation.resolve();
-            }
-            if (this.held) {
-                this.requestKeepAlive();
-            }
-        };
-        request.onerror = () => {
-            this.failure = request.error ?? new Error('Admission transaction activation failed');
-            this.held = false;
-            for (const activation of this.pending.splice(0)) {
-                activation.reject(this.failure);
-            }
-        };
+async function removeExpiredIndexedDbAdmissionValues(
+    input: RemoveExpiredIndexedDbAdmissionValuesInput
+): Promise<void> {
+    const committed = await writeIndexedDbAdmissionMutations({
+        db: input.db,
+        storeName: input.storeName,
+        expectedRevision: input.expectedRevision,
+        mutations: input.keys.map((key) => ({ kind: 'remove', key })),
+        revisionWrite: {
+            key: AL_ADMISSION_REVISION_KEY,
+            value: input.expectedRevision + 1,
+            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
+        }
+    });
+    if (!committed) {
+        throw new ALAdmissionBackendConflictError('IndexedDB AL admission expiry cleanup conflicted');
     }
 }
 
-async function requestToPromise<T>(
-    request: IDBRequest<T>
-): Promise<T> {
+async function readIndexedDbAdmissionRevision(db: IDBDatabase, storeName: string): Promise<number> {
+    const stored = await readIndexedDbAdmissionStoredValue(db, storeName, AL_ADMISSION_REVISION_KEY);
+    return stored === undefined
+        ? 0
+        : decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+}
+
+async function readIndexedDbAdmissionStoredValue(
+    db: IDBDatabase,
+    storeName: string,
+    key: string
+): Promise<ALAdmissionStoredValue | undefined> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const completed = transactionDone(transaction);
+    const value = await requestToPromise<unknown>(transaction.objectStore(storeName).get(key));
+    await completed;
+    return value === undefined
+        ? undefined
+        : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue);
+}
+
+async function listIndexedDbAdmissionStoredValues(
+    db: IDBDatabase,
+    storeName: string,
+    prefix: string
+): Promise<readonly ALAdmissionStoredValue[]> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const completed = transactionDone(transaction);
+    const values = await collectIndexedDbAdmissionStoredValues(transaction.objectStore(storeName), prefix);
+    await completed;
+    return values;
+}
+
+interface WriteIndexedDbAdmissionMutationsInput {
+    readonly db: IDBDatabase;
+    readonly expectedRevision: number;
+    readonly mutations: readonly IndexedDbAdmissionMutation[];
+    readonly revisionWrite: ALAdmissionStoredValue;
+    readonly storeName: string;
+}
+
+async function writeIndexedDbAdmissionMutations(
+    input: WriteIndexedDbAdmissionMutationsInput
+): Promise<boolean> {
+    return await new Promise<boolean>((resolve, reject) => {
+        const transaction = input.db.transaction(input.storeName, 'readwrite');
+        const store = transaction.objectStore(input.storeName);
+        const revisionRequest = store.get(AL_ADMISSION_REVISION_KEY);
+        let conflict = false;
+
+        transaction.oncomplete = () => resolve(true);
+        transaction.onabort = () => {
+            if (conflict) {
+                resolve(false);
+                return;
+            }
+            reject(transaction.error ?? new Error('IndexedDB AL admission write aborted'));
+        };
+        transaction.onerror = () => {
+            if (!conflict) {
+                reject(transaction.error ?? new Error('IndexedDB AL admission write failed'));
+            }
+        };
+        revisionRequest.onerror = () =>
+            reject(revisionRequest.error ?? new Error('IndexedDB AL admission revision read failed'));
+        revisionRequest.onsuccess = () => {
+            const storedRevision = revisionRequest.result as ALAdmissionStoredValue | undefined;
+            const actualRevision = storedRevision?.value ?? 0;
+            if (actualRevision !== input.expectedRevision) {
+                conflict = true;
+                transaction.abort();
+                return;
+            }
+            for (const mutation of input.mutations) {
+                const request = mutation.kind === 'set'
+                    ? store.put(mutation.stored)
+                    : store.delete(mutation.key);
+                request.onerror = () => reject(request.error ?? new Error('IndexedDB AL admission mutation failed'));
+            }
+            if (input.mutations.length > 0) {
+                const request = store.put(input.revisionWrite);
+                request.onerror = () =>
+                    reject(request.error ?? new Error('IndexedDB AL admission revision write failed'));
+            }
+        };
+    });
+}
+
+async function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
         request.onsuccess = () => resolve(request.result);
         request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
@@ -231,11 +422,10 @@ async function cursorEach(
         request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'));
         request.onsuccess = () => {
             const cursor = request.result;
-            if (!cursor) {
+            if (cursor === null) {
                 resolve();
                 return;
             }
-
             try {
                 handler(cursor);
                 cursor.continue();
@@ -247,12 +437,10 @@ async function cursorEach(
     });
 }
 
-async function transactionDone(
-    tx: IDBTransaction
-): Promise<void> {
+async function transactionDone(transaction: IDBTransaction): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-        tx.oncomplete = () => resolve();
-        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB transaction aborted'));
-        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB transaction failed'));
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+        transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
     });
 }

--- a/packages/shared/persistence/IndexedDbStringPersistenceProvider.ts
+++ b/packages/shared/persistence/IndexedDbStringPersistenceProvider.ts
@@ -1,11 +1,11 @@
+import {
+    deleteComputedIndexedDbStringValues,
+    removeComputedIndexedDbStringValue,
+    StoredIndexedDbValue,
+    writeComputedIndexedDbStringValue
+} from './indexed-db-string-persistence-write.ts';
 import { openIndexedDbWithStore } from './openIndexedDb.ts';
 import type { PersistenceProvider, PersistenceSetItemOptions } from './PersistenceProvider.ts';
-
-type StoredIndexedDbValue<V> = Readonly<{
-    key: string;
-    value: V;
-    expireAtTimestamp: number;
-}>;
 
 export type IndexedDbStringPersistenceProviderOptions = Readonly<{
     dbName?: string;
@@ -35,33 +35,20 @@ export class IndexedDbStringPersistenceProvider<V> implements PersistenceProvide
     async getItem(key: string): Promise<V | undefined> {
         const db = await this.openDb();
         const storedKey = this.toStoredKey(key);
-
-        return await new Promise<V | undefined>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.get(storedKey);
-            let value: V | undefined;
-
-            tx.oncomplete = () => resolve(value);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB getItem aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB getItem failed'));
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB get failed'));
-            request.onsuccess = () => {
-                const result = request.result as StoredIndexedDbValue<V> | undefined;
-                if (!result) {
-                    return;
-                }
-
-                if (this.isExpired(result.expireAtTimestamp)) {
-                    const deleteRequest = store.delete(storedKey);
-                    deleteRequest.onerror = () =>
-                        reject(deleteRequest.error ?? new Error('IndexedDB delete failed during getItem'));
-                    return;
-                }
-
-                value = result.value;
-            };
-        });
+        const result = await this.readStoredValue(db, storedKey);
+        if (!result) {
+            return undefined;
+        }
+        if (!this.isExpired(result.expireAtTimestamp, Date.now())) {
+            return result.value;
+        }
+        this.requireCleanupCommit(
+            await deleteComputedIndexedDbStringValues(db, this.storeName, [{
+                key: storedKey,
+                expectedExpireAtTimestamp: result.expireAtTimestamp
+            }])
+        );
+        return undefined;
     }
 
     async setItem(
@@ -71,114 +58,99 @@ export class IndexedDbStringPersistenceProvider<V> implements PersistenceProvide
     ): Promise<void> {
         const db = await this.openDb();
         const storedKey = this.toStoredKey(key);
-
-        await new Promise<void>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.put(
-                {
-                    key: storedKey,
-                    value,
-                    expireAtTimestamp: this.toExpireAtTimestamp(options.expireAtTimestamp)
-                } satisfies StoredIndexedDbValue<V>
-            );
-
-            tx.oncomplete = () => resolve();
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB setItem aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB setItem failed'));
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB put failed'));
-        });
+        const stored = {
+            key: storedKey,
+            value,
+            expireAtTimestamp: this.toExpireAtTimestamp(options.expireAtTimestamp)
+        } satisfies StoredIndexedDbValue<V>;
+        await writeComputedIndexedDbStringValue(db, this.storeName, stored);
     }
 
     async removeItem(key: string): Promise<void> {
         const db = await this.openDb();
         const storedKey = this.toStoredKey(key);
 
-        await new Promise<void>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.delete(storedKey);
-
-            tx.oncomplete = () => resolve();
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB removeItem aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB removeItem failed'));
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB delete failed'));
-        });
+        await removeComputedIndexedDbStringValue(db, this.storeName, storedKey);
     }
 
     async getAllKeys(): Promise<string[]> {
         const db = await this.openDb();
+        const storedValues = await this.readAllStoredValues(db);
+        const now = Date.now();
+        const matching = storedValues.filter((stored) => this.matchesPrefix(stored.key));
+        const expired = matching.filter((stored) => this.isExpired(stored.expireAtTimestamp, now));
+        const keys = matching
+            .filter((stored) => !this.isExpired(stored.expireAtTimestamp, now))
+            .map((stored) => this.fromStoredKey(stored.key));
+        this.requireCleanupCommit(
+            await deleteComputedIndexedDbStringValues(
+                db,
+                this.storeName,
+                expired.map((stored) => ({
+                    key: stored.key,
+                    expectedExpireAtTimestamp: stored.expireAtTimestamp
+                }))
+            )
+        );
+        return keys;
+    }
 
-        return await new Promise<string[]>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.openCursor();
-            const keys: string[] = [];
+    async deleteExpired(): Promise<number> {
+        const db = await this.openDb();
+        const storedValues = await this.readAllStoredValues(db);
+        const now = Date.now();
+        const expired = storedValues.filter(
+            (stored) =>
+                this.matchesPrefix(stored.key) &&
+                this.isExpired(stored.expireAtTimestamp, now)
+        );
+        this.requireCleanupCommit(
+            await deleteComputedIndexedDbStringValues(
+                db,
+                this.storeName,
+                expired.map((stored) => ({
+                    key: stored.key,
+                    expectedExpireAtTimestamp: stored.expireAtTimestamp
+                }))
+            )
+        );
+        return expired.length;
+    }
 
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB getAllKeys aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB getAllKeys failed'));
-            tx.oncomplete = () => resolve(keys);
+    private async readStoredValue(
+        db: IDBDatabase,
+        storedKey: string
+    ): Promise<StoredIndexedDbValue<V> | undefined> {
+        return await new Promise((resolve, reject) => {
+            const tx = db.transaction(this.storeName, 'readonly');
+            const request = tx.objectStore(this.storeName).get(storedKey);
+            request.onsuccess = () => resolve(request.result as StoredIndexedDbValue<V> | undefined);
+            request.onerror = () => reject(request.error ?? new Error('IndexedDB get failed'));
+        });
+    }
 
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB getAllKeys failed'));
+    private async readAllStoredValues(db: IDBDatabase): Promise<readonly StoredIndexedDbValue<V>[]> {
+        return await new Promise((resolve, reject) => {
+            const tx = db.transaction(this.storeName, 'readonly');
+            const request = tx.objectStore(this.storeName).openCursor();
+            const values: StoredIndexedDbValue<V>[] = [];
+            request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'));
             request.onsuccess = () => {
                 const cursor = request.result;
                 if (!cursor) {
+                    resolve(values);
                     return;
                 }
-
-                const stored = cursor.value as StoredIndexedDbValue<V>;
-                if (!this.matchesPrefix(stored.key)) {
-                    cursor.continue();
-                    return;
-                }
-
-                if (this.isExpired(stored.expireAtTimestamp)) {
-                    const deleteRequest = cursor.delete();
-                    deleteRequest.onerror = () =>
-                        reject(deleteRequest.error ?? new Error('IndexedDB delete failed during getAllKeys'));
-                    deleteRequest.onsuccess = () => cursor.continue();
-                    return;
-                }
-
-                keys.push(this.fromStoredKey(stored.key));
+                values.push(cursor.value as StoredIndexedDbValue<V>);
                 cursor.continue();
             };
         });
     }
 
-    async deleteExpired(): Promise<number> {
-        const db = await this.openDb();
-
-        return await new Promise<number>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.openCursor();
-            let deleted = 0;
-
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB deleteExpired aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB deleteExpired failed'));
-            tx.oncomplete = () => resolve(deleted);
-
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB deleteExpired cursor failed'));
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor) {
-                    return;
-                }
-
-                const stored = cursor.value as StoredIndexedDbValue<V>;
-                if (!this.matchesPrefix(stored.key) || !this.isExpired(stored.expireAtTimestamp)) {
-                    cursor.continue();
-                    return;
-                }
-
-                deleted += 1;
-                const deleteRequest = cursor.delete();
-                deleteRequest.onerror = () =>
-                    reject(deleteRequest.error ?? new Error('IndexedDB delete failed during deleteExpired'));
-                deleteRequest.onsuccess = () => cursor.continue();
-            };
-        });
+    private requireCleanupCommit(committed: boolean): void {
+        if (!committed) {
+            throw new Error('IndexedDB persistence cleanup conflicted');
+        }
     }
 
     private async openDb(): Promise<IDBDatabase> {
@@ -225,8 +197,8 @@ export class IndexedDbStringPersistenceProvider<V> implements PersistenceProvide
         return storedKey.startsWith(`${this.keyPrefix}:`);
     }
 
-    private isExpired(expireAtTimestamp: number): boolean {
-        return !Number.isFinite(expireAtTimestamp) || expireAtTimestamp <= Date.now();
+    private isExpired(expireAtTimestamp: number, now: number): boolean {
+        return !Number.isFinite(expireAtTimestamp) || expireAtTimestamp <= now;
     }
 
     private toExpireAtTimestamp(expireAtTimestamp: number): number {

--- a/packages/shared/persistence/indexed-db-string-persistence-write.ts
+++ b/packages/shared/persistence/indexed-db-string-persistence-write.ts
@@ -1,0 +1,99 @@
+export type StoredIndexedDbValue<Value> = Readonly<{
+    key: string;
+    value: Value;
+    expireAtTimestamp: number;
+}>;
+
+export type ComputedIndexedDbStringDeletion = Readonly<{
+    key: string;
+    expectedExpireAtTimestamp: number;
+}>;
+
+export async function writeComputedIndexedDbStringValue<Value>(
+    db: IDBDatabase,
+    storeName: string,
+    stored: StoredIndexedDbValue<Value>
+): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readwrite');
+        const request = tx.objectStore(storeName).put(stored);
+        tx.oncomplete = () => resolve();
+        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB setItem aborted'));
+        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB setItem failed'));
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB put failed'));
+    });
+}
+
+export async function removeComputedIndexedDbStringValue(
+    db: IDBDatabase,
+    storeName: string,
+    key: string
+): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readwrite');
+        const request = tx.objectStore(storeName).delete(key);
+        tx.oncomplete = () => resolve();
+        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB removeItem aborted'));
+        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB removeItem failed'));
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB delete failed'));
+    });
+}
+
+export async function deleteComputedIndexedDbStringValues(
+    db: IDBDatabase,
+    storeName: string,
+    deletions: readonly ComputedIndexedDbStringDeletion[]
+): Promise<boolean> {
+    if (deletions.length === 0) {
+        return true;
+    }
+
+    return await new Promise<boolean>((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readwrite');
+        const store = tx.objectStore(storeName);
+        let conflict = false;
+        tx.oncomplete = () => resolve(true);
+        tx.onabort = () => {
+            if (conflict) {
+                resolve(false);
+                return;
+            }
+            reject(tx.error ?? new Error('IndexedDB computed delete aborted'));
+        };
+        tx.onerror = () => {
+            if (!conflict) {
+                reject(tx.error ?? new Error('IndexedDB computed delete failed'));
+            }
+        };
+
+        for (const deletion of deletions) {
+            const getRequest = store.get(deletion.key);
+            getRequest.onerror = () => {
+                if (!conflict) {
+                    reject(getRequest.error ?? new Error('IndexedDB computed delete compare failed'));
+                }
+            };
+            getRequest.onsuccess = () => {
+                if (conflict) {
+                    return;
+                }
+                const current = getRequest.result as
+                    | Readonly<{
+                        expireAtTimestamp: number;
+                    }>
+                    | undefined;
+                if (current?.expireAtTimestamp !== deletion.expectedExpireAtTimestamp) {
+                    conflict = true;
+                    tx.abort();
+                    return;
+                }
+                const deleteRequest = store.delete(deletion.key);
+                deleteRequest.onerror = () => {
+                    if (!conflict) {
+                        reject(deleteRequest.error ?? new Error('IndexedDB computed delete failed'));
+                    }
+                };
+            };
+        }
+    });
+}

--- a/packages/shared/persistence/openIndexedDb.ts
+++ b/packages/shared/persistence/openIndexedDb.ts
@@ -1,15 +1,26 @@
-export type IndexedDbIndexDefinition = Readonly<{
-    name: string;
-    keyPath: string | readonly string[];
-    unique?: boolean;
-}>;
+export interface IndexedDbIndexDefinition {
+    readonly name: string;
+    readonly keyPath: string | readonly string[];
+    readonly unique?: boolean;
+}
 
-export type IndexedDbStoreDefinition = Readonly<{
-    name: string;
-    keyPath: string;
-    indexes?: readonly IndexedDbIndexDefinition[];
-    migrateOnUpgrade?: (store: IDBObjectStore) => void;
-}>;
+export interface IndexedDbStoreDefinition {
+    readonly name: string;
+    readonly keyPath: string;
+    readonly indexes?: readonly IndexedDbIndexDefinition[];
+}
+
+interface IndexedDbIndexSchema {
+    readonly name: string;
+    readonly keyPath: string | string[];
+    readonly options: { readonly unique: boolean; };
+}
+
+interface IndexedDbStoreSchema {
+    readonly name: string;
+    readonly options: { readonly keyPath: string; };
+    readonly indexes: readonly IndexedDbIndexSchema[];
+}
 
 export async function openIndexedDbWithStore(
     dbName: string,
@@ -26,12 +37,19 @@ export async function openIndexedDbWithStores(
         throw new Error('IndexedDB is not supported in this environment');
     }
 
-    const initialDb = await openIndexedDb(
-        dbName,
-        undefined,
-        (db, transaction) => ensureStores(db, transaction, stores)
-    );
-    if (!hasSchemaMismatch(initialDb, stores)) {
+    const schema: readonly IndexedDbStoreSchema[] = stores.map((store) => ({
+        name: store.name,
+        options: { keyPath: store.keyPath },
+        indexes: (store.indexes ?? []).map((index) => ({
+            name: index.name,
+            keyPath: typeof index.keyPath === 'string'
+                ? index.keyPath
+                : [...index.keyPath],
+            options: { unique: index.unique ?? false }
+        }))
+    }));
+    const initialDb = await openIndexedDb(dbName, schema);
+    if (!hasSchemaMismatch(initialDb, schema)) {
         initialDb.onversionchange = () => initialDb.close();
         return initialDb;
     }
@@ -39,20 +57,16 @@ export async function openIndexedDbWithStores(
     const nextVersion = Math.max(1, initialDb.version) + 1;
     initialDb.close();
 
-    const upgradedDb = await openIndexedDb(
-        dbName,
-        nextVersion,
-        (db, transaction) => ensureStores(db, transaction, stores)
-    );
+    const upgradedDb = await openIndexedDb(dbName, schema, nextVersion);
     upgradedDb.onversionchange = () => upgradedDb.close();
 
-    for (const store of stores) {
+    for (const store of schema) {
         if (!upgradedDb.objectStoreNames.contains(store.name)) {
             upgradedDb.close();
             throw new Error(`IndexedDB store "${store.name}" was not created`);
         }
         const existingStore = upgradedDb.transaction(store.name).objectStore(store.name);
-        for (const index of store.indexes ?? []) {
+        for (const index of store.indexes) {
             if (!isMatchingIndex(existingStore, index)) {
                 upgradedDb.close();
                 throw new Error(`IndexedDB index "${index.name}" does not match its schema`);
@@ -65,8 +79,8 @@ export async function openIndexedDbWithStores(
 
 async function openIndexedDb(
     dbName: string,
-    version?: number,
-    onUpgradeNeeded?: (db: IDBDatabase, transaction: IDBTransaction) => void
+    stores: readonly IndexedDbStoreSchema[],
+    version?: number
 ): Promise<IDBDatabase> {
     return await new Promise<IDBDatabase>((resolve, reject) => {
         const request = version === undefined
@@ -78,7 +92,7 @@ async function openIndexedDb(
                 reject(new Error('IndexedDB upgrade transaction is unavailable'));
                 return;
             }
-            onUpgradeNeeded?.(request.result, request.transaction);
+            writeIndexedDbSchema(request.result, request.transaction, stores);
         };
 
         request.onsuccess = () => {
@@ -90,18 +104,16 @@ async function openIndexedDb(
     });
 }
 
-function ensureStores(
+function writeIndexedDbSchema(
     db: IDBDatabase,
     transaction: IDBTransaction,
-    stores: readonly IndexedDbStoreDefinition[]
+    stores: readonly IndexedDbStoreSchema[]
 ): void {
     for (const store of stores) {
         const objectStore = !db.objectStoreNames.contains(store.name)
-            ? db.createObjectStore(store.name, {
-                keyPath: store.keyPath
-            })
+            ? db.createObjectStore(store.name, store.options)
             : transaction.objectStore(store.name);
-        for (const index of store.indexes ?? []) {
+        for (const index of store.indexes) {
             if (
                 objectStore.indexNames.contains(index.name) &&
                 !isMatchingIndex(objectStore, index)
@@ -111,25 +123,24 @@ function ensureStores(
             if (!objectStore.indexNames.contains(index.name)) {
                 objectStore.createIndex(
                     index.name,
-                    Array.isArray(index.keyPath) ? [...index.keyPath] : index.keyPath,
-                    { unique: index.unique ?? false }
+                    index.keyPath,
+                    index.options
                 );
             }
         }
-        store.migrateOnUpgrade?.(objectStore);
     }
 }
 
 function hasSchemaMismatch(
     db: IDBDatabase,
-    stores: readonly IndexedDbStoreDefinition[]
+    stores: readonly IndexedDbStoreSchema[]
 ): boolean {
     for (const store of stores) {
         if (!db.objectStoreNames.contains(store.name)) {
             return true;
         }
         const objectStore = db.transaction(store.name).objectStore(store.name);
-        for (const index of store.indexes ?? []) {
+        for (const index of store.indexes) {
             if (!isMatchingIndex(objectStore, index)) {
                 return true;
             }
@@ -140,14 +151,14 @@ function hasSchemaMismatch(
 
 function isMatchingIndex(
     store: IDBObjectStore,
-    definition: IndexedDbIndexDefinition
+    definition: IndexedDbIndexSchema
 ): boolean {
     if (!store.indexNames.contains(definition.name)) {
         return false;
     }
 
     const index = store.index(definition.name);
-    return index.unique === (definition.unique ?? false) &&
+    return index.unique === definition.options.unique &&
         isEqualKeyPath(index.keyPath, definition.keyPath);
 }
 
@@ -158,6 +169,13 @@ function isEqualKeyPath(
     if (typeof actual === 'string' || typeof expected === 'string') {
         return actual === expected;
     }
-    return actual.length === expected.length &&
-        actual.every((part, index) => part === expected[index]);
+    if (actual.length !== expected.length) {
+        return false;
+    }
+    for (let index = 0; index < actual.length; index += 1) {
+        if (actual[index] !== expected[index]) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/packages/shared/queuebox/indexed-db-queue-box-entry.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-entry.ts
@@ -1,0 +1,256 @@
+import { Temporal } from '@js-temporal/polyfill';
+import {
+    EntityStatus,
+    Key,
+    NEVER_EXPIRE_TS,
+    ResourceEntry,
+    ResourceEntryKeyString,
+    toKeyAsString
+} from './ResourceEntry.ts';
+
+export type StoredResourceEntry = Readonly<{
+    keyString: ResourceEntryKeyString;
+    revision?: number;
+    fairnessDueEpochMs?: number;
+    key: Key;
+    resource: string;
+    typeId: string;
+    audit: Readonly<{
+        date: string;
+        createdBy: string;
+        createdTs: string;
+        expiryTs?: string;
+    }>;
+    status: EntityStatus;
+    dequeueAudit: Readonly<{
+        startTs?: string;
+        endTs?: string;
+        nextTs?: string;
+        attempts: number;
+    }>;
+}>;
+
+export type ComputedIndexedDbQueueMutation = Readonly<{
+    keyString: ResourceEntryKeyString;
+    expectedRevision?: number | null;
+    value?: StoredResourceEntry;
+}>;
+
+export function encodeStoredResourceEntry(
+    entry: ResourceEntry,
+    revision: number
+): StoredResourceEntry {
+    return {
+        keyString: toKeyAsString(entry.key),
+        revision,
+        fairnessDueEpochMs: entry.dequeueAudit.nextTs
+            ? Number(entry.dequeueAudit.nextTs.epochMilliseconds)
+            : undefined,
+        key: entry.key,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        audit: {
+            date: toPlainTime(entry.audit.date).toString(),
+            createdBy: entry.audit.createdBy,
+            createdTs: toPlainDateTime(entry.audit.createdTs).toString(),
+            expiryTs: toInstant(entry.audit.expiryTs).toString()
+        },
+        status: entry.status,
+        dequeueAudit: {
+            startTs: toOptionalInstant(entry.dequeueAudit.startTs)?.toString(),
+            endTs: toOptionalInstant(entry.dequeueAudit.endTs)?.toString(),
+            nextTs: toOptionalInstant(entry.dequeueAudit.nextTs)?.toString({
+                fractionalSecondDigits: 9
+            }),
+            attempts: entry.dequeueAudit.attempts
+        }
+    };
+}
+
+export function decodeStoredResourceEntry(stored: StoredResourceEntry): ResourceEntry {
+    return {
+        key: stored.key,
+        resource: stored.resource,
+        typeId: stored.typeId,
+        audit: {
+            date: toPlainTime(stored.audit.date),
+            createdBy: stored.audit.createdBy,
+            createdTs: toPlainDateTime(stored.audit.createdTs),
+            expiryTs: stored.audit.expiryTs
+                ? toInstant(stored.audit.expiryTs)
+                : NEVER_EXPIRE_TS
+        },
+        status: stored.status,
+        dequeueAudit: {
+            startTs: toOptionalInstant(stored.dequeueAudit.startTs),
+            endTs: toOptionalInstant(stored.dequeueAudit.endTs),
+            nextTs: toOptionalInstant(stored.dequeueAudit.nextTs),
+            attempts: stored.dequeueAudit.attempts
+        },
+        db: {
+            id: stored.keyString
+        }
+    };
+}
+
+export function storedResourceEntryRevision(stored: StoredResourceEntry): number {
+    return stored.revision ?? 0;
+}
+
+export function computeIndexedDbQueuePut(
+    stored: StoredResourceEntry | undefined,
+    entry: ResourceEntry
+): ComputedIndexedDbQueueMutation {
+    const expectedRevision = stored ? storedResourceEntryRevision(stored) : null;
+    return {
+        keyString: toKeyAsString(entry.key),
+        expectedRevision,
+        value: encodeStoredResourceEntry(entry, (expectedRevision ?? -1) + 1)
+    };
+}
+
+export function computeIndexedDbQueueDelete(
+    stored: StoredResourceEntry
+): ComputedIndexedDbQueueMutation {
+    return {
+        keyString: stored.keyString,
+        expectedRevision: storedResourceEntryRevision(stored)
+    };
+}
+
+export function computeReservedQueueEntry(
+    entry: ResourceEntry,
+    now: Temporal.Instant
+): ResourceEntry {
+    return {
+        ...entry,
+        status: EntityStatus.RESERVED,
+        dequeueAudit: {
+            startTs: now,
+            endTs: undefined,
+            nextTs: undefined,
+            attempts: entry.dequeueAudit.attempts + 1
+        }
+    };
+}
+
+export function isStoredQueueEntryExpired(
+    stored: StoredResourceEntry,
+    now: Temporal.Instant
+): boolean {
+    const expiryTs = stored.audit.expiryTs
+        ? Temporal.Instant.from(stored.audit.expiryTs)
+        : NEVER_EXPIRE_TS;
+    return Temporal.Instant.compare(now, expiryTs) >= 0;
+}
+
+export function isStoredQueueEntryReservable(
+    input: Readonly<{
+        stored: StoredResourceEntry;
+        typeIds: ReadonlySet<string>;
+        statusIds: ReadonlySet<EntityStatus>;
+        now: Temporal.Instant;
+        maxAttempts: number;
+    }>
+): boolean {
+    const { stored, typeIds, statusIds, now, maxAttempts } = input;
+    if (isStoredQueueEntryExpired(stored, now)) {
+        return false;
+    }
+    if (!typeIds.has(stored.typeId) || !statusIds.has(stored.status)) {
+        return false;
+    }
+    if (stored.status === EntityStatus.FAILED || stored.dequeueAudit.attempts >= maxAttempts) {
+        return false;
+    }
+    return !stored.dequeueAudit.nextTs ||
+        Temporal.Instant.compare(now, Temporal.Instant.from(stored.dequeueAudit.nextTs)) >= 0;
+}
+
+export function isStoredQueueEntryTimedOut(
+    input: Readonly<{
+        stored: StoredResourceEntry;
+        typeIds: ReadonlySet<string>;
+        duration: Temporal.Duration;
+        now: Temporal.Instant;
+    }>
+): boolean {
+    const { stored, typeIds, duration, now } = input;
+    if (
+        isStoredQueueEntryExpired(stored, now) ||
+        !typeIds.has(stored.typeId) ||
+        stored.status !== EntityStatus.RESERVED ||
+        !stored.dequeueAudit.startTs
+    ) {
+        return false;
+    }
+    const startTs = Temporal.Instant.from(stored.dequeueAudit.startTs);
+    return Temporal.Instant.compare(now, startTs.add(duration)) >= 0;
+}
+
+function temporalText(value: string | object, fallback: string): string {
+    if (typeof value === 'string' && value.length > 0 && value !== '[object Object]') {
+        return value;
+    }
+
+    if (
+        value &&
+        typeof value === 'object' &&
+        'toString' in value &&
+        typeof value.toString === 'function'
+    ) {
+        const text = value.toString();
+        if (text.length > 0 && text !== '[object Object]') {
+            return text;
+        }
+    }
+
+    return fallback;
+}
+
+function toPlainTime(value: string | Temporal.PlainTime): Temporal.PlainTime {
+    const fallback = Temporal.Now.plainTimeISO();
+    try {
+        return Temporal.PlainTime.from(temporalText(value, fallback.toString()));
+    }
+    catch {
+        return fallback;
+    }
+}
+
+function toPlainDateTime(value: string | Temporal.PlainDateTime): Temporal.PlainDateTime {
+    const fallback = Temporal.Now.plainDateTimeISO();
+    try {
+        return Temporal.PlainDateTime.from(temporalText(value, fallback.toString()));
+    }
+    catch {
+        return fallback;
+    }
+}
+
+function toInstant(
+    value: string | Temporal.Instant,
+    fallback: Temporal.Instant = NEVER_EXPIRE_TS
+): Temporal.Instant {
+    try {
+        return Temporal.Instant.from(temporalText(value, fallback.toString()));
+    }
+    catch {
+        return fallback;
+    }
+}
+
+function toOptionalInstant(
+    value: string | Temporal.Instant | undefined
+): Temporal.Instant | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    try {
+        return Temporal.Instant.from(temporalText(value, ''));
+    }
+    catch {
+        return undefined;
+    }
+}

--- a/packages/shared/queuebox/indexed-db-queue-box-fairness.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-fairness.ts
@@ -1,0 +1,77 @@
+import { Temporal } from '@js-temporal/polyfill';
+import {
+    computeIndexedDbQueuePut,
+    computeReservedQueueEntry,
+    decodeStoredResourceEntry,
+    isStoredQueueEntryExpired,
+    type ComputedIndexedDbQueueMutation,
+    type StoredResourceEntry
+} from './indexed-db-queue-box-entry.ts';
+import type { ResourceInboxFairnessSelection } from './queue-box-types.ts';
+import type { Key } from './ResourceEntry.ts';
+
+export type ComputeIndexedDbFairnessReservationInput = Readonly<{
+    entriesByType: ReadonlyMap<string, readonly StoredResourceEntry[]>;
+    maxAttempts: number;
+    maxToReserve: number;
+    maxToScan: number;
+    now: Temporal.Instant;
+    requestedTypes: readonly string[];
+}>;
+
+export type ComputedIndexedDbFairnessReservation = Readonly<{
+    mutations: readonly ComputedIndexedDbQueueMutation[];
+    result: Map<Key, ResourceInboxFairnessSelection>;
+}>;
+
+export function computeIndexedDbFairnessReservation(
+    input: ComputeIndexedDbFairnessReservationInput
+): ComputedIndexedDbFairnessReservation {
+    const states = input.requestedTypes.map((typeId) => ({
+        entries: input.entriesByType.get(typeId) ?? [],
+        offset: 0
+    }));
+    const result = new Map<Key, ResourceInboxFairnessSelection>();
+    const mutations: ComputedIndexedDbQueueMutation[] = [];
+    let scanned = states.length;
+
+    while (result.size < input.maxToReserve) {
+        const available = states.filter((state) => state.offset < state.entries.length);
+        if (available.length === 0) {
+            break;
+        }
+        const selectedState = available.reduce(earlierFairnessState);
+        const stored = selectedState.entries[selectedState.offset];
+        if (
+            !isStoredQueueEntryExpired(stored, input.now) &&
+            stored.dequeueAudit.attempts < input.maxAttempts
+        ) {
+            const selectedDueTs = Temporal.Instant.from(stored.dequeueAudit.nextTs!);
+            const entry = computeReservedQueueEntry(decodeStoredResourceEntry(stored), input.now);
+            result.set(entry.key, { entry, selectedDueTs });
+            mutations.push(computeIndexedDbQueuePut(stored, entry));
+        }
+        if (result.size >= input.maxToReserve || scanned >= input.maxToScan) {
+            selectedState.offset = selectedState.entries.length;
+            continue;
+        }
+        scanned += 1;
+        selectedState.offset += 1;
+    }
+    return { mutations, result };
+}
+
+type FairnessState = {
+    readonly entries: readonly StoredResourceEntry[];
+    offset: number;
+};
+
+function earlierFairnessState(left: FairnessState, right: FairnessState): FairnessState {
+    const leftEntry = left.entries[left.offset];
+    const rightEntry = right.entries[right.offset];
+    const dueOrder = leftEntry.fairnessDueEpochMs! - rightEntry.fairnessDueEpochMs!;
+    if (dueOrder !== 0) {
+        return dueOrder < 0 ? left : right;
+    }
+    return indexedDB.cmp(leftEntry.keyString, rightEntry.keyString) <= 0 ? left : right;
+}

--- a/packages/shared/queuebox/indexed-db-queue-box-fairness.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-fairness.ts
@@ -73,5 +73,5 @@ function earlierFairnessState(left: FairnessState, right: FairnessState): Fairne
     if (dueOrder !== 0) {
         return dueOrder < 0 ? left : right;
     }
-    return indexedDB.cmp(leftEntry.keyString, rightEntry.keyString) <= 0 ? left : right;
+    return leftEntry.keyString <= rightEntry.keyString ? left : right;
 }

--- a/packages/shared/queuebox/indexed-db-queue-box-release.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-release.ts
@@ -1,0 +1,73 @@
+import { Temporal } from '@js-temporal/polyfill';
+import {
+    computeIndexedDbQueuePut,
+    isStoredQueueEntryExpired,
+    type ComputedIndexedDbQueueMutation,
+    type StoredResourceEntry
+} from './indexed-db-queue-box-entry.ts';
+import {
+    isIdempotentHandlerFinalizedRelease,
+    ResourceInboxLostReservationError,
+    type ResourceInboxReleaseDisposition
+} from './queue-box-types.ts';
+import { EntityStatus, toKeyAsString, type Key, type ResourceEntry } from './ResourceEntry.ts';
+
+export type ComputeIndexedDbQueueReleaseInput = Readonly<{
+    currentEntries: ReadonlyMap<string, ResourceEntry>;
+    disposition: ResourceInboxReleaseDisposition;
+    releasedAt: Temporal.Instant;
+    resources: readonly ResourceEntry[];
+    storedEntries: ReadonlyMap<string, StoredResourceEntry>;
+}>;
+
+export type ComputedIndexedDbQueueRelease = Readonly<{
+    mutations: readonly ComputedIndexedDbQueueMutation[];
+    result: Map<Key, ResourceEntry>;
+}>;
+
+export function computeIndexedDbQueueRelease(
+    input: ComputeIndexedDbQueueReleaseInput
+): ComputedIndexedDbQueueRelease {
+    const result = new Map<Key, ResourceEntry>();
+    const mutations: ComputedIndexedDbQueueMutation[] = [];
+    for (const resource of input.resources) {
+        const stored = input.storedEntries.get(toKeyAsString(resource.key));
+        const current = input.currentEntries.get(toKeyAsString(resource.key));
+        if (
+            !stored ||
+            !current ||
+            (
+                (
+                    isStoredQueueEntryExpired(stored, input.releasedAt) ||
+                    stored.status !== EntityStatus.RESERVED ||
+                    stored.dequeueAudit.attempts !== resource.dequeueAudit.attempts
+                ) &&
+                !isIdempotentHandlerFinalizedRelease(current, resource, input.disposition)
+            )
+        ) {
+            throw new ResourceInboxLostReservationError(
+                resource.key,
+                resource.dequeueAudit.attempts
+            );
+        }
+        if (current.status !== EntityStatus.RESERVED) {
+            result.set(current.key, current);
+            continue;
+        }
+        const updated: ResourceEntry = {
+            ...current,
+            status: input.disposition.status,
+            dequeueAudit: {
+                startTs: current.dequeueAudit.startTs,
+                endTs: input.releasedAt,
+                nextTs: input.disposition.delayMs !== null
+                    ? input.releasedAt.add({ milliseconds: input.disposition.delayMs })
+                    : undefined,
+                attempts: current.dequeueAudit.attempts
+            }
+        };
+        result.set(updated.key, updated);
+        mutations.push(computeIndexedDbQueuePut(stored, updated));
+    }
+    return { mutations, result };
+}

--- a/packages/shared/queuebox/indexed-db-queue-box-store.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-store.ts
@@ -1,0 +1,107 @@
+import { EntityStatus, type ResourceEntryKeyString } from './ResourceEntry.ts';
+import type { StoredResourceEntry } from './indexed-db-queue-box-entry.ts';
+
+export type ReadFairnessStoredQueueEntriesInput = Readonly<{
+    db: IDBDatabase;
+    indexName: string;
+    maxPerType: number;
+    overdueBeforeEpochMs: number;
+    storeName: string;
+    typeIds: readonly string[];
+}>;
+
+export async function readStoredQueueEntry(
+    db: IDBDatabase,
+    storeName: string,
+    keyString: ResourceEntryKeyString
+): Promise<StoredResourceEntry | undefined> {
+    const entries = await readStoredQueueEntries(db, storeName, [keyString]);
+    return entries.get(keyString);
+}
+
+export async function readStoredQueueEntries(
+    db: IDBDatabase,
+    storeName: string,
+    keyStrings: readonly ResourceEntryKeyString[]
+): Promise<ReadonlyMap<ResourceEntryKeyString, StoredResourceEntry>> {
+    if (keyStrings.length === 0) {
+        return new Map();
+    }
+
+    return await new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readonly');
+        const store = tx.objectStore(storeName);
+        const entries = new Map<ResourceEntryKeyString, StoredResourceEntry>();
+
+        tx.oncomplete = () => resolve(entries);
+        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB queue read aborted'));
+        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB queue read failed'));
+
+        for (const keyString of keyStrings) {
+            const request = store.get(keyString);
+            request.onerror = () => reject(request.error ?? new Error('IndexedDB queue get failed'));
+            request.onsuccess = () => {
+                const stored = request.result as StoredResourceEntry | undefined;
+                if (stored) {
+                    entries.set(keyString, stored);
+                }
+            };
+        }
+    });
+}
+
+export async function readAllStoredQueueEntries(
+    db: IDBDatabase,
+    storeName: string
+): Promise<readonly StoredResourceEntry[]> {
+    return await new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readonly');
+        const request = tx.objectStore(storeName).openCursor();
+        const entries: StoredResourceEntry[] = [];
+
+        tx.oncomplete = () => resolve(entries);
+        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB queue scan aborted'));
+        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB queue scan failed'));
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB queue cursor failed'));
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+                return;
+            }
+            entries.push(cursor.value as StoredResourceEntry);
+            cursor.continue();
+        };
+    });
+}
+
+export async function readFairnessStoredQueueEntries(
+    input: ReadFairnessStoredQueueEntriesInput
+): Promise<ReadonlyMap<string, readonly StoredResourceEntry[]>> {
+    return await new Promise((resolve, reject) => {
+        const tx = input.db.transaction(input.storeName, 'readonly');
+        const index = tx.objectStore(input.storeName).index(input.indexName);
+        const entriesByType = new Map<string, StoredResourceEntry[]>();
+
+        tx.oncomplete = () => resolve(entriesByType);
+        tx.onabort = () => reject(tx.error ?? new Error('IndexedDB fairness read aborted'));
+        tx.onerror = () => reject(tx.error ?? new Error('IndexedDB fairness read failed'));
+
+        for (const typeId of input.typeIds) {
+            const entries: StoredResourceEntry[] = [];
+            entriesByType.set(typeId, entries);
+            const request = index.openCursor(IDBKeyRange.bound(
+                [typeId, EntityStatus.RETRY, Number.MIN_SAFE_INTEGER, ''],
+                [typeId, EntityStatus.RETRY, input.overdueBeforeEpochMs, '\uffff']
+            ));
+            request.onerror = () => reject(request.error ?? new Error('IndexedDB fairness cursor failed'));
+            request.onsuccess = () => {
+                const cursor = request.result;
+                if (!cursor || entries.length >= input.maxPerType) {
+                    return;
+                }
+                entries.push(cursor.value as StoredResourceEntry);
+                cursor.continue();
+            };
+        }
+    });
+}

--- a/packages/shared/queuebox/indexed-db-queue-box-store.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-store.ts
@@ -1,5 +1,5 @@
-import { EntityStatus, type ResourceEntryKeyString } from './ResourceEntry.ts';
 import type { StoredResourceEntry } from './indexed-db-queue-box-entry.ts';
+import { EntityStatus, type ResourceEntryKeyString } from './ResourceEntry.ts';
 
 export type ReadFairnessStoredQueueEntriesInput = Readonly<{
     db: IDBDatabase;

--- a/packages/shared/queuebox/indexed-db-queue-box-write.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-write.ts
@@ -1,0 +1,76 @@
+import type {
+    ComputedIndexedDbQueueMutation,
+    StoredResourceEntry
+} from './indexed-db-queue-box-entry.ts';
+
+export async function writeComputedIndexedDbQueueMutations(
+    db: IDBDatabase,
+    storeName: string,
+    mutations: readonly ComputedIndexedDbQueueMutation[]
+): Promise<boolean> {
+    if (mutations.length === 0) {
+        return true;
+    }
+
+    return await new Promise<boolean>((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readwrite');
+        const store = tx.objectStore(storeName);
+        let conflict = false;
+
+        tx.oncomplete = () => resolve(true);
+        tx.onabort = () => {
+            if (conflict) {
+                resolve(false);
+                return;
+            }
+            reject(tx.error ?? new Error('IndexedDB computed queue write aborted'));
+        };
+        tx.onerror = () => {
+            if (!conflict) {
+                reject(tx.error ?? new Error('IndexedDB computed queue write failed'));
+            }
+        };
+
+        for (const mutation of mutations) {
+            if (mutation.expectedRevision === undefined) {
+                const request = mutation.value
+                    ? store.put(mutation.value)
+                    : store.delete(mutation.keyString);
+                request.onerror = () =>
+                    reject(
+                        request.error ?? new Error('IndexedDB computed queue mutation failed')
+                    );
+                continue;
+            }
+
+            const getRequest = store.get(mutation.keyString);
+            getRequest.onerror = () => {
+                if (!conflict) {
+                    reject(getRequest.error ?? new Error('IndexedDB computed queue compare failed'));
+                }
+            };
+            getRequest.onsuccess = () => {
+                if (conflict) {
+                    return;
+                }
+                const current = getRequest.result as StoredResourceEntry | undefined;
+                const actualRevision = current ? current.revision ?? 0 : null;
+                if (actualRevision !== mutation.expectedRevision) {
+                    conflict = true;
+                    tx.abort();
+                    return;
+                }
+                const writeRequest = mutation.value
+                    ? store.put(mutation.value)
+                    : store.delete(mutation.keyString);
+                writeRequest.onerror = () => {
+                    if (!conflict) {
+                        reject(
+                            writeRequest.error ?? new Error('IndexedDB computed queue mutation failed')
+                        );
+                    }
+                };
+            };
+        }
+    });
+}

--- a/packages/shared/queuebox/indexed-db-queue-box.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box.ts
@@ -5,13 +5,31 @@ import type { PersistenceSetItemOptions } from '../persistence/PersistenceProvid
 import { RateLimiter } from '../resilience/Resilience.ts';
 import { ResilienceDto } from './DequeueResourceEntryController.ts';
 import {
-    isIdempotentHandlerFinalizedRelease,
+    ComputedIndexedDbQueueMutation,
+    computeIndexedDbQueueDelete,
+    computeIndexedDbQueuePut,
+    computeReservedQueueEntry,
+    decodeStoredResourceEntry,
+    isStoredQueueEntryExpired,
+    isStoredQueueEntryReservable,
+    isStoredQueueEntryTimedOut,
+    StoredResourceEntry
+} from './indexed-db-queue-box-entry.ts';
+import { computeIndexedDbFairnessReservation } from './indexed-db-queue-box-fairness.ts';
+import { computeIndexedDbQueueRelease } from './indexed-db-queue-box-release.ts';
+import {
+    readAllStoredQueueEntries,
+    readFairnessStoredQueueEntries,
+    readStoredQueueEntries,
+    readStoredQueueEntry
+} from './indexed-db-queue-box-store.ts';
+import { writeComputedIndexedDbQueueMutations } from './indexed-db-queue-box-write.ts';
+import {
     QueueBoxResourceEntryRepository,
     ResourceInboxFairnessReservationInput,
     ResourceInboxFairnessSelection,
     ResourceInboxFinalizationReservationOptions,
     ResourceInboxFinalizationSelection,
-    ResourceInboxLostReservationError,
     ResourceInboxReleaseDisposition,
     ResourceInboxReservationInput,
     ResourceInboxWorkAdvertisementOptions,
@@ -25,100 +43,17 @@ import {
     COMPLETED_STATUSES,
     EntityStatus,
     Key,
-    NEVER_EXPIRE_TS,
     NEW_AND_RETRY_STATUSES,
     ResourceEntry,
-    ResourceEntryKeyString,
     TIMEOUT_ON_NON_RESPONSIVE_ENTRY,
     toKeyAsString
 } from './ResourceEntry.ts';
 import { DEFAULT_RESOURCE_INBOX_RETRY_POLICY } from './ResourceInboxRetryPolicy.ts';
 
-type StoredResourceEntry = Readonly<{
-    keyString: ResourceEntryKeyString;
-    fairnessDueEpochMs?: number;
-    key: Key;
-    resource: string;
-    typeId: string;
-    audit: Readonly<{
-        date: string;
-        createdBy: string;
-        createdTs: string;
-        expiryTs?: string;
-    }>;
-    status: EntityStatus;
-    dequeueAudit: Readonly<{
-        startTs?: string;
-        endTs?: string;
-        nextTs?: string;
-        attempts: number;
-    }>;
+type IndexedDbQueueWriteOperation<Result> = Readonly<{
+    mutations: readonly ComputedIndexedDbQueueMutation[];
+    result: Result;
 }>;
-
-function temporalText(value: unknown, fallback: string): string {
-    if (typeof value === 'string' && value.length > 0 && value !== '[object Object]') {
-        return value;
-    }
-
-    if (
-        value &&
-        typeof value === 'object' &&
-        'toString' in value &&
-        typeof value.toString === 'function'
-    ) {
-        const text = value.toString();
-        if (text.length > 0 && text !== '[object Object]') {
-            return text;
-        }
-    }
-
-    return fallback;
-}
-
-function toPlainTime(value: unknown): Temporal.PlainTime {
-    const fallback = Temporal.Now.plainTimeISO();
-    try {
-        return Temporal.PlainTime.from(temporalText(value, fallback.toString()));
-    }
-    catch {
-        return fallback;
-    }
-}
-
-function toPlainDateTime(value: unknown): Temporal.PlainDateTime {
-    const fallback = Temporal.Now.plainDateTimeISO();
-    try {
-        return Temporal.PlainDateTime.from(temporalText(value, fallback.toString()));
-    }
-    catch {
-        return fallback;
-    }
-}
-
-function toInstant(
-    value: unknown,
-    fallback: Temporal.Instant = NEVER_EXPIRE_TS
-): Temporal.Instant {
-    try {
-        return Temporal.Instant.from(temporalText(value, fallback.toString()));
-    }
-    catch {
-        return fallback;
-    }
-}
-
-function toOptionalInstant(value: unknown): Temporal.Instant | undefined {
-    if (value === undefined || value === null) {
-        return undefined;
-    }
-
-    try {
-        return Temporal.Instant.from(temporalText(value, ''));
-    }
-    catch {
-        return undefined;
-    }
-}
 
 export type IndexedDbQueueBoxOptions = Readonly<{
     dbName?: string;
@@ -164,98 +99,61 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
 
     private async cleanupNow(): Promise<boolean> {
         const db = await this.openDb();
-
-        return await new Promise<boolean>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            let removedEntries = 0;
-
-            tx.oncomplete = () => {
-                if (removedEntries > 0) {
-                    console.log('Removed entries: ', removedEntries);
-                }
-                resolve(removedEntries > 0);
-            };
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB cleanup aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB cleanup failed'));
-
-            const request = store.openCursor();
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed during cleanup'));
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor) {
-                    return;
-                }
-
-                const stored = cursor.value as StoredResourceEntry;
-                if (COMPLETED_STATUSES.has(stored.status) || this.isExpiredStoredEntry(stored)) {
-                    removedEntries += 1;
-                    const deleteRequest = cursor.delete();
-                    deleteRequest.onerror = () =>
-                        reject(deleteRequest.error ?? new Error('IndexedDB delete failed during cleanup'));
-                }
-
-                cursor.continue();
+        const now = Temporal.Now.instant();
+        const removedEntries = await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const expired = entries.filter(
+                (stored) =>
+                    COMPLETED_STATUSES.has(stored.status) ||
+                    isStoredQueueEntryExpired(stored, now)
+            );
+            return {
+                mutations: expired.map(computeIndexedDbQueueDelete),
+                result: expired.length
             };
         });
+        if (removedEntries > 0) {
+            console.log('Removed entries: ', removedEntries);
+        }
+        return removedEntries > 0;
     }
 
     async enqueue(resourceEntry: ResourceEntry): Promise<ResourceEntry | undefined> {
         const db = await this.openDb();
-
-        return await new Promise<ResourceEntry | undefined>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const keyString = toKeyAsString(resourceEntry.key);
-            let previous: ResourceEntry | undefined;
-
-            tx.oncomplete = () => resolve(previous);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB enqueue aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB enqueue failed'));
-
-            const getRequest = store.get(keyString);
-            getRequest.onerror = () => reject(getRequest.error ?? new Error('IndexedDB get failed during enqueue'));
-            getRequest.onsuccess = () => {
-                const stored = getRequest.result as StoredResourceEntry | undefined;
-                previous = stored ? this.toResourceEntry(stored) : undefined;
-
-                const putRequest = store.put(this.toStoredEntry(resourceEntry));
-                putRequest.onerror = () => reject(putRequest.error ?? new Error('IndexedDB put failed during enqueue'));
+        const keyString = toKeyAsString(resourceEntry.key);
+        return await this.commitOnce(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            return {
+                mutations: [computeIndexedDbQueuePut(stored, resourceEntry)],
+                result: stored ? this.toResourceEntry(stored) : undefined
             };
         });
     }
 
     async enqueueIfAbsent(resourceEntry: ResourceEntry): Promise<ResourceEntry> {
         const db = await this.openDb();
-
-        return await new Promise<ResourceEntry>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const keyString = toKeyAsString(resourceEntry.key);
-            let result = resourceEntry;
-
-            tx.oncomplete = () => resolve(result);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB enqueueIfAbsent aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB enqueueIfAbsent failed'));
-
-            const getRequest = store.get(keyString);
-            getRequest.onerror = () =>
-                reject(getRequest.error ?? new Error('IndexedDB get failed during enqueueIfAbsent'));
-            getRequest.onsuccess = () => {
-                const stored = getRequest.result as StoredResourceEntry | undefined;
-                if (stored && !this.isExpiredStoredEntry(stored)) {
-                    console.log('Entry already exists: ', resourceEntry.key);
-                    result = this.toResourceEntry(stored);
-                    return;
-                }
-
-                const writeRequest = stored
-                    ? store.put(this.toStoredEntry(resourceEntry))
-                    : store.add(this.toStoredEntry(resourceEntry));
-                writeRequest.onerror = () =>
-                    reject(writeRequest.error ?? new Error('IndexedDB write failed during enqueueIfAbsent'));
+        const keyString = toKeyAsString(resourceEntry.key);
+        const result = await this.commitOnce<{
+            entry: ResourceEntry;
+            existing: boolean;
+        }>(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            const now = Temporal.Now.instant();
+            if (stored && !isStoredQueueEntryExpired(stored, now)) {
+                return {
+                    mutations: [],
+                    result: { entry: this.toResourceEntry(stored), existing: true }
+                };
+            }
+            return {
+                mutations: [computeIndexedDbQueuePut(stored, resourceEntry)],
+                result: { entry: resourceEntry, existing: false }
             };
         });
+        if (result.existing) {
+            console.log('Entry already exists: ', resourceEntry.key);
+        }
+        return result.entry;
     }
 
     async enqueueIf(
@@ -263,46 +161,32 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         enqueueIt: (existing: ResourceEntry) => boolean
     ): Promise<ResourceEntry | undefined> {
         const db = await this.openDb();
-
-        return await new Promise<ResourceEntry | undefined>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const keyString = toKeyAsString(resourceEntry.key);
-            let result: ResourceEntry | undefined;
-
-            tx.oncomplete = () => resolve(result);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB enqueueIf aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB enqueueIf failed'));
-
-            const getRequest = store.get(keyString);
-            getRequest.onerror = () => reject(getRequest.error ?? new Error('IndexedDB get failed during enqueueIf'));
-            getRequest.onsuccess = () => {
-                const stored = getRequest.result as StoredResourceEntry | undefined;
-                if (stored && !this.isExpiredStoredEntry(stored)) {
-                    const previous = this.toResourceEntry(stored);
-                    result = previous;
-
-                    let shouldOverwrite: boolean;
-                    try {
-                        shouldOverwrite = enqueueIt(previous);
-                    }
-                    catch (error) {
-                        reject(error);
-                        tx.abort();
-                        return;
-                    }
-
-                    if (!shouldOverwrite) {
-                        console.log('Entry already exists: ', resourceEntry.key);
-                        return;
-                    }
+        const keyString = toKeyAsString(resourceEntry.key);
+        const result = await this.commitOnce<{
+            previous: ResourceEntry | undefined;
+            skipped: boolean;
+        }>(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            const now = Temporal.Now.instant();
+            if (stored && !isStoredQueueEntryExpired(stored, now)) {
+                const previous = this.toResourceEntry(stored);
+                if (!enqueueIt(previous)) {
+                    return { mutations: [], result: { previous, skipped: true } };
                 }
-
-                const writeRequest = store.put(this.toStoredEntry(resourceEntry));
-                writeRequest.onerror = () =>
-                    reject(writeRequest.error ?? new Error('IndexedDB write failed during enqueueIf'));
+                return {
+                    mutations: [computeIndexedDbQueuePut(stored, resourceEntry)],
+                    result: { previous, skipped: false }
+                };
+            }
+            return {
+                mutations: [computeIndexedDbQueuePut(stored, resourceEntry)],
+                result: { previous: undefined, skipped: false }
             };
         });
+        if (result.skipped) {
+            console.log('Entry already exists: ', resourceEntry.key);
+        }
+        return result.previous;
     }
 
     async enqueueOrUpdate(
@@ -310,71 +194,38 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         updateExisting: (existing: ResourceEntry) => ResourceEntry | undefined
     ) {
         const db = await this.openDb();
-
-        return await new Promise<{
+        const keyString = toKeyAsString(resourceEntry.key);
+        const result = await this.commitOnce<{
             action: 'inserted' | 'updated' | 'unchanged';
             entry: ResourceEntry;
             previous?: ResourceEntry;
-        }>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const keyString = toKeyAsString(resourceEntry.key);
-            let result: {
-                action: 'inserted' | 'updated' | 'unchanged';
-                entry: ResourceEntry;
-                previous?: ResourceEntry;
-            } = {
-                action: 'inserted',
-                entry: resourceEntry
-            };
-
-            tx.oncomplete = () => resolve(result);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB enqueueOrUpdate aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB enqueueOrUpdate failed'));
-
-            const getRequest = store.get(keyString);
-            getRequest.onerror = () =>
-                reject(getRequest.error ?? new Error('IndexedDB get failed during enqueueOrUpdate'));
-            getRequest.onsuccess = () => {
-                const stored = getRequest.result as StoredResourceEntry | undefined;
-                if (!stored || this.isExpiredStoredEntry(stored)) {
-                    const writeRequest = store.put(this.toStoredEntry(resourceEntry));
-                    writeRequest.onerror = () =>
-                        reject(writeRequest.error ?? new Error('IndexedDB write failed during enqueueOrUpdate'));
-                    return;
-                }
-
-                const previous = this.toResourceEntry(stored);
-                let updated: ResourceEntry | undefined;
-                try {
-                    updated = updateExisting(previous);
-                }
-                catch (error) {
-                    reject(error);
-                    tx.abort();
-                    return;
-                }
-
-                if (!updated) {
-                    console.log('Entry already exists: ', resourceEntry.key);
-                    result = {
-                        action: 'unchanged',
-                        entry: previous,
-                        previous
-                    };
-                    return;
-                }
-
-                result = {
-                    action: 'updated',
-                    entry: updated,
-                    previous
+        }>(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            const now = Temporal.Now.instant();
+            if (!stored || isStoredQueueEntryExpired(stored, now)) {
+                return {
+                    mutations: [computeIndexedDbQueuePut(stored, resourceEntry)],
+                    result: { action: 'inserted', entry: resourceEntry }
                 };
-                const writeRequest = store.put(this.toStoredEntry(updated));
-                writeRequest.onerror = () =>
-                    reject(writeRequest.error ?? new Error('IndexedDB update failed during enqueueOrUpdate'));
+            }
+
+            const previous = this.toResourceEntry(stored);
+            const updated = updateExisting(previous);
+            if (!updated) {
+                return {
+                    mutations: [],
+                    result: { action: 'unchanged', entry: previous, previous }
+                };
+            }
+            return {
+                mutations: [computeIndexedDbQueuePut(stored, updated)],
+                result: { action: 'updated', entry: updated, previous }
             };
         });
+        if (result.action === 'unchanged') {
+            console.log('Entry already exists: ', resourceEntry.key);
+        }
+        return result;
     }
 
     async releaseEntries(
@@ -387,74 +238,20 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         }
 
         const db = await this.openDb();
-        const released = new Map<Key, ResourceEntry>();
         const releasedAt = Temporal.Now.instant();
-
-        return await new Promise<Map<Key, ResourceEntry>>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-
-            tx.oncomplete = () => resolve(released);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB releaseEntries aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB releaseEntries failed'));
-
-            for (const resource of resources) {
-                const keyString = toKeyAsString(resource.key);
-                const getRequest = store.get(keyString);
-                getRequest.onerror = () =>
-                    reject(getRequest.error ?? new Error('IndexedDB get failed during releaseEntries'));
-                getRequest.onsuccess = () => {
-                    const stored = getRequest.result as StoredResourceEntry | undefined;
-                    const current = stored ? this.toResourceEntry(stored) : undefined;
-                    if (
-                        !stored ||
-                        !current ||
-                        (
-                            (
-                                this.isExpiredStoredEntry(stored) ||
-                                stored.status !== EntityStatus.RESERVED ||
-                                stored.dequeueAudit.attempts !== resource.dequeueAudit.attempts
-                            ) &&
-                            !isIdempotentHandlerFinalizedRelease(
-                                current,
-                                resource,
-                                disposition
-                            )
-                        )
-                    ) {
-                        reject(
-                            new ResourceInboxLostReservationError(
-                                resource.key,
-                                resource.dequeueAudit.attempts
-                            )
-                        );
-                        tx.abort();
-                        return;
-                    }
-                    if (current.status !== EntityStatus.RESERVED) {
-                        released.set(current.key, current);
-                        return;
-                    }
-                    const updated: ResourceEntry = {
-                        ...current,
-                        status: disposition.status,
-                        dequeueAudit: {
-                            startTs: current.dequeueAudit.startTs,
-                            endTs: releasedAt,
-                            nextTs: disposition.delayMs !== null
-                                ? releasedAt.add({ milliseconds: disposition.delayMs })
-                                : undefined,
-                            attempts: current.dequeueAudit.attempts
-                        }
-                    };
-
-                    released.set(updated.key, updated);
-
-                    const putRequest = store.put(this.toStoredEntry(updated));
-                    putRequest.onerror = () =>
-                        reject(putRequest.error ?? new Error('IndexedDB put failed during releaseEntries'));
-                };
-            }
+        const keyStrings = resources.map((resource) => toKeyAsString(resource.key));
+        return await this.commitOnce(db, async () => {
+            const storedEntries = await readStoredQueueEntries(db, this.storeName, keyStrings);
+            const currentEntries = new Map(
+                [...storedEntries].map(([key, stored]) => [key, this.toResourceEntry(stored)])
+            );
+            return computeIndexedDbQueueRelease({
+                currentEntries,
+                disposition,
+                releasedAt,
+                resources,
+                storedEntries
+            });
         });
     }
 
@@ -468,44 +265,31 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
             DEFAULT_RESOURCE_INBOX_RETRY_POLICY.maxAttempts
         );
         const db = await this.openDb();
-        const reserved = new Map<Key, ResourceEntry>();
         const now = Temporal.Now.instant();
-
-        return await new Promise<Map<Key, ResourceEntry>>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const timeoutRequest = store.openCursor();
-
-            tx.oncomplete = () => resolve(reserved);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB reserveTimeoutEntries aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB reserveTimeoutEntries failed'));
-
-            timeoutRequest.onerror = () =>
-                reject(timeoutRequest.error ?? new Error('IndexedDB cursor failed during reserveTimeoutEntries'));
-            timeoutRequest.onsuccess = () => {
-                const cursor = timeoutRequest.result;
-                if (!cursor || reserved.size >= maxToReserve) {
-                    return;
+        return await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const reserved = new Map<Key, ResourceEntry>();
+            const mutations: ComputedIndexedDbQueueMutation[] = [];
+            for (const stored of entries) {
+                if (reserved.size >= maxToReserve) {
+                    break;
                 }
-
-                const stored = cursor.value as StoredResourceEntry;
                 if (
                     stored.dequeueAudit.attempts >= maxAttempts ||
-                    !this.isTimedOutReservedEntry(stored, typeIds, timeSinceStartTs, now)
+                    !isStoredQueueEntryTimedOut({
+                        stored,
+                        typeIds,
+                        duration: timeSinceStartTs,
+                        now
+                    })
                 ) {
-                    cursor.continue();
-                    return;
+                    continue;
                 }
-
-                const updated = this.toReservedEntry(this.toResourceEntry(stored), now);
-                const updateRequest = cursor.update(this.toStoredEntry(updated));
-                updateRequest.onerror = () =>
-                    reject(updateRequest.error ?? new Error('IndexedDB update failed during reserveTimeoutEntries'));
-                updateRequest.onsuccess = () => {
-                    reserved.set(updated.key, updated);
-                    cursor.continue();
-                };
-            };
+                const updated = computeReservedQueueEntry(this.toResourceEntry(stored), now);
+                reserved.set(updated.key, updated);
+                mutations.push(computeIndexedDbQueuePut(stored, updated));
+            }
+            return { mutations, result: reserved };
         });
     }
 
@@ -519,45 +303,34 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
             DEFAULT_RESOURCE_INBOX_RETRY_POLICY.maxAttempts
         );
         const db = await this.openDb();
-        const reserved = new Map<Key, ResourceEntry>();
         const now = Temporal.Now.instant();
-
-        return await new Promise<Map<Key, ResourceEntry>>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.openCursor();
-
-            tx.oncomplete = () => resolve(reserved);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB reserveEntries aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB reserveEntries failed'));
-
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed during reserveEntries'));
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor || reserved.size >= maxToReserve) {
-                    return;
+        return await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const reserved = new Map<Key, ResourceEntry>();
+            const mutations: ComputedIndexedDbQueueMutation[] = [];
+            for (const stored of entries) {
+                if (reserved.size >= maxToReserve) {
+                    break;
                 }
-
-                const stored = cursor.value as StoredResourceEntry;
-                if (!this.isReservableEntry(stored, typeIds, statusIds, now, maxAttempts)) {
-                    if (this.isExpiredStoredEntry(stored)) {
-                        const deleteRequest = cursor.delete();
-                        deleteRequest.onerror = () =>
-                            reject(deleteRequest.error ?? new Error('IndexedDB delete failed during reserveEntries'));
+                if (
+                    !isStoredQueueEntryReservable({
+                        stored,
+                        typeIds,
+                        statusIds,
+                        now,
+                        maxAttempts
+                    })
+                ) {
+                    if (isStoredQueueEntryExpired(stored, now)) {
+                        mutations.push(computeIndexedDbQueueDelete(stored));
                     }
-                    cursor.continue();
-                    return;
+                    continue;
                 }
-
-                const updated = this.toReservedEntry(this.toResourceEntry(stored), now);
-                const updateRequest = cursor.update(this.toStoredEntry(updated));
-                updateRequest.onerror = () =>
-                    reject(updateRequest.error ?? new Error('IndexedDB update failed during reserveEntries'));
-                updateRequest.onsuccess = () => {
-                    reserved.set(updated.key, updated);
-                    cursor.continue();
-                };
-            };
+                const updated = computeReservedQueueEntry(this.toResourceEntry(stored), now);
+                reserved.set(updated.key, updated);
+                mutations.push(computeIndexedDbQueuePut(stored, updated));
+            }
+            return { mutations, result: reserved };
         });
     }
 
@@ -582,114 +355,25 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         }
 
         const db = await this.openDb();
-        const reserved = new Map<Key, ResourceInboxFairnessSelection>();
         const now = Temporal.Now.instant();
-        const overdueBefore = Temporal.Instant.fromEpochMilliseconds(overdueBeforeEpochMs);
-
-        return await new Promise<Map<Key, ResourceInboxFairnessSelection>>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const index = store.index(IndexedDbQueueBox.FAIRNESS_INDEX_NAME);
-            const states = [...typeIds].map((typeId) => ({
-                typeId,
-                ready: false,
-                cursor: undefined as IDBCursorWithValue | undefined
-            }));
-            let scanned = states.length;
-            let stopped = false;
-
-            tx.oncomplete = () => resolve(reserved);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB fairness reservation aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB fairness reservation failed'));
-
-            const advanceOrDropCursor = (
-                state: typeof states[number],
-                cursor: IDBCursorWithValue
-            ) => {
-                if (scanned >= maxToScan) {
-                    state.cursor = undefined;
-                    state.ready = true;
-                    drain();
-                    return;
-                }
-
-                scanned += 1;
-                state.ready = false;
-                cursor.continue();
-            };
-
-            const drain = () => {
-                if (stopped || states.some((state) => !state.ready)) {
-                    return;
-                }
-
-                const available = states.filter(
-                    (state): state is typeof state & { cursor: IDBCursorWithValue; } => state.cursor !== undefined
-                );
-                if (available.length === 0) {
-                    return;
-                }
-
-                const selectedState = available.reduce((left, right) => {
-                    const leftEntry = left.cursor.value as StoredResourceEntry;
-                    const rightEntry = right.cursor.value as StoredResourceEntry;
-                    const dueOrder = leftEntry.fairnessDueEpochMs! -
-                        rightEntry.fairnessDueEpochMs!;
-                    return dueOrder < 0 || (
-                            dueOrder === 0 && indexedDB.cmp(
-                                    leftEntry.keyString,
-                                    rightEntry.keyString
-                                ) <= 0
-                        )
-                        ? left
-                        : right;
-                });
-                const cursor = selectedState.cursor;
-                const stored = cursor.value as StoredResourceEntry;
-
-                if (
-                    this.isExpiredStoredEntry(stored, now) ||
-                    stored.dequeueAudit.attempts >= maxAttempts
-                ) {
-                    advanceOrDropCursor(selectedState, cursor);
-                    return;
-                }
-
-                const selectedDueTs = Temporal.Instant.from(stored.dequeueAudit.nextTs!);
-                const entry = this.toReservedEntry(this.toResourceEntry(stored), now);
-                selectedState.ready = false;
-                const updateRequest = cursor.update(this.toStoredEntry(entry));
-                updateRequest.onerror = () =>
-                    reject(
-                        updateRequest.error ?? new Error('IndexedDB fairness update failed')
-                    );
-                updateRequest.onsuccess = () => {
-                    reserved.set(entry.key, { entry, selectedDueTs });
-                    if (reserved.size >= maxToReserve) {
-                        stopped = true;
-                        return;
-                    }
-                    advanceOrDropCursor(selectedState, cursor);
-                };
-            };
-
-            for (const state of states) {
-                const request = index.openCursor(IDBKeyRange.bound(
-                    [state.typeId, EntityStatus.RETRY, Number.MIN_SAFE_INTEGER, ''],
-                    [
-                        state.typeId,
-                        EntityStatus.RETRY,
-                        Number(overdueBefore.epochMilliseconds),
-                        '\uffff'
-                    ]
-                ));
-                request.onerror = () => reject(request.error ?? new Error('IndexedDB fairness cursor failed'));
-                request.onsuccess = () => {
-                    state.cursor = request.result ?? undefined;
-                    state.ready = true;
-                    drain();
-                };
-            }
+        const requestedTypes = [...typeIds];
+        return await this.commitOnce(db, async () => {
+            const entriesByType = await readFairnessStoredQueueEntries({
+                db,
+                storeName: this.storeName,
+                indexName: IndexedDbQueueBox.FAIRNESS_INDEX_NAME,
+                typeIds: requestedTypes,
+                overdueBeforeEpochMs,
+                maxPerType: maxToScan
+            });
+            return computeIndexedDbFairnessReservation({
+                entriesByType,
+                maxAttempts,
+                maxToReserve,
+                maxToScan,
+                now,
+                requestedTypes
+            });
         });
     }
 
@@ -704,33 +388,26 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         const db = await this.openDb();
         const now = Temporal.Now.instant();
         const staleBefore = now.subtract({ milliseconds: options.staleAfterMs });
-        const reserved = new Map<Key, ResourceInboxFinalizationSelection>();
-        return await new Promise((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const request = tx.objectStore(this.storeName).openCursor();
-            tx.oncomplete = () => resolve(reserved);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB finalization reservation aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB finalization reservation failed'));
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB finalization cursor failed'));
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor || reserved.size >= options.maxToReserve) {
-                    return;
+        return await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const reserved = new Map<Key, ResourceInboxFinalizationSelection>();
+            const mutations: ComputedIndexedDbQueueMutation[] = [];
+            for (const stored of entries) {
+                if (reserved.size >= options.maxToReserve) {
+                    break;
                 }
-                const stored = cursor.value as StoredResourceEntry;
                 const startTs = stored.dequeueAudit.startTs
                     ? Temporal.Instant.from(stored.dequeueAudit.startTs)
                     : undefined;
                 const eligible = stored.typeId === EnqueuedType.APP_INBOX &&
                     stored.status === EntityStatus.RESERVED &&
-                    !this.isExpiredStoredEntry(stored, now) &&
+                    !isStoredQueueEntryExpired(stored, now) &&
                     stored.dequeueAudit.attempts >= options.processingAttempts &&
                     stored.dequeueAudit.attempts < Number.MAX_SAFE_INTEGER &&
                     startTs !== undefined &&
                     Temporal.Instant.compare(startTs, staleBefore) <= 0;
                 if (!eligible) {
-                    cursor.continue();
-                    return;
+                    continue;
                 }
                 const entry = this.toResourceEntry(stored);
                 const updated: ResourceEntry = {
@@ -742,16 +419,10 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
                         nextTs: undefined
                     }
                 };
-                const update = cursor.update(this.toStoredEntry(updated));
-                update.onerror = () => reject(update.error ?? new Error('IndexedDB finalization update failed'));
-                update.onsuccess = () => {
-                    reserved.set(updated.key, {
-                        entry: updated,
-                        selectedDueTs: startTs
-                    });
-                    cursor.continue();
-                };
-            };
+                reserved.set(updated.key, { entry: updated, selectedDueTs: startTs });
+                mutations.push(computeIndexedDbQueuePut(stored, updated));
+            }
+            return { mutations, result: reserved };
         });
     }
 
@@ -811,7 +482,7 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
                 : undefined;
             return stored.typeId === EnqueuedType.APP_INBOX &&
                 stored.status === EntityStatus.RESERVED &&
-                !this.isExpiredStoredEntry(stored, now) &&
+                !isStoredQueueEntryExpired(stored, now) &&
                 stored.dequeueAudit.attempts >= processingAttempts &&
                 stored.dequeueAudit.attempts < Number.MAX_SAFE_INTEGER &&
                 startTs !== undefined &&
@@ -826,7 +497,13 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
     ): Promise<boolean> {
         return await this.findAnyStoredEntry((stored) => {
             const now = Temporal.Now.instant();
-            return this.isReservableEntry(stored, typeIds, statusesToFind, now, maxAttempts);
+            return isStoredQueueEntryReservable({
+                stored,
+                typeIds,
+                statusIds: statusesToFind,
+                now,
+                maxAttempts
+            });
         });
     }
 
@@ -838,7 +515,7 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         return await this.findAnyStoredEntry((stored) => {
             const now = Temporal.Now.instant();
             return stored.dequeueAudit.attempts < maxAttempts &&
-                this.isTimedOutReservedEntry(stored, typeIds, duration, now);
+                isStoredQueueEntryTimedOut({ stored, typeIds, duration, now });
         });
     }
 
@@ -873,74 +550,18 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         });
     }
 
-    private isReservableEntry(
-        stored: StoredResourceEntry,
-        typeIds: ReadonlySet<string>,
-        statusIds: ReadonlySet<EntityStatus>,
-        now: Temporal.Instant,
-        maxAttempts: number = DEFAULT_RESOURCE_INBOX_RETRY_POLICY.maxAttempts
-    ): boolean {
-        if (this.isExpiredStoredEntry(stored, now)) {
-            return false;
+    private async commitOnce<Result>(
+        db: IDBDatabase,
+        createOperation: () => Promise<IndexedDbQueueWriteOperation<Result>>
+    ): Promise<Result> {
+        const operation = await createOperation();
+        if (operation.mutations.length === 0) {
+            return operation.result;
         }
-
-        if (!typeIds.has(stored.typeId) || !statusIds.has(stored.status)) {
-            return false;
+        if (!await writeComputedIndexedDbQueueMutations(db, this.storeName, operation.mutations)) {
+            throw new Error('IndexedDB queue write conflicted');
         }
-
-        if (
-            stored.status === EntityStatus.FAILED ||
-            stored.dequeueAudit.attempts >= maxAttempts
-        ) {
-            return false;
-        }
-
-        if (!stored.dequeueAudit.nextTs) {
-            return true;
-        }
-
-        return Temporal.Instant.compare(now, Temporal.Instant.from(stored.dequeueAudit.nextTs)) >= 0;
-    }
-
-    private isTimedOutReservedEntry(
-        stored: StoredResourceEntry,
-        typeIds: ReadonlySet<string>,
-        duration: Temporal.Duration,
-        now: Temporal.Instant
-    ): boolean {
-        if (this.isExpiredStoredEntry(stored, now)) {
-            return false;
-        }
-
-        if (!typeIds.has(stored.typeId) || stored.status !== EntityStatus.RESERVED || !stored.dequeueAudit.startTs) {
-            return false;
-        }
-
-        const startTs = Temporal.Instant.from(stored.dequeueAudit.startTs);
-        return Temporal.Instant.compare(now, startTs.add(duration)) >= 0;
-    }
-
-    private toReservedEntry(entry: ResourceEntry, now: Temporal.Instant): ResourceEntry {
-        return {
-            ...entry,
-            status: EntityStatus.RESERVED,
-            dequeueAudit: {
-                startTs: now,
-                endTs: undefined,
-                nextTs: undefined,
-                attempts: entry.dequeueAudit.attempts + 1
-            }
-        };
-    }
-
-    private isExpiredStoredEntry(
-        stored: StoredResourceEntry,
-        now: Temporal.Instant = Temporal.Now.instant()
-    ): boolean {
-        const expiryTs = stored.audit.expiryTs
-            ? toInstant(stored.audit.expiryTs)
-            : NEVER_EXPIRE_TS;
-        return Temporal.Instant.compare(now, expiryTs) >= 0;
+        return operation.result;
     }
 
     private async openDb(): Promise<IDBDatabase> {
@@ -977,82 +598,22 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
         return await this.dbPromise;
     }
 
-    private toStoredEntry(entry: ResourceEntry): StoredResourceEntry {
-        return {
-            keyString: toKeyAsString(entry.key),
-            fairnessDueEpochMs: entry.dequeueAudit.nextTs
-                ? Number(entry.dequeueAudit.nextTs.epochMilliseconds)
-                : undefined,
-            key: entry.key,
-            resource: entry.resource,
-            typeId: entry.typeId,
-            audit: {
-                date: toPlainTime(entry.audit.date).toString(),
-                createdBy: entry.audit.createdBy,
-                createdTs: toPlainDateTime(entry.audit.createdTs).toString(),
-                expiryTs: toInstant(entry.audit.expiryTs).toString()
-            },
-            status: entry.status,
-            dequeueAudit: {
-                startTs: toOptionalInstant(entry.dequeueAudit.startTs)?.toString(),
-                endTs: toOptionalInstant(entry.dequeueAudit.endTs)?.toString(),
-                nextTs: toOptionalInstant(entry.dequeueAudit.nextTs)?.toString({
-                    fractionalSecondDigits: 9
-                }),
-                attempts: entry.dequeueAudit.attempts
-            }
-        };
-    }
-
     private toResourceEntry(stored: StoredResourceEntry): ResourceEntry {
-        return {
-            key: stored.key,
-            resource: stored.resource,
-            typeId: stored.typeId,
-            audit: {
-                date: toPlainTime(stored.audit.date),
-                createdBy: stored.audit.createdBy,
-                createdTs: toPlainDateTime(stored.audit.createdTs),
-                expiryTs: stored.audit.expiryTs
-                    ? toInstant(stored.audit.expiryTs)
-                    : NEVER_EXPIRE_TS
-            },
-            status: stored.status,
-            dequeueAudit: {
-                startTs: toOptionalInstant(stored.dequeueAudit.startTs),
-                endTs: toOptionalInstant(stored.dequeueAudit.endTs),
-                nextTs: toOptionalInstant(stored.dequeueAudit.nextTs),
-                attempts: stored.dequeueAudit.attempts
-            },
-            db: {
-                id: stored.keyString
-            }
-        };
+        return decodeStoredResourceEntry(stored);
     }
 
     async getItem(key: Key): Promise<ResourceEntry | undefined> {
         const db = await this.openDb();
-        return await new Promise<ResourceEntry | undefined>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.get(toKeyAsString(key));
-            request.onsuccess = () => {
-                const stored = request.result as StoredResourceEntry | undefined;
-                if (!stored) {
-                    resolve(undefined);
-                    return;
-                }
-
-                if (this.isExpiredStoredEntry(stored)) {
-                    const deleteRequest = store.delete(toKeyAsString(key));
-                    deleteRequest.onsuccess = () => resolve(undefined);
-                    deleteRequest.onerror = () => reject(deleteRequest.error);
-                    return;
-                }
-
-                resolve(this.toResourceEntry(stored));
-            };
-            request.onerror = () => reject(request.error);
+        const keyString = toKeyAsString(key);
+        return await this.commitOnce(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            if (!stored) {
+                return { mutations: [], result: undefined };
+            }
+            if (isStoredQueueEntryExpired(stored, Temporal.Now.instant())) {
+                return { mutations: [computeIndexedDbQueueDelete(stored)], result: undefined };
+            }
+            return { mutations: [], result: this.toResourceEntry(stored) };
         });
     }
 
@@ -1066,87 +627,48 @@ export class IndexedDbQueueBox implements QueueBoxResourceEntryRepository {
             ...value,
             key
         };
-        return await new Promise<void>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.put(this.toStoredEntry(entry));
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
+        const keyString = toKeyAsString(key);
+        await this.commitOnce(db, async () => {
+            const stored = await readStoredQueueEntry(db, this.storeName, keyString);
+            return { mutations: [computeIndexedDbQueuePut(stored, entry)], result: undefined };
         });
     }
 
     async removeItem(key: Key): Promise<void> {
         const db = await this.openDb();
-        return await new Promise<void>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.delete(toKeyAsString(key));
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
-        });
+        await writeComputedIndexedDbQueueMutations(db, this.storeName, [{
+            keyString: toKeyAsString(key)
+        }]);
     }
 
     async getAllKeys(): Promise<Key[]> {
         const db = await this.openDb();
-        return await new Promise<Key[]>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.openCursor();
+        return await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const now = Temporal.Now.instant();
             const keys: Key[] = [];
-
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor) {
-                    resolve(keys);
-                    return;
+            const mutations: ComputedIndexedDbQueueMutation[] = [];
+            for (const stored of entries) {
+                if (isStoredQueueEntryExpired(stored, now)) {
+                    mutations.push(computeIndexedDbQueueDelete(stored));
                 }
-
-                const stored = cursor.value as StoredResourceEntry;
-                if (this.isExpiredStoredEntry(stored)) {
-                    const deleteRequest = cursor.delete();
-                    deleteRequest.onerror = () => reject(deleteRequest.error);
-                    cursor.continue();
-                    return;
+                else {
+                    keys.push(stored.key);
                 }
-
-                keys.push(stored.key);
-                cursor.continue();
-            };
-            request.onerror = () => reject(request.error);
+            }
+            return { mutations, result: keys };
         });
     }
 
     async deleteExpired(): Promise<number> {
         const db = await this.openDb();
-
-        return await new Promise<number>((resolve, reject) => {
-            const tx = db.transaction(this.storeName, 'readwrite');
-            const store = tx.objectStore(this.storeName);
-            const request = store.openCursor();
-            let deleted = 0;
-
-            tx.oncomplete = () => resolve(deleted);
-            tx.onabort = () => reject(tx.error ?? new Error('IndexedDB deleteExpired aborted'));
-            tx.onerror = () => reject(tx.error ?? new Error('IndexedDB deleteExpired failed'));
-
-            request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed during deleteExpired'));
-            request.onsuccess = () => {
-                const cursor = request.result;
-                if (!cursor) {
-                    return;
-                }
-
-                const stored = cursor.value as StoredResourceEntry;
-                if (!this.isExpiredStoredEntry(stored)) {
-                    cursor.continue();
-                    return;
-                }
-
-                deleted += 1;
-                const deleteRequest = cursor.delete();
-                deleteRequest.onerror = () =>
-                    reject(deleteRequest.error ?? new Error('IndexedDB delete failed during deleteExpired'));
-                cursor.continue();
+        const now = Temporal.Now.instant();
+        return await this.commitOnce(db, async () => {
+            const entries = await readAllStoredQueueEntries(db, this.storeName);
+            const expired = entries.filter((stored) => isStoredQueueEntryExpired(stored, now));
+            return {
+                mutations: expired.map(computeIndexedDbQueueDelete),
+                result: expired.length
             };
         });
     }

--- a/packages/tests/shared-web/al-runtime/browser-al-runtime-stores.test.ts
+++ b/packages/tests/shared-web/al-runtime/browser-al-runtime-stores.test.ts
@@ -22,8 +22,8 @@ import {
     resolveBrowserRtcOverlayALOutboundRuntimeStores,
     resolveBrowserWsClientALOutboundRuntimeStores
 } from '@shared-web/browser/al-runtime/browser-al-runtime-stores.ts';
-import { decodeALOutboundPreparedMessage } from '@shared/alm/outbound/al-outbound-effect-validation.ts';
 import { ALAdmissionCorruptionError } from '@shared/alm/al-admission-decoder.ts';
+import { decodeALOutboundPreparedMessage } from '@shared/alm/outbound/al-outbound-effect-validation.ts';
 import {
     IndexedDbStringPersistenceProvider,
     newALUnicastMessage,
@@ -366,7 +366,17 @@ describe('Browser AL runtime IndexedDB stores', () => {
     it('initialises repeated browser AL runtime expiry eviction', async () => {
         vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
         vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        let evictionCount = 0;
+        let resolveSecondEviction!: () => void;
+        const secondEviction = new Promise<void>((resolve) => {
+            resolveSecondEviction = resolve;
+        });
+        vi.spyOn(console, 'log').mockImplementation(() => {
+            evictionCount += 1;
+            if (evictionCount === 2) {
+                resolveSecondEviction();
+            }
+        });
 
         const retention = {
             sentMessageTtlMs: 20
@@ -389,6 +399,7 @@ describe('Browser AL runtime IndexedDB stores', () => {
         ]);
 
         await vi.advanceTimersByTimeAsync(29);
+        await secondEviction;
 
         expect(await readBrowserALRuntimeEntryKeys(sentPrefix)).toEqual([]);
     });

--- a/packages/tests/shared-web/queuebox/browser-queuebox-persistence.test.ts
+++ b/packages/tests/shared-web/queuebox/browser-queuebox-persistence.test.ts
@@ -84,7 +84,9 @@ describe('Browser queuebox expiry eviction', () => {
 
         await vi.advanceTimersByTimeAsync(50);
 
-        expect(await readQueueBoxEntryKeys(storeName)).toEqual([]);
+        await vi.waitFor(async () => {
+            expect(await readQueueBoxEntryKeys(storeName)).toEqual([]);
+        });
     });
 });
 

--- a/packages/tests/shared/expiring-persistence-provider.test.ts
+++ b/packages/tests/shared/expiring-persistence-provider.test.ts
@@ -2,8 +2,9 @@
 
 import '../setup-browser-indexeddb.ts';
 
-import { IndexedDbStringPersistenceProvider, InMemoryPersistenceProvider } from '@shared/mod.ts';
-import { describe, expect, it } from 'vitest';
+import { IndexedDbStringPersistenceProvider } from '@shared/persistence/IndexedDbStringPersistenceProvider.ts';
+import { InMemoryPersistenceProvider } from '@shared/persistence/PersistenceProvider.ts';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('Expiring persistence providers', () => {
     it('lazy-evicts expired entries from InMemoryPersistenceProvider', async () => {
@@ -67,4 +68,57 @@ describe('Expiring persistence providers', () => {
         expect(await outbound.getItem('expired')).toBeUndefined();
         expect(await outbound.getAllKeys()).toEqual([]);
     });
+
+    it.each(['getItem', 'getAllKeys', 'deleteExpired'] as const)(
+        '%s surfaces an expiry conflict without retrying or deleting the refreshed value',
+        async (operation) => {
+            const dbName = `expiry-conflict-${crypto.randomUUID()}`;
+            const storeName = 'entries';
+            const provider = new IndexedDbStringPersistenceProvider<{ value: number; }>({
+                dbName,
+                storeName,
+                keyPrefix: 'inbound'
+            });
+            const now = Date.now();
+            await provider.setItem('expired', { value: 1 }, { expireAtTimestamp: now - 1 });
+
+            const openTransaction = IDBDatabase.prototype.transaction;
+            let cleanupAttempts = 0;
+            const transactions = vi.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (
+                this: IDBDatabase,
+                storeNames,
+                mode,
+                options
+            ) {
+                if (this.name === dbName && mode === 'readwrite') {
+                    cleanupAttempts += 1;
+                    if (cleanupAttempts === 1) {
+                        // Queue a real competing write after the expiry read, before its cleanup transaction.
+                        const refresh = openTransaction.call(this, storeNames, mode, options);
+                        refresh.objectStore(storeName).put({
+                            key: 'inbound:expired',
+                            value: { value: 2 },
+                            expireAtTimestamp: now + 60_000
+                        });
+                    }
+                }
+                return openTransaction.call(this, storeNames, mode, options);
+            });
+            try {
+                const cleanup = operation === 'getItem'
+                    ? provider.getItem('expired')
+                    : operation === 'getAllKeys'
+                    ? provider.getAllKeys()
+                    : provider.deleteExpired();
+
+                await expect(cleanup).rejects.toThrow('IndexedDB persistence cleanup conflicted');
+                expect(cleanupAttempts).toBe(1);
+                expect(await provider.getItem('expired')).toEqual({ value: 2 });
+                expect(await provider.getAllKeys()).toEqual(['expired']);
+            }
+            finally {
+                transactions.mockRestore();
+            }
+        }
+    );
 });

--- a/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
@@ -5,10 +5,11 @@ import '../setup-browser-indexeddb.ts';
 import { Temporal } from '@js-temporal/polyfill';
 import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
 import { encodeStoredResourceEntry } from '@shared/queuebox/indexed-db-queue-box-entry.ts';
+import { computeIndexedDbFairnessReservation } from '@shared/queuebox/indexed-db-queue-box-fairness.ts';
 import { readStoredQueueEntry } from '@shared/queuebox/indexed-db-queue-box-store.ts';
 import { writeComputedIndexedDbQueueMutations } from '@shared/queuebox/indexed-db-queue-box-write.ts';
 import { EntityStatus, NEVER_EXPIRE_TS, ResourceEntry, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('IndexedDbQueueBox computed writes', () => {
     it('allows only one writer to commit a computed revision', async () => {
@@ -76,6 +77,39 @@ describe('IndexedDbQueueBox computed writes', () => {
         expect(committed).toBe(false);
         expect((await readStoredQueueEntry(db, storeName, firstKey))?.resource).toBe(first.resource);
         expect((await readStoredQueueEntry(db, storeName, secondKey))?.resource).toBe(second.resource);
+    });
+
+    it('computes fairness ordering without reading the IndexedDB global', () => {
+        const dueAt = Temporal.Instant.from('2026-01-01T12:00:00Z');
+        const stored = ['z-type', 'a-type'].map((typeId) => ({
+            ...encodeStoredResourceEntry(createEntry(typeId, typeId), 0),
+            typeId,
+            status: EntityStatus.RETRY,
+            fairnessDueEpochMs: Number(dueAt.epochMilliseconds),
+            dequeueAudit: {
+                attempts: 0,
+                nextTs: dueAt.toString()
+            }
+        }));
+        vi.stubGlobal('indexedDB', undefined);
+        try {
+            const computed = computeIndexedDbFairnessReservation({
+                entriesByType: new Map([
+                    ['z-type', [stored[0]]],
+                    ['a-type', [stored[1]]]
+                ]),
+                maxAttempts: 3,
+                maxToReserve: 1,
+                maxToScan: 2,
+                now: dueAt,
+                requestedTypes: ['z-type', 'a-type']
+            });
+
+            expect([...computed.result.values()][0]?.entry.typeId).toBe('a-type');
+        }
+        finally {
+            vi.unstubAllGlobals();
+        }
     });
 });
 

--- a/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import '../setup-browser-indexeddb.ts';
+
+import { Temporal } from '@js-temporal/polyfill';
+import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
+import { encodeStoredResourceEntry } from '@shared/queuebox/indexed-db-queue-box-entry.ts';
+import { readStoredQueueEntry } from '@shared/queuebox/indexed-db-queue-box-store.ts';
+import { writeComputedIndexedDbQueueMutations } from '@shared/queuebox/indexed-db-queue-box-write.ts';
+import { EntityStatus, NEVER_EXPIRE_TS, ResourceEntry, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+
+describe('IndexedDbQueueBox computed writes', () => {
+    it('allows only one writer to commit a computed revision', async () => {
+        const storeName = 'entries';
+        const db = await openIndexedDbWithStore(
+            `indexeddb-computed-write-${crypto.randomUUID()}`,
+            { name: storeName, keyPath: 'keyString' }
+        );
+        const initial = createEntry('initial');
+        const keyString = toKeyAsString(initial.key);
+        await writeComputedIndexedDbQueueMutations(db, storeName, [{
+            keyString,
+            value: encodeStoredResourceEntry(initial, 0)
+        }]);
+
+        const first = createEntry('first');
+        const second = createEntry('second');
+        const outcomes = await Promise.all([
+            writeComputedIndexedDbQueueMutations(db, storeName, [{
+                keyString,
+                expectedRevision: 0,
+                value: encodeStoredResourceEntry(first, 1)
+            }]),
+            writeComputedIndexedDbQueueMutations(db, storeName, [{
+                keyString,
+                expectedRevision: 0,
+                value: encodeStoredResourceEntry(second, 1)
+            }])
+        ]);
+
+        expect(outcomes.toSorted()).toEqual([false, true]);
+        const stored = await readStoredQueueEntry(db, storeName, keyString);
+        expect(stored?.revision).toBe(1);
+        expect([first.resource, second.resource]).toContain(stored?.resource);
+    });
+
+    it('rolls back every computed mutation when one comparison conflicts', async () => {
+        const storeName = 'entries';
+        const db = await openIndexedDbWithStore(
+            `indexeddb-computed-batch-${crypto.randomUUID()}`,
+            { name: storeName, keyPath: 'keyString' }
+        );
+        const first = createEntry('first', 'first-row');
+        const second = createEntry('second', 'second-row');
+        const firstKey = toKeyAsString(first.key);
+        const secondKey = toKeyAsString(second.key);
+        await writeComputedIndexedDbQueueMutations(db, storeName, [
+            { keyString: firstKey, value: encodeStoredResourceEntry(first, 0) },
+            { keyString: secondKey, value: encodeStoredResourceEntry(second, 0) }
+        ]);
+
+        const committed = await writeComputedIndexedDbQueueMutations(db, storeName, [
+            {
+                keyString: firstKey,
+                expectedRevision: 0,
+                value: encodeStoredResourceEntry(createEntry('changed-first', 'first-row'), 1)
+            },
+            {
+                keyString: secondKey,
+                expectedRevision: 99,
+                value: encodeStoredResourceEntry(createEntry('changed-second', 'second-row'), 100)
+            }
+        ]);
+
+        expect(committed).toBe(false);
+        expect((await readStoredQueueEntry(db, storeName, firstKey))?.resource).toBe(first.resource);
+        expect((await readStoredQueueEntry(db, storeName, secondKey))?.resource).toBe(second.resource);
+    });
+});
+
+function createEntry(resource: string, resourceId: string = 'shared-resource'): ResourceEntry {
+    return {
+        key: {
+            topicId: 'computed-write',
+            resourceId,
+            contextId: 'test'
+        },
+        resource,
+        typeId: 'computed-write',
+        audit: {
+            date: Temporal.PlainTime.from('12:00:00'),
+            createdBy: 'test',
+            createdTs: Temporal.PlainDateTime.from('2026-01-01T12:00:00'),
+            expiryTs: NEVER_EXPIRE_TS
+        },
+        status: EntityStatus.NEW,
+        dequeueAudit: { attempts: 0 }
+    };
+}

--- a/packages/tests/shared/indexeddb-queuebox.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox.test.ts
@@ -117,6 +117,27 @@ describe('IndexedDbQueueBox', () => {
         expect((await queue.getItem(original.key))?.resource).toBe(acceptedReplacement.resource);
     });
 
+    it('computes an enqueueIf replacement before opening its write transaction', async () => {
+        const dbName = `indexeddb-queue-${crypto.randomUUID()}`;
+        const queue = new IndexedDbQueueBox({ dbName });
+        const original = createEntry('presence.state.v1', 'prepared-write', {
+            resource: JSON.stringify({ version: 1 })
+        });
+        const replacement = createEntry('presence.state.v1', 'prepared-write', {
+            resource: JSON.stringify({ version: 2 })
+        });
+        await queue.enqueue(original);
+
+        const transaction = vi.spyOn(IDBDatabase.prototype, 'transaction');
+        await queue.enqueueIf(replacement, () => {
+            expect(transaction.mock.calls.some((call) => call[1] === 'readwrite')).toBe(false);
+            return true;
+        });
+
+        expect(transaction.mock.calls.some((call) => call[1] === 'readonly')).toBe(true);
+        expect(transaction.mock.calls.some((call) => call[1] === 'readwrite')).toBe(true);
+    });
+
     it('overwrites expired entries with enqueueIf without calling the predicate', async () => {
         const dbName = `indexeddb-queue-${crypto.randomUUID()}`;
         const typeId = 'presence.state.v1';

--- a/packages/tests/shared/open-indexed-db.test.ts
+++ b/packages/tests/shared/open-indexed-db.test.ts
@@ -1,7 +1,4 @@
-import { readFileSync } from 'node:fs';
-
 import * as FakeIndexedDb from 'fake-indexeddb';
-import { ts } from 'ts-morph';
 // dprint-ignore
 import {
     afterEach,
@@ -16,7 +13,6 @@ import { openIndexedDbWithStore, openIndexedDbWithStores } from '@shared/persist
 interface SchemaWriteObservation {
     readonly kind: 'store' | 'index';
     readonly name: string;
-    readonly readyBeforeOpen: boolean;
     readonly transactionMode: IDBTransactionMode;
 }
 
@@ -26,28 +22,16 @@ describe('IndexedDB schema upgrades', () => {
         vi.unstubAllGlobals();
     });
 
-    it.each(['creation', 'upgrade'])('finishes DDL option records before %s opens a transaction', async (operation) => {
+    it.each(['creation', 'upgrade'])('applies the complete schema in the %s versionchange transaction', async (operation) => {
         const factory = new FakeIndexedDb.IDBFactory();
         vi.stubGlobal('indexedDB', factory);
         if (operation === 'upgrade') {
             const previous = await openIndexedDbWithStore('schema-options', { name: 'previous', keyPath: 'id' });
             previous.close();
         }
-        const allocationsBeforeOpen = new WeakSet<object>();
-        let openStarted = false;
-        const nativeOpen = factory.open.bind(factory);
-        vi.spyOn(factory, 'open').mockImplementation((...args) => {
-            openStarted = true;
-            return nativeOpen(...args);
-        });
-        const openObservedDatabase = createAllocationObservedOpener((value) => {
-            if (!openStarted) {
-                allocationsBeforeOpen.add(value);
-            }
-        });
-        const writes = observeSchemaWrites(allocationsBeforeOpen);
+        const writes = observeSchemaWrites();
 
-        const database = await openObservedDatabase('schema-options', [{
+        const database = await openIndexedDbWithStores('schema-options', [{
             name: 'items',
             keyPath: 'id',
             indexes: [
@@ -57,11 +41,11 @@ describe('IndexedDB schema upgrades', () => {
         }]);
         try {
             expect(writes).toEqual(expect.arrayContaining([
-                { kind: 'store', name: 'items', readyBeforeOpen: true, transactionMode: 'versionchange' },
-                { kind: 'index', name: 'by-group', readyBeforeOpen: true, transactionMode: 'versionchange' },
-                { kind: 'index', name: 'by-reference', readyBeforeOpen: true, transactionMode: 'versionchange' }
+                { kind: 'store', name: 'items', transactionMode: 'versionchange' },
+                { kind: 'index', name: 'by-group', transactionMode: 'versionchange' },
+                { kind: 'index', name: 'by-reference', transactionMode: 'versionchange' }
             ]));
-            expect(writes.filter((write) => !write.readyBeforeOpen || write.transactionMode !== 'versionchange')).toEqual([]);
+            expect(writes.every((write) => write.transactionMode === 'versionchange')).toBe(true);
             const items = database.transaction('items').objectStore('items');
             expect(items.keyPath).toBe('id');
             expect(items.index('by-group').keyPath).toEqual(['groupId', 'position']);
@@ -144,35 +128,7 @@ describe('IndexedDB schema upgrades', () => {
     });
 });
 
-function createAllocationObservedOpener(recordAllocation: (value: object) => void): typeof openIndexedDbWithStores {
-    const source = readFileSync(new URL('../../shared/persistence/openIndexedDb.ts', import.meta.url), 'utf8');
-    const compiled = ts.transpileModule(source, {
-        compilerOptions: { target: ts.ScriptTarget.ES2023, module: ts.ModuleKind.CommonJS },
-        transformers: { before: [observeObjectAllocations] }
-    });
-    const exports: Partial<typeof import('@shared/persistence/openIndexedDb.ts')> = {};
-    const evaluate = new Function('exports', 'recordAllocation', compiled.outputText);
-    evaluate(exports, (value: object) => {
-        recordAllocation(value);
-        return value;
-    });
-    if (typeof exports.openIndexedDbWithStores !== 'function') {
-        throw new TypeError('Instrumented IndexedDB module did not expose its opener');
-    }
-    return exports.openIndexedDbWithStores;
-}
-
-function observeObjectAllocations(context: ts.TransformationContext): ts.Transformer<ts.SourceFile> {
-    const visit: ts.Visitor = (node) => {
-        const visited = ts.visitEachChild(node, visit, context);
-        return ts.isObjectLiteralExpression(visited)
-            ? ts.factory.createCallExpression(ts.factory.createIdentifier('recordAllocation'), undefined, [visited])
-            : visited;
-    };
-    return (source) => ts.visitEachChild(source, visit, context);
-}
-
-function observeSchemaWrites(allocationsBeforeOpen: WeakSet<object>): SchemaWriteObservation[] {
+function observeSchemaWrites(): SchemaWriteObservation[] {
     const writes: SchemaWriteObservation[] = [];
     const createStore = FakeIndexedDb.IDBDatabase.prototype.createObjectStore;
     const createIndex = FakeIndexedDb.IDBObjectStore.prototype.createIndex;
@@ -181,7 +137,6 @@ function observeSchemaWrites(allocationsBeforeOpen: WeakSet<object>): SchemaWrit
         writes.push({
             kind: 'store',
             name,
-            readyBeforeOpen: options !== undefined && allocationsBeforeOpen.has(options),
             transactionMode: store.transaction.mode
         });
         return store;
@@ -191,7 +146,6 @@ function observeSchemaWrites(allocationsBeforeOpen: WeakSet<object>): SchemaWrit
         writes.push({
             kind: 'index',
             name,
-            readyBeforeOpen: options !== undefined && allocationsBeforeOpen.has(options),
             transactionMode: this.transaction.mode
         });
         return index;

--- a/packages/tests/shared/open-indexed-db.test.ts
+++ b/packages/tests/shared/open-indexed-db.test.ts
@@ -1,0 +1,215 @@
+import { readFileSync } from 'node:fs';
+
+import * as FakeIndexedDb from 'fake-indexeddb';
+import { ts } from 'ts-morph';
+// dprint-ignore
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+import { openIndexedDbWithStore, openIndexedDbWithStores } from '@shared/persistence/openIndexedDb.ts';
+
+interface SchemaWriteObservation {
+    readonly kind: 'store' | 'index';
+    readonly name: string;
+    readonly readyBeforeOpen: boolean;
+    readonly transactionMode: IDBTransactionMode;
+}
+
+describe('IndexedDB schema upgrades', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it.each(['creation', 'upgrade'])('finishes DDL option records before %s opens a transaction', async (operation) => {
+        const factory = new FakeIndexedDb.IDBFactory();
+        vi.stubGlobal('indexedDB', factory);
+        if (operation === 'upgrade') {
+            const previous = await openIndexedDbWithStore('schema-options', { name: 'previous', keyPath: 'id' });
+            previous.close();
+        }
+        const allocationsBeforeOpen = new WeakSet<object>();
+        let openStarted = false;
+        const nativeOpen = factory.open.bind(factory);
+        vi.spyOn(factory, 'open').mockImplementation((...args) => {
+            openStarted = true;
+            return nativeOpen(...args);
+        });
+        const openObservedDatabase = createAllocationObservedOpener((value) => {
+            if (!openStarted) {
+                allocationsBeforeOpen.add(value);
+            }
+        });
+        const writes = observeSchemaWrites(allocationsBeforeOpen);
+
+        const database = await openObservedDatabase('schema-options', [{
+            name: 'items',
+            keyPath: 'id',
+            indexes: [
+                { name: 'by-group', keyPath: ['groupId', 'position'] },
+                { name: 'by-reference', keyPath: 'reference', unique: true }
+            ]
+        }]);
+        try {
+            expect(writes).toEqual(expect.arrayContaining([
+                { kind: 'store', name: 'items', readyBeforeOpen: true, transactionMode: 'versionchange' },
+                { kind: 'index', name: 'by-group', readyBeforeOpen: true, transactionMode: 'versionchange' },
+                { kind: 'index', name: 'by-reference', readyBeforeOpen: true, transactionMode: 'versionchange' }
+            ]));
+            expect(writes.filter((write) => !write.readyBeforeOpen || write.transactionMode !== 'versionchange')).toEqual([]);
+            const items = database.transaction('items').objectStore('items');
+            expect(items.keyPath).toBe('id');
+            expect(items.index('by-group').keyPath).toEqual(['groupId', 'position']);
+            expect(items.index('by-group').unique).toBe(false);
+            expect(items.index('by-reference').unique).toBe(true);
+        }
+        finally {
+            database.close();
+        }
+    });
+
+    it('replaces mismatched indexes without losing stored records and keeps a matching schema version', async () => {
+        vi.stubGlobal('indexedDB', new FakeIndexedDb.IDBFactory());
+        const initial = await openIndexedDbWithStore('schema-replacement', {
+            name: 'items',
+            keyPath: 'id',
+            indexes: [{ name: 'by-group', keyPath: 'legacy', unique: false }]
+        });
+        const seed = initial.transaction('items', 'readwrite');
+        seed.objectStore('items').put({ id: 'one', legacy: 'old', groupId: 'group', position: 1 });
+        await waitForTransaction(seed);
+        const initialVersion = initial.version;
+        initial.close();
+
+        const stores = [{
+            name: 'items',
+            keyPath: 'id',
+            indexes: [{ name: 'by-group', keyPath: ['groupId', 'position'], unique: true }]
+        }];
+        const upgraded = await openIndexedDbWithStores('schema-replacement', stores);
+        try {
+            expect(upgraded.version).toBe(initialVersion + 1);
+            const index = upgraded.transaction('items').objectStore('items').index('by-group');
+            expect(index.keyPath).toEqual(['groupId', 'position']);
+            expect(index.unique).toBe(true);
+            expect(await readRequest(index.get(['group', 1]))).toEqual({
+                id: 'one',
+                legacy: 'old',
+                groupId: 'group',
+                position: 1
+            });
+        }
+        finally {
+            upgraded.close();
+        }
+        const unchanged = await openIndexedDbWithStores('schema-replacement', stores);
+        expect(unchanged.version).toBe(initialVersion + 1);
+        unchanged.close();
+    });
+
+    it('rolls back a rejected unique-index upgrade, including a preceding store creation', async () => {
+        vi.stubGlobal('indexedDB', new FakeIndexedDb.IDBFactory());
+        const initial = await openIndexedDbWithStore('schema-rollback', { name: 'items', keyPath: 'id' });
+        const seed = initial.transaction('items', 'readwrite');
+        seed.objectStore('items').put({ id: 'one', reference: 'duplicate' });
+        seed.objectStore('items').put({ id: 'two', reference: 'duplicate' });
+        await waitForTransaction(seed);
+        const initialVersion = initial.version;
+        initial.close();
+
+        await expect(openIndexedDbWithStores('schema-rollback', [
+            { name: 'audit', keyPath: 'id' },
+            { name: 'items', keyPath: 'id', indexes: [{ name: 'by-reference', keyPath: 'reference', unique: true }] }
+        ])).rejects.toMatchObject({ name: 'AbortError' });
+
+        const unchanged = await openIndexedDbWithStore('schema-rollback', { name: 'items', keyPath: 'id' });
+        try {
+            expect(unchanged.version).toBe(initialVersion);
+            expect([...unchanged.objectStoreNames]).toEqual(['items']);
+            const items = unchanged.transaction('items').objectStore('items');
+            expect([...items.indexNames]).toEqual([]);
+            expect(await readRequest(items.getAll())).toEqual([
+                { id: 'one', reference: 'duplicate' },
+                { id: 'two', reference: 'duplicate' }
+            ]);
+        }
+        finally {
+            unchanged.close();
+        }
+    });
+});
+
+function createAllocationObservedOpener(recordAllocation: (value: object) => void): typeof openIndexedDbWithStores {
+    const source = readFileSync(new URL('../../shared/persistence/openIndexedDb.ts', import.meta.url), 'utf8');
+    const compiled = ts.transpileModule(source, {
+        compilerOptions: { target: ts.ScriptTarget.ES2023, module: ts.ModuleKind.CommonJS },
+        transformers: { before: [observeObjectAllocations] }
+    });
+    const exports: Partial<typeof import('@shared/persistence/openIndexedDb.ts')> = {};
+    const evaluate = new Function('exports', 'recordAllocation', compiled.outputText);
+    evaluate(exports, (value: object) => {
+        recordAllocation(value);
+        return value;
+    });
+    if (typeof exports.openIndexedDbWithStores !== 'function') {
+        throw new TypeError('Instrumented IndexedDB module did not expose its opener');
+    }
+    return exports.openIndexedDbWithStores;
+}
+
+function observeObjectAllocations(context: ts.TransformationContext): ts.Transformer<ts.SourceFile> {
+    const visit: ts.Visitor = (node) => {
+        const visited = ts.visitEachChild(node, visit, context);
+        return ts.isObjectLiteralExpression(visited)
+            ? ts.factory.createCallExpression(ts.factory.createIdentifier('recordAllocation'), undefined, [visited])
+            : visited;
+    };
+    return (source) => ts.visitEachChild(source, visit, context);
+}
+
+function observeSchemaWrites(allocationsBeforeOpen: WeakSet<object>): SchemaWriteObservation[] {
+    const writes: SchemaWriteObservation[] = [];
+    const createStore = FakeIndexedDb.IDBDatabase.prototype.createObjectStore;
+    const createIndex = FakeIndexedDb.IDBObjectStore.prototype.createIndex;
+    vi.spyOn(FakeIndexedDb.IDBDatabase.prototype, 'createObjectStore').mockImplementation(function (this: IDBDatabase, name, options) {
+        const store = createStore.call(this, name, options);
+        writes.push({
+            kind: 'store',
+            name,
+            readyBeforeOpen: options !== undefined && allocationsBeforeOpen.has(options),
+            transactionMode: store.transaction.mode
+        });
+        return store;
+    });
+    vi.spyOn(FakeIndexedDb.IDBObjectStore.prototype, 'createIndex').mockImplementation(function (this: IDBObjectStore, name, keyPath, options) {
+        const index = createIndex.call(this, name, keyPath, options);
+        writes.push({
+            kind: 'index',
+            name,
+            readyBeforeOpen: options !== undefined && allocationsBeforeOpen.has(options),
+            transactionMode: this.transaction.mode
+        });
+        return index;
+    });
+    return writes;
+}
+
+async function waitForTransaction(transaction: IDBTransaction): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error);
+        transaction.onerror = () => reject(transaction.error);
+    });
+}
+
+async function readRequest<T>(request: IDBRequest<T>): Promise<T> {
+    return await new Promise<T>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}


### PR DESCRIPTION
## Goal

Move deterministic browser persistence work out of IndexedDB `readwrite` and `versionchange` transactions while preserving atomic comparisons and cross-tab conflict behavior.

## Changes

- split IndexedDB QueueBox into explicit stored-entry codec, readonly store access, pure fairness/release computation, and computed write execution
- add revision-based compare-and-write for QueueBox batches; conflicts abort the entire transaction and are surfaced without an inner retry
- move string-persistence expiry scans and deletion selection before the write transaction; the transaction only compares the observed expiry and deletes
- buffer AL admission writes before transaction entry and guard the batch with a persisted revision
- compute browser AL cleanup keys and revision write before its transaction
- precompute IndexedDB store/index schema records before opening a versionchange transaction
- remove the hidden `indexedDB.cmp` dependency from pure fairness computation

## Review remediation

- removed a brittle test that transpiled production source with `ts-morph` and evaluated it via `new Function`
- replaced it with direct schema, versionchange, row-preservation, and rollback behavior tests
- retained no extra preparation phase and added no retry loop
- QueueBox was reduced from roughly 1,500 lines to 675 lines with named operation owners

## Validation

- focused browser/IndexedDB tests: 6 files, 105 passed
- maintained test typecheck: 1,021 files, zero errors
- shared and shared-web TypeScript checks: passed
- changed-file formatting and diff checks: passed
- scoped navigation: no findings

## Honest assessment

This is a meaningful 17-file refactor and remains draft for CI plus final diff review. Two larger touched owners remain above the advisory aggregate cognitive-load threshold, but no individual function reaches the review threshold; their responsibilities are cohesive and the extracted files expose real read/compute/write boundaries rather than pass-through indirection.
