### PR TITLE
Precompute complete topology transaction writes

### DIFF
--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
@@ -1,0 +1,243 @@
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
+
+import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import {
+    validateTopologyMutation,
+    type RtcTopologyMutationComputed,
+    type RtcTopologyMutationInput
+} from '../../mutation/rtc-topology-mutations.ts';
+import type { GroupTopologyPlanningAuthority } from '../../planning/group-topology-planning-authority.ts';
+import type { RtcTopologyPublication } from '../../publication/rtc-topology-publication.ts';
+import { computeRtcTopologyInputFingerprintWrite } from './rtc-topology-input-fingerprint.ts';
+import type { PersistedRtcTopologyWork } from './rtc-topology-work-codec.ts';
+import { computeTopologyPromotionRequest } from './topology-promotion-request.ts';
+import type { TopologyPromotionRead } from './topology-promotion-request.ts';
+import { computePublicationConnectTriggerRequests } from './write-group-connect-trigger-requests.ts';
+import {
+    computeRtcTopologyPublicationDeliveryWrite,
+    type RtcTopologyPublicationTransactionWrite
+} from './write-rtc-topology-publication-transaction.ts';
+
+export type AcceptedRtcTopologyMutation = Exclude<
+    RtcTopologyMutationComputed,
+    Readonly<{ outcome: 'loaded' | 'retry'; }>
+>;
+
+/** A formation criterion check deferred until the topology write commits. */
+export interface CommittedCriterionPetition {
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly planned: RallarOverlayTopologySnapshot;
+}
+
+export type AcceptedRtcTopologyWork =
+    | Readonly<{
+        decision: 'accepted';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+        computed: AcceptedRtcTopologyMutation;
+        mutationInput: RtcTopologyMutationInput;
+        publication: RtcTopologyPublication | null;
+        inputFingerprint: string;
+        promotionRead: TopologyPromotionRead | null;
+        criterionPetition: CommittedCriterionPetition | null;
+    }>
+    | Readonly<{
+        decision: 'skipped-fingerprint';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+        promotionRead: TopologyPromotionRead | null;
+        criterionPetition: CommittedCriterionPetition;
+    }>
+    | Readonly<{
+        decision: 'skipped-unchanged';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+        inputFingerprint: string;
+        promotionRead: TopologyPromotionRead | null;
+        criterionPetition: CommittedCriterionPetition | null;
+    }>
+    | Readonly<{
+        decision: 'skipped-frozen';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+        promotionRead: TopologyPromotionRead | null;
+        criterionPetition: CommittedCriterionPetition;
+    }>
+    | Readonly<{
+        decision: 'skipped-rtt-refinement';
+        work: PersistedRtcTopologyWork;
+        group: GroupSnapshot;
+    }>;
+
+export type AcceptedRtcTopologyWorkWrite =
+    | Readonly<{
+        kind: 'completion-only';
+        reservationFinish: ResourceInboxReservationFinish;
+    }>
+    | Readonly<{
+        kind: 'transaction';
+        transaction: RtcTopologyPublicationTransactionWrite;
+    }>;
+
+export interface ComputeRtcTopologyWorkWriteInput {
+    readonly accepted: AcceptedRtcTopologyWork;
+    readonly entry: ResourceEntry;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly formationAutomationEnabled: boolean;
+    readonly serviceId: string | undefined;
+    readonly publisherStreamId: string | undefined;
+}
+
+export function computeRtcTopologyWorkWrite(
+    input: ComputeRtcTopologyWorkWriteInput
+): AcceptedRtcTopologyWorkWrite {
+    const { accepted, entry, reservationFinish } = input;
+    if (
+        accepted.decision === 'skipped-rtt-refinement' ||
+        accepted.decision === 'skipped-fingerprint' ||
+        (accepted.decision === 'accepted' && accepted.computed.outcome === 'superseded')
+    ) {
+        return { kind: 'completion-only', reservationFinish };
+    }
+    const target = accepted.decision === 'accepted'
+        ? accepted.computed.outcome === 'write'
+            ? accepted.computed.snapshotGuard.candidate
+            : null
+        : accepted.criterionPetition?.planned ?? null;
+    const mutation = accepted.decision === 'accepted' &&
+            accepted.computed.outcome !== 'superseded'
+        ? accepted.computed
+        : null;
+    return {
+        kind: 'transaction',
+        transaction: {
+            mutation,
+            promotionRequest: computeTopologyPromotionRequest({
+                read: accepted.promotionRead,
+                serviceId: input.serviceId,
+                entry,
+                target
+            }),
+            connectRequests: computePublicationConnectTriggerRequests({
+                automationEnabled: input.formationAutomationEnabled,
+                target,
+                entry
+            }),
+            fingerprint: computeFingerprintWrite(accepted),
+            delivery: accepted.decision === 'accepted' && accepted.publication
+                ? computeRtcTopologyPublicationDeliveryWrite(
+                    accepted.publication,
+                    input.publisherStreamId
+                )
+                : null,
+            reservationFinish
+        }
+    };
+}
+
+export function validateRtcTopologyWorkWrite(
+    input: ComputeRtcTopologyWorkWriteInput,
+    computed: AcceptedRtcTopologyWorkWrite
+): void {
+    if (input.accepted.decision === 'accepted') {
+        validateTopologyMutation({
+            ...input.accepted.mutationInput,
+            computed: input.accepted.computed
+        });
+    }
+    const expected = computeRtcTopologyWorkWrite(input);
+    if (!jsonEquals(toValidationProjection(computed), toValidationProjection(expected))) {
+        throw new TypeError('RTC topology work write differs from its canonical computation');
+    }
+}
+
+function computeFingerprintWrite(
+    accepted: Exclude<AcceptedRtcTopologyWork, { decision: 'skipped-rtt-refinement' | 'skipped-fingerprint'; }>
+) {
+    if (
+        accepted.decision === 'skipped-frozen' ||
+        (accepted.decision === 'accepted' && accepted.computed.outcome !== 'write')
+    ) {
+        return null;
+    }
+    return computeRtcTopologyInputFingerprintWrite(
+        accepted.group.group,
+        accepted.inputFingerprint
+    );
+}
+
+function toValidationProjection(computed: AcceptedRtcTopologyWorkWrite): object {
+    if (computed.kind === 'completion-only') {
+        return {
+            kind: computed.kind,
+            reservationFinish: toReservationFinishProjection(computed.reservationFinish)
+        };
+    }
+    const transaction = computed.transaction;
+    return {
+        kind: computed.kind,
+        transaction: {
+            mutation: transaction.mutation,
+            promotionRequest: toResourceEntryProjection(transaction.promotionRequest),
+            connectRequests: transaction.connectRequests.map(toRequiredResourceEntryProjection),
+            fingerprint: transaction.fingerprint,
+            delivery: transaction.delivery === null
+                ? null
+                : {
+                    outboxWrite: {
+                        ...transaction.delivery.outboxWrite,
+                        entry: toRequiredResourceEntryProjection(
+                            transaction.delivery.outboxWrite.entry
+                        ),
+                        conflict: {
+                            name: transaction.delivery.outboxWrite.conflict.name,
+                            message: transaction.delivery.outboxWrite.conflict.message,
+                            code: transaction.delivery.outboxWrite.conflict.code,
+                            status: transaction.delivery.outboxWrite.conflict.status,
+                            key: transaction.delivery.outboxWrite.conflict.key
+                        }
+                    },
+                    deliveryAppend: transaction.delivery.deliveryAppend
+                },
+            reservationFinish: toReservationFinishProjection(transaction.reservationFinish)
+        }
+    };
+}
+
+function toReservationFinishProjection(computed: ResourceInboxReservationFinish): object {
+    return {
+        key: computed.key,
+        expectedAttempts: computed.expectedAttempts,
+        status: computed.status,
+        completedAt: computed.completedAt.toISOString()
+    };
+}
+
+function toResourceEntryProjection(entry: ResourceEntry | null): object | null {
+    return entry === null ? null : toRequiredResourceEntryProjection(entry);
+}
+
+function toRequiredResourceEntryProjection(entry: Readonly<ResourceEntry>): object {
+    return {
+        key: entry.key,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        status: entry.status,
+        audit: {
+            date: entry.audit.date.toString(),
+            createdBy: entry.audit.createdBy,
+            createdTs: entry.audit.createdTs.toString(),
+            expiryTs: entry.audit.expiryTs.toString()
+        },
+        dequeueAudit: {
+            startTs: entry.dequeueAudit.startTs?.toString() ?? null,
+            endTs: entry.dequeueAudit.endTs?.toString() ?? null,
+            nextTs: entry.dequeueAudit.nextTs?.toString() ?? null,
+            attempts: entry.dequeueAudit.attempts
+        },
+        db: entry.db ?? null
+    };
+}

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -5,15 +5,6 @@ import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/queue-message-callbacks.ts';
-import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
-import {
-    computePublicationConnectTriggerRequests
-} from './write-group-connect-trigger-requests.ts';
-import {
-    computeRtcTopologyPublicationDeliveryWrite,
-    writeRtcTopologyPublicationTransaction,
-    type RtcTopologyDeliveryOptions
-} from './write-rtc-topology-publication-transaction.ts';
 
 import { toRtcTopologyPublicationId } from '@shared-server/rallar-system/topology/persistence/rtc-topology-identifiers.ts';
 import type { GroupTopologyPlanningAuthority } from '@shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts';
