### PR TITLE
Reject malformed IndexedDB queue timestamps

### DIFF
--- a/packages/shared/queuebox/indexed-db-queue-box-entry.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-entry.ts
@@ -188,56 +188,25 @@ export function isStoredQueueEntryTimedOut(
     return Temporal.Instant.compare(now, startTs.add(duration)) >= 0;
 }
 
-function temporalText(value: string | object, fallback: string): string {
-    if (typeof value === 'string' && value.length > 0 && value !== '[object Object]') {
-        return value;
-    }
-
-    if (
-        value &&
-        typeof value === 'object' &&
-        'toString' in value &&
-        typeof value.toString === 'function'
-    ) {
-        const text = value.toString();
-        if (text.length > 0 && text !== '[object Object]') {
-            return text;
-        }
-    }
-
-    return fallback;
-}
-
 function toPlainTime(value: string | Temporal.PlainTime): Temporal.PlainTime {
-    const fallback = Temporal.Now.plainTimeISO();
-    try {
-        return Temporal.PlainTime.from(temporalText(value, fallback.toString()));
+    if (typeof value !== 'string' && !(value instanceof Temporal.PlainTime)) {
+        throw new TypeError('IndexedDB queue audit date must be a plain time');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.PlainTime.from(value);
 }
 
 function toPlainDateTime(value: string | Temporal.PlainDateTime): Temporal.PlainDateTime {
-    const fallback = Temporal.Now.plainDateTimeISO();
-    try {
-        return Temporal.PlainDateTime.from(temporalText(value, fallback.toString()));
+    if (typeof value !== 'string' && !(value instanceof Temporal.PlainDateTime)) {
+        throw new TypeError('IndexedDB queue creation timestamp must be a plain date-time');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.PlainDateTime.from(value);
 }
 
-function toInstant(
-    value: string | Temporal.Instant,
-    fallback: Temporal.Instant = NEVER_EXPIRE_TS
-): Temporal.Instant {
-    try {
-        return Temporal.Instant.from(temporalText(value, fallback.toString()));
+function toInstant(value: string | Temporal.Instant): Temporal.Instant {
+    if (typeof value !== 'string' && !(value instanceof Temporal.Instant)) {
+        throw new TypeError('IndexedDB queue timestamp must be an instant');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.Instant.from(value);
 }
 
 function toOptionalInstant(
@@ -247,10 +216,5 @@ function toOptionalInstant(
         return undefined;
     }
 
-    try {
-        return Temporal.Instant.from(temporalText(value, ''));
-    }
-    catch {
-        return undefined;
-    }
+    return toInstant(value);
 }

--- a/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
@@ -4,7 +4,11 @@ import '../setup-browser-indexeddb.ts';
 
 import { Temporal } from '@js-temporal/polyfill';
 import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
-import { encodeStoredResourceEntry } from '@shared/queuebox/indexed-db-queue-box-entry.ts';
+import {
+    decodeStoredResourceEntry,
+    encodeStoredResourceEntry,
+    type StoredResourceEntry
+} from '@shared/queuebox/indexed-db-queue-box-entry.ts';
 import { computeIndexedDbFairnessReservation } from '@shared/queuebox/indexed-db-queue-box-fairness.ts';
 import { readStoredQueueEntry } from '@shared/queuebox/indexed-db-queue-box-store.ts';
 import { writeComputedIndexedDbQueueMutations } from '@shared/queuebox/indexed-db-queue-box-write.ts';
@@ -12,6 +16,30 @@ import { EntityStatus, NEVER_EXPIRE_TS, ResourceEntry, toKeyAsString } from '@sh
 import { describe, expect, it, vi } from 'vitest';
 
 describe('IndexedDbQueueBox computed writes', () => {
+    it.each(
+        [
+            ['audit.date', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, date: 'not-a-time' } })],
+            ['audit.createdTs', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, createdTs: 'not-a-time' } })],
+            ['audit.expiryTs', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, expiryTs: 'not-a-time' } })],
+            ['dequeueAudit.startTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, startTs: 'not-a-time' }
+            })],
+            ['dequeueAudit.endTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, endTs: 'not-a-time' }
+            })],
+            ['dequeueAudit.nextTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, nextTs: 'not-a-time' }
+            })]
+        ] as const
+    )('rejects malformed persisted %s instead of substituting a fallback', (_field, corrupt) => {
+        const stored = encodeStoredResourceEntry(createEntry('malformed-timestamp'), 0);
+
+        expect(() => decodeStoredResourceEntry(corrupt(stored))).toThrow();
+    });
+
     it('allows only one writer to commit a computed revision', async () => {
         const storeName = 'entries';
         const db = await openIndexedDbWithStore(

--- a/packages/tests/shared/indexeddb-queuebox.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox.test.ts
@@ -27,8 +27,18 @@ describe('IndexedDbQueueBox', () => {
                 dbName: `indexeddb-summary-finalized-${crypto.randomUUID()}`
             });
             const { reserved, current } = entries();
-            await queue.enqueue(current);
-            // IndexedDB serialization normalizes malformed inputs; release must still fence a malformed runtime row.
+            const persistedCurrent = {
+                ...current,
+                audit: {
+                    ...current.audit,
+                    date: current.audit.date instanceof Temporal.PlainTime ||
+                            typeof current.audit.date === 'string'
+                        ? current.audit.date
+                        : reserved.audit.date
+                }
+            };
+            await queue.enqueue(persistedCurrent);
+            // Inject malformed runtime data at the release boundary without relying on persistence normalization.
             vi.spyOn(queue as unknown as IndexedDbRuntimeDecoder, 'toResourceEntry')
                 .mockReturnValue(current);
 


### PR DESCRIPTION
## Summary

- reject malformed persisted QueueBox timestamps instead of substituting clocks, never-expire values, or `undefined`
- reject non-Temporal runtime timestamp impostors before IndexedDB persistence
- preserve reservation-fence coverage by seeding canonical storage before injecting malformed runtime data at the release boundary

## Review assessment

This slice is small and maintainable: it removes fallback machinery and leaves one direct decode path for each Temporal type. There is no compatibility wrapper or new phase. The test setup explicitly separates persistence validation from release-fence validation, which makes the intent easier to navigate.

The scoped style check reports only pre-existing warnings outside these changed implementations; the changed test's `unknown` is the intentional mocked decoder boundary.

## Validation

- `npx vitest run packages/tests/shared/indexeddb-queuebox.test.ts packages/tests/shared/indexeddb-queuebox-computed-write.test.ts --silent` — 87/87 pass
- browser bundle/persistence boundary tests — 4/4 pass
- `npx tsc -p packages/shared/tsconfig.json --noEmit --pretty false` — pass
- `npm run typecheck:tests` — 1024 files, 0 errors
- `zsh -lic 'deno check packages/shared/queuebox/indexed-db-queue-box-entry.ts'` — pass
- `npm run check:transaction-writes` — pass
- `npm run check:repo-structure` — pass
- dprint and diff checks — pass
