### PR TITLE
Remove AppInbox compute-in-write APIs

### DIFF
--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
@@ -1,22 +1,13 @@
-import { Temporal } from '@js-temporal/polyfill';
-import {
-    EntityStatus,
-    toResourceEntryWithUpdatedResource,
-    type ResourceEntry
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
-import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
 import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { writeResourceInboxResultReplacement } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
-import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
 import type { RallarTimingDetails, RallarTimingSink } from '../../observability/timing.ts';
 import { timeRallarAsync } from '../../observability/timing.ts';
 import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import {
-    AppInboxReservationConflictError,
-    type AppInboxExecutionMetadata,
-    type AppInboxMessageContext
+    type AppInboxExecutionMetadata
 } from '../app-inbox-contracts.ts';
 import { toAppInboxAttemptTimingDetails } from './app-inbox-attempt-timing.ts';
 import type { AppInboxCompletionComputed, AppInboxCompletionFacts } from './app-inbox-completion-computation.ts';
@@ -48,23 +39,6 @@ export interface AppInboxMutationTransactionWriter {
         computed: AppInboxCompletionComputed<DurableResult>,
         write: (transaction: PSqlSql) => Promise<AfterCommitResult>
     ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
-
-    writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result>;
-
-    writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
-}
-
-interface AppInboxMutationFinalization<DurableResult, ReturnResult> {
-    readonly durableResult: DurableResult;
-    readonly returnResult: ReturnResult;
 }
 
 export namespace AppInboxTransactionWriter {
@@ -113,7 +87,7 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result> {
-        await this.writeComputedFinalizedMutation(context, computed, write);
+        await this.writeFinalizedMutation(context, computed, write);
         return computed.durableResult;
     }
 
@@ -122,109 +96,18 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         computed: AppInboxCompletionComputed<DurableResult>,
         write: (transaction: PSqlSql) => Promise<AfterCommitResult>
     ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        const afterCommitResult = await this.writeComputedFinalizedMutation(context, computed, write);
+        const afterCommitResult = await this.writeFinalizedMutation(context, computed, write);
         return { durableResult: computed.durableResult, afterCommitResult };
-    }
-
-    async writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result> {
-        return await this.writeFinalizedMutation(context, async (transaction) => {
-            const durableResult = await write(transaction);
-            return { durableResult, returnResult: durableResult };
-        });
-    }
-
-    async writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        return await this.writeFinalizedMutation(context, async (transaction) => {
-            const result = await write(transaction);
-            return { durableResult: result.durableResult, returnResult: result };
-        });
-    }
-
-    private async writeFinalizedMutation<DurableResult, ReturnResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationFinalization<DurableResult, ReturnResult>>
-    ): Promise<ReturnResult> {
-        this.ensurePending(context);
-        const finalized = await this.inTransaction(
-            context,
-            this.toTimingDetails(context),
-            async (transaction, repositories) => {
-                const result = await this.timeWrite(
-                    context,
-                    this.toTimingDetails(context),
-                    async () => await write(transaction)
-                );
-                await repositories.results.replace(
-                    toResourceEntryWithUpdatedResource(
-                        context.entry,
-                        EntityStatus.COMPLETED,
-                        context.encodeResult(result.durableResult)
-                    )
-                );
-                await this.finish(
-                    context,
-                    repositories.finalization,
-                    EntityStatus.COMPLETED,
-                    this.nowEpochMs()
-                );
-                return result;
-            }
-        );
-        this.finalizationByContext.set(context, {
-            state: 'transaction-finalized',
-            status: EntityStatus.COMPLETED,
-            result: context.encodeResult(finalized.durableResult)
-        });
-        return finalized.returnResult;
-    }
-
-    async writeTerminalFailure<Result>(
-        context: AppInboxMessageContext<Result>,
-        result: JsonWireValue
-    ): Promise<void> {
-        this.ensurePending(context);
-        const details = {
-            ...this.toTimingDetails(context),
-            classification: 'terminal'
-        };
-        await this.inTransaction(context, details, async (_transaction, repositories) => {
-            await this.timeWrite(context, details, async () => {
-                await repositories.results.replace(
-                    toResourceEntryWithUpdatedResource(context.entry, EntityStatus.FAILED, result)
-                );
-                await this.finish(
-                    context,
-                    repositories.finalization,
-                    EntityStatus.FAILED,
-                    this.nowEpochMs()
-                );
-            });
-        });
-        this.finalizationByContext.set(context, {
-            state: 'transaction-finalized',
-            status: EntityStatus.FAILED,
-            result
-        });
     }
 
     async writeComputedTerminalFailure<Result>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<Result>
     ): Promise<void> {
-        await this.writeComputedFinalizedMutation(context, computed, async () => {});
+        await this.writeFinalizedMutation(context, computed, async () => {});
     }
 
