### PR TITLE
Compute group inbox results before transactions

### DIFF
--- a/apps/api-v1/src/composition/create-api-v1-mutation-runtime.ts
+++ b/apps/api-v1/src/composition/create-api-v1-mutation-runtime.ts
@@ -136,6 +136,7 @@ interface ApiV1MutationResources {
 
 interface CreateGroupStateInboxServiceFactoryInput extends ApiV1StateMutationDependencies {
     readonly groupStateService: ReturnType<typeof createCachedGroupStateService>;
+    readonly resultReader: ApiV1MutationResources['groupsRepository'];
     readonly groupFormationRecomputeDebounceMs: number;
 }
 
@@ -200,6 +201,7 @@ export function createApiV1MutationRuntime(
         createGroupStateInboxService: createGroupStateInboxServiceFactory({
             ...stateDependencies,
             groupStateService,
+            resultReader: resources.groupsRepository,
             groupFormationRecomputeDebounceMs: input.groupFormationRecomputeDebounceMs
         }),
         createAppClientInboxService: createAppClientInboxServiceFactory(stateDependencies),
@@ -323,7 +325,8 @@ function createGroupStateInboxServiceFactory(
                 resourceInboxRepository: input.resourceInboxRepository.entries,
                 resourceInboxResultsRepository: input.resourceInboxResultsRepository,
                 database: input.database,
-                groupStateService: input.groupStateService
+                groupStateService: input.groupStateService,
+                resultReader: input.resultReader
             },
             {
                 serviceId: input.serviceId,

--- a/apps/api-v1/test/db/pglite-group-state-and-auth.test.ts
+++ b/apps/api-v1/test/db/pglite-group-state-and-auth.test.ts
@@ -229,11 +229,13 @@ Deno.test(
             for (const joiningAuthority of joiningAuthorities) {
                 await authSessions.putSession(joiningAuthority);
             }
+            const groupEvents = new PSqlGroupStateEventRepository(sql);
+            const groups = new GroupStateRepository(runtime, groupEvents);
             const groupState = createGroupStateService({
                 readPlannedLayoutRow: () => Promise.resolve(null),
                 readAcceptedLayoutRow: () => Promise.resolve(null),
                 runtimeRepository: runtime,
-                groupStateEventStore: new PSqlGroupStateEventRepository(sql),
+                groupStateEventStore: groupEvents,
                 authSessionRepository: authSessions,
                 serviceId: 'pglite-group-service',
                 now: () => nowEpochMs
@@ -244,7 +246,8 @@ Deno.test(
                     resourceInboxRepository: resourceInbox.entries,
                     resourceInboxResultsRepository: resourceResults,
                     database: sql,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: groups
                 },
                 {
                     serviceId: 'pglite-group-service',
@@ -360,7 +363,7 @@ Deno.test(
                 groupId: 'vertical-group'
             };
             assert.equal(
-                (await new GroupStateRepository(runtime, new PSqlGroupStateEventRepository(runtime.sql)).findGroup(ref))?.displayName,
+                (await groups.findGroup(ref))?.displayName,
                 'Vertical Group'
             );
             assert.equal((await new PSqlGroupStateEventRepository(sql).listGroupEvents(ref)).length, 3);
@@ -437,11 +440,13 @@ Deno.test(
             };
             const authSessions = new AuthSessionRepository(runtime);
             await authSessions.putSession(authority);
+            const groupEvents = new PSqlGroupStateEventRepository(sql);
+            const groups = new GroupStateRepository(runtime, groupEvents);
             const groupState = createGroupStateService({
                 readPlannedLayoutRow: () => Promise.resolve(null),
                 readAcceptedLayoutRow: () => Promise.resolve(null),
                 runtimeRepository: runtime,
-                groupStateEventStore: new PSqlGroupStateEventRepository(sql),
+                groupStateEventStore: groupEvents,
                 authSessionRepository: authSessions,
                 serviceId: 'pglite-summary-fence',
                 now: () => nowEpochMs
@@ -452,7 +457,8 @@ Deno.test(
                     resourceInboxRepository: resourceInbox.entries,
                     resourceInboxResultsRepository: resourceResults,
                     database: sql,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: groups
                 },
                 {
                     serviceId: 'pglite-summary-fence',
@@ -519,8 +525,7 @@ Deno.test(
                 workspaceId: 'main',
                 groupId: 'fence-group'
             };
-            const repository = new GroupStateRepository(runtime, new PSqlGroupStateEventRepository(runtime.sql));
-            const summaryBefore = await repository.findPresenceSummaryEntry(ref);
+            const summaryBefore = await groups.findPresenceSummaryEntry(ref);
             const work = new GroupPresenceSummaryWork({
                 outboxQueueReader: new OutboxQueueReader(
                     new PSqlQueueBox(createPSqlResourceInboxRepository(sql))
@@ -541,7 +546,7 @@ Deno.test(
                 /reservation changed before commit/
             );
 
-            assert.deepEqual(await repository.findPresenceSummaryEntry(ref), summaryBefore);
+            assert.deepEqual(await groups.findPresenceSummaryEntry(ref), summaryBefore);
             const stillReserved = await resourceInbox.entries.findAnyByKey(key);
             assert.equal(stillReserved?.status, EntityStatus.RESERVED);
             assert.equal(stillReserved?.dequeueAudit.attempts, 1);

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
@@ -1,28 +1,47 @@
+import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { GroupFormationMutationOutcome } from '@shared/rtc/group-formation-metrics.ts';
 import { type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed,
+    type AppInboxCompletionInput
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupFormationGroupMutationSink } from '../../observability/formation-metrics.ts';
 import type { WsSessionGenerationLifecycleComputed } from '../../websocket/ws-session-generation-computation.ts';
+import { validateWsSessionConnectGuard } from '../../websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '../../websocket/ws-session-generation-lifecycle.ts';
 import type {
     AuthorizedGroupMutation,
     GroupMutationAuthority,
     GroupMutationPreparation,
     GroupStateMutationCommand,
-    GroupStateMutationService,
-    GroupStateService
+    GroupStateMutationService
 } from '../group-state-service-contracts.ts';
-import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
+import type { GroupMutationComputed, GroupMutationRead } from '../mutation/group-mutation-contracts.ts';
 import { toGroupMutationRejectionError } from '../mutation/group-mutation-result.ts';
-import { createTransactionBoundGroupStateRepository } from '../persistence/group-state-repository.ts';
-import { processGroupPresenceConnect, type InactiveGroupPresenceResult } from '../presence/group-presence-service.ts';
+import {
+    readAndComputeGroupPresenceConnect,
+    type InactiveGroupPresenceResult
+} from '../presence/group-presence-service.ts';
 import { decodeGroupStateInboxAuthority } from './decode-group-state-inbox-authority.ts';
-import { readGroupStateInboxResult, type GroupStateInboxDurableResult } from './group-state-inbox-result.ts';
+import {
+    computeGroupStateInboxResult,
+    validateGroupStateInboxResult,
+    type GroupStateInboxDurableResult
+} from './group-state-inbox-result.ts';
+
+export interface GroupStateInboxResultReader {
+    readSnapshot(ref: GroupRef): Promise<GroupSnapshot | undefined>;
+    readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined>;
+}
 
 export interface GroupStateInboxHandlerDependencies {
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
-    readonly snapshotObserver: Pick<GroupStateService, 'observeSnapshot'>;
+    readonly resultReader: GroupStateInboxResultReader;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly wakeQueue?: () => void;
     readonly formationMetrics?: GroupFormationGroupMutationSink;
@@ -39,8 +58,16 @@ export interface GroupStateInboxHandlerDependencies {
 interface CommitGroupStateMutationInput {
     readonly context: AppInboxMessageContext<GroupStateInboxDurableResult>;
     readonly command: GroupStateMutationCommand;
-    readonly computed: GroupMutationComputed;
+    readonly computed: Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>;
+    readonly durableResult: GroupStateInboxDurableResult;
+    readonly completion: AppInboxCompletionComputed<GroupStateInboxDurableResult>;
     readonly lifecycleGuard?: WsSessionGenerationLifecycleComputed;
+}
+
+interface GroupStateInboxResultRead {
+    readonly mutationRead: GroupMutationRead;
+    readonly currentSnapshot: GroupSnapshot | undefined;
+    readonly recordedEvent: GroupEvent | undefined;
 }
 
 export class GroupStateInboxHandler {
@@ -64,30 +91,88 @@ export class GroupStateInboxHandler {
             }
         };
         if (command.command.operation === 'connectPresence') {
-            const outcome = await processGroupPresenceConnect({
+            const outcome = await readAndComputeGroupPresenceConnect({
                 command,
                 mutationService: this.dependencies.mutationService,
                 sessionGenerationLifecycle: this.dependencies.sessionGenerationLifecycle
             });
             if (outcome.status === 'inactive') {
-                const durableResult = await this.dependencies.transactionWriter.writeMutation(
+                const completionInput = this.readCompletionInput(context, outcome);
+                const completion = computeAppInboxCompletion(completionInput);
+                this.validateCompletion(completionInput, completion);
+                const durableResult = await this.dependencies.transactionWriter.writeComputedMutation(
                     context,
-                    () => Promise.resolve(outcome)
+                    completion,
+                    async () => {}
                 );
                 this.recordGroupMutation(command, 'rejected');
                 return durableResult;
             }
+            if (!isCommittableMutation(outcome.computed)) {
+                this.dependencies.mutationService.validate(command, outcome.read, outcome.computed);
+                validateWsSessionConnectGuard(
+                    outcome.lifecycleGuardFacts,
+                    outcome.lifecycleRead,
+                    outcome.lifecycleGuard
+                );
+                throwNonCommittableMutation(outcome.computed);
+            }
+            const computed = outcome.computed;
+            const durableResult = computed.receipt;
+            const completionInput = this.readCompletionInput(context, durableResult);
+            const completion = computeAppInboxCompletion(completionInput);
+            this.dependencies.mutationService.validate(command, outcome.read, computed);
+            validateWsSessionConnectGuard(
+                outcome.lifecycleGuardFacts,
+                outcome.lifecycleRead,
+                outcome.lifecycleGuard
+            );
+            this.validateCompletion(completionInput, completion);
             return await this.commitMutation({
                 context,
                 command,
-                computed: outcome.computed,
+                computed,
+                durableResult,
+                completion,
                 lifecycleGuard: outcome.lifecycleGuard
             });
         }
-        const read = await this.dependencies.mutationService.read(command);
-        const computed = this.dependencies.mutationService.compute(command, read);
-        this.dependencies.mutationService.validate(command, read, computed);
-        return await this.commitMutation({ context, command, computed });
+        const resultRead = await this.readResultFacts(command);
+        const computed = this.dependencies.mutationService.compute(command, resultRead.mutationRead);
+        if (!isCommittableMutation(computed)) {
+            this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed);
+            throwNonCommittableMutation(computed);
+        }
+        const resultInput = {
+            command,
+            read: resultRead.mutationRead,
+            computed,
+            currentSnapshot: resultRead.currentSnapshot,
+            recordedEvent: resultRead.recordedEvent
+        } as const;
+        const durableResult = computeGroupStateInboxResult(resultInput);
+        const completionInput = this.readCompletionInput(context, durableResult);
+        const completion = computeAppInboxCompletion(completionInput);
+        this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed);
+        validateGroupStateInboxResult(resultInput, durableResult);
+        this.validateCompletion(completionInput, completion);
+        return await this.commitMutation({ context, command, computed, durableResult, completion });
+    }
+
+    private async readResultFacts(command: GroupStateMutationCommand): Promise<GroupStateInboxResultRead> {
+        const readsSnapshot = !isPresenceOperation(command.command.operation);
+        const [mutationRead, currentSnapshot] = await Promise.all([
+            this.dependencies.mutationService.read(command),
+            readsSnapshot
+                ? this.dependencies.resultReader.readSnapshot(command.command.aggregateRef)
+                : Promise.resolve(undefined)
+        ]);
+        const receipt = mutationRead.idempotency?.value.receipt;
+        const recordedEvent =
+            readsSnapshot && receipt?.commandHash === command.facts.commandHash && receipt.eventId !== null
+                ? await this.dependencies.resultReader.readEvent(command.command.aggregateRef, receipt.eventId)
+                : undefined;
+        return { mutationRead, currentSnapshot, recordedEvent };
     }
 
     private async readOrPrepareGroupMutation(
@@ -108,12 +193,10 @@ export class GroupStateInboxHandler {
     private async commitMutation(
         input: CommitGroupStateMutationInput
     ): Promise<GroupStateInboxDurableResult> {
-        if (input.computed.outcome === 'rejected') {
-            throw toGroupMutationRejectionError(input.computed);
-        }
-        const { durableResult, afterCommitResult } = await this.dependencies.transactionWriter
-            .writeMutationWithAfterCommitResult(
+        const durableResult = await this.dependencies.transactionWriter
+            .writeComputedMutation(
                 input.context,
+                input.completion,
                 async (transaction) => {
                     if (input.lifecycleGuard) {
                         await this.dependencies.sessionGenerationLifecycle.write(
@@ -121,27 +204,11 @@ export class GroupStateInboxHandler {
                             input.lifecycleGuard
                         );
                     }
-                    if (input.computed.outcome === 'idempotency-conflict') {
-                        throw new TypeError('Validated group idempotency conflict is unreachable');
-                    }
                     if (input.computed.outcome === 'write') {
                         await this.dependencies.mutationService.write(transaction, input.computed);
                     }
-                    const inboxResult = await readGroupStateInboxResult({
-                        repository: createTransactionBoundGroupStateRepository(transaction),
-                        command: input.command,
-                        receipt: input.computed.receipt
-                    });
-                    return {
-                        durableResult: inboxResult.durableResult,
-                        afterCommitResult: { committedSnapshot: inboxResult.committedSnapshot }
-                    };
                 }
             );
-        const { committedSnapshot } = afterCommitResult;
-        if (committedSnapshot) {
-            await this.dependencies.snapshotObserver.observeSnapshot(committedSnapshot);
-        }
         this.dependencies.wakeQueue?.();
         this.recordGroupMutation(
             input.command,
@@ -150,6 +217,27 @@ export class GroupStateInboxHandler {
                 : 'noOp'
         );
         return durableResult;
+    }
+
+    private readCompletionInput<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionInput<Result> {
+        return {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+    }
+
+    private validateCompletion<Result>(
+        input: AppInboxCompletionInput<Result>,
+        computed: AppInboxCompletionComputed<Result>
+    ): void {
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
     }
 
     private recordGroupMutation(
@@ -166,4 +254,23 @@ export class GroupStateInboxHandler {
             // Recording must never affect group mutation behavior.
         }
     }
+}
+
+function isCommittableMutation(
+    computed: GroupMutationComputed
+): computed is Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }> {
+    return computed.outcome !== 'idempotency-conflict' && computed.outcome !== 'rejected';
+}
+
+function throwNonCommittableMutation(
+    computed: Extract<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>
+): never {
+    if (computed.outcome === 'idempotency-conflict') {
+        throw new TypeError('Validated group idempotency conflict is unreachable');
+    }
+    throw toGroupMutationRejectionError(computed);
+}
+
+function isPresenceOperation(operation: GroupStateMutationCommand['command']['operation']): boolean {
+    return operation === 'connectPresence' || operation === 'heartbeatPresence' || operation === 'disconnectPresence';
 }

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
@@ -1,24 +1,66 @@
-import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { GroupEvent, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
 
 import type { GroupStateMutationCommand } from '../group-state-service-contracts.ts';
 import type { GroupJoinCodeWritten, GroupStateWritten } from '../group-state-service-contracts.ts';
-import type { GroupMutationReceipt } from '../mutation/group-mutation-contracts.ts';
-import type { GroupStateRepository } from '../persistence/group-state-repository.ts';
+import type {
+    GroupMutationComputed,
+    GroupMutationRead,
+    GroupMutationReceipt
+} from '../mutation/group-mutation-contracts.ts';
+import { assembleGroupStateSnapshot } from '../persistence/assemble-group-state-snapshot.ts';
+import { GroupStateRepositoryInvariantCorruptionError } from '../persistence/group-state-persistence-contracts.ts';
+import { groupStateMemberStorageKey } from '../persistence/membership/group-membership-storage-key.ts';
 import type { InactiveGroupPresenceResult } from '../presence/group-presence-service.ts';
 
 export type GroupPresenceInboxDurableResult = GroupMutationReceipt | InactiveGroupPresenceResult;
 
 export type GroupStateInboxDurableResult = GroupPresenceInboxDurableResult | GroupJoinCodeWritten | GroupStateWritten;
 
-export interface GroupStateInboxResult {
-    readonly durableResult: GroupStateInboxDurableResult;
-    readonly committedSnapshot: GroupSnapshot | undefined;
+export interface ComputeGroupStateInboxResultInput {
+    readonly command: GroupStateMutationCommand;
+    readonly read: GroupMutationRead;
+    readonly computed: Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>;
+    readonly currentSnapshot: GroupSnapshot | undefined;
+    readonly recordedEvent: GroupEvent | undefined;
 }
 
-export interface ReadGroupStateInboxResultInput {
-    readonly repository: GroupStateRepository;
-    readonly command: GroupStateMutationCommand;
-    readonly receipt: GroupMutationReceipt;
+export class GroupStateInboxResultReadConflictError extends Error {
+    readonly code = 'runtime-state-write-conflict';
+
+    constructor() {
+        super('Group state result snapshot no longer matches the mutation read.');
+        this.name = 'GroupStateInboxResultReadConflictError';
+    }
+}
+
+export function computeGroupStateInboxResult(input: ComputeGroupStateInboxResultInput): GroupStateInboxDurableResult {
+    if (isPresenceOperation(input.command.command.operation)) {
+        return input.computed.receipt;
+    }
+    assertSnapshotMatchesRead(input.currentSnapshot, input.read);
+    const snapshot = input.computed.outcome === 'write'
+        ? assembleCommittedSnapshot(input, input.computed)
+        : input.currentSnapshot;
+    if (snapshot === undefined) {
+        throw new GroupStateInboxResultReadConflictError();
+    }
+    const event = input.computed.outcome === 'write'
+        ? input.computed.event
+        : readRecordedEvent(input.recordedEvent, input.computed.receipt);
+    return input.command.command.operation === 'rotateGroupJoinCode'
+        ? toJoinCodeResult(input.computed.receipt, snapshot, event)
+        : toGroupMutationResult({ command: input.command, receipt: input.computed.receipt, snapshot, event });
+}
+
+export function validateGroupStateInboxResult(
+    input: ComputeGroupStateInboxResultInput,
+    computed: GroupStateInboxDurableResult
+): void {
+    const expected = computeGroupStateInboxResult(input);
+    if (JSON.stringify(computed) !== JSON.stringify(expected)) {
+        throw new TypeError('Computed group-state inbox result does not match its inputs.');
+    }
 }
 
 interface ToGroupMutationResultInput {
@@ -28,25 +70,77 @@ interface ToGroupMutationResultInput {
     readonly event: GroupEvent | null;
 }
 
-export async function readGroupStateInboxResult(
-    input: ReadGroupStateInboxResultInput
-): Promise<GroupStateInboxResult> {
-    const snapshot = await input.repository.readSnapshot(input.command.command.aggregateRef);
-    if (isPresenceOperation(input.command.command.operation)) {
-        return { durableResult: input.receipt, committedSnapshot: snapshot };
+function assertSnapshotMatchesRead(
+    snapshot: GroupSnapshot | undefined,
+    read: GroupMutationRead
+): void {
+    if (read.group === null) {
+        if (snapshot !== undefined) {
+            throw new GroupStateInboxResultReadConflictError();
+        }
+        return;
     }
-    if (!snapshot) {
-        throw new TypeError(`Group snapshot not found after ${input.command.command.operation}`);
+    if (
+        snapshot === undefined ||
+        !jsonEquals(snapshot.group, read.group.value) ||
+        snapshot.causalRevision.groupRevision !== read.group.value.snapshotVersion ||
+        snapshot.causalRevision.presenceRevision !==
+            (read.presenceSummary?.value.causalRevision.presenceRevision ?? 0)
+    ) {
+        throw new GroupStateInboxResultReadConflictError();
     }
-    const event = await readReceiptEvent(
-        input.repository,
-        input.command.command.aggregateRef,
-        input.receipt
+}
+
+function assembleCommittedSnapshot(
+    input: ComputeGroupStateInboxResultInput,
+    computed: Extract<GroupMutationComputed, { outcome: 'write'; }>
+): GroupSnapshot {
+    if (computed.guard.kind !== 'group') {
+        throw new TypeError('Presence mutations do not assemble group snapshots.');
+    }
+    return assembleGroupStateSnapshot(
+        {
+            group: computed.guard.value,
+            members: mergeMembers(input.currentSnapshot?.members ?? [], computed.members),
+            summary: computed.initialPresenceSummary?.value ?? input.read.presenceSummary?.value,
+            authoritativeSessions: input.currentSnapshot?.activeSessions ?? [],
+            groupRevision: computed.guard.value.snapshotVersion,
+            observedAtEpochMs: input.command.facts.nowEpochMs,
+            sessionLeaseFields: 'authoritative'
+        },
+        (storageKey, message) => new GroupStateRepositoryInvariantCorruptionError(storageKey, message)
     );
-    const durableResult = input.command.command.operation === 'rotateGroupJoinCode'
-        ? toJoinCodeResult(input.receipt, snapshot, event)
-        : toGroupMutationResult({ command: input.command, receipt: input.receipt, snapshot, event });
-    return { durableResult, committedSnapshot: snapshot };
+}
+
+function mergeMembers(
+    current: readonly GroupMember[],
+    changed: readonly GroupMember[]
+): readonly GroupMember[] {
+    const members = new Map(current.map((member) => [groupStateMemberStorageKey(member), member]));
+    for (const member of changed) {
+        members.set(groupStateMemberStorageKey(member), member);
+    }
+    return [...members.entries()]
+        .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+        .map(([, member]) => member);
+}
+
+function readRecordedEvent(
+    event: GroupEvent | undefined,
+    receipt: GroupMutationReceipt
+): GroupEvent | null {
+    if (receipt.eventId === null) {
+        return null;
+    }
+    if (
+        event === undefined ||
+        event.eventId !== receipt.eventId ||
+        event.snapshotVersion !== receipt.snapshotVersion ||
+        event.requestId !== receipt.requestId
+    ) {
+        throw new TypeError(`Group mutation event not found: ${receipt.eventId}`);
+    }
+    return event;
 }
 
 function isPresenceOperation(
@@ -57,23 +151,6 @@ function isPresenceOperation(
         operation === 'heartbeatPresence' ||
         operation === 'disconnectPresence'
     );
-}
-
-async function readReceiptEvent(
-    repository: GroupStateRepository,
-    ref: GroupRef,
-    receipt: GroupMutationReceipt
-): Promise<GroupEvent | null> {
-    if (receipt.eventId === null) {
-        return null;
-    }
-    const event = (await repository.listEvents(ref)).find(
-        (candidate) => candidate.eventId === receipt.eventId
-    );
-    if (!event) {
-        throw new TypeError(`Group mutation event not found: ${receipt.eventId}`);
-    }
-    return event;
 }
 
 function toJoinCodeResult(

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
@@ -39,7 +39,10 @@ import {
     isAuthenticatedGroupMutationEnqueue,
     type AuthenticatedGroupMutationEnqueue
 } from './group-state-inbox-contracts.ts';
-import { GroupStateInboxHandler } from './group-state-inbox-handler.ts';
+import {
+    GroupStateInboxHandler,
+    type GroupStateInboxResultReader
+} from './group-state-inbox-handler.ts';
 import { decodeGroupStateInboxDurableResult } from './group-state-inbox-result-codec.ts';
 import type { GroupStateInboxDurableResult } from './group-state-inbox-result.ts';
 import { toGroupMutationDescriptor } from './to-group-mutation-descriptor.ts';
@@ -51,6 +54,7 @@ export namespace GroupStateInboxService {
         readonly resourceInboxResultsRepository: AppInboxResultRepository;
         readonly database: PSqlSql;
         readonly groupStateService: GroupStateService;
+        readonly resultReader: GroupStateInboxResultReader;
     }
 
     export interface Config {
@@ -107,7 +111,7 @@ export class GroupStateInboxService {
         this.groupStateInboxHandler = new GroupStateInboxHandler({
             mutationService: this.groupStateService,
             sessionGenerationLifecycle: this.groupStateService.sessionGenerationLifecycle,
-            snapshotObserver: this.groupStateService,
+            resultReader: dependencies.resultReader,
             transactionWriter: this.transactionWriter,
             wakeQueue: this.wakeQueue,
             formationMetrics: config.formationMetrics,

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -13,7 +13,9 @@ import {
     validateWsSessionConnectGuard,
     validateWsSessionGenerationClosed,
     type WsSessionGenerationCloseFacts,
+    type WsSessionGenerationGuardFacts,
     type WsSessionGenerationLifecycleComputed,
+    type WsSessionGenerationLifecycleRead,
     type WsSessionHighWaterIdentity
 } from '../../websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '../../websocket/ws-session-generation-lifecycle.ts';
@@ -24,6 +26,7 @@ import type {
     GroupStateService
 } from '../group-state-service-contracts.ts';
 import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
+import type { GroupMutationRead } from '../mutation/group-mutation-contracts.ts';
 import type { GroupPresenceSessionCleanupAppInboxPayload } from './group-presence-session-cleanup-app-inbox-payload.ts';
 
 export interface InactiveGroupPresenceResult {
@@ -37,10 +40,13 @@ export type GroupPresenceConnectOutcome =
     | Readonly<{
         status: 'ready-to-commit';
         computed: GroupMutationComputed;
+        read: GroupMutationRead;
+        lifecycleGuardFacts: WsSessionGenerationGuardFacts;
+        lifecycleRead: WsSessionGenerationLifecycleRead;
         lifecycleGuard: WsSessionGenerationLifecycleComputed;
     }>;
 
-interface ProcessGroupPresenceConnectInput {
+interface ReadAndComputeGroupPresenceConnectInput {
     readonly command: GroupStateMutationCommand;
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
@@ -84,8 +90,8 @@ export function toExpiredPresenceEnqueue(
     };
 }
 
-export async function processGroupPresenceConnect(
-    input: ProcessGroupPresenceConnectInput
+export async function readAndComputeGroupPresenceConnect(
+    input: ReadAndComputeGroupPresenceConnectInput
 ): Promise<GroupPresenceConnectOutcome> {
     const operation = input.command.command;
     if (operation.operation !== 'connectPresence') {
@@ -108,7 +114,6 @@ export async function processGroupPresenceConnect(
     }
     const read = await input.mutationService.read(input.command);
     const computed = input.mutationService.compute(input.command, read);
-    input.mutationService.validate(input.command, read, computed);
     const lifecycleGuardFacts = {
         ...identity,
         generationId: operation.input.generationId,
@@ -116,8 +121,7 @@ export async function processGroupPresenceConnect(
         expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(observedAtEpochMs)
     };
     const lifecycleGuard = lifecycle.computeConnectGuard(lifecycleGuardFacts, lifecycleRead);
-    validateWsSessionConnectGuard(lifecycleGuardFacts, lifecycleRead, lifecycleGuard);
-    return { status: 'ready-to-commit', computed, lifecycleGuard };
+    return { status: 'ready-to-commit', computed, read, lifecycleGuardFacts, lifecycleRead, lifecycleGuard };
 }
 
 export async function processGroupSessionCleanup(
@@ -134,7 +138,6 @@ export async function processGroupSessionCleanup(
     const lifecycle = input.groupStateService.sessionGenerationLifecycle;
     const lifecycleRead = await lifecycle.read(closeFacts);
     const lifecycleComputed = lifecycle.computeClosed(closeFacts, lifecycleRead);
-    validateWsSessionGenerationClosed(closeFacts, lifecycleRead, lifecycleComputed);
     const preparations = await input.groupStateService.prepareSessionCleanupMutations({
         scope: input.facts.connection.scope,
         authSession: input.facts.connection.authSession,
@@ -151,8 +154,7 @@ export async function processGroupSessionCleanup(
             };
             const read = await input.groupStateService.read(command);
             const computed = input.groupStateService.compute(command, read);
-            input.groupStateService.validate(command, read, computed);
-            return computed;
+            return { command, read, computed };
         })
     );
     const durableResult = {
@@ -167,6 +169,10 @@ export async function processGroupSessionCleanup(
         status: EntityStatus.COMPLETED
     } as const;
     const completion = computeAppInboxCompletion(completionInput);
+    validateWsSessionGenerationClosed(closeFacts, lifecycleRead, lifecycleComputed);
+    for (const mutation of mutations) {
+        input.groupStateService.validate(mutation.command, mutation.read, mutation.computed);
+    }
     const completionIssues = validateAppInboxCompletion(completionInput, completion);
     if (completionIssues[0] !== undefined) {
         throw completionIssues[0].cause;
@@ -176,9 +182,9 @@ export async function processGroupSessionCleanup(
         completion,
         async (transaction) => {
             await lifecycle.write(transaction, lifecycleComputed);
-            for (const computed of mutations) {
-                if (computed.outcome === 'write') {
-                    await input.groupStateService.write(transaction, computed);
+            for (const mutation of mutations) {
+                if (mutation.computed.outcome === 'write') {
+                    await input.groupStateService.write(transaction, mutation.computed);
                 }
             }
         }

--- a/packages/tests/shared-server/integration/postgres/test-support/postgres-app-inbox-worker-services.ts
+++ b/packages/tests/shared-server/integration/postgres/test-support/postgres-app-inbox-worker-services.ts
@@ -74,9 +74,10 @@ export function createPostgresAppInboxWorkerServices(
         clientStateEventStore: new PSqlClientStateEventRepository(input.sql),
         serviceId: input.serviceId
     });
+    const groupEventStore = new PSqlGroupStateEventRepository(input.sql);
     const groupState = createGroupStateService({
         runtimeRepository,
-        groupStateEventStore: new PSqlGroupStateEventRepository(input.sql),
+        groupStateEventStore: groupEventStore,
         authSessionRepository: authSessions,
         now: () => input.atEpochMs,
         serviceId: input.serviceId,
@@ -103,7 +104,8 @@ export function createPostgresAppInboxWorkerServices(
             resourceInboxRepository: resourceInbox.entries,
             resourceInboxResultsRepository: resourceInboxResults,
             database: input.transactionSql,
-            groupStateService: groupState
+            groupStateService: groupState,
+            resultReader: createTestGroupStateRepository(runtimeRepository, groupEventStore)
         },
         {
             serviceId: input.serviceId,
@@ -113,7 +115,7 @@ export function createPostgresAppInboxWorkerServices(
     );
     const topologyGroupStateRepository = createTestGroupStateRepository(
         runtimeRepository,
-        new PSqlGroupStateEventRepository(input.sql)
+        groupEventStore
     );
     const topologyConfigRepository = new GroupTopologyConfigRepository(topologyRuntimeRepository);
     const topologyRuntimeOwners = createGroupTopologyRuntimeOwners({

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-expired-row-replacement.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-expired-row-replacement.test.ts
@@ -240,7 +240,11 @@ describe('AppInbox expired row replacement', () => {
                     resourceInboxRepository: queue,
                     resourceInboxResultsRepository: results,
                     database: database,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: {
+                        readSnapshot: (ref) => groupState.readSnapshot(ref),
+                        readEvent: (ref, eventId) => database.groupEventStore.readGroupEvent(ref, eventId)
+                    }
                 },
                 {
                     serviceId: 'expired-group-service'

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-ws-close-test-harness.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-ws-close-test-harness.ts
@@ -150,7 +150,14 @@ function installWsCloseReader(
             { serviceId: 'server-12345678' }
         ),
         group: new GroupStateInboxService(
-            { ...shared, groupStateService: dependencies.groupState },
+            {
+                ...shared,
+                groupStateService: dependencies.groupState,
+                resultReader: {
+                    readSnapshot: (ref) => dependencies.groupState.readSnapshot(ref),
+                    readEvent: (ref, eventId) => dependencies.database.groupEventStore.readGroupEvent(ref, eventId)
+                }
+            },
             { serviceId: 'server-12345678' }
         )
     };

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
@@ -247,6 +247,8 @@ describe('GroupStateInboxService authenticated authority', () => {
         const queue = new TestResourceInbox();
         const reader = new InboxQueueReader(queue);
         const results = new TestResourceInboxResults();
+        const eventStore = new InMemoryGroupStateEventStore();
+        const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
         const groupStateService = createGroupStateService(
             {
                 runtimeRepository,
@@ -254,7 +256,7 @@ describe('GroupStateInboxService authenticated authority', () => {
                 readPlannedLayoutRow: async () => null,
                 readAcceptedLayoutRow: async () => null,
                 now: () => nowEpochMs,
-                groupStateEventStore: new InMemoryGroupStateEventStore(),
+                groupStateEventStore: eventStore,
                 authSessionRepository: authSessions
             } as
                 & Parameters<typeof createGroupStateService>[0]
@@ -267,8 +269,12 @@ describe('GroupStateInboxService authenticated authority', () => {
                 inboxQueueReader: reader,
                 resourceInboxRepository: queue,
                 resourceInboxResultsRepository: results,
-                database: createAppInboxTestDatabase(queue, results, { runtimeRepository }),
-                groupStateService: groupStateService
+                database,
+                groupStateService,
+                resultReader: {
+                    readSnapshot: (ref) => groupStateService.readSnapshot(ref),
+                    readEvent: (ref, eventId) => eventStore.readGroupEvent(ref, eventId)
+                }
             },
             {
                 serviceId: 'server-12345678'

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -18,12 +18,15 @@ import type {
     GroupMutationAuthority,
     GroupMutationDescriptor,
     GroupMutationPreparation,
-    GroupStateMutationService,
-    GroupStateService
+    GroupStateMutationService
 } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import { createGroupStateService as createDurableGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
 import type { AuthenticatedGroupMutationEnqueue } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
-import { GroupStateInboxHandler, type GroupStateInboxHandlerDependencies } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
+import {
+    GroupStateInboxHandler,
+    type GroupStateInboxHandlerDependencies,
+    type GroupStateInboxResultReader
+} from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
 import type { GroupStateInboxDurableResult } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts';
 import { toGroupMutationDescriptor } from '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
 import type { GroupMutationComputed } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
@@ -63,7 +66,7 @@ type ExpectedTransactionWriter = {
 type ExpectedHandlerDependencies = {
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
-    readonly snapshotObserver: Pick<GroupStateService, 'observeSnapshot'>;
+    readonly resultReader: GroupStateInboxResultReader;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly wakeQueue?: () => void;
     readonly formationMetrics?: GroupFormationGroupMutationSink;
@@ -119,7 +122,7 @@ describe('convergent group and presence state', () => {
         expectTypeOf<GroupStateInboxHandlerDependencies>().toEqualTypeOf<ExpectedHandlerDependencies>();
         expectTypeOf<GroupStateInboxHandlerDependencies['mutationService']>().toEqualTypeOf<GroupStateMutationService>();
         expectTypeOf<GroupStateInboxHandlerDependencies['sessionGenerationLifecycle']>().toEqualTypeOf<WsSessionGenerationLifecycleService>();
-        expectTypeOf<GroupStateInboxHandlerDependencies['snapshotObserver']>().toEqualTypeOf<Pick<GroupStateService, 'observeSnapshot'>>();
+        expectTypeOf<GroupStateInboxHandlerDependencies['resultReader']>().toEqualTypeOf<GroupStateInboxResultReader>();
         expectTypeOf<GroupStateInboxHandlerDependencies['transactionWriter']>().toEqualTypeOf<AppInboxMutationTransactionWriter>();
         expectTypeOf<GroupStateInboxHandlerDependencies['wakeQueue']>().toEqualTypeOf<(() => void) | undefined>();
         expectTypeOf<ConstructorParameters<typeof GroupStateInboxHandler>>().toEqualTypeOf<[GroupStateInboxHandlerDependencies]>();

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-retry.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-retry.test.ts
@@ -54,16 +54,19 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                     commandMac: 'a'.repeat(64)
                 },
                 descriptor: {
-                    operation: 'updateGroup' as const,
+                    operation: 'heartbeatPresence' as const,
                     scope: SCOPE,
                     groupId: 'outer-retry-room',
                     targetPrincipalId: null,
-                    sessionId: null,
+                    sessionId: 'owner-session',
                     request: {
-                        displayName: 'Must Not Apply',
                         actorPrincipalId: 'owner',
                         actorSessionId: 'owner-session',
-                        requestId: 'outer-retry-authority-change'
+                        requestId: 'outer-retry-authority-change',
+                        principalId: 'owner',
+                        generationId: 'owner-generation',
+                        lastHeartbeatAtEpochMs: nowEpochMs,
+                        expiresAtEpochMs: nowEpochMs + 60_000
                     }
                 }
             };
@@ -72,27 +75,20 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                 prepareAppInboxMutation: async () => ({
                     ...authorizedMutation,
                     command: {
-                        operation: 'updateGroup',
+                        operation: 'heartbeatPresence',
                         aggregateRef: { ...SCOPE, groupId: 'outer-retry-room' },
                         commandId: 'outer-retry-authority-change',
                         requestId: 'outer-retry-authority-change',
+                        sessionId: 'owner-session',
                         input: {
                             actorPrincipalId: 'owner',
                             actorSessionId: 'owner-session',
                             reason: null,
                             traceId: null,
-                            slug: null,
-                            displayName: 'Must Not Apply',
-                            description: null,
-                            kind: null,
-                            status: null,
-                            joinMode: null,
-                            maxMembers: null,
-                            maxSessionsPerMember: null,
-                            metadata: null,
-                            expiresAtEpochMs: null,
-                            emptySinceEpochMs: null,
-                            purgeAfterEpochMs: null
+                            principalId: 'owner',
+                            generationId: 'owner-generation',
+                            lastHeartbeatAtEpochMs: nowEpochMs,
+                            expiresAtEpochMs: nowEpochMs + 60_000
                         }
                     },
                     facts: {
@@ -169,7 +165,11 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                     resourceInboxRepository: queue,
                     resourceInboxResultsRepository: results,
                     database: createAppInboxTestDatabase(queue, results),
-                    groupStateService: phaseService as never
+                    groupStateService: phaseService as never,
+                    resultReader: {
+                        readSnapshot: async () => undefined,
+                        readEvent: async () => undefined
+                    }
                 },
                 {
                     serviceId: 'server-12345678'
@@ -183,18 +183,22 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
             });
             const pending = service.processAuthenticatedGroupEntryUntilCompletion(
                 {
-                    type: AppInboxType.GROUP_UPDATE,
+                    type: AppInboxType.GROUP_PRESENCE_HEARTBEAT,
                     resourceId: 'outer-retry-authority-change',
                     contextId: 'ar-eye-hunter:default:outer-retry-room',
                     senderId: 'owner',
                     data: {
                         scope: SCOPE,
                         groupId: 'outer-retry-room',
+                        sessionId: 'owner-session',
                         request: {
-                            displayName: 'Must Not Apply',
                             actorPrincipalId: 'owner',
                             actorSessionId: 'owner-session',
-                            requestId: 'outer-retry-authority-change'
+                            requestId: 'outer-retry-authority-change',
+                            principalId: 'owner',
+                            generationId: 'owner-generation',
+                            lastHeartbeatAtEpochMs: nowEpochMs,
+                            expiresAtEpochMs: nowEpochMs + 60_000
                         }
                     }
                 },

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-test-runtime.ts
@@ -148,7 +148,11 @@ function createAuthorityAppInboxService(
             resourceInboxRepository: input.queue,
             resourceInboxResultsRepository: input.results,
             database: input.database,
-            groupStateService: input.groupStateService
+            groupStateService: input.groupStateService,
+            resultReader: {
+                readSnapshot: (ref) => input.groupStateService.readSnapshot(ref),
+                readEvent: (ref, eventId) => input.database.groupEventStore.readGroupEvent(ref, eventId)
+            }
         },
         {
             serviceId: 'server-12345678',

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -61,7 +61,7 @@ const EXPECTED_CREATE_GROUP_DURABLE_JSON = '{"status":"created","result":{"snaps
     '"traceId":null,"requestId":"create-transaction-boundary-room","payload":{}}}}';
 
 describe('group-state AppInbox transaction result boundary', () => {
-    it('persists the real durable result before exposing the committed snapshot', async () => {
+    it('persists the exact durable result without an inbox-owned cache observation', async () => {
         const harness = await createGroupStateTransactionBoundaryHarness();
 
         const created = await harness.handler.processGroupStateMutation(harness.context);
@@ -85,9 +85,7 @@ describe('group-state AppInbox transaction result boundary', () => {
             status: EntityStatus.COMPLETED,
             result: created
         });
-        expect(harness.observedSnapshots).toHaveLength(1);
-        expect(harness.observedSnapshots[0]).toEqual(created.result.snapshot);
-        expect(harness.observedSnapshots[0]).toBe(created.result.snapshot);
+        expect(harness.observedSnapshots).toEqual([]);
         expect(harness.readWakeCount()).toBe(1);
         expect(harness.outboxEntries.size).toBe(1);
     });
@@ -129,23 +127,23 @@ describe('group-state AppInbox transaction result boundary', () => {
     it('persists an inactive presence result once without active mutation effects', async () => {
         const actions: string[] = [];
         const transactionWriter: AppInboxMutationTransactionWriter = {
-            readCompletionFacts: (_context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
-                throw new Error('Inactive presence must not read computed completion facts');
+            readCompletionFacts: (context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
+                actions.push('completion');
+                return { entry: context.entry, completedAtEpochMs: context.message.id.ts };
             },
             writeComputedMutation: async <Result>(
                 _context: AppInboxExecutionMetadata,
-                _computed: AppInboxCompletionComputed<Result>,
-                _write: (transaction: PSqlSql) => Promise<void>
+                computed: AppInboxCompletionComputed<Result>,
+                write: (transaction: PSqlSql) => Promise<void>
             ): Promise<Result> => {
-                throw new Error('Inactive presence must not use computed mutation transaction');
+                actions.push('inactive-transaction');
+                await write(createUnusedTransaction());
+                return computed.durableResult;
             },
             writeComputedMutationWithAfterCommitResult: async () => {
                 throw new Error('Inactive presence must not use computed after-commit transaction');
             },
-            writeMutation: async (_context, write) => {
-                actions.push('inactive-transaction');
-                return await write(createUnusedTransaction());
-            },
+            writeMutation: () => Promise.reject(new Error('Inactive presence must not use legacy mutation transaction')),
             writeMutationWithAfterCommitResult: () =>
                 Promise.reject(
                     new Error('Inactive presence must not enter the active mutation transaction')
@@ -192,9 +190,12 @@ describe('group-state AppInbox transaction result boundary', () => {
                     throw new Error('Inactive presence must not write lifecycle state');
                 }
             },
-            snapshotObserver: {
-                observeSnapshot: async () => {
-                    throw new Error('Inactive presence must not observe a snapshot');
+            resultReader: {
+                readSnapshot: async () => {
+                    throw new Error('Inactive presence must not read a snapshot');
+                },
+                readEvent: async () => {
+                    throw new Error('Inactive presence must not read an event');
                 }
             },
             transactionWriter,
@@ -202,33 +203,7 @@ describe('group-state AppInbox transaction result boundary', () => {
         });
         const result = await handler.processGroupStateMutation(inactiveConnectContext());
         expect(JSON.stringify(result)).toBe('{"status":"inactive","sessionId":"inactive-session","generationId":"inactive-generation"}');
-        expect(actions).toEqual(['inactive-transaction']);
-    });
-
-    it('keeps the existing durable-only writer result and serialization unchanged', async () => {
-        const harness = await createGroupStateTransactionBoundaryHarness();
-        const durableResult = {
-            status: 'durable-only',
-            result: { value: 0, omitted: null }
-        } as const;
-        const durableContext = {
-            ...harness.context,
-            encodeResult: (result: typeof durableResult) => encodeAppInboxResult(result, 'Durable-only transaction test result')
-        };
-
-        const returned = await harness.transactionWriter.writeMutation(
-            durableContext,
-            async () => durableResult
-        );
-        const persisted = await harness.results.findByKey(harness.context.entry.key);
-
-        expect(returned).toBe(durableResult);
-        expect(persisted?.resource).toBe('{"status":"durable-only","result":{"value":0,"omitted":null}}');
-        expect(harness.transactionWriter.read(durableContext)).toEqual({
-            state: 'transaction-finalized',
-            status: EntityStatus.COMPLETED,
-            result: durableResult
-        });
+        expect(actions).toEqual(['completion', 'inactive-transaction']);
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-transaction-boundary-fixture.ts
@@ -166,7 +166,10 @@ function createTransactionBoundaryExecution(
             throw new Error('A reserved transaction-boundary command must already be prepared.');
         },
         sessionGenerationLifecycle: groupState.service.sessionGenerationLifecycle,
-        snapshotObserver: groupState.service,
+        resultReader: createTestGroupStateRepository(
+            storage.runtimeRepository,
+            storage.database.groupEventStore
+        ),
         transactionWriter,
         wakeQueue: () => {
             wakeCount += 1;

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import type { GroupStateMutationCommand, GroupStateMutationService } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import type { GroupMutationComputed, GroupMutationRead } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
-import { processGroupPresenceConnect } from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
+import { readAndComputeGroupPresenceConnect } from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
 import type {
     WsSessionGenerationLifecycleComputed,
     WsSessionGenerationLifecycleRead
 } from '@shared-server/rallar-system/websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '@shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts';
 
-describe('group presence connect decision', () => {
+describe('group presence connect read and compute', () => {
     it('returns inactive without reading or computing a group mutation', async () => {
         const phases: string[] = [];
         const dependencies = createDecisionDependencies({
@@ -17,7 +17,7 @@ describe('group presence connect decision', () => {
             closedAtObservation: true
         });
 
-        const outcome = await processGroupPresenceConnect({
+        const outcome = await readAndComputeGroupPresenceConnect({
             command: dependencies.command,
             mutationService: dependencies.mutationService,
             sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle
@@ -34,7 +34,7 @@ describe('group presence connect decision', () => {
             closedAtObservation: false
         });
 
-        const outcome = await processGroupPresenceConnect({
+        const outcome = await readAndComputeGroupPresenceConnect({
             command: dependencies.command,
             mutationService: dependencies.mutationService,
             sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle
@@ -43,19 +43,27 @@ describe('group presence connect decision', () => {
         expect(outcome).toEqual({
             status: 'ready-to-commit',
             computed: dependencies.computed,
+            read: dependencies.read,
+            lifecycleGuardFacts: {
+                ...dependencies.lifecycleRead.identity,
+                generationId: 'generation-1',
+                generationStartedAtEpochMs: 1_000,
+                expireAtEpochMs: 422_240
+            },
+            lifecycleRead: dependencies.lifecycleRead,
             lifecycleGuard: dependencies.lifecycleGuard
         });
         if (outcome.status !== 'ready-to-commit') {
             throw new Error('Expected a ready-to-commit presence decision');
         }
         expect(outcome.computed).toBe(dependencies.computed);
+        expect(outcome.read).toBe(dependencies.read);
         expect(outcome.lifecycleGuard).toBe(dependencies.lifecycleGuard);
         expect(phases).toEqual([
             'lifecycle-read',
             'lifecycle-closed-check',
             'mutation-read',
             'mutation-compute',
-            'mutation-validate',
             'lifecycle-compute-guard'
         ]);
     });
@@ -69,6 +77,8 @@ interface CreateDecisionDependenciesInput {
 interface DecisionDependencies {
     readonly command: GroupStateMutationCommand;
     readonly computed: GroupMutationComputed;
+    readonly read: GroupMutationRead;
+    readonly lifecycleRead: WsSessionGenerationLifecycleRead;
     readonly lifecycleGuard: WsSessionGenerationLifecycleComputed;
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
@@ -76,11 +86,13 @@ interface DecisionDependencies {
 
 interface MutationServiceFixture {
     readonly computed: GroupMutationComputed;
+    readonly read: GroupMutationRead;
     readonly service: GroupStateMutationService;
 }
 
 interface LifecycleServiceFixture {
     readonly lifecycleGuard: WsSessionGenerationLifecycleComputed;
+    readonly lifecycleRead: WsSessionGenerationLifecycleRead;
     readonly service: WsSessionGenerationLifecycleService;
 }
 
@@ -91,6 +103,8 @@ function createDecisionDependencies(input: CreateDecisionDependenciesInput): Dec
     return {
         command,
         computed: mutation.computed,
+        read: mutation.read,
+        lifecycleRead: lifecycle.lifecycleRead,
         lifecycleGuard: lifecycle.lifecycleGuard,
         mutationService: mutation.service,
         sessionGenerationLifecycle: lifecycle.service
@@ -125,7 +139,7 @@ function createMutationServiceFixture(command: GroupStateMutationCommand, phases
             throw new Error('The presence decision must not own the transaction write');
         }
     };
-    return { computed, service };
+    return { computed, read, service };
 }
 
 function createLifecycleServiceFixture(input: CreateDecisionDependenciesInput): LifecycleServiceFixture {
@@ -163,7 +177,7 @@ function createLifecycleServiceFixture(input: CreateDecisionDependenciesInput): 
             throw new Error('The presence decision must not own the lifecycle write');
         }
     };
-    return { lifecycleGuard, service };
+    return { lifecycleGuard, lifecycleRead, service };
 }
 
 function lifecycleReadFixture(): WsSessionGenerationLifecycleRead {

--- a/packages/tests/shared-server/rallar-system/middleware/rallar-middleware-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/middleware/rallar-middleware-test-runtime.ts
@@ -110,7 +110,8 @@ export function createRallarMiddlewareTestRuntime(
                     resourceInboxRepository: inbox,
                     resourceInboxResultsRepository: results,
                     database,
-                    groupStateService
+                    groupStateService,
+                    resultReader: groupsRepository
                 },
                 {
                     serviceId: TEST_SERVICE_ID,


### PR DESCRIPTION
## Goal
Move group-state durable-result, completion, snapshot, replay-event, and lifecycle materialization before AppInbox transaction entry while preserving outer AppInbox retry and atomic writes.

## Changes
- Read the current snapshot and exact replay event before computation.
- Compute the mutation, durable result, lifecycle candidate, and AppInbox completion before validation.
- Validate the exact candidates, then enter a transaction whose callback only executes prepared lifecycle and mutation writes.
- Remove the transaction-bound result read and inbox-owned snapshot cache observation.
- Keep retry ownership in AppInbox; snapshot/read drift raises the existing retry-classified conflict and re-enters read/compute/validate.
- Update production composition, PostgreSQL/PGlite construction, fixtures, and semantic tests.
- Delete touched legacy-only coverage for the old `writeMutation` result path.

## Acceptance
- No inner retry loop.
- No deterministic result/completion construction after validation or inside the transaction.
- Compute and validate functions remain deterministic and side-effect free; reads stay in the shell.
- The transaction callback only conditionally invokes prepared write ports.
- Exact durable bytes, conflict/redelivery, rollback, WS-close, and native PGlite behavior remain covered.

## Validation
- PASS: group-state Vitest suite, 79 files / 445 passed / 3 skipped.
- PASS: focused transaction, retry, and presence phase tests, 15/15.
- PASS: AppInbox WS-close convergence, 8/8.
- PASS: fresh-login-shell PGlite group/auth suite, 7/7.
- PASS: fresh-login-shell `deno task check`.
- PASS: shared-server TypeScript and governed test typecheck (1,024 files, zero errors/debt).
- PASS: `npm run check:transaction-writes`.
- PASS: changed-range repository style, repository structure, dprint, and diff checks.
- PASS: scoped navigation execution. Manual 5/5 trace reaches registration, group mutation policy, guarded batch/CAS, exact durable result/completion, and post-commit wake.

## Risk and rollback
The main risk is snapshot/event drift between independent pre-transaction reads. It fails closed with the existing retry-classified conflict, so AppInbox performs a full outer read/compute/validate retry. Rollback is this single stacked commit.

Review disposition: the navigation report retains one pre-existing registration-indirection warning for the canonical group-message type loop. All listed types intentionally share one decoder/handler control-flow family. Expanding that into 31 duplicated registration objects would worsen readability and maintenance; the changed-range gate confirms the warning is neither new nor worsened.

## Follow-up
The next stacked PR removes the now-unneeded legacy AppInbox writer APIs and repairs their aggregate governance coverage. No independent follow-up issue.