### PR TITLE
Inspect AppInbox transaction callbacks

### DIFF
--- a/packages/tests/repo/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check.test.ts
@@ -45,6 +45,33 @@ describe('transaction write check', () => {
         expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
     });
 
+    it('inspects AppInbox domain write callbacks', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            interface AppInboxMutationTransactionWriter {
+                writeComputedMutation<Result>(
+                    context: object,
+                    computed: Result,
+                    write: (transaction: PSqlSql) => Promise<void>
+                ): Promise<Result>;
+            }
+            declare const transactionWriter: AppInboxMutationTransactionWriter;
+            declare const context: object;
+            declare const computed: { value: number };
+            export async function process(): Promise<void> {
+                await transactionWriter.writeComputedMutation(
+                    context,
+                    computed,
+                    async (transaction) => {
+                        await transaction.query(JSON.stringify(computed));
+                    }
+                );
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
+    });
+
     it('inspects inferred object-property write implementations', () => {
         const findings = analyzeFixture(`
             interface PSqlSql { query(value: unknown): Promise<void>; }

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -14,7 +14,8 @@ The checker reports:
 
 It recognizes PostgreSQL/PGlite `begin` and `transaction` callbacks, the
 `runInPSqlTransaction` wrapper, IndexedDB `readwrite` transactions, IndexedDB
-upgrade callbacks, and callback identifiers that resolve to authored source.
+upgrade callbacks, AppInbox computed-write callbacks, and callback identifiers
+that resolve to authored source.
 It inspects the lexical transaction body rather than expanding arbitrary helper
 graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
 their call site. Readonly IndexedDB transactions, tests, fixtures,

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -15,6 +15,11 @@ const PRECOMPUTABLE_METHODS = new Set(['sort', 'toSorted']);
 const PRECOMPUTABLE_NAME = /^(?:compute|prepare|serialize|canonicalize|hash|encode)(?:$|[A-Z_])/u;
 const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
 const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
+const APP_INBOX_TRANSACTION_WRITER_TYPE = /AppInbox(?:Mutation)?TransactionWriter/u;
+const APP_INBOX_WRITE_METHODS = new Set([
+    'writeComputedMutation',
+    'writeComputedMutationWithAfterCommitResult'
+]);
 const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
 
 export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
@@ -41,6 +46,12 @@ export function analyzeTransactionWrites(project, sourceFiles = project.getSourc
             }
         }
         for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+            const appInboxWrite = appInboxWriteBoundary(call);
+            if (!specialized && appInboxWrite) {
+                for (const callback of resolveCallbackBodies(appInboxWrite, project)) {
+                    roots.push(analysisRoot(callback));
+                }
+            }
             const boundary = transactionBoundary(call);
             if (!boundary) {
                 continue;
@@ -148,6 +159,18 @@ function precomputableOperation(call, operation) {
         return undefined;
     }
     return PRECOMPUTABLE_NAME.test(name) ? name : undefined;
+}
+
+function appInboxWriteBoundary(call) {
+    const expression = call.getExpression();
+    if (!Node.isPropertyAccessExpression(expression) || !APP_INBOX_WRITE_METHODS.has(expression.getName())) {
+        return undefined;
+    }
+    const receiver = expression.getExpression();
+    if (!APP_INBOX_TRANSACTION_WRITER_TYPE.test(receiver.getType().getText(receiver))) {
+        return undefined;
+    }
+    return call.getArguments()[2];
 }
 
 function transactionBoundary(call) {


### PR DESCRIPTION
## Summary
- inspect callbacks passed to the two typed AppInbox computed-write APIs
- reject precomputable work inside those domain transaction callbacks
- document the additional resolved boundary

## Why
The focused checker previously inspected the generic transaction wrapper but not the domain callback supplied to it. A callback containing `JSON.stringify(computed)` therefore passed the governance gate. This keeps the checker narrow while closing the primary AppInbox false-negative.

## Validation
- `npm run test:transaction-writes` (11 passed)
- `npm run check:transaction-writes`
- `npx dprint check scripts/transaction-write-check packages/tests/repo/transaction-write-check.test.ts`
- `npm run check:repo-style -- --root scripts/transaction-write-check --root packages/tests/repo/transaction-write-check.test.ts`
- `git diff --check`

## Review assessment
The change is intentionally small and type-resolved. It does not add whole-program provenance, helper recursion, registries, or waivers. The checker remains a high-confidence lexical guard; manual review is still required for unresolved helper provenance and SQL semantics.