### PR TITLE
Validate exact CRDT persistence writes

### DIFF
--- a/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
+++ b/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
@@ -43,6 +43,27 @@ export function computeAppOutboxInsert(entry: ResourceEntry): AppOutboxInsert {
     };
 }
 
+export function isExactAppOutboxInsert(
+    entry: ResourceEntry,
+    computed: AppOutboxInsert
+): boolean {
+    const expected = computeAppOutboxInsert(entry);
+    return computed.entry.key.topicId === expected.entry.key.topicId &&
+        computed.entry.key.resourceId === expected.entry.key.resourceId &&
+        computed.entry.key.contextId === expected.entry.key.contextId &&
+        computed.entry.resource === expected.entry.resource &&
+        computed.entry.typeId === expected.entry.typeId &&
+        computed.entry.status === expected.entry.status &&
+        computed.entry.audit.createdBy === expected.entry.audit.createdBy &&
+        computed.systemDate === expected.systemDate &&
+        computed.createdAt === expected.createdAt &&
+        computed.expiresAt === expected.expiresAt &&
+        computed.startedAt === expected.startedAt &&
+        computed.finishedAt === expected.finishedAt &&
+        computed.nextAt === expected.nextAt &&
+        computed.attempts === expected.attempts;
+}
+
 export async function writeAppOutboxInsert(transaction: PSqlSql, computed: AppOutboxInsert): Promise<void> {
     if (!await insertAppOutboxRow(transaction, computed)) {
         throw computed.conflict;

--- a/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
@@ -258,7 +258,7 @@ function createCrdtMutationComputedBase<TDocument extends RallarCrdtDocumentMeta
     };
 }
 
