### PR TITLE
Bound the ResourceInbox checker exemption

### DIFF
--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -226,8 +226,9 @@ checker does not substitute for following production symbols.
   allowance is the exact guarded winner materializer, which may construct its
   bounded winner-only row. Outside that allowance, prohibit ordinary domain
   mutation logic, external effects, timers, polling, unbounded work, and
-  arbitrary unresolved operation callbacks. Treat its reported boundary
-  inventory as review evidence, not as a strict pass or an exception.
+  arbitrary unresolved operation callbacks. Treat the checker's explicit file
+  inventory as review evidence, not as a strict pass or an exception. A new
+  file is strict by default until its exact specialized ownership is reviewed.
 - Prefer a functional core with an explicitly owned stateful shell. Model domain
   decisions and conditional-write outcomes as separate typed values.
 - Authoritative persisted and shared contracts use mandatory fields by default.

--- a/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
+++ b/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
@@ -109,9 +109,9 @@ callbacks; and opening or taking ownership of an unrelated nested transaction.
 Caller-owned mutation and dynamically unresolved behavior fail closed. The
 same external-effect, timer, polling, boundedness, caller-mutation, and nested
 transaction prohibitions apply inside the winner materializer. The checker
-reports specialized ResourceInbox boundaries separately from strict findings.
-That inventory is neither an exception nor proof that the boundary satisfies
-`strict-domain-write`.
+keeps specialized ResourceInbox files in an explicit reviewed inventory and
+analyzes new files by default. Inventory membership is neither an exception nor
+proof that the boundary satisfies `strict-domain-write`.
 
 The one externally supplied operation-callback shape permitted by this policy
 is the exact guarded winner materializer. The ResourceInbox owner must first

--- a/packages/tests/repo/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check.test.ts
@@ -237,6 +237,18 @@ describe('transaction write check', () => {
             operation: 'JSON.stringify'
         });
     });
+
+    it('does not exempt new files merely because they are in the ResourceInbox directory', () => {
+        const project = new Project({ useInMemoryFileSystem: true });
+        const source = project.createSourceFile(
+            '/packages/shared-server/queuebox/postgres/unreviewed-domain-write.ts',
+            transactionSource('Date.now()')
+        );
+
+        const findings = analyzeTransactionWrites(project, [source]);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['Date.now']);
+    });
 });
 
 function analyzeFixture(source: string) {

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -21,9 +21,10 @@ graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
 their call site. Readonly IndexedDB transactions, tests, fixtures,
 generated/vendor code, `packages/shared-test/**`, and
 `packages/shared-rtc-bench/**` are excluded.
-Exact PostgreSQL ResourceInbox owners under
-`packages/shared-server/queuebox/postgres/**` are governed by their specialized
-SQL review and semantic tests instead.
+The explicitly inventoried PostgreSQL ResourceInbox owners in the analyzer are
+governed by their specialized SQL review and semantic tests instead. Directory
+placement alone grants no specialization: a new file is analyzed by default
+until its exact ownership is reviewed and added to that inventory.
 
 This is intentionally a narrow check. It does not attempt whole-program
 provenance, arbitrary helper-body expansion, SQL semantic proof, dynamic

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -17,7 +17,13 @@ const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
 const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
 const APP_INBOX_TRANSACTION_WRITER_TYPE = /AppInbox(?:Mutation)?TransactionWriter/u;
 const APP_INBOX_WRITE_METHOD = 'writeComputedMutation';
-const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
+const SPECIALIZED_RESOURCE_INBOX_FILES = new Set([
+    'packages/shared-server/queuebox/postgres/create-p-sql-resource-inbox-repository.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-queue-box.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-results-queue-box.ts',
+    'packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts'
+]);
 
 export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
     const findings = new Map();
@@ -28,7 +34,7 @@ export function analyzeTransactionWrites(project, sourceFiles = project.getSourc
         if (!isAnalyzedSource(path)) {
             continue;
         }
-        const specialized = path.startsWith(SPECIALIZED_RESOURCE_INBOX_ROOT);
+        const specialized = SPECIALIZED_RESOURCE_INBOX_FILES.has(path);
         for (const declaration of sourceFile.getDescendants().filter(isFunctionDeclaration)) {
             if (!specialized && isTransactionWriteDeclaration(declaration)) {
                 roots.push(analysisRoot(declaration));


### PR DESCRIPTION
## Summary
- replace the directory-wide ResourceInbox checker exemption with five explicitly reviewed transaction-owner files
- analyze every new file in that directory by default
- align skill/reference wording with the explicit inventory and its limited evidentiary role

## Why
A directory prefix made specialization transferable by file placement, contrary to the ownership rule. It could hide ordinary domain transaction code added under the ResourceInbox directory.

## Review assessment
This is intentionally not a claim of whole-program proof. The checker remains lexical and its findings are blocking high-confidence signals; helper provenance and SQL semantics remain human-review boundaries. The five inventoried files are the existing PostgreSQL ResourceInbox/Results/QueueBox transaction owners. Helper files in the same directory are no longer automatically exempt. No registry, fingerprint, waiver, or dynamic provenance framework is added.

## Validation
- RED: an unreviewed file under the directory produced zero findings before the change
- checker fixtures: 12 passed
- transaction-write full scan: pass
- skill/governance integrity focus: 4 files, 75 tests passed
- repository structure, dprint, and diff checks: pass

## Wider limitation
A passing checker still does not prove transaction purity. This PR narrows one ownership false negative; it does not add whole-program helper or SQL analysis.