### PR TITLE
Validate group persistence and projected presence revisions

### DIFF
--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
@@ -80,12 +80,16 @@ function assertSnapshotMatchesRead(
         }
         return;
     }
+    const presenceRevision = read.presenceSummary?.value.causalRevision.presenceRevision ?? 0;
+    const expectedSnapshotGroup = {
+        ...read.group.value,
+        presenceVersion: presenceRevision
+    };
     if (
         snapshot === undefined ||
-        !jsonEquals(snapshot.group, read.group.value) ||
+        !jsonEquals(snapshot.group, expectedSnapshotGroup) ||
         snapshot.causalRevision.groupRevision !== read.group.value.snapshotVersion ||
-        snapshot.causalRevision.presenceRevision !==
-            (read.presenceSummary?.value.causalRevision.presenceRevision ?? 0)
+        snapshot.causalRevision.presenceRevision !== presenceRevision
     ) {
         throw new GroupStateInboxResultReadConflictError();
     }

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
@@ -9,6 +9,7 @@ import { createAppInboxTestDatabase, type AppInboxTestDatabase } from '../../app
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
 
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
+import { groupStateUpdatePresenceSummaryDescriptor } from '@shared-server/rallar-system/group-state/persistence/presence/group-presence-write-descriptors.ts';
 import type { JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
@@ -111,6 +112,56 @@ describe('GroupStateInboxService authenticated authority', () => {
             }
         });
         expect(requireGroupStateResult(joined).status).toBe('ok');
