### PR TITLE
Validate exact admin prune writes

### DIFF
--- a/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
@@ -12,13 +12,13 @@ import {
 } from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     computeAppOutboxInsert,
+    isExactAppOutboxInsert,
     type AppOutboxInsert
 } from '../../app-outbox/app-outbox-insert.ts';
 import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
 import {
     createAdminPruneAggregate,
-    toAdminPruneAggregateEntry,
-    toAdminPruneAggregateKey
+    toAdminPruneAggregateEntry
 } from '../prune/admin-prune-progress.ts';
 import type { AdminPruneCommand } from './admin-prune-command-codec.ts';
 import type { AdminPruneEnqueueResult } from './admin-prune-inbox-codec.ts';
@@ -93,6 +93,7 @@ export function validateAdminPruneMutation(
     computed: AdminPruneComputed
 ): readonly AdminPruneValidationIssue[] {
     const issues: AdminPruneValidationIssue[] = [];
+    const expected = computeAdminPruneMutation(read);
     if (!read.authority.allowed || read.command.expireAtEpochMs <= read.nowEpochMs) {
         issues.push({
             code: 'admin-prune-authority-denied',
@@ -118,10 +119,10 @@ export function validateAdminPruneMutation(
             status: 400
         });
     }
-    if (!hasExpectedAggregateWrite(read, computed.aggregateWrite)) {
+    if (!hasExactAdminPrunePersistence(computed, expected)) {
         issues.push({
-            code: 'admin-prune-aggregate-presence-invalid',
-            message: 'Admin prune aggregate write differs from its command',
+            code: 'admin-prune-computed-persistence-invalid',
+            message: 'Admin prune prepared persistence differs from its computed mutation',
             status: 400
         });
     }
@@ -140,6 +141,41 @@ export function validateAdminPruneMutation(
         }))
     );
     return issues;
+}
+
+function hasExactAdminPrunePersistence(
+    computed: AdminPruneComputed,
+    expected: AdminPruneComputed
+): boolean {
+    if (
+        computed.outboxWrites.length !== expected.outboxWrites.length ||
+        !computed.outboxWrites.every((write, index) => {
+            const expectedWrite = expected.outboxWrites[index];
+            return expectedWrite !== undefined && isExactAppOutboxInsert(expectedWrite.entry, write);
+        })
+    ) {
+        return false;
+    }
+    return hasSameAdminPruneAggregateWrite(computed.aggregateWrite, expected.aggregateWrite);
+}
+
+function hasSameAdminPruneAggregateWrite(
+    left: AdminPruneAggregateWrite | null,
+    right: AdminPruneAggregateWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.entry.key.topicId === right.entry.key.topicId &&
+        left.entry.key.resourceId === right.entry.key.resourceId &&
+        left.entry.key.contextId === right.entry.key.contextId &&
+        left.entry.resource === right.entry.resource &&
+        left.entry.typeId === right.entry.typeId &&
+        left.entry.status === right.entry.status &&
+        left.entry.audit.createdBy === right.entry.audit.createdBy &&
+        left.systemDate === right.systemDate &&
+        left.createdAt === right.createdAt &&
+        left.expiresAt === right.expiresAt;
 }
 
 function computeInitialAdminPrunePages(
@@ -179,20 +215,4 @@ function computeAdminPruneAggregateWrite(entry: ResourceEntry): AdminPruneAggreg
         createdAt: toPgTimestamp(snapshot.audit.createdTs),
         expiresAt: toPgTimestamp(snapshot.audit.expiryTs)
     };
-}
-
-function hasExpectedAggregateWrite(
-    read: AdminPruneRead,
-    aggregateWrite: AdminPruneAggregateWrite | null
-): boolean {
-    if (read.command.dryRun) {
-        return aggregateWrite === null;
-    }
-    if (aggregateWrite === null) {
-        return false;
-    }
-    const expectedKey = toAdminPruneAggregateKey(read.command.jobId);
-    return aggregateWrite.entry.key.topicId === expectedKey.topicId &&
-        aggregateWrite.entry.key.resourceId === expectedKey.resourceId &&
-        aggregateWrite.entry.key.contextId === expectedKey.contextId;
 }

--- a/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
@@ -57,6 +57,42 @@ describe('admin prune computation', () => {
         expect(changed.result.jobId).toBe('another-job');
     });
 
+    it('rejects prepared admin prune rows that differ from the computed mutation', async () => {
+        const read = await createRead();
+        const computed = computeAdminPruneMutation(read);
+        const firstOutboxWrite = computed.outboxWrites[0];
+        if (firstOutboxWrite === undefined || computed.aggregateWrite === null) {
+            throw new TypeError('Expected prepared admin prune writes');
+        }
+        const tampered = [
+            {
+                ...computed,
+                outboxWrites: [{ ...firstOutboxWrite, expiresAt: '2000-01-01T00:00:00.000Z' }]
+            },
+            {
+                ...computed,
+                aggregateWrite: {
+                    ...computed.aggregateWrite,
+                    createdAt: '2000-01-01T00:00:00.000Z'
+                }
+            },
+            {
+                ...computed,
+                aggregateWrite: {
+                    ...computed.aggregateWrite,
+                    entry: { ...computed.aggregateWrite.entry, resource: '{"jobId":"tampered"}' }
+                }
+            }
+        ];
+
+        for (const candidate of tampered) {
+            expect(validateAdminPruneMutation(read, candidate)).toContainEqual(expect.objectContaining({
+                code: 'admin-prune-computed-persistence-invalid',
+                status: 400
+            }));
+        }
+    });
+
     it('writes the prepared aggregate without formatting timestamps in the transaction', async () => {
         const computed = computeAdminPruneMutation(await createRead());
         const aggregateWrite = computed.aggregateWrite;


### PR DESCRIPTION
## Summary

- recompute the pure canonical initial admin-prune mutation during validation
- compare every SQL-bound initial outbox and aggregate value before opening the transaction
- remove the subsumed partial aggregate-key validator
- add RED-to-green coverage for altered outbox timestamps, aggregate timestamps, and aggregate payloads

## Review assessment

The initial admin path now matches the established admin page-worker model: read, pure compute, pure validation against the canonical persistence projection, then execution-only write. The exact AppOutbox rule is owned once by AppOutbox and reused here; no duplicated serializer, compatibility layer, new phase, or retry loop was added.

Navigability improved because the old partial aggregate check was deleted rather than layered under the exact rule. Scoped style warnings are pre-existing outside the two changed files.

## Validation

- admin operations: 15 files passed, 103/103 tests pass; 1 file/4 tests intentionally skipped
- focused computation: 4/4 pass
- PostgreSQL admin reader PGlite: 6/6 pass via fresh-shell Deno
- shared-server TypeScript: pass
- governed test typecheck: 1024 files, 0 errors
- fresh-shell Deno check: pass
- transaction-write checker: pass
- repository style/structure, dprint, and diff checks: pass