@@ -28,6 +19,7 @@ import {
     computeTopologyMutation,
     validateTopologyMutation,
     type RtcTopologyMutationComputed,
+    type RtcTopologyMutationInput,
     type RtcTopologyMutationRead
 } from '../../mutation/rtc-topology-mutations.ts';
 import type { RtcTopologyWorkRuntime } from '../../mutation/rtc-topology-outbox-work.ts';
@@ -38,10 +30,19 @@ import {
     materializeRtcOverlayTopologyBroadcastMessage,
     type RtcOverlayTopologyMessageFacts
 } from '../../planning/materialize-rtc-overlay-topology-broadcast-message.ts';
+import {
+    computeRtcTopologyWorkWrite,
+    validateRtcTopologyWorkWrite,
+    type AcceptedRtcTopologyMutation,
+    type AcceptedRtcTopologyWork,
+    type AcceptedRtcTopologyWorkWrite,
+    type CommittedCriterionPetition,
+    type ComputeRtcTopologyWorkWriteInput
+} from './compute-rtc-topology-work-write.ts';
+import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
 import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
 import {
-    computeAuthorityTopologyInputFingerprint,
-    computeRtcTopologyInputFingerprintWrite
+    computeAuthorityTopologyInputFingerprint
 } from './rtc-topology-input-fingerprint.ts';
 import {
     readRtcTopologyWorkEnvelope,
@@ -54,13 +55,16 @@ import {
     writeRtcTopologyWorkCompletion
 } from './rtc-topology-work-completion.ts';
 import {
-    computeTopologyPromotionRequest,
     readTopologyPromotion,
     type TopologyPromotionPublicationPort,
     type TopologyPromotionRead
 } from './topology-promotion-request.ts';
-
-type AcceptedRtcTopologyMutation = Exclude<RtcTopologyMutationComputed, Readonly<{ outcome: 'loaded' | 'retry'; }>>;
+import {
+    computeRtcTopologyPublicationDeliveryWrite,
+    writeRtcTopologyPublicationTransaction,
+    type RtcTopologyDeliveryOptions,
+    type RtcTopologyPublicationTransactionWrite
+} from './write-rtc-topology-publication-transaction.ts';
 
 import {
     createDeferredCriterionPetitioner,
@@ -99,56 +103,6 @@ interface RtcTopologyWorkHandlerOptions {
     readonly timing?: RallarTimingSink;
     readonly serviceId?: string;
 }
-
-/**
- * A criterion petition deferred until the write phase commits: the fence
- * must name the layout identity the store actually holds, so the petition
- * fires only after the row it names is durable (product decisions 19/32,
- * the plan's post-publication boundary).
- */
-interface CommittedCriterionPetition {
-    readonly authority: GroupTopologyPlanningAuthority;
-    readonly planned: RallarOverlayTopologySnapshot;
-}
-
-type AcceptedRtcTopologyWork =
-    | Readonly<{
-        decision: 'accepted';
-        work: PersistedRtcTopologyWork;
-        group: GroupSnapshot;
-        computed: AcceptedRtcTopologyMutation;
-        publication: RtcTopologyPublication | null;
-        inputFingerprint: string;
-        promotionRead: TopologyPromotionRead | null;
-        criterionPetition: CommittedCriterionPetition | null;
-    }>
-    | Readonly<{
-        decision: 'skipped-fingerprint';
-        work: PersistedRtcTopologyWork;
-        group: GroupSnapshot;
-        promotionRead: TopologyPromotionRead | null;
-        criterionPetition: CommittedCriterionPetition;
-    }>
-    | Readonly<{
-        decision: 'skipped-unchanged';
-        work: PersistedRtcTopologyWork;
-        group: GroupSnapshot;
-        inputFingerprint: string;
-        promotionRead: TopologyPromotionRead | null;
-        criterionPetition: CommittedCriterionPetition | null;
-    }>
-    | Readonly<{
-        decision: 'skipped-frozen';
-        work: PersistedRtcTopologyWork;
-        group: GroupSnapshot;
-        promotionRead: TopologyPromotionRead | null;
-        criterionPetition: CommittedCriterionPetition;
-    }>
-    | Readonly<{
-        decision: 'skipped-rtt-refinement';
-        work: PersistedRtcTopologyWork;
-        group: GroupSnapshot;
-    }>;
 
 interface PrepareRtcTopologyWorkInput {
     readonly options: RtcTopologyWorkHandlerOptions;
@@ -207,7 +161,17 @@ async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promi
         expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds,
         deferredCriterionPetitioner
     });
-    await writeAcceptedRtcTopologyWork({ options, entry, accepted, reservationFinish });
+    const writeInput: ComputeRtcTopologyWorkWriteInput = {
+        entry,
+        accepted,
+        reservationFinish,
+        formationAutomationEnabled: options.formationAutomation !== undefined,
+        serviceId: options.serviceId,
+        publisherStreamId: options.topologyDelivery?.publisherStreamId
+    };
+    const computedWrite = computeRtcTopologyWorkWrite(writeInput);
+    validateRtcTopologyWorkWrite(writeInput, computedWrite);
+    await writeAcceptedRtcTopologyWork({ options, accepted, computedWrite });
 }
 
 async function processLoadedRtcTopologyWork(
@@ -436,13 +400,13 @@ async function prepareTopologyMutation(
             commandHash: null,
             attemptCount: null
         } as const);
