### PR TITLE
Separate topology reads from pure computation

### DIFF
--- a/packages/shared-server/rallar-system/topology/planning/compute-group-topology-from-authority.ts
+++ b/packages/shared-server/rallar-system/topology/planning/compute-group-topology-from-authority.ts
@@ -1,0 +1,140 @@
+import { validateGroupTopologyNextHops } from '@shared-graph/group-topology-validation.ts';
+import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { readGroupCreatedByPrincipalId, readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+
+import { filterRtcRttMeasurementsForGroup } from '../../rtc-rtt/policy/rtc-rtt-measurement-policy.ts';
+import { GroupTopologyValidationError } from '../group-topology-errors.ts';
+import { compareRtcTopologyIdentifiers } from '../persistence/rtc-topology-identifiers.ts';
+import type { RtcTopologyPlanningIntent } from '../runtime/rallar-rtc-topology-service.ts';
+import type { GroupTopologyPlanningAuthority } from './group-topology-planning-authority.ts';
+import type { ReconcileGroupTopologyResult } from './group-topology-planning-contracts.ts';
+import {
+    resolveTopologyPlanAction,
+    type TopologyWorkOrigin
+} from './resolve-topology-plan-action.ts';
+import { computeRtcTopologyPlan } from './rtc-topology-planner.ts';
+import { isGroupTopologyActiveAt } from './select-group-topology-planning-snapshot.ts';
+
+export interface TopologyPlanningRequest {
+    readonly intent: RtcTopologyPlanningIntent;
+    readonly origin: TopologyWorkOrigin;
+}
+
+export function computeGroupTopologyFromAuthority(
+    authority: GroupTopologyPlanningAuthority,
+    previous: RallarOverlayTopologySnapshot | undefined,
+    planning: TopologyPlanningRequest
+): ReconcileGroupTopologyResult {
+    if (!isGroupTopologyActiveAt(authority.group, authority.nowEpochMs)) {
+        return computeRemovedTopology(authority.group, previous);
+    }
+    const action = resolveTopologyPlanAction({
+        lifecycleState: authority.group.group.lifecycleState,
+        replanning: authority.replanning,
+        workOrigin: planning.origin,
+        previous
+    });
+    if (action === 'publish-removal') {
+        return computeRemovedTopology(authority.group, previous);
+    }
+    if (action === 'freeze') {
+        return { action: 'frozen', current: requireFrozenTopology(previous) };
+    }
+    const result = computeRtcTopologyPlan(
+        {
+            ...authority.config.effective,
+            ...authority.kindHysteresisWidths,
+            rttReportingDegreeLimit: authority.rttReportingDegreeLimit
+        },
+        {
+            group: authority.group,
+            rttMeasurements: filterRtcRttMeasurementsForGroup({
+                group: authority.group,
+                rttMeasurements: authority.rttMeasurements,
+                overlaySnapshot: previous,
+                degreeLimit: authority.rttReportingDegreeLimit
+            }),
+            previous,
+            updateOptions: {
+                previous,
+                topologyOptions: authority.config.effective,
+                planningIntent: planning.intent
+            },
+            nowEpochMs: authority.nowEpochMs
+        }
+    );
+    return { ...result, action: 'planned' };
+}
+
+export function validateComputedGroupTopology(computed: ReconcileGroupTopologyResult): void {
+    validateComputedTopologySnapshot(computed.action === 'planned' ? computed.snapshot : computed.current);
+}
+
+export function validateComputedTopologySnapshot(snapshot: RallarOverlayTopologySnapshot): void {
+    if (snapshot.state === 'removed') {
+        return;
+    }
+    const result = validateGroupTopologyNextHops({
+        activeSessionIds: new Set(snapshot.activeSessionIds),
+        nextHopsBySessionId: snapshot.nextHopsBySessionId,
+        maxDegree: snapshot.degreeLimit
+    });
+    if (!result.valid) {
+        throw new GroupTopologyValidationError(
+            result.issues.map((issue) => ({
+                code: issue.code,
+                path: issue.sessionId ? ['nextHopsBySessionId', issue.sessionId] : undefined,
+                message: issue.code,
+                details: issue
+            }))
+        );
+    }
+}
+
+export function requireFrozenTopology(
+    previous: RallarOverlayTopologySnapshot | undefined
+): RallarOverlayTopologySnapshot {
+    if (!previous) {
+        throw new TypeError('A frozen topology plan requires a stored layout');
+    }
+    return previous;
+}
+
+function computeRemovedTopology(
+    group: GroupSnapshot,
+    previous: RallarOverlayTopologySnapshot | undefined
+): ReconcileGroupTopologyResult {
+    const activeSessionIds = [
+        ...new Set([...(previous?.activeSessionIds ?? []), ...readGroupMemberSessionIds(group)])
+    ].sort(compareRtcTopologyIdentifiers);
+    return {
+        action: 'planned',
+        snapshot: {
+            sourceGroupStateCausalRevision: group.causalRevision,
+            state: 'removed',
+            overlayId: toScopedOverlayId(group.group),
+            groupRef: canonicalGroupRef(group.group),
+            name: previous?.name ?? group.group.displayName,
+            topology: previous?.topology ?? 'star',
+            activeSessionIds,
+            nextHopsBySessionId: Object.fromEntries(activeSessionIds.map((sessionId) => [sessionId, []])),
+            degreeLimit: previous?.degreeLimit ?? 1,
+            version: previous?.version ?? 0,
+            createdByClientId: previous?.createdByClientId ?? readGroupCreatedByPrincipalId(group),
+            createdAtEpochMs: previous?.createdAtEpochMs ?? group.group.created.atEpochMs,
+            updatedAtEpochMs: group.group.updated.atEpochMs
+        },
+        previous: previous ?? null,
+        changed: previous?.state !== 'removed'
+    };
+}
+
+function canonicalGroupRef(groupRef: GroupRef): GroupRef {
+    return {
+        applicationId: groupRef.applicationId,
+        workspaceId: groupRef.workspaceId,
+        groupId: groupRef.groupId
+    };
+}

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts
@@ -18,6 +18,7 @@ export interface GroupTopologyPlanningAuthority {
     readonly group: GroupSnapshot;
     readonly config: GroupTopologyConfigView;
     readonly kindHysteresisWidths: RtcTopologyKindHysteresisWidths;
+    readonly rttReportingDegreeLimit: number;
     readonly rttMeasurements: readonly RttMeasurementInfo[];
     /**
      * The replanning mode the planning gate consults. Read from the stored

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -1,11 +1,8 @@
-import { validateGroupTopologyNextHops } from '@shared-graph/group-topology-validation.ts';
 import type { RttMeasurementInfo } from '@shared/api/api-config.ts';
-import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type {
     EffectiveGroupTopologyConfig,
     ReconfigureGroupTopologyResponse
 } from '@shared/api/graph-topology-management-types.ts';
-import { readGroupCreatedByPrincipalId, readGroupMemberSessionIds } from '@shared/api/group-client-views.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
@@ -14,14 +11,17 @@ import type { GroupLifecyclePolicyRead } from '../../group-state/persistence/gro
 import { filterRtcRttMeasurementsForGroup } from '../../rtc-rtt/policy/rtc-rtt-measurement-policy.ts';
 import type { GroupTopologyConfigQueryService } from '../config/group-topology-config-query-service.ts';
 import type { GroupTopologyServerOptions } from '../config/group-topology-config.ts';
-import { GroupTopologyValidationError } from '../group-topology-errors.ts';
-import { compareRtcTopologyIdentifiers } from '../persistence/rtc-topology-identifiers.ts';
 import { RTC_TOPOLOGY_REPLAY_RETENTION_MS } from '../replay/consumer/rtc-topology-replay-policy.ts';
 import {
     RallarRtcTopologyService,
-    type RallarRtcTopologyUpdateResult,
-    type RtcTopologyPlanningIntent
+    type RallarRtcTopologyUpdateResult
 } from '../runtime/rallar-rtc-topology-service.ts';
+import {
+    computeGroupTopologyFromAuthority,
+    requireFrozenTopology,
+    validateComputedGroupTopology,
+    type TopologyPlanningRequest
+} from './compute-group-topology-from-authority.ts';
 import type {
     GroupTopologyPlanningAuthority,
     ReadGroupTopologyPlanningAuthorityInput
@@ -41,10 +41,7 @@ import {
     type TopologyPlanAction,
     type TopologyWorkOrigin
 } from './resolve-topology-plan-action.ts';
-import {
-    isGroupTopologyActiveAt,
-    selectGroupTopologyPlanningSnapshot
-} from './select-group-topology-planning-snapshot.ts';
+import { selectGroupTopologyPlanningSnapshot } from './select-group-topology-planning-snapshot.ts';
 
 export interface GroupTopologyPlanningServiceDependencies {
     readonly findGroupSnapshotByRef: GroupTopologyGroupSnapshotReader;
@@ -68,11 +65,6 @@ export interface GroupTopologyPlanningServiceDependencies {
     readonly readLifecyclePolicy?: (ref: GroupRef) => Promise<GroupLifecyclePolicyRead>;
     readonly publisher?: GroupTopologyPublisher;
     readonly serverDefaults?: GroupTopologyServerOptions;
-}
-
-export interface TopologyPlanningRequest {
-    readonly intent: RtcTopologyPlanningIntent;
-    readonly origin: TopologyWorkOrigin;
 }
 
 export class GroupTopologyPlanningService {
@@ -113,6 +105,10 @@ export class GroupTopologyPlanningService {
             group,
             config,
             kindHysteresisWidths: this.dependencies.topologyService.readKindHysteresisWidths(),
+            rttReportingDegreeLimit: this.dependencies.topologyService.readRttReportingDegreeLimit({
+                ...config.effective,
+                rttReportingDegreeLimit: this.dependencies.serverDefaults?.rttReportingDegreeLimit
+            }),
             rttMeasurements,
             replanning,
             nowEpochMs: this.dependencies.topologyService.readNowEpochMs()
@@ -124,35 +120,7 @@ export class GroupTopologyPlanningService {
         previous: RallarOverlayTopologySnapshot | undefined,
         planning: TopologyPlanningRequest
     ): ReconcileGroupTopologyResult {
-        if (!isGroupTopologyActiveAt(authority.group, authority.nowEpochMs)) {
-            return removedTopologyResult(authority.group, previous);
-        }
-        const action = resolveTopologyPlanAction({
-            lifecycleState: authority.group.group.lifecycleState,
-            replanning: authority.replanning,
-            workOrigin: planning.origin,
-            previous
-        });
-        if (action === 'publish-removal') {
-            return removedTopologyResult(authority.group, previous);
-        }
-        if (action === 'freeze') {
-            return { action: 'frozen', current: requireFrozenTopology(previous) };
-        }
-        const filteredRttMeasurements = this.filterRttMeasurementsForGroup(
-            authority.group,
-            authority.rttMeasurements,
-            authority.config.effective,
-            previous
-        );
-        const result = this.dependencies.topologyService.planGroupTopologyAt(
-            authority.group,
-            filteredRttMeasurements,
-            { previous, topologyOptions: authority.config.effective, planningIntent: planning.intent },
-            authority.nowEpochMs
-        );
-        this.validateTopology(result.snapshot);
-        return { ...result, action: 'planned' };
+        return computeGroupTopologyFromAuthority(authority, previous, planning);
     }
 
     async computeGroupTopology(
@@ -165,10 +133,12 @@ export class GroupTopologyPlanningService {
             snapshotSelection: 'prefer-current'
         });
         // The machinery's own reconcile sweep: automatic by definition.
-        return this.computeTopologyFromAuthority(authority, previous, {
+        const computed = this.computeTopologyFromAuthority(authority, previous, {
             intent: 'full-rebuild',
             origin: 'automatic'
         });
+        validateComputedGroupTopology(computed);
+        return computed;
     }
 
     async reconfigureGroupTopology(
@@ -203,7 +173,7 @@ export class GroupTopologyPlanningService {
             ),
             { previous, topologyOptions: config.effective }
         );
-        this.validateTopology(result.snapshot);
+        validateComputedGroupTopology({ ...result, action: 'planned' });
         const published = await this.publishIfRequested(
             group,
             result,
@@ -267,7 +237,7 @@ export class GroupTopologyPlanningService {
         if (!result) {
             return undefined;
         }
-        this.validateTopology(result.snapshot);
+        validateComputedGroupTopology({ ...result, action: 'planned' });
         const published = await this.publishIfRequested(
             group,
             result,
@@ -351,27 +321,6 @@ export class GroupTopologyPlanningService {
         });
     }
 
-    private validateTopology(snapshot: RallarOverlayTopologySnapshot): void {
-        if (snapshot.state === 'removed') {
-            return;
-        }
-        const result = validateGroupTopologyNextHops({
-            activeSessionIds: new Set(snapshot.activeSessionIds),
-            nextHopsBySessionId: snapshot.nextHopsBySessionId,
-            maxDegree: snapshot.degreeLimit
-        });
-        if (!result.valid) {
-            throw new GroupTopologyValidationError(
-                result.issues.map((issue) => ({
-                    code: issue.code,
-                    path: issue.sessionId ? ['nextHopsBySessionId', issue.sessionId] : undefined,
-                    message: issue.code,
-                    details: issue
-                }))
-            );
-        }
-    }
-
     private async publishIfRequested(
         group: GroupSnapshot,
         result: RallarRtcTopologyUpdateResult,
@@ -417,44 +366,6 @@ function requireGroupTopologyPlanningSnapshot(
     return snapshot;
 }
 
-function requireFrozenTopology(
-    previous: RallarOverlayTopologySnapshot | undefined
-): RallarOverlayTopologySnapshot {
-    if (!previous) {
-        throw new TypeError('A frozen topology plan requires a stored layout');
-    }
-    return previous;
-}
-
-function removedTopologyResult(
-    group: GroupSnapshot,
-    previous: RallarOverlayTopologySnapshot | undefined
-): ReconcileGroupTopologyResult {
-    const activeSessionIds = [
-        ...new Set([...(previous?.activeSessionIds ?? []), ...readGroupMemberSessionIds(group)])
-    ].sort(compareRtcTopologyIdentifiers);
-    return {
-        action: 'planned',
-        snapshot: {
-            sourceGroupStateCausalRevision: group.causalRevision,
-            state: 'removed',
-            overlayId: toScopedOverlayId(group.group),
-            groupRef: canonicalGroupRef(group.group),
-            name: previous?.name ?? group.group.displayName,
-            topology: previous?.topology ?? 'star',
-            activeSessionIds,
-            nextHopsBySessionId: Object.fromEntries(activeSessionIds.map((sessionId) => [sessionId, []])),
-            degreeLimit: previous?.degreeLimit ?? 1,
-            version: previous?.version ?? 0,
-            createdByClientId: previous?.createdByClientId ?? readGroupCreatedByPrincipalId(group),
-            createdAtEpochMs: previous?.createdAtEpochMs ?? group.group.created.atEpochMs,
-            updatedAtEpochMs: group.group.updated.atEpochMs
-        },
-        previous: previous ?? null,
-        changed: previous?.state !== 'removed'
-    };
-}
-
 interface ReconfigureGroupTopologyResponseInput {
     readonly groupRef: GroupRef;
     readonly result: RallarRtcTopologyUpdateResult;
@@ -473,13 +384,5 @@ function toReconfigureGroupTopologyResponse(
         previous: input.result.previous,
         config: input.config,
         published: input.published
-    };
-}
-
-function canonicalGroupRef(groupRef: GroupRef): GroupRef {
-    return {
-        applicationId: groupRef.applicationId,
-        workspaceId: groupRef.workspaceId,
-        groupId: groupRef.groupId
     };
 }

--- a/packages/shared-server/rallar-system/topology/planning/rtc-topology-planner.ts
+++ b/packages/shared-server/rallar-system/topology/planning/rtc-topology-planner.ts
@@ -61,8 +61,25 @@ interface CreateMeasuredRoomGraphInput {
 }
 
 export namespace RtcTopologyPlanner {
+    export type Metrics = Pick<
+        RtcTopologyMetrics,
+        | 'recordHysteresisHold'
+        | 'recordIncrementalFallback'
+        | 'recordIncrementalPlan'
+        | 'recordNoRttMeshPlan'
+        | 'recordNoRttTreePlan'
+        | 'recordStarPlan'
+        | 'recordTopologyResult'
+        | 'recordTopologyRttMeasurementCount'
+        | 'recordWeightedPlanAttempt'
+        | 'recordWeightedPlanDuration'
+        | 'recordWeightedRoomGraphAttempt'
+        | 'recordWeightedRoomGraphDuration'
+        | 'recordWeightedRoomGraphSparseFallback'
+    >;
+
     export interface Dependencies {
-        readonly metrics: RtcTopologyMetrics;
+        readonly metrics: Metrics;
         readonly durationNowMs: () => number;
     }
 
@@ -94,6 +111,33 @@ export namespace RtcTopologyPlanner {
         ): RallarRtcTopologyKind;
         readRttReportingDegreeLimit(options: RallarRtcTopologyServiceOptions): number;
     }
+}
+
+const UNOBSERVED_PLANNING_DEPENDENCIES: RtcTopologyPlanner.Dependencies = {
+    metrics: {
+        recordHysteresisHold: () => {},
+        recordIncrementalFallback: () => {},
+        recordIncrementalPlan: () => {},
+        recordNoRttMeshPlan: () => {},
+        recordNoRttTreePlan: () => {},
+        recordStarPlan: () => {},
+        recordTopologyResult: () => {},
+        recordTopologyRttMeasurementCount: () => {},
+        recordWeightedPlanAttempt: () => {},
+        recordWeightedPlanDuration: () => {},
+        recordWeightedRoomGraphAttempt: () => {},
+        recordWeightedRoomGraphDuration: () => {},
+        recordWeightedRoomGraphSparseFallback: () => {}
+    },
+    durationNowMs: () => 0
+};
+
+/** Runs the canonical planner without reading mutable runtime state or emitting observations. */
+export function computeRtcTopologyPlan(
+    serviceOptions: RallarRtcTopologyServiceOptions,
+    input: RtcTopologyPlanner.PlanInput
+): RallarRtcTopologyUpdateResult {
+    return new RtcTopologyPlanner(serviceOptions, UNOBSERVED_PLANNING_DEPENDENCIES).plan(input);
 }
 
 export class RtcTopologyPlanner {

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
@@ -4,7 +4,9 @@ import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { jsonEquals } from '@shared/repository/state-utils.ts';
 
 import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import {
+    computeTopologyMutation,
     validateTopologyMutation,
     type RtcTopologyMutationComputed,
     type RtcTopologyMutationInput
@@ -82,6 +84,17 @@ export type AcceptedRtcTopologyWorkWrite =
         transaction: RtcTopologyPublicationTransactionWrite;
     }>;
 
+export interface ComputeRtcTopologyReplayWriteInput {
+    readonly read: RtcTopologyMutationInput['read'];
+    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly publisherStreamId: string | undefined;
+}
+
+export interface ComputedRtcTopologyReplayWrite {
+    readonly loaded: Extract<RtcTopologyMutationComputed, { outcome: 'loaded'; }>;
+    readonly transaction: RtcTopologyPublicationTransactionWrite;
+}
+
 export interface ComputeRtcTopologyWorkWriteInput {
     readonly accepted: AcceptedRtcTopologyWork;
     readonly entry: ResourceEntry;
@@ -154,6 +167,57 @@ export function validateRtcTopologyWorkWrite(
     }
 }
 
+export function computeRtcTopologyReplayWrite(
+    input: ComputeRtcTopologyReplayWriteInput
+): ComputedRtcTopologyReplayWrite {
+    const mutationInput = toReplayMutationInput(input.read);
+    const computed = computeTopologyMutation(mutationInput);
+    if (computed.outcome !== 'loaded') {
+        throw new RuntimeStateWriteConflictError();
+    }
+    return {
+        loaded: computed,
+        transaction: {
+            mutation: null,
+            promotionRequest: null,
+            connectRequests: [],
+            fingerprint: null,
+            delivery: computeRtcTopologyPublicationDeliveryWrite(
+                computed.publication,
+                input.publisherStreamId
+            ),
+            reservationFinish: input.reservationFinish
+        }
+    };
+}
+
+export function validateRtcTopologyReplayWrite(
+    input: ComputeRtcTopologyReplayWriteInput,
+    computed: ComputedRtcTopologyReplayWrite
+): void {
+    validateTopologyMutation({
+        ...toReplayMutationInput(input.read),
+        computed: computed.loaded
+    });
+    const expected = computeRtcTopologyReplayWrite(input);
+    if (!jsonEquals(toTransactionProjection(computed.transaction), toTransactionProjection(expected.transaction))) {
+        throw new TypeError('RTC topology replay write differs from its canonical computation');
+    }
+}
+
+function toReplayMutationInput(read: RtcTopologyMutationInput['read']): RtcTopologyMutationInput {
+    return {
+        read,
+        candidate: null,
+        publication: null,
+        facts: {
+            publicationExpireAtTimestamp: null,
+            commandHash: null,
+            attemptCount: null
+        }
+    };
+}
+
 function computeFingerprintWrite(
     accepted: Exclude<AcceptedRtcTopologyWork, { decision: 'skipped-rtt-refinement' | 'skipped-fingerprint'; }>
 ) {
@@ -179,31 +243,35 @@ function toValidationProjection(computed: AcceptedRtcTopologyWorkWrite): object 
     const transaction = computed.transaction;
     return {
         kind: computed.kind,
-        transaction: {
-            mutation: transaction.mutation,
-            promotionRequest: toResourceEntryProjection(transaction.promotionRequest),
-            connectRequests: transaction.connectRequests.map(toRequiredResourceEntryProjection),
-            fingerprint: transaction.fingerprint,
-            delivery: transaction.delivery === null
-                ? null
-                : {
-                    outboxWrite: {
-                        ...transaction.delivery.outboxWrite,
-                        entry: toRequiredResourceEntryProjection(
-                            transaction.delivery.outboxWrite.entry
-                        ),
-                        conflict: {
-                            name: transaction.delivery.outboxWrite.conflict.name,
-                            message: transaction.delivery.outboxWrite.conflict.message,
-                            code: transaction.delivery.outboxWrite.conflict.code,
-                            status: transaction.delivery.outboxWrite.conflict.status,
-                            key: transaction.delivery.outboxWrite.conflict.key
-                        }
-                    },
-                    deliveryAppend: transaction.delivery.deliveryAppend
+        transaction: toTransactionProjection(transaction)
+    };
+}
+
+function toTransactionProjection(transaction: RtcTopologyPublicationTransactionWrite): object {
+    return {
+        mutation: transaction.mutation,
+        promotionRequest: toResourceEntryProjection(transaction.promotionRequest),
+        connectRequests: transaction.connectRequests.map(toRequiredResourceEntryProjection),
+        fingerprint: transaction.fingerprint,
+        delivery: transaction.delivery === null
+            ? null
+            : {
+                outboxWrite: {
+                    ...transaction.delivery.outboxWrite,
+                    entry: toRequiredResourceEntryProjection(
+                        transaction.delivery.outboxWrite.entry
+                    ),
+                    conflict: {
+                        name: transaction.delivery.outboxWrite.conflict.name,
+                        message: transaction.delivery.outboxWrite.conflict.message,
+                        code: transaction.delivery.outboxWrite.conflict.code,
+                        status: transaction.delivery.outboxWrite.conflict.status,
+                        key: transaction.delivery.outboxWrite.conflict.key
+                    }
                 },
-            reservationFinish: toReservationFinishProjection(transaction.reservationFinish)
-        }
+                deliveryAppend: transaction.delivery.deliveryAppend
+            },
+        reservationFinish: toReservationFinishProjection(transaction.reservationFinish)
     };
 }
 

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work.ts
@@ -1,0 +1,308 @@
+import { toRtcTopologyPublicationId } from '@shared-server/rallar-system/topology/persistence/rtc-topology-identifiers.ts';
+import type { GroupTopologyPlanningAuthority } from '@shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts';
+import { hashRtcTopologyExecutionCommand } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
+import type { RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
+import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
+
+import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
+import {
+    computeTopologyMutation,
+    type RtcTopologyMutationInput,
+    type RtcTopologyMutationRead
+} from '../../mutation/rtc-topology-mutations.ts';
+import {
+    computeGroupTopologyFromAuthority,
+    validateComputedTopologySnapshot
+} from '../../planning/compute-group-topology-from-authority.ts';
+import type { ReconcileGroupTopologyResult } from '../../planning/group-topology-planning-contracts.ts';
+import {
+    materializeRtcOverlayTopologyBroadcastMessage,
+    type RtcOverlayTopologyMessageFacts
+} from '../../planning/materialize-rtc-overlay-topology-broadcast-message.ts';
+import {
+    computeRtcTopologyWorkWrite,
+    validateRtcTopologyWorkWrite,
+    type AcceptedRtcTopologyWork,
+    type AcceptedRtcTopologyWorkWrite,
+    type ComputeRtcTopologyWorkWriteInput
+} from './compute-rtc-topology-work-write.ts';
+import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
+import { computeAuthorityTopologyInputFingerprint } from './rtc-topology-input-fingerprint.ts';
+import {
+    toRtcTopologyExecutionId,
+    type PersistedRtcTopologyWork,
+    type RtcTopologyWorkEnvelope
+} from './rtc-topology-work-codec.ts';
+import type { TopologyPromotionRead } from './topology-promotion-request.ts';
+
+export interface RtcTopologyWorkFacts {
+    readonly workEnvelope: RtcTopologyWorkEnvelope<PersistedRtcTopologyWork>;
+    readonly workId: string;
+    readonly attemptCount: number;
+    readonly expireAtEpochMs: number;
+}
+
+export interface RtcTopologyWorkRead {
+    readonly mutation: RtcTopologyMutationRead;
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly promotion: TopologyPromotionRead | null;
+    readonly storedInputFingerprint: string | null;
+}
+
+export interface ComputeRtcTopologyWorkInput {
+    readonly facts: RtcTopologyWorkFacts;
+    readonly read: RtcTopologyWorkRead;
+    readonly publicationExpireAtTimestamp: number | null;
+    readonly entry: ResourceEntry;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly formationAutomationEnabled: boolean;
+    readonly serviceId: string | undefined;
+    readonly publisherStreamId: string | undefined;
+}
+
+export interface ComputedRtcTopologyWork {
+    readonly accepted: AcceptedRtcTopologyWork;
+    readonly write: AcceptedRtcTopologyWorkWrite;
+}
+
+interface ComputeFingerprintSkipInput {
+    readonly facts: RtcTopologyWorkFacts;
+    readonly mutationRead: RtcTopologyMutationRead;
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly inputFingerprint: string;
+    readonly promotionRead: TopologyPromotionRead | null;
+    readonly storedInputFingerprint: string | null;
+}
+
+interface ComputeAcceptedTopologyMutationInput {
+    readonly facts: RtcTopologyWorkFacts;
+    readonly mutationRead: RtcTopologyMutationRead;
+    readonly authority: GroupTopologyPlanningAuthority;
+    readonly planned: Extract<ReconcileGroupTopologyResult, { action: 'planned'; }>;
+    readonly inputFingerprint: string;
+    readonly promotionRead: TopologyPromotionRead | null;
+    readonly publicationExpireAtTimestamp: number | null;
+}
+
+interface ToTopologyPublicationInput {
+    readonly envelope: RtcTopologyWorkEnvelope<PersistedRtcTopologyWork>;
+    readonly group: GroupSnapshot;
+    readonly snapshot: RallarOverlayTopologySnapshot;
+    readonly facts: RtcOverlayTopologyMessageFacts;
+}
+
+export async function computeRtcTopologyWork(
+    input: ComputeRtcTopologyWorkInput
+): Promise<ComputedRtcTopologyWork> {
+    const accepted = await computeAcceptedRtcTopologyWork(input);
+    return {
+        accepted,
+        write: computeRtcTopologyWorkWrite(toRtcTopologyWorkWriteInput(input, accepted))
+    };
+}
+
+export async function validateRtcTopologyWork(
+    input: ComputeRtcTopologyWorkInput,
+    computed: ComputedRtcTopologyWork
+): Promise<void> {
+    const expected = await computeRtcTopologyWork(input);
+    validateAcceptedTopologyDecision(expected.accepted);
+    if (!jsonEquals(computed.accepted, expected.accepted)) {
+        throw new TypeError('RTC topology work decision differs from its canonical computation');
+    }
+    validateRtcTopologyWorkWrite(
+        toRtcTopologyWorkWriteInput(input, expected.accepted),
+        computed.write
+    );
+}
+
+function validateAcceptedTopologyDecision(accepted: AcceptedRtcTopologyWork): void {
+    if (accepted.decision === 'skipped-rtt-refinement') {
+        return;
+    }
+    if (accepted.decision === 'accepted') {
+        if (accepted.mutationInput.candidate === null) {
+            throw new TypeError('Accepted RTC topology work requires a computed topology');
+        }
+        validateComputedTopologySnapshot(accepted.mutationInput.candidate);
+        return;
+    }
+    if (accepted.criterionPetition === null) {
+        throw new TypeError('Skipped RTC topology work requires its selected topology');
+    }
+    validateComputedTopologySnapshot(accepted.criterionPetition.planned);
+}
+
+function toRtcTopologyWorkWriteInput(
+    input: ComputeRtcTopologyWorkInput,
+    accepted: AcceptedRtcTopologyWork
+): ComputeRtcTopologyWorkWriteInput {
+    return {
+        accepted,
+        entry: input.entry,
+        reservationFinish: input.reservationFinish,
+        formationAutomationEnabled: input.formationAutomationEnabled,
+        serviceId: input.serviceId,
+        publisherStreamId: input.publisherStreamId
+    };
+}
+
+async function computeAcceptedRtcTopologyWork(
+    input: ComputeRtcTopologyWorkInput
+): Promise<AcceptedRtcTopologyWork> {
+    const { facts, read } = input;
+    const work = facts.workEnvelope.data;
+    const { authority, promotion: promotionRead, storedInputFingerprint } = read;
+    const inputFingerprint = await computeAuthorityTopologyInputFingerprint(authority);
+    const fingerprintSkip = computeFingerprintSkip({
+        facts,
+        mutationRead: read.mutation,
+        authority,
+        inputFingerprint,
+        promotionRead,
+        storedInputFingerprint
+    });
+    if (fingerprintSkip !== null) {
+        return fingerprintSkip;
+    }
+    const computedTopology = computeGroupTopologyFromAuthority(
+        authority,
+        read.mutation.snapshot?.value,
+        {
+            intent: work.kind === 'group-revision' ? 'membership-delta' : 'full-rebuild',
+            origin: toTopologyWorkOrigin(work)
+        }
+    );
+    if (computedTopology.action === 'frozen') {
+        return {
+            decision: 'skipped-frozen',
+            work,
+            group: authority.group,
+            promotionRead,
+            criterionPetition: { authority, planned: computedTopology.current }
+        };
+    }
+    const unchangedGated = isChangeGatedGroupRevisionWork(work) || work.kind !== 'group-revision';
+    if (unchangedGated && read.mutation.snapshot !== null && !computedTopology.changed) {
+        return {
+            decision: 'skipped-unchanged',
+            work,
+            group: authority.group,
+            inputFingerprint,
+            promotionRead,
+            criterionPetition: { authority, planned: read.mutation.snapshot.value }
+        };
+    }
+    return await computeAcceptedTopologyMutation({
+        facts,
+        mutationRead: read.mutation,
+        authority,
+        planned: computedTopology,
+        inputFingerprint,
+        promotionRead,
+        publicationExpireAtTimestamp: input.publicationExpireAtTimestamp
+    });
+}
+
+function computeFingerprintSkip(
+    input: ComputeFingerprintSkipInput
+): Extract<AcceptedRtcTopologyWork, { decision: 'skipped-fingerprint'; }> | null {
+    const { facts, mutationRead, authority, inputFingerprint, promotionRead, storedInputFingerprint } = input;
+    const work = facts.workEnvelope.data;
+    const snapshot = mutationRead.snapshot;
+    if (!isChangeGatedGroupRevisionWork(work) || snapshot?.value.state !== 'active') {
+        return null;
+    }
+    return storedInputFingerprint === inputFingerprint
+        ? {
+            decision: 'skipped-fingerprint',
+            work,
+            group: authority.group,
+            promotionRead,
+            criterionPetition: { authority, planned: snapshot.value }
+        }
+        : null;
+}
+
+async function computeAcceptedTopologyMutation(
+    input: ComputeAcceptedTopologyMutationInput
+): Promise<AcceptedRtcTopologyWork> {
+    const { authority, planned, inputFingerprint, promotionRead, publicationExpireAtTimestamp } = input;
+    const { workEnvelope, workId, attemptCount } = input.facts;
+    const work = workEnvelope.data;
+    const publication = publicationExpireAtTimestamp === null
+        ? null
+        : toTopologyPublication({
+            envelope: workEnvelope,
+            group: authority.group,
+            snapshot: planned.snapshot,
+            facts: {
+                workId,
+                createdAtEpochMs: work.requestedAtEpochMs,
+                expiresAtEpochMs: publicationExpireAtTimestamp
+            }
+        });
+    const facts = publication && publicationExpireAtTimestamp !== null
+        ? {
+            publicationExpireAtTimestamp,
+            commandHash: await hashRtcTopologyExecutionCommand(publication),
+            attemptCount
+        }
+        : ({ publicationExpireAtTimestamp: null, commandHash: null, attemptCount: null } as const);
+    const mutationInput: RtcTopologyMutationInput = {
+        read: input.mutationRead,
+        candidate: planned.snapshot,
+        publication,
+        facts
+    };
+    const computed = computeTopologyMutation(mutationInput);
+    if (computed.outcome === 'retry') {
+        throw new RuntimeStateWriteConflictError();
+    }
+    if (computed.outcome === 'loaded') {
+        throw new TypeError('RTC topology publication claim appeared on a claim-miss path');
+    }
+    return {
+        decision: 'accepted',
+        work,
+        group: authority.group,
+        computed,
+        mutationInput,
+        publication,
+        inputFingerprint,
+        promotionRead,
+        criterionPetition: { authority, planned: planned.snapshot }
+    };
+}
+
+function toTopologyPublication(input: ToTopologyPublicationInput): RtcTopologyPublication {
+    const { envelope, group, snapshot, facts } = input;
+    const workId = toRtcTopologyExecutionId(envelope);
+    return {
+        publicationId: toRtcTopologyPublicationId({
+            workId,
+            sourceGroupStateCausalRevision: snapshot.sourceGroupStateCausalRevision,
+            overlayVersion: snapshot.version
+        }),
+        workId,
+        groupRef: canonicalGroupRef(group.group),
+        sourceGroupStateCausalRevision: snapshot.sourceGroupStateCausalRevision,
+        overlayVersion: snapshot.version,
+        targetGroupSnapshotVersion: group.group.snapshotVersion,
+        recipientSessionIds: snapshot.activeSessionIds,
+        message: materializeRtcOverlayTopologyBroadcastMessage(group, snapshot, facts),
+        createdAtEpochMs: facts.createdAtEpochMs
+    };
+}
+
+function canonicalGroupRef(ref: GroupRef): GroupRef {
+    return {
+        applicationId: ref.applicationId,
+        workspaceId: ref.workspaceId,
+        groupId: ref.groupId
+    };
+}

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -1,37 +1,21 @@
 import type { ALMessage } from '@shared/al-contracts/al-contract.ts';
 import { toWebRtcGroupKey } from '@shared/api/api-type-utils.ts';
 import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
-import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
-import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { OnMessageCallback } from '@shared/services/queue-message-callbacks.ts';
 
-import { toRtcTopologyPublicationId } from '@shared-server/rallar-system/topology/persistence/rtc-topology-identifiers.ts';
-import type { GroupTopologyPlanningAuthority } from '@shared-server/rallar-system/topology/planning/group-topology-planning-authority.ts';
-import { hashRtcTopologyExecutionCommand } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication-repository-contracts.ts';
-import { type RtcTopologyPublication } from '@shared-server/rallar-system/topology/publication/rtc-topology-publication.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import type { ResourceInboxReservationFinish } from '../../../../queuebox/postgres/resource-inbox-reservation-write.ts';
-import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { RallarTimingSink } from '../../../observability/timing.ts';
 import type { RtcRttRefinementService } from '../../../rtc-rtt/topic/rtc-rtt-refinement-service.ts';
-import {
-    computeTopologyMutation,
-    validateTopologyMutation,
-    type RtcTopologyMutationComputed,
-    type RtcTopologyMutationInput,
-    type RtcTopologyMutationRead
-} from '../../mutation/rtc-topology-mutations.ts';
+import type { RtcTopologyMutationComputed, RtcTopologyMutationRead } from '../../mutation/rtc-topology-mutations.ts';
 import type { RtcTopologyWorkRuntime } from '../../mutation/rtc-topology-outbox-work.ts';
 import type { RtcTopologyExecutionRepository } from '../../persistence/rtc-topology-execution-repository.ts';
-import type { ReconcileGroupTopologyResult } from '../../planning/group-topology-planning-contracts.ts';
 import type { GroupTopologyPlanningService } from '../../planning/group-topology-planning-service.ts';
 import {
-    materializeRtcOverlayTopologyBroadcastMessage,
-    type RtcOverlayTopologyMessageFacts
-} from '../../planning/materialize-rtc-overlay-topology-broadcast-message.ts';
-import {
+    computeRtcTopologyReplayWrite,
     computeRtcTopologyWorkWrite,
+    validateRtcTopologyReplayWrite,
     validateRtcTopologyWorkWrite,
     type AcceptedRtcTopologyMutation,
     type AcceptedRtcTopologyWork,
@@ -39,16 +23,17 @@ import {
     type CommittedCriterionPetition,
     type ComputeRtcTopologyWorkWriteInput
 } from './compute-rtc-topology-work-write.ts';
-import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
-import { isChangeGatedGroupRevisionWork, toTopologyWorkOrigin } from './rtc-topology-coalesced-group-revision-work.ts';
 import {
-    computeAuthorityTopologyInputFingerprint
-} from './rtc-topology-input-fingerprint.ts';
+    computeRtcTopologyWork,
+    validateRtcTopologyWork,
+    type ComputeRtcTopologyWorkInput,
+    type RtcTopologyWorkFacts,
+    type RtcTopologyWorkRead
+} from './compute-rtc-topology-work.ts';
+import type { GroupFormationAutomationPort } from './create-group-connect-trigger-work-handler.ts';
 import {
     readRtcTopologyWorkEnvelope,
-    toRtcTopologyExecutionId,
-    type PersistedRtcTopologyWork,
-    type RtcTopologyWorkEnvelope
+    toRtcTopologyExecutionId
 } from './rtc-topology-work-codec.ts';
 import {
     computeRtcTopologyReservationFinish,
@@ -56,11 +41,9 @@ import {
 } from './rtc-topology-work-completion.ts';
 import {
     readTopologyPromotion,
-    type TopologyPromotionPublicationPort,
-    type TopologyPromotionRead
+    type TopologyPromotionPublicationPort
 } from './topology-promotion-request.ts';
 import {
-    computeRtcTopologyPublicationDeliveryWrite,
     writeRtcTopologyPublicationTransaction,
     type RtcTopologyDeliveryOptions,
     type RtcTopologyPublicationTransactionWrite
@@ -79,7 +62,6 @@ interface RtcTopologyWorkHandlerOptions {
     readonly topologyPlanning: Pick<
         GroupTopologyPlanningService,
         | 'readTopologyPlanningAuthority'
-        | 'computeTopologyFromAuthority'
         | 'observeCommittedTopology'
         | 'recordTopologyPublication'
         | 'recordTopologyPlanFrozen'
@@ -104,21 +86,11 @@ interface RtcTopologyWorkHandlerOptions {
     readonly serviceId?: string;
 }
 
-interface PrepareRtcTopologyWorkInput {
+interface RtcTopologyWorkAttemptInput {
     readonly options: RtcTopologyWorkHandlerOptions;
-    readonly workEnvelope: RtcTopologyWorkEnvelope<PersistedRtcTopologyWork>;
-    readonly workId: string;
-    readonly attemptCount: number;
-    readonly read: RtcTopologyMutationRead;
-    readonly expireAtEpochMs: number;
+    readonly facts: RtcTopologyWorkFacts;
+    readonly mutationRead: RtcTopologyMutationRead;
     readonly deferredCriterionPetitioner: DeferredCriterionPetitioner | null;
-}
-
-interface ToTopologyPublicationInput {
-    readonly envelope: RtcTopologyWorkEnvelope<PersistedRtcTopologyWork>;
-    readonly group: GroupSnapshot;
-    readonly snapshot: Parameters<typeof materializeRtcOverlayTopologyBroadcastMessage>[1];
-    readonly facts: RtcOverlayTopologyMessageFacts;
 }
 
 export function createRtcTopologyWorkHandler(
@@ -144,34 +116,64 @@ async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promi
     const reservationFinish = computeRtcTopologyReservationFinish(entry, new Date());
     const workEnvelope = readRtcTopologyWorkEnvelope(message, options.runtime.workType);
     const workId = toRtcTopologyExecutionId(workEnvelope);
-    const read = await options.executionRepository.readTopologyMutation(
+    const mutationRead = await options.executionRepository.readTopologyMutation(
         workEnvelope.data.groupSnapshot.group,
         workId
     );
-    if (read.publicationClaim) {
-        await processLoadedRtcTopologyWork(options, read, reservationFinish);
+    if (mutationRead.publicationClaim) {
+        await processLoadedRtcTopologyWork(options, mutationRead, reservationFinish);
         return;
     }
-    const accepted = await prepareRtcTopologyWork({
-        options,
+    const facts: RtcTopologyWorkFacts = {
         workEnvelope,
         workId,
         attemptCount: entry.dequeueAudit.attempts,
-        read,
-        expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds,
+        expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds
+    };
+    const attempt = {
+        options,
+        facts,
+        mutationRead,
         deferredCriterionPetitioner
-    });
-    const writeInput: ComputeRtcTopologyWorkWriteInput = {
+    };
+    const rttRefinementSkip = await processRttRefinementGate(attempt);
+    if (rttRefinementSkip !== null) {
+        const writeInput: ComputeRtcTopologyWorkWriteInput = {
+            accepted: rttRefinementSkip,
+            entry,
+            reservationFinish,
+            formationAutomationEnabled: options.formationAutomation !== undefined,
+            serviceId: options.serviceId,
+            publisherStreamId: options.topologyDelivery?.publisherStreamId
+        };
+        const computedWrite = computeRtcTopologyWorkWrite(writeInput);
+        validateRtcTopologyWorkWrite(writeInput, computedWrite);
+        await writeAcceptedRtcTopologyWork({
+            options,
+            accepted: rttRefinementSkip,
+            computedWrite
+        });
+        return;
+    }
+    const computationInput: ComputeRtcTopologyWorkInput = {
+        facts,
+        read: await readRtcTopologyWork(attempt),
+        publicationExpireAtTimestamp: workEnvelope.data.publish
+            ? options.executionRepository.publicationExpireAtTimestamp()
+            : null,
         entry,
-        accepted,
         reservationFinish,
         formationAutomationEnabled: options.formationAutomation !== undefined,
         serviceId: options.serviceId,
         publisherStreamId: options.topologyDelivery?.publisherStreamId
     };
-    const computedWrite = computeRtcTopologyWorkWrite(writeInput);
-    validateRtcTopologyWorkWrite(writeInput, computedWrite);
-    await writeAcceptedRtcTopologyWork({ options, accepted, computedWrite });
+    const computed = await computeRtcTopologyWork(computationInput);
+    await validateRtcTopologyWork(computationInput, computed);
+    await writeAcceptedRtcTopologyWork({
+        options,
+        accepted: computed.accepted,
+        computedWrite: computed.write
+    });
 }
 
 async function processLoadedRtcTopologyWork(
@@ -181,35 +183,16 @@ async function processLoadedRtcTopologyWork(
 ): Promise<void> {
     const replayInput = {
         read,
-        candidate: null,
-        publication: null,
-        facts: {
-            publicationExpireAtTimestamp: null,
-            commandHash: null,
-            attemptCount: null
-        }
-    } as const;
-    const computed = computeTopologyMutation(replayInput);
-    validateTopologyMutation({ ...replayInput, computed });
-    if (computed.outcome !== 'loaded') {
-        throw new RuntimeStateWriteConflictError();
-    }
-    const deliveryWrite = computeRtcTopologyPublicationDeliveryWrite(
-        computed.publication,
-        options.topologyDelivery?.publisherStreamId
-    );
+        reservationFinish,
+        publisherStreamId: options.topologyDelivery?.publisherStreamId
+    };
+    const computed = computeRtcTopologyReplayWrite(replayInput);
+    validateRtcTopologyReplayWrite(replayInput, computed);
     await writeRtcTopologyPublicationTransaction({
         database: options.database,
         executionRepository: options.executionRepository,
         deliveryAppend: options.topologyDelivery?.append
-    }, {
-        mutation: null,
-        promotionRequest: null,
-        connectRequests: [],
-        fingerprint: null,
-        delivery: deliveryWrite,
-        reservationFinish
-    });
+    }, computed.transaction);
     options.topologyPlanning.recordTopologyPublication(true);
     options.wakeQueue?.();
     options.wakeReplay?.();
@@ -223,23 +206,23 @@ async function processLoadedRtcTopologyWork(
  * empty edge set would read as trivially-complete readiness.
  */
 async function processRttRefinementGate(
-    input: PrepareRtcTopologyWorkInput
+    input: RtcTopologyWorkAttemptInput
 ): Promise<AcceptedRtcTopologyWork | null> {
-    const work = input.workEnvelope.data;
+    const work = input.facts.workEnvelope.data;
     if (
         work.kind !== 'rtt-refresh' ||
         !input.options.rttRefinementService ||
         input.options.rttRefinementService.claimWork({
             observationId: work.refinementObservationId,
-            workId: input.workId,
+            workId: input.facts.workId,
             groupKey: toWebRtcGroupKey(work.groupSnapshot.group),
             rtt: work.rtt,
-            expireAtEpochMs: input.expireAtEpochMs
+            expireAtEpochMs: input.facts.expireAtEpochMs
         })
     ) {
         return null;
     }
-    await input.deferredCriterionPetitioner?.request(work, input.read);
+    await input.deferredCriterionPetitioner?.request(work, input.mutationRead);
     return {
         decision: 'skipped-rtt-refinement',
         work,
@@ -247,15 +230,12 @@ async function processRttRefinementGate(
     };
 }
 
-async function prepareRtcTopologyWork(
-    input: PrepareRtcTopologyWorkInput
-): Promise<AcceptedRtcTopologyWork> {
-    const { options, workEnvelope, read } = input;
+async function readRtcTopologyWork(
+    input: RtcTopologyWorkAttemptInput
+): Promise<RtcTopologyWorkRead> {
+    const { options, facts, mutationRead } = input;
+    const { workEnvelope } = facts;
     const work = workEnvelope.data;
-    const rttRefinementSkip = await processRttRefinementGate(input);
-    if (rttRefinementSkip !== null) {
-        return rttRefinementSkip;
-    }
     const membershipDeltaWork = work.kind === 'group-revision';
     const [authority, promotionRead, storedInputFingerprint] = await Promise.all([
         options.topologyPlanning.readTopologyPlanningAuthority({
@@ -272,157 +252,11 @@ async function prepareRtcTopologyWork(
             work.groupSnapshot.group
         )
     ]);
-    const inputFingerprint = await computeAuthorityTopologyInputFingerprint(authority);
-    const fingerprintSkip = computeFingerprintSkip({
-        input,
-        authority,
-        inputFingerprint,
-        promotionRead,
-        storedInputFingerprint
-    });
-    if (fingerprintSkip !== null) {
-        return fingerprintSkip;
-    }
-    const computedTopology = options.topologyPlanning.computeTopologyFromAuthority(
-        authority,
-        read.snapshot?.value,
-        {
-            intent: membershipDeltaWork ? 'membership-delta' : 'full-rebuild',
-            origin: toTopologyWorkOrigin(work)
-        }
-    );
-    if (computedTopology.action === 'frozen') {
-        // The union's own payload is the row the freeze decision named.
-        return {
-            decision: 'skipped-frozen',
-            work,
-            group: authority.group,
-            promotionRead,
-            criterionPetition: { authority, planned: computedTopology.current }
-        };
-    }
-    // RTT is deliberately outside the fingerprint, so an RTT refresh always
-    // replans — but an unchanged planned graph publishes nothing (M8). The
-    // criterion petition fences on the stored row, not the recomputed
-    // candidate: an unchanged graph still drifts its causal revision, and a
-    // candidate-identity fence would reject the decisive activation.
-    const unchangedGated = isChangeGatedGroupRevisionWork(work) || work.kind !== 'group-revision';
-    if (unchangedGated && read.snapshot !== null && !computedTopology.changed) {
-        return {
-            decision: 'skipped-unchanged',
-            work,
-            group: authority.group,
-            inputFingerprint,
-            promotionRead,
-            criterionPetition: { authority, planned: read.snapshot.value }
-        };
-    }
-    return await prepareTopologyMutation({
-        base: input,
-        authority,
-        planned: computedTopology,
-        inputFingerprint,
-        promotionRead
-    });
-}
-
-interface ComputeFingerprintSkipInput {
-    readonly input: PrepareRtcTopologyWorkInput;
-    readonly authority: GroupTopologyPlanningAuthority;
-    readonly inputFingerprint: string;
-    readonly promotionRead: TopologyPromotionRead | null;
-    readonly storedInputFingerprint: string | null;
-}
-
-function computeFingerprintSkip(
-    input: ComputeFingerprintSkipInput
-): Extract<AcceptedRtcTopologyWork, { decision: 'skipped-fingerprint'; }> | null {
-    const {
-        input: preparation,
-        authority,
-        inputFingerprint,
-        promotionRead,
-        storedInputFingerprint
-    } = input;
-    const work = preparation.workEnvelope.data;
-    const snapshot = preparation.read.snapshot;
-    if (!isChangeGatedGroupRevisionWork(work) || snapshot?.value.state !== 'active') {
-        return null;
-    }
-    return storedInputFingerprint === inputFingerprint
-        ? {
-            decision: 'skipped-fingerprint',
-            work,
-            group: authority.group,
-            promotionRead,
-            criterionPetition: { authority, planned: snapshot.value }
-        }
-        : null;
-}
-
-interface PrepareTopologyMutationInput {
-    readonly base: PrepareRtcTopologyWorkInput;
-    readonly authority: GroupTopologyPlanningAuthority;
-    readonly planned: Extract<ReconcileGroupTopologyResult, { action: 'planned'; }>;
-    readonly inputFingerprint: string;
-    readonly promotionRead: TopologyPromotionRead | null;
-}
-
-async function prepareTopologyMutation(
-    input: PrepareTopologyMutationInput
-): Promise<AcceptedRtcTopologyWork> {
-    const { authority, planned, inputFingerprint, promotionRead } = input;
-    const { options, workEnvelope, workId, attemptCount, read } = input.base;
-    const work = workEnvelope.data;
-    const publicationExpireAtTimestamp = work.publish
-        ? options.executionRepository.publicationExpireAtTimestamp()
-        : null;
-    const publication = publicationExpireAtTimestamp === null
-        ? null
-        : toTopologyPublication({
-            envelope: workEnvelope,
-            group: authority.group,
-            snapshot: planned.snapshot,
-            facts: {
-                workId,
-                createdAtEpochMs: work.requestedAtEpochMs,
-                expiresAtEpochMs: publicationExpireAtTimestamp
-            }
-        });
-    const facts = publication && publicationExpireAtTimestamp !== null
-        ? {
-            publicationExpireAtTimestamp,
-            commandHash: await hashRtcTopologyExecutionCommand(publication),
-            attemptCount
-        }
-        : ({
-            publicationExpireAtTimestamp: null,
-            commandHash: null,
-            attemptCount: null
-        } as const);
-    const mutationInput: RtcTopologyMutationInput = {
-        read,
-        candidate: planned.snapshot,
-        publication,
-        facts
-    };
-    const computed = computeTopologyMutation(mutationInput);
-    if (computed.outcome === 'retry') {
-        throw new RuntimeStateWriteConflictError();
-    }
-    if (computed.outcome === 'loaded') {
-        throw new TypeError('RTC topology publication claim appeared on a claim-miss path');
-    }
     return {
-        decision: 'accepted',
-        work,
-        group: authority.group,
-        computed,
-        mutationInput,
-        publication,
-        inputFingerprint,
-        promotionRead,
-        criterionPetition: { authority, planned: planned.snapshot }
+        mutation: mutationRead,
+        authority,
+        promotion: promotionRead,
+        storedInputFingerprint
     };
 }
 
@@ -552,32 +386,4 @@ async function petitionCommittedCriterion(
         return;
     }
     await petitionFormationCriterion(options, petition.authority, petition.planned);
-}
-
-function toTopologyPublication(input: ToTopologyPublicationInput): RtcTopologyPublication {
-    const { envelope, group, snapshot, facts } = input;
-    const workId = toRtcTopologyExecutionId(envelope);
-    return {
-        publicationId: toRtcTopologyPublicationId({
-            workId,
-            sourceGroupStateCausalRevision: snapshot.sourceGroupStateCausalRevision,
-            overlayVersion: snapshot.version
-        }),
-        workId,
-        groupRef: canonicalGroupRef(group.group),
-        sourceGroupStateCausalRevision: snapshot.sourceGroupStateCausalRevision,
-        overlayVersion: snapshot.version,
-        targetGroupSnapshotVersion: group.group.snapshotVersion,
-        recipientSessionIds: snapshot.activeSessionIds,
-        message: materializeRtcOverlayTopologyBroadcastMessage(group, snapshot, facts),
-        createdAtEpochMs: facts.createdAtEpochMs
-    };
-}
-
-function canonicalGroupRef(ref: GroupRef): GroupRef {
-    return {
-        applicationId: ref.applicationId,
-        workspaceId: ref.workspaceId,
-        groupId: ref.groupId
-    };
 }

--- a/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
@@ -152,6 +152,7 @@ function createRead(actorIsPlatformAdmin = false) {
             group: createTopologyTestGroupSnapshot(),
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+            rttReportingDegreeLimit: 5,
             rttMeasurements: [],
             replanning: 'auto' as const,
             nowEpochMs: 1_000

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -424,6 +424,7 @@ function reconfigureRead(): GroupTopologyReconfigureRead {
                 effective
             },
             kindHysteresisWidths: { meshExitWidth: 1, treeExitWidth: 1 },
+            rttReportingDegreeLimit: effective.degreeLimit,
             rttMeasurements: [],
             replanning: 'auto',
             nowEpochMs: NOW_EPOCH_MS

--- a/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-work.test.ts
@@ -623,7 +623,6 @@ describe('RTC topology APP_OUTBOX work', () => {
             }),
             topologyPlanning: {
                 readTopologyPlanningAuthority,
-                computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
                 recordTopologyPlanFrozen: vi.fn(),
@@ -732,7 +731,6 @@ describe('RTC topology APP_OUTBOX work', () => {
             }),
             topologyPlanning: {
                 readTopologyPlanningAuthority: async () => authority,
-                computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
                 recordTopologyPlanFrozen: vi.fn(),
@@ -807,7 +805,6 @@ describe('RTC topology APP_OUTBOX work', () => {
             }),
             topologyPlanning: {
                 readTopologyPlanningAuthority,
-                computeTopologyFromAuthority: vi.fn(),
                 observeCommittedTopology: vi.fn(),
                 recordTopologyPublication: vi.fn(),
                 recordTopologyPlanFrozen: vi.fn(),

--- a/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/planning/group-topology-planning-service.test.ts
@@ -28,6 +28,7 @@ describe('GroupTopologyPlanningService', () => {
             group,
             config,
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+            rttReportingDegreeLimit: 7,
             rttMeasurements: [],
             replanning: 'auto',
             nowEpochMs: 2_000
@@ -58,6 +59,7 @@ describe('GroupTopologyPlanningService', () => {
                 group: inactive,
                 config: resolveGroupTopologyConfig({}),
                 kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+                rttReportingDegreeLimit: 5,
                 rttMeasurements: [],
                 replanning: 'debounced',
                 nowEpochMs: 2_000
@@ -76,6 +78,29 @@ describe('GroupTopologyPlanningService', () => {
                 nextHopsBySessionId: {}
             }
         });
+    });
+
+    it('computes from explicit authority without metrics or hidden snapshot state', () => {
+        const group = groupWithSessionsIn('active');
+        const authority = planningAuthority(group);
+        const cleanTopology = new RallarRtcTopologyService({ now: () => 2_000 });
+        const cleanPlanning = createPlanningService({ group, topologyService: cleanTopology });
+        const expected = cleanPlanning.computeTopologyFromAuthority(
+            authority,
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
+        );
+        const statefulTopology = new RallarRtcTopologyService({ now: () => 2_000 });
+        statefulTopology.observeCommittedTopologySnapshot(requirePlannedTopology(expected).snapshot);
+        const statefulPlanning = createPlanningService({ group, topologyService: statefulTopology });
+
+        expect(statefulPlanning.computeTopologyFromAuthority(
+            authority,
+            undefined,
+            { intent: 'full-rebuild', origin: 'automatic' }
+        )).toEqual(expected);
+        expect(cleanTopology.readMetrics().topologyUpdateCount).toBe(0);
+        expect(statefulTopology.readMetrics().topologyUpdateCount).toBe(0);
     });
 
     it('holds topology planning while the group is FORMING', () => {
@@ -292,6 +317,7 @@ function planningAuthority(
         group,
         config: resolveGroupTopologyConfig({}),
         kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+        rttReportingDegreeLimit: 5,
         rttMeasurements: [],
         replanning,
         nowEpochMs: 2_000

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { resolveGroupTopologyConfig } from '@shared-server/rallar-system/topology/config/group-topology-config.ts';
 import { computeTopologyMutation } from '@shared-server/rallar-system/topology/mutation/rtc-topology-mutations.ts';
 import {
     computeRtcTopologyWorkWrite,
@@ -6,6 +7,11 @@ import {
     type AcceptedRtcTopologyWork,
     type ComputeRtcTopologyWorkWriteInput
 } from '@shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts';
+import {
+    computeRtcTopologyWork,
+    validateRtcTopologyWork,
+    type ComputeRtcTopologyWorkInput
+} from '@shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
@@ -14,6 +20,29 @@ import { describe, expect, it } from 'vitest';
 import { createRtcTopologyGroupSnapshot } from '../../rtc-topology-test-fixtures.ts';
 
 describe('RTC topology complete write computation', () => {
+    it('recomputes the complete decision and persistence-ready write from explicit input', async () => {
+        const input = createCompleteWorkInput();
+        const computed = await computeRtcTopologyWork(input);
+        if (computed.write.kind !== 'transaction') {
+            throw new Error('Expected a topology transaction fixture');
+        }
+        const altered = {
+            ...computed,
+            write: {
+                ...computed.write,
+                transaction: {
+                    ...computed.write.transaction,
+                    promotionRequest: null
+                }
+            }
+        } as const;
+
+        await expect(validateRtcTopologyWork(input, altered)).rejects.toThrow(
+            'RTC topology work write differs from its canonical computation'
+        );
+        await expect(computeRtcTopologyWork(input)).resolves.toEqual(computed);
+    });
+
     it('rejects a write whose precomputed promotion request was removed', () => {
         const input = createWriteInput();
         const computed = computeRtcTopologyWorkWrite(input);
@@ -34,6 +63,61 @@ describe('RTC topology complete write computation', () => {
         expect(computeRtcTopologyWorkWrite(input)).toEqual(computed);
     });
 });
+
+function createCompleteWorkInput(): ComputeRtcTopologyWorkInput {
+    const group = createRtcTopologyGroupSnapshot('group-1', ['session-1']);
+    const entry = createReservedEntry();
+    const work = {
+        kind: 'group-revision',
+        overlayId: toScopedOverlayId(group.group),
+        groupSnapshot: group,
+        sourceGroupStateCausalRevision: group.causalRevision,
+        requestedAtEpochMs: 1,
+        requestOptions: toCanonicalGroupTopologyConfigPatch({}),
+        origin: 'automatic',
+        publish: false
+    } as const;
+    return {
+        facts: {
+            workEnvelope: {
+                type: 'RTC_TOPOLOGY_RECOMPUTE',
+                topicId: entry.key.topicId,
+                resourceId: entry.key.resourceId,
+                contextId: entry.key.contextId,
+                senderId: entry.audit.createdBy,
+                data: work
+            },
+            workId: 'work-1',
+            attemptCount: entry.dequeueAudit.attempts,
+            expireAtEpochMs: entry.audit.expiryTs.epochMilliseconds
+        },
+        read: {
+            mutation: { snapshot: null, publicationClaim: null },
+            authority: {
+                group,
+                config: resolveGroupTopologyConfig({}),
+                kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+                rttReportingDegreeLimit: 5,
+                rttMeasurements: [],
+                replanning: 'auto',
+                nowEpochMs: 1
+            },
+            promotion: { group: group.group, policy: { status: 'absent' } },
+            storedInputFingerprint: null
+        },
+        publicationExpireAtTimestamp: null,
+        entry,
+        reservationFinish: {
+            key: entry.key,
+            expectedAttempts: entry.dequeueAudit.attempts,
+            status: EntityStatus.COMPLETED,
+            completedAt: new Date('2026-01-02T03:05:00.000Z')
+        },
+        formationAutomationEnabled: false,
+        serviceId: 'topology-service',
+        publisherStreamId: undefined
+    };
+}
 
 function createWriteInput(): ComputeRtcTopologyWorkWriteInput {
     const group = createRtcTopologyGroupSnapshot('group-1', ['session-1']);

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-fingerprint.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-fingerprint.test.ts
@@ -41,7 +41,6 @@ interface CriterionFingerprintFixture {
     readonly queue: InMemoryQueueBox;
     readonly snapshots: RtcTopologySnapshotRepository;
     readonly handler: OnMessageCallback;
-    readonly computeTopology: MockInstance<GroupTopologyPlanningService['computeTopologyFromAuthority']>;
     readonly skippedFingerprint: MockInstance<GroupTopologyPlanningService['recordTopologyRebuildSkippedFingerprint']>;
     readonly recordPublication: MockInstance<GroupTopologyPlanningService['recordTopologyPublication']>;
     process(input: ProcessGroupRevisionInput): Promise<ResourceEntry>;
@@ -58,13 +57,11 @@ describe('formation criterion after unchanged topology inputs', () => {
             expect(published).toMatchObject({ state: 'active', activeSessionIds: [], version: 1 });
             expect(fixture.submitted).toEqual([]);
             fixture.effects.length = 0;
-            fixture.computeTopology.mockClear();
             fixture.recordPublication.mockClear();
 
             const entry = await fixture.process({ group: lifecycleSnapshot(stage, 2), origin: 'automatic' });
 
             expect(fixture.skippedFingerprint).toHaveBeenCalledOnce();
-            expect(fixture.computeTopology).not.toHaveBeenCalled();
             expect(fixture.recordPublication).not.toHaveBeenCalled();
             expect(await fixture.snapshots.findSnapshot(fixture.current.group)).toEqual(published);
             expect((await fixture.queue.getItem(entry.key))?.status).toBe(EntityStatus.COMPLETED);
@@ -131,15 +128,14 @@ describe('formation criterion after unchanged topology inputs', () => {
             if (state === 'removed') {
                 await fixture.snapshots.commitSnapshot({ candidate: { ...published, state: 'removed' } });
             }
-            fixture.computeTopology.mockImplementationOnce(() => {
-                throw new Error('Rebuild must complete before criterion evaluation');
-            });
-
-            await expect(fixture.process({ group: lifecycleSnapshot('connecting', 2), origin: 'automatic' }))
-                .rejects.toThrow('Rebuild must complete before criterion evaluation');
+            await fixture.process({ group: lifecycleSnapshot('connecting', 2), origin: 'automatic' });
 
             expect(fixture.skippedFingerprint).not.toHaveBeenCalled();
-            expect(fixture.submitted).toEqual([]);
+            expect(await fixture.snapshots.findSnapshot(fixture.current.group)).toMatchObject({
+                state: 'active',
+                sourceGroupStateCausalRevision: { groupRevision: 2, presenceRevision: 0 }
+            });
+            expect(fixture.submitted).toHaveLength(1);
         }
     );
 
@@ -218,7 +214,6 @@ function createCriterionFingerprintFixture(): CriterionFingerprintFixture {
         topologyService: new RallarRtcTopologyService({ now: () => NOW }),
         topologySnapshotRepository: snapshots
     }).planning;
-    const computeTopology = vi.spyOn(planning, 'computeTopologyFromAuthority');
     const skippedFingerprint = vi.spyOn(planning, 'recordTopologyRebuildSkippedFingerprint');
     const recordPublication = vi.spyOn(planning, 'recordTopologyPublication');
     const runtime = createRtcTopologyOutboxPublisher({ outboxQueueReader: new OutboxQueueReader(queue) });
@@ -251,7 +246,7 @@ function createCriterionFingerprintFixture(): CriterionFingerprintFixture {
         await handler.onMessage(decodePersistedALMessage(entry.resource), entry);
         return entry;
     };
-    return Object.assign(state, { queue, snapshots, handler, computeTopology, skippedFingerprint, recordPublication, process });
+    return Object.assign(state, { queue, snapshots, handler, skippedFingerprint, recordPublication, process });
 }
 
 interface ProcessGroupRevisionInput {

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-observer.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-observer.test.ts
@@ -94,6 +94,7 @@ class ObserverHarness {
             group,
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+            rttReportingDegreeLimit: 5,
             rttMeasurements: [],
             replanning: 'auto' as const,
             nowEpochMs: this.nowEpochMs

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-timer-work-handler.test.ts
@@ -98,6 +98,7 @@ describe('formation timer work handler', () => {
                     group,
                     config: resolveGroupTopologyConfig({}),
                     kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+                    rttReportingDegreeLimit: 5,
                     rttMeasurements: [],
                     replanning: 'auto' as const,
                     nowEpochMs
@@ -294,6 +295,7 @@ function unusedTopologyPlanning(group: ReturnType<typeof formationGroup>, nowEpo
             group,
             config: resolveGroupTopologyConfig({}),
             kindHysteresisWidths: { meshExitWidth: 4, treeExitWidth: 0 },
+            rttReportingDegreeLimit: 5,
             rttMeasurements: [],
             replanning: 'auto' as const,
             nowEpochMs


### PR DESCRIPTION
## Summary

- materialize topology authority, RTT policy, clocks, promotion state, and fingerprints before computation
- compute and validate the complete topology decision and persistence-ready write from explicit immutable inputs
- remove hidden snapshot access and metric side effects from authoritative topology computation
- preserve one outer AppInbox redelivery boundary; add no inner retry or prepare phase

## Review

The handler now reads facts, calls one operation-owned compute function, validates the exact decision and write projection, then opens the existing transaction. The transaction only executes validated writes and interprets database-returned conflict or lease outcomes.

Navigability improved by moving the pure authority planner and complete work computation into named modules. The stateful handler is reduced from 679 lines at the start of this stack to 389 lines in this slice. No new repository style, structure, or navigation findings were introduced.

Observability note: the pure authoritative planner no longer mutates low-level planner metrics while computing. Existing operation-level publication, frozen, fingerprint-skip, committed observation, queue, and replay signals remain after validation/commit. Stateful local planning paths retain their existing measured planner behavior.

## Validation

- topology tests: 62 files passed, 3 skipped; 518 tests passed, 5 skipped
- shared-server TypeScript: pass
- governed test typecheck: 1026 files, zero debt/errors
- fresh-login-shell Deno checks: pass
- scoped transaction-write checker: pass
- changed-file style, structure, navigation, formatting, and diff checks: pass