-    private async writeComputedFinalizedMutation<DurableResult, WriteResult>(
+    private async writeFinalizedMutation<DurableResult, WriteResult>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<DurableResult>,
         write: (transaction: PSqlSql) => Promise<WriteResult>
@@ -260,13 +143,7 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
     private async inTransaction<ReturnResult>(
         context: AppInboxExecutionMetadata,
         details: RallarTimingDetails,
-        write: (
-            transaction: PSqlSql,
-            repositories: Readonly<{
-                finalization: PSqlResourceInboxFinalizationRepository;
-                results: ResourceInboxResultsRepository;
-            }>
-        ) => Promise<ReturnResult>
+        write: (transaction: PSqlSql) => Promise<ReturnResult>
     ): Promise<ReturnResult> {
         return await timeRallarAsync(
             this.config.timing,
@@ -280,30 +157,8 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
             async () =>
                 await runInPSqlTransaction(
                     this.database,
-                    async (transaction) =>
-                        await write(transaction, {
-                            finalization: new PSqlResourceInboxFinalizationRepository(transaction),
-                            results: new ResourceInboxResultsRepository(transaction)
-                        })
+                    async (transaction) => await write(transaction)
                 )
-        );
-    }
-
-    private async timeWrite<ReturnResult, Result>(
-        context: AppInboxMessageContext<Result>,
-        details: RallarTimingDetails,
-        write: () => Promise<ReturnResult>
-    ): Promise<ReturnResult> {
-        return await timeRallarAsync(
-            this.config.timing,
-            {
-                component: 'app-inbox-phase',
-                operation: 'write',
-                serviceId: this.config.serviceId,
-                requestId: context.enqueue.resourceId,
-                details
-            },
-            write
         );
     }
 
@@ -318,37 +173,4 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
     private nowEpochMs(): number {
         return this.config.nowEpochMs?.() ?? Date.now();
     }
-
-    private async finish(
-        context: AppInboxExecutionMetadata,
-        finalization: PSqlResourceInboxFinalizationRepository,
-        status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED,
-        completedAtEpochMs: number
-    ): Promise<void> {
-        const completed = await finalization.finishReserved(
-            context.entry.key,
-            context.entry.dequeueAudit.attempts,
-            status,
-            new Date(completedAtEpochMs)
-        );
-        if (!completed) {
-            throw new AppInboxReservationConflictError(context.entry.key);
-        }
-    }
-}
-
-export function toFinalizedResourceEntry(
-    context: AppInboxExecutionMetadata,
-    status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED,
-    completedAtEpochMs: number
-): ResourceEntry {
-    return {
-        ...context.entry,
-        status,
-        dequeueAudit: {
-            ...context.entry.dequeueAudit,
-            endTs: Temporal.Instant.fromEpochMilliseconds(completedAtEpochMs),
-            nextTs: undefined
-        }
-    };
 }

--- a/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
+++ b/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
@@ -122,7 +122,7 @@ it.each([
             'this.dependencies.mutationService.read(command)',
             'this.dependencies.mutationService.compute(command, read, materialized.facts)',
             'this.dependencies.mutationService.validate(command, read, computed)',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'this.dependencies.mutationService.write(transaction, computed)'
         ]
     },
