### PR TITLE
Compute client inbox completion before transactions

### DIFF
--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -1,6 +1,12 @@
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import type { AppInboxExecutionMetadata, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import {
     validateWsSessionConnectGuard,
@@ -131,18 +137,17 @@ export class ClientStateInboxHandler {
         const computed = await this.readComputeValidateExpiredSessionMutations(context, atEpochMs);
         const applied = computed.filter((successor) => successor.outcome === 'write');
         const durableResult = applied.map(toClientStateWritten);
-        const result = await this.dependencies.transactionWriter.writeMutationWithAfterCommitResult(
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutationWithAfterCommitResult(
             context,
+            completion,
             async (transaction) => {
                 for (const successor of computed) {
                     if (requiresClientWrite(successor)) {
                         await this.dependencies.mutationService.write(transaction, successor);
                     }
                 }
-                return {
-                    durableResult,
-                    afterCommitResult: { committedSnapshots: applied.map((successor) => successor.snapshot) }
-                };
+                return { committedSnapshots: applied.map((successor) => successor.snapshot) };
             }
         );
         await this.observeCommittedSnapshots(result.afterCommitResult);
@@ -167,21 +172,20 @@ export class ClientStateInboxHandler {
             throw new Error('Validated client idempotency conflict is unreachable');
         }
         const durableResult = toClientStateWritten(computed);
-        const result = await this.dependencies.transactionWriter.writeMutationWithAfterCommitResult(
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutationWithAfterCommitResult(
             context,
+            completion,
             async (transaction) => {
-                await this.writeComputedMutation(transaction, computed, lifecycleComputed);
-                return {
-                    durableResult,
-                    afterCommitResult: { committedSnapshots: [computed.snapshot] }
-                };
+                await this.writeClientMutation(transaction, computed, lifecycleComputed);
+                return { committedSnapshots: [computed.snapshot] };
             }
         );
         await this.observeCommittedSnapshots(result.afterCommitResult);
         return result.durableResult;
     }
 
-    private async writeComputedMutation(
+    private async writeClientMutation(
         transaction: PSqlSql,
         computed: Exclude<ClientMutationComputed, { outcome: 'idempotency-conflict'; }>,
         lifecycleComputed: WsSessionGenerationLifecycleComputed | undefined
@@ -217,11 +221,17 @@ export class ClientStateInboxHandler {
         context: AppInboxMessageContext<InactiveAuthorisedWsSessionResult>,
         connection: ClientAuthorisedWsSessionConnectAppInboxPayload
     ): Promise<InactiveAuthorisedWsSessionResult> {
-        return await this.dependencies.transactionWriter.writeMutation(context, async () => ({
+        const durableResult = {
             status: 'inactive',
             sessionId: connection.authSession.sessionId,
             generationId: connection.generationId
-        }));
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            completion,
+            async () => {}
+        );
     }
 
     private async readComputeValidateAuthorisedWsDisconnectLifecycle(
@@ -254,14 +264,36 @@ export class ClientStateInboxHandler {
         lifecycleComputed
     }: WriteMissingSessionDisconnectInput): Promise<InactiveAuthorisedWsSessionResult> {
         validateClientMutationAuthorityPolicy(command, read);
-        return await this.dependencies.transactionWriter.writeMutation(context, async (transaction) => {
-            await this.dependencies.sessionGenerationLifecycle.write(transaction, lifecycleComputed);
-            return {
-                status: 'inactive',
-                sessionId: disconnect.connection.authSession.sessionId,
-                generationId: disconnect.connection.generationId
-            };
-        });
+        const durableResult = {
+            status: 'inactive',
+            sessionId: disconnect.connection.authSession.sessionId,
+            generationId: disconnect.connection.generationId
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            completion,
+            async (transaction) => {
+                await this.dependencies.sessionGenerationLifecycle.write(transaction, lifecycleComputed);
+            }
+        );
+    }
+
+    private readComputeValidateCompletion<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionComputed<Result> {
+        const input = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues.length > 0) {
+            throw issues[0].cause;
+        }
+        return computed;
     }
 
     private async toAuthorisedWsConnectCommand(

--- a/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
@@ -29,7 +29,7 @@ import { createClientMutationTransactionBoundaryFixture } from './create-client-
 const SCOPE = { applicationId: 'ar-eye-hunter', workspaceId: 'default' } as const;
 
 describe('client mutation transaction and outbox', () => {
-    it('persists durable JSON bytes before observing the exact committed snapshot', async () => {
+    it('serializes durable completion before the transaction and observes after commit', async () => {
         const harness = await createClientMutationTransactionBoundaryFixture();
 
         const result = await harness.handler.processCommand(
@@ -62,7 +62,7 @@ describe('client mutation transaction and outbox', () => {
             'status',
             'result'
         ]);
-        expect(harness.actions).toEqual(['write', 'commit', 'observe']);
+        expect(harness.actions).toEqual(['completion', 'write', 'commit', 'observe']);
         expect(harness.observedSnapshots).toHaveLength(1);
         expect(harness.observedSnapshots[0]).toBe(harness.computedSnapshots[0]);
         expect(result.result?.snapshot).toBe(harness.computedSnapshots[0]);
@@ -88,7 +88,7 @@ describe('client mutation transaction and outbox', () => {
             )
         ).rejects.toThrow('injected transaction failure');
 
-        expect(harness.actions).toEqual([]);
+        expect(harness.actions).toEqual(['completion']);
         expect(harness.observedSnapshots).toEqual([]);
         expect(await harness.results.findByKey(harness.context.entry.key)).toBeUndefined();
     });

--- a/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
@@ -79,11 +79,21 @@ export async function createClientMutationTransactionBoundaryFixture(
         },
         transactionWriter: new AppInboxTransactionWriter({ database }, {
             serviceId: 'client-inbox-service',
-            nowEpochMs: () => context.message.id.ts
+            nowEpochMs: () => {
+                actions.push('completion');
+                return context.message.id.ts;
+            }
         }),
         serviceId: 'client-inbox-service'
     });
-    return { actions, computedSnapshots, context, handler, observedSnapshots, results };
+    return {
+        actions,
+        computedSnapshots,
+        context,
+        handler,
+        observedSnapshots,
+        results
+    };
 }
 
 interface ObservedMutationEffects {


### PR DESCRIPTION
## Summary
- compute and validate every client AppInbox durable completion before transaction entry
- keep transaction callbacks limited to prepared client/lifecycle writes
- preserve post-commit snapshot observation and existing outer redelivery behavior

## Review assessment
This bounded slice is readable and follows the strict read → compute → validate → write flow. It removes client use of the legacy compute-in-write AppInbox API without adding a compatibility wrapper or an inner retry. The stack as a whole is not yet merge-ready: other domain handlers still use the legacy API, and exact AppInbox completion validation remains a subsequent blocker.

## Evidence
- focused boundary test: 4 passed
- complete client-state suite: 24 files / 93 tests passed
- shared-server TypeScript check passed
- governed test typecheck: 1024 files, zero errors/debt
- transaction-write checker passed
- changed-file repository style check passed
- formatting and diff checks passed
