### PR TITLE
Group state: compute persistence before transactions

### DIFF
--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -20,7 +20,10 @@ import type {
     GroupStatus
 } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
-import type { RuntimeStateGuardedBatchEffect } from '../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import type {
+    RuntimeStateGuardedBatch,
+    RuntimeStateGuardedBatchEffect
+} from '../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { GroupConnectTriggerLatchRow } from '../persistence/group-connect-trigger-latch-repository.ts';
 import type {
     GroupAcceptedLayoutRow,
@@ -493,6 +496,46 @@ export type PresenceAdmissionCandidate =
         expectedRevision: number;
     }>;
 
+export type GroupMutationDomainWrite = Readonly<{
+    outcome: 'write';
+    guard: GroupGuardCandidate | PresenceGuardCandidate;
+    members: readonly GroupMember[];
+    initialPresenceSummary: InitialGroupPresenceSummaryCandidate | null;
+    presenceAdmission: PresenceAdmissionCandidate | null;
+    event: GroupEvent;
+    receipt: GroupMutationReceipt;
+    idempotency: GroupMutationIdempotencyRecord | null;
+    outboxEntries: readonly ResourceEntry[];
+    lifecyclePolicy: GroupLifecyclePolicy | null;
+    /** Accepted layout committed atomically with the authoritative group row. */
+    acceptedLayoutPromotion: Extract<PlannedLayoutPromotion, { outcome: 'apply'; }> | null;
+    /** Planned layout revision re-asserted by a layout-fenced command. */
+    plannedLayoutFence: GroupPlannedLayoutRow | null;
+    layoutTombstones: GroupLayoutTombstones | null;
+    connectTriggerLatchEffect: RuntimeStateGuardedBatchEffect | null;
+}>;
+
+export type GroupMutationPersistence = Readonly<{
+    guardedBatch: RuntimeStateGuardedBatch;
+    lifecyclePolicyWrite:
+        | Readonly<{
+            namespace: string;
+            key: string;
+            value: string;
+            expireAtIsoTimestamp: string;
+        }>
+        | null;
+    eventWrite: Readonly<{
+        event: GroupEvent;
+        workspaceKey: string;
+        eventJson: string;
+    }>;
+}>;
+
+export type GroupMutationComputedWrite =
+    & GroupMutationDomainWrite
+    & Readonly<{ persistence: GroupMutationPersistence; }>;
+
 export type GroupMutationComputed =
     | Readonly<{
         outcome: 'replay' | 'no-op';
@@ -515,40 +558,12 @@ export type GroupMutationComputed =
         policyDenial: GroupPolicyDenied;
         receipt: GroupMutationReceipt;
     }>
-    | Readonly<{
-        outcome: 'write';
-        guard: GroupGuardCandidate | PresenceGuardCandidate;
-        members: readonly GroupMember[];
-        initialPresenceSummary: InitialGroupPresenceSummaryCandidate | null;
-        presenceAdmission: PresenceAdmissionCandidate | null;
-        event: GroupEvent;
-        receipt: GroupMutationReceipt;
-        idempotency: GroupMutationIdempotencyRecord | null;
-        outboxEntries: readonly ResourceEntry[];
-        lifecyclePolicy: GroupLifecyclePolicy | null;
-        /**
-         * The accepted-layout facts an activation or applyPlannedLayout
-         * commits atomically with the group row (product decisions 24/42);
-         * null for every other operation and when no plan exists to promote.
-         */
-        acceptedLayoutPromotion: Extract<PlannedLayoutPromotion, { outcome: 'apply'; }> | null;
-        /**
-         * The planned row a layout-fenced command matched, re-asserted under
-         * its revision inside the write transaction. Null when the command
-         * carries no layout fence or already promotes (a promotion emits the
-         * same guard itself).
-         */
-        plannedLayoutFence: GroupPlannedLayoutRow | null;
-        layoutTombstones: GroupLayoutTombstones | null;
-        connectTriggerLatchEffect: RuntimeStateGuardedBatchEffect | null;
-    }>;
+    | GroupMutationComputedWrite;
 
 export interface GroupLayoutTombstones {
     readonly planned: GroupPlannedLayoutRow | null;
     readonly accepted: GroupAcceptedLayoutRow | null;
 }
