### PR TITLE
Add exact group event point reads

### DIFF
--- a/apps/api-v1/test/db/pglite-state-event-validation.test.ts
+++ b/apps/api-v1/test/db/pglite-state-event-validation.test.ts
@@ -46,6 +46,7 @@ Deno.test('PSql group event reads fail closed on a wrong-scope payload', async (
 
         for (
             const read of [
+                () => repository.readGroupEvent(expectedRef, corruptEvent.eventId),
                 () => repository.listGroupEvents(expectedRef),
                 () => repository.listRecentGroupEvents(expectedRef),
                 () => repository.listGroupEventPage(expectedRef, { limit: 10 })
@@ -93,6 +94,7 @@ Deno.test(
 
             for (
                 const read of [
+                    () => repository.readGroupEvent(ref, incompleteEvent.eventId),
                     () => repository.listGroupEvents(ref),
                     () => repository.listRecentGroupEvents(ref),
                     () => repository.listGroupEventPage(ref, { limit: 1 })

--- a/packages/shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-repository.ts
@@ -92,6 +92,10 @@ export class GroupAggregateRepository extends RuntimeStateJsonStore {
         return await this.events.listGroupEvents(ref);
     }
 
+    async readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return await this.events.readGroupEvent(ref, eventId);
+    }
+
     async listRecentEvents(
         ref: GroupRef,
         query: StateEventListQuery = {}

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
@@ -143,6 +143,10 @@ export class GroupStateRepository extends GroupStateRepositoryReads {
         return await this.aggregate.listEvents(ref);
     }
 
+    async readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return await this.aggregate.readEvent(ref, eventId);
+    }
+
     async listRecentEvents(
         ref: GroupRef,
         query: StateEventListQuery = {}

--- a/packages/shared-server/rallar-system/state-events/group-state-event-store.ts
+++ b/packages/shared-server/rallar-system/state-events/group-state-event-store.ts
@@ -5,6 +5,7 @@ import type { StateEventListQuery } from './state-event-listing.ts';
 
 export interface GroupStateEventStore {
     appendGroupEvent(event: GroupEvent): Promise<void>;
+    readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined>;
     listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]>;
     listRecentGroupEvents(
         ref: GroupRef,

--- a/packages/shared-server/rallar-system/state-events/in-memory-group-state-event-store.ts
+++ b/packages/shared-server/rallar-system/state-events/in-memory-group-state-event-store.ts
@@ -19,6 +19,10 @@ export class InMemoryGroupStateEventStore implements GroupStateEventStore {
         }
     }
 
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return this.events.find((event) => isGroupEventForRef(event, ref) && event.eventId === eventId);
+    }
+
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         return this.events
             .filter((event) => isGroupEventForRef(event, ref))

--- a/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-queries.ts
+++ b/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-queries.ts
@@ -71,6 +71,22 @@ export async function readAllPSqlGroupStateEventRows(
     `;
 }
 
+export async function readPSqlGroupStateEventRow(
+    sql: PSqlSql,
+    ref: GroupRef,
+    eventId: string
+): Promise<GroupStateEventRow | undefined> {
+    const [row] = await sql<GroupStateEventRow[]>`
+        select event_id, event_type, snapshot_version, occurred_at_epoch_ms, event_json
+        from group_state_events
+        where application_id = ${ref.applicationId}
+          and workspace_key = ${groupStateEventWorkspaceKey(ref.workspaceId)}
+          and group_id = ${ref.groupId}
+          and event_id = ${eventId}
+    `;
+    return row;
+}
+
 export async function readRecentPSqlGroupStateEventRows(
     input: GroupStateEventRowsQuery
 ): Promise<readonly GroupStateEventRow[]> {

--- a/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts
+++ b/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts
@@ -15,6 +15,7 @@ import {
     readAllPSqlGroupStateEventRows,
     readPSqlGroupStateEventCollision,
     readPSqlGroupStateEventPageRows,
+    readPSqlGroupStateEventRow,
     readRecentPSqlGroupStateEventRows
 } from './p-sql-group-state-event-queries.ts';
 
@@ -40,6 +41,11 @@ export class PSqlGroupStateEventRepository implements GroupStateEventStore {
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         const rows = await readAllPSqlGroupStateEventRows(this.sql, ref);
         return rows.map((row) => toValidatedGroupStateEvent(row, ref));
+    }
+
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        const row = await readPSqlGroupStateEventRow(this.sql, ref, eventId);
+        return row === undefined ? undefined : toValidatedGroupStateEvent(row, ref);
     }
 
     async listRecentGroupEvents(

--- a/packages/shared-test/shared-server/test-group-state-event-store.ts
+++ b/packages/shared-test/shared-server/test-group-state-event-store.ts
@@ -25,6 +25,10 @@ export class TestGroupStateEventStore implements GroupStateEventStore {
         }
     }
 
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return this.events.find((event) => isEventForRef(event, ref) && event.eventId === eventId);
+    }
+
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         return this.events
             .filter((event) => isEventForRef(event, ref))

--- a/packages/tests/shared-server/rallar-system/state-events/in-memory-group-state-event-collision.test.ts
+++ b/packages/tests/shared-server/rallar-system/state-events/in-memory-group-state-event-collision.test.ts
@@ -22,6 +22,10 @@ describe('in-memory group state event identity', () => {
         await store.appendGroupEvent(event);
         await store.appendGroupEvent(structuredClone(event));
 
+        await expect(store.readGroupEvent(event, event.eventId)).resolves.toBe(event);
+        await expect(
+            store.readGroupEvent({ ...event, groupId: 'another-group' }, event.eventId)
+        ).resolves.toBeUndefined();
         await expect(store.listGroupEvents(event)).resolves.toEqual([event]);
     });
 });


### PR DESCRIPTION
## Goal
Provide the exact persisted-event read needed to materialize group replay results before an AppInbox write transaction starts.

## Changes
- Add `readGroupEvent(ref, eventId)` to the group event-store contract.
- Implement scoped point reads in memory, PostgreSQL/PGlite, aggregate, and test repositories.
- Validate decoded PostgreSQL rows through the existing canonical event decoder.
- Add direct memory and PGlite coverage.

## Acceptance
- Exact reads are scoped by application, workspace, group, and event identity.
- Missing events return `undefined`; malformed persisted events still fail closed.
- No transaction, retry, or result-construction behavior changes in this PR.

## Validation
- PASS: in-memory event tests, 2/2.
- PASS: fresh-login-shell PGlite state-event validation, 9/9.
- PASS: changed-range repository style, repository structure, and diff checks.

## Risk and rollback
Low, additive internal repository capability. The SQL predicate uses the complete group scope and event id; rollback is the single commit.

## Follow-up
PR #437 consumes this point read to compute replay and snapshot results before transaction entry. No independent follow-up issue.