### PR TITLE
Finalize group presence cleanup before transactions

### DIFF
--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
@@ -243,8 +243,9 @@ export class GroupStateInboxService {
                 await processGroupSessionCleanup({
                     facts: payload,
                     attemptCount: context.entry.dequeueAudit.attempts,
+                    context,
                     groupStateService: this.groupStateService,
-                    writeMutation: async (write) => await this.transactionWriter.writeMutation(context, write),
+                    transactionWriter: this.transactionWriter,
                     wakeQueue: this.wakeQueue
                 })
         });

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -1,8 +1,13 @@
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
-import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
+import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import { decodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
 import {
     validateWsSessionConnectGuard,
@@ -20,10 +25,6 @@ import type {
 } from '../group-state-service-contracts.ts';
 import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
 import type { GroupPresenceSessionCleanupAppInboxPayload } from './group-presence-session-cleanup-app-inbox-payload.ts';
-
-type WriteMutation = <Result>(
-    write: (transaction: PSqlSql) => Promise<Result>
-) => Promise<Result>;
 
 export interface InactiveGroupPresenceResult {
     readonly status: 'inactive';
@@ -123,8 +124,9 @@ export async function processGroupSessionCleanup(
     input: Readonly<{
         facts: GroupPresenceSessionCleanupAppInboxPayload;
         attemptCount: number;
+        context: AppInboxMessageContext<GroupSessionCleanupResult>;
         groupStateService: GroupStateService;
-        writeMutation: WriteMutation;
+        transactionWriter: Pick<AppInboxMutationTransactionWriter, 'readCompletionFacts' | 'writeComputedMutation'>;
         wakeQueue?: () => void;
     }>
 ): Promise<GroupSessionCleanupResult> {
@@ -153,20 +155,34 @@ export async function processGroupSessionCleanup(
             return computed;
         })
     );
-    const result = await input.writeMutation(async (transaction) => {
-        await lifecycle.write(transaction, lifecycleComputed);
-        for (const computed of mutations) {
-            if (computed.outcome === 'write') {
-                await input.groupStateService.write(transaction, computed);
+    const durableResult = {
+        status: 'inactive',
+        sessionId: input.facts.connection.authSession.sessionId,
+        generationId: input.facts.connection.generationId,
+        affectedGroups: mutations.length
+    } as const;
+    const completionInput = {
+        ...input.transactionWriter.readCompletionFacts(input.context),
+        durableResult,
+        status: EntityStatus.COMPLETED
+    } as const;
+    const completion = computeAppInboxCompletion(completionInput);
+    const completionIssues = validateAppInboxCompletion(completionInput, completion);
+    if (completionIssues[0] !== undefined) {
+        throw completionIssues[0].cause;
+    }
+    const result = await input.transactionWriter.writeComputedMutation(
+        input.context,
+        completion,
+        async (transaction) => {
+            await lifecycle.write(transaction, lifecycleComputed);
+            for (const computed of mutations) {
+                if (computed.outcome === 'write') {
+                    await input.groupStateService.write(transaction, computed);
+                }
             }
         }
-        return {
-            status: 'inactive',
-            sessionId: input.facts.connection.authSession.sessionId,
-            generationId: input.facts.connection.generationId,
-            affectedGroups: mutations.length
-        } as const;
-    });
+    );
     input.wakeQueue?.();
     return result;
 }


### PR DESCRIPTION
## Summary
- compute and validate group-session cleanup completion before transaction entry
- pass the typed AppInbox transaction writer instead of a result-producing callback
- restrict the transaction callback to lifecycle and prepared group mutation writes

## Review assessment
The cleanup durable result is now explicit before the write boundary, with wake-up remaining after commit and no inner retry. The existing `prepareSessionCleanupMutations` call occurs before each mutation's read/compute/validate flow; this PR does not introduce a post-compute prepare phase.

Scoped navigation identifies an existing indirect group-handler registration in the touched service file. The changed-range style gate confirms this PR does not add or worsen it; replacing the fixed registration inventory is a separate navigation cleanup, not necessary to understand this two-line wiring change. The aggregate stack remains not merge-ready until the main group handler and legacy writer API are resolved.

## Evidence
- group-state suite 79 files / 446 tests passed; 3 tests skipped
- WS-close convergence 8/8 passed
- shared-server and governed test typechecks passed (1024 files, zero errors/debt)
- transaction-write checker passed
- changed-file style check passed
- formatting and diff checks passed
