### PR TITLE
Compute WebSocket lifecycle writes before transactions

### DIFF
--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -3,6 +3,8 @@ import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import type { AppInboxExecutionMetadata, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import {
+    validateWsSessionConnectGuard,
+    validateWsSessionGenerationClosed,
     type WsSessionGenerationFacts,
     type WsSessionGenerationLifecycleComputed
 } from '../../websocket/ws-session-generation-computation.ts';
@@ -86,16 +88,18 @@ export class ClientStateInboxHandler {
         }
         const command = await this.toAuthorisedWsConnectCommand(context, connection);
         const computed = await this.computeValidatedMutation(command);
+        const lifecycleGuardFacts = {
+            ...lifecycleFacts,
+            expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(
+                connection.generationStartedAtEpochMs,
+                connection.expiresAtEpochMs
+            )
+        };
         const lifecycleComputed = this.dependencies.sessionGenerationLifecycle.computeConnectGuard(
-            {
-                ...lifecycleFacts,
-                expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(
-                    connection.generationStartedAtEpochMs,
-                    connection.expiresAtEpochMs
-                )
-            },
+            lifecycleGuardFacts,
             lifecycleRead
         );
+        validateWsSessionConnectGuard(lifecycleGuardFacts, lifecycleRead, lifecycleComputed);
         return await this.commitComputed(context, computed, lifecycleComputed);
     }
 
@@ -233,10 +237,13 @@ export class ClientStateInboxHandler {
                 Math.max(input.disconnectedAtEpochMs, connection.expiresAtEpochMs)
             )
         };