-
-export type GroupMutationComputedWrite = Extract<GroupMutationComputed, { outcome: 'write'; }>;
 
 export type GroupLifecycleTransitionOperation = Extract<
     GroupMutationCommand['operation'],

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-result.ts
@@ -23,6 +23,7 @@ import type {
     GroupLayoutTombstones,
     GroupMutationCommand,
     GroupMutationComputed,
+    GroupMutationDomainWrite,
     GroupMutationFacts,
     GroupMutationIdempotencyRecord,
     GroupMutationRead,
@@ -33,6 +34,7 @@ import type {
 import { GroupAlreadyExistsError, GroupMutationRejectedError } from './group-mutation-contracts.ts';
 import { groupMutationIdempotencyKey } from './group-mutation-idempotency-key.ts';
 import { GroupConnectDeniedError, type GroupMutationRejectionCode } from './group-mutation-rejection-codes.ts';
+import { computeGroupMutationPersistence } from './orchestration/compute-group-mutation-persistence.ts';
 
 const DEFAULT_GROUP_JOIN_CODE_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
 
@@ -135,7 +137,7 @@ export function computeGroupMutationWriteResult(
         outboxIds: outboxEntries.map((outboxEntry) => outboxEntry.key.resourceId),
         rejection: null
     });
-    return {
+    const computed: GroupMutationDomainWrite = {
         outcome: 'write',
         guard: input.guard,
         members: input.members,
@@ -151,6 +153,7 @@ export function computeGroupMutationWriteResult(
         layoutTombstones,
         connectTriggerLatchEffect: input.connectTriggerLatchEffect ?? null
     };
+    return { ...computed, persistence: computeGroupMutationPersistence(computed) };
 }
 
 function toGroupMutationIdempotency(

--- a/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
@@ -1,0 +1,145 @@
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
+
+import {
+    type RuntimeStateGuardedBatchEffect,
+    type RuntimeStateGuardedBatchGuard
+} from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import { validateRuntimeStateGuardedBatch } from '../../../../runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
+import { encodeRuntimeStateJsonValue } from '../../../../runtime-state/runtime-state-json-store.ts';
+import { decodeJsonWireValue } from '../../../protocol/json-wire-identity.ts';
+import { groupStateEventWorkspaceKey } from '../../../state-events/postgres/group-state-event-workspace-key.ts';
+import { groupStateGroupStorageKey } from '../../persistence/aggregate/group-aggregate-storage-keys.ts';
+import {
+    groupStateInsertGroupDescriptor,
+    groupStateUpdateGroupDescriptor
+} from '../../persistence/aggregate/group-aggregate-write-descriptors.ts';
+import { decodeCurrentGroupLifecyclePolicy } from '../../persistence/decode-stored-group-lifecycle-policy.ts';
+import { GROUP_LIFECYCLE_POLICIES_NAMESPACE } from '../../persistence/group-lifecycle-policy-repository.ts';
+import { groupStateInsertIdempotencyDescriptor } from '../../persistence/idempotency/group-idempotency-write-descriptor.ts';
+import {
+    toGroupLayoutPromotionEffects,
+    toGroupLayoutTombstoneEffects,
+    toPlannedLayoutFenceEffect
+} from '../../persistence/layout/to-group-layout-promotion-effects.ts';
+import { groupStateMemberPutDescriptor } from '../../persistence/membership/group-state-member-put-descriptor.ts';
+import {
+    groupStateDeletePresenceDescriptor,
+    groupStateInsertPresenceAdmissionDescriptor,
+    groupStateInsertPresenceDescriptor,
+    groupStateInsertPresenceSummaryDescriptor,
+    groupStateUpdatePresenceAdmissionDescriptor,
+    groupStateUpdatePresenceDescriptor,
+    groupStateUpdatePresenceSummaryDescriptor
+} from '../../persistence/presence/group-presence-write-descriptors.ts';
+import type {
+    GroupMutationDomainWrite,
+    GroupMutationPersistence
+} from '../group-mutation-contracts.ts';
+
+export function computeGroupMutationPersistence(
+    computed: GroupMutationDomainWrite
+): GroupMutationPersistence {
+    return {
+        guardedBatch: computeGroupMutationGuardedBatch(computed),
+        lifecyclePolicyWrite: computed.lifecyclePolicy === null
+            ? null
+            : {
+                namespace: GROUP_LIFECYCLE_POLICIES_NAMESPACE,
+                key: groupStateGroupStorageKey(computed.receipt.aggregateRef),
+                value: encodeRuntimeStateJsonValue({
+                    groupRef: computed.receipt.aggregateRef,
+                    policy: decodeCurrentGroupLifecyclePolicy(
+                        decodeJsonWireValue(computed.lifecyclePolicy, 'Group lifecycle policy')
+                    )
+                }),
+                expireAtIsoTimestamp: new Date(NEVER_EXPIRE_AT_TIMESTAMP).toISOString()
+            },
+        eventWrite: {
+            event: computed.event,
+            workspaceKey: groupStateEventWorkspaceKey(computed.event.workspaceId),
+            eventJson: JSON.stringify(computed.event)
+        }
+    };
+}
+
+function computeGroupMutationGuardedBatch(
+    computed: GroupMutationDomainWrite
+): GroupMutationPersistence['guardedBatch'] {
+    const effects: RuntimeStateGuardedBatchEffect[] = [];
+    effects.push(...computePresenceAndMembershipEffects(computed));
+    if (computed.acceptedLayoutPromotion) {
+        effects.push(...toGroupLayoutPromotionEffects(computed.acceptedLayoutPromotion));
+    }
+    if (computed.layoutTombstones) {
+        effects.push(...toGroupLayoutTombstoneEffects(computed.layoutTombstones));
+    }
+    if (computed.plannedLayoutFence) {
+        effects.push(toPlannedLayoutFenceEffect(computed.plannedLayoutFence));
+    }
+    if (computed.connectTriggerLatchEffect) {
+        effects.push(computed.connectTriggerLatchEffect);
+    }
+    if (computed.idempotency) {
+        effects.push({
+            effectId: 'receipt',
+            ...groupStateInsertIdempotencyDescriptor({
+                ref: computed.idempotency.aggregateRef,
+                requestId: computed.idempotency.requestId,
+                record: computed.idempotency,
+                expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
+            })
+        });
+    }
+    return validateRuntimeStateGuardedBatch({
+        guard: computeGroupMutationGuard(computed),
+        effects
+    });
+}
+
+function computeGroupMutationGuard(
+    computed: GroupMutationDomainWrite
+): RuntimeStateGuardedBatchGuard {
+    const guard = computed.guard;
+    if (guard.kind === 'group') {
+        return guard.operation === 'insert'
+            ? groupStateInsertGroupDescriptor(guard.value)
+            : groupStateUpdateGroupDescriptor(guard.value, guard.expectedRevision);
+    }
+    if (guard.operation === 'delete') {
+        return groupStateDeletePresenceDescriptor(guard.value, guard.expectedRevision);
+    }
+    return guard.operation === 'insert'
+        ? groupStateInsertPresenceDescriptor(guard.value)
+        : groupStateUpdatePresenceDescriptor(guard.value, guard.expectedRevision);
+}
+
+function computePresenceAndMembershipEffects(
+    computed: GroupMutationDomainWrite
+): RuntimeStateGuardedBatchEffect[] {
+    const effects: RuntimeStateGuardedBatchEffect[] = [];
+    if (computed.presenceAdmission) {
+        const admission = computed.presenceAdmission;
+        effects.push({
+            effectId: 'presence-admission',
+            ...(admission.operation === 'insert'
+                ? groupStateInsertPresenceAdmissionDescriptor(admission.value)
+                : groupStateUpdatePresenceAdmissionDescriptor(admission.value, admission.expectedRevision))
+        });
+    }
+    for (const member of computed.members) {
+        effects.push({
+            effectId: `member:${member.principalId}`,
+            ...groupStateMemberPutDescriptor(member)
+        });
+    }
+    if (computed.initialPresenceSummary) {
+        const summary = computed.initialPresenceSummary;
+        effects.push({
+            effectId: 'initial-presence-summary',
+            ...(summary.operation === 'insert'
+                ? groupStateInsertPresenceSummaryDescriptor(summary.value)
+                : groupStateUpdatePresenceSummaryDescriptor(summary.value, summary.expectedRevision))
+        });
+    }
+    return effects;
+}

--- a/packages/shared-server/rallar-system/group-state/mutation/result-validation/assert-computed-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/result-validation/assert-computed-group-mutation.ts
@@ -111,7 +111,8 @@ function assertWriteOutcomeKeys(computed: Extract<GroupMutationComputed, { outco
         'acceptedLayoutPromotion',
         'plannedLayoutFence',
         'layoutTombstones',
-        'connectTriggerLatchEffect'
+        'connectTriggerLatchEffect',
+        'persistence'
     ];
     assertExactKeys(computed, keys, 'Group mutation computed result');
     assertRequiredKeys(computed, keys, 'Group mutation computed result');

--- a/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
@@ -1,101 +1,25 @@
-import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import {
-    type RuntimeStateGuardedBatch,
-    type RuntimeStateGuardedBatchEffect,
-    type RuntimeStateGuardedBatchGuard
-} from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatchResult } from '../../../../runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
-import { validateRuntimeStateGuardedBatch } from '../../../../runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
+import type { RuntimeStateGuardedBatch } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
-import {
-    createTransactionBoundPSqlRuntimeStateRepository,
-    type PSqlRuntimeStateRepository
-} from '../../../../runtime-state/postgres/p-sql-runtime-state-repository.ts';
-import {
-    groupStateInsertGroupDescriptor,
-    groupStateUpdateGroupDescriptor
-} from '../../persistence/aggregate/group-aggregate-write-descriptors.ts';
-import { GroupLifecyclePolicyRepository } from '../../persistence/group-lifecycle-policy-repository.ts';
-import { createTransactionBoundGroupStateRepository } from '../../persistence/group-state-repository.ts';
-import { groupStateInsertIdempotencyDescriptor } from '../../persistence/idempotency/group-idempotency-write-descriptor.ts';
-import {
-    toGroupLayoutPromotionEffects,
-    toGroupLayoutTombstoneEffects,
-    toPlannedLayoutFenceEffect
-} from '../../persistence/layout/to-group-layout-promotion-effects.ts';
-import { groupStateMemberPutDescriptor } from '../../persistence/membership/group-state-member-put-descriptor.ts';
-import {
-    groupStateDeletePresenceDescriptor,
-    groupStateInsertPresenceAdmissionDescriptor,
-    groupStateInsertPresenceDescriptor,
-    groupStateInsertPresenceSummaryDescriptor,
-    groupStateUpdatePresenceAdmissionDescriptor,
-    groupStateUpdatePresenceDescriptor,
-    groupStateUpdatePresenceSummaryDescriptor
-} from '../../persistence/presence/group-presence-write-descriptors.ts';
-import type { GroupMutationComputedWrite, GroupMutationReceipt } from '../group-mutation-contracts.ts';
-
-export function materializeGroupStateGuardedBatch(
-    computed: GroupMutationComputedWrite
-): RuntimeStateGuardedBatch {
-    const effects: RuntimeStateGuardedBatchEffect[] = [];
-
-    effects.push(...materializePresenceAndMembershipEffects(computed));
-
-    if (computed.acceptedLayoutPromotion) {
-        effects.push(...toGroupLayoutPromotionEffects(computed.acceptedLayoutPromotion));
-    }
-
-    if (computed.layoutTombstones) {
-        effects.push(...toGroupLayoutTombstoneEffects(computed.layoutTombstones));
-    }
-
-    if (computed.plannedLayoutFence) {
-        effects.push(toPlannedLayoutFenceEffect(computed.plannedLayoutFence));
-    }
-
-    if (computed.connectTriggerLatchEffect) {
-        effects.push(computed.connectTriggerLatchEffect);
-    }
-
-    if (computed.idempotency) {
-        effects.push({
-            effectId: 'receipt',
-            ...groupStateInsertIdempotencyDescriptor({
-                ref: computed.idempotency.aggregateRef,
-                requestId: computed.idempotency.requestId,
-                record: computed.idempotency,
-                expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
-            })
-        });
-    }
-
-    return validateRuntimeStateGuardedBatch({
-        guard: materializeGuard(computed),
-        effects
-    });
-}
+import { executeComputedRuntimeStateGuardedBatch } from '../../../../runtime-state/postgres/execute-runtime-state-guarded-batch.ts';
+import { GroupStateEventCollisionError } from '../../../state-events/group-state-event-store.ts';
+import type { GroupStateEventCollisionRow } from '../../../state-events/postgres/group-state-event-row-codec.ts';
+import type {
+    GroupMutationComputedWrite,
+    GroupMutationPersistence,
+    GroupMutationReceipt
+} from '../group-mutation-contracts.ts';
 
 export async function writeGroupMutation(
     transaction: PSqlSql,
     computed: GroupMutationComputedWrite
 ): Promise<GroupMutationReceipt> {
-    const batch = materializeGroupStateGuardedBatch(computed);
-    const runtime = createTransactionBoundPSqlRuntimeStateRepository(transaction);
-    const repository = createTransactionBoundGroupStateRepository(transaction);
-
-    await executeGuardedGroupMutationBatch(runtime, batch);
-
-    if (computed.lifecyclePolicy !== null) {
-        await new GroupLifecyclePolicyRepository(runtime).writePolicy(
-            computed.receipt.aggregateRef,
-            computed.lifecyclePolicy
-        );
+    await executeGuardedGroupMutationBatch(transaction, computed.persistence.guardedBatch);
+    if (computed.persistence.lifecyclePolicyWrite) {
+        await writeLifecyclePolicy(transaction, computed.persistence.lifecyclePolicyWrite);
     }
-
-    await repository.appendEvent(computed.event);
+    await writeGroupEvent(transaction, computed.persistence.eventWrite);
     const outbox = new PSqlResourceInboxEntryRepository(transaction);
     for (const entry of computed.outboxEntries) {
         await outbox.writeIfAbsentOrMatch(entry);
@@ -104,13 +28,10 @@ export async function writeGroupMutation(
 }
 
 async function executeGuardedGroupMutationBatch(
-    runtime: PSqlRuntimeStateRepository,
+    transaction: PSqlSql,
     batch: RuntimeStateGuardedBatch
 ): Promise<void> {
-    const result = validateRuntimeStateGuardedBatchResult(
-        batch,
-        await runtime.executeGuardedBatch(batch)
-    );
+    const result = await executeComputedRuntimeStateGuardedBatch(transaction, batch);
     if (result.guard.status === 'conflict') {
         throw new RuntimeStateWriteConflictError();
     }
@@ -121,51 +42,77 @@ async function executeGuardedGroupMutationBatch(
     }
 }
 
-function materializeGuard(computed: GroupMutationComputedWrite): RuntimeStateGuardedBatchGuard {
-    const guard = computed.guard;
-    if (guard.kind === 'group') {
-        return guard.operation === 'insert'
-            ? groupStateInsertGroupDescriptor(guard.value)
-            : groupStateUpdateGroupDescriptor(guard.value, guard.expectedRevision);
-    }
-    if (guard.operation === 'delete') {
-        return groupStateDeletePresenceDescriptor(guard.value, guard.expectedRevision);
-    }
-    return guard.operation === 'insert'
-        ? groupStateInsertPresenceDescriptor(guard.value)
-        : groupStateUpdatePresenceDescriptor(guard.value, guard.expectedRevision);
+async function writeLifecyclePolicy(
+    transaction: PSqlSql,
+    policy: NonNullable<GroupMutationPersistence['lifecyclePolicyWrite']>
+): Promise<void> {
+    await transaction`
+        insert into runtime_state_store (store_namespace, store_key, store_value,
+                                         expire_at_ts, updated_ts, revision)
+        values (${policy.namespace}, ${policy.key}, ${policy.value},
+                ${policy.expireAtIsoTimestamp}, now(), 0)
+        on conflict (store_namespace, store_key)
+            do update set store_value = excluded.store_value,
+                          expire_at_ts = excluded.expire_at_ts,
+                          updated_ts = now(),
+                          revision = runtime_state_store.revision + 1
+    `;
 }
 
-function materializePresenceAndMembershipEffects(
-    computed: GroupMutationComputedWrite
-): RuntimeStateGuardedBatchEffect[] {
-    const effects: RuntimeStateGuardedBatchEffect[] = [];
-    if (computed.presenceAdmission) {
-        const admission = computed.presenceAdmission;
-        effects.push({
-            effectId: 'presence-admission',
-            ...(admission.operation === 'insert'
-                ? groupStateInsertPresenceAdmissionDescriptor(admission.value)
-                : groupStateUpdatePresenceAdmissionDescriptor(admission.value, admission.expectedRevision))
-        });
+async function writeGroupEvent(
+    transaction: PSqlSql,
+    eventWrite: GroupMutationPersistence['eventWrite']
+): Promise<void> {
+    const event = eventWrite.event;
+    const inserted = await transaction<{ event_id: string; }[]>`
+        insert into group_state_events (application_id,
+                                        workspace_key,
+                                        group_id,
+                                        event_id,
+                                        event_type,
+                                        snapshot_version,
+                                        occurred_at_epoch_ms,
+                                        event_json)
+        values (${event.applicationId},
+                ${eventWrite.workspaceKey},
+                ${event.groupId},
+                ${event.eventId},
+                ${event.eventType},
+                ${event.snapshotVersion},
+                ${event.occurredAtEpochMs},
+                ${eventWrite.eventJson})
+        on conflict (application_id, workspace_key, group_id, event_id)
+            do nothing
+        returning event_id
+    `;
+    if (inserted.length === 1) {
+        return;
     }
-
-    for (const member of computed.members) {
-        effects.push({
-            effectId: `member:${member.principalId}`,
-            ...groupStateMemberPutDescriptor(member)
-        });
+    const [existing] = await transaction<GroupStateEventCollisionRow[]>`
+        select application_id, workspace_key, group_id, event_id,
+               event_type, snapshot_version, occurred_at_epoch_ms, event_json
+        from group_state_events
+        where application_id = ${event.applicationId}
+          and workspace_key = ${eventWrite.workspaceKey}
+          and group_id = ${event.groupId}
+          and event_id = ${event.eventId}
+    `;
+    if (!existing || !isExactGroupEvent(existing, eventWrite)) {
+        throw new GroupStateEventCollisionError(event);
     }
+}
 
-    if (computed.initialPresenceSummary) {
-        const summary = computed.initialPresenceSummary;
-        effects.push({
-            effectId: 'initial-presence-summary',
-            ...(summary.operation === 'insert'
-                ? groupStateInsertPresenceSummaryDescriptor(summary.value)
-                : groupStateUpdatePresenceSummaryDescriptor(summary.value, summary.expectedRevision))
-        });
-    }
-
-    return effects;
+function isExactGroupEvent(
+    row: GroupStateEventCollisionRow,
+    eventWrite: GroupMutationPersistence['eventWrite']
+): boolean {
+    const event = eventWrite.event;
+    return row.application_id === event.applicationId &&
+        row.workspace_key === eventWrite.workspaceKey &&
+        row.group_id === event.groupId &&
+        row.event_id === event.eventId &&
+        row.event_type === event.eventType &&
+        Number(row.snapshot_version) === event.snapshotVersion &&
+        Number(row.occurred_at_epoch_ms) === event.occurredAtEpochMs &&
+        row.event_json === eventWrite.eventJson;
 }

--- a/packages/shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts
+++ b/packages/shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts
@@ -22,6 +22,13 @@ export function validateRuntimeStateGuardedBatchResult(
     input: RuntimeStateGuardedBatchResult | JsonWireValue
 ): RuntimeStateGuardedBatchResult {
     const batch = validateRuntimeStateGuardedBatch(expectedBatch);
+    return validateComputedRuntimeStateGuardedBatchResult(batch, input);
+}
+
+export function validateComputedRuntimeStateGuardedBatchResult(
+    batch: RuntimeStateGuardedBatch,
+    input: RuntimeStateGuardedBatchResult | JsonWireValue
+): RuntimeStateGuardedBatchResult {
     const result = requireResultRecord(
         input,
         'root'

--- a/packages/shared-server/runtime-state/postgres/decode-runtime-state-guarded-batch-rows.ts
+++ b/packages/shared-server/runtime-state/postgres/decode-runtime-state-guarded-batch-rows.ts
@@ -5,7 +5,10 @@ import type {
     RuntimeStateGuardedBatchGuardResult,
     RuntimeStateGuardedBatchResult
 } from '../guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatchResult } from '../guarded-batch/validate-runtime-state-guarded-batch-result.ts';
+import {
+    validateComputedRuntimeStateGuardedBatchResult,
+    validateRuntimeStateGuardedBatchResult
+} from '../guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { decodeRuntimeStateRevision } from './runtime-state-row-codec.ts';
 
 export interface RuntimeStateGuardedBatchDatabaseRow {
@@ -30,6 +33,25 @@ export function decodeRuntimeStateGuardedBatchRows(
     batch: RuntimeStateGuardedBatch,
     rows: readonly RuntimeStateGuardedBatchDatabaseRow[]
 ): RuntimeStateGuardedBatchResult {
+    return decodeGuardedBatchRows(batch, rows, validateRuntimeStateGuardedBatchResult);
+}
+
+export function decodeComputedRuntimeStateGuardedBatchRows(
+    batch: RuntimeStateGuardedBatch,
+    rows: readonly RuntimeStateGuardedBatchDatabaseRow[]
+): RuntimeStateGuardedBatchResult {
+    return decodeGuardedBatchRows(
+        batch,
+        rows,
+        validateComputedRuntimeStateGuardedBatchResult
+    );
+}
+
+function decodeGuardedBatchRows(
+    batch: RuntimeStateGuardedBatch,
+    rows: readonly RuntimeStateGuardedBatchDatabaseRow[],
+    validateResult: typeof validateRuntimeStateGuardedBatchResult
+): RuntimeStateGuardedBatchResult {
     requireDenseRows(rows);
     let guardRow: DecodedRuntimeStateGuardedBatchRow | undefined;
     const effectRows = new Map<string, DecodedRuntimeStateGuardedBatchRow>();
@@ -52,7 +74,7 @@ export function decodeRuntimeStateGuardedBatchRows(
         if (effectRows.size > 0) {
             throw invalidDatabaseResult('effects applied without guard authority');
         }
-        return validateRuntimeStateGuardedBatchResult(batch, {
+        return validateResult(batch, {
             guard: {
                 status: 'conflict',
                 operation: batch.guard.operation,
@@ -96,7 +118,7 @@ export function decodeRuntimeStateGuardedBatchRows(
         throw invalidDatabaseResult('received an unexpected effect row');
     }
 
-    return validateRuntimeStateGuardedBatchResult(batch, {
+    return validateResult(batch, {
         guard: guardResult,
         effects
     });

--- a/packages/shared-server/runtime-state/postgres/execute-runtime-state-guarded-batch.ts
+++ b/packages/shared-server/runtime-state/postgres/execute-runtime-state-guarded-batch.ts
@@ -6,7 +6,7 @@ import type {
 } from '../guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatch } from '../guarded-batch/validate-runtime-state-guarded-batch.ts';
 import {
-    decodeRuntimeStateGuardedBatchRows,
+    decodeComputedRuntimeStateGuardedBatchRows,
     type RuntimeStateGuardedBatchDatabaseRow
 } from './decode-runtime-state-guarded-batch-rows.ts';
 
@@ -25,6 +25,13 @@ export async function executeRuntimeStateGuardedBatch(
     input: RuntimeStateGuardedBatch
 ): Promise<RuntimeStateGuardedBatchResult> {
     const batch = validateRuntimeStateGuardedBatch(input);
+    return await executeComputedRuntimeStateGuardedBatch(sql, batch);
+}
+
+export async function executeComputedRuntimeStateGuardedBatch(
+    sql: PSqlSql,
+    batch: RuntimeStateGuardedBatch
+): Promise<RuntimeStateGuardedBatchResult> {
     const rows = await sql<RuntimeStateGuardedBatchDatabaseRow[]>`
         with guard_input as (
             select descriptor ->> 'operation' as operation,
@@ -262,7 +269,7 @@ export async function executeRuntimeStateGuardedBatch(
         from effect_put_result
     `;
 
-    return decodeRuntimeStateGuardedBatchRows(batch, rows);
+    return decodeComputedRuntimeStateGuardedBatchRows(batch, rows);
 }
 
 function toSqlDescriptor(

--- a/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
@@ -18,7 +18,6 @@ import { toGroupMutationRejectionError } from '@shared-server/rallar-system/grou
 import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
 import { readGroupMutation } from '@shared-server/rallar-system/group-state/mutation/read/read-group-mutation.ts';
 import { assertGroupMutation } from '@shared-server/rallar-system/group-state/mutation/state-validation/assert-group-mutation.ts';
-import { materializeGroupStateGuardedBatch } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
 import { GroupLifecyclePolicyRepository } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { decodeJsonWireValue, hashMutationCommand } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
@@ -229,7 +228,7 @@ export class GroupStateTestMutationExecutor {
 }
 
 async function writeGuardedBatch(transaction: RuntimeStateGuardedBatchTransaction, computed: GroupMutationComputedWrite): Promise<void> {
-    const materialized = materializeGroupStateGuardedBatch(computed);
+    const materialized = computed.persistence.guardedBatch;
     const result = validateRuntimeStateGuardedBatchResult(
         materialized,
         await transaction.executeGuardedBatch(materialized)

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
@@ -16,7 +16,6 @@ import { createAuthorityHarness } from '../inbox/group-state-inbox-test-runtime.
 
 import type { GroupMutationCommand, GroupMutationRead } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
-import { materializeGroupStateGuardedBatch } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
 import {
     GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
     GroupConnectTriggerLatchCorruptionError,
@@ -50,7 +49,7 @@ describe('automatic retry connect intent', () => {
         if (computed.outcome !== 'write') {
             throw new Error('Automatic retry must plan');
         }
-        const batch = materializeGroupStateGuardedBatch(computed);
+        const batch = computed.persistence.guardedBatch;
         const latch = batch.effects.find((effect) => effect.effectId === 'connect-trigger-latch');
         expect(latch?.operation).toBe('insert');
         expect(latch && 'value' in latch ? JSON.parse(latch.value) : null).toEqual({
@@ -139,7 +138,7 @@ describe('connect intent handoff', () => {
         if (computed.outcome !== 'write') {
             throw new Error('Expected connect');
         }
-        const batch = materializeGroupStateGuardedBatch(computed);
+        const batch = computed.persistence.guardedBatch;
         expect(JSON.parse('value' in batch.guard ? batch.guard.value : '{}').lifecycleState).toBe('connecting');
         expect(batch.effects.find((effect) => effect.effectId === 'planned-layout-fence')).toMatchObject({ operation: 'update', expectedRevision: 1 });
         const latch = batch.effects.find((effect) => effect.effectId === 'connect-trigger-latch');
@@ -201,7 +200,7 @@ async function connectWriteHarness() {
     if (computed.outcome !== 'write') {
         throw new Error('Expected connect write');
     }
-    const batch = materializeGroupStateGuardedBatch(computed);
+    const batch = computed.persistence.guardedBatch;
     await harness.runtimeRepository.upsert(batch.guard.namespace, batch.guard.key, JSON.stringify(read.group!.value), NEVER_EXPIRE_AT_TIMESTAMP);
     for (const effect of batch.effects) {
         if (effect.effectId !== 'planned-layout-fence' && effect.effectId !== 'connect-trigger-latch') {

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-sql.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-sql.test.ts
@@ -5,7 +5,7 @@ import { PSqlQueueBox } from '@shared-server/queuebox/postgres/p-sql-queue-box.t
 import { PSqlResourceInboxEntryRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
 import { computeGroupConnectTriggerEntry } from '@shared-server/rallar-system/group-state/group-connect-trigger-outbox-entry.ts';
 import { computeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation.ts';
-import { materializeGroupStateGuardedBatch, writeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
+import { writeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
 import { groupStateGroupStorageKey } from '@shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-storage-keys.ts';
 import { GroupConnectTriggerLatchRepository } from '@shared-server/rallar-system/group-state/persistence/group-connect-trigger-latch-repository.ts';
 import { createRtcTopologyOutboxPublisher } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.ts';
@@ -42,7 +42,7 @@ describe.each(['memory', 'postgres'] as const)('connect trigger SQL atomicity (%
             const latches = new GroupConnectTriggerLatchRepository(runtime);
             await expect(sql.begin((tx) => writeGroupMutation(tx, computed))).rejects.toMatchObject({ code: 'resource-inbox-invariant-corruption' });
             expect((await latches.read(identity))?.latch.state).toBe('awaiting-publication');
-            const batch = materializeGroupStateGuardedBatch(computed);
+            const batch = computed.persistence.guardedBatch;
             expect(JSON.parse((await runtime.findEntry(batch.guard.namespace, batch.guard.key))!.value).lifecycleState).toBe('planned');
             await sql`delete from resource_inbox where fk_ext_bank_id = ${entry.key.contextId} and ri_resource_id = ${entry.key.resourceId}`;
             await sql.begin((tx) => writeGroupMutation(tx, computed));
@@ -146,7 +146,7 @@ async function seedConnectWrite(sql: PSqlSql, applicationId: string) {
         throw new Error('Expected connect write');
     }
     const runtime = new PSqlRuntimeStateRepository(sql);
-    const batch = materializeGroupStateGuardedBatch(computed);
+    const batch = computed.persistence.guardedBatch;
     await runtime.upsert(batch.guard.namespace, batch.guard.key, JSON.stringify(group.value), NEVER_EXPIRE_AT_TIMESTAMP);
     for (const effect of batch.effects) {
         if (effect.effectId === 'planned-layout-fence' || effect.effectId === 'connect-trigger-latch') {

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
@@ -1,8 +1,10 @@
+import type { PSqlParameter, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import { mutationDescriptor } from '@shared-server/rallar-system/group-state/group-mutation-authority.ts';
-import { materializeGroupStateGuardedBatch } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
+import { writeGroupMutation } from '@shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts';
 import { groupStateGroupStorageKey } from '@shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-storage-keys.ts';
+import { RuntimeStateWriteConflictError } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createTestAuthSession, createTestGroupStateRuntime } from '../group-state-test-runtime.ts';
 import { ApplyingGuardedBatchRepository, OrderedGroupEventStore } from './group-mutation-test-runtime.ts';
 
@@ -12,7 +14,7 @@ const SCOPE = {
 } as const;
 
 describe('GroupStateService guarded batch write boundary', () => {
-    it('materializes only authoritative state and receipt while ResourceInbox stays transaction-bound', async () => {
+    it('computes authoritative persistence and receipt before the ResourceInbox transaction', async () => {
         const runtime = new ApplyingGuardedBatchRepository();
         const eventStore = new OrderedGroupEventStore(runtime);
         const authority = createTestAuthSession('alice');
@@ -56,8 +58,8 @@ describe('GroupStateService guarded batch write boundary', () => {
             throw new TypeError('Expected group write');
         }
 
-        const materialized = materializeGroupStateGuardedBatch(computed);
-        expect(materialized.guard).toEqual({
+        const guardedBatch = computed.persistence.guardedBatch;
+        expect(guardedBatch.guard).toEqual({
             operation: 'update',
             namespace: 'group-state:groups',
             key: groupStateGroupStorageKey(computed.guard.value),
@@ -65,8 +67,43 @@ describe('GroupStateService guarded batch write boundary', () => {
             value: JSON.stringify(computed.guard.value),
             expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
         });
-        expect(materialized.effects.map(({ effectId }) => effectId)).toEqual(['receipt']);
+        expect(guardedBatch.effects.map(({ effectId }) => effectId)).toEqual(['receipt']);
         expect(computed.outboxEntries).toHaveLength(1);
         expect(computed.outboxEntries[0]?.typeId).toBe('APP_OUTBOX');
+        expect(() =>
+            group.durable.validate(command, read, {
+                ...computed,
+                persistence: {
+                    ...computed.persistence,
+                    guardedBatch: {
+                        ...computed.persistence.guardedBatch,
+                        guard: {
+                            ...computed.persistence.guardedBatch.guard,
+                            key: `${computed.persistence.guardedBatch.guard.key}:tampered`
+                        }
+                    }
+                }
+            })
+        ).toThrow('differs from its canonical deterministic projection');
+
+        const stringify = vi.spyOn(JSON, 'stringify').mockImplementation(() => {
+            throw new Error('group serialization must finish during compute');
+        });
+        try {
+            await expect(writeGroupMutation(conflictingSql(), computed)).rejects.toBeInstanceOf(
+                RuntimeStateWriteConflictError
+            );
+        }
+        finally {
+            stringify.mockRestore();
+        }
     });
 });
+
+function conflictingSql(): PSqlSql {
+    const sql = (
+        _stringsOrValues: TemplateStringsArray | readonly PSqlParameter[],
+        ..._values: readonly PSqlParameter[]
+    ): Promise<readonly object[]> | object => Promise.resolve([]);
+    return sql as PSqlSql;
+}


### PR DESCRIPTION
## Summary

- compute the group guarded batch, lifecycle-policy bytes/key/expiry, and event workspace key/JSON before transaction entry
- validate the persistence projection as part of the canonical computed group mutation
- make the transaction writer execute computed data, retain only DB-result conflict/refinement logic, and keep specialized ResourceInbox writes unchanged
- remove the legacy group batch materialization export and migrate its verified test consumers
- add a narrow runtime-state executor for an already-computed batch while preserving the generic validating API

## Flow

`read → compute (including persistence projection) → validate exact canonical result → write(transaction, computed)`

There is no post-compute prepare/materialize phase and no inner retry loop. AppInbox remains responsible for outer redelivery.

## Review assessment

- **Correctness:** guarded CAS, event collision handling, lifecycle policy storage, receipt atomicity, ResourceInbox behavior, rollback, and outer retries are preserved by focused and PGlite tests.
- **Navigability/readability:** computation is owned by one named group mutation module; the 118-line writer now exposes its SQL and permitted DB-result decisions directly. Scoped navigation reports zero findings.
- **Maintainability:** the generic guarded-batch API remains available; the added computed-batch path only avoids re-running deterministic input validation inside a transaction. No repository-wide prepared-write abstraction was introduced.
- **Residual:** ResourceInbox remains intentionally specialized and outside this transaction-write rule.

## Validation

- `npx vitest run packages/tests/shared-server/rallar-system/group-state packages/tests/shared-server/runtime-state/guarded-batch --silent` — 80 files, 469 passed, 3 skipped
- focused write-boundary regression — 1 passed
- `npx tsc -p packages/shared-server/tsconfig.json --noEmit --pretty false` — pass
- `npm run typecheck:tests` — 1,023 files enforced, zero debt/errors
- `/Users/knuthelge/.deno/bin/deno task check` in `apps/api-v1` — pass
- focused PGlite group/runtime/WS convergence — 21 passed
- changed-file repo style — pass, no new findings
- scoped navigation — pass, zero findings
- repository structure — pass; two inherited review prompts outside this slice
- dprint and diff checks — pass
