### PR TITLE
Read topology promotion facts before compute

### DIFF
--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -54,9 +54,11 @@ import {
     writeRtcTopologyWorkCompletion
 } from './rtc-topology-work-completion.ts';
 import {
-    readTopologyPromotionRequest,
-    type TopologyPromotionPublicationPort
-} from './write-topology-promotion-request.ts';
+    computeTopologyPromotionRequest,
+    readTopologyPromotion,
+    type TopologyPromotionPublicationPort,
+    type TopologyPromotionRead
+} from './topology-promotion-request.ts';
 
 type AcceptedRtcTopologyMutation = Exclude<RtcTopologyMutationComputed, Readonly<{ outcome: 'loaded' | 'retry'; }>>;
 
@@ -117,12 +119,14 @@ type AcceptedRtcTopologyWork =
         computed: AcceptedRtcTopologyMutation;
         publication: RtcTopologyPublication | null;
         inputFingerprint: string;
+        promotionRead: TopologyPromotionRead | null;
         criterionPetition: CommittedCriterionPetition | null;
     }>
     | Readonly<{
         decision: 'skipped-fingerprint';
         work: PersistedRtcTopologyWork;
         group: GroupSnapshot;
+        promotionRead: TopologyPromotionRead | null;
         criterionPetition: CommittedCriterionPetition;
     }>
     | Readonly<{
@@ -130,12 +134,14 @@ type AcceptedRtcTopologyWork =
         work: PersistedRtcTopologyWork;
         group: GroupSnapshot;
         inputFingerprint: string;
+        promotionRead: TopologyPromotionRead | null;
         criterionPetition: CommittedCriterionPetition | null;
     }>
     | Readonly<{
         decision: 'skipped-frozen';
         work: PersistedRtcTopologyWork;
         group: GroupSnapshot;
+        promotionRead: TopologyPromotionRead | null;
         criterionPetition: CommittedCriterionPetition;
     }>
     | Readonly<{
@@ -287,14 +293,29 @@ async function prepareRtcTopologyWork(
         return rttRefinementSkip;
     }
     const membershipDeltaWork = work.kind === 'group-revision';
-    const authority = await options.topologyPlanning.readTopologyPlanningAuthority({
-        groupRef: work.groupSnapshot.group,
-        requestOptions: fromCanonicalGroupTopologyConfigPatch(work.requestOptions),
-        knownGroup: work.groupSnapshot,
-        snapshotSelection: membershipDeltaWork ? 'preserve-known-revision' : 'prefer-current'
-    });
+    const [authority, promotionRead, storedInputFingerprint] = await Promise.all([
+        options.topologyPlanning.readTopologyPlanningAuthority({
+            groupRef: work.groupSnapshot.group,
+            requestOptions: fromCanonicalGroupTopologyConfigPatch(work.requestOptions),
+            knownGroup: work.groupSnapshot,
+            snapshotSelection: membershipDeltaWork ? 'preserve-known-revision' : 'prefer-current'
+        }),
+        readTopologyPromotion({
+            publication: options.topologyPublication,
+            groupRef: work.groupSnapshot.group
+        }),
+        options.executionRepository.readTopologyInputFingerprint(
+            work.groupSnapshot.group
+        )
+    ]);
     const inputFingerprint = await computeAuthorityTopologyInputFingerprint(authority);
-    const fingerprintSkip = await readFingerprintSkip(input, authority, inputFingerprint);
+    const fingerprintSkip = computeFingerprintSkip({
+        input,
+        authority,
+        inputFingerprint,
+        promotionRead,
+        storedInputFingerprint
+    });
     if (fingerprintSkip !== null) {
         return fingerprintSkip;
     }
@@ -312,6 +333,7 @@ async function prepareRtcTopologyWork(
             decision: 'skipped-frozen',
             work,
             group: authority.group,
+            promotionRead,
             criterionPetition: { authority, planned: computedTopology.current }
         };
     }
@@ -327,6 +349,7 @@ async function prepareRtcTopologyWork(
             work,
             group: authority.group,
             inputFingerprint,
+            promotionRead,
             criterionPetition: { authority, planned: read.snapshot.value }
         };
     }
@@ -334,28 +357,40 @@ async function prepareRtcTopologyWork(
         base: input,
         authority,
         planned: computedTopology,
-        inputFingerprint
+        inputFingerprint,
+        promotionRead
     });
 }
 
