### PR TITLE
Precompute client after-commit snapshots

### DIFF
--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
@@ -20,11 +20,6 @@ export type AppInboxHandlerFinalization =
         result: JsonWireValue;
     }>;
 
-export interface AppInboxMutationTransactionResult<DurableResult, AfterCommitResult> {
-    readonly durableResult: DurableResult;
-    readonly afterCommitResult: AfterCommitResult;
-}
-
 export interface AppInboxMutationTransactionWriter {
     readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
 
@@ -33,12 +28,6 @@ export interface AppInboxMutationTransactionWriter {
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result>;
-
-    writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
 }
 
 export namespace AppInboxTransactionWriter {
@@ -91,15 +80,6 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         return computed.durableResult;
     }
 
-    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        const afterCommitResult = await this.writeFinalizedMutation(context, computed, write);
-        return { durableResult: computed.durableResult, afterCommitResult };
-    }
-
     async writeComputedTerminalFailure<Result>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<Result>
@@ -107,27 +87,25 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         await this.writeFinalizedMutation(context, computed, async () => {});
     }
 
-    private async writeFinalizedMutation<DurableResult, WriteResult>(
+    private async writeFinalizedMutation<DurableResult>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<WriteResult>
-    ): Promise<WriteResult> {
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<void> {
         this.ensurePending(context);
-        const result = await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
-            const writeResult = await write(transaction);
+        await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
+            await write(transaction);
             await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
             const completed = await writeResourceInboxReservationFinish(transaction, computed.reservationFinish);
             if (!completed) {
                 throw computed.reservationConflict;
             }
-            return writeResult;
         });
         this.finalizationByContext.set(context, {
             state: 'transaction-finalized',
             status: computed.reservationFinish.status,
             result: computed.encodedResult
         });
