### PR TITLE
Precompute AppInbox retry finalization

### DIFF
--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
@@ -1,21 +1,20 @@
-import { Temporal } from '@js-temporal/polyfill';
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '@shared-server/postgres/run-in-p-sql-transaction.ts';
-import { PSqlResourceInboxFinalizationRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
-import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
+import { writeResourceInboxReservationFinish } from '@shared-server/queuebox/postgres/resource-inbox-reservation-write.ts';
+import { writeResourceInboxResultReplacement } from '@shared-server/queuebox/postgres/resource-inbox-result-replacement.ts';
 import type {
     ResourceInboxRetryExhaustion,
     ResourceInboxRetryExhaustionRecovery
 } from '@shared/queuebox/DequeueResourceEntryController.ts';
-import {
-    EntityStatus,
-    toResourceEntryWithUpdatedResource,
-    type ResourceEntry
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { timeRallarAsync, type RallarTimingDetails, type RallarTimingSink } from '../observability/timing.ts';
 import { validateAppInboxCommandIdentity } from './app-inbox-command-identity.ts';
-import { AppInboxReservationConflictError } from './app-inbox-contracts.ts';
 import type { AppInboxFailure } from './app-inbox-failure.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from './handler/app-inbox-completion-computation.ts';
 
 export type AppInboxRetryFinalization =
     | ResourceInboxRetryExhaustion
@@ -27,10 +26,7 @@ export interface AppInboxRetryFinalizerDependencies {
 }
 
 interface AppInboxRetryFinalizationWork {
-    readonly finalization: AppInboxRetryFinalization;
-    readonly finalizedAtEpochMs: number;
-    readonly finalizedAt: Date;
-    readonly diagnostics: AppInboxFailure;
+    readonly completion: AppInboxCompletionComputed<AppInboxFailure>;
     readonly timingDetails: RallarTimingDetails;
 }
 
@@ -61,11 +57,19 @@ function createAppInboxRetryFinalizationWork(
     finalization: AppInboxRetryFinalization
 ): AppInboxRetryFinalizationWork {
     const finalizedAtEpochMs = toFinalizedAtEpochMs(finalization);
+    const completionInput = {
+        entry: finalization.entry,
+        completedAtEpochMs: finalizedAtEpochMs,
+        durableResult: toDiagnostics(finalization),
+        status: EntityStatus.FAILED
+    } as const;
+    const completion = computeAppInboxCompletion(completionInput);
+    const issues = validateAppInboxCompletion(completionInput, completion);
+    if (issues[0] !== undefined) {
+        throw issues[0].cause;
+    }
     return {
-        finalization,
-        finalizedAtEpochMs,
-        finalizedAt: new Date(finalizedAtEpochMs),
-        diagnostics: toDiagnostics(finalization),
+        completion,
         timingDetails: {
             processingAttempts: finalization.processingAttempts,
             reservationAttempt: finalization.reservationAttempt,
@@ -83,56 +87,20 @@ async function finalizeAppInboxRetry(
     dependencies: AppInboxRetryFinalizerDependencies,
     work: AppInboxRetryFinalizationWork
 ): Promise<ResourceEntry> {
-    return await runInPSqlTransaction(dependencies.database, async (transaction) => {
-        await writeAppInboxRetryFinalization(dependencies.timing, transaction, work);
-        return toFinalizedAppInboxEntry(work);
+    await runInPSqlTransaction(dependencies.database, async (transaction) => {
+        await writeAppInboxRetryFinalization(transaction, work.completion);
     });
+    return work.completion.finalizedEntry;
 }
 
 async function writeAppInboxRetryFinalization(
-    timing: RallarTimingSink | undefined,
     transaction: PSqlSql,
-    work: AppInboxRetryFinalizationWork
+    computed: AppInboxCompletionComputed<AppInboxFailure>
 ): Promise<void> {
-    const finalizationRepository = new PSqlResourceInboxFinalizationRepository(transaction);
-    const results = new ResourceInboxResultsRepository(transaction);
-    await timeRallarAsync(
-        timing,
-        {
-            component: 'app-inbox-phase',
-            operation: 'write',
-            requestId: work.finalization.entry.key.resourceId,
-            details: work.timingDetails
-        },
-        async () => {
-            await results.replace(toResourceEntryWithUpdatedResource(
-                work.finalization.entry,
-                EntityStatus.FAILED,
-                work.diagnostics
-            ));
-            const finished = await finalizationRepository.finishReserved(
-                work.finalization.entry.key,
-                work.finalization.reservationAttempt,
-                EntityStatus.FAILED,
-                work.finalizedAt
-            );
-            if (!finished) {
-                throw new AppInboxReservationConflictError(work.finalization.entry.key);
-            }
-        }
-    );
-}
-
-function toFinalizedAppInboxEntry(work: AppInboxRetryFinalizationWork): ResourceEntry {
-    return {
-        ...work.finalization.entry,
-        status: EntityStatus.FAILED,
-        dequeueAudit: {
-            ...work.finalization.entry.dequeueAudit,
-            endTs: Temporal.Instant.fromEpochMilliseconds(work.finalizedAtEpochMs),
-            nextTs: undefined
-        }
-    };
+    await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
+    if (!await writeResourceInboxReservationFinish(transaction, computed.reservationFinish)) {
+        throw computed.reservationConflict;
+    }
 }
 
 function toDiagnostics(exhaustion: AppInboxRetryFinalization): AppInboxFailure {


### PR DESCRIPTION
## Summary
- compute and validate retry-exhaustion completion before transaction entry
- execute prepared result replacement and reservation finish operations in the transaction
- return the already-computed finalized entry after commit
- remove the inner write-phase timer while retaining whole-transaction timing

## Why
The retry-exhaustion callback still built the failed result row and finalized entry inside the transaction. The inner timing helper also read a clock in the critical section. Both were precomputable and contradicted the strict AppInbox write model.

## Validation
- 6 files / 68 focused retry-exhaustion and AppInbox handler tests passed
- shared-server TypeScript check passed
- maintained test typecheck: 1024 files, 0 errors
- fresh-login-shell Deno check passed
- transaction checker passed
- dprint and diff checks passed

## Review assessment
The mutation path is shorter and more direct: compute/validate one canonical AppInbox completion, then perform two prepared SQL writes. Atomic rollback and reservation-conflict behavior are unchanged. The removed nested timing event was not a valid transaction-purity exception; overall transaction timing remains available.