### PR TITLE
Finalize auth inbox results before transactions

### DIFF
--- a/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
@@ -1,7 +1,12 @@
 import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 
 import { toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AuthMutationService } from '../auth-mutation-service.ts';
 import type { AuthCredentialIssuer } from '../credentials/auth-credential-issuer.ts';
 import type { AuthMutationIntent, AuthMutationResult } from '../mutation/auth-mutation-contracts.ts';
@@ -47,9 +52,22 @@ export class AuthInboxHandler {
         const read = await this.dependencies.mutationService.read(command);
         const computed = this.dependencies.mutationService.compute(command, read, materialized.facts);
         this.dependencies.mutationService.validate(command, read, computed);
-        return await this.dependencies.transactionWriter.writeMutation(
+        const completionInput = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult: computed.result,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const completionIssues = validateAppInboxCompletion(completionInput, completion);
+        if (completionIssues[0] !== undefined) {
+            throw completionIssues[0].cause;
+        }
+        return await this.dependencies.transactionWriter.writeComputedMutation(
             context,
-            async (transaction) => await this.dependencies.mutationService.write(transaction, computed)
+            completion,
+            async (transaction) => {
+                await this.dependencies.mutationService.write(transaction, computed);
+            }
         );
     }
 }

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -89,6 +89,7 @@ describe('auth inbox mutation phase order', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write'
         ]);
@@ -204,16 +205,19 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
         this.transaction = transaction;
     }
 
-    readCompletionFacts(_context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
-        throw new Error('Computed transaction path must not run');
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        this.actions.push('completion');
+        return { entry: context.entry, completedAtEpochMs: context.message.id.ts };
     }
 
     async writeComputedMutation<Result>(
         _context: AppInboxExecutionMetadata,
-        _computed: AppInboxCompletionComputed<Result>,
-        _write: (transaction: PSqlSql) => Promise<void>
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result> {
-        throw new Error('Computed transaction path must not run');
+        this.actions.push('transaction');
+        await write(this.transaction);
+        return computed.durableResult;
     }
 
     async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
@@ -226,10 +230,9 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
 
     async writeMutation<Result>(
         _context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
+        _write: (transaction: PSqlSql) => Promise<Result>
     ): Promise<Result> {
-        this.actions.push('transaction');
-        return await write(this.transaction);
+        throw new Error('Legacy compute-in-write transaction path must not run');
     }
 
     async writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(


### PR DESCRIPTION
## Summary
- compute and validate auth AppInbox completion from the validated auth result before transaction entry
- restrict the transaction callback to writing the prepared auth mutation
- reject regression to the legacy compute-in-write transaction API in the phase-order test

## Review assessment
This is a small, direct migration with visible read → compute → validate → write dataflow. It introduces no helper layer, compatibility wrapper, post-compute preparation, or inner retry. The auth suite's scoped navigation scan reports one pre-existing indirect registration in untouched `app-auth-inbox-service.ts`; this PR does not worsen or depend on it.

The aggregate stack remains not merge-ready while other domain handlers retain legacy transaction finalization.

## Evidence
- RED: strict recording writer rejected the handler's legacy API call
- GREEN: auth suite 30 files / 108 tests passed
- shared-server TypeScript check passed
- governed test typecheck 1024 files / zero errors/debt
- transaction-write checker passed
- changed-file style check passed
- formatting and diff checks passed