-        return result;
     }
 
     private ensurePending(context: AppInboxExecutionMetadata): void {

--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -1,3 +1,4 @@
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
 import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
@@ -49,10 +50,6 @@ export interface ClientStateInboxHandlerDependencies {
     readonly snapshotObserver: Pick<ClientStateService, 'observeSnapshot'>;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly serviceId: string;
-}
-
-export interface ClientStateInboxAfterCommitResult {
-    readonly committedSnapshots: readonly import('@shared/api/client-types.ts').ClientSnapshot[];
 }
 
 interface WriteMissingSessionDisconnectInput {
@@ -137,8 +134,9 @@ export class ClientStateInboxHandler {
         const computed = await this.readComputeValidateExpiredSessionMutations(context, atEpochMs);
         const applied = computed.filter((successor) => successor.outcome === 'write');
         const durableResult = applied.map(toClientStateWritten);
+        const committedSnapshots = applied.map((successor) => successor.snapshot);
         const completion = this.readComputeValidateCompletion(context, durableResult);
-        const result = await this.dependencies.transactionWriter.writeComputedMutationWithAfterCommitResult(
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
             completion,
             async (transaction) => {
@@ -147,11 +145,10 @@ export class ClientStateInboxHandler {
                         await this.dependencies.mutationService.write(transaction, successor);
                     }
                 }
-                return { committedSnapshots: applied.map((successor) => successor.snapshot) };
             }
         );
-        await this.observeCommittedSnapshots(result.afterCommitResult);
-        return result.durableResult;
+        await this.observeCommittedSnapshots(committedSnapshots);
+        return result;
     }
 
     private async readComputeValidateMutation(
@@ -172,17 +169,17 @@ export class ClientStateInboxHandler {
             throw new Error('Validated client idempotency conflict is unreachable');
         }
         const durableResult = toClientStateWritten(computed);
+        const committedSnapshots = [computed.snapshot];
         const completion = this.readComputeValidateCompletion(context, durableResult);
-        const result = await this.dependencies.transactionWriter.writeComputedMutationWithAfterCommitResult(
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
             completion,
             async (transaction) => {
                 await this.writeClientMutation(transaction, computed, lifecycleComputed);
-                return { committedSnapshots: [computed.snapshot] };
             }
         );
-        await this.observeCommittedSnapshots(result.afterCommitResult);
-        return result.durableResult;
+        await this.observeCommittedSnapshots(committedSnapshots);
+        return result;
     }
 
     private async writeClientMutation(
@@ -198,10 +195,8 @@ export class ClientStateInboxHandler {
         }
     }
 
-    private async observeCommittedSnapshots(
-        result: ClientStateInboxAfterCommitResult
-    ): Promise<void> {
-        for (const snapshot of result.committedSnapshots) {
+    private async observeCommittedSnapshots(snapshots: readonly ClientSnapshot[]): Promise<void> {
+        for (const snapshot of snapshots) {
             await this.dependencies.snapshotObserver.observeSnapshot(snapshot);
         }
     }

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
@@ -134,23 +134,4 @@ describe('AppInbox successful completion computation', () => {
         expect(harness.database.state.results.get(key)?.resource).toBe(JSON.stringify(durableResult));
         expect(harness.database.state.inbox.get(key)?.status).toBe(EntityStatus.COMPLETED);
     });
-
-    it('keeps private after-commit data separate from the computed durable result', async () => {
-        const harness = createAtomicHarness();
-        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
-        const durableResult = { status: 'accepted' } as const;
-        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
-        const computed = computeAppInboxCompletion(input);
-        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
-        const afterCommitResult = { wakeQueue: true };
-
-        const result = await writer.writeComputedMutationWithAfterCommitResult(
-            harness.context,
-            computed,
-            async () => afterCommitResult
-        );
-
-        expect(result).toEqual({ durableResult, afterCommitResult });
-        expect(harness.database.state.results.get(toKeyAsString(harness.entry.key))?.resource).toBe(JSON.stringify(durableResult));
-    });
 });

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -28,10 +28,7 @@ import type {
     AppInboxCompletionComputed,
     AppInboxCompletionFacts
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
-import type {
-    AppInboxMutationTransactionResult,
-    AppInboxMutationTransactionWriter
-} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import { materializeAuthMutationIntent } from '@shared-server/rallar-system/auth/mutation/materialize-auth-mutation-intent.ts';
 
 const decodeOrderCase = 'decodes before queue identity validation and exits before mutation phases on mismatch';
@@ -218,14 +215,6 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
         this.actions.push('transaction');
         await write(this.transaction);
         return computed.durableResult;
-    }
-
-    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        _context: AppInboxExecutionMetadata,
-        _computed: AppInboxCompletionComputed<DurableResult>,
-        _write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        throw new Error('Computed after-commit transaction path must not run');
     }
 }
 

--- a/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
@@ -92,6 +92,31 @@ describe('client mutation transaction and outbox', () => {
         expect(harness.observedSnapshots).toEqual([]);
         expect(await harness.results.findByKey(harness.context.entry.key)).toBeUndefined();
     });