-async function readFingerprintSkip(
-    input: PrepareRtcTopologyWorkInput,
-    authority: GroupTopologyPlanningAuthority,
-    inputFingerprint: string
-): Promise<Extract<AcceptedRtcTopologyWork, { decision: 'skipped-fingerprint'; }> | null> {
-    const work = input.workEnvelope.data;
-    const snapshot = input.read.snapshot;
+interface ComputeFingerprintSkipInput {
+    readonly input: PrepareRtcTopologyWorkInput;
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly inputFingerprint: string;
+    readonly promotionRead: TopologyPromotionRead | null;
+    readonly storedInputFingerprint: string | null;
+}
+
+function computeFingerprintSkip(
+    input: ComputeFingerprintSkipInput
+): Extract<AcceptedRtcTopologyWork, { decision: 'skipped-fingerprint'; }> | null {
+    const {
+        input: preparation,
+        authority,
+        inputFingerprint,
+        promotionRead,
+        storedInputFingerprint
+    } = input;
+    const work = preparation.workEnvelope.data;
+    const snapshot = preparation.read.snapshot;
     if (!isChangeGatedGroupRevisionWork(work) || snapshot?.value.state !== 'active') {
         return null;
     }
-    const storedFingerprint = await input.options.executionRepository.readTopologyInputFingerprint(
-        authority.group.group
-    );
-    return storedFingerprint === inputFingerprint
+    return storedInputFingerprint === inputFingerprint
         ? {
             decision: 'skipped-fingerprint',
             work,
             group: authority.group,
+            promotionRead,
             criterionPetition: { authority, planned: snapshot.value }
         }
         : null;
@@ -366,12 +401,13 @@ interface PrepareTopologyMutationInput {
     readonly authority: GroupTopologyPlanningAuthority;
     readonly planned: Extract<ReconcileGroupTopologyResult, { action: 'planned'; }>;
     readonly inputFingerprint: string;
+    readonly promotionRead: TopologyPromotionRead | null;
 }
 
 async function prepareTopologyMutation(
     input: PrepareTopologyMutationInput
 ): Promise<AcceptedRtcTopologyWork> {
-    const { authority, planned, inputFingerprint } = input;
+    const { authority, planned, inputFingerprint, promotionRead } = input;
     const { options, workEnvelope, workId, attemptCount, read } = input.base;
     const work = workEnvelope.data;
     const publicationExpireAtTimestamp = work.publish
@@ -420,6 +456,7 @@ async function prepareTopologyMutation(
         computed,
         publication,
         inputFingerprint,
+        promotionRead,
         criterionPetition: { authority, planned: planned.snapshot }
     };
 }
@@ -460,8 +497,8 @@ async function writeAcceptedRtcTopologyWork(
     // Read outside, mint inside: the gate reads use the shared database
     // handle and must not run while the transaction holds the session.
     const promotionRequest = computed.outcome === 'write'
-        ? await readTopologyPromotionRequest({
-            publication: options.topologyPublication,
+        ? computeTopologyPromotionRequest({
+            read: accepted.promotionRead,
             serviceId: options.serviceId,
             entry,
             target: computed.snapshotGuard.candidate
@@ -519,8 +556,8 @@ async function writeSkippedTopologyWork(
     input: WriteSkippedTopologyWorkInput
 ): Promise<void> {
     const { options, entry, accepted, reservationFinish } = input;
-    const promotionRequest = await readTopologyPromotionRequest({
-        publication: options.topologyPublication,
+    const promotionRequest = computeTopologyPromotionRequest({
+        read: accepted.promotionRead,
         serviceId: options.serviceId,
         entry,
         target: accepted.criterionPetition?.planned ?? null

--- a/packages/shared-server/rallar-system/topology/replay/work/topology-promotion-request.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/topology-promotion-request.ts
@@ -23,6 +23,16 @@ export interface TopologyPromotionPublicationPort {
 
 export interface ReadTopologyPromotionRequestInput {
     readonly publication: TopologyPromotionPublicationPort | undefined;
+    readonly groupRef: GroupRef;
+}
+
+export interface TopologyPromotionRead {
+    readonly group: Group | null;
+    readonly policy: GroupLifecyclePolicyRead | null;
+}
+
+export interface ComputeTopologyPromotionRequestInput {
+    readonly read: TopologyPromotionRead | null;
     readonly serviceId: string | undefined;
     readonly entry: ResourceEntry;
     readonly target: RallarOverlayTopologySnapshot | null;
@@ -33,23 +43,35 @@ export interface ReadTopologyPromotionRequestInput {
  * port's group and policy reads run on the shared database handle, and a
  * single-session backend (PGlite) deadlocks if they run while the
  * transaction holds that session. Every gate fact is read fresh here — the
- * current group snapshot, never the work payload's enqueue-time copy — and
- * the read also reconciles: an entry is produced whenever the group's
- * accepted identity trails the target layout, so a cycle that once saw a
- * stale stage heals on the next pass. The cheap checks run before the
- * policy read; hold promotes only through activate; a corrupt policy and an
- * absent consumer port fail closed; and the entry never expires, so an
- * outbox backlog delays a promotion but cannot drop it.
+ * current group snapshot, never the work payload's enqueue-time copy. An
+ * inactive or missing current group avoids the policy read.
  */
-export async function readTopologyPromotionRequest(
+export async function readTopologyPromotion(
     input: ReadTopologyPromotionRequestInput
-): Promise<ResourceEntry | null> {
-    const { publication, target } = input;
-    if (!publication || target === null || target.state !== 'active') {
+): Promise<TopologyPromotionRead | null> {
+    const { publication, groupRef } = input;
+    if (!publication) {
         return null;
     }
-    const group = await publication.findCurrentGroup(target.groupRef);
+    const group = await publication.findCurrentGroup(groupRef);
     if (group === null || group.lifecycleState !== 'active') {
+        return { group, policy: null };
+    }
+    return {
+        group,
+        policy: await publication.readLifecyclePolicy(groupRef)
+    };
+}
+
+export function computeTopologyPromotionRequest(
+    input: ComputeTopologyPromotionRequestInput
+): ResourceEntry | null {
+    const { read, target } = input;
+    if (read === null || target === null || target.state !== 'active') {
+        return null;
+    }
+    const { group, policy: policyRead } = read;
+    if (group === null || group.lifecycleState !== 'active' || policyRead === null) {
         return null;
     }
     const targetIdentity = toGroupLayoutIdentity(target);
@@ -59,7 +81,6 @@ export async function readTopologyPromotionRequest(
     ) {
         return null;
     }
-    const policyRead = await publication.readLifecyclePolicy(target.groupRef);
     if (policyRead.status === 'corrupt') {
         return null;
     }

--- a/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-rtc-topology-publication-transaction.ts
@@ -22,8 +22,8 @@ import type { RtcTopologyInputFingerprintWrite } from './rtc-topology-input-fing
 import {
     finishRtcTopologyReservation
 } from './rtc-topology-work-completion.ts';
+import { writeTopologyPromotionRequest } from './topology-promotion-request.ts';
 import { writeGroupConnectTriggerRequests } from './write-group-connect-trigger-requests.ts';
-import { writeTopologyPromotionRequest } from './write-topology-promotion-request.ts';
 
 export interface RtcTopologyDeliveryOptions {
     readonly publisherStreamId: string;

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/topology-promotion-request.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/topology-promotion-request.test.ts
@@ -6,11 +6,62 @@ import type {
 import {
     ResourceInboxInvariantCorruptionError
 } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import { writeTopologyPromotionRequest } from '@shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts';
+import {
+    computeTopologyPromotionRequest,
+    readTopologyPromotion,
+    writeTopologyPromotionRequest
+} from '@shared-server/rallar-system/topology/replay/work/topology-promotion-request.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { describe, expect, it } from 'vitest';
+import { createTestGroup } from '../../../../../create-test-group.ts';
 
 describe('topology promotion request write', () => {
+    it('reads current authority before pure promotion selection', async () => {
+        const calls: string[] = [];
+        const group = createTestGroup({ lifecycleState: 'active' });
+        const read = await readTopologyPromotion({
+            groupRef: group,
+            publication: {
+                findCurrentGroup: async () => {
+                    calls.push('group');
+                    return group;
+                },
+                readLifecyclePolicy: async () => {
+                    calls.push('policy');
+                    return { status: 'absent' };
+                }
+            }
+        });
+
+        expect(calls).toEqual(['group', 'policy']);
+        expect(computeTopologyPromotionRequest({
+            read,
+            serviceId: 'topology-service',
+            entry: promotionEntry(),
+            target: null
+        })).toBeNull();
+        expect(calls).toEqual(['group', 'policy']);
+    });
+
+    it('does not read policy for an inactive current group', async () => {
+        const group = createTestGroup({ lifecycleState: 'dormant' });
+        let policyReads = 0;
+
+        const read = await readTopologyPromotion({
+            groupRef: group,
+            publication: {
+                findCurrentGroup: async () => group,
+                readLifecyclePolicy: async () => {
+                    policyReads += 1;
+                    return { status: 'absent' };
+                }
+            }
+        });
+
+        expect(read).toEqual({ group, policy: null });
+        expect(policyReads).toBe(0);
+    });
+
     it('rejects an immutable ResourceInbox collision', async () => {
         const entry = promotionEntry();
 


### PR DESCRIPTION
## Summary
- read current promotion authority and stored input fingerprint before topology computation
- split promotion handling into explicit `readTopologyPromotion`, pure `computeTopologyPromotionRequest`, and write
- preserve the inactive-group policy-read short circuit
- rename the owner and test files to match their full responsibility

## Correctness and phase ordering
The old handler validated the topology mutation, then performed fresh group/policy reads while materializing its transaction input. It also read the stored fingerprint after computing the candidate fingerprint. The new read set completes first; subsequent promotion and fingerprint decisions consume explicit read data.

## Review assessment
This removes the post-validation DB-read violation without adding a prepare phase or compatibility wrapper. The handler remains larger than ideal and still computes several final transaction values after the domain topology validation; that is the next focused slice. Scoped style is clean.

## Validation
- topology replay/work focus: 19 files, 167 tests passed
- focused promotion/handler tests: 3 files, 35 tests passed
- shared-server TypeScript and governed test typecheck: pass (1025 files, zero debt)
- fresh-shell Deno checks for affected PGlite topology consumers: pass
- transaction-write, repository-structure, scoped style, dprint, and diff checks: pass