+    });
+
+    it('writes a group mutation after presence advances the projected snapshot revision', async () => {
+        const harness = await createAuthorityHarness(['owner']);
+        const groupId = 'presence-revision-room';
+        await createRoom(harness, groupId, 'Before presence');
+        const summaryWrite = groupStateUpdatePresenceSummaryDescriptor({
+            ...SCOPE,
+            groupId,
+            causalRevision: { groupRevision: 1, presenceRevision: 1 },
+            activePrincipalIds: [],
+            activeSessionIds: [],
+            activeSessions: [],
+            activePrincipalCount: 0,
+            activeSessionCount: 0,
+            computedAtEpochMs: harness.nowEpochMs
+        }, 0);
+        await harness.runtimeRepository.upsert(
+            summaryWrite.namespace,
+            summaryWrite.key,
+            summaryWrite.value,
+            summaryWrite.expireAtTimestamp
+        );
+
+        const updated = await processAuthenticated({
+            service: harness.service,
+            reader: harness.reader,
+            authority: harness.sessions.owner,
+            input: {
+                type: AppInboxType.GROUP_UPDATE,
+                resourceId: 'update-after-presence-revision',
+                contextId: `${SCOPE.applicationId}:${SCOPE.workspaceId}:${groupId}`,
+                senderId: 'owner',
+                data: {
+                    scope: SCOPE,
+                    groupId,
+                    request: {
+                        displayName: 'After presence',
+                        actorPrincipalId: 'owner',
+                        actorSessionId: 'owner-session',
+                        requestId: 'update-after-presence-revision'
+                    }
+                }
+            }
+        });
+
+        expect(requireGroupStateResult(updated).result.snapshot).toMatchObject({
+            causalRevision: { groupRevision: 2, presenceRevision: 1 },
+            group: { displayName: 'After presence', presenceVersion: 1 }
+        });
     });
 
     it('rejects a dequeued user command whose authority proof has extra fields', async () => {

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
@@ -69,9 +69,13 @@ describe('GroupStateService guarded batch write boundary', () => {
         });
         expect(guardedBatch.effects.map(({ effectId }) => effectId)).toEqual(['receipt']);
         expect(computed.outboxEntries).toHaveLength(1);
-        expect(computed.outboxEntries[0]?.typeId).toBe('APP_OUTBOX');
-        expect(() =>
-            group.durable.validate(command, read, {
+        const outboxEntry = computed.outboxEntries[0];
+        expect(outboxEntry?.typeId).toBe('APP_OUTBOX');
+        if (outboxEntry === undefined) {
+            throw new TypeError('Expected a prepared group outbox entry');
+        }
+        const tampered = [
+            {
                 ...computed,
                 persistence: {
                     ...computed.persistence,
@@ -83,8 +87,25 @@ describe('GroupStateService guarded batch write boundary', () => {
                         }
                     }
                 }
-            })
-        ).toThrow('differs from its canonical deterministic projection');
+            },
+            {
+                ...computed,
+                persistence: {
+                    ...computed.persistence,
+                    eventWrite: {
+                        ...computed.persistence.eventWrite,
+                        eventJson: '{"eventId":"tampered"}'
+                    }
+                }
+            },
+            {
+                ...computed,
+                outboxEntries: [{ ...outboxEntry, resource: '{"kind":"tampered"}' }]
+            }
+        ];
+        for (const candidate of tampered) {
+            expect(() => group.durable.validate(command, read, candidate)).toThrow();
+        }
 
         const stringify = vi.spyOn(JSON, 'stringify').mockImplementation(() => {
             throw new Error('group serialization must finish during compute');

--- a/scripts/perf/create-state-write-service-runtime.ts
+++ b/scripts/perf/create-state-write-service-runtime.ts
@@ -83,6 +83,7 @@ export function createStateWriteServiceRuntime({
     const authSessionRepository = new AuthSessionRepository(runtimeRepository);
     const clientStateEventStore = new PSqlClientStateEventRepository(instrumentedSql);
     const groupStateEventStore = new PSqlGroupStateEventRepository(instrumentedSql);
+    const groupStateRepository = new GroupStateRepository(runtimeRepository, groupStateEventStore);
     const groupState = createGroupStateService({
         runtimeRepository,
         groupStateEventStore,
@@ -122,7 +123,8 @@ export function createStateWriteServiceRuntime({
             resourceInboxRepository: resourceInbox.entries,
             resourceInboxResultsRepository: results,
             database: instrumentedSql,
-            groupStateService: groupState
+            groupStateService: groupState,
+            resultReader: groupStateRepository
         },
         {
             serviceId,
@@ -130,17 +132,16 @@ export function createStateWriteServiceRuntime({
             options: STATE_WRITE_BENCHMARK_APP_INBOX_OPTIONS.group
         }
     );
-    const topologyGroupStateRepository = new GroupStateRepository(runtimeRepository, groupStateEventStore);
     const topologyConfigRepository = new GroupTopologyConfigRepository(runtimeRepository);
     const topologyRuntimeOwners = createGroupTopologyRuntimeOwners({
         findGroupSnapshotByRef: (ref) => groupState.readSnapshot(ref),
-        readCurrentGroupSnapshot: async (ref) => await topologyGroupStateRepository.readSnapshot(ref),
+        readCurrentGroupSnapshot: async (ref) => await groupStateRepository.readSnapshot(ref),
         readRttMeasurements: () => [],
         configRepository: topologyConfigRepository,
         topologyService: new RallarRtcTopologyService()
     });
     const topologyMutationOwners = createGroupTopologyMutationOwners({
-        groupStateRepository: topologyGroupStateRepository,
+        groupStateRepository,
         configRepository: topologyConfigRepository,
         planning: topologyRuntimeOwners.planning,
         nowEpochMs: () => Date.now(),


### PR DESCRIPTION
## Summary

- prove group validation rejects tampered guarded-batch descriptors, serialized event writes, and outbox payloads
- fix a permanent false conflict when `readSnapshot()` projects `group.presenceVersion` from the presence summary
- compare that projected field to the mutation read's presence-summary revision while retaining strict group and causal predecessor checks

## Review assessment

The live medium-scale PostgreSQL gate exposed a deterministic bug: after presence advanced, the repository snapshot correctly projected a newer `presenceVersion`, but result validation compared it to the denormalized value stored on the group row. Every non-presence mutation then retried until its caller timed out.

The fix normalizes one expected projection before exact comparison. It adds no retry loop, phase, callback, compatibility layer, or write-time computation. Group compute/validate remain pure and write remains execution-only. The regression reproduces create → presence-summary advance → group update through the actual AppInbox path.

## Validation

- focused regression: RED with repeated `GroupStateInboxResultReadConflictError`, then GREEN
- full group-state suite: 79 files, 446/446 pass; 3 intentionally skipped
- governed test typecheck: 1024 files, 0 errors
- shared-server TypeScript and fresh-shell Deno checks: pass
- transaction-write checker, repository structure/style, dprint, and diff checks: pass
- medium-scale PostgreSQL rerun pending in this PR update