+
+    it('selects the after-commit snapshot before opening the transaction', async () => {
+        const harness = await createClientMutationTransactionBoundaryFixture({
+            rejectSnapshotReadInTransaction: true
+        });
+
+        await expect(
+            harness.handler.processCommand(
+                harness.context,
+                toUpsertClientPrincipalMutationInput({
+                    scope: SCOPE,
+                    principalId: 'alice',
+                    request: {
+                        username: 'alice',
+                        actorPrincipalId: 'alice',
+                        actorSessionId: 'alice-session',
+                        requestId: 'client-snapshot-selection'
+                    },
+                    defaultCommandId: 'client-snapshot-selection'
+                })
+            )
+        ).resolves.toBeDefined();
+
+        expect(harness.observedSnapshots).toHaveLength(1);
+    });
 });
 
 describe('client mutation AppInbox retry and rollback', () => {

--- a/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
@@ -32,6 +32,7 @@ const SCOPE: StateScope = { applicationId: 'ar-eye-hunter', workspaceId: 'defaul
 
 interface ClientMutationTransactionBoundaryOptions {
     readonly failTransaction?: boolean;
+    readonly rejectSnapshotReadInTransaction?: boolean;
 }
 
 interface ClientMutationTransactionBoundaryFixture {
@@ -53,6 +54,7 @@ export async function createClientMutationTransactionBoundaryFixture(
     const results = new TestResourceInboxResults();
     const runtimeRepository = new FakeRuntimeStateRepository();
     const context = createReservedClientContext();
+    let transactionActive = false;
     await queue.enqueue(context.entry);
     const database = createAppInboxTestDatabase(queue, results, {
         runtimeRepository,
@@ -60,14 +62,25 @@ export async function createClientMutationTransactionBoundaryFixture(
             if (options.failTransaction) {
                 throw new Error('injected transaction failure');
             }
-            const result = await write();
-            actions.push('commit');
-            return result;
+            transactionActive = true;
+            try {
+                const result = await write();
+                actions.push('commit');
+                return result;
+            }
+            finally {
+                transactionActive = false;
+            }
         }
     });
     const durable = createAutoAuthorizingClientStateService(runtimeRepository, database);
     const handler = new ClientStateInboxHandler({
-        mutationService: observeMutationWrites(durable, { actions, computedSnapshots }),
+        mutationService: observeMutationWrites(durable, {
+            actions,
+            computedSnapshots,
+            rejectSnapshotReadInTransaction: options.rejectSnapshotReadInTransaction === true,
+            isTransactionActive: () => transactionActive
+        }),
         sessionGenerationLifecycle: durable.sessionGenerationLifecycle,
         expiryCandidates: durable,
         snapshotObserver: {
@@ -99,6 +112,8 @@ export async function createClientMutationTransactionBoundaryFixture(
 interface ObservedMutationEffects {
     readonly actions: string[];
     readonly computedSnapshots: ClientSnapshot[];
+    readonly rejectSnapshotReadInTransaction: boolean;
+    readonly isTransactionActive: () => boolean;
 }
 
 function observeMutationWrites(
@@ -111,6 +126,16 @@ function observeMutationWrites(
             const computed = durable.compute(command, read);
             if (computed.outcome !== 'idempotency-conflict') {
                 effects.computedSnapshots.push(computed.snapshot);
+                if (effects.rejectSnapshotReadInTransaction) {
+                    return Object.defineProperty({ ...computed }, 'snapshot', {
+                        get: () => {
+                            if (effects.isTransactionActive()) {
+                                throw new Error('snapshot selection must finish before the transaction');
+                            }
+                            return computed.snapshot;
+                        }
+                    });
+                }
             }
             return computed;
         },

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -11,7 +11,6 @@ import type {
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     AppInboxTransactionWriter,
-    type AppInboxMutationTransactionResult,
     type AppInboxMutationTransactionWriter
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import type {
@@ -33,13 +32,10 @@ import type { GroupMutationComputed } from '@shared-server/rallar-system/group-s
 import { computeGroupMutationWriteResult, type GroupMutationWriteInput } from '@shared-server/rallar-system/group-state/mutation/group-mutation-result.ts';
 import type { GroupFormationGroupMutationSink } from '@shared-server/rallar-system/observability/formation-metrics.ts';
 import type { WsSessionGenerationLifecycleService } from '@shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts';
-import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { GroupBarrierRepository } from '../group-state-concurrency-test-runtime.ts';
 
 type DurableResult = Readonly<{ status: 'durable'; }>;
-type AfterCommitResult = Readonly<{ committedSnapshot: GroupSnapshot | undefined; }>;
-type TransactionResult = AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>;
 type ExpectedTransactionWriter = {
     readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
     writeComputedMutation<Result>(
@@ -47,11 +43,6 @@ type ExpectedTransactionWriter = {
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result>;
-    writeComputedMutationWithAfterCommitResult<Durable, AfterCommit>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<Durable>,
-        write: (transaction: PSqlSql) => Promise<AfterCommit>
-    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
 };
 type ExpectedHandlerDependencies = {
     readonly mutationService: GroupStateMutationService;
@@ -81,22 +72,8 @@ describe('convergent group and presence state', () => {
         ).toThrow(/auth.*required/i);
     });
 
-    it('returns immutable committed snapshot data through the named transaction result', () => {
-        expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
-        expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
-        expectTypeOf<ReturnType<AppInboxMutationTransactionWriter['writeComputedMutationWithAfterCommitResult']>>().toMatchTypeOf<
-            Promise<AppInboxMutationTransactionResult<unknown, unknown>>
-        >();
-    });
-
-    it('requires distinct durable and after-commit transaction results', () => {
-        expectTypeOf<TransactionResult>().toEqualTypeOf<Readonly<{ durableResult: DurableResult; afterCommitResult: AfterCommitResult; }>>();
-        expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
-        expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
+    it('returns the computed durable result after the transaction commits', () => {
         expectTypeOf<AppInboxMutationTransactionWriter>().toEqualTypeOf<ExpectedTransactionWriter>();
-        expectTypeOf<AppInboxMutationTransactionWriter['writeComputedMutationWithAfterCommitResult']>().toEqualTypeOf<
-            ExpectedTransactionWriter['writeComputedMutationWithAfterCommitResult']
-        >();
         expectTypeOf<AppInboxTransactionWriter>().toMatchTypeOf<AppInboxMutationTransactionWriter>();
     });
 

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -139,9 +139,6 @@ describe('group-state AppInbox transaction result boundary', () => {
                 actions.push('inactive-transaction');
                 await write(createUnusedTransaction());
                 return computed.durableResult;
-            },
-            writeComputedMutationWithAfterCommitResult: async () => {
-                throw new Error('Inactive presence must not use computed after-commit transaction');
             }
         };
         const handler = new GroupStateInboxHandler({

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -16,10 +16,7 @@ const PRECOMPUTABLE_NAME = /^(?:compute|prepare|serialize|canonicalize|hash|enco
 const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
 const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
 const APP_INBOX_TRANSACTION_WRITER_TYPE = /AppInbox(?:Mutation)?TransactionWriter/u;
-const APP_INBOX_WRITE_METHODS = new Set([
-    'writeComputedMutation',
-    'writeComputedMutationWithAfterCommitResult'
-]);
+const APP_INBOX_WRITE_METHOD = 'writeComputedMutation';
 const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
 
 export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
@@ -163,7 +160,7 @@ function precomputableOperation(call, operation) {
 
 function appInboxWriteBoundary(call) {
     const expression = call.getExpression();
-    if (!Node.isPropertyAccessExpression(expression) || !APP_INBOX_WRITE_METHODS.has(expression.getName())) {
+    if (!Node.isPropertyAccessExpression(expression) || expression.getName() !== APP_INBOX_WRITE_METHOD) {
         return undefined;
     }
     const receiver = expression.getExpression();


### PR DESCRIPTION
## Summary
- select client snapshots before opening the AppInbox transaction
- observe those snapshots only after a successful commit
- delete the unused generic after-commit transaction-result API and test-only implementations

## Why
Client callbacks were constructing an array—and, for expiry batches, mapping computed mutations—while the database transaction was open. The work is deterministic and available beforehand. The generic API existed only for this consumer, so deletion is clearer than retaining a compatibility layer.

## Validation
- focused RED proved snapshot access occurred in the transaction before the change
- 32 files / 159 focused tests passed
- shared-server TypeScript check passed
- maintained test typecheck: 1024 files, 0 errors
- fresh-login-shell Deno check passed
- `npm run check:transaction-writes` passed
- dprint and diff checks passed

## Review assessment
This reduces API surface and cognitive indirection. The transaction callback now only iterates prepared mutations and invokes write services. Snapshot observation remains after a successful commit and is skipped on transaction failure.