### PR TITLE
Finalize topology inbox results before transactions

### DIFF
--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -1,6 +1,12 @@
 import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 
 import { type AppInboxEnqueueInput, type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { PersistedAuthSession } from '../../auth/persistence/persisted-auth-session.ts';
@@ -30,7 +36,10 @@ import type { TopologyReconfigureAppInboxAuthority } from './topology-app-inbox-
 
 export interface TopologyAppInboxHandlerDependencies {
     readonly groupStateService: Pick<GroupStateService, 'readIssuedAuthSession'>;
-    readonly transactionWriter: Pick<AppInboxMutationTransactionWriter, 'writeMutation'>;
+    readonly transactionWriter: Pick<
+        AppInboxMutationTransactionWriter,
+        'readCompletionFacts' | 'writeComputedMutation'
+    >;
     readonly nowEpochMs: () => number;
     readonly wakeQueue?: () => void;
 }
@@ -193,13 +202,15 @@ export class TopologyAppInboxHandler {
                 computed.receivedCommandHash
             );
         }
-        const result = await this.dependencies.transactionWriter.writeMutation(
+        const durableResult = toTopologyConfigMutationResult(computed);
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
                 if (computed.outcome === 'write' || computed.outcome === 'claim') {
                     await owners.configMutationService.write(transaction, computed);
                 }
-                return toTopologyConfigMutationResult(computed);
             }
         );
         if (computed.outcome === 'write') {
@@ -230,20 +241,39 @@ export class TopologyAppInboxHandler {
         const read = await mutation.read(command);
         const computed = mutation.compute(command, read);
         mutation.validate(command, read, computed);
-        const result = await this.dependencies.transactionWriter.writeMutation(
+        const durableResult = {
+            status: 'queued',
+            groupRef: command.groupRef,
+            requestId: command.commandId,
+            outboxId: computed.resourceId
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
                 await mutation.write(transaction, computed);
-                return {
-                    status: 'queued',
-                    groupRef: command.groupRef,
-                    requestId: command.commandId,
-                    outboxId: computed.resourceId
-                } as const;
             }
         );
         mutation.recordCommittedWrite();
         this.dependencies.wakeQueue?.();
         return result;
+    }
+
+    private readComputeValidateCompletion<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionComputed<Result> {
+        const input = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        return computed;
     }
 }

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -6,6 +6,7 @@ import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import type { EffectiveGroupTopologyConfig, StoredGroupTopologyConfig } from '@shared/api/graph-topology-management-types.ts';
 import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
 
 import type { PersistedAuthSession } from '@shared-server/rallar-system/auth/persistence/persisted-auth-session.ts';
@@ -118,11 +119,15 @@ describe('TopologyAppInboxHandler', () => {
             nowEpochMs: () => NOW_EPOCH_MS,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => {
+                readCompletionFacts: (context) => {
+                    phases.push('completion');
+                    return { entry: context.entry, completedAtEpochMs: NOW_EPOCH_MS };
+                },
+                writeComputedMutation: async (_context, computed, write) => {
                     phases.push('transaction');
-                    const result = await write({} as PSqlSql);
+                    await write({} as PSqlSql);
                     phases.push('commit');
-                    return result;
+                    return computed.durableResult;
                 }
             }
         });
@@ -132,6 +137,7 @@ describe('TopologyAppInboxHandler', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write',
             'commit',
@@ -143,7 +149,7 @@ describe('TopologyAppInboxHandler', () => {
     it('rejects idempotency conflict before transaction or wake', async () => {
         const phases: string[] = [];
         const context = await topologyContext(phases);
-        const writeMutation = async () => {
+        const unreachableTransaction = (): never => {
             phases.push('transaction');
             throw new Error('Idempotency conflicts must not open a transaction');
         };
@@ -170,7 +176,10 @@ describe('TopologyAppInboxHandler', () => {
         const handler = new TopologyAppInboxHandler({
             groupStateService: sessionReader(phases),
             nowEpochMs: () => NOW_EPOCH_MS,
-            transactionWriter: { writeMutation },
+            transactionWriter: {
+                readCompletionFacts: unreachableTransaction,
+                writeComputedMutation: async () => unreachableTransaction()
+            },
             wakeQueue
         });
 
@@ -209,11 +218,15 @@ describe('TopologyAppInboxHandler', () => {
             nowEpochMs: () => NOW_EPOCH_MS,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => {
+                readCompletionFacts: (context) => {
+                    phases.push('completion');
+                    return { entry: context.entry, completedAtEpochMs: NOW_EPOCH_MS };
+                },
+                writeComputedMutation: async (_context, computed, write) => {
                     phases.push('transaction');
-                    const result = await write({} as PSqlSql);
+                    await write({} as PSqlSql);
                     phases.push('commit');
-                    return result;
+                    return computed.durableResult;
                 }
             }
         });
@@ -227,6 +240,7 @@ describe('TopologyAppInboxHandler', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write',
             'commit',
@@ -325,6 +339,7 @@ function createMessageContext(
         encodeResult: (result) => encodeAppInboxResult(result, 'Topology handler test result'),
         entry: {
             ...entry,
+            status: EntityStatus.RESERVED,
             dequeueAudit: { ...entry.dequeueAudit, attempts: 7 }
         }
     };

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
@@ -34,6 +34,7 @@ import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/inbox-queue-reader.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
 
@@ -389,7 +390,14 @@ describe('topology AppInbox transaction and idempotency', () => {
             nowEpochMs: () => harness.nowEpochMs,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => await harness.database.begin(write)
+                readCompletionFacts: (context) => ({
+                    entry: context.entry,
+                    completedAtEpochMs: harness.nowEpochMs
+                }),
+                writeComputedMutation: async (_context, computed, write) => {
+                    await harness.database.begin(write);
+                    return computed.durableResult;
+                }
             }
         });
 
@@ -398,7 +406,11 @@ describe('topology AppInbox transaction and idempotency', () => {
                 {
                     enqueue: wireEnqueue,
                     message,
-                    entry: { ...entry, dequeueAudit: { ...entry.dequeueAudit, attempts: 1 } },
+                    entry: {
+                        ...entry,
+                        status: EntityStatus.RESERVED,
+                        dequeueAudit: { ...entry.dequeueAudit, attempts: 1 }
+                    },
                     encodeResult: (result) => encodeAppInboxResult(result, 'Topology transaction test result')
                 } satisfies AppInboxMessageContext<TopologyAppInboxResult>,
                 management.mutationOwners


### PR DESCRIPTION
## Summary
- compute and validate config and reconfigure AppInbox results before transaction entry
- restrict both transaction callbacks to prepared topology mutation writes
- strengthen phase-order fixtures to require completion before transaction and represent reserved entries accurately

## Review assessment
The handler keeps both operation branches visible and shares only the operation-neutral completion validation helper. No post-compute preparation, compatibility layer, or retry loop was added. Full topology behavior remains green. Scoped navigation reports one pre-existing indirect registration in untouched `topology-inbox-service.ts`; this PR neither worsens nor depends on it.

The aggregate stack remains not merge-ready while group/presence and the legacy writer API remain.

## Evidence
- RED: strict test writers exposed both legacy topology transaction calls
- focused transaction tests 11/11 passed
- topology suite 60 files passed / 3 skipped; 513 tests passed / 5 skipped
- shared-server and governed test typechecks passed (1024 files, zero errors/debt)
- transaction-write checker passed
- changed-file style check passed
- formatting and diff checks passed