-interface ComputeCrdtMutationWritesInput {
+export interface ComputeCrdtMutationWritesInput {
     readonly read: CrdtMutationRead;
     readonly document: RallarCrdtDocumentMetadata;
     readonly update: CrdtAppendCommand['update'] | null;
@@ -266,7 +266,7 @@ interface ComputeCrdtMutationWritesInput {
     readonly snapshot: CrdtCanonicalSnapshotEnvelope | null;
 }
 
-function computeCrdtMutationWrites(
+export function computeCrdtMutationWrites(
     input: ComputeCrdtMutationWritesInput
 ): Pick<CrdtMutationComputedWrite, 'documentWrite' | 'updateWrite' | 'snapshotWrite' | 'conflict'> {
     const { read, document, update, append, snapshot } = input;

--- a/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
@@ -1,4 +1,4 @@
-import { computeAppOutboxInsert, type AppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import { isExactAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
 import { computeCrdtMutationWrites } from './compute-crdt-mutation-outcome.ts';
 import type {
     CrdtDocumentWrite,
@@ -84,7 +84,7 @@ function hasConsistentCrdtPersistence(computed: CrdtMutationComputed): boolean {
     const outboxMatches = computed.outboxWrites.length === computed.outboxEntries.length &&
         computed.outboxWrites.every((write, index) => {
             const entry = computed.outboxEntries[index];
-            return entry !== undefined && sameAppOutboxInsert(write, computeAppOutboxInsert(entry));
+            return entry !== undefined && isExactAppOutboxInsert(entry, write);
         });
     if (!outboxMatches || computed.outcome !== 'write') {
         return outboxMatches;
@@ -168,23 +168,6 @@ function sameOptionalSnapshotWrite(
         left.snapshotEnvelopeJson === right.snapshotEnvelopeJson &&
         sameDate(left.createdAt, right.createdAt) &&
         left.reason === right.reason;
-}
-
-function sameAppOutboxInsert(left: AppOutboxInsert, right: AppOutboxInsert): boolean {
-    return left.entry.key.topicId === right.entry.key.topicId &&
-        left.entry.key.resourceId === right.entry.key.resourceId &&
-        left.entry.key.contextId === right.entry.key.contextId &&
-        left.entry.resource === right.entry.resource &&
-        left.entry.typeId === right.entry.typeId &&
-        left.entry.status === right.entry.status &&
-        left.entry.audit.createdBy === right.entry.audit.createdBy &&
-        left.systemDate === right.systemDate &&
-        left.createdAt === right.createdAt &&
-        left.expiresAt === right.expiresAt &&
-        left.startedAt === right.startedAt &&
-        left.finishedAt === right.finishedAt &&
-        left.nextAt === right.nextAt &&
-        left.attempts === right.attempts;
 }
 
 function sameDate(left: Date, right: Date): boolean {

--- a/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
@@ -1,8 +1,13 @@
+import { computeAppOutboxInsert, type AppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import { computeCrdtMutationWrites } from './compute-crdt-mutation-outcome.ts';
 import type {
+    CrdtDocumentWrite,
     CrdtMutationCommand,
     CrdtMutationComputed,
     CrdtMutationRead,
     CrdtMutationValidationIssue,
+    CrdtSnapshotWrite,
+    CrdtUpdateWrite,
     ValidateCrdtMutationInput
 } from './crdt-mutation-contracts.ts';
 import { decodeCrdtMutationResult } from './decode-crdt-mutation-result.ts';
@@ -79,28 +84,115 @@ function hasConsistentCrdtPersistence(computed: CrdtMutationComputed): boolean {
     const outboxMatches = computed.outboxWrites.length === computed.outboxEntries.length &&
         computed.outboxWrites.every((write, index) => {
             const entry = computed.outboxEntries[index];
-            return entry !== undefined && write.entry.key.topicId === entry.key.topicId &&
-                write.entry.key.resourceId === entry.key.resourceId &&
-                write.entry.key.contextId === entry.key.contextId &&
-                write.entry.resource === entry.resource;
+            return entry !== undefined && sameAppOutboxInsert(write, computeAppOutboxInsert(entry));
         });
     if (!outboxMatches || computed.outcome !== 'write') {
         return outboxMatches;
     }
-    const documentMatches = computed.documentWrite.documentKey === computed.document.documentKey &&
-        computed.documentWrite.documentRevision === computed.document.documentRevision &&
-        computed.documentWrite.lifecycle === computed.document.lifecycle;
-    const updateMatches = computed.update === null || computed.append === null
-        ? computed.updateWrite === null
-        : computed.updateWrite?.documentKey === computed.documentKey &&
-            computed.updateWrite.updateId === computed.update.updateId &&
-            computed.updateWrite.appendSequence === computed.append.appendSequence;
-    const snapshotMatches = computed.snapshot === null
-        ? computed.snapshotWrite === null
-        : computed.snapshotWrite?.documentKey === computed.documentKey &&
-            computed.snapshotWrite.snapshotId === computed.snapshot.snapshotId &&
-            computed.snapshotWrite.appendSequence === computed.document.lastAppendSequence;
-    return documentMatches && updateMatches && snapshotMatches;
+    try {
+        const expected = computeCrdtMutationWrites({
+            read: computed.read,
+            document: computed.document,
+            update: computed.update,
+            append: computed.append,
+            snapshot: computed.snapshot
+        });
+        return sameDocumentWrite(computed.documentWrite, expected.documentWrite) &&
+            sameOptionalUpdateWrite(computed.updateWrite, expected.updateWrite) &&
+            sameOptionalSnapshotWrite(computed.snapshotWrite, expected.snapshotWrite);
+    }
+    catch {
+        return false;
+    }
+}
+
+function sameDocumentWrite(left: CrdtDocumentWrite, right: CrdtDocumentWrite): boolean {
+    return left.operation === right.operation &&
+        left.documentKey === right.documentKey &&
+        left.applicationId === right.applicationId &&
+        left.workspaceId === right.workspaceId &&
+        left.scope === right.scope &&
+        left.documentType === right.documentType &&
+        left.documentId === right.documentId &&
+        left.documentRefJson === right.documentRefJson &&
+        left.documentRevision === right.documentRevision &&
+        left.lifecycle === right.lifecycle &&
+        sameDate(left.createdAt, right.createdAt) &&
+        sameDate(left.updatedAt, right.updatedAt) &&
+        sameOptionalDate(left.archivedAt, right.archivedAt) &&
+        sameOptionalDate(left.destroyedAt, right.destroyedAt) &&
+        left.lastAppendSequence === right.lastAppendSequence &&
+        left.updateCount === right.updateCount &&
+        left.snapshotCount === right.snapshotCount &&
+        left.storedUpdateBytes === right.storedUpdateBytes &&
+        left.retentionJson === right.retentionJson &&
+        left.quotaJson === right.quotaJson &&
+        left.projectionIdsJson === right.projectionIdsJson &&
+        (left.operation === 'insert' || right.operation === 'insert' || (
+            left.expectedRevision === right.expectedRevision &&
+            left.expectedLifecycle === right.expectedLifecycle &&
+            left.expectedAppendSequence === right.expectedAppendSequence
+        ));
+}
+
+function sameOptionalUpdateWrite(
+    left: CrdtUpdateWrite | null,
+    right: CrdtUpdateWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.documentKey === right.documentKey &&
+        left.appendSequence === right.appendSequence &&
+        left.updateId === right.updateId &&
+        left.updateEnvelopeJson === right.updateEnvelopeJson &&
+        left.acceptedUpdateHash === right.acceptedUpdateHash &&
+        left.actorId === right.actorId &&
+        left.principalId === right.principalId &&
+        left.sessionId === right.sessionId &&
+        left.serverId === right.serverId &&
+        left.authorizationScope === right.authorizationScope &&
+        sameDate(left.acceptedAt, right.acceptedAt);
+}
+
+function sameOptionalSnapshotWrite(
+    left: CrdtSnapshotWrite | null,
+    right: CrdtSnapshotWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.documentKey === right.documentKey &&
+        left.snapshotId === right.snapshotId &&
+        left.appendSequence === right.appendSequence &&
+        left.snapshotEnvelopeJson === right.snapshotEnvelopeJson &&
+        sameDate(left.createdAt, right.createdAt) &&
+        left.reason === right.reason;
+}
+
+function sameAppOutboxInsert(left: AppOutboxInsert, right: AppOutboxInsert): boolean {
+    return left.entry.key.topicId === right.entry.key.topicId &&
+        left.entry.key.resourceId === right.entry.key.resourceId &&
+        left.entry.key.contextId === right.entry.key.contextId &&
+        left.entry.resource === right.entry.resource &&
+        left.entry.typeId === right.entry.typeId &&
+        left.entry.status === right.entry.status &&
+        left.entry.audit.createdBy === right.entry.audit.createdBy &&
+        left.systemDate === right.systemDate &&
+        left.createdAt === right.createdAt &&
+        left.expiresAt === right.expiresAt &&
+        left.startedAt === right.startedAt &&
+        left.finishedAt === right.finishedAt &&
+        left.nextAt === right.nextAt &&
+        left.attempts === right.attempts;
+}
+
+function sameDate(left: Date, right: Date): boolean {
+    return left instanceof Date && right instanceof Date && left.getTime() === right.getTime();
+}
+
+function sameOptionalDate(left: Date | null, right: Date | null): boolean {
+    return left === null || right === null ? left === right : sameDate(left, right);
 }
 
 function readSnapshotReason(snapshot: object | null | undefined): string | null {

--- a/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
@@ -202,6 +202,86 @@ describe('CRDT mutation service', () => {
         expect(service.validate({ command, read, computed: persistenceMismatch })).toMatchObject([{ code: 'computed-persistence-differs' }]);
     });
 
+    it('rejects prepared CRDT persistence that differs from the computed domain result', async () => {
+        const repository = new MemoryCrdtMutationRepository();
+        const service = createCrdtMutationService({
+            repository,
+            createWriter: () => repository,
+            serviceId: 'server-1'
+        });
+        const command = await createAppendCommand('append-persistence-validation', 'update-persistence-validation');
+        const read = await service.read(command);
+        const computed = service.compute({ command, read });
+        if (computed.outcome !== 'write' || computed.updateWrite === null) {
+            throw new TypeError('Expected an accepted append mutation');
+        }
+        const firstOutboxWrite = computed.outboxWrites[0];
+        if (firstOutboxWrite === undefined) {
+            throw new TypeError('Expected an append outbox write');
+        }
+        const tampered = [
+            {
+                ...computed,
+                documentWrite: { ...computed.documentWrite, retentionJson: '{"kind":"tampered"}' }
+            },
+            {
+                ...computed,
+                updateWrite: { ...computed.updateWrite, updateEnvelopeJson: '{"kind":"tampered"}' }
+            },
+            {
+                ...computed,
+                outboxWrites: [
+                    { ...firstOutboxWrite, createdAt: '2000-01-01T00:00:00.000Z' },
+                    ...computed.outboxWrites.slice(1)
+                ]
+            }
+        ];
+
+        for (const candidate of tampered) {
+            expect(service.validate({ command, read, computed: candidate })).toMatchObject([
+                { code: 'computed-persistence-differs' }
+            ]);
+        }
+    });
+
+    it('rejects a prepared CRDT snapshot row that differs from the computed snapshot', async () => {
+        const repository = new MemoryCrdtMutationRepository();
+        repository.metadata = createMetadata();
+        const service = createCrdtMutationService({
+            repository,
+            createWriter: () => repository,
+            serviceId: 'server-1'
+        });
+        const command = await createCrdtMutationCommand({
+            operation: 'compact',
+            commandId: 'compact-persistence-validation',
+            actor: createActor(),
+            capturedAtEpochMs: 1_000,
+            expireAtEpochMs: 61_000,
+            document: DOCUMENT,
+            snapshotId: 'snapshot-persistence-validation',
+            snapshot: null,
+            reason: 'persistence-validation',
+            responseAudience: createAudience()
+        });
+        const read = await service.read(command);
+        const computed = service.compute({ command, read });
+        if (computed.outcome !== 'write' || computed.snapshotWrite === null) {
+            throw new TypeError('Expected an accepted compact mutation');
+        }
+        const tampered = {
+            ...computed,
+            snapshotWrite: {
+                ...computed.snapshotWrite,
+                snapshotEnvelopeJson: '{"kind":"tampered"}'
+            }
+        };
+
+        expect(service.validate({ command, read, computed: tampered })).toMatchObject([
+            { code: 'computed-persistence-differs' }
+        ]);
+    });
+
     it('returns all ordered validation issues for a malformed compact accepted result', async () => {
         const repository = new MemoryCrdtMutationRepository();
         repository.metadata = createMetadata();


### PR DESCRIPTION
## Summary

- reuse the CRDT compute phase as the canonical source for document, update, and snapshot writes
- validate every SQL-bound CRDT persistence value, including dates and serialized payloads
- validate every SQL-bound AppOutbox value instead of only key/resource identity
- retain non-throwing ordered validation for malformed candidates

## Review assessment

This closes real validator false-negatives demonstrated by RED tests for altered document policy JSON, update-envelope JSON, snapshot-envelope JSON, and outbox timestamps. Compute remains pure and owns persistence preparation; validate recomputes the same pure projection; write remains execution-only.

The explicit field comparisons are deliberately local. A generic JSON/deep-equality helper would obscure governed columns and mishandle `Date` or custom serialization. No compatibility wrapper, additional phase, or retry loop was added.

## Validation

- CRDT domain tests: 23 files, 115/115 pass
- focused mutation service: 8/8 pass
- PGlite queue/CRDT: 7/7 pass via fresh login shell Deno
- shared-server TypeScript: pass
- governed test typecheck: 1024 files, 0 errors
- fresh-shell Deno check: pass
- transaction-write checker: pass
- repository structure, style, dprint, and diff checks: pass (style warnings are pre-existing test-boundary warnings)
