### PR TITLE
Capture presence completion before transactions

### DIFF
--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-worker.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-worker.ts
@@ -146,13 +146,14 @@ export class GroupPresenceSummaryWork {
         const read = await this.read(work);
         const computed = this.compute(work, read);
         this.validate(work, read, computed);
+        const completedAt = new Date(this.now());
         await runInPSqlTransaction(this.options.database, async (transaction) => {
             await this.write(transaction, computed);
             const finished = await new PSqlResourceInboxFinalizationRepository(transaction).finishReserved(
                 entry.key,
                 entry.dequeueAudit.attempts,
                 EntityStatus.COMPLETED,
-                new Date(this.now())
+                completedAt
             );
             if (!finished) {
                 throw new Error('Presence-summary reservation changed before commit');


### PR DESCRIPTION
Stacks on #420.

Captures the queue reservation completion time after pure group-presence compute/validate and before transaction entry. The transaction consumes that fact without invoking the clock or constructing a Date.

Validation:
- group-presence and read-through-cache suites: 74 passed
- shared-server TypeScript check
- maintained test typecheck: 1021 files, zero errors
- scoped style and navigation checks: pass