### PR TITLE
Consolidate reservation finalization SQL

### DIFF
--- a/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts
+++ b/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts
@@ -3,6 +3,7 @@ import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/Res
 import { Either } from '@shared/resilience/Either.ts';
 import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
 import type { StartProcessingEntitySkipped } from './p-sql-resource-inbox-reservation-repository.ts';
+import { writeResourceInboxReservationFinish } from './resource-inbox-reservation-write.ts';
 import { rowsToMap, toDomain, type ResourceInboxRow } from './resource-inbox-row-codec.ts';
 
 export class PSqlResourceInboxFinalizationRepository {
@@ -111,18 +112,11 @@ export class PSqlResourceInboxFinalizationRepository {
             );
         }
 
-        const rows = await this.sql<{ ri_row_id: bigint; }[]>`
-            update resource_inbox
-            set ri_status = ${status}, end_ts = ${completedAt}, next_ts = null
-            where ri_topic_id = ${key.topicId}
-              and ri_resource_id = ${key.resourceId}
-              and fk_ext_bank_id = ${key.contextId}
-              and ri_status = 'RESERVED'
-              and ri_attempts = ${expectedAttempts}
-              and expire_ts > (now() at time zone 'UTC')
-            returning ri_row_id
-        `;
-
-        return rows.length === 1;
+        return await writeResourceInboxReservationFinish(this.sql, {
+            key,
+            expectedAttempts,
+            status,
+            completedAt
+        });
     }
 }


### PR DESCRIPTION
## Summary
- make the established ResourceInbox finalization repository delegate to the prepared reservation-write function
- remove the duplicated `UPDATE resource_inbox` statement
- preserve the repository’s specialized status validation and public method

## Why
The strict AppInbox completion path introduced a persistence-ready reservation operation, but left the original repository with a second copy of the same SQL. One canonical SQL owner is easier to review and prevents the two paths drifting.

## Validation
- 18 files / 178 focused ResourceInbox, AppInbox, and group-presence tests passed
- shared-server TypeScript check passed
- fresh-login-shell Deno check passed
- transaction checker passed
- dprint and diff checks passed

## Review assessment
This does not impose strict domain-write rules on ResourceInbox. Its specialized API and validation remain intact; only the identical SQL implementation is consolidated. The change removes duplication without adding an adapter layer.