### PR TITLE
Finalize RTC RTT inbox results before transactions

### DIFF
--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
@@ -1,6 +1,11 @@
-import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
-import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
+import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupStateService } from '../../group-state/group-state-service-contracts.ts';
 import { computeRtcRttMutation } from '../mutation/compute-rtc-rtt-mutation.ts';
 import { readRtcRttMutation } from '../mutation/read-rtc-rtt-mutation.ts';
@@ -13,17 +18,13 @@ import {
 } from './rtc-rtt-app-inbox-authority.ts';
 import type {
     CreateRtcRttAppInboxEnqueueInput,
-    RtcRttAppInboxCommand,
     RtcRttAppInboxDependencies
 } from './rtc-rtt-app-inbox-contracts.ts';
 import { toRtcRttAppInboxResult, type RtcRttAppInboxResult } from './rtc-rtt-app-inbox-result.ts';
 
 export interface RtcRttAppInboxHandlerDependencies {
     readonly groupStateService: GroupStateService;
-    readonly writeMutation: (
-        context: AppInboxMessageContext<RtcRttAppInboxResult>,
-        write: (transaction: PSqlSql) => Promise<RtcRttAppInboxResult>
-    ) => Promise<RtcRttAppInboxResult>;
+    readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly nowEpochMs: () => number;
     readonly wakeQueue?: () => void;
 }
@@ -82,9 +83,20 @@ export class RtcRttAppInboxHandler {
         };
         const computed = computeRtcRttMutation({ command, read, facts });
         validateRtcRttMutation({ command, read, facts, computed });
+        const durableResult = toRtcRttAppInboxResult(computed, authority.command.requestId);
+        const completionInput = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const completionIssues = validateAppInboxCompletion(completionInput, completion);
+        if (completionIssues[0] !== undefined) {
+            throw completionIssues[0].cause;
+        }
         const result = await this.commitMutation({
             context,
-            command: authority.command,
+            completion,
             computed,
             mutationDependencies: rtcRttDependencies
         });
@@ -105,23 +117,26 @@ export class RtcRttAppInboxHandler {
     }
 
     private async commitMutation(input: CommitRtcRttMutationInput): Promise<RtcRttAppInboxResult> {
-        const { context, command, computed } = input;
-        return await this.dependencies.writeMutation(context, async (transaction) => {
-            if (computed.outcome === 'write') {
-                await writeRtcRttMutation({
-                    transaction,
-                    computed,
-                    outboxWriter: input.mutationDependencies.outboxWriter
-                });
+        const { context, computed } = input;
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            input.completion,
+            async (transaction) => {
+                if (computed.outcome === 'write') {
+                    await writeRtcRttMutation({
+                        transaction,
+                        computed,
+                        outboxWriter: input.mutationDependencies.outboxWriter
+                    });
+                }
             }
-            return toRtcRttAppInboxResult(computed, command.requestId);
-        });
+        );
     }
 }
 
 interface CommitRtcRttMutationInput {
     readonly context: AppInboxMessageContext<RtcRttAppInboxResult>;
-    readonly command: RtcRttAppInboxCommand;
+    readonly completion: AppInboxCompletionComputed<RtcRttAppInboxResult>;
     readonly computed: ReturnType<typeof computeRtcRttMutation>;
     readonly mutationDependencies: RtcRttAppInboxDependencies;
 }

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-inbox-service.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-inbox-service.ts
@@ -64,8 +64,7 @@ export class RtcRttInboxService {
         const handlers = handlerRuntime.registry;
         this.handler = new RtcRttAppInboxHandler({
             groupStateService: dependencies.groupStateService,
-            writeMutation: async (context, write) =>
-                await handlerRuntime.transactionWriter.writeMutation(context, write),
+            transactionWriter: handlerRuntime.transactionWriter,
             nowEpochMs: config.options?.nowEpochMs ?? Date.now,
             wakeQueue: config.wakeOwningQueue
         });


### PR DESCRIPTION
## Summary
- compute and validate the RTC RTT durable result and AppInbox completion before transaction entry
- replace the callback-shaped transaction seam with the typed AppInbox transaction writer
- leave only prepared RTT/admission/receipt/outbox writes inside the transaction callback

## Review assessment
This removes an unnecessary callback indirection and makes the phase order visible in one handler. It adds no new abstraction, compatibility path, or retry loop. Scoped navigation reports zero findings and classifies all effect ports as legitimate named boundaries.

The repository-wide authoritative ownership test is already stale on this stack for unrelated auth/topology symbol changes; it was not broadened into this two-file RTC PR. That aggregate test remains an explicit later closure item. The aggregate stack is not merge-ready yet.

## Evidence
- intended RED: ownership check could not find pre-transaction RTC durable-result construction or strict writer use
- RTC RTT suite 10 files / 92 tests passed
- shared-server TypeScript check passed
- governed test typecheck 1024 files / zero errors/debt
- transaction-write checker passed
- changed-file style and scoped navigation checks passed
- formatting and diff checks passed
