### PR TITLE
Capture AppInbox retry completion before transactions

### DIFF
--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
@@ -29,6 +29,7 @@ export interface AppInboxRetryFinalizerDependencies {
 interface AppInboxRetryFinalizationWork {
     readonly finalization: AppInboxRetryFinalization;
     readonly finalizedAtEpochMs: number;
+    readonly finalizedAt: Date;
     readonly diagnostics: AppInboxFailure;
     readonly timingDetails: RallarTimingDetails;
 }
@@ -59,9 +60,11 @@ export function createAppInboxRetryFinalizer(
 function createAppInboxRetryFinalizationWork(
     finalization: AppInboxRetryFinalization
 ): AppInboxRetryFinalizationWork {
+    const finalizedAtEpochMs = toFinalizedAtEpochMs(finalization);
     return {
         finalization,
-        finalizedAtEpochMs: toFinalizedAtEpochMs(finalization),
+        finalizedAtEpochMs,
+        finalizedAt: new Date(finalizedAtEpochMs),
         diagnostics: toDiagnostics(finalization),
         timingDetails: {
             processingAttempts: finalization.processingAttempts,
@@ -111,7 +114,7 @@ async function writeAppInboxRetryFinalization(
                 work.finalization.entry.key,
                 work.finalization.reservationAttempt,
                 EntityStatus.FAILED,
-                new Date(work.finalizedAtEpochMs)
+                work.finalizedAt
             );
             if (!finished) {
                 throw new AppInboxReservationConflictError(work.finalization.entry.key);


### PR DESCRIPTION
Stacks on #419.

Captures the deterministic reservation completion Date in AppInbox retry computation so the write transaction only consumes computed data. ResourceInbox result/finalization behavior is otherwise unchanged.

Validation:
- AppInbox retry exhaustion: 22 passed
- shared-server TypeScript check
- maintained test typecheck: 1021 files, zero errors
- scoped style and navigation review