### PR TITLE
Gate transaction-write purity

### DIFF
--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -204,6 +204,9 @@ checker does not substitute for following production symbols.
   validation, sorting, candidate/event/outbox construction, arbitrary helpers,
   and other precomputable work before transaction entry. Deterministic work is
   non-waivable even when cheap or under deadline pressure.
+- Run `npm run check:transaction-writes` for authored package or API mutation
+  paths. Treat its lexical findings as blocking; helper provenance and SQL
+  semantics remain required human review boundaries.
 - Treat transaction timing and value provenance as separate facts. A value
   desired only for a transaction winner is not thereby database-derived. Only
   actual database-returned facts justify inside-transaction refinement. One

--- a/.agents/skills/rallar-testing/SKILL.md
+++ b/.agents/skills/rallar-testing/SKILL.md
@@ -62,6 +62,9 @@ compute, validate, and write. Prove through transaction and redelivery behavior
 that the handler and persistence helper do not own an inner retry loop. Prove that
 inside-transaction refinement starts from actual database-returned facts, and
 keep human review responsible for PostgreSQL semantics.
+Run `npm run check:transaction-writes` for affected authored package or API
+mutation paths. The check supplements semantic tests; helper provenance and
+PostgreSQL business semantics remain human review boundaries.
 
 For both phases, the same explicit input produces the same result. They perform
 no repository reads, clocks, randomness, mutable dependency lookups, or hidden

--- a/packages/tests/repo/governance-gate/governance-gate-command.test.ts
+++ b/packages/tests/repo/governance-gate/governance-gate-command.test.ts
@@ -12,7 +12,8 @@ const fixtureRoots: string[] = [];
 const requiredPhaseCommands = {
     'check:repo-structure': ['repo-structure', 0],
     'check:repo-style': ['repo-style', 0],
-    'check:retained-legacy': ['retained-legacy', 0]
+    'check:retained-legacy': ['retained-legacy', 0],
+    'check:transaction-writes': ['transaction-writes', 0]
 } as const;
 
 afterEach(() => {
@@ -33,12 +34,14 @@ describe('governance gate command', () => {
             'PASS: governance gate repo-style',
             'retained-legacy fixture success',
             'PASS: governance gate retained-legacy',
-            'PASS: governance gate (3 phases)'
+            'PASS: governance gate transaction-writes',
+            'PASS: governance gate (4 phases)'
         ]);
         expect(readExecutedPhases(fixtureRoot).sort()).toEqual([
             'repo-structure',
             'repo-style',
-            'retained-legacy'
+            'retained-legacy',
+            'transaction-writes'
         ]);
     });
 
@@ -80,7 +83,8 @@ describe('governance gate command', () => {
         [
             ['repo-structure', 'check:repo-structure'],
             ['repo-style', 'check:repo-style'],
-            ['retained-legacy', 'check:retained-legacy']
+            ['retained-legacy', 'check:retained-legacy'],
+            ['transaction-writes', 'check:transaction-writes']
         ] as const
     )('attributes a non-zero %s result to its canonical command', (phase, command) => {
         const commands = { ...requiredPhaseCommands, [command]: [phase, 7] as const };

--- a/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
+++ b/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
@@ -40,6 +40,10 @@ const strictMutationPhaseGuidancePaths = [
     '.agents/skills/rallar-testing/SKILL.md',
     '.agents/skills/performance-analysis/SKILL.md'
 ] as const;
+const transactionWriteCheckGuidancePaths = [
+    '.agents/skills/rallar-code-writing/SKILL.md',
+    '.agents/skills/rallar-testing/SKILL.md'
+] as const;
 const canonicalSnapshotOrderingGuidancePaths = [
     canonicalServiceWritingPath,
     'docs/rallar-convergent-state-and-rtc-topology.md'
@@ -430,6 +434,17 @@ describe('authoritative mutation guidance integrity', () => {
                 'Adding another service mutation phase requires explicit human approval',
                 'One queue delivery performs one mutation attempt',
                 'A conflict exits that attempt; queue redelivery starts again from `read`'
+            ]);
+        }
+    );
+
+    it.each(transactionWriteCheckGuidancePaths)(
+        '%s publishes the transaction-write check without overstating its proof',
+        (filePath) => {
+            expectAllNormalized(readRepo(filePath), [
+                'npm run check:transaction-writes',
+                'helper provenance',
+                'human review'
             ]);
         }
     );

--- a/scripts/governance-gate/governance-gate-phases.mjs
+++ b/scripts/governance-gate/governance-gate-phases.mjs
@@ -10,7 +10,8 @@ export const governanceGatePhases = [
         phase: 'retained-legacy',
         command: 'check:retained-legacy',
         showSuccessfulOutput: true
-    }
+    },
+    { phase: 'transaction-writes', command: 'check:transaction-writes' }
 ];
 
 const forbiddenScriptPatterns = [


### PR DESCRIPTION
## Summary

- publish the focused transaction-write check in the code-writing and testing skills without overstating what it proves
- add `check:transaction-writes` as the fourth governance-gate phase
- verify phase success/failure attribution and guidance source integrity

## Review assessment

- **Correctness:** the governance gate invokes the canonical package script and attributes failures to `check:transaction-writes`.
- **Navigability/readability:** the phase is one explicit entry in the existing phase list; skill additions are three lines each beside the existing transaction-write rule.
- **Maintainability:** no parallel gate, registry, waiver, or metadata system is introduced.
- **Skill evidence:** existing fresh-agent transaction-pressure results remain the behavioral evidence for the purity rule. The new source-integrity assertion proves publication only.
- **Honest limitation:** both skills state that helper provenance and PostgreSQL semantics still require human review.

## Validation

- `npm run test:governance-gate` — 18/18 passed
- guidance integrity and existing evaluation-result tests — 74/74 passed
- `npm run check:governance-gate` — all 4 phases passed
- `npm run typecheck:tests` — 1,024 files, zero debt/errors
- changed-file repo style — pass, no new findings
- dprint and diff checks — pass
