### PR TITLE
Compute client-state persistence before transactions

### DIFF
--- a/packages/shared-server/rallar-system/client-state/client-state-service.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service.ts
@@ -8,10 +8,7 @@ import { computeClientMutation } from './mutation/compute/compute-client-mutatio
 import { readClientMutation } from './mutation/read-client-mutation.ts';
 import { validateClientMutation } from './mutation/result-validation/validate-client-mutation.ts';
 import { writeClientMutation } from './mutation/write-client-mutation.ts';
-import {
-    ClientStateRepository,
-    createTransactionBoundClientStateRepository
-} from './persistence/client-state-repository.ts';
+import { ClientStateRepository } from './persistence/client-state-repository.ts';
 
 export function createClientStateService(
     dependencies: ClientStateServiceDependencies
@@ -32,12 +29,7 @@ export function createClientStateService(
             await readClientMutation(repositoryFor(runtimeRepository), authSessionRepository, command),
         compute: (command, read) => computeClientMutation({ command, read }),
         validate: (command, read, computed) => validateClientMutation({ command, read, computed }),
-        write: async (transaction, computed) =>
-            await writeClientMutation(
-                transaction,
-                createTransactionBoundClientStateRepository(transaction),
-                computed
-            ),
+        write: async (transaction, computed) => await writeClientMutation(transaction, computed),
         listExpiredSessionCandidates: async (atEpochMs) =>
             (await repositoryFor(runtimeRepository).listAllSessions())
                 .filter(isExpiredActiveSession(atEpochMs))

--- a/packages/shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts
@@ -240,7 +240,7 @@ export type ConditionalCandidate<T> =
     | Readonly<{ operation: 'insert'; value: T; }>
     | Readonly<{ operation: 'update'; value: T; expectedRevision: number; }>;
 
-export type ClientMutationComputedPersistedNoOp = Readonly<{
+export type ClientMutationDomainPersistedNoOp = Readonly<{
     outcome: 'no-op';
     persistIdempotency: true;
     aggregateRef: ClientPrincipalRef;
@@ -258,7 +258,7 @@ export type ClientMutationComputedNonPersistedNoOp = Readonly<{
     event: null;
 }>;
 
-export type ClientMutationComputedAppliedWrite = Readonly<{
+export type ClientMutationDomainAppliedWrite = Readonly<{
     outcome: 'write';
     principal: Exclude<ConditionalCandidate<ClientPrincipal>, { operation: 'none'; }>;
     instance: ConditionalCandidate<ClientInstance>;
@@ -271,7 +271,50 @@ export type ClientMutationComputedAppliedWrite = Readonly<{
     outboxEntries: readonly ResourceEntry[];
 }>;
 
-export type ClientMutationComputedWrite = ClientMutationComputedAppliedWrite | ClientMutationComputedPersistedNoOp;
+export type ClientRuntimePersistenceOperation =
+    | Readonly<{
+        kind: 'insert';
+        namespace: string;
+        key: string;
+        value: string;
+        expireAtIsoTimestamp: string;
+        expectedRevision: null;
+    }>
+    | Readonly<{
+        kind: 'update';
+        namespace: string;
+        key: string;
+        value: string;
+        expireAtIsoTimestamp: string;
+        expectedRevision: number;
+    }>;
+
+export type ClientMutationPersistence = Readonly<{
+    runtimeWrites: readonly ClientRuntimePersistenceOperation[];
+    eventWrite:
+        | Readonly<{
+            event: ClientEvent;
+            workspaceKey: string;
+            eventJson: string;
+        }>
+        | null;
+}>;
+
+export type ClientMutationComputedPersistedNoOp =
+    & ClientMutationDomainPersistedNoOp
+    & Readonly<{ persistence: ClientMutationPersistence; }>;
+
+export type ClientMutationComputedAppliedWrite =
+    & ClientMutationDomainAppliedWrite
+    & Readonly<{ persistence: ClientMutationPersistence; }>;
+
+export type ClientMutationDomainWrite =
+    | ClientMutationDomainAppliedWrite
+    | ClientMutationDomainPersistedNoOp;
+
+export type ClientMutationComputedWrite =
+    | ClientMutationComputedAppliedWrite
+    | ClientMutationComputedPersistedNoOp;
 
 export type ClientMutationComputed =
     | Readonly<{

--- a/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-mutation-result.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-mutation-result.ts
@@ -16,10 +16,13 @@ import { ClientMutationRejectedError } from '../../validation/client-mutation-re
 import type {
     ClientMutationCommand,
     ClientMutationComputed,
+    ClientMutationDomainAppliedWrite,
+    ClientMutationDomainPersistedNoOp,
     ClientMutationRead,
     ConditionalCandidate
 } from '../client-mutation-contracts.ts';
 import { toClientMutationActor } from './compute-client-mutation-state.ts';
+import { computeClientPersistence } from './compute-client-persistence.ts';
 
 export type AppliedClientMutationInput = Readonly<{
     command: ClientMutationCommand;
@@ -56,7 +59,7 @@ export function computeClientMutationResult(
         stateRevision,
         outboxIds: outboxEntries.map((entry) => entry.key.resourceId)
     });
-    return {
+    const computed: ClientMutationDomainAppliedWrite = {
         outcome: 'write',
         principal: read.principal
             ? { operation: 'update', value: principal, expectedRevision: read.principal.entry.revision }
@@ -72,6 +75,7 @@ export function computeClientMutationResult(
         stateSync,
         outboxEntries
     };
+    return { ...computed, persistence: computeClientPersistence(computed) };
 }
 
 export function computeClientMutationNoOp(
@@ -91,7 +95,7 @@ export function computeClientMutationNoOp(
     const receipt = toNoOpClientMutationReceipt(command, read);
     const snapshot = requireClientMutationReadSnapshot(read, command);
     if (persistIdempotency && command.requestId !== null) {
-        return {
+        const computed: ClientMutationDomainPersistedNoOp = {
             outcome: 'no-op',
             persistIdempotency: true,
             aggregateRef: command.aggregateRef,
@@ -104,6 +108,7 @@ export function computeClientMutationNoOp(
             snapshot,
             event: null
         };
+        return { ...computed, persistence: computeClientPersistence(computed) };
     }
     return {
         outcome: 'no-op',

--- a/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-persistence.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/compute/compute-client-persistence.ts
@@ -1,0 +1,138 @@
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
+
+import { encodeRuntimeStateJsonValue } from '../../../../runtime-state/runtime-state-json-store.ts';
+import { toSessionPurgeAfterEpochMs } from '../../../presence/session-expiry.ts';
+import { clientStateIdempotencyStorageKey } from '../../persistence/client-state-idempotency-storage-key.ts';
+import { clientStateInstanceStorageKey } from '../../persistence/client-state-instance-storage-key.ts';
+import { clientStatePrincipalStorageKey } from '../../persistence/client-state-principal-storage-key.ts';
+import {
+    CLIENT_STATE_IDEMPOTENT_NAMESPACE,
+    CLIENT_STATE_INSTANCES_NAMESPACE,
+    CLIENT_STATE_PRINCIPALS_NAMESPACE,
+    CLIENT_STATE_SESSIONS_NAMESPACE
+} from '../../persistence/client-state-runtime-namespaces.ts';
+import { clientStateSessionStorageKey } from '../../persistence/client-state-session-storage-key.ts';
+import { clientStateWorkspaceStorageKey } from '../../persistence/client-state-workspace-storage-key.ts';
+import type {
+    ClientMutationDomainWrite,
+    ClientMutationPersistence,
+    ClientRuntimePersistenceOperation,
+    ConditionalCandidate
+} from '../client-mutation-contracts.ts';
+
+interface ClientRuntimeInsertInput {
+    readonly namespace: string;
+    readonly key: string;
+    readonly value: object;
+    readonly expireAtEpochMs: number;
+}
+
+export function computeClientPersistence(
+    computed: ClientMutationDomainWrite
+): ClientMutationPersistence {
+    if (computed.outcome === 'no-op') {
+        return {
+            runtimeWrites: [runtimeInsert({
+                namespace: CLIENT_STATE_IDEMPOTENT_NAMESPACE,
+                key: clientStateIdempotencyStorageKey(
+                    computed.aggregateRef,
+                    computed.idempotency.requestId
+                ),
+                value: computed.idempotency,
+                expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
+            })],
+            eventWrite: null
+        };
+    }
+
+    const runtimeWrites: ClientRuntimePersistenceOperation[] = [runtimeCandidate(
+        CLIENT_STATE_PRINCIPALS_NAMESPACE,
+        clientStatePrincipalStorageKey(computed.principal.value),
+        computed.principal,
+        NEVER_EXPIRE_AT_TIMESTAMP
+    )];
+    appendInstanceWrite(runtimeWrites, computed.instance);
+    appendSessionWrite(runtimeWrites, computed.session);
+    if (computed.idempotency) {
+        runtimeWrites.push(runtimeInsert({
+            namespace: CLIENT_STATE_IDEMPOTENT_NAMESPACE,
+            key: clientStateIdempotencyStorageKey(
+                computed.receipt.aggregateRef,
+                computed.idempotency.requestId
+            ),
+            value: computed.idempotency,
+            expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
+        }));
+    }
+    return {
+        runtimeWrites,
+        eventWrite: {
+            event: computed.event,
+            workspaceKey: clientStateWorkspaceStorageKey(computed.event.workspaceId),
+            eventJson: JSON.stringify(computed.event)
+        }
+    };
+}
+
+function appendInstanceWrite(
+    writes: ClientRuntimePersistenceOperation[],
+    candidate: Extract<ClientMutationDomainWrite, { outcome: 'write'; }>['instance']
+): void {
+    if (candidate.operation === 'none') {
+        return;
+    }
+    writes.push(runtimeCandidate(
+        CLIENT_STATE_INSTANCES_NAMESPACE,
+        clientStateInstanceStorageKey(candidate.value),
+        candidate,
+        NEVER_EXPIRE_AT_TIMESTAMP
+    ));
+}
+
+function appendSessionWrite(
+    writes: ClientRuntimePersistenceOperation[],
+    candidate: Extract<ClientMutationDomainWrite, { outcome: 'write'; }>['session']
+): void {
+    if (candidate.operation === 'none') {
+        return;
+    }
+    writes.push(runtimeCandidate(
+        CLIENT_STATE_SESSIONS_NAMESPACE,
+        clientStateSessionStorageKey(candidate.value),
+        candidate,
+        toSessionPurgeAfterEpochMs(
+            candidate.value.expiresAtEpochMs,
+            candidate.value.disconnectedAtEpochMs
+        )
+    ));
+}
+
+function runtimeCandidate<T extends object>(
+    namespace: string,
+    key: string,
+    candidate: Exclude<ConditionalCandidate<T>, { operation: 'none'; }>,
+    expireAtEpochMs: number
+): ClientRuntimePersistenceOperation {
+    const stored = {
+        namespace,
+        key,
+        value: encodeRuntimeStateJsonValue(candidate.value),
+        expireAtIsoTimestamp: new Date(expireAtEpochMs).toISOString()
+    };
+    return candidate.operation === 'insert'
+        ? { ...stored, kind: 'insert', expectedRevision: null }
+        : { ...stored, kind: 'update', expectedRevision: candidate.expectedRevision };
+}
+
+function runtimeInsert(
+    input: ClientRuntimeInsertInput
+): ClientRuntimePersistenceOperation {
+    return {
+        kind: 'insert',
+        namespace: input.namespace,
+        key: input.key,
+        value: encodeRuntimeStateJsonValue(input.value),
+        expireAtIsoTimestamp: new Date(input.expireAtEpochMs).toISOString(),
+        expectedRevision: null
+    };
+}

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-result.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-result.ts
@@ -15,9 +15,10 @@ import { rejectClientMutation } from '../../validation/client-mutation-rejection
 import {
     decodeClientValidationRecord,
     requireExactKeys,
-    type ClientValidationRecord
+    type ClientValidationRecord,
+    type ClientValidationValue
 } from '../../validation/client-record-validation.ts';
-import { requireSha256 } from '../../validation/client-string-validation.ts';
+import { requireSha256, requireString } from '../../validation/client-string-validation.ts';
 import { validateClientPrincipalRef } from '../../validation/validate-client-principal-ref.ts';
 import type { ClientMutationComputed, ConditionalCandidate } from '../client-mutation-contracts.ts';
 
@@ -64,7 +65,8 @@ function validateNoOpResult(value: ClientValidationRecord): void {
                 'idempotency',
                 'receipt',
                 'snapshot',
-                'event'
+                'event',
+                'persistence'
             ]
             : ['outcome', 'persistIdempotency', 'receipt', 'snapshot', 'event'],
         'Client mutation computed'
@@ -80,6 +82,7 @@ function validateNoOpResult(value: ClientValidationRecord): void {
             value.idempotency,
             'Client mutation computed.idempotency'
         );
+        validateClientPersistence(value.persistence);
     }
 }
 
@@ -106,7 +109,8 @@ function validateAppliedWriteResult(value: ClientValidationRecord): void {
             'snapshot',
             'idempotency',
             'stateSync',
-            'outboxEntries'
+            'outboxEntries',
+            'persistence'
         ],
         'Client mutation computed'
     );
@@ -144,13 +148,69 @@ function validateAppliedWriteResult(value: ClientValidationRecord): void {
     if (!Array.isArray(value.outboxEntries) || value.outboxEntries.length !== 2) {
         rejectClientMutation('Client mutation computed outboxEntries must contain snapshot and event');
     }
+    validateClientPersistence(value.persistence);
+}
+
+function validateClientPersistence(value: ClientValidationValue): void {
+    const persistence = decodeClientValidationRecord(
+        value,
+        'Client mutation computed.persistence'
+    );
+    requireExactKeys(
+        persistence,
+        ['runtimeWrites', 'eventWrite'],
+        'Client mutation computed.persistence'
+    );
+    if (!Array.isArray(persistence.runtimeWrites)) {
+        rejectClientMutation('Client mutation computed.persistence.runtimeWrites must be an array');
+    }
+    persistence.runtimeWrites.forEach(validateClientRuntimeWrite);
+    if (persistence.eventWrite === null) {
+        return;
+    }
+    const eventWrite = decodeClientValidationRecord(
+        persistence.eventWrite,
+        'Client mutation computed.persistence.eventWrite'
+    );
+    requireExactKeys(
+        eventWrite,
+        ['event', 'workspaceKey', 'eventJson'],
+        'Client mutation computed.persistence.eventWrite'
+    );
+    validateClientEvent(eventWrite.event, 'Client mutation computed.persistence.eventWrite.event');
+    requireString(
+        eventWrite.workspaceKey,
+        'Client mutation computed.persistence.eventWrite.workspaceKey'
+    );
+    requireString(eventWrite.eventJson, 'Client mutation computed.persistence.eventWrite.eventJson');
+}
+
+function validateClientRuntimeWrite(value: ClientValidationValue, index: number): void {
+    const label = `Client mutation computed.persistence.runtimeWrites[${index}]`;
+    const write = decodeClientValidationRecord(value, label);
+    const commonKeys = ['kind', 'namespace', 'key', 'value', 'expireAtIsoTimestamp'];
+    requireExactKeys(write, [...commonKeys, 'expectedRevision'], label);
+    requireString(write.namespace, `${label}.namespace`);
+    requireString(write.key, `${label}.key`);
+    requireString(write.value, `${label}.value`);
+    requireString(write.expireAtIsoTimestamp, `${label}.expireAtIsoTimestamp`);
+    if (write.kind === 'insert' && write.expectedRevision === null) {
+        return;
+    }
+    if (
+        write.kind !== 'update' ||
+        !Number.isSafeInteger(write.expectedRevision) ||
+        (write.expectedRevision as number) < 0
+    ) {
+        rejectClientMutation(`${label} guard is invalid`);
+    }
 }
 
 function validateConditionalCandidate<T>(
-    value: unknown,
+    value: ClientValidationValue,
     label: string,
-    validateValue: (value: unknown, label: string) => void
-): asserts value is ConditionalCandidate<T> {
+    validateValue: (value: ClientValidationValue, label: string) => void
+): asserts value is ClientValidationRecord & ConditionalCandidate<T> {
     const candidate = decodeClientValidationRecord(value, label);
     switch (candidate.operation) {
         case 'none':

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
@@ -15,6 +15,7 @@ import {
 } from './validate-client-mutation-authority-policy.ts';
 import { validateClientMutationRead } from './validate-client-mutation-read.ts';
 import { validateClientMutationResult } from './validate-client-mutation-result.ts';
+import { validateClientPersistence } from './validate-client-persistence.ts';
 
 export class ClientMutationIdempotencyConflictError extends Error {
     readonly code = 'client-mutation-idempotency-conflict';
@@ -60,6 +61,7 @@ export function validateClientMutation(
         );
     }
     validateClientMutationReceiptIdentity(command, computed);
+    validateClientPersistence(computed);
     if (computed.outcome !== 'write') {
         return;
     }

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-persistence.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-persistence.ts
@@ -1,0 +1,57 @@
+import { assertPersistableClientStateEvent } from '../../../state-events/postgres/client-state-event-row-codec.ts';
+import { assertCanonicalClientStateIdempotencyRecord } from '../../persistence/client-state-repository-reads.ts';
+import {
+    validatePersistedClientInstance,
+    validatePersistedClientPrincipal,
+    validatePersistedClientSession
+} from '../../persistence/validate-persisted-client-state.ts';
+import { ClientMutationRejectedError } from '../../validation/client-mutation-rejection.ts';
+import type {
+    ClientMutationComputed,
+    ClientMutationDomainWrite
+} from '../client-mutation-contracts.ts';
+import { computeClientPersistence } from '../compute/compute-client-persistence.ts';
+
+export function validateClientPersistence(
+    computed: Exclude<ClientMutationComputed, { outcome: 'idempotency-conflict'; }>
+): void {
+    if (
+        computed.outcome !== 'write' &&
+        !(computed.outcome === 'no-op' && computed.persistIdempotency)
+    ) {
+        return;
+    }
+    validateClientPersistenceInput(computed);
+    if (
+        JSON.stringify(computeClientPersistence(computed)) !==
+            JSON.stringify(computed.persistence)
+    ) {
+        throw new ClientMutationRejectedError('Client computed persistence differs');
+    }
+}
+
+function validateClientPersistenceInput(computed: ClientMutationDomainWrite): void {
+    if (computed.outcome === 'no-op') {
+        assertCanonicalClientStateIdempotencyRecord(
+            computed.idempotency,
+            computed.aggregateRef,
+            computed.idempotency.requestId
+        );
+        return;
+    }
+    validatePersistedClientPrincipal(computed.principal.value, computed.principal.value);
+    if (computed.instance.operation !== 'none') {
+        validatePersistedClientInstance(computed.instance.value, computed.instance.value);
+    }
+    if (computed.session.operation !== 'none') {
+        validatePersistedClientSession(computed.session.value, computed.session.value);
+    }
+    if (computed.idempotency) {
+        assertCanonicalClientStateIdempotencyRecord(
+            computed.idempotency,
+            computed.receipt.aggregateRef,
+            computed.idempotency.requestId
+        );
+    }
+    assertPersistableClientStateEvent(computed.event, computed.event);
+}

--- a/packages/shared-server/rallar-system/client-state/mutation/write-client-mutation.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/write-client-mutation.ts
@@ -1,94 +1,131 @@
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { PSqlResourceInboxEntryRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import { requireConditionalWrite } from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
+import { ClientStateEventCollisionError } from '../../state-events/client-state-event-store.ts';
+import type { ClientStateEventCollisionRow } from '../../state-events/postgres/client-state-event-row-codec.ts';
 import type { ClientMutationReceipt } from '../persistence/client-state-persistence-contracts.ts';
-import { ClientStateRepository } from '../persistence/client-state-repository.ts';
-import type { ClientMutationComputedWrite } from './client-mutation-contracts.ts';
+import type {
+    ClientMutationComputedWrite,
+    ClientMutationPersistence,
+    ClientRuntimePersistenceOperation
+} from './client-mutation-contracts.ts';
 
 export async function writeClientMutation(
     transaction: PSqlSql,
-    repository: ClientStateRepository,
     computed: ClientMutationComputedWrite
 ): Promise<ClientMutationReceipt> {
-    if (computed.outcome === 'no-op') {
-        await writeIdempotencyRecord(repository, computed.aggregateRef, computed.idempotency);
-        return computed.receipt;
+    for (const operation of computed.persistence.runtimeWrites) {
+        await writeRuntimeState(transaction, operation);
     }
-
-    await writePrincipalCandidate(repository, computed);
-    await writeInstanceCandidate(repository, computed.instance);
-    await writeSessionCandidate(repository, computed.session);
-    if (computed.idempotency) {
-        await writeIdempotencyRecord(repository, computed.receipt.aggregateRef, computed.idempotency);
+    if (computed.persistence.eventWrite) {
+        await writeClientEvent(transaction, computed.persistence.eventWrite);
     }
-
-    await repository.appendEvent(computed.event);
-    await writeFinalOutboxEntries(transaction, computed);
+    if (computed.outcome === 'write') {
+        const outbox = new PSqlResourceInboxEntryRepository(transaction);
+        for (const entry of computed.outboxEntries) {
+            await outbox.writeIfAbsentOrMatch(entry);
+        }
+    }
     return computed.receipt;
 }
 
-async function writePrincipalCandidate(
-    repository: ClientStateRepository,
-    computed: Extract<ClientMutationComputedWrite, { outcome: 'write'; }>
-): Promise<void> {
-    requireConditionalWrite(
-        computed.principal.operation === 'insert'
-            ? await repository.insertPrincipal(computed.principal.value)
-            : await repository.updatePrincipal(
-                computed.principal.value,
-                computed.principal.expectedRevision
-            )
-    );
-}
-
-async function writeInstanceCandidate(
-    repository: ClientStateRepository,
-    candidate: Extract<ClientMutationComputedWrite, { outcome: 'write'; }>['instance']
-): Promise<void> {
-    if (candidate.operation === 'none') {
-        return;
-    }
-    requireConditionalWrite(
-        candidate.operation === 'insert'
-            ? await repository.insertInstance(candidate.value)
-            : await repository.updateInstance(candidate.value, candidate.expectedRevision)
-    );
-}
-
-async function writeSessionCandidate(
-    repository: ClientStateRepository,
-    candidate: Extract<ClientMutationComputedWrite, { outcome: 'write'; }>['session']
-): Promise<void> {
-    if (candidate.operation === 'none') {
-        return;
-    }
-    requireConditionalWrite(
-        candidate.operation === 'insert'
-            ? await repository.insertSession(candidate.value)
-            : await repository.updateSession(candidate.value, candidate.expectedRevision)
-    );
-}
-
-async function writeIdempotencyRecord(
-    repository: ClientStateRepository,
-    aggregateRef: ClientMutationComputedWrite['receipt']['aggregateRef'],
-    idempotency: NonNullable<Extract<ClientMutationComputedWrite, { outcome: 'no-op'; }>['idempotency']>
-): Promise<void> {
-    requireConditionalWrite(
-        await repository.insertIdempotentClientStateWritten(
-            aggregateRef,
-            idempotency.requestId,
-            idempotency
-        )
-    );
-}
-
-async function writeFinalOutboxEntries(
+async function writeRuntimeState(
     transaction: PSqlSql,
-    computed: Extract<ClientMutationComputedWrite, { outcome: 'write'; }>
+    operation: ClientRuntimePersistenceOperation
 ): Promise<void> {
-    const outbox = new PSqlResourceInboxEntryRepository(transaction);
-    for (const entry of computed.outboxEntries) {
-        await outbox.writeIfAbsentOrMatch(entry);
+    if (operation.kind === 'insert') {
+        const rows = await transaction<Array<{ revision: number | string; }>>`
+            insert into runtime_state_store (store_namespace, store_key, store_value,
+                                             expire_at_ts, updated_ts, revision)
+            values (${operation.namespace}, ${operation.key}, ${operation.value},
+                    ${operation.expireAtIsoTimestamp}, now(), 0)
+            on conflict (store_namespace, store_key) do nothing
+            returning revision
+        `;
+        requireApplied(rows);
+        return;
+    }
+    const rows = await transaction<Array<{ revision: number | string; }>>`
+        update runtime_state_store
+        set store_value = ${operation.value},
+            expire_at_ts = ${operation.expireAtIsoTimestamp},
+            updated_ts = now(),
+            revision = revision + 1
+        where store_namespace = ${operation.namespace}
+          and store_key = ${operation.key}
+          and revision = ${operation.expectedRevision}
+        returning revision
+    `;
+    requireApplied(rows);
+}
+
+async function writeClientEvent(
+    transaction: PSqlSql,
+    eventWrite: NonNullable<ClientMutationPersistence['eventWrite']>
+): Promise<void> {
+    const event = eventWrite.event;
+    const inserted = await transaction<{ event_id: string; }[]>`
+        insert into client_state_events (application_id,
+                                         workspace_key,
+                                         principal_id,
+                                         event_id,
+                                         event_type,
+                                         snapshot_version,
+                                         occurred_at_epoch_ms,
+                                         client_instance_id,
+                                         session_id,
+                                         event_json)
+        values (${event.applicationId},
+                ${eventWrite.workspaceKey},
+                ${event.principalId},
+                ${event.eventId},
+                ${event.eventType},
+                ${event.snapshotVersion},
+                ${event.occurredAtEpochMs},
+                ${event.clientInstanceId ?? null},
+                ${event.sessionId ?? null},
+                ${eventWrite.eventJson})
+        on conflict (application_id, workspace_key, principal_id, event_id)
+            do nothing
+        returning event_id
+    `;
+    if (inserted.length === 1) {
+        return;
+    }
+    const [existing] = await transaction<ClientStateEventCollisionRow[]>`
+        select application_id, workspace_key, principal_id, event_id,
+               event_type, snapshot_version, occurred_at_epoch_ms,
+               client_instance_id, session_id, event_json
+        from client_state_events
+        where application_id = ${event.applicationId}
+          and workspace_key = ${eventWrite.workspaceKey}
+          and principal_id = ${event.principalId}
+          and event_id = ${event.eventId}
+    `;
+    if (!existing || !isExactClientEvent(existing, eventWrite)) {
+        throw new ClientStateEventCollisionError(event);
+    }
+}
+
+function isExactClientEvent(
+    row: ClientStateEventCollisionRow,
+    eventWrite: NonNullable<ClientMutationPersistence['eventWrite']>
+): boolean {
+    const event = eventWrite.event;
+    return row.application_id === event.applicationId &&
+        row.workspace_key === eventWrite.workspaceKey &&
+        row.principal_id === event.principalId &&
+        row.event_id === event.eventId &&
+        row.event_type === event.eventType &&
+        Number(row.snapshot_version) === event.snapshotVersion &&
+        Number(row.occurred_at_epoch_ms) === event.occurredAtEpochMs &&
+        row.client_instance_id === event.clientInstanceId &&
+        row.session_id === event.sessionId &&
+        row.event_json === eventWrite.eventJson;
+}
+
+function requireApplied(rows: readonly Readonly<{ revision: number | string; }>[]): void {
+    if (rows.length === 0) {
+        throw new RuntimeStateWriteConflictError();
     }
 }

--- a/packages/shared-server/rallar-system/client-state/persistence/client-state-repository.ts
+++ b/packages/shared-server/rallar-system/client-state/persistence/client-state-repository.ts
@@ -9,8 +9,6 @@ import type {
 } from '@shared/api/client-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
-import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { PSqlRuntimeStateRepository } from '../../../runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import type {
     RuntimeStateConditionalDeleteResult,
     RuntimeStateConditionalWriteResult,
@@ -18,7 +16,6 @@ import type {
 } from '../../../runtime-state/runtime-state-repository.ts';
 import { toSessionPurgeAfterEpochMs } from '../../presence/session-expiry.ts';
 import type { ClientStateEventStore } from '../../state-events/client-state-event-store.ts';
-import { PSqlClientStateEventRepository } from '../../state-events/postgres/p-sql-client-state-event-repository.ts';
 import { clientStateIdempotencyStorageKey } from './client-state-idempotency-storage-key.ts';
 import { clientStateInstanceStorageKey } from './client-state-instance-storage-key.ts';
 import { type ClientMutationIdempotencyRecord } from './client-state-persistence-contracts.ts';
@@ -38,13 +35,6 @@ import {
     validatePersistedClientPrincipal,
     validatePersistedClientSession
 } from './validate-persisted-client-state.ts';
-
-export function createTransactionBoundClientStateRepository(
-    transaction: PSqlSql
-): ClientStateRepository {
-    const runtime = new PSqlRuntimeStateRepository(transaction);
-    return new ClientStateRepository(runtime, new PSqlClientStateEventRepository(transaction));
-}
 
 export class ClientStateRepository extends ClientStateSnapshotRepository {
     constructor(repository: RuntimeStateRepositoryLike, events: ClientStateEventStore) {

--- a/packages/tests/shared-server/rallar-system/client-state/client-state-test-transaction.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-state-test-transaction.ts
@@ -126,14 +126,14 @@ async function insertRuntimeState(input: ClientStateTestSqlInput): Promise<PSqlR
     const namespace = requireStringParameter(input.values[0], 'runtime-state namespace');
     const key = requireStringParameter(input.values[1], 'runtime-state key');
     const value = requireStringParameter(input.values[2], 'runtime-state value');
-    const expireAt = requireDateParameter(input.values[3], 'runtime-state expiry');
+    const expireAt = requireTimestampParameter(input.values[3], 'runtime-state expiry');
     const result = await input.runtime.insertIfAbsent(namespace, key, value, expireAt.getTime());
     return result.status === 'applied' ? [{ revision: result.revision }] : [];
 }
 
 async function updateRuntimeState(input: ClientStateTestSqlInput): Promise<PSqlRows> {
     const value = requireStringParameter(input.values[0], 'runtime-state value');
-    const expireAt = requireDateParameter(input.values[1], 'runtime-state expiry');
+    const expireAt = requireTimestampParameter(input.values[1], 'runtime-state expiry');
     const namespace = requireStringParameter(input.values[2], 'runtime-state namespace');
     const key = requireStringParameter(input.values[3], 'runtime-state key');
     const expectedRevision = requireIntegerParameter(
@@ -279,11 +279,16 @@ function requireStringParameter(value: PSqlParameter, label: string): string {
     return value;
 }
 
-function requireDateParameter(value: PSqlParameter, label: string): Date {
-    if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+function requireTimestampParameter(value: PSqlParameter, label: string): Date {
+    const date = value instanceof Date
+        ? value
+        : typeof value === 'string'
+        ? new Date(value)
+        : null;
+    if (date === null || !Number.isFinite(date.getTime())) {
         throw new TypeError(`${label} must be a valid Date`);
     }
-    return value;
+    return date;
 }
 
 function requireIntegerParameter(value: PSqlParameter, label: string): number {

--- a/packages/tests/shared-server/rallar-system/client-state/client-write-purity.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-write-purity.test.ts
@@ -1,0 +1,62 @@
+import type { PSqlParameter, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { computeClientMutation } from '@shared-server/rallar-system/client-state/mutation/compute/compute-client-mutation.ts';
+import { validateClientMutation } from '@shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts';
+import { writeClientMutation } from '@shared-server/rallar-system/client-state/mutation/write-client-mutation.ts';
+import { describe, expect, it } from 'vitest';
+import { emptyRead, principalCommand } from './client-mutation-compute-test-fixtures.ts';
+
+describe('client mutation write purity', () => {
+    it('serializes runtime and event rows during compute', async () => {
+        const command = await principalCommand('write-purity');
+        const computed = computeClientMutation({ command, read: emptyRead(command) });
+        expect(computed.outcome).toBe('write');
+        if (computed.outcome !== 'write') {
+            return;
+        }
+        expect(computed.persistence.runtimeWrites.length).toBeGreaterThan(0);
+
+        const stringify = JSON.stringify;
+        JSON.stringify = () => {
+            throw new Error('client serialization must finish during compute');
+        };
+        try {
+            await expect(writeClientMutation(appliedSql(), computed)).resolves.toEqual(
+                computed.receipt
+            );
+        }
+        finally {
+            JSON.stringify = stringify;
+        }
+    });
+
+    it('rejects a persistence projection that differs from the computed domain result', async () => {
+        const command = await principalCommand('write-purity-validation');
+        const read = emptyRead(command);
+        const computed = computeClientMutation({ command, read });
+        expect(computed.outcome).toBe('write');
+        if (computed.outcome !== 'write') {
+            return;
+        }
+        const tampered = {
+            ...computed,
+            persistence: {
+                ...computed.persistence,
+                runtimeWrites: computed.persistence.runtimeWrites.map((operation, index) =>
+                    index === 0 ? { ...operation, key: `${operation.key}:tampered` } : operation
+                )
+            }
+        };
+
+        expect(() => validateClientMutation({ command, read, computed: tampered })).toThrow(
+            'Client computed persistence differs'
+        );
+    });
+});
+
+function appliedSql(): PSqlSql {
+    const sql = (
+        _stringsOrValues: TemplateStringsArray | readonly PSqlParameter[],
+        ..._values: readonly PSqlParameter[]
+    ): Promise<readonly Readonly<{ revision: number; }>[]> | object => Promise.resolve([{ revision: 0 }]);
+    return sql as PSqlSql;
+}


### PR DESCRIPTION
## Summary
- compute runtime-state keys, expiry timestamps, JSON values, and event JSON in the client compute phase
- validate the exact persistence projection before transaction entry
- make client write execute prepared runtime/event operations and specialised ResourceInbox writes only
- remove the unused transaction-bound client repository factory

## Review assessment
This is a bounded client-state slice. The write path is now direct and readable: compute owns deterministic persistence materialization, validate owns storage-specific checks and exact comparison, and write owns SQL execution plus database-result collision checks. No prepare phase or inner retry was added.

Changed-file style has no new or worsened findings. Navigation has no high-confidence finding. The existing ClientStateService interface pivot in ClientStateInboxHandler remains a manual-review warning; production composition resolves directly through AppClientInboxService to createClientStateService, so adding another wrapper would worsen navigability.

## Validation
- 24 client-state files / 93 tests passed
- governed test typecheck: 1023 files, zero debt, zero errors
- shared-server TypeScript check passed
- API Deno check passed with /Users/knuthelge/.deno/bin/deno
- native PGlite: 19 passed, zero failed
- changed-file repo style passed
- formatting and diff checks passed

Stacked on PR #422.