-    const computed = computeTopologyMutation({
+    const mutationInput: RtcTopologyMutationInput = {
         read,
         candidate: planned.snapshot,
         publication,
         facts
-    });
-    validateTopologyMutation({ read, candidate: planned.snapshot, publication, facts, computed });
+    };
+    const computed = computeTopologyMutation(mutationInput);
     if (computed.outcome === 'retry') {
         throw new RuntimeStateWriteConflictError();
     }
@@ -454,6 +418,7 @@ async function prepareTopologyMutation(
         work,
         group: authority.group,
         computed,
+        mutationInput,
         publication,
         inputFingerprint,
         promotionRead,
@@ -463,21 +428,20 @@ async function prepareTopologyMutation(
 
 interface WriteAcceptedRtcTopologyWorkInput {
     readonly options: RtcTopologyWorkHandlerOptions;
-    readonly entry: ResourceEntry;
     readonly accepted: AcceptedRtcTopologyWork;
-    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly computedWrite: AcceptedRtcTopologyWorkWrite;
 }
 
 async function writeAcceptedRtcTopologyWork(
     input: WriteAcceptedRtcTopologyWorkInput
 ): Promise<void> {
-    const { options, entry, accepted, reservationFinish } = input;
+    const { options, accepted, computedWrite } = input;
     if (accepted.decision === 'skipped-rtt-refinement') {
-        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
+        await writeCompletionOnly(options.database, computedWrite);
         return;
     }
     if (accepted.decision === 'skipped-fingerprint') {
-        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
+        await writeCompletionOnly(options.database, computedWrite);
         options.topologyPlanning.recordTopologyRebuildSkippedFingerprint();
         // Topology inputs exclude lifecycle: entering a dialing stage can
         // activate against this stored layout without a rebuild/publication.
@@ -485,106 +449,65 @@ async function writeAcceptedRtcTopologyWork(
         return;
     }
     if (accepted.decision === 'skipped-unchanged' || accepted.decision === 'skipped-frozen') {
-        await writeSkippedTopologyWork({ options, entry, accepted, reservationFinish });
+        await writeSkippedTopologyWork({ options, accepted, computedWrite });
         return;
     }
     const computed = accepted.computed;
     if (computed.outcome === 'superseded') {
-        await writeRtcTopologyWorkCompletion(options.database, reservationFinish);
+        await writeCompletionOnly(options.database, computedWrite);
         options.topologyPlanning.observeCommittedTopology(accepted.group, computed.current);
         return;
     }
-    // Read outside, mint inside: the gate reads use the shared database
-    // handle and must not run while the transaction holds the session.
-    const promotionRequest = computed.outcome === 'write'
-        ? computeTopologyPromotionRequest({
-            read: accepted.promotionRead,
-            serviceId: options.serviceId,
-            entry,
-            target: computed.snapshotGuard.candidate
-        })
-        : null;
-    const connectRequests = computePublicationConnectTriggerRequests({
-        automation: options.formationAutomation,
-        target: computed.outcome === 'write' ? computed.snapshotGuard.candidate : null,
-        entry
-    });
-    const deliveryWrite = accepted.publication
-        ? computeRtcTopologyPublicationDeliveryWrite(
-            accepted.publication,
-            options.topologyDelivery?.publisherStreamId
-        )
-        : null;
-    const fingerprintWrite = computed.outcome === 'write'
-        ? computeRtcTopologyInputFingerprintWrite(
-            accepted.group.group,
-            accepted.inputFingerprint
-        )
-        : null;
+    const transaction = requireTopologyTransactionWrite(computedWrite);
     await writeRtcTopologyPublicationTransaction({
         database: options.database,
         executionRepository: options.executionRepository,
         deliveryAppend: options.topologyDelivery?.append
-    }, {
-        mutation: computed,
-        promotionRequest,
-        connectRequests,
-        fingerprint: fingerprintWrite,
-        delivery: deliveryWrite,
-        reservationFinish
-    });
+    }, transaction);
     await finishCommittedTopologyWork(options, accepted, computed);
 }
 
+async function writeCompletionOnly(
+    database: PSqlSql,
+    computed: AcceptedRtcTopologyWorkWrite
+): Promise<void> {
+    if (computed.kind !== 'completion-only') {
+        throw new TypeError('RTC topology work expected a completion-only write');
+    }
+    await writeRtcTopologyWorkCompletion(database, computed.reservationFinish);
+}
+
+function requireTopologyTransactionWrite(
+    computed: AcceptedRtcTopologyWorkWrite
+): RtcTopologyPublicationTransactionWrite {
+    if (computed.kind !== 'transaction') {
+        throw new TypeError('RTC topology work expected a publication transaction');
+    }
+    return computed.transaction;
+}
+
 /**
- * The one transaction both skip decisions share: the promotion reconcile —
- * a request a stale cycle failed to mint is re-derived from the stored row
- * here, so accepted and planned can never diverge silently — plus the
- * reservation finish. Only the unchanged decision refreshes the input
- * fingerprint: the frozen path must NOT write it, because the stale
- * fingerprint is decision 11's latched signal that the stored layout
- * trails the authority.
+ * Both skip decisions commit one already validated transaction write. Only
+ * the unchanged decision refreshes the input fingerprint: the frozen path
+ * must NOT write it, because the stale fingerprint is decision 11's latched
+ * signal that the stored layout trails the authority.
  */
 interface WriteSkippedTopologyWorkInput {
     readonly options: RtcTopologyWorkHandlerOptions;
-    readonly entry: ResourceEntry;
     readonly accepted: Extract<AcceptedRtcTopologyWork, { decision: 'skipped-unchanged' | 'skipped-frozen'; }>;
-    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly computedWrite: AcceptedRtcTopologyWorkWrite;
 }
 
 async function writeSkippedTopologyWork(
     input: WriteSkippedTopologyWorkInput
 ): Promise<void> {
-    const { options, entry, accepted, reservationFinish } = input;
-    const promotionRequest = computeTopologyPromotionRequest({
-        read: accepted.promotionRead,
-        serviceId: options.serviceId,
-        entry,
-        target: accepted.criterionPetition?.planned ?? null
-    });
-    const connectRequests = computePublicationConnectTriggerRequests({
-        automation: options.formationAutomation,
-        target: accepted.criterionPetition?.planned ?? null,
-        entry
-    });
-    const fingerprintWrite = accepted.decision === 'skipped-unchanged'
-        ? computeRtcTopologyInputFingerprintWrite(
-            accepted.group.group,
-            accepted.inputFingerprint
-        )
-        : null;
+    const { options, accepted, computedWrite } = input;
+    const transaction = requireTopologyTransactionWrite(computedWrite);
     await writeRtcTopologyPublicationTransaction({
         database: options.database,
         executionRepository: options.executionRepository,
         deliveryAppend: undefined
-    }, {
-        mutation: null,
-        promotionRequest,
-        connectRequests,
-        fingerprint: fingerprintWrite,
-        delivery: null,
-        reservationFinish
-    });
+    }, transaction);
     if (accepted.decision === 'skipped-frozen') {
         options.topologyPlanning.recordTopologyPlanFrozen();
     }

