### PR TITLE
Precompute topology maintenance writes

### DIFF
--- a/apps/api-v1/test/db/pglite-queue-and-crdt.test.ts
+++ b/apps/api-v1/test/db/pglite-queue-and-crdt.test.ts
@@ -17,6 +17,7 @@ import { RtcTopologyExecutionRepository } from '@shared-server/rallar-system/top
 import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import { createRtcTopologyWorkHandler } from '@shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts';
 import { computeCoalescedRtcTopologyGroupRevisionWork } from '@shared-server/rallar-system/topology/replay/work/rtc-topology-coalesced-group-revision-work.ts';
+import { computeRtcTopologyInputFingerprintWrite } from '@shared-server/rallar-system/topology/replay/work/rtc-topology-input-fingerprint.ts';
 import { createGroupTopologyRuntimeOwners } from '@shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
@@ -735,11 +736,14 @@ Deno.test(
             assert.equal(metrics.topologyUpdateCount, 1);
 
             const mismatchedFingerprint = `sha256:${'0'.repeat(64)}`;
+            const mismatchedFingerprintWrite = computeRtcTopologyInputFingerprintWrite(
+                groupRef,
+                mismatchedFingerprint
+            );
             await sql.begin(async (transaction) =>
                 await executionRepository.writeTopologyInputFingerprint(
                     transaction,
-                    groupRef,
-                    mismatchedFingerprint
+                    mismatchedFingerprintWrite
                 )
             );
             await runCoalescedIntent(currentSnapshot);

--- a/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
+++ b/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
@@ -10,7 +10,14 @@ import { toRtcTopologyPublicationId, toRtcTopologyPublicationMessageId } from '@
 import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import { hashRtcTopologyExecutionCommand } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
 import type { RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
-import { writeRtcTopologyPublicationOutbox } from '@shared-server/rallar-system/topology/publication/rtc-topology-ws-outbox-entry.ts';
+import {
+    computeRtcTopologyPublicationOutboxInsert,
+    writeRtcTopologyPublicationOutbox
+} from '@shared-server/rallar-system/topology/publication/rtc-topology-ws-outbox-entry.ts';
+import {
+    computeRtcTopologyReservationFinish,
+    finishRtcTopologyReservation
+} from '@shared-server/rallar-system/topology/replay/work/finish-rtc-topology-work.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { AppTopics, EnqueuedType } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
@@ -24,10 +31,11 @@ Deno.test('PGlite persists distinct topology publications with one logical route
     const sql = lifecycle.database;
     try {
         const publications = [publication('work-1'), publication('work-2')];
+        const outboxWrites = publications.map(computeRtcTopologyPublicationOutboxInsert);
         const entries = await sql.begin(async (transaction) => {
             const written = [];
-            for (const item of publications) {
-                written.push(await writeRtcTopologyPublicationOutbox(transaction, item));
+            for (const write of outboxWrites) {
+                written.push(await writeRtcTopologyPublicationOutbox(transaction, write));
             }
             return written;
         });
@@ -118,19 +126,22 @@ Deno.test('PGlite atomically publishes stale topology work without regressing la
         assert.ok(reserved);
         assert.equal(reserved.status, EntityStatus.RESERVED);
         assert.equal(reserved.dequeueAudit.attempts, 1);
-        await sql.begin(async (transaction) => {
-            await executions.writeTopologyMutation(transaction, computed);
-            await writeRtcTopologyPublicationOutbox(transaction, stalePublication);
-            assert.equal(
-                await createPSqlResourceInboxRepository(transaction).finalization.finishReserved(
-                    reserved.key,
-                    1,
-                    EntityStatus.COMPLETED,
-                    new Date()
-                ),
-                true
-            );
-        });
+        const outboxWrite = computeRtcTopologyPublicationOutboxInsert(stalePublication);
+        const reservationFinish = computeRtcTopologyReservationFinish(reserved, new Date());
+        const stringify = JSON.stringify;
+        JSON.stringify = () => {
+            throw new Error('serialization must finish before the transaction');
+        };
+        try {
+            await sql.begin(async (transaction) => {
+                await executions.writeTopologyMutation(transaction, computed);
+                await writeRtcTopologyPublicationOutbox(transaction, outboxWrite);
+                await finishRtcTopologyReservation(transaction, reservationFinish);
+            });
+        }
+        finally {
+            JSON.stringify = stringify;
+        }
 
         const after = await snapshots.findSnapshotEntry(currentSnapshot.groupRef);
         assert.ok(after);

--- a/packages/shared-server/rallar-system/topology/mutation/compute-rtc-topology-persistence.ts
+++ b/packages/shared-server/rallar-system/topology/mutation/compute-rtc-topology-persistence.ts
@@ -1,0 +1,91 @@
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
+
+import { encodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
+import { toStoredRtcTopologySnapshotRow } from '../persistence/rtc-topology-snapshot-repository.ts';
+import { createRtcTopologyExecutionReceipt } from '../publication/rtc-topology-publication-repository-contracts.ts';
+import { childKey } from '../publication/rtc-topology-publication-repository-state.ts';
+import type { RtcTopologyPublication } from '../publication/rtc-topology-publication.ts';
+
+export interface RtcTopologyPersistenceInput {
+    readonly snapshot: RallarOverlayTopologySnapshot;
+    readonly expectedRevision: number | null;
+    readonly publication: RtcTopologyPublication | null;
+    readonly publicationExpireAtTimestamp: number | null;
+    readonly commandHash: string | null;
+    readonly attemptCount: number | null;
+}
+
+export interface RtcTopologyPersistenceComputed {
+    readonly snapshot: {
+        readonly key: string;
+        readonly value: string;
+        readonly expireAtIsoTimestamp: string;
+        readonly expectedRevision: number | null;
+        readonly acceptedStorageRevision: number;
+    };
+    readonly publication: {
+        readonly key: string;
+        readonly value: string;
+        readonly receiptKey: string;
+        readonly receiptValue: string;
+        readonly expireAtIsoTimestamp: string;
+    } | null;
+}
+
+export function computeRtcTopologyPersistence(
+    input: RtcTopologyPersistenceInput
+): RtcTopologyPersistenceComputed {
+    const acceptedStorageRevision = input.expectedRevision === null
+        ? 0
+        : input.expectedRevision + 1;
+    if (!Number.isSafeInteger(acceptedStorageRevision) || acceptedStorageRevision < 0) {
+        throw new TypeError('RTC topology accepted storage revision is invalid');
+    }
+    const snapshot = toStoredRtcTopologySnapshotRow(input.snapshot);
+    return {
+        snapshot: {
+            ...snapshot,
+            expireAtIsoTimestamp: new Date(NEVER_EXPIRE_AT_TIMESTAMP).toISOString(),
+            expectedRevision: input.expectedRevision,
+            acceptedStorageRevision
+        },
+        publication: computePublicationPersistence(input, acceptedStorageRevision)
+    };
+}
+
+function computePublicationPersistence(
+    input: RtcTopologyPersistenceInput,
+    acceptedStorageRevision: number
+): RtcTopologyPersistenceComputed['publication'] {
+    const publication = input.publication;
+    if (publication === null) {
+        return null;
+    }
+    if (
+        input.publicationExpireAtTimestamp === null ||
+        input.commandHash === null ||
+        input.attemptCount === null
+    ) {
+        throw new TypeError('RTC topology publication persistence facts are incomplete');
+    }
+    if (
+        !Number.isSafeInteger(input.publicationExpireAtTimestamp) ||
+        input.publicationExpireAtTimestamp <= publication.createdAtEpochMs
+    ) {
+        throw new TypeError('RTC topology publication expiry is invalid');
+    }
+    const receipt = createRtcTopologyExecutionReceipt(publication, {
+        commandHash: input.commandHash,
+        attemptCount: input.attemptCount,
+        acceptedStorageRevision
+    });
+    const key = childKey(publication.groupRef, 'publication', publication.publicationId);
+    return {
+        key,
+        value: JSON.stringify(encodeJsonWireValue(publication, 'RTC topology publication')),
+        receiptKey: childKey(publication.groupRef, 'work', publication.workId),
+        receiptValue: JSON.stringify(encodeJsonWireValue(receipt, 'RTC topology execution receipt')),
+        expireAtIsoTimestamp: new Date(input.publicationExpireAtTimestamp).toISOString()
+    };
+}

--- a/packages/shared-server/rallar-system/topology/mutation/rtc-topology-mutations.ts
+++ b/packages/shared-server/rallar-system/topology/mutation/rtc-topology-mutations.ts
@@ -8,6 +8,10 @@ import { rtcTopologySemanticEqual } from '../persistence/rtc-topology-semantic-e
 import { compareTopologyTuple, decideTopologySnapshot } from '../persistence/rtc-topology-snapshot-contract.ts';
 import type { RtcTopologyPublication } from '../publication/rtc-topology-publication.ts';
 import { validateRtcTopologyPublication } from '../publication/validate-rtc-topology-publication.ts';
+import {
+    computeRtcTopologyPersistence,
+    type RtcTopologyPersistenceComputed
+} from './compute-rtc-topology-persistence.ts';
 import { computeStaleTopologyPublication } from './rtc-topology-stale-publication.ts';
 import type { RtcTopologyStaleMutationComputed } from './rtc-topology-stale-publication.ts';
 
@@ -51,6 +55,7 @@ export type RtcTopologyMutationComputed =
         & Readonly<{
             outcome: 'write';
             observation: 'inserted' | 'advanced' | 'duplicate';
+            persistence: RtcTopologyPersistenceComputed;
             snapshotGuard: Readonly<{
                 expectedRevision: number | null;
                 candidate: RallarOverlayTopologySnapshot;
@@ -138,6 +143,12 @@ export function computeTopologyMutation(
     const write = {
         outcome: 'write',
         observation,
+        persistence: computeRtcTopologyPersistence({
+            snapshot: input.candidate,
+            expectedRevision: input.read.snapshot?.entry.revision ?? null,
+            publication: input.publication,
+            ...input.facts
+        }),
         snapshotGuard: {
             expectedRevision: input.read.snapshot?.entry.revision ?? null,
             candidate: input.candidate

--- a/packages/shared-server/rallar-system/topology/mutation/rtc-topology-stale-publication.ts
+++ b/packages/shared-server/rallar-system/topology/mutation/rtc-topology-stale-publication.ts
@@ -1,6 +1,10 @@
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { RuntimeStateEntryValue } from '../../../runtime-state/runtime-state-json-store.ts';
 import type { RtcTopologyPublication } from '../publication/rtc-topology-publication.ts';
+import {
+    computeRtcTopologyPersistence,
+    type RtcTopologyPersistenceComputed
+} from './compute-rtc-topology-persistence.ts';
 
 export type RtcTopologyStaleMutationComputed =
     | Readonly<{
@@ -13,6 +17,7 @@ export type RtcTopologyStaleMutationComputed =
             expectedRevision: number;
             current: RallarOverlayTopologySnapshot;
         }>;
+        persistence: RtcTopologyPersistenceComputed;
         publication: RtcTopologyPublication;
         publicationExpireAtTimestamp: number;
         commandHash: string;
@@ -43,6 +48,14 @@ export function computeStaleTopologyPublication(
     }
     return {
         outcome: 'publish-superseded',
+        persistence: computeRtcTopologyPersistence({
+            snapshot: input.current.value,
+            expectedRevision: input.current.entry.revision,
+            publication: input.publication,
+            publicationExpireAtTimestamp: expiresAt,
+            commandHash: input.commandHash,
+            attemptCount: input.attemptCount
+        }),
         currentGuard: {
             expectedRevision: input.current.entry.revision,
             current: input.current.value

--- a/packages/shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts
+++ b/packages/shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts
@@ -1,6 +1,8 @@
 import {
-    createRtcTopologyExecutionReceipt,
-    hashRtcTopologyExecutionCommand
+    hashRtcTopologyExecutionCommand,
+    RTC_TOPOLOGY_PUBLICATION_WORK_INDEX_NAMESPACE,
+    RTC_TOPOLOGY_PUBLICATIONS_NAMESPACE,
+    RtcTopologyPublicationCollisionError
 } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
 import { RtcTopologyPublicationRepository } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.ts';
 import { type RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
@@ -8,8 +10,8 @@ import type { GroupRef } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
-import { PSqlRuntimeStateRepository } from '../../../runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../../runtime-state/runtime-state-repository.ts';
+import type { RtcTopologyPersistenceComputed } from '../mutation/compute-rtc-topology-persistence.ts';
 import {
     computeTopologyMutation,
     validateTopologyMutation,
@@ -17,10 +19,17 @@ import {
     type RtcTopologyMutationRead
 } from '../mutation/rtc-topology-mutations.ts';
 import { RTC_TOPOLOGY_REPLAY_RETENTION_MS } from '../replay/consumer/rtc-topology-replay-policy.ts';
-import { RtcTopologyInputFingerprintRepository } from '../replay/work/rtc-topology-input-fingerprint.ts';
+import {
+    RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE,
+    RtcTopologyInputFingerprintRepository,
+    type RtcTopologyInputFingerprintWrite
+} from '../replay/work/rtc-topology-input-fingerprint.ts';
 import { RtcTopologyRepositoryInvariantCorruptionError } from './rtc-topology-errors.ts';
 import { rtcTopologySemanticEqual } from './rtc-topology-semantic-equal.ts';
-import { RtcTopologySnapshotRepository } from './rtc-topology-snapshot-repository.ts';
+import {
+    RTC_TOPOLOGY_SNAPSHOTS_NAMESPACE,
+    RtcTopologySnapshotRepository
+} from './rtc-topology-snapshot-repository.ts';
 
 export type RtcTopologyExecutionCommitResult =
     | Readonly<{
@@ -74,12 +83,27 @@ export class RtcTopologyExecutionRepository {
 
     async writeTopologyInputFingerprint(
         transaction: PSqlSql,
-        groupRef: GroupRef,
-        fingerprint: string
+        computed: RtcTopologyInputFingerprintWrite
     ): Promise<void> {
-        await new RtcTopologyInputFingerprintRepository(
-            new PSqlRuntimeStateRepository(transaction)
-        ).putFingerprint(groupRef, fingerprint);
+        await transaction`
+            insert into runtime_state_store (store_namespace,
+                                             store_key,
+                                             store_value,
+                                             expire_at_ts,
+                                             updated_ts,
+                                             revision)
+            values (${RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE},
+                    ${computed.key},
+                    ${computed.value},
+                    ${computed.expireAtIsoTimestamp},
+                    now(),
+                    0)
+            on conflict (store_namespace, store_key)
+                do update set store_value  = excluded.store_value,
+                              expire_at_ts = excluded.expire_at_ts,
+                              updated_ts   = now(),
+                              revision     = runtime_state_store.revision + 1
+        `;
     }
 
     async readTopologyMutation(
@@ -119,43 +143,10 @@ export class RtcTopologyExecutionRepository {
         transaction: PSqlSql,
         computed: Extract<RtcTopologyMutationComputed, { outcome: 'write' | 'publish-superseded'; }>
     ): Promise<'committed'> {
-        const publicationWrite = requirePublicationWrite(computed);
-        const runtime = new PSqlRuntimeStateRepository(transaction);
-        const snapshots = new RtcTopologySnapshotRepository(runtime);
-        const snapshotGuard = computed.outcome === 'write'
-            ? computed.snapshotGuard
-            : {
-                expectedRevision: computed.currentGuard.expectedRevision,
-                candidate: computed.currentGuard.current
-            };
-        const guard = await snapshots.commitSnapshotGuard(
-            snapshotGuard.candidate,
-            snapshotGuard.expectedRevision
-        );
-        if (guard.status === 'conflict') {
-            throw new RuntimeStateWriteConflictError();
-        }
-        if (publicationWrite) {
-            const publications = this.publications(runtime);
-            const receipt = createRtcTopologyExecutionReceipt(
-                publicationWrite.publication,
-                {
-                    commandHash: publicationWrite.commandHash,
-                    attemptCount: publicationWrite.attemptCount,
-                    acceptedStorageRevision: guard.storageRevision
-                }
-            );
-            const claimed = await publications.insertWorkClaim(
-                receipt,
-                publicationWrite.expireAtTimestamp
-            );
-            if (!claimed) {
-                throw new RuntimeStateWriteConflictError();
-            }
-            await publications.insertPublication(
-                publicationWrite.publication,
-                publicationWrite.expireAtTimestamp
-            );
+        await writeRtcTopologySnapshot(transaction, computed.persistence.snapshot);
+        const publication = computed.persistence.publication;
+        if (publication) {
+            await writeRtcTopologyPublication(transaction, publication);
         }
         return 'committed';
     }
@@ -237,37 +228,68 @@ export class RtcTopologyExecutionRepository {
     }
 }
 
-function requirePublicationWrite(
-    computed: Extract<RtcTopologyMutationComputed, { outcome: 'write' | 'publish-superseded'; }>
-):
-    | Readonly<{
-        publication: RtcTopologyPublication;
-        expireAtTimestamp: number;
-        commandHash: string;
-        attemptCount: number;
-    }>
-    | null {
-    if (computed.publication === null) {
-        if (computed.publicationExpireAtTimestamp !== null) {
-            throw new TypeError(
-                'RTC topology publication expiry must be null without publication'
-            );
-        }
-        return null;
+async function writeRtcTopologySnapshot(
+    transaction: PSqlSql,
+    snapshot: RtcTopologyPersistenceComputed['snapshot']
+): Promise<void> {
+    const rows = snapshot.expectedRevision === null
+        ? await transaction<Array<{ revision: number | string; }>>`
+            insert into runtime_state_store (store_namespace, store_key, store_value,
+                                             expire_at_ts, updated_ts, revision)
+            values (${RTC_TOPOLOGY_SNAPSHOTS_NAMESPACE}, ${snapshot.key}, ${snapshot.value},
+                    ${snapshot.expireAtIsoTimestamp}, now(), 0)
+            on conflict (store_namespace, store_key) do nothing
+            returning revision
+        `
+        : await transaction<Array<{ revision: number | string; }>>`
+            update runtime_state_store
+            set store_value = ${snapshot.value},
+                expire_at_ts = ${snapshot.expireAtIsoTimestamp},
+                updated_ts = now(),
+                revision = revision + 1
+            where store_namespace = ${RTC_TOPOLOGY_SNAPSHOTS_NAMESPACE}
+              and store_key = ${snapshot.key}
+              and revision = ${snapshot.expectedRevision}
+            returning revision
+        `;
+    if (!rows[0]) {
+        throw new RuntimeStateWriteConflictError();
     }
-    const expireAtTimestamp = computed.publicationExpireAtTimestamp;
-    if (
-        !Number.isSafeInteger(expireAtTimestamp) ||
-        expireAtTimestamp <= computed.publication.createdAtEpochMs
-    ) {
-        throw new TypeError('RTC topology publication expiry is invalid');
+    if (Number(rows[0].revision) !== snapshot.acceptedStorageRevision) {
+        throw new RtcTopologyRepositoryInvariantCorruptionError(
+            snapshot.key,
+            'RTC topology write returned an unexpected storage revision'
+        );
     }
-    return {
-        publication: computed.publication,
-        expireAtTimestamp,
-        commandHash: computed.commandHash,
-        attemptCount: computed.attemptCount
-    };
+}
+
+async function writeRtcTopologyPublication(
+    transaction: PSqlSql,
+    publication: NonNullable<RtcTopologyPersistenceComputed['publication']>
+): Promise<void> {
+    const claims = await transaction<Array<{ revision: number | string; }>>`
+        insert into runtime_state_store (store_namespace, store_key, store_value,
+                                         expire_at_ts, updated_ts, revision)
+        values (${RTC_TOPOLOGY_PUBLICATION_WORK_INDEX_NAMESPACE},
+                ${publication.receiptKey}, ${publication.receiptValue},
+                ${publication.expireAtIsoTimestamp}, now(), 0)
+        on conflict (store_namespace, store_key) do nothing
+        returning revision
+    `;
+    if (!claims[0]) {
+        throw new RuntimeStateWriteConflictError();
+    }
+    const publications = await transaction<Array<{ revision: number | string; }>>`
+        insert into runtime_state_store (store_namespace, store_key, store_value,
+                                         expire_at_ts, updated_ts, revision)
+        values (${RTC_TOPOLOGY_PUBLICATIONS_NAMESPACE}, ${publication.key},
+                ${publication.value}, ${publication.expireAtIsoTimestamp}, now(), 0)
+        on conflict (store_namespace, store_key) do nothing
+        returning revision
+    `;
+    if (!publications[0]) {
+        throw new RtcTopologyPublicationCollisionError(publication.key);
+    }
 }
 
 function sameSnapshot(

--- a/packages/shared-server/rallar-system/topology/publication/rtc-topology-ws-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/topology/publication/rtc-topology-ws-outbox-entry.ts
@@ -6,7 +6,11 @@ import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry
 import { decodePersistedALMessageValue } from '@shared/al-contracts/al-message-persistence-validation.ts';
 import { toAppQueueCreatedBy, toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { PSqlResourceInboxEntryRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import {
+    computeAppOutboxInsert,
+    writeAppOutboxInsert,
+    type AppOutboxInsert
+} from '../../app-outbox/app-outbox-insert.ts';
 import type { RtcTopologyPublication } from './rtc-topology-publication.ts';
 import { validateRtcTopologyPublication } from './validate-rtc-topology-publication.ts';
 
@@ -65,9 +69,14 @@ export function computeRtcTopologyPublicationOutbox(
 
 export async function writeRtcTopologyPublicationOutbox(
     transaction: PSqlSql,
-    publication: RtcTopologyPublication
+    computed: AppOutboxInsert
 ): Promise<ResourceEntry> {
-    const entry = computeRtcTopologyPublicationOutbox(publication);
-    await new PSqlResourceInboxEntryRepository(transaction).writeIfAbsentOrMatch(entry);
-    return entry;
+    await writeAppOutboxInsert(transaction, computed);
+    return computed.entry;
+}
+
+export function computeRtcTopologyPublicationOutboxInsert(
+    publication: RtcTopologyPublication
+): AppOutboxInsert {
+    return computeAppOutboxInsert(computeRtcTopologyPublicationOutbox(publication));
 }

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -7,11 +7,10 @@ import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/queue-message-callbacks.ts';
 import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
 import {
-    computePublicationConnectTriggerRequests,
-    writeGroupConnectTriggerRequests
+    computePublicationConnectTriggerRequests
 } from './write-group-connect-trigger-requests.ts';
 import {
-    writePublicationDelivery,
+    computeRtcTopologyPublicationDeliveryWrite,
     writeRtcTopologyPublicationTransaction,
     type RtcTopologyDeliveryOptions
 } from './write-rtc-topology-publication-transaction.ts';
@@ -21,7 +20,6 @@ import type { GroupTopologyPlanningAuthority } from '@shared-server/rallar-syste
 import { hashRtcTopologyExecutionCommand } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
 import { type RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
-import { runInPSqlTransaction } from '../../../../postgres/run-in-p-sql-transaction.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { RallarTimingSink } from '../../../observability/timing.ts';
 import type { RtcRttRefinementService } from '../../../rtc-rtt/topic/rtc-rtt-refinement-service.ts';
@@ -39,9 +37,15 @@ import {
     materializeRtcOverlayTopologyBroadcastMessage,
     type RtcOverlayTopologyMessageFacts
 } from '../../planning/materialize-rtc-overlay-topology-broadcast-message.ts';
-import { finishRtcTopologyReservation, finishRtcTopologyWork } from './finish-rtc-topology-work.ts';
+import {
+    computeRtcTopologyReservationFinish,
+    finishRtcTopologyWork
+} from './finish-rtc-topology-work.ts';
 import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
-import { computeAuthorityTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
+import {
+    computeAuthorityTopologyInputFingerprint,
+    computeRtcTopologyInputFingerprintWrite
+} from './rtc-topology-input-fingerprint.ts';
 import {
     readRtcTopologyWorkEnvelope,
     toRtcTopologyExecutionId,
@@ -50,7 +54,6 @@ import {
 } from './rtc-topology-work-codec.ts';
 import {
     readTopologyPromotionRequest,
-    writeTopologyPromotionRequest,
     type TopologyPromotionPublicationPort
 } from './write-topology-promotion-request.ts';
 
@@ -219,8 +222,21 @@ async function processLoadedRtcTopologyWork(
     if (computed.outcome !== 'loaded') {
         throw new RuntimeStateWriteConflictError();
     }
-    await writeRtcTopologyPublicationTransaction(options, entry, async (transaction) => {
-        await writePublicationDelivery(transaction, computed.publication, options.topologyDelivery);
+    const deliveryWrite = computeRtcTopologyPublicationDeliveryWrite(
+        computed.publication,
+        options.topologyDelivery?.publisherStreamId
+    );
+    await writeRtcTopologyPublicationTransaction({
+        database: options.database,
+        executionRepository: options.executionRepository,
+        deliveryAppend: options.topologyDelivery?.append
+    }, {
+        mutation: null,
+        promotionRequest: null,
+        connectRequests: [],
+        fingerprint: null,
+        delivery: deliveryWrite,
+        reservationFinish: computeRtcTopologyReservationFinish(entry, new Date())
     });
     options.topologyPlanning.recordTopologyPublication(true);
     options.wakeQueue?.();
@@ -448,20 +464,29 @@ async function writeAcceptedRtcTopologyWork(
         target: computed.outcome === 'write' ? computed.snapshotGuard.candidate : null,
         entry
     });
-    await writeRtcTopologyPublicationTransaction(options, entry, async (transaction) => {
-        await options.executionRepository.writeTopologyMutation(transaction, computed);
-        await writeTopologyPromotionRequest(transaction, promotionRequest);
-        await writeGroupConnectTriggerRequests(transaction, connectRequests);
-        if (computed.outcome === 'write') {
-            await options.executionRepository.writeTopologyInputFingerprint(
-                transaction,
-                accepted.group.group,
-                accepted.inputFingerprint
-            );
-        }
-        if (accepted.publication) {
-            await writePublicationDelivery(transaction, accepted.publication, options.topologyDelivery);
-        }
+    const deliveryWrite = accepted.publication
+        ? computeRtcTopologyPublicationDeliveryWrite(
+            accepted.publication,
+            options.topologyDelivery?.publisherStreamId
+        )
+        : null;
+    const fingerprintWrite = computed.outcome === 'write'
+        ? computeRtcTopologyInputFingerprintWrite(
+            accepted.group.group,
+            accepted.inputFingerprint
+        )
+        : null;
+    await writeRtcTopologyPublicationTransaction({
+        database: options.database,
+        executionRepository: options.executionRepository,
+        deliveryAppend: options.topologyDelivery?.append
+    }, {
+        mutation: computed,
+        promotionRequest,
+        connectRequests,
+        fingerprint: fingerprintWrite,
+        delivery: deliveryWrite,
+        reservationFinish: computeRtcTopologyReservationFinish(entry, new Date())
     });
     await finishCommittedTopologyWork(options, accepted, computed);
 }
@@ -491,17 +516,24 @@ async function writeSkippedTopologyWork(
         target: accepted.criterionPetition?.planned ?? null,
         entry
     });
-    await runInPSqlTransaction(options.database, async (transaction) => {
-        if (accepted.decision === 'skipped-unchanged') {
-            await options.executionRepository.writeTopologyInputFingerprint(
-                transaction,
-                accepted.group.group,
-                accepted.inputFingerprint
-            );
-        }
-        await writeTopologyPromotionRequest(transaction, promotionRequest);
-        await writeGroupConnectTriggerRequests(transaction, connectRequests);
-        await finishRtcTopologyReservation(transaction, entry);
+    const reservationFinish = computeRtcTopologyReservationFinish(entry, new Date());
+    const fingerprintWrite = accepted.decision === 'skipped-unchanged'
+        ? computeRtcTopologyInputFingerprintWrite(
+            accepted.group.group,
+            accepted.inputFingerprint
+        )
+        : null;
+    await writeRtcTopologyPublicationTransaction({
+        database: options.database,
+        executionRepository: options.executionRepository,
+        deliveryAppend: undefined
+    }, {
+        mutation: null,
+        promotionRequest,
+        connectRequests,
+        fingerprint: fingerprintWrite,
+        delivery: null,
+        reservationFinish
     });
     if (accepted.decision === 'skipped-frozen') {
         options.topologyPlanning.recordTopologyPlanFrozen();

--- a/packages/shared-server/rallar-system/topology/replay/work/finish-rtc-topology-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/finish-rtc-topology-work.ts
@@ -2,28 +2,39 @@ import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry
 
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../../postgres/run-in-p-sql-transaction.ts';
-import { PSqlResourceInboxFinalizationRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
+import {
+    writeResourceInboxReservationFinish,
+    type ResourceInboxReservationFinish
+} from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 
 export async function finishRtcTopologyWork(
     database: PSqlSql,
     entry: ResourceEntry
 ): Promise<void> {
+    const computed = computeRtcTopologyReservationFinish(entry, new Date());
     await runInPSqlTransaction(database, async (transaction) => {
-        await finishRtcTopologyReservation(transaction, entry);
+        await finishRtcTopologyReservation(transaction, computed);
     });
+}
+
+export function computeRtcTopologyReservationFinish(
+    entry: ResourceEntry,
+    completedAt: Date
+): ResourceInboxReservationFinish {
+    return {
+        key: { ...entry.key },
+        expectedAttempts: entry.dequeueAudit.attempts,
+        status: EntityStatus.COMPLETED,
+        completedAt
+    };
 }
 
 export async function finishRtcTopologyReservation(
     transaction: PSqlSql,
-    entry: ResourceEntry
+    computed: ResourceInboxReservationFinish
 ): Promise<void> {
-    const finished = await new PSqlResourceInboxFinalizationRepository(transaction).finishReserved(
-        entry.key,
-        entry.dequeueAudit.attempts,
-        EntityStatus.COMPLETED,
-        new Date()
-    );
+    const finished = await writeResourceInboxReservationFinish(transaction, computed);
     if (!finished) {
         throw new RuntimeStateWriteConflictError();
     }

--- a/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-input-fingerprint.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-input-fingerprint.ts
@@ -36,6 +36,34 @@ interface StoredRtcTopologyInputFingerprint {
     readonly fingerprint: string;
 }
 
+export interface RtcTopologyInputFingerprintWrite {
+    readonly key: string;
+    readonly value: string;
+    readonly expireAtIsoTimestamp: string;
+}
+
+export function computeRtcTopologyInputFingerprintWrite(
+    ref: GroupRef,
+    fingerprint: string
+): RtcTopologyInputFingerprintWrite {
+    if (!/^sha256:[0-9a-f]{64}$/u.test(fingerprint)) {
+        throw new TypeError('RTC topology input fingerprint is invalid');
+    }
+    const stored: StoredRtcTopologyInputFingerprint = {
+        groupRef: {
+            applicationId: ref.applicationId,
+            workspaceId: ref.workspaceId,
+            groupId: ref.groupId
+        },
+        fingerprint
+    };
+    return {
+        key: groupStateGroupStorageKey(ref),
+        value: JSON.stringify(stored),
+        expireAtIsoTimestamp: new Date(NEVER_EXPIRE_AT_TIMESTAMP).toISOString()
+    };
+}
+
 export async function computeRtcTopologyInputFingerprint(
     facts: RtcTopologyInputFingerprintFacts
 ): Promise<string> {

--- a/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
@@ -1,32 +1,77 @@
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../../postgres/run-in-p-sql-transaction.ts';
+import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
+import type { AppOutboxInsert } from '../../../app-outbox/app-outbox-insert.ts';
+import type { RtcTopologyMutationComputed } from '../../mutation/rtc-topology-mutations.ts';
+import type { RtcTopologyExecutionRepository } from '../../persistence/rtc-topology-execution-repository.ts';
 import type { RtcTopologyPublication } from '../../publication/rtc-topology-publication.ts';
-import { writeRtcTopologyPublicationOutbox } from '../../publication/rtc-topology-ws-outbox-entry.ts';
+import {
+    computeRtcTopologyPublicationOutboxInsert,
+    writeRtcTopologyPublicationOutbox
+} from '../../publication/rtc-topology-ws-outbox-entry.ts';
 import type { RtcTopologyDeliveryAppendPort } from '../delivery/rtc-topology-delivery-append-port.ts';
+import type { RtcTopologyDeliveryAppendInput } from '../delivery/rtc-topology-delivery-contracts.ts';
 import { RtcTopologyDeliveryLeaseLostError } from '../delivery/rtc-topology-delivery-stream-service.ts';
 import {
     isRtcTopologyDeliveryRetryableConflict,
     toRtcTopologyDeliveryAppendInput
 } from '../delivery/rtc-topology-delivery-validation.ts';
-import { finishRtcTopologyReservation } from './finish-rtc-topology-work.ts';
+import {
+    finishRtcTopologyReservation
+} from './finish-rtc-topology-work.ts';
+import type { RtcTopologyInputFingerprintWrite } from './rtc-topology-input-fingerprint.ts';
+import { writeGroupConnectTriggerRequests } from './write-group-connect-trigger-requests.ts';
+import { writeTopologyPromotionRequest } from './write-topology-promotion-request.ts';
 
 export interface RtcTopologyDeliveryOptions {
     readonly publisherStreamId: string;
     readonly append: RtcTopologyDeliveryAppendPort;
 }
 
-/** Publication, immutable delivery records and reservation completion share one transaction. */
+export interface RtcTopologyPublicationTransactionWrite {
+    readonly mutation: Extract<RtcTopologyMutationComputed, { outcome: 'write' | 'publish-superseded'; }> | null;
+    readonly promotionRequest: ResourceEntry | null;
+    readonly connectRequests: readonly ResourceEntry[];
+    readonly fingerprint: RtcTopologyInputFingerprintWrite | null;
+    readonly delivery: RtcTopologyPublicationDeliveryWrite | null;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+}
+
+/** Executes only computed writes; immutable delivery and reservation completion are atomic. */
 export async function writeRtcTopologyPublicationTransaction(
-    options: { readonly database: PSqlSql; },
-    entry: ResourceEntry,
-    write: (transaction: PSqlSql) => Promise<void>
+    options: Readonly<{
+        database: PSqlSql;
+        executionRepository: RtcTopologyExecutionRepository;
+        deliveryAppend: RtcTopologyDeliveryAppendPort | undefined;
+    }>,
+    computed: RtcTopologyPublicationTransactionWrite
 ): Promise<void> {
     try {
         await runInPSqlTransaction(options.database, async (transaction) => {
-            await write(transaction);
-            await finishRtcTopologyReservation(transaction, entry);
+            if (computed.mutation) {
+                await options.executionRepository.writeTopologyMutation(
+                    transaction,
+                    computed.mutation
+                );
+            }
+            await writeTopologyPromotionRequest(transaction, computed.promotionRequest);
+            await writeGroupConnectTriggerRequests(transaction, computed.connectRequests);
+            if (computed.fingerprint) {
+                await options.executionRepository.writeTopologyInputFingerprint(
+                    transaction,
+                    computed.fingerprint
+                );
+            }
+            if (computed.delivery) {
+                await writePublicationDelivery(
+                    transaction,
+                    computed.delivery,
+                    options.deliveryAppend
+                );
+            }
+            await finishRtcTopologyReservation(transaction, computed.reservationFinish);
         });
     }
     catch (error) {
@@ -37,25 +82,47 @@ export async function writeRtcTopologyPublicationTransaction(
     }
 }
 
+export interface RtcTopologyPublicationDeliveryWrite {
+    readonly outboxWrite: AppOutboxInsert;
+    readonly deliveryAppend: RtcTopologyDeliveryAppendInput | null;
+}
+
+export function computeRtcTopologyPublicationDeliveryWrite(
+    publication: RtcTopologyPublication,
+    publisherStreamId: string | undefined
+): RtcTopologyPublicationDeliveryWrite {
+    const outboxWrite = computeRtcTopologyPublicationOutboxInsert(publication);
+    return {
+        outboxWrite,
+        deliveryAppend: publisherStreamId === undefined
+            ? null
+            : toRtcTopologyDeliveryAppendInput(
+                publisherStreamId,
+                publication,
+                outboxWrite.entry
+            )
+    };
+}
+
 export async function writePublicationDelivery(
     transaction: PSqlSql,
-    publication: RtcTopologyPublication,
-    delivery: RtcTopologyDeliveryOptions | undefined
+    computed: RtcTopologyPublicationDeliveryWrite,
+    append: RtcTopologyDeliveryAppendPort | undefined
 ): Promise<void> {
-    const outbox = await writeRtcTopologyPublicationOutbox(transaction, publication);
-    if (!delivery) {
+    await writeRtcTopologyPublicationOutbox(transaction, computed.outboxWrite);
+    if (!append || computed.deliveryAppend === null) {
         return;
     }
-    const result = await delivery.append.appendOrValidate(
+    const result = await append.appendOrValidate(
         transaction,
-        toRtcTopologyDeliveryAppendInput(delivery.publisherStreamId, publication, outbox)
+        computed.deliveryAppend
     );
     if (result.status === 'conflict') {
         throw new RuntimeStateWriteConflictError();
     }
     if (result.status === 'lease-lost') {
         throw new RtcTopologyDeliveryLeaseLostError(
-            `RTC topology publisher stream ${delivery.publisherStreamId} lost its lease`
+            `RTC topology publisher stream ${computed.deliveryAppend.publisherStreamId} lost its lease`
         );
     }
 }

--- a/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
@@ -25,7 +25,6 @@ import type { AuditStamp, GroupPresenceSummary, GroupRef, GroupSnapshot, GroupSt
 import { EntityStatus, InMemoryQueueBox, type ALMessage } from '@shared/mod.ts';
 import { toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
 import { OutboxQueueReader } from '@shared/services/outbox-queue-reader.ts';
-import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { createTestGroup } from '../../../../create-test-group.ts';
 import { createAppInboxTestDatabase } from '../../app-inbox/test-support/app-inbox-test-database.ts';
@@ -44,32 +43,6 @@ interface EnqueueAndReserveRttInput {
 import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
 
 describe('RTC topology APP_OUTBOX work', () => {
-    it('lets ResourceInbox retry the handler-owned write and reservation-fenced completion transaction', () => {
-        const handler = readSource('create-rtc-topology-work-handler.ts');
-        const transaction = readSource('write-rtc-topology-publication-transaction.ts');
-        const completion = readSource('finish-rtc-topology-work.ts');
-
-        const acceptedWrite = handler.slice(handler.indexOf('async function writeAcceptedRtcTopologyWork'));
-        expect(acceptedWrite).not.toMatch(/waitForRuntimeStateWriteRetry/);
-        expect(acceptedWrite).not.toMatch(/\bfor\s*\([^)]*attempt/);
-        expect(acceptedWrite).toMatch(/writeTopologyMutation\(\s*transaction/);
-        expect(acceptedWrite.indexOf('writeTopologyMutation')).toBeLessThan(
-            acceptedWrite.indexOf('writePublicationDelivery')
-        );
-        expect(transaction).toMatch(/runInPSqlTransaction/);
-        expect(transaction).toMatch(/appendOrValidate\(/);
-        expect(transaction.indexOf('await write(transaction)')).toBeGreaterThanOrEqual(0);
-        expect(transaction.indexOf('await write(transaction)')).toBeLessThan(
-            transaction.indexOf('finishRtcTopologyReservation(transaction, entry)')
-        );
-        expect(completion).not.toMatch(/waitForRuntimeStateWriteRetry/);
-        expect(completion).not.toMatch(/\bfor\s*\([^)]*attempt/);
-        expect(completion).toMatch(
-            /new PSqlResourceInboxFinalizationRepository\(\s*transaction\s*,?\s*\)\.finishReserved\(/
-        );
-        expect(completion).toMatch(/throw new RuntimeStateWriteConflictError\(\)/);
-    });
-
     it('keeps each committed group revision as an immutable queue entry', async () => {
         const queue = new InMemoryQueueBox();
         const runtime = createRtcTopologyOutboxPublisher({
@@ -858,16 +831,6 @@ describe('RTC topology APP_OUTBOX work', () => {
         expect(observedRttVersions).toEqual([1]);
     });
 });
-
-function readSource(fileName: string): string {
-    return readFileSync(
-        new URL(
-            `../../../../../shared-server/rallar-system/topology/replay/work/${fileName}`,
-            import.meta.url
-        ),
-        'utf8'
-    );
-}
 
 async function entriesIn(queue: InMemoryQueueBox) {
     return await Promise.all((await queue.getAllKeys()).map((key) => queue.getItem(key))).then(


### PR DESCRIPTION
Stacks on #418.

Moves topology snapshot/publication receipts, input fingerprints, WS outbox records, delivery append inputs, and reservation completion data before transaction entry. The transaction now has an explicit computed-write graph instead of an arbitrary callback. ResourceInbox SQL remains separately governed.

Validation:
- shared-server TypeScript check
- maintained test typecheck (1021 files, zero errors)
- complete shared-server topology suite (513 passed, 5 skipped)
- PGlite topology WS outbox (2 passed) with serialization poisoned after compute
- PGlite topology fingerprint gate (1 passed)
- scoped style, navigation, and repository-structure review