### PR TITLE
Close transaction-purity stack navigation findings

### DIFF
--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -87,7 +87,7 @@ export class ClientStateInboxHandler {
             return await this.writeInactiveGeneration(context, connection);
         }
         const command = await this.toAuthorisedWsConnectCommand(context, connection);
-        const computed = await this.computeValidatedMutation(command);
+        const computed = await this.readComputeValidateMutation(command);
         const lifecycleGuardFacts = {
             ...lifecycleFacts,
             expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(
@@ -107,7 +107,7 @@ export class ClientStateInboxHandler {
         input: ClientAuthorisedWsSessionDisconnectAppInboxPayload,
         context: AppInboxMessageContext<AuthorisedWsClientMutationResult>
     ): Promise<AuthorisedWsClientMutationResult> {
-        const lifecycleComputed = await this.computeAuthorisedWsDisconnectLifecycle(input);
+        const lifecycleComputed = await this.readComputeValidateAuthorisedWsDisconnectLifecycle(input);
         const command = await this.toAuthorisedWsDisconnectCommand(context, input);
         const read = await this.dependencies.mutationService.read(command);
         if (!read.session) {
@@ -128,7 +128,7 @@ export class ClientStateInboxHandler {
         context: AppInboxMessageContext<readonly ClientStateWritten[]>,
         atEpochMs: number
     ): Promise<readonly ClientStateWritten[]> {
-        const computed = await this.computeExpiredSessionMutations(context, atEpochMs);
+        const computed = await this.readComputeValidateExpiredSessionMutations(context, atEpochMs);
         const applied = computed.filter((successor) => successor.outcome === 'write');
         const durableResult = applied.map(toClientStateWritten);
         const result = await this.dependencies.transactionWriter.writeMutationWithAfterCommitResult(
@@ -149,7 +149,7 @@ export class ClientStateInboxHandler {
         return result.durableResult;
     }
 
-    private async computeValidatedMutation(
+    private async readComputeValidateMutation(
         command: ClientMutationCommand
     ): Promise<ClientMutationComputed> {
         const read = await this.dependencies.mutationService.read(command);
@@ -224,7 +224,7 @@ export class ClientStateInboxHandler {
         }));
     }
 
-    private async computeAuthorisedWsDisconnectLifecycle(
+    private async readComputeValidateAuthorisedWsDisconnectLifecycle(
         input: ClientAuthorisedWsSessionDisconnectAppInboxPayload
     ): Promise<WsSessionGenerationLifecycleComputed> {
         const connection = input.connection;
@@ -327,7 +327,7 @@ export class ClientStateInboxHandler {
         );
     }
 
-    private async computeExpiredSessionMutations(
+    private async readComputeValidateExpiredSessionMutations(
         context: AppInboxExecutionMetadata,
         atEpochMs: number
     ): Promise<readonly ClientMutationComputed[]> {
@@ -341,7 +341,7 @@ export class ClientStateInboxHandler {
                 context,
                 toExpireClientSessionMutationInput(candidate)
             );
-            computed.push(await this.computeValidatedMutation(command));
+            computed.push(await this.readComputeValidateMutation(command));
         }
         return computed;
     }

--- a/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
@@ -80,8 +80,8 @@ describe('CRDT mutation service', () => {
         });
         await applyCrdtMutation(service, repository, await createAppendCommand('append-first', 'update-1'));
 
-        const replay = await computeCrdtMutation(service, await createAppendCommand('append-replay', 'update-1'));
-        const collision = await computeCrdtMutation(service, await createAppendCommand('append-collision', 'update-1', 'different'));
+        const replay = await readComputeValidateCrdtMutation(service, await createAppendCommand('append-replay', 'update-1'));
+        const collision = await readComputeValidateCrdtMutation(service, await createAppendCommand('append-collision', 'update-1', 'different'));
 
         expect(replay.outcome).toBe('replay');
         expect(collision).toMatchObject({
@@ -99,7 +99,7 @@ describe('CRDT mutation service', () => {
             serviceId: 'server-1'
         });
         const command = await createAppendCommand('append-conflict', 'update-1');
-        const first = await computeCrdtMutation(service, command);
+        const first = await readComputeValidateCrdtMutation(service, command);
         repository.failNextConflict = true;
 
         await expect(service.write(repository.transaction, first)).rejects.toBeInstanceOf(CrdtMutationConflictError);
@@ -108,7 +108,7 @@ describe('CRDT mutation service', () => {
             documentRevision: 1,
             archivedAtEpochMs: 1_000
         });
-        const retried = await computeCrdtMutation(service, command);
+        const retried = await readComputeValidateCrdtMutation(service, command);
 
         expect(retried).toMatchObject({
             outcome: 'rejected',
@@ -392,7 +392,7 @@ function createUnusedTransaction(): PSqlSql {
     return transaction;
 }
 
-async function computeCrdtMutation(
+async function readComputeValidateCrdtMutation(
     service: ReturnType<typeof createCrdtMutationService>,
     command: Awaited<ReturnType<typeof createAppendCommand>>
 ) {
@@ -407,6 +407,6 @@ async function applyCrdtMutation(
     repository: MemoryCrdtMutationRepository,
     command: Awaited<ReturnType<typeof createAppendCommand>>
 ) {
-    const computed = await computeCrdtMutation(service, command);
+    const computed = await readComputeValidateCrdtMutation(service, command);
     return await service.write(repository.transaction, computed);
 }

--- a/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
@@ -9,7 +9,7 @@ import {
     createTopologyTestAuthorityGuard,
     createTopologyTestGroupRef,
     createTopologyTestGroupSnapshot
-} from '../config/mutation/group-topology-config-mutation-test-fixtures.ts';
+} from './config/mutation/group-topology-config-mutation-test-fixtures.ts';
 
 describe('GroupTopologyReconfigureMutation', () => {
     it('computes the deterministic explicit outbox intent from the captured command', () => {
@@ -105,12 +105,10 @@ describe('GroupTopologyReconfigureMutation', () => {
 });
 
 function createSuccessfulTransaction(): PSqlSql {
-    function sql<Result>(
-        strings: TemplateStringsArray,
+    const sql = (
+        stringsOrValues: TemplateStringsArray | readonly PSqlParameter[],
         ..._values: readonly PSqlParameter[]
-    ): Promise<Result>;
-    function sql(_values: readonly PSqlParameter[]): object;
-    function sql(stringsOrValues: TemplateStringsArray | readonly PSqlParameter[]): Promise<unknown> | object {
+    ): Promise<readonly object[]> | object => {
         if (Array.isArray(stringsOrValues) && !Object.hasOwn(stringsOrValues, 'raw')) {
             return {};
         }
@@ -118,12 +116,12 @@ function createSuccessfulTransaction(): PSqlSql {
         return Promise.resolve(
             query.includes('returning ri_row_id') ? [{ ri_row_id: 1n }] : [{ revision: 1 }]
         );
-    }
+    };
     return Object.assign(sql, {
         begin: async <T>(_write: (transaction: PSqlSql) => Promise<T>): Promise<T> => {
             throw new Error('Reconfigure write must not open a transaction');
         }
-    });
+    }) as PSqlSql;
 }
 
 function createMutation(

--- a/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
@@ -1,4 +1,8 @@
-import type { PSqlParameter, PSqlRows, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import type {
+    PSqlParameter,
+    PSqlRows,
+    PSqlSql
+} from '@shared-server/postgres/p-sql-sql.ts';
 import { type RuntimeStateGuardedBatch, type RuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';


### PR DESCRIPTION
## Summary

- move two singleton test suites to their owning test directories
- name client and CRDT helpers according to the actual read → compute → validate flow
- make the moved topology SQL fake concrete enough for human-style/type analysis

## Review assessment

This is a non-behavioral closure slice after reviewing the full transaction-purity stack.

- **Navigability:** improved; phase-composing helpers no longer claim to be compute-only, and singleton test subtrees are removed
- **Readability:** improved; names expose the actual ordering without introducing another phase or abstraction
- **Maintainability:** improved; tests now live with their owning topology/runtime-state surfaces
- **Repository standards/skills:** passes touched-file style closure, repository structure, scoped navigation, and all four governance phases
- **Known navigation output:** 12 manual interface-pivot notices on the existing typed `ClientStateService` port; zero high-confidence findings and eight legitimate named effect boundaries

No product behavior, transaction semantics, retry behavior, public API, persisted format, or compatibility behavior changes.

## Validation

- focused Vitest — 27 files, 127 tests passed
- test typecheck — 1,024 files, zero errors/debt
- shared-server TypeScript — passed
- changed-file style and repository structure — passed
- scoped navigation — zero high-confidence findings
- complete governance gate — all four phases passed
- scoped dprint and diff check — passed