--- a/packages/shared-server/rallar-system/topology/replay/work/write-group-connect-trigger-requests.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-group-connect-trigger-requests.ts
@@ -7,10 +7,8 @@ import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/
 import { computeGroupConnectTriggerEntry } from '../../../group-state/group-connect-trigger-outbox-entry.ts';
 import { GROUP_MUTATION_QUEUE_EXPIRE_AT_EPOCH_MS } from '../../../group-state/group-state-service-contracts.ts';
 import { serializeCanonicalJson } from '../../../protocol/canonical-json.ts';
-import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
-
 export interface PublicationConnectTriggerRequestsInput {
-    readonly automation: GroupFormationAutomationPort | undefined;
+    readonly automationEnabled: boolean;
     readonly target: RallarOverlayTopologySnapshot | null;
     readonly entry: ResourceEntry;
 }
@@ -18,8 +16,8 @@ export interface PublicationConnectTriggerRequestsInput {
 export function computePublicationConnectTriggerRequests(
     input: PublicationConnectTriggerRequestsInput
 ): readonly ResourceEntry[] {
-    const { automation, target, entry } = input;
-    if (automation === undefined || target === null || target.state !== 'active') {
+    const { automationEnabled, target, entry } = input;
+    if (!automationEnabled || target === null || target.state !== 'active') {
         return [];
     }
     return [computeGroupConnectTriggerEntry({

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
@@ -285,7 +285,7 @@ describe('retry handoff commit races and replay', () => {
             createdAtEpochMs: 1000,
             expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
         });
-        const requests = computePublicationConnectTriggerRequests({ automation: port, target: PLANNED, entry: source });
+        const requests = computePublicationConnectTriggerRequests({ automationEnabled: true, target: PLANNED, entry: source });
         expect(requests).toHaveLength(1);
         expect(decodeGroupConnectTriggerWork(requests[0]!.resource).kind).toBe('publication');
         await harness.runtimeRepository.upsert(
@@ -320,8 +320,8 @@ describe('retry handoff commit races and replay', () => {
             createdAtEpochMs: 1000,
             expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
         });
-        const first = computePublicationConnectTriggerRequests({ automation: port, target: PLANNED, entry: source });
-        const next = computePublicationConnectTriggerRequests({ automation: port, target: { ...PLANNED, version: 2 }, entry: source });
+        const first = computePublicationConnectTriggerRequests({ automationEnabled: true, target: PLANNED, entry: source });
+        const next = computePublicationConnectTriggerRequests({ automationEnabled: true, target: { ...PLANNED, version: 2 }, entry: source });
         expect(first[0]!.key).not.toEqual(next[0]!.key);
         await expect(harness.database.begin(async (tx) => {
             await writeGroupConnectTriggerRequests(tx, first);

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
@@ -1,0 +1,124 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { computeTopologyMutation } from '@shared-server/rallar-system/topology/mutation/rtc-topology-mutations.ts';
+import {
+    computeRtcTopologyWorkWrite,
+    validateRtcTopologyWorkWrite,
+    type AcceptedRtcTopologyWork,
+    type ComputeRtcTopologyWorkWriteInput
+} from '@shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+import { createRtcTopologyGroupSnapshot } from '../../rtc-topology-test-fixtures.ts';
+
+describe('RTC topology complete write computation', () => {
+    it('rejects a write whose precomputed promotion request was removed', () => {
+        const input = createWriteInput();
+        const computed = computeRtcTopologyWorkWrite(input);
+        if (computed.kind !== 'transaction' || computed.transaction.promotionRequest === null) {
+            throw new Error('Expected a promotion transaction fixture');
+        }
+        const altered = {
+            ...computed,
+            transaction: {
+                ...computed.transaction,
+                promotionRequest: null
+            }
+        } as const;
+
+        expect(() => validateRtcTopologyWorkWrite(input, altered)).toThrow(
+            'RTC topology work write differs from its canonical computation'
+        );
+        expect(computeRtcTopologyWorkWrite(input)).toEqual(computed);
+    });
+});
+
+function createWriteInput(): ComputeRtcTopologyWorkWriteInput {
+    const group = createRtcTopologyGroupSnapshot('group-1', ['session-1']);
+    const candidate: RallarOverlayTopologySnapshot = {
+        sourceGroupStateCausalRevision: group.causalRevision,
+        state: 'active',
+        overlayId: toScopedOverlayId(group.group),
+        groupRef: group.group,
+        name: 'group-1',
+        topology: 'star',
+        activeSessionIds: ['session-1'],
+        nextHopsBySessionId: { 'session-1': [] },
+        degreeLimit: 5,
+        version: 1,
+        createdByClientId: 'session-1',
+        createdAtEpochMs: 1,
+        updatedAtEpochMs: 1
+    };
+    const mutationInput = {
+        read: { snapshot: null, publicationClaim: null },
+        candidate,
+        publication: null,
+        facts: {
+            publicationExpireAtTimestamp: null,
+            commandHash: null,
+            attemptCount: null
+        }
+    } as const;
+    const computed = computeTopologyMutation(mutationInput);
+    if (computed.outcome === 'loaded' || computed.outcome === 'retry') {
+        throw new Error('Expected an accepted topology mutation fixture');
+    }
+    const entry = createReservedEntry();
+    const accepted: AcceptedRtcTopologyWork = {
+        decision: 'accepted',
+        work: {
+            kind: 'group-revision',
+            overlayId: candidate.overlayId,
+            groupSnapshot: group,
+            sourceGroupStateCausalRevision: group.causalRevision,
+            requestedAtEpochMs: 1,
+            requestOptions: toCanonicalGroupTopologyConfigPatch({}),
+            origin: 'automatic',
+            publish: false
+        },
+        group,
+        computed,
+        mutationInput,
+        publication: null,
+        inputFingerprint: `sha256:${'a'.repeat(64)}`,
+        promotionRead: { group: group.group, policy: { status: 'absent' } },
+        criterionPetition: null
+    };
+    return {
+        accepted,
+        entry,
+        reservationFinish: {
+            key: entry.key,
+            expectedAttempts: entry.dequeueAudit.attempts,
+            status: EntityStatus.COMPLETED,
+            completedAt: new Date('2026-01-02T03:05:00.000Z')
+        },
+        formationAutomationEnabled: false,
+        serviceId: 'topology-service',
+        publisherStreamId: undefined
+    };
+}
+
+function createReservedEntry(): ResourceEntry {
+    const createdTs = Temporal.PlainDateTime.from('2026-01-02T03:04:05');
+    return {
+        key: {
+            topicId: 'rtc-topology',
+            resourceId: 'work-1',
+            contextId: 'group-1'
+        },
+        resource: '{"work":1}',
+        typeId: 'APP_OUTBOX',
+        status: EntityStatus.RESERVED,
+        audit: {
+            date: createdTs.toPlainTime(),
+            createdBy: 'topology-service',
+            createdTs,
+            expiryTs: Temporal.Instant.from('2026-01-02T04:04:05Z')
+        },
+        dequeueAudit: { attempts: 2 }
+    };
+}


### PR DESCRIPTION
## Goal

Make the RTC topology worker validate one complete persistence-ready write before opening a transaction.

## Changes

- Computes mutation, promotion, connect-trigger, fingerprint, delivery, and reservation-completion writes together before validation.
- Narrows formation automation to an immutable enabled fact at the pure computation boundary.
- Makes transaction paths consume only the validated computed write.
- Adds a direct regression proving altered prepared promotion data is rejected.

## Acceptance

- No topology publication write component is constructed inside the transaction path.
- The same explicit computation input produces the same write value.
- The final write is validated before transaction entry.

## Validation

- Focused Vitest topology/replay, topology outbox, and connect-trigger suite: 21 files, 184 tests passed.
- Shared-server TypeScript check: passed.
- Governed test typecheck: 1026 files, zero errors.
- Fresh-login-shell Deno checks for PGlite topology WebSocket outbox and topology test runtime: passed.
- Scoped transaction-write, repository-style, and structure checks: passed; unrelated warning-only test-directory findings remain outside the changed files.

## Risk and rollback

Risk is confined to topology worker write assembly. Existing replay, skip, promotion, trigger, and publication semantics are covered by the focused suite. Roll back this commit to restore the prior per-branch assembly.

## Follow-up

Split the remaining mixed read/compute preparation path and remove its hidden clock from compute inputs.