### PR TITLE
Validate exact AppInbox completion projections

### DIFF
--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
@@ -9,6 +9,7 @@ import {
     computeResourceInboxResultReplacement,
     type ResourceInboxResultReplacement
 } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
+import { serializeCanonicalJson } from '../../protocol/canonical-json.ts';
 import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import { AppInboxReservationConflictError } from '../app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '../app-inbox-registration-codecs.ts';
@@ -76,8 +77,18 @@ export function validateAppInboxCompletion<Result>(
     computed: AppInboxCompletionComputed<Result>
 ): readonly AppInboxCompletionValidationIssue[] {
     const issues = validateAppInboxCompletionFacts(input);
+    if (issues.length > 0) {
+        return issues;
+    }
+    const expected = computeAppInboxCompletion(input);
     if (computed.durableResult !== input.durableResult) {
         issues.push(toAppInboxCompletionValidationIssue('computed.durableResult', 'must be the computed result'));
+    }
+    if (!hasSameJsonWireValue(computed.encodedResult, expected.encodedResult)) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.encodedResult',
+            'must encode the computed durable result'
+        ));
     }
     if (
         !hasSameResourceInboxKey(computed.reservationFinish.key, input.entry.key) ||
@@ -91,10 +102,7 @@ export function validateAppInboxCompletion<Result>(
         ));
     }
     if (
-        computed.resultReplacement.resourceId !== input.entry.key.resourceId ||
-        computed.resultReplacement.topicId !== input.entry.key.topicId ||
-        computed.resultReplacement.contextId !== input.entry.key.contextId ||
-        computed.resultReplacement.status !== input.status
+        !hasSameResultReplacement(computed.resultReplacement, expected.resultReplacement)
     ) {
         issues.push(toAppInboxCompletionValidationIssue(
             'computed.resultReplacement',
@@ -102,14 +110,20 @@ export function validateAppInboxCompletion<Result>(
         ));
     }
     if (
-        !hasSameResourceInboxKey(computed.finalizedEntry.key, input.entry.key) ||
-        computed.finalizedEntry.status !== input.status ||
-        computed.finalizedEntry.dequeueAudit.endTs?.epochMilliseconds !== input.completedAtEpochMs ||
-        computed.finalizedEntry.dequeueAudit.nextTs !== undefined
+        !hasSameFinalizedEntry(computed.finalizedEntry, expected.finalizedEntry)
     ) {
         issues.push(toAppInboxCompletionValidationIssue(
             'computed.finalizedEntry',
             'must describe the completed reservation'
+        ));
+    }
+    if (
+        !(computed.reservationConflict instanceof AppInboxReservationConflictError) ||
+        !hasSameResourceInboxKey(computed.reservationConflict.key, input.entry.key)
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.reservationConflict',
+            'must describe the reserved entry'
         ));
     }
     return issues;
@@ -145,6 +159,56 @@ function hasSameResourceInboxKey(
     return left.topicId === right.topicId &&
         left.resourceId === right.resourceId &&
         left.contextId === right.contextId;
+}
+
+function hasSameJsonWireValue(left: JsonWireValue, right: JsonWireValue): boolean {
+    try {
+        return serializeCanonicalJson(left) === serializeCanonicalJson(right);
+    }
+    catch {
+        return false;
+    }
+}
+
+function hasSameResultReplacement(
+    left: ResourceInboxResultReplacement,
+    right: ResourceInboxResultReplacement
+): boolean {
+    return left.resourceId === right.resourceId &&
+        left.topicId === right.topicId &&
+        left.resource === right.resource &&
+        left.typeId === right.typeId &&
+        left.status === right.status &&
+        left.contextId === right.contextId &&
+        left.systemDate === right.systemDate &&
+        left.createdBy === right.createdBy &&
+        left.createdAt === right.createdAt &&
+        left.expiresAt === right.expiresAt;
+}
+
+function hasSameFinalizedEntry(left: ResourceEntry, right: ResourceEntry): boolean {
+    return hasSameResourceInboxKey(left.key, right.key) &&
+        left.resource === right.resource &&
+        left.typeId === right.typeId &&
+        left.status === right.status &&
+        left.audit.date.equals(right.audit.date) &&
+        left.audit.createdBy === right.audit.createdBy &&
+        left.audit.createdTs.equals(right.audit.createdTs) &&
+        left.audit.expiryTs.equals(right.audit.expiryTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.startTs, right.dequeueAudit.startTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.endTs, right.dequeueAudit.endTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.nextTs, right.dequeueAudit.nextTs) &&
+        left.dequeueAudit.attempts === right.dequeueAudit.attempts &&
+        left.db?.id === right.db?.id;
+}
+
+function hasSameOptionalInstant(
+    left: Temporal.Instant | undefined,
+    right: Temporal.Instant | undefined
+): boolean {
+    return left === undefined || right === undefined
+        ? left === right
+        : left.equals(right);
 }
 
 function toAppInboxCompletionValidationIssue(

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
@@ -49,6 +49,37 @@ describe('AppInbox successful completion computation', () => {
         expect(harness.database.beginCalls).toBe(0);
     });
 
+    it('rejects completion projections that do not match the durable result', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const input = {
+            ...writer.readCompletionFacts(harness.context),
+            status: EntityStatus.COMPLETED,
+            durableResult: { status: 'accepted', revision: 2 }
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+
+        const issues = validateAppInboxCompletion(input, {
+            ...computed,
+            encodedResult: { status: 'substituted' },
+            resultReplacement: {
+                ...computed.resultReplacement,
+                resource: JSON.stringify({ status: 'substituted' })
+            },
+            finalizedEntry: {
+                ...computed.finalizedEntry,
+                resource: 'substituted request'
+            }
+        });
+
+        expect(issues.map((issue) => issue.path)).toEqual([
+            'computed.encodedResult',
+            'computed.resultReplacement',
+            'computed.finalizedEntry'
+        ]);
+        expect(harness.database.beginCalls).toBe(0);
+    });
+
     it('validates reservation identity by value rather than object identity', () => {
         const harness = createAtomicHarness();
         const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });


### PR DESCRIPTION
## Summary
- reject encoded AppInbox results that differ from the computed durable result
- validate every persisted result-replacement field and the full finalized entry
- validate reservation-conflict identity before transaction entry

## Review assessment
This closes a serious integrity hole: previously a candidate could pass validation while persisting substituted result bytes. The implementation keeps the rule in the existing completion computation/validation owner and adds no new phase or compatibility layer. The explicit flat-field comparisons are longer than a generic deep-equality helper, but are type-visible, deterministic, and avoid introducing another abstraction for two operation-owned projections.

The aggregate stack is still not merge-ready: remaining handlers use the legacy compute-in-write API, and group/domain persistence validators require further exactness work.

## Evidence
- RED: substituted encoded/result/finalized projections produced zero issues
- GREEN: focused completion tests 6/6
- AppInbox suite 14 files / 112 tests passed
- shared-server TypeScript check passed
- governed test typecheck 1024 files / zero errors/debt
- transaction-write checker passed
- changed-file style and scoped navigation checks passed
- formatting and diff checks passed
