### PR TITLE
Precompute guarded runtime-state writes

### DIFF
--- a/apps/api-v1/test/db/pglite-runtime-state-and-collisions.test.ts
+++ b/apps/api-v1/test/db/pglite-runtime-state-and-collisions.test.ts
@@ -18,6 +18,7 @@ import { createGroupTopologyMutationOwners } from '@shared-server/rallar-system/
 import { RtcTopologyOutboxWriter } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-writer.ts';
 import { createGroupTopologyRuntimeOwners } from '@shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { decodePersistedALMessage } from '@shared/al-contracts/al-message-persistence-validation.ts';
@@ -234,8 +235,9 @@ Deno.test(
                 }]
             };
 
+            const insertWrite = computeRuntimeStateGuardedBatchWrite(insertBatch);
             const insertResult = await repository.begin(async (transactionRepository) => {
-                return await transactionRepository.executeGuardedBatch(insertBatch);
+                return await transactionRepository.writeGuardedBatch(insertWrite);
             });
 
             assert.deepEqual(insertResult, {
@@ -306,9 +308,10 @@ Deno.test(
                     expireAtTimestamp: FUTURE_MS
                 }]
             };
+            const updateWrite = computeRuntimeStateGuardedBatchWrite(updateBatch);
             assert.deepEqual(
                 await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch(updateBatch);
+                    return await transactionRepository.writeGuardedBatch(updateWrite);
                 }),
                 {
                     guard: {
@@ -345,9 +348,10 @@ Deno.test(
                     expireAtTimestamp: FUTURE_MS
                 }]
             };
+            const deleteWrite = computeRuntimeStateGuardedBatchWrite(deleteBatch);
             assert.deepEqual(
                 await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch(deleteBatch);
+                    return await transactionRepository.writeGuardedBatch(deleteWrite);
                 }),
                 {
                     guard: {
@@ -404,8 +408,9 @@ Deno.test(
                 }]
             };
 
