### PR TITLE
Reject topology promotion collisions

### DIFF
--- a/packages/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts
@@ -8,10 +8,7 @@ import { GROUP_MUTATION_QUEUE_EXPIRE_AT_EPOCH_MS } from '@shared-server/rallar-s
 import type { GroupLifecyclePolicyRead } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
 import { computeTopologyPromotionEntry } from '@shared-server/rallar-system/group-state/topology-promotion-outbox-entry.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
-import {
-    PSqlResourceInboxEntryRepository,
-    ResourceInboxInvariantCorruptionError
-} from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
 
 /**
  * The route-less promotion producer's read surface (decision 27): present
@@ -95,16 +92,5 @@ export async function writeTopologyPromotionRequest(
     if (requestEntry === null) {
         return;
     }
-    try {
-        await new PSqlResourceInboxEntryRepository(transaction).writeIfAbsentOrMatch(requestEntry);
-    }
-    catch (error) {
-        // A same-identity request with different audit bytes already exists:
-        // the promotion is already durably requested, which is this write's
-        // whole goal — swallow the mismatch instead of wedging the
-        // publication transaction.
-        if (!(error instanceof ResourceInboxInvariantCorruptionError)) {
-            throw error;
-        }
-    }
+    await new PSqlResourceInboxEntryRepository(transaction).writeIfAbsentOrMatch(requestEntry);
 }

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.test.ts
@@ -1,0 +1,62 @@
+import { Temporal } from '@js-temporal/polyfill';
+import type {
+    PSqlParameter,
+    PSqlSql
+} from '@shared-server/postgres/p-sql-sql.ts';
+import {
+    ResourceInboxInvariantCorruptionError
+} from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import { writeTopologyPromotionRequest } from '@shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+
+describe('topology promotion request write', () => {
+    it('rejects an immutable ResourceInbox collision', async () => {
+        const entry = promotionEntry();
+
+        await expect(
+            writeTopologyPromotionRequest(createConflictingTransaction(), entry)
+        ).rejects.toBeInstanceOf(ResourceInboxInvariantCorruptionError);
+    });
+});
+
+function promotionEntry(): ResourceEntry {
+    const createdTs = Temporal.PlainDateTime.from('2026-01-02T03:04:05');
+    return {
+        key: {
+            topicId: 'topology-promotion',
+            resourceId: 'promotion-1',
+            contextId: 'group-1'
+        },
+        resource: '{"promotion":1}',
+        typeId: 'APP_OUTBOX',
+        status: EntityStatus.NEW,
+        audit: {
+            date: createdTs.toPlainTime(),
+            createdBy: 'topology-service',
+            createdTs,
+            expiryTs: Temporal.Instant.from('9999-12-31T23:59:59.999Z')
+        },
+        dequeueAudit: { attempts: 0 }
+    };
+}
+
+function createConflictingTransaction(): PSqlSql {
+    function sql<Result>(
+        _strings: TemplateStringsArray,
+        ..._values: readonly PSqlParameter[]
+    ): Promise<Result>;
+    function sql(_values: readonly PSqlParameter[]): object;
+    function sql(
+        stringsOrValues: TemplateStringsArray | readonly PSqlParameter[]
+    ): Promise<readonly object[]> | object {
+        return Array.isArray(stringsOrValues) && !Object.hasOwn(stringsOrValues, 'raw')
+            ? {}
+            : Promise.resolve([]);
+    }
+    return Object.assign(sql, {
+        begin: async <T>(_write: (transaction: PSqlSql) => Promise<T>): Promise<T> => {
+            throw new Error('Topology promotion write must not open a transaction');
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- stop swallowing immutable ResourceInbox collisions during topology promotion publication
- add a focused regression proving different persisted content fails the write

## Correctness
The old catch treated every `ResourceInboxInvariantCorruptionError` as evidence that promotion was already durably requested. That error also represents different immutable content or invalid lifecycle. Allowing it to resolve let the surrounding topology transaction commit inconsistent state. Propagating it restores atomic rollback.

## Review assessment
This is deliberately small: one removed catch and one boundary regression. It adds no abstraction, compatibility layer, retry, phase, or policy change to ResourceInbox itself. Navigation is direct from the topology transaction to the promotion writer and repository error. Scoped repository style reports no findings.

## Validation
- RED: regression resolved under old code instead of rejecting
- topology replay/publication focus: 18 files, 144 tests passed
- shared-server TypeScript and governed test typecheck: pass (1025 files, zero debt)
- transaction-write and repository-structure checks: pass
- scoped style, dprint, and diff checks: pass

## Wider stack
The full recovery stack remains not ready; topology phase ordering, auth retry facts, and checker claim precision remain open.