-        return this.dependencies.sessionGenerationLifecycle.computeClosed(
+        const lifecycleRead = await this.dependencies.sessionGenerationLifecycle.read(lifecycleFacts);
+        const computed = this.dependencies.sessionGenerationLifecycle.computeClosed(
             lifecycleFacts,
-            await this.dependencies.sessionGenerationLifecycle.read(lifecycleFacts)
+            lifecycleRead
         );
+        validateWsSessionGenerationClosed(lifecycleFacts, lifecycleRead, computed);
+        return computed;
     }
 
     private async writeMissingSessionDisconnect({

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -4,10 +4,12 @@ import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.t
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
 import { decodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
-import type {
-    WsSessionGenerationCloseFacts,
-    WsSessionGenerationLifecycleComputed,
-    WsSessionHighWaterIdentity
+import {
+    validateWsSessionConnectGuard,
+    validateWsSessionGenerationClosed,
+    type WsSessionGenerationCloseFacts,
+    type WsSessionGenerationLifecycleComputed,
+    type WsSessionHighWaterIdentity
 } from '../../websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '../../websocket/ws-session-generation-lifecycle.ts';
 import type {
@@ -106,15 +108,14 @@ export async function processGroupPresenceConnect(
     const read = await input.mutationService.read(input.command);
     const computed = input.mutationService.compute(input.command, read);
     input.mutationService.validate(input.command, read, computed);
-    const lifecycleGuard = lifecycle.computeConnectGuard(
-        {
-            ...identity,
-            generationId: operation.input.generationId,
-            generationStartedAtEpochMs: observedAtEpochMs,
-            expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(observedAtEpochMs)
-        },
-        lifecycleRead
-    );
+    const lifecycleGuardFacts = {
+        ...identity,
+        generationId: operation.input.generationId,
+        generationStartedAtEpochMs: observedAtEpochMs,
+        expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(observedAtEpochMs)
+    };
+    const lifecycleGuard = lifecycle.computeConnectGuard(lifecycleGuardFacts, lifecycleRead);
+    validateWsSessionConnectGuard(lifecycleGuardFacts, lifecycleRead, lifecycleGuard);
     return { status: 'ready-to-commit', computed, lifecycleGuard };
 }
 
@@ -131,6 +132,7 @@ export async function processGroupSessionCleanup(
     const lifecycle = input.groupStateService.sessionGenerationLifecycle;
     const lifecycleRead = await lifecycle.read(closeFacts);
     const lifecycleComputed = lifecycle.computeClosed(closeFacts, lifecycleRead);
+    validateWsSessionGenerationClosed(closeFacts, lifecycleRead, lifecycleComputed);
     const preparations = await input.groupStateService.prepareSessionCleanupMutations({
         scope: input.facts.connection.scope,
         authSession: input.facts.connection.authSession,

--- a/packages/shared-server/rallar-system/websocket/ws-session-generation-computation.ts
+++ b/packages/shared-server/rallar-system/websocket/ws-session-generation-computation.ts
@@ -62,12 +62,20 @@ export interface WsSessionGenerationLifecycleRead {
     readonly state: WsSessionCloseHighWaterState | null;
 }
 
-export interface WsSessionGenerationLifecycleComputed {
-    readonly outcome: 'none' | 'insert' | 'update';
+type WsSessionGenerationLifecycleComputedValue = Readonly<{
     readonly key: string;
-    readonly expectedRevision: number | null;
     readonly state: WsSessionCloseHighWaterState;
-}
+    readonly value: string;
+    readonly expireAtIsoTimestamp: string;
+}>;
+
+export type WsSessionGenerationLifecycleComputed =
+    & WsSessionGenerationLifecycleComputedValue
+    & (
+        | Readonly<{ outcome: 'none'; expectedRevision: number | null; }>
+        | Readonly<{ outcome: 'insert'; expectedRevision: null; }>
+        | Readonly<{ outcome: 'update'; expectedRevision: number; }>
+    );
 
 export function isWsSessionGenerationClosed(
     facts: WsSessionGenerationFacts,
@@ -126,6 +134,28 @@ export function computeWsSessionConnectGuard(
                 : { ...read.state, expireAtEpochMs }
         );
     return toComputed('update', read, state);
+}
+
+export function validateWsSessionGenerationClosed(
+    facts: WsSessionGenerationCloseFacts,
+    read: WsSessionGenerationLifecycleRead,
+    computed: WsSessionGenerationLifecycleComputed
+): void {
+    validateWsSessionGenerationLifecycleComputed(
+        computeWsSessionGenerationClosed(facts, read),
+        computed
+    );
+}
+
+export function validateWsSessionConnectGuard(
+    facts: WsSessionGenerationGuardFacts,
+    read: WsSessionGenerationLifecycleRead,
+    computed: WsSessionGenerationLifecycleComputed
+): void {
+    validateWsSessionGenerationLifecycleComputed(
+        computeWsSessionConnectGuard(facts, read),
+        computed
+    );
 }
 
 export function decodeWsSessionCloseHighWaterState(
@@ -292,12 +322,38 @@ function toComputed(
     read: WsSessionGenerationLifecycleRead,
     state: WsSessionCloseHighWaterState
 ): WsSessionGenerationLifecycleComputed {
-    return {
-        outcome,
+    const value = {
         key: read.key,
-        expectedRevision: read.revision,
-        state
+        state,
+        value: JSON.stringify(state),
+        expireAtIsoTimestamp: new Date(state.expireAtEpochMs).toISOString()
     };
+    if (outcome === 'insert') {
+        return { ...value, outcome, expectedRevision: null };
+    }
+    if (outcome === 'update') {
+        if (read.revision === null) {
+            throw new TypeError('WebSocket session close high-water update revision is missing');
+        }
+        return { ...value, outcome, expectedRevision: read.revision };
+    }
+    return { ...value, outcome, expectedRevision: read.revision };
+}
+
+function validateWsSessionGenerationLifecycleComputed(
+    expected: WsSessionGenerationLifecycleComputed,
+    computed: WsSessionGenerationLifecycleComputed
+): void {
+    if (
+        expected.outcome !== computed.outcome ||
+        expected.key !== computed.key ||
+        expected.expectedRevision !== computed.expectedRevision ||
+        expected.value !== computed.value ||
+        expected.expireAtIsoTimestamp !== computed.expireAtIsoTimestamp ||
+        JSON.stringify(expected.state) !== JSON.stringify(computed.state)
+    ) {
+        throw new TypeError('WebSocket session lifecycle computed result differs');
+    }
 }
 
 function toClosedHighWaterState(

--- a/packages/shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts
+++ b/packages/shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts
@@ -1,6 +1,5 @@
 import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
 import { RuntimeStateWriteConflictError } from '../../runtime-state/optimistic-runtime-state-write.ts';
-import { PSqlRuntimeStateRepository } from '../../runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import type {
     RuntimeStateEntry,
     RuntimeStateOptimisticTransactionalRepositoryLike
@@ -73,23 +72,27 @@ export function createWsSessionGenerationLifecycleService(
             if (computed.outcome === 'none') {
                 return;
             }
-            const target = new PSqlRuntimeStateRepository(transaction);
-            const value = JSON.stringify(computed.state);
-            const result = computed.outcome === 'insert'
-                ? await target.insertIfAbsent(
-                    SESSION_CLOSE_HIGH_WATER_NAMESPACE,
-                    computed.key,
-                    value,
-                    computed.state.expireAtEpochMs
-                )
-                : await target.upsertIfRevision(
-                    SESSION_CLOSE_HIGH_WATER_NAMESPACE,
-                    computed.key,
-                    value,
-                    computed.state.expireAtEpochMs,
-                    requireExpectedRevision(computed)
-                );
-            if (result.status === 'conflict') {
+            const rows = computed.outcome === 'insert'
+                ? await transaction<Array<{ revision: number | string; }>>`
+                    insert into runtime_state_store (store_namespace, store_key, store_value,
+                                                     expire_at_ts, updated_ts, revision)
+                    values (${SESSION_CLOSE_HIGH_WATER_NAMESPACE}, ${computed.key},
+                            ${computed.value}, ${computed.expireAtIsoTimestamp}, now(), 0)
+                    on conflict (store_namespace, store_key) do nothing
+                    returning revision
+                `
+                : await transaction<Array<{ revision: number | string; }>>`
+                    update runtime_state_store
+                    set store_value = ${computed.value},
+                        expire_at_ts = ${computed.expireAtIsoTimestamp},
+                        updated_ts = now(),
+                        revision = revision + 1
+                    where store_namespace = ${SESSION_CLOSE_HIGH_WATER_NAMESPACE}
+                      and store_key = ${computed.key}
+                      and revision = ${computed.expectedRevision}
+                    returning revision
+                `;
+            if (rows.length === 0) {
                 throw new RuntimeStateWriteConflictError();
             }
         }
@@ -111,11 +114,4 @@ function decodeCurrentSessionGenerationRow(
         throw new TypeError('WebSocket session close high-water row expiry is invalid');
     }
     return state;
-}
-
-function requireExpectedRevision(computed: WsSessionGenerationLifecycleComputed): number {
-    if (computed.expectedRevision === null) {
-        throw new TypeError('WebSocket session close high-water update revision is missing');
-    }
-    return computed.expectedRevision;
 }

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
@@ -177,7 +177,7 @@ function lifecycleReadFixture(): WsSessionGenerationLifecycleRead {
             },
             sessionId: 'session-1'
         },
-        key: 'lifecycle-key',
+        key: 'group:ar-eye-hunter:default:owner:session-1',
         revision: null,
         persistedExpireAtEpochMs: null,
         state: null
@@ -185,18 +185,21 @@ function lifecycleReadFixture(): WsSessionGenerationLifecycleRead {
 }
 
 function lifecycleGuardFixture(lifecycleRead: WsSessionGenerationLifecycleRead): WsSessionGenerationLifecycleComputed {
+    const state = {
+        version: 3,
+        status: 'open',
+        ...lifecycleRead.identity,
+        generationId: 'generation-1',
+        generationStartedAtEpochMs: 1_000,
+        expireAtEpochMs: 422_240
+    } as const;
     return {
         outcome: 'insert',
         key: lifecycleRead.key,
         expectedRevision: null,
-        state: {
-            version: 3,
-            status: 'open',
-            ...lifecycleRead.identity,
-            generationId: 'generation-1',
-            generationStartedAtEpochMs: 1_000,
-            expireAtEpochMs: 422_240
-        }
+        state,
+        value: JSON.stringify(state),
+        expireAtIsoTimestamp: new Date(state.expireAtEpochMs).toISOString()
     };
 }
 

--- a/packages/tests/shared-server/rallar-system/websocket/ws-session-generation-lifecycle.test.ts
+++ b/packages/tests/shared-server/rallar-system/websocket/ws-session-generation-lifecycle.test.ts
@@ -1,9 +1,76 @@
+import type { PSqlParameter, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { validateWsSessionConnectGuard } from '@shared-server/rallar-system/websocket/ws-session-generation-computation.ts';
 import { createWsSessionGenerationLifecycleService } from '@shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts';
 import { describe, expect, it } from 'vitest';
 
 import { FakeRuntimeStateRepository } from '../../runtime-state/test-support/fake-runtime-state-repository.ts';
 
 describe('WebSocket session generation lifecycle persisted state', () => {
+    it('computes the serialized write before transaction entry', async () => {
+        const lifecycle = createWsSessionGenerationLifecycleService(
+            new FakeRuntimeStateRepository()
+        );
+        const identity = {
+            scope: {
+                kind: 'client',
+                applicationId: 'app-1',
+                workspaceId: 'workspace-1',
+                principalId: 'principal-1',
+                clientInstanceId: 'instance-1'
+            },
+            sessionId: 'session-1'
+        } as const;
+        const facts = {
+            ...identity,
+            generationId: 'generation-1',
+            generationStartedAtEpochMs: 1_000,
+            expireAtEpochMs: 10_000
+        } as const;
+        const computed = lifecycle.computeConnectGuard(facts, await lifecycle.read(identity));
+        expect(computed).toHaveProperty('value', JSON.stringify(computed.state));
+
+        const stringify = JSON.stringify;
+        JSON.stringify = () => {
+            throw new Error('WebSocket lifecycle serialization must finish during compute');
+        };
+        try {
+            await expect(lifecycle.write(appliedSql(), computed)).resolves.toBeUndefined();
+        }
+        finally {
+            JSON.stringify = stringify;
+        }
+    });
+
+    it('rejects a lifecycle write projection that differs from compute', async () => {
+        const lifecycle = createWsSessionGenerationLifecycleService(
+            new FakeRuntimeStateRepository()
+        );
+        const identity = {
+            scope: {
+                kind: 'group',
+                applicationId: 'app-1',
+                workspaceId: 'workspace-1',
+                principalId: 'principal-1'
+            },
+            sessionId: 'session-1'
+        } as const;
+        const facts = {
+            ...identity,
+            generationId: 'generation-1',
+            generationStartedAtEpochMs: 1_000,
+            expireAtEpochMs: 10_000
+        };
+        const read = await lifecycle.read(identity);
+        const computed = lifecycle.computeConnectGuard(facts, read);
+
+        expect(() =>
+            validateWsSessionConnectGuard(facts, read, {
+                ...computed,
+                value: `${computed.value} `
+            })
+        ).toThrow('WebSocket session lifecycle computed result differs');
+    });
+
     it('rejects a version-3 row whose JSON expiry differs from its RuntimeState expiry', async () => {
         const repository = new FakeRuntimeStateRepository();
         const lifecycle = createWsSessionGenerationLifecycleService(repository);
@@ -80,3 +147,11 @@ describe('WebSocket session generation lifecycle persisted state', () => {
         });
     });
 });
+
+function appliedSql(): PSqlSql {
+    const sql = (
+        _stringsOrValues: TemplateStringsArray | readonly PSqlParameter[],
+        ..._values: readonly PSqlParameter[]
+    ): Promise<readonly Readonly<{ revision: number; }>[]> | object => Promise.resolve([{ revision: 0 }]);
+    return sql as PSqlSql;
+}


### PR DESCRIPTION
## Summary
- add serialized value and ISO expiry to WebSocket lifecycle computed results
- validate close and connect-guard projections immediately after compute
- replace transaction-bound repository computation with direct insert/update CAS SQL
- preserve outer AppInbox redelivery; no inner retry or additional phase

## Review assessment
This is a small shared lifecycle slice: six files, 203 additions and 64 deletions. Compute, validation, and write ownership are visible at each client/group caller. The write method now only selects insert/update SQL, binds computed data, and checks the database result. There is no prepare phase.

Changed-file style has no new findings. Scoped navigation passes with zero findings and six legitimate effect boundaries. Repository structure passes with two inherited findings outside this slice.

## Validation
- affected shared-server: 117 files, 650 passed, 3 skipped
- focused WebSocket/client/group tests: 56 passed
- governed test typecheck: 1023 files, zero debt, zero errors
- shared-server TypeScript check passed
- API Deno check passed with /Users/knuthelge/.deno/bin/deno
- native PGlite lifecycle/AppInbox/group tests: 14 passed, zero failed
- formatting and diff checks passed

Stacked on PR #423.