@@ -166,10 +166,14 @@ it.each([
         source: sources.groupHandler,
         owner: 'processGroupStateMutation',
         calls: [
-            'this.dependencies.mutationService.read(command)',
-            'this.dependencies.mutationService.compute(command, read)',
-            'this.dependencies.mutationService.validate(command, read, computed)',
-            'this.commitMutation({ context, command, computed })'
+            'this.readResultFacts(command)',
+            'this.dependencies.mutationService.compute(command, resultRead.mutationRead)',
+            'computeGroupStateInboxResult(resultInput)',
+            'computeAppInboxCompletion(completionInput)',
+            'this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed)',
+            'validateGroupStateInboxResult(resultInput, durableResult)',
+            'this.validateCompletion(completionInput, completion)',
+            'this.commitMutation({ context, command, computed, durableResult, completion })'
         ]
     },
     {
@@ -180,7 +184,7 @@ it.each([
             'owners.configMutationService.read(',
             'owners.configMutationService.compute(',
             'owners.configMutationService.validate(',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'owners.configMutationService.write('
         ]
     },
@@ -192,7 +196,7 @@ it.each([
             'mutation.read(command)',
             'mutation.compute(command, read)',
             'mutation.validate(command, read, computed)',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'mutation.write(transaction, computed)'
         ]
     },
@@ -244,8 +248,8 @@ it('keeps AppInbox as the only retry and transaction owner for HTTP and WS mutat
         expect(source).not.toMatch(/waitForRuntimeStateWriteRetry/);
         expect(source).not.toMatch(/for\s*\([^)]*attempt/);
     }
-    expect(sources.topologyHandler).toContain('this.dependencies.transactionWriter.writeMutation(');
-    expect(sources.rtcHandler).toContain('this.dependencies.writeMutation(');
+    expect(sources.topologyHandler).toContain('this.dependencies.transactionWriter.writeComputedMutation(');
+    expect(sources.rtcHandler).toContain('this.dependencies.transactionWriter.writeComputedMutation(');
     expect(sources.rtcInbox).toContain('AppInboxType.RTC_RTT_SUBMIT');
     expect(sources.topologyInbox).toContain('AppInboxType.TOPOLOGY_RECONFIGURE');
 });
@@ -254,39 +258,41 @@ it('keeps transport boundaries free of direct mutators and persistence owners', 
     expect(findMutationBoundaryViolations()).toEqual([]);
 }, 15_000);
 
