### PR TITLE
Add focused transaction-write purity checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "check:adaptive-agent-evaluation": "node .agents/evaluations/adaptive-agent-execution/v1/validate-result.mjs",
     "check:repo-structure": "node scripts/repo-structure-check.mjs",
     "check:transaction-writes": "node scripts/transaction-write-check/check-transaction-writes.mjs",
-    "test:transaction-writes": "vitest run packages/tests/repo/transaction-write-check",
+    "test:transaction-writes": "vitest run packages/tests/repo/transaction-write-check.test.ts",
     "test:repo-structure": "vitest run packages/tests/repo/repo-structure-check",
     "check:governance-gate": "node scripts/governance-gate.mjs",
     "test:governance-gate": "vitest run packages/tests/repo/governance-gate",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "test:rallar-code-writing": "vitest run packages/tests/repo/rallar-code-writing packages/tests/repo/repo-code-style-authority-integrity.test.ts packages/tests/repo/repo-code-style-review-evidence-integrity.test.ts",
     "check:adaptive-agent-evaluation": "node .agents/evaluations/adaptive-agent-execution/v1/validate-result.mjs",
     "check:repo-structure": "node scripts/repo-structure-check.mjs",
+    "check:transaction-writes": "node scripts/transaction-write-check/check-transaction-writes.mjs",
+    "test:transaction-writes": "vitest run packages/tests/repo/transaction-write-check",
     "test:repo-structure": "vitest run packages/tests/repo/repo-structure-check",
     "check:governance-gate": "node scripts/governance-gate.mjs",
     "test:governance-gate": "vitest run packages/tests/repo/governance-gate",

--- a/packages/tests/repo/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check.test.ts
@@ -1,19 +1,22 @@
 import { Project } from 'ts-morph';
 import { describe, expect, it } from 'vitest';
 
