### PR TITLE
Compute topology completion before writes

### DIFF
--- a/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
+++ b/apps/api-v1/test/db/pglite-rtc-topology-ws-outbox.test.ts
@@ -17,7 +17,7 @@ import {
 import {
     computeRtcTopologyReservationFinish,
     finishRtcTopologyReservation
-} from '@shared-server/rallar-system/topology/replay/work/finish-rtc-topology-work.ts';
+} from '@shared-server/rallar-system/topology/replay/work/rtc-topology-work-completion.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { AppTopics, EnqueuedType } from '@shared/api/api-config.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -20,6 +20,7 @@ import type { GroupTopologyPlanningAuthority } from '@shared-server/rallar-syste
 import { hashRtcTopologyExecutionCommand } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
 import { type RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
+import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { RallarTimingSink } from '../../../observability/timing.ts';
 import type { RtcRttRefinementService } from '../../../rtc-rtt/topic/rtc-rtt-refinement-service.ts';
@@ -37,10 +38,6 @@ import {
     materializeRtcOverlayTopologyBroadcastMessage,
     type RtcOverlayTopologyMessageFacts
 } from '../../planning/materialize-rtc-overlay-topology-broadcast-message.ts';
-import {
-    computeRtcTopologyReservationFinish,
-    finishRtcTopologyWork
-} from './finish-rtc-topology-work.ts';
 import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
 import {
     computeAuthorityTopologyInputFingerprint,
@@ -52,6 +49,10 @@ import {
     type PersistedRtcTopologyWork,
     type RtcTopologyWorkEnvelope
 } from './rtc-topology-work-codec.ts';
+import {
+    computeRtcTopologyReservationFinish,
+    writeRtcTopologyWorkCompletion
+} from './rtc-topology-work-completion.ts';
 import {
     readTopologyPromotionRequest,
     type TopologyPromotionPublicationPort
@@ -180,6 +181,7 @@ interface ProcessRtcTopologyWorkInput {
 
 async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promise<void> {
     const { options, message, entry, deferredCriterionPetitioner } = input;
+    const reservationFinish = computeRtcTopologyReservationFinish(entry, new Date());
     const workEnvelope = readRtcTopologyWorkEnvelope(message, options.runtime.workType);
     const workId = toRtcTopologyExecutionId(workEnvelope);
     const read = await options.executionRepository.readTopologyMutation(
@@ -187,7 +189,7 @@ async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promi
         workId
     );
     if (read.publicationClaim) {
-        await processLoadedRtcTopologyWork(options, entry, read);
+        await processLoadedRtcTopologyWork(options, read, reservationFinish);
         return;
     }
     const accepted = await prepareRtcTopologyWork({
@@ -199,13 +201,13 @@ async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promi
         expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds,
         deferredCriterionPetitioner
     });
-    await writeAcceptedRtcTopologyWork(options, entry, accepted);
+    await writeAcceptedRtcTopologyWork({ options, entry, accepted, reservationFinish });
 }
 
 async function processLoadedRtcTopologyWork(
     options: RtcTopologyWorkHandlerOptions,
-    entry: ResourceEntry,
-    read: RtcTopologyMutationRead
+    read: RtcTopologyMutationRead,
+    reservationFinish: ResourceInboxReservationFinish
 ): Promise<void> {
     const replayInput = {
         read,
@@ -236,7 +238,7 @@ async function processLoadedRtcTopologyWork(
         connectRequests: [],
         fingerprint: null,
         delivery: deliveryWrite,
-        reservationFinish: computeRtcTopologyReservationFinish(entry, new Date())
+        reservationFinish
     });
     options.topologyPlanning.recordTopologyPublication(true);
     options.wakeQueue?.();
@@ -422,17 +424,23 @@ async function prepareTopologyMutation(
     };
 }
 
+interface WriteAcceptedRtcTopologyWorkInput {
+    readonly options: RtcTopologyWorkHandlerOptions;
+    readonly entry: ResourceEntry;
+    readonly accepted: AcceptedRtcTopologyWork;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+}
+
 async function writeAcceptedRtcTopologyWork(
-    options: RtcTopologyWorkHandlerOptions,
-    entry: ResourceEntry,
-    accepted: AcceptedRtcTopologyWork
+    input: WriteAcceptedRtcTopologyWorkInput
 ): Promise<void> {
+    const { options, entry, accepted, reservationFinish } = input;
     if (accepted.decision === 'skipped-rtt-refinement') {
-        await finishRtcTopologyWork(options.database, entry);
+        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
         return;
     }
     if (accepted.decision === 'skipped-fingerprint') {
-        await finishRtcTopologyWork(options.database, entry);
+        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
         options.topologyPlanning.recordTopologyRebuildSkippedFingerprint();
         // Topology inputs exclude lifecycle: entering a dialing stage can
         // activate against this stored layout without a rebuild/publication.
@@ -440,12 +448,12 @@ async function writeAcceptedRtcTopologyWork(
         return;
     }
     if (accepted.decision === 'skipped-unchanged' || accepted.decision === 'skipped-frozen') {
-        await writeSkippedTopologyWork(options, entry, accepted);
+        await writeSkippedTopologyWork({ options, entry, accepted, reservationFinish });
         return;
     }
     const computed = accepted.computed;
     if (computed.outcome === 'superseded') {
-        await finishRtcTopologyWork(options.database, entry);
+        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
         options.topologyPlanning.observeCommittedTopology(accepted.group, computed.current);
         return;
     }
@@ -486,7 +494,7 @@ async function writeAcceptedRtcTopologyWork(
         connectRequests,
         fingerprint: fingerprintWrite,
         delivery: deliveryWrite,
-        reservationFinish: computeRtcTopologyReservationFinish(entry, new Date())
+        reservationFinish
     });
     await finishCommittedTopologyWork(options, accepted, computed);
 }
@@ -500,11 +508,17 @@ async function writeAcceptedRtcTopologyWork(
  * fingerprint is decision 11's latched signal that the stored layout
  * trails the authority.
  */
+interface WriteSkippedTopologyWorkInput {
+    readonly options: RtcTopologyWorkHandlerOptions;
+    readonly entry: ResourceEntry;
+    readonly accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-unchanged' | 'skipped-frozen'; }>;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+}
+
 async function writeSkippedTopologyWork(
-    options: RtcTopologyWorkHandlerOptions,
-    entry: ResourceEntry,
-    accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-unchanged' | 'skipped-frozen'; }>
+    input: WriteSkippedTopologyWorkInput
 ): Promise<void> {
+    const { options, entry, accepted, reservationFinish } = input;
     const promotionRequest = await readTopologyPromotionRequest({
         publication: options.topologyPublication,
         serviceId: options.serviceId,
@@ -516,7 +530,6 @@ async function writeSkippedTopologyWork(
         target: accepted.criterionPetition?.planned ?? null,
         entry
     });
-    const reservationFinish = computeRtcTopologyReservationFinish(entry, new Date());
     const fingerprintWrite = accepted.decision === 'skipped-unchanged'
         ? computeRtcTopologyInputFingerprintWrite(
             accepted.group.group,

--- a/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-work-completion.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/rtc-topology-work-completion.ts
@@ -8,11 +8,10 @@ import {
 } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 
-export async function finishRtcTopologyWork(
+export async function writeRtcTopologyWorkCompletion(
     database: PSqlSql,
-    entry: ResourceEntry
+    computed: ResourceInboxReservationFinish
 ): Promise<void> {
-    const computed = computeRtcTopologyReservationFinish(entry, new Date());
     await runInPSqlTransaction(database, async (transaction) => {
         await finishRtcTopologyReservation(transaction, computed);
     });

--- a/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
@@ -18,10 +18,10 @@ import {
     isRtcTopologyDeliveryRetryableConflict,
     toRtcTopologyDeliveryAppendInput
 } from '../delivery/rtc-topology-delivery-validation.ts';
+import type { RtcTopologyInputFingerprintWrite } from './rtc-topology-input-fingerprint.ts';
 import {
     finishRtcTopologyReservation
-} from './finish-rtc-topology-work.ts';
-import type { RtcTopologyInputFingerprintWrite } from './rtc-topology-input-fingerprint.ts';
+} from './rtc-topology-work-completion.ts';
 import { writeGroupConnectTriggerRequests } from './write-group-connect-trigger-requests.ts';
 import { writeTopologyPromotionRequest } from './write-topology-promotion-request.ts';
 


### PR DESCRIPTION
## Summary
- compute one reservation-completion value at topology handler entry
- pass that exact value through loaded, skipped, superseded, and accepted write paths
- remove clock capture from the completion write helper
- rename the helper owner to match its compute/write responsibility

## Review assessment
This is the first bounded part of the larger topology phase-order correction. It removes hidden post-compute clock work without changing transaction semantics or adding a phase. The two helpers widened by the dataflow now use named input contracts; scoped style is clean. The next PR still must move promotion/fingerprint reads and persistence computation ahead of final validation.

## Validation
- topology replay/work focus: 19 files, 165 tests passed
- shared-server TypeScript and governed test typecheck: pass (1025 files, zero debt)
- fresh-shell Deno check of the affected PGlite test: pass
- transaction-write, repository-structure, scoped style, dprint, and diff checks: pass

## Compatibility
The renamed helper had only the migrated verified consumers. No compatibility wrapper remains.