+            const computed = computeRuntimeStateGuardedBatchWrite(batch);
             const result = await repository.begin(async (transactionRepository) => {
-                return await transactionRepository.executeGuardedBatch(batch);
+                return await transactionRepository.writeGuardedBatch(computed);
             });
 
             assert.deepEqual(result, {
@@ -459,24 +464,25 @@ Deno.test(
                 fractionalEpochMs
             );
 
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'insert',
+                    namespace: 'guarded-expiry',
+                    key: 'guarded-future',
+                    value: 'future',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'fractional',
+                    operation: 'insert',
+                    namespace: 'guarded-expiry',
+                    key: 'guarded-fractional',
+                    value: 'fractional',
+                    expireAtTimestamp: fractionalEpochMs
+                }]
+            });
             await repository.begin(async (transactionRepository) => {
-                await transactionRepository.executeGuardedBatch({
-                    guard: {
-                        operation: 'insert',
-                        namespace: 'guarded-expiry',
-                        key: 'guarded-future',
-                        value: 'future',
-                        expireAtTimestamp: FUTURE_MS
-                    },
-                    effects: [{
-                        effectId: 'fractional',
-                        operation: 'insert',
-                        namespace: 'guarded-expiry',
-                        key: 'guarded-fractional',
-                        value: 'fractional',
-                        expireAtTimestamp: fractionalEpochMs
-                    }]
-                });
+                await transactionRepository.writeGuardedBatch(computed);
             });
 
             const rows = await sql<RuntimeStateExpiryRow[]>`
@@ -506,36 +512,37 @@ Deno.test(
         await withPGliteSql(async (sql) => {
             const repository = new PSqlRuntimeStateRepository(sql);
             await repository.insertIfAbsent('guarded-rollback', 'root', 'before', FUTURE_MS);
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'update',
+                    namespace: 'guarded-rollback',
+                    key: 'root',
+                    expectedRevision: 0,
+                    value: 'after',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'sibling',
+                    operation: 'insert',
+                    namespace: 'guarded-rollback',
+                    key: 'sibling',
+                    value: 'inserted',
+                    expireAtTimestamp: FUTURE_MS
+                }, {
+                    effectId: 'conflict',
+                    operation: 'update',
+                    namespace: 'guarded-rollback',
+                    key: 'missing',
+                    expectedRevision: 0,
+                    value: 'never',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             await assert.rejects(
                 async () => {
                     await repository.begin(async (transactionRepository) => {
-                        const observedResult = await transactionRepository.executeGuardedBatch({
-                            guard: {
-                                operation: 'update',
-                                namespace: 'guarded-rollback',
-                                key: 'root',
-                                expectedRevision: 0,
-                                value: 'after',
-                                expireAtTimestamp: FUTURE_MS
-                            },
-                            effects: [{
-                                effectId: 'sibling',
-                                operation: 'insert',
-                                namespace: 'guarded-rollback',
-                                key: 'sibling',
-                                value: 'inserted',
-                                expireAtTimestamp: FUTURE_MS
-                            }, {
-                                effectId: 'conflict',
-                                operation: 'update',
-                                namespace: 'guarded-rollback',
-                                key: 'missing',
-                                expectedRevision: 0,
-                                value: 'never',
-                                expireAtTimestamp: FUTURE_MS
-                            }]
-                        });
+                        const observedResult = await transactionRepository.writeGuardedBatch(computed);
                         assert.deepEqual(observedResult, {
                             guard: {
                                 status: 'applied',

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -21,8 +21,8 @@ import type {
 } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type {
-    RuntimeStateGuardedBatch,
-    RuntimeStateGuardedBatchEffect
+    RuntimeStateGuardedBatchEffect,
+    RuntimeStateGuardedBatchWrite
 } from '../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { GroupConnectTriggerLatchRow } from '../persistence/group-connect-trigger-latch-repository.ts';
 import type {
@@ -516,7 +516,7 @@ export type GroupMutationDomainWrite = Readonly<{
 }>;
 
 export type GroupMutationPersistence = Readonly<{
-    guardedBatch: RuntimeStateGuardedBatch;
+    guardedBatch: RuntimeStateGuardedBatchWrite;
     lifecyclePolicyWrite:
         | Readonly<{
             namespace: string;

--- a/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
@@ -1,6 +1,8 @@
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
+import { computeRuntimeStateGuardedBatchWrite } from '../../../../runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import {
+    type RuntimeStateGuardedBatch,
     type RuntimeStateGuardedBatchEffect,
     type RuntimeStateGuardedBatchGuard
 } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
@@ -40,7 +42,9 @@ export function computeGroupMutationPersistence(
     computed: GroupMutationDomainWrite
 ): GroupMutationPersistence {
     return {
-        guardedBatch: computeGroupMutationGuardedBatch(computed),
+        guardedBatch: computeRuntimeStateGuardedBatchWrite(
+            computeGroupMutationGuardedBatch(computed)
+        ),
         lifecyclePolicyWrite: computed.lifecyclePolicy === null
             ? null
             : {
@@ -64,7 +68,7 @@ export function computeGroupMutationPersistence(
 
 function computeGroupMutationGuardedBatch(
     computed: GroupMutationDomainWrite
-): GroupMutationPersistence['guardedBatch'] {
+): RuntimeStateGuardedBatch {
     const effects: RuntimeStateGuardedBatchEffect[] = [];
     effects.push(...computePresenceAndMembershipEffects(computed));
     if (computed.acceptedLayoutPromotion) {

--- a/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
@@ -1,8 +1,8 @@
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import type { RuntimeStateGuardedBatch } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import type { RuntimeStateGuardedBatchWrite } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
-import { executeComputedRuntimeStateGuardedBatch } from '../../../../runtime-state/postgres/execute-runtime-state-guarded-batch.ts';
+import { writeRuntimeStateGuardedBatch } from '../../../../runtime-state/postgres/write-runtime-state-guarded-batch.ts';
 import { GroupStateEventCollisionError } from '../../../state-events/group-state-event-store.ts';
 import type { GroupStateEventCollisionRow } from '../../../state-events/postgres/group-state-event-row-codec.ts';
 import type {
@@ -29,9 +29,9 @@ export async function writeGroupMutation(
 
 async function executeGuardedGroupMutationBatch(
     transaction: PSqlSql,
-    batch: RuntimeStateGuardedBatch
+    computed: RuntimeStateGuardedBatchWrite
 ): Promise<void> {
-    const result = await executeComputedRuntimeStateGuardedBatch(transaction, batch);
+    const result = await writeRuntimeStateGuardedBatch(transaction, computed);
     if (result.guard.status === 'conflict') {
         throw new RuntimeStateWriteConflictError();
     }

--- a/packages/shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts
+++ b/packages/shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts
@@ -1,0 +1,34 @@
+import type {
+    RuntimeStateGuardedBatch,
+    RuntimeStateGuardedBatchEffect,
+    RuntimeStateGuardedBatchSqlDescriptor,
+    RuntimeStateGuardedBatchWrite
+} from './runtime-state-guarded-batch.ts';
+
+export function computeRuntimeStateGuardedBatchWrite(
+    batch: RuntimeStateGuardedBatch
+): RuntimeStateGuardedBatchWrite {
+    return {
+        ...batch,
+        guardSqlDescriptor: computeSqlDescriptor(batch.guard),
+        effectSqlDescriptors: batch.effects.map(computeSqlDescriptor)
+    };
+}
+
+function computeSqlDescriptor(
+    input: RuntimeStateGuardedBatch['guard'] | RuntimeStateGuardedBatchEffect
+): RuntimeStateGuardedBatchSqlDescriptor {
+    return {
+        ...('effectId' in input ? { effectId: input.effectId } : {}),
+        operation: input.operation,
+        namespace: input.namespace,
+        key: input.key,
+        ...('expectedRevision' in input
+            ? { expectedRevision: input.expectedRevision }
+            : {}),
+        ...('value' in input ? { value: input.value } : {}),
+        ...('expireAtTimestamp' in input
+            ? { expireAtTimestamp: new Date(input.expireAtTimestamp).toISOString() }
+            : {})
+    };
+}

--- a/packages/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts
+++ b/packages/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts
@@ -54,6 +54,21 @@ export interface RuntimeStateGuardedBatch {
     readonly effects: readonly RuntimeStateGuardedBatchEffect[];
 }
 
+export interface RuntimeStateGuardedBatchSqlDescriptor {
+    readonly effectId?: string;
+    readonly operation: RuntimeStateGuardedBatchEffect['operation'];
+    readonly namespace: string;
+    readonly key: string;
+    readonly expectedRevision?: number;
+    readonly value?: string;
+    readonly expireAtTimestamp?: string;
+}
+
+export interface RuntimeStateGuardedBatchWrite extends RuntimeStateGuardedBatch {
+    readonly guardSqlDescriptor: RuntimeStateGuardedBatchSqlDescriptor;
+    readonly effectSqlDescriptors: readonly RuntimeStateGuardedBatchSqlDescriptor[];
+}
+
 export type RuntimeStateGuardedBatchGuardResult =
     | Readonly<{
         status: 'applied';
@@ -117,7 +132,7 @@ export interface RuntimeStateGuardedBatchResult {
 }
 
 export interface RuntimeStateGuardedBatchTransaction {
-    executeGuardedBatch(
-        batch: RuntimeStateGuardedBatch
+    writeGuardedBatch(
+        computed: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult>;
 }

--- a/packages/shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts
+++ b/packages/shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts
@@ -1,7 +1,7 @@
 import type {
-    RuntimeStateGuardedBatch,
     RuntimeStateGuardedBatchResult,
-    RuntimeStateGuardedBatchTransaction
+    RuntimeStateGuardedBatchTransaction,
+    RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type {
     RuntimeStateConditionalDeleteResult,
@@ -19,7 +19,7 @@ import type {
     RuntimeStateReadBatchSelection,
     RuntimeStateReadBatchSelector
 } from '../read-batch/runtime-state-read-batch.ts';
-import { executeRuntimeStateGuardedBatch } from './execute-runtime-state-guarded-batch.ts';
+import { writeRuntimeStateGuardedBatch } from './write-runtime-state-guarded-batch.ts';
 import { readRuntimeStateBatch } from './read-runtime-state-batch.ts';
 import {
     decodeRuntimeStateRevision,
@@ -89,15 +89,15 @@ export class PSqlRuntimeStateRepository
         });
     }
 
-    async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    async writeGuardedBatch(
+        computed: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.sqlState.kind !== 'transaction') {
             throw new Error(
                 'Guarded runtime state batches require a transaction-scoped repository.'
             );
         }
-        return await executeRuntimeStateGuardedBatch(this.sql, input);
+        return await writeRuntimeStateGuardedBatch(this.sql, computed);
     }
 
     async findEntry(

--- a/packages/shared-server/runtime-state/postgres/write-runtime-state-guarded-batch.ts
+++ b/packages/shared-server/runtime-state/postgres/write-runtime-state-guarded-batch.ts
@@ -1,37 +1,18 @@
 import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
 import type {
-    RuntimeStateGuardedBatch,
-    RuntimeStateGuardedBatchEffect,
-    RuntimeStateGuardedBatchResult
+    RuntimeStateGuardedBatchResult,
+    RuntimeStateGuardedBatchWrite
 } from '../guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatch } from '../guarded-batch/validate-runtime-state-guarded-batch.ts';
 import {
     decodeComputedRuntimeStateGuardedBatchRows,
     type RuntimeStateGuardedBatchDatabaseRow
 } from './decode-runtime-state-guarded-batch-rows.ts';
 
-interface RuntimeStateGuardedBatchSqlDescriptor {
-    readonly effectId?: string;
-    readonly operation: RuntimeStateGuardedBatchEffect['operation'];
-    readonly namespace: string;
-    readonly key: string;
-    readonly expectedRevision?: number;
-    readonly value?: string;
-    readonly expireAtTimestamp?: string;
-}
-
-export async function executeRuntimeStateGuardedBatch(
+export async function writeRuntimeStateGuardedBatch(
     sql: PSqlSql,
-    input: RuntimeStateGuardedBatch
+    computed: RuntimeStateGuardedBatchWrite
 ): Promise<RuntimeStateGuardedBatchResult> {
-    const batch = validateRuntimeStateGuardedBatch(input);
-    return await executeComputedRuntimeStateGuardedBatch(sql, batch);
-}
-
-export async function executeComputedRuntimeStateGuardedBatch(
-    sql: PSqlSql,
-    batch: RuntimeStateGuardedBatch
-): Promise<RuntimeStateGuardedBatchResult> {
+    const batch = computed;
     const rows = await sql<RuntimeStateGuardedBatchDatabaseRow[]>`
         with guard_input as (
             select descriptor ->> 'operation' as operation,
@@ -40,7 +21,7 @@ export async function executeComputedRuntimeStateGuardedBatch(
                    descriptor ->> 'value' as store_value,
                    (descriptor ->> 'expireAtTimestamp')::timestamptz as expire_at_ts,
                    (descriptor ->> 'expectedRevision')::bigint as expected_revision
-            from (select ${toSqlDescriptor(batch.guard)}::jsonb as descriptor) guard_json
+            from (select ${computed.guardSqlDescriptor}::jsonb as descriptor) guard_json
         ),
         effect_input as (
             select descriptor ->> 'effectId' as effect_id,
@@ -50,7 +31,7 @@ export async function executeComputedRuntimeStateGuardedBatch(
                    descriptor ->> 'value' as store_value,
                    (descriptor ->> 'expireAtTimestamp')::timestamptz as expire_at_ts,
                    (descriptor ->> 'expectedRevision')::bigint as expected_revision
-            from jsonb_array_elements(${batch.effects.map(toSqlDescriptor)}::jsonb) descriptor
+            from jsonb_array_elements(${computed.effectSqlDescriptors}::jsonb) descriptor
         ),
         guard_insert as (
             insert into runtime_state_store (store_namespace,
@@ -270,26 +251,4 @@ export async function executeComputedRuntimeStateGuardedBatch(
     `;
 
     return decodeComputedRuntimeStateGuardedBatchRows(batch, rows);
-}
-
-function toSqlDescriptor(
-    input: RuntimeStateGuardedBatch['guard'] | RuntimeStateGuardedBatchEffect
-): RuntimeStateGuardedBatchSqlDescriptor {
-    const effectId = 'effectId' in input ? input.effectId : undefined;
-    const expectedRevision = 'expectedRevision' in input
-        ? input.expectedRevision
-        : undefined;
-    const value = 'value' in input ? input.value : undefined;
-    const expireAtTimestamp = 'expireAtTimestamp' in input
-        ? new Date(input.expireAtTimestamp).toISOString()
-        : undefined;
-    return {
-        effectId,
-        operation: input.operation,
-        namespace: input.namespace,
-        key: input.key,
-        expectedRevision,
-        value,
-        expireAtTimestamp
-    };
 }

--- a/packages/tests/shared-server/integration/postgres/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/integration/postgres/runtime-state-guarded-batch.test.ts
@@ -17,6 +17,7 @@ import {
     RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE,
     RtcTopologySnapshotRepository
 } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
@@ -51,28 +52,27 @@ describe('Postgres runtime-state guarded batches', () => {
             const sql = await createRuntimeStatePostgresSql(requireDatabaseUrl());
             const repository = new PSqlRuntimeStateRepository(sql);
             const namespace = `guarded-batch-${crypto.randomUUID()}`;
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'insert',
+                    namespace,
+                    key: 'guard',
+                    value: 'guard-value',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'insert-effect',
+                    operation: 'insert',
+                    namespace,
+                    key: 'effect',
+                    value: 'effect-value',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             try {
                 const result = await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch({
-                        guard: {
-                            operation: 'insert',
-                            namespace,
-                            key: 'guard',
-                            value: 'guard-value',
-                            expireAtTimestamp: FUTURE_MS
-                        },
-                        effects: [
-                            {
-                                effectId: 'insert-effect',
-                                operation: 'insert',
-                                namespace,
-                                key: 'effect',
-                                value: 'effect-value',
-                                expireAtTimestamp: FUTURE_MS
-                            }
-                        ]
-                    });
+                    return await transactionRepository.writeGuardedBatch(computed);
                 });
 
                 expect(result).toEqual({
@@ -134,20 +134,21 @@ describe('Postgres runtime-state guarded batches', () => {
                 ...outboxEntry,
                 resource: `${outboxEntry.resource}mismatch`
             };
+            const seedWrite = computeRuntimeStateGuardedBatchWrite({
+                guard: groupStateInsertGroupDescriptor(read.group!.value),
+                effects: [{
+                    effectId: 'reset-rollback-seed',
+                    operation: 'insert',
+                    namespace: seedNamespace,
+                    key: 'seed',
+                    value: 'seed',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             try {
                 await runtime.begin(async (transactionRuntime) => {
-                    await transactionRuntime.executeGuardedBatch({
-                        guard: groupStateInsertGroupDescriptor(read.group!.value),
-                        effects: [{
-                            effectId: 'reset-rollback-seed',
-                            operation: 'insert',
-                            namespace: seedNamespace,
-                            key: 'seed',
-                            value: 'seed',
-                            expireAtTimestamp: FUTURE_MS
-                        }]
-                    });
+                    await transactionRuntime.writeGuardedBatch(seedWrite);
                     await new RtcTopologySnapshotRepository(transactionRuntime).commitSnapshotGuard(snapshot, null);
                     await new RtcTopologySnapshotRepository(
                         transactionRuntime,

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-runtime-state-mutation.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-runtime-state-mutation.ts
@@ -1,4 +1,5 @@
 import { decodeJsonWireValue, type JsonWireObject, type JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch, type RuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
 import type { RuntimeStateGuardedBatchDatabaseRow } from '@shared-server/runtime-state/postgres/decode-runtime-state-guarded-batch-rows.ts';
@@ -15,7 +16,8 @@ export async function tryExecuteRuntimeStateGuardedBatch(
         throw new Error('Guarded runtime-state SQL requires a transaction runtime');
     }
     const batch = decodeRuntimeStateGuardedBatchSqlValues(values);
-    return toRuntimeStateGuardedBatchRows(await runtime.executeGuardedBatch(batch));
+    const computed = computeRuntimeStateGuardedBatchWrite(batch);
+    return toRuntimeStateGuardedBatchRows(await runtime.writeGuardedBatch(computed));
 }
 
 export async function tryExecuteRuntimeStateConditionalMutation(

--- a/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
@@ -23,7 +23,7 @@ import { GroupStateRepository } from '@shared-server/rallar-system/group-state/p
 import { decodeJsonWireValue, hashMutationCommand } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import type { GroupStateEventStore } from '@shared-server/rallar-system/state-events/group-state-event-store.ts';
 import type { RuntimeStateGuardedBatchTransaction } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
+import { validateComputedRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { RuntimeStateRetryExhaustedError, RuntimeStateWriteConflictError } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import type {
     RuntimeStateGuardedBatchTransactionalRepositoryLike,
@@ -229,9 +229,9 @@ export class GroupStateTestMutationExecutor {
 
 async function writeGuardedBatch(transaction: RuntimeStateGuardedBatchTransaction, computed: GroupMutationComputedWrite): Promise<void> {
     const materialized = computed.persistence.guardedBatch;
-    const result = validateRuntimeStateGuardedBatchResult(
+    const result = validateComputedRuntimeStateGuardedBatchResult(
         materialized,
-        await transaction.executeGuardedBatch(materialized)
+        await transaction.writeGuardedBatch(materialized)
     );
     if (result.guard.status === 'conflict' || result.effects.some((effect) => effect.status !== 'applied')) {
         throw new RuntimeStateWriteConflictError();

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
@@ -11,7 +11,8 @@ import {
     type RuntimeStateGuardedBatchEffectResult,
     type RuntimeStateGuardedBatchGuard,
     type RuntimeStateGuardedBatchGuardResult,
-    type RuntimeStateGuardedBatchResult
+    type RuntimeStateGuardedBatchResult,
+    type RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -336,13 +337,16 @@ export class ApplyingGuardedBatchRepository extends FakeRuntimeStateRepository {
         return result;
     }
 
-    override async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    override async writeGuardedBatch(
+        input: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.transactionDepth === 0) {
             throw new Error('Guarded batch requires an active transaction');
         }
-        const batch = validateRuntimeStateGuardedBatch(input);
+        const batch = validateRuntimeStateGuardedBatch({
+            guard: input.guard,
+            effects: input.effects
+        });
         this.batches.push(batch);
         this.readCountsBeforeBatch.push(this.outsideTransactionReadCount);
         this.transactionOrder.push('batch');

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-state-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-state-mutation.test.ts
@@ -5,7 +5,7 @@ import { groupStateGroupStorageKey } from '@shared-server/rallar-system/group-st
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { groupStateIdempotencyStorageKey } from '@shared-server/rallar-system/group-state/persistence/idempotency/group-idempotency-storage-key.ts';
 import { groupStateMemberStorageKey } from '@shared-server/rallar-system/group-state/persistence/membership/group-membership-storage-key.ts';
-import type { RuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import type { RuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { GroupMember, GroupRef } from '@shared/api/group-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
@@ -17,7 +17,7 @@ const BATCH_SELECTED = new Error('guarded group batch selected');
 class RejectingGuardedBatchRepository extends FakeRuntimeStateRepository {
     batchCalls = 0;
 
-    executeGuardedBatch(_batch: RuntimeStateGuardedBatch): Promise<never> {
+    writeGuardedBatch(_batch: RuntimeStateGuardedBatchWrite): Promise<never> {
         this.batchCalls += 1;
         return Promise.reject(BATCH_SELECTED);
     }

--- a/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
@@ -3,6 +3,7 @@ import type {
     PSqlRows,
     PSqlSql
 } from '@shared-server/postgres/p-sql-sql.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch, type RuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -12,6 +13,60 @@ import { describe, expect, it } from 'vitest';
 const FUTURE_MS = Date.parse('9999-12-31T23:59:59.999Z');
 
 describe('runtime-state guarded batches', () => {
+    it('computes SQL persistence values before entering a transaction', () => {
+        const batch = createBatch();
+
+        expect(computeRuntimeStateGuardedBatchWrite(batch)).toEqual({
+            ...batch,
+            guardSqlDescriptor: {
+                ...batch.guard,
+                expireAtTimestamp: new Date(FUTURE_MS).toISOString()
+            },
+            effectSqlDescriptors: batch.effects.map((effect) =>
+                'expireAtTimestamp' in effect
+                    ? {
+                        ...effect,
+                        expireAtTimestamp: new Date(effect.expireAtTimestamp).toISOString()
+                    }
+                    : effect
+            )
+        });
+    });
+
+    it('does not recompute persistence values while writing', async () => {
+        let expiryReads = 0;
+        const batch: RuntimeStateGuardedBatch = {
+            guard: {
+                operation: 'insert',
+                namespace: 'guard',
+                key: 'root',
+                value: 'value',
+                get expireAtTimestamp() {
+                    expiryReads += 1;
+                    if (expiryReads > 1) {
+                        throw new Error('expiry recomputed during write');
+                    }
+                    return FUTURE_MS;
+                }
+            },
+            effects: [{
+                effectId: 'delete',
+                operation: 'delete',
+                namespace: 'effect',
+                key: 'missing',
+                expectedRevision: 0
+            }]
+        };
+        const computed = computeRuntimeStateGuardedBatchWrite(batch);
+        const repository = new PSqlRuntimeStateRepository(createTransactionalSql([], []));
+
+        await repository.begin(async (transactionRepository) => {
+            await transactionRepository.writeGuardedBatch(computed);
+        });
+
+        expect(expiryReads).toBe(1);
+    });
+
     it('accepts dense mandatory descriptors at operation-specific revision bounds', () => {
         const batch = createBatch();
 
@@ -306,12 +361,13 @@ describe('runtime-state guarded batches', () => {
         const sql = createTransactionalSql(captured, []);
         const repository = new PSqlRuntimeStateRepository(sql);
 
-        await expect(repository.executeGuardedBatch(createBatch())).rejects.toThrow(
+        const computed = computeRuntimeStateGuardedBatchWrite(createBatch());
+        await expect(repository.writeGuardedBatch(computed)).rejects.toThrow(
             /transaction/iu
         );
 
         await repository.begin(async (transactionRepository) => {
-            await transactionRepository.executeGuardedBatch(createBatch());
+            await transactionRepository.writeGuardedBatch(computed);
         });
         expect(captured).toHaveLength(1);
     });
@@ -346,8 +402,9 @@ describe('runtime-state guarded batches', () => {
         }]);
         const repository = new PSqlRuntimeStateRepository(sql);
 
+        const computed = computeRuntimeStateGuardedBatchWrite(batch);
         const result = await repository.begin(async (transactionRepository) => {
-            return await transactionRepository.executeGuardedBatch(batch);
+            return await transactionRepository.writeGuardedBatch(computed);
         });
 
         expect(result).toEqual({
@@ -453,8 +510,9 @@ describe('runtime-state guarded batches', () => {
             createTransactionalSql([], rows)
         );
 
+        const computed = computeRuntimeStateGuardedBatchWrite(createBatch());
         await expect(repository.begin(async (transactionRepository) => {
-            return await transactionRepository.executeGuardedBatch(createBatch());
+            return await transactionRepository.writeGuardedBatch(computed);
         })).rejects.toThrow(/guarded batch database result/iu);
     });
 });

--- a/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
+++ b/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
@@ -4,7 +4,8 @@ import type {
     RuntimeStateGuardedBatchEffectResult,
     RuntimeStateGuardedBatchGuard,
     RuntimeStateGuardedBatchGuardResult,
-    RuntimeStateGuardedBatchResult
+    RuntimeStateGuardedBatchResult,
+    RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -246,13 +247,16 @@ export class FakeRuntimeStateRepository
         return { status: 'applied' };
     }
 
-    async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    async writeGuardedBatch(
+        input: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.activeTransactionCount === 0) {
             throw new Error('Guarded runtime state batch requires an active transaction');
         }
-        const batch = validateRuntimeStateGuardedBatch(input);
+        const batch = validateRuntimeStateGuardedBatch({
+            guard: input.guard,
+            effects: input.effects
+        });
         const guard = await applyGuardedBatchGuard(this, batch.guard);
         if (guard.status === 'conflict') {
             return validateRuntimeStateGuardedBatchResult(batch, {


### PR DESCRIPTION
## Summary
- compute guarded-batch SQL descriptors before transaction entry
- replace the transaction API that accepted raw batches with `writeGuardedBatch(computed)`
- keep the group write path limited to SQL execution and database-result conflict handling
- rename the PostgreSQL owner from `execute-...` to `write-...` to match its responsibility

## Why
The previous writer converted expiry epochs with `Date#toISOString` and mapped effect descriptors while the transaction was open. That deterministic work belongs in the compute result.

## Review assessment
This is a cohesive internal contract change with no verified production compatibility consumer outside the migrated group path. The new contract makes the transaction boundary obvious and removes the legacy raw-batch entry point rather than retaining a wrapper. Test-only repository consumers were updated to compute before opening transactions. No ResourceInbox policy is changed.

## Validation
- 46 focused Vitest files: 340 passed, 3 skipped
- focused runtime boundary: 25 passed
- fresh-shell Deno check and PGlite suite: 8 passed
- real PostgreSQL integration: 2 passed
- shared-server TypeScript and governed test typecheck: pass (1024 files, zero debt)
- transaction-write checker: pass
- repository structure, dprint, and diff checks: pass

## Known wider-branch status
This PR does not make the full recovery stack merge-ready. Separate P1 findings remain in topology sequencing/collision handling, auth retry facts, and checker claims.