-import { analyzeTransactionWrites } from '../../../../scripts/transaction-write-check/analyze-transaction-writes.mjs';
+import { analyzeTransactionWrites } from '../../../scripts/transaction-write-check/analyze-transaction-writes.mjs';
 
 describe('transaction write check', () => {
     it('reports named precomputable helpers in transaction callbacks', () => {
         const findings = analyzeFixture(`
-            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            interface Sql {
+                begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>;
+                query(value: string): Promise<void>;
+            }
             declare const database: Sql;
             declare const computed: { row: string };
             function computeRow(): string { return JSON.stringify(computed); }
             export async function execute(): Promise<void> {
                 await database.begin(async (transaction) => {
                     const row = computeRow();
-                    await transaction.begin(async () => row);
+                    await transaction.query(row);
                 });
             }
         `);
@@ -21,20 +24,89 @@ describe('transaction write check', () => {
         expect(findings.map((finding) => finding.operation)).toEqual(['computeRow']);
     });
 
+    it('follows imported transaction callback aliases', () => {
+        const project = new Project({ useInMemoryFileSystem: true });
+        project.createSourceFile(
+            '/packages/domain/write-callback.ts',
+            `export async function persist(): Promise<void> { JSON.stringify({ value: 1 }); }`
+        );
+        project.createSourceFile(
+            '/packages/domain/mutation.ts',
+            `import { persist as writeComputed } from './write-callback.ts';
+             interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+             declare const database: Sql;
+             export async function execute(): Promise<void> {
+                 await database.begin(writeComputed);
+             }`
+        );
+
+        const findings = analyzeTransactionWrites(project);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
+    });
+
+    it('inspects inferred object-property write implementations', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            interface MutationWriter {
+                write(transaction: PSqlSql, computed: { value: number }): Promise<void>;
+            }
+            export const writer: MutationWriter = {
+                write: async (transaction, computed) => {
+                    await transaction.query(JSON.stringify(computed));
+                }
+            };
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
+    });
+
+    it('does not treat unrelated begin methods as transaction boundaries', () => {
+        const findings = analyzeFixture(`
+            interface Status { begin(work: () => void): void; }
+            declare const status: Status;
+            export function start(): void {
+                status.begin(() => JSON.stringify({ value: 1 }));
+            }
+        `);
+
+        expect(findings).toEqual([]);
+    });
+
+    it('recognizes the canonical PostgreSQL transaction wrapper', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            declare function runInPSqlTransaction<T>(
+                database: PSqlSql,
+                write: (transaction: PSqlSql) => Promise<T>
+            ): Promise<T>;
+            declare const database: PSqlSql;
+            export async function execute(): Promise<void> {
+                await runInPSqlTransaction(database, async (transaction) => {
+                    await transaction.query(JSON.stringify({ value: 1 }));
+                });
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
+    });
+
     it('reports clocks, randomness, hashing, and sorting in transaction write functions', () => {
         const findings = analyzeFixture(`
             interface PSqlSql { query(value: unknown): Promise<void>; }
             export async function writeMutation(transaction: PSqlSql, computed: string[]): Promise<void> {
                 const now = Date.now();
+                const expireAt = new Date(0);
                 const id = crypto.randomUUID();
                 const sorted = computed.toSorted();
                 const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(id));
-                await transaction.query({ now, sorted, bytes });
+                await transaction.query({ now, expireAt, sorted, bytes });
             }
         `);
 
         expect(findings.map((finding) => finding.operation)).toEqual([
             'Date.now',
+            'Date',
             'crypto.randomUUID',
             'toSorted',
             'crypto.subtle.digest',
@@ -92,12 +164,20 @@ describe('transaction write check', () => {
 
     it('reports transaction loops without rejecting ordinary computed-write iteration', () => {
         const findings = analyzeFixture(`
-            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            interface Sql {
+                begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>;
+                query(value: string): Promise<void>;
+            }
             declare const database: Sql;
             export async function writeWithRetry(): Promise<void> {
                 for (let attempt = 0; attempt < 3; attempt += 1) {
                     await database.begin(async () => undefined);
                 }
+            }
+            export async function writeComputed(computed: readonly string[]): Promise<void> {
+                await database.begin(async (transaction) => {
+                    for (const write of computed) await transaction.query(write);
+                });
             }
         `);
 

--- a/packages/tests/repo/transaction-write-check/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check/transaction-write-check.test.ts
@@ -1,0 +1,149 @@
+import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
+
+import { analyzeTransactionWrites } from '../../../../scripts/transaction-write-check/analyze-transaction-writes.mjs';
+
+describe('transaction write check', () => {
+    it('reports named precomputable helpers in transaction callbacks', () => {
+        const findings = analyzeFixture(`
+            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            declare const database: Sql;
+            declare const computed: { row: string };
+            function computeRow(): string { return JSON.stringify(computed); }
+            export async function execute(): Promise<void> {
+                await database.begin(async (transaction) => {
+                    const row = computeRow();
+                    await transaction.begin(async () => row);
+                });
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['computeRow']);
+    });
+
+    it('reports clocks, randomness, hashing, and sorting in transaction write functions', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            export async function writeMutation(transaction: PSqlSql, computed: string[]): Promise<void> {
+                const now = Date.now();
+                const id = crypto.randomUUID();
+                const sorted = computed.toSorted();
+                const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(id));
+                await transaction.query({ now, sorted, bytes });
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual([
+            'Date.now',
+            'crypto.randomUUID',
+            'toSorted',
+            'crypto.subtle.digest',
+            'TextEncoder'
+        ]);
+    });
+
+    it('allows executing computed writes and bounded database-result checks', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<{ rows: { id: number }[] }>; }
+            export async function writeMutation(
+                transaction: PSqlSql,
+                computed: readonly { sql: string }[]
+            ): Promise<number> {
+                for (const write of computed) await transaction.query(write.sql);
+                const result = await transaction.query('returning id');
+                const id = Number(result.rows[0].id);
+                if (!Number.isSafeInteger(id)) throw new Error('Invalid database id');
+                return id;
+            }
+        `);
+
+        expect(findings).toEqual([]);
+    });
+
+    it('recognizes IndexedDB readwrite and upgrade callbacks but excludes readonly work', () => {
+        const findings = analyzeFixture(`
+            declare const db: IDBDatabase;
+            declare const request: IDBOpenDBRequest;
+            export function read(): void {
+                const transaction = db.transaction('items', 'readonly');
+                JSON.stringify(transaction.objectStore('items'));
+            }
+            export function write(): void {
+                const transaction = db.transaction('items', 'readwrite');
+                const encoded = JSON.stringify({ value: 1 });
+                transaction.objectStore('items').put(encoded);
+            }
+            export function computedBeforeWrite(): void {
+                const encoded = JSON.stringify({ value: 1 });
+                const transaction = db.transaction('items', 'readwrite');
+                transaction.objectStore('items').put(encoded);
+            }
+            request.onupgradeneeded = () => {
+                const stores = ['items'].toSorted();
+                request.result.createObjectStore(stores[0]);
+            };
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual([
+            'JSON.stringify',
+            'toSorted'
+        ]);
+    });
+
+    it('reports transaction loops without rejecting ordinary computed-write iteration', () => {
+        const findings = analyzeFixture(`
+            interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+            declare const database: Sql;
+            export async function writeWithRetry(): Promise<void> {
+                for (let attempt = 0; attempt < 3; attempt += 1) {
+                    await database.begin(async () => undefined);
+                }
+            }
+        `);
+
+        expect(findings).toMatchObject([{
+            rule: 'transaction.inner-retry',
+            operation: 'database.begin'
+        }]);
+    });
+
+    it('exempts exact PostgreSQL ResourceInbox owners but not browser QueueBox writes', () => {
+        const project = new Project({ useInMemoryFileSystem: true });
+        const specialized = project.createSourceFile(
+            '/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts',
+            transactionSource('Date.now()')
+        );
+        const browser = project.createSourceFile(
+            '/packages/shared/queuebox/indexed-db-queue-box-write.ts',
+            `declare const db: IDBDatabase;
+             export function write(): void {
+                 const transaction = db.transaction('items', 'readwrite');
+                 transaction.objectStore('items').put(JSON.stringify({ value: 1 }));
+             }`
+        );
+
+        const findings = analyzeTransactionWrites(project, [specialized, browser]);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({
+            path: 'packages/shared/queuebox/indexed-db-queue-box-write.ts',
+            operation: 'JSON.stringify'
+        });
+    });
+});
+
+function analyzeFixture(source: string) {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile('/packages/domain/mutation.ts', source);
+    return analyzeTransactionWrites(project, [sourceFile]);
+}
+
+function transactionSource(work: string): string {
+    return `
+        interface Sql { begin<T>(write: (transaction: Sql) => Promise<T>): Promise<T>; }
+        declare const database: Sql;
+        export async function write(): Promise<void> {
+            await database.begin(async () => { ${work}; });
+        }
+    `;
+}

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -1,0 +1,31 @@
+# Transaction write check
+
+`npm run check:transaction-writes` checks authored `packages/**` and
+`apps/api-v1/src/**` execution paths for high-confidence work that must happen
+before a write-capable transaction starts.
+
+The checker reports:
+
+- `transaction.precomputable-work` for clocks, randomness, serialization,
+  hashing, sorting/canonicalization, and named compute/prepare builders reached
+  from a resolved transaction callback or transaction-write function;
+- `transaction.inner-retry` when a write transaction is opened from a
+  retry/attempt loop.
+
+It recognizes PostgreSQL/PGlite `begin` and `transaction` callbacks, the
+`runInPSqlTransaction` wrapper, IndexedDB `readwrite` transactions, IndexedDB
+upgrade callbacks, and callback identifiers that resolve to authored source.
+It inspects the lexical transaction body rather than expanding arbitrary helper
+graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
+their call site. Readonly IndexedDB transactions, tests, fixtures, generated/vendor code,
+`packages/shared-test/**`, and `packages/shared-rtc-bench/**` are excluded.
+Exact PostgreSQL ResourceInbox owners under
+`packages/shared-server/queuebox/postgres/**` are governed by their specialized
+SQL review and semantic tests instead.
+
+This is intentionally a narrow check. It does not attempt whole-program
+provenance, arbitrary helper-body expansion, SQL semantic proof, dynamic
+callback resolution, or an exception/fingerprint registry. Human review remains
+responsible for ambiguous helpers and database-result refinements. Extend the
+checker only with a focused failing fixture and a demonstrated production class
+of error.

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -17,8 +17,9 @@ It recognizes PostgreSQL/PGlite `begin` and `transaction` callbacks, the
 upgrade callbacks, and callback identifiers that resolve to authored source.
 It inspects the lexical transaction body rather than expanding arbitrary helper
 graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
-their call site. Readonly IndexedDB transactions, tests, fixtures, generated/vendor code,
-`packages/shared-test/**`, and `packages/shared-rtc-bench/**` are excluded.
+their call site. Readonly IndexedDB transactions, tests, fixtures,
+generated/vendor code, `packages/shared-test/**`, and
+`packages/shared-rtc-bench/**` are excluded.
 Exact PostgreSQL ResourceInbox owners under
 `packages/shared-server/queuebox/postgres/**` are governed by their specialized
 SQL review and semantic tests instead.

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -218,10 +218,10 @@ function isTransactionWriteDeclaration(declaration) {
     }
     return declaration.getParameters().some((parameter) => {
         const typeNode = parameter.getTypeNode();
+        const typeText = typeNode?.getText() ?? parameter.getType().getText(parameter);
         return /^(?:transaction|tx|sql)$/iu.test(parameter.getName()) &&
-            typeNode !== undefined &&
-            !Node.isFunctionTypeNode(typeNode) &&
-            TRANSACTION_TYPE.test(typeNode.getText());
+            (typeNode === undefined || !Node.isFunctionTypeNode(typeNode)) &&
+            TRANSACTION_TYPE.test(typeText);
     });
 }
 
@@ -301,7 +301,9 @@ function declarationName(declaration) {
         return declaration.getName() ?? '';
     }
     const parent = declaration.getParent();
-    return Node.isVariableDeclaration(parent) ? parent.getName() : '';
+    return Node.isVariableDeclaration(parent) || Node.isPropertyAssignment(parent)
+        ? parent.getName()
+        : '';
 }
 
 function callOperation(call) {

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -1,0 +1,352 @@
+import { Node, SyntaxKind } from 'ts-morph';
+
+const PRECOMPUTABLE_CALLS = new Set([
+    'Date.now',
+    'JSON.parse',
+    'JSON.stringify',
+    'Math.random',
+    'crypto.getRandomValues',
+    'crypto.randomUUID',
+    'crypto.subtle.digest',
+    'structuredClone'
+]);
+
+const PRECOMPUTABLE_METHODS = new Set(['sort', 'toSorted']);
+const PRECOMPUTABLE_NAME = /^(?:compute|prepare|serialize|canonicalize|hash|encode)(?:$|[A-Z_])/u;
+const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
+const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
+const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
+
+export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
+    const findings = new Map();
+    const roots = [];
+
+    for (const sourceFile of sourceFiles) {
+        const path = sourcePath(sourceFile);
+        if (!isAnalyzedSource(path)) {
+            continue;
+        }
+        const specialized = path.startsWith(SPECIALIZED_RESOURCE_INBOX_ROOT);
+        for (const declaration of sourceFile.getDescendants().filter(isFunctionDeclaration)) {
+            if (!specialized && isTransactionWriteDeclaration(declaration)) {
+                roots.push(analysisRoot(declaration));
+            }
+        }
+        for (const assignment of sourceFile.getDescendantsOfKind(SyntaxKind.BinaryExpression)) {
+            if (!specialized && isUpgradeCallbackAssignment(assignment)) {
+                const callback = assignment.getRight();
+                if (Node.isArrowFunction(callback) || Node.isFunctionExpression(callback)) {
+                    roots.push(analysisRoot(callback));
+                }
+            }
+        }
+        for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+            const boundary = transactionBoundary(call);
+            if (!boundary) {
+                continue;
+            }
+            if (!specialized) {
+                reportTransactionLoop(call, findings);
+            }
+            if (specialized || boundary.kind === 'readonly') {
+                continue;
+            }
+            if (boundary.kind === 'indexed-db') {
+                const owner = call.getFirstAncestor(isFunctionDeclaration);
+                if (owner) {
+                    roots.push(analysisRoot(owner, call.getEnd()));
+                }
+                continue;
+            }
+            for (const callback of resolveCallbackBodies(boundary.callback, project)) {
+                roots.push(analysisRoot(callback));
+            }
+        }
+    }
+
+    const visited = new Set();
+    for (const root of roots) {
+        analyzeBody({
+            root: root.node,
+            start: root.start,
+            findings,
+            visited,
+            boundary: root.node
+        });
+    }
+    return [...findings.values()].sort(compareFindings);
+}
+
+function analyzeBody(input) {
+    const { root, start, findings, visited, boundary } = input;
+    const body = functionBody(root);
+    if (!body) {
+        return;
+    }
+    const identity = `${body.getSourceFile().getFilePath()}:${body.getStart()}:${start}`;
+    if (visited.has(identity)) {
+        return;
+    }
+    visited.add(identity);
+
+    for (const construct of body.getDescendantsOfKind(SyntaxKind.NewExpression)) {
+        if (construct.getStart() < start) {
+            continue;
+        }
+        const operation = construct.getExpression().getText();
+        if (operation === 'Date' || operation === 'TextEncoder') {
+            addFinding({
+                findings,
+                node: construct,
+                rule: 'transaction.precomputable-work',
+                operation,
+                boundary
+            });
+        }
+    }
+    for (const call of body.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+        if (call.getStart() < start) {
+            continue;
+        }
+        const operation = callOperation(call);
+        const precomputable = precomputableOperation(call, operation);
+        if (precomputable) {
+            addFinding({
+                findings,
+                node: call,
+                rule: 'transaction.precomputable-work',
+                operation: precomputable,
+                boundary
+            });
+        }
+    }
+}
+
+function analysisRoot(node, start = node.getStart()) {
+    return { node, start };
+}
+
+function precomputableOperation(call, operation) {
+    if (PRECOMPUTABLE_CALLS.has(operation) || operation.startsWith('Temporal.Now.')) {
+        return operation;
+    }
+    const expression = call.getExpression();
+    const name = Node.isPropertyAccessExpression(expression)
+        ? expression.getName()
+        : Node.isIdentifier(expression)
+        ? expression.getText()
+        : '';
+    if (PRECOMPUTABLE_METHODS.has(name)) {
+        return name;
+    }
+    if (
+        name === 'encode' &&
+        Node.isPropertyAccessExpression(expression) &&
+        Node.isNewExpression(expression.getExpression()) &&
+        expression.getExpression().getExpression().getText() === 'TextEncoder'
+    ) {
+        return undefined;
+    }
+    return PRECOMPUTABLE_NAME.test(name) ? name : undefined;
+}
+
+function transactionBoundary(call) {
+    const expression = call.getExpression();
+    if (Node.isIdentifier(expression) && expression.getText() === 'runInPSqlTransaction') {
+        return { kind: 'callback', callback: call.getArguments()[1] };
+    }
+    if (!Node.isPropertyAccessExpression(expression)) {
+        return undefined;
+    }
+    const method = expression.getName();
+    if (method === 'transaction') {
+        const mode = call.getArguments()[1]?.getText().replaceAll(/["']/gu, '');
+        if (mode === 'readonly') {
+            return { kind: 'readonly' };
+        }
+        if (mode === 'readwrite') {
+            return { kind: 'indexed-db' };
+        }
+        const callback = call.getArguments()[0];
+        if (isCallbackReference(callback) && looksLikeDatabaseReceiver(expression.getExpression())) {
+            return { kind: 'callback', callback };
+        }
+        return undefined;
+    }
+    if (method !== 'begin') {
+        return undefined;
+    }
+    const callback = call.getArguments()[0];
+    if (!isCallbackReference(callback) || !looksLikeDatabaseReceiver(expression.getExpression())) {
+        return undefined;
+    }
+    return { kind: 'callback', callback };
+}
+
+function looksLikeDatabaseReceiver(receiver) {
+    const typeText = receiver.getType().getText(receiver);
+    if (DATABASE_RECEIVER_TYPE.test(typeText)) {
+        return true;
+    }
+    const name = receiver.getText();
+    return /(?:database|repository|runtime|sql|pglite)/iu.test(name);
+}
+
+function reportTransactionLoop(call, findings) {
+    const loop = call.getFirstAncestor((ancestor) =>
+        Node.isForStatement(ancestor) ||
+        Node.isForInStatement(ancestor) ||
+        Node.isForOfStatement(ancestor) ||
+        Node.isWhileStatement(ancestor) ||
+        Node.isDoStatement(ancestor)
+    );
+    if (loop && isRetryLoop(loop)) {
+        addFinding({
+            findings,
+            node: call,
+            rule: 'transaction.inner-retry',
+            operation: callOperation(call),
+            boundary: call
+        });
+    }
+}
+
+function isTransactionWriteDeclaration(declaration) {
+    const name = declarationName(declaration);
+    if (!/^(?:write|commit|insert|update|delete|remove|put|finish)/u.test(name)) {
+        return false;
+    }
+    return declaration.getParameters().some((parameter) => {
+        const typeNode = parameter.getTypeNode();
+        return /^(?:transaction|tx|sql)$/iu.test(parameter.getName()) &&
+            typeNode !== undefined &&
+            !Node.isFunctionTypeNode(typeNode) &&
+            TRANSACTION_TYPE.test(typeNode.getText());
+    });
+}
+
+function isCallbackReference(node) {
+    return node !== undefined && (
+        Node.isArrowFunction(node) ||
+        Node.isFunctionExpression(node) ||
+        Node.isIdentifier(node)
+    );
+}
+
+function isRetryLoop(loop) {
+    const owner = loop.getFirstAncestor(isFunctionDeclaration);
+    return /(?:retry|attempt)/iu.test(loop.getText()) ||
+        (owner !== undefined && /(?:retry|attempt)/iu.test(declarationName(owner)));
+}
+
+function isUpgradeCallbackAssignment(assignment) {
+    if (assignment.getOperatorToken().getKind() !== SyntaxKind.EqualsToken) {
+        return false;
+    }
+    const left = assignment.getLeft();
+    return Node.isPropertyAccessExpression(left) && left.getName() === 'onupgradeneeded';
+}
+
+function resolveCallbackBodies(node, project) {
+    if (!node) {
+        return [];
+    }
+    if (Node.isArrowFunction(node) || Node.isFunctionExpression(node)) {
+        return [node];
+    }
+    if (!Node.isIdentifier(node)) {
+        return [];
+    }
+    return resolveDeclarations(node.getSymbol(), project);
+}
+
+function resolveDeclarations(symbol, project) {
+    if (!symbol) {
+        return [];
+    }
+    const resolved = symbol.isAlias() ? symbol.getAliasedSymbol() : symbol;
+    const bodies = [];
+    for (const declaration of resolved?.getDeclarations() ?? []) {
+        const source = sourcePath(declaration.getSourceFile());
+        if (!isAnalyzedSource(source) || !project.getSourceFile(declaration.getSourceFile().getFilePath())) {
+            continue;
+        }
+        if (isFunctionDeclaration(declaration)) {
+            bodies.push(declaration);
+            continue;
+        }
+        if (Node.isVariableDeclaration(declaration) || Node.isPropertyAssignment(declaration)) {
+            const initializer = declaration.getInitializer();
+            if (initializer && (Node.isArrowFunction(initializer) || Node.isFunctionExpression(initializer))) {
+                bodies.push(initializer);
+            }
+        }
+    }
+    return bodies;
+}
+
+function isFunctionDeclaration(node) {
+    return Node.isFunctionDeclaration(node) ||
+        Node.isMethodDeclaration(node) ||
+        Node.isArrowFunction(node) ||
+        Node.isFunctionExpression(node);
+}
+
+function functionBody(node) {
+    return typeof node.getBody === 'function' ? node.getBody() : undefined;
+}
+
+function declarationName(declaration) {
+    if (Node.isFunctionDeclaration(declaration) || Node.isMethodDeclaration(declaration)) {
+        return declaration.getName() ?? '';
+    }
+    const parent = declaration.getParent();
+    return Node.isVariableDeclaration(parent) ? parent.getName() : '';
+}
+
+function callOperation(call) {
+    return call.getExpression().getText().replaceAll(/\s+/gu, ' ');
+}
+
+function addFinding(input) {
+    const { findings, node, rule, operation, boundary } = input;
+    const sourceFile = node.getSourceFile();
+    const position = sourceFile.getLineAndColumnAtPos(node.getStart());
+    const finding = {
+        rule,
+        path: sourcePath(sourceFile),
+        line: position.line,
+        column: position.column,
+        operation,
+        boundary: boundaryLabel(boundary)
+    };
+    findings.set(`${finding.rule}:${finding.path}:${node.getStart()}`, finding);
+}
+
+function boundaryLabel(boundary) {
+    const sourceFile = boundary.getSourceFile();
+    const position = sourceFile.getLineAndColumnAtPos(boundary.getStart());
+    return `${sourcePath(sourceFile)}:${position.line}`;
+}
+
+function sourcePath(sourceFile) {
+    return sourceFile.getFilePath()
+        .replaceAll('\\', '/')
+        .replace(/^.*\/(packages|apps\/api-v1\/src)\//u, '$1/');
+}
+
+function isAnalyzedSource(path) {
+    return (path.startsWith('packages/') || path.startsWith('apps/api-v1/src/')) &&
+        !path.startsWith('packages/tests/') &&
+        !path.startsWith('packages/shared-test/') &&
+        !path.startsWith('packages/shared-rtc-bench/') &&
+        !/(?:^|\/)(?:generated|vendor|fixtures?|mocks?)(?:\/|$)/u.test(path) &&
+        !/\.(?:test|spec|d)\.ts$/u.test(path);
+}
+
+function compareFindings(left, right) {
+    return left.path.localeCompare(right.path) ||
+        left.line - right.line ||
+        left.column - right.column ||
+        left.operation.localeCompare(right.operation);
+}

--- a/scripts/transaction-write-check/check-transaction-writes.mjs
+++ b/scripts/transaction-write-check/check-transaction-writes.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { Project } from 'ts-morph';
+
+import { analyzeTransactionWrites } from './analyze-transaction-writes.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../..');
+const project = new Project({
+    tsConfigFilePath: path.join(repositoryRoot, 'tsconfig.json'),
+    skipAddingFilesFromTsConfig: true
+});
+
+project.addSourceFilesAtPaths([
+    path.join(repositoryRoot, 'packages/**/*.ts'),
+    path.join(repositoryRoot, 'apps/api-v1/src/**/*.ts'),
+    `!${path.join(repositoryRoot, 'packages/tests/**')}`,
+    `!${path.join(repositoryRoot, 'packages/shared-test/**')}`,
+    `!${path.join(repositoryRoot, 'packages/shared-rtc-bench/**')}`
+]);
+
+const findings = analyzeTransactionWrites(project);
+for (const finding of findings) {
+    console.error(
+        `${finding.path}:${finding.line}:${finding.column} ` +
+            `${finding.rule} ${finding.operation} (boundary ${finding.boundary})`
+    );
+}
+if (findings.length > 0) {
+    console.error(`FAIL: transaction write check (${findings.length} findings)`);
+    process.exitCode = 1;
+}
+else {
+    console.log('PASS: transaction write check');
+}


### PR DESCRIPTION
## Summary

- add a focused ts-morph checker for high-confidence precomputable work in PostgreSQL/PGlite and IndexedDB write transactions
- reject transaction creation from retry/attempt loops while allowing iteration over already-computed writes
- exclude readonly IndexedDB work, tests/generated/vendor surfaces, and the separately governed PostgreSQL ResourceInbox implementation
- provide stable file/line/rule/boundary diagnostics and package scripts
- document the check's deliberate human-review boundaries

## Complexity assessment

The checker is deliberately lexical: it recognizes resolved transaction callbacks and transaction-write functions, direct forbidden operations, suspicious compute/prepare/serialize/hash helper calls, and inner retry loops. It does **not** contain a SQL parser, whole-program fixed point, dynamic provenance engine, fingerprint/exception registry, or waiver mechanism.

Diff composition: 354 analyzer lines, 229 test lines, 38 CLI lines, 32 README lines, and 2 package-script lines.

## Review assessment

- **Correctness:** a RED fixture exposed inferred object-property `write` implementations as a blind spot; the analyzer now resolves their contextual transaction types.
- **False-positive control:** tests distinguish unrelated `.begin()`, readonly IndexedDB, permitted DB-result checks, ordinary prepared-write iteration, and specialized ResourceInbox owners.
- **Navigability/readability:** one analyzer, one CLI, one colocated README, and one root repo test; scoped navigation reports zero findings.
- **Maintainability:** extensions require a focused failing fixture and demonstrated production error class. The README explicitly preserves helper provenance and SQL semantics as human responsibilities.
- **Honest limitation:** arbitrary helper graphs and dynamic/external behavior are not proved by this check.

## Validation

- `npm run test:transaction-writes` — 10/10 passed
- `npm run check:transaction-writes` — pass, zero production findings
- `npm run typecheck:tests` — 1,024 files, zero debt/errors
- changed-file repo style — pass, no new findings
- scoped navigation — pass, zero findings
- repository structure — pass; only two inherited prompts from earlier stacked PRs
- dprint and diff checks — pass