-it('writes topology config state, receipt, authority fence, and APP_OUTBOX atomically', () => {
+it('executes prepared topology config runtime writes before prepared APP_OUTBOX', () => {
     const seam = readFunctionBody(sources.topologyConfig, 'writeTopologyConfigMutation');
     expectInOrder(seam, [
-        'writeTopologyConfigAuthorityFence(',
-        'writeTopologyConfigState(',
-        'insertMutationRecord(',
-        'input.outboxWriter.write(transaction, computed.outboxWrite)'
+        'for (const write of input.computed.runtimeWrites)',
+        'executeTopologyConfigRuntimeWrite(input.transaction, write)',
+        'input.outboxWriter.write(input.transaction, input.computed.outboxWrite)'
     ]);
-    expectInOrder(readFunctionBody(sources.topologyConfig, 'writeTopologyConfigAuthorityFence'), [
-        'advanceGroupStateAuthorityFence(',
-        'computed.groupAuthorityGuard',
+    expectInOrder(readFunctionBody(sources.topologyConfig, 'executeTopologyConfigRuntimeWrite'), [
+        'switch (write.operation)',
+        'requireExpectedRevision('
+    ]);
+    expect(readFunctionBody(sources.topologyConfig, 'requireExpectedRevision')).toContain(
         'throw new RuntimeStateWriteConflictError()'
-    ]);
+    );
     expect(seam).not.toContain('StateMutation' + 'Outbox');
 });
 
 it('fences explicit reconfigure authority before inserting APP_OUTBOX', () => {
     const seam = readMethodBody(sources.topologyReconfigure, 'write');
     expectInOrder(seam, [
-        'advanceGroupStateAuthorityFence(',
-        'computed.authorityGuard',
+        'const write = computed.authorityWrite',
+        'where store_namespace = ${write.namespace}',
+        'decodeRuntimeStateRevision(rows[0].revision) !== write.expectedResultRevision',
         'throw new RuntimeStateWriteConflictError()',
         'this.dependencies.outboxWriter.write(transaction, computed.outboxWrite)'
     ]);
 });
 
-it('writes RTT admission, measurement, receipt, and direct APP_OUTBOX rows atomically', () => {
+it('executes prepared RTT runtime and APP_OUTBOX writes atomically', () => {
     const seam = readFunctionBody(sources.rtt, 'writeRtcRttMutation');
     expectInOrder(seam, [
-        'commitEndpointAdmission(',
-        'commitMeasurement(',
-        'insertMutationReceipt(',
-        'input.outboxWriter.write(transaction,'
+        'for (const write of input.computed.runtimeWrites)',
+        'executeRuntimeWrite(input.transaction, write)',
+        'for (const outboxWrite of input.computed.outboxWrites)',
+        'input.outboxWriter.write(input.transaction, outboxWrite)'
     ]);
     expect(seam).not.toContain('insertRecomputeIntent');
     expect(seam).not.toContain('StateMutation' + 'Outbox');

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.test.ts
@@ -33,10 +33,11 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
         harness.service.onStateMessage(
             AppInboxType.GROUP_CREATE,
             async (_data, context) =>
-                await harness.service.commit(context, async () => ({
-                    status: 'accepted',
-                    source: 'transaction'
-                }))
+                await harness.service.commit(
+                    context,
+                    { status: 'accepted', source: 'transaction' },
+                    async () => {}
+                )
         );
 
         const pending = harness.service.enqueueAndWait(harness.enqueue);
@@ -58,10 +59,11 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
             timing: (event) => timing.push(event)
         });
         harness.service.onStateMessage(AppInboxType.GROUP_CREATE, async (_data, context) => {
-            await harness.service.commit(context, async () => ({
-                status: 'accepted',
-                source: 'transaction'
-            }));
+            await harness.service.commit(
+                context,
+                { status: 'accepted', source: 'transaction' },
+                async () => {}
+            );
             throw new Error('secret-after-commit');
         });
 
@@ -245,9 +247,8 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
             });
             let acceptedMutationExecutions = 0;
             const handler = async (_data: JsonWireValue, context: Parameters<typeof harness.service.commit>[0]) =>
-                await harness.service.commit(context, async () => {
+                await harness.service.commit(context, { status: 'accepted' }, async () => {
                     acceptedMutationExecutions += 1;
-                    return { status: 'accepted' };
                 });
             harness.service.onStateMessage(outerType as AppInboxType, handler);
             harness.service.enqueueWithoutWaiting(harness.enqueue);
@@ -298,9 +299,8 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
         const harness = createRegisteredHandlerHarness();
         let mutationCommitted = false;
         const handler = async (_data: JsonWireValue, context: Parameters<typeof harness.service.commit>[0]) =>
-            await harness.service.commit(context, async () => {
+            await harness.service.commit(context, { status: 'accepted' }, async () => {
                 mutationCommitted = true;
-                return { status: 'accepted' };
             });
         harness.service.onStateMessage(AppInboxType.GROUP_UPDATE, handler);
         harness.service.enqueueWithoutWaiting(harness.enqueue);

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-p-sql-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-p-sql-transaction.test.ts
@@ -18,6 +18,10 @@ import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres
 
 import { AppInboxType, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import { AppInboxTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 
@@ -141,17 +145,24 @@ describe('Postgres transaction write boundary', () => {
             encodeResult: (result) => encodeAppInboxResult(result, 'Postgres transaction test result')
         };
 
-        const result = await transactionWriter.writeMutation(context, async (transaction) => {
+        const durableResult = { status: 'accepted' };
+        const completionInput = {
+            ...transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.COMPLETED,
+            durableResult
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        expect(validateAppInboxCompletion(completionInput, completion)).toEqual([]);
+        const result = await transactionWriter.writeComputedMutation(context, completion, async (transaction) => {
             await new PSqlRuntimeStateRepository(transaction).insertIfAbsent(
                 'app-inbox-transaction',
                 'aggregate-1',
                 JSON.stringify({ state: 'accepted' }),
                 NEVER_EXPIRE_AT_TIMESTAMP
             );
-            return { status: 'accepted' };
         });
 
-        expect(result).toEqual({ status: 'accepted' });
+        expect(result).toEqual(durableResult);
         expect(database.beginCalls).toBe(1);
         expect(new Set(database.statementTransactions).size).toBe(1);
         expect(database.committed.inbox.get(toKey(incomingEntry.key))?.ri_status).toBe(

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.test.ts
@@ -13,11 +13,10 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness();
         const receipt = { status: 'accepted', revision: 2 } as const;
 
-        const result = await harness.service.commit(harness.context, async (transaction) => {
+        const result = await harness.service.commit(harness.context, receipt, async (transaction) => {
             expect(transaction).toBe(harness.database.activeTransaction);
             harness.database.writeMutation('group-1', { revision: 2 });
             harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-            return receipt;
         });
 
         expect(result).toEqual(receipt);
@@ -38,7 +37,7 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
             const harness = createAtomicHarness();
 
             await expect(
-                harness.service.commit(harness.context, async () => {
+                harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                     harness.database.writeMutation('group-1', { revision: 2 });
                     if (failurePhase === 'dependent-write') {
                         throw new Error('dependent write failed');
@@ -61,10 +60,9 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness({ failResultWrite: true });
 
         await expect(
-            harness.service.commit(harness.context, async () => {
+            harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                 harness.database.writeMutation('group-1', { revision: 2 });
                 harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-                return { status: 'accepted' };
             })
         ).rejects.toThrow('result write failed');
 
@@ -77,14 +75,13 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness({ loseReservation: true });
 
         await expect(
-            harness.service.commit(harness.context, async () => {
+            harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                 harness.database.writeMutation('group-1', { revision: 2 });
                 harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-                return { status: 'accepted' };
             })
         ).rejects.toBeInstanceOf(AppInboxReservationConflictError);
         await expect(
-            harness.service.commit(harness.context, async () => null)
+            harness.service.commit(harness.context, null, async () => {})
         ).rejects.toMatchObject({ code: 'app-inbox-reservation-conflict' });
 
         expect(harness.database.state.mutations.size).toBe(0);
@@ -145,14 +142,13 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         });
     });
 
-    it('records transaction and write timing for the winning attempt', async () => {
+    it('records transaction timing for the winning attempt', async () => {
         const timing: RallarTimingEvent[] = [];
         const harness = createAtomicHarness({ timing: (event) => timing.push(event) });
 
-        await harness.service.commit(harness.context, async () => ({ status: 'accepted' }));
+        await harness.service.commit(harness.context, { status: 'accepted' }, async () => {});
 
         expect(timing.filter((event) => event.operation === 'transaction')).toHaveLength(1);
-        expect(timing.filter((event) => event.operation === 'write')).toHaveLength(1);
         for (const event of timing) {
             expect(event.details).toMatchObject({ attempt: 7 });
             expect(event.details).not.toHaveProperty('plan');

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
@@ -14,6 +14,10 @@ import type { AppInboxEntryRepository, AppInboxResultRepository } from '@shared-
 import type { AppInboxCommandClient } from '@shared-server/rallar-system/app-inbox/client/app-inbox-command-client.ts';
 import type { AppInboxQueueEntryWriter } from '@shared-server/rallar-system/app-inbox/client/app-inbox-queue-entry-writer.ts';
 import { createAppInboxClientRuntime } from '@shared-server/rallar-system/app-inbox/client/create-app-inbox-client-runtime.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxHandlerRegistration } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-registration.ts';
 import { AppInboxHandlerRegistry } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-registry.ts';
 import { createAppInboxHandlerRuntime } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-runtime.ts';
@@ -136,13 +140,34 @@ class AtomicAppInboxService {
 
     async commit<R>(
         context: AppInboxMessageContext<R>,
-        write: (transaction: PSqlSql) => Promise<R>
+        durableResult: R,
+        write: (transaction: PSqlSql) => Promise<void>
     ): Promise<R> {
-        return await this.transactionWriter.writeMutation(context, write);
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.COMPLETED,
+            durableResult
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, completion);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        return await this.transactionWriter.writeComputedMutation(context, completion, write);
     }
 
     async fail(context: AppInboxMessageContext<JsonWireValue>, error: JsonWireValue): Promise<void> {
-        await this.transactionWriter.writeTerminalFailure(context, error);
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.FAILED,
+            durableResult: error
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, completion);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        await this.transactionWriter.writeComputedTerminalFailure(context, completion);
     }
 
     onStateMessage<Result>(

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -227,22 +227,6 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
     ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
         throw new Error('Computed after-commit transaction path must not run');
     }
-
-    async writeMutation<Result>(
-        _context: AppInboxMessageContext<Result>,
-        _write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result> {
-        throw new Error('Legacy compute-in-write transaction path must not run');
-    }
-
-    async writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        _context: AppInboxMessageContext<DurableResult>,
-        _write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        throw new Error('After-commit transaction must not run');
-    }
 }
 
 function createContext(

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -52,16 +52,6 @@ type ExpectedTransactionWriter = {
         computed: AppInboxCompletionComputed<Durable>,
         write: (transaction: PSqlSql) => Promise<AfterCommit>
     ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
-    writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result>;
-    writeMutationWithAfterCommitResult<Durable, AfterCommit>(
-        context: AppInboxMessageContext<Durable>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>
-    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
 };
 type ExpectedHandlerDependencies = {
     readonly mutationService: GroupStateMutationService;
@@ -94,7 +84,7 @@ describe('convergent group and presence state', () => {
     it('returns immutable committed snapshot data through the named transaction result', () => {
         expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
         expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
-        expectTypeOf<ReturnType<AppInboxMutationTransactionWriter['writeMutationWithAfterCommitResult']>>().toMatchTypeOf<
+        expectTypeOf<ReturnType<AppInboxMutationTransactionWriter['writeComputedMutationWithAfterCommitResult']>>().toMatchTypeOf<
             Promise<AppInboxMutationTransactionResult<unknown, unknown>>
         >();
     });
@@ -104,8 +94,8 @@ describe('convergent group and presence state', () => {
         expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
         expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
         expectTypeOf<AppInboxMutationTransactionWriter>().toEqualTypeOf<ExpectedTransactionWriter>();
-        expectTypeOf<AppInboxMutationTransactionWriter['writeMutationWithAfterCommitResult']>().toEqualTypeOf<
-            ExpectedTransactionWriter['writeMutationWithAfterCommitResult']
+        expectTypeOf<AppInboxMutationTransactionWriter['writeComputedMutationWithAfterCommitResult']>().toEqualTypeOf<
+            ExpectedTransactionWriter['writeComputedMutationWithAfterCommitResult']
         >();
         expectTypeOf<AppInboxTransactionWriter>().toMatchTypeOf<AppInboxMutationTransactionWriter>();
     });

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -142,12 +142,7 @@ describe('group-state AppInbox transaction result boundary', () => {
             },
             writeComputedMutationWithAfterCommitResult: async () => {
                 throw new Error('Inactive presence must not use computed after-commit transaction');
-            },
-            writeMutation: () => Promise.reject(new Error('Inactive presence must not use legacy mutation transaction')),
-            writeMutationWithAfterCommitResult: () =>
-                Promise.reject(
-                    new Error('Inactive presence must not enter the active mutation transaction')
-                )
+            }
         };
         const handler = new GroupStateInboxHandler({
             prepareMutation: async () => {


### PR DESCRIPTION
## Goal
Remove the legacy AppInbox APIs that allowed handlers to construct durable results and finalization data after transaction entry.

## Changes
- Delete `writeMutation` and `writeMutationWithAfterCommitResult` from the AppInbox writer contract and implementation.
- Keep the explicit strict APIs `writeComputedMutation*`; no alias or compatibility wrapper remains.
- Remove writer-owned result serialization, completion clocks, transaction-bound result/finalization repositories, and legacy write timing from that path.
- Migrate atomic test support to compute and validate AppInbox completion before transaction entry.
- Move the lone PostgreSQL transaction test beside its AppInbox handler owner.
- Repair aggregate authoritative-mutation governance assertions to the current prepared runtime-write/CAS/outbox owners.

## Acceptance
- No AppInbox compute-in-write method or consumer remains.
- The strict writer only executes the supplied write callback plus prepared result replacement and reservation finish.
- Existing atomic commit, rollback, reservation conflict, terminal failure, and finalization behavior is preserved.

## Validation
- PASS: focused AppInbox/auth/group tests, 56/56.
- PASS: authoritative governance suite, 21/21.
- PASS: AppInbox PSQL transaction tests, 3/3.
- PASS: shared-server TypeScript and governed test typecheck (1,024 files, zero errors/debt).
- PASS: fresh-login-shell API-v1 Deno check.
- PASS: transaction-write checker, changed-range style, repository structure, dprint, and diff checks.

## Risk and rollback
Internal breaking contract change with all verified consumers migrated atomically. Repository-wide searches show no remaining legacy symbol or call. Rollback is this single commit.

Review assessment: the writer is substantially easier to navigate (one strict finalization path instead of strict plus legacy parallel paths), and the test move removes a singleton technical-role subtree. No maintainability or readability violation remains in the changed closure.

## Follow-up
Next stacked work addresses remaining exact persistence validators and QueueBox timestamp fail-closed behavior. No independent follow-up issue.