### PR TITLE
Consolidate client persistence validation

### DIFF
--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-result.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation-result.ts
@@ -18,9 +18,10 @@ import {
     type ClientValidationRecord,
     type ClientValidationValue
 } from '../../validation/client-record-validation.ts';
-import { requireSha256, requireString } from '../../validation/client-string-validation.ts';
+import { requireSha256 } from '../../validation/client-string-validation.ts';
 import { validateClientPrincipalRef } from '../../validation/validate-client-principal-ref.ts';
 import type { ClientMutationComputed, ConditionalCandidate } from '../client-mutation-contracts.ts';
+import { validateClientPersistenceShape } from './validate-client-persistence.ts';
 
 export function validateClientMutationResult(
     computed: unknown
@@ -82,7 +83,7 @@ function validateNoOpResult(value: ClientValidationRecord): void {
             value.idempotency,
             'Client mutation computed.idempotency'
         );
-        validateClientPersistence(value.persistence);
+        validateClientPersistenceShape(value.persistence);
     }
 }
 
@@ -148,62 +149,7 @@ function validateAppliedWriteResult(value: ClientValidationRecord): void {
     if (!Array.isArray(value.outboxEntries) || value.outboxEntries.length !== 2) {
         rejectClientMutation('Client mutation computed outboxEntries must contain snapshot and event');
     }
-    validateClientPersistence(value.persistence);
-}
-
-function validateClientPersistence(value: ClientValidationValue): void {
-    const persistence = decodeClientValidationRecord(
-        value,
-        'Client mutation computed.persistence'
-    );
-    requireExactKeys(
-        persistence,
-        ['runtimeWrites', 'eventWrite'],
-        'Client mutation computed.persistence'
-    );
-    if (!Array.isArray(persistence.runtimeWrites)) {
-        rejectClientMutation('Client mutation computed.persistence.runtimeWrites must be an array');
-    }
-    persistence.runtimeWrites.forEach(validateClientRuntimeWrite);
-    if (persistence.eventWrite === null) {
-        return;
-    }
-    const eventWrite = decodeClientValidationRecord(
-        persistence.eventWrite,
-        'Client mutation computed.persistence.eventWrite'
-    );
-    requireExactKeys(
-        eventWrite,
-        ['event', 'workspaceKey', 'eventJson'],
-        'Client mutation computed.persistence.eventWrite'
-    );
-    validateClientEvent(eventWrite.event, 'Client mutation computed.persistence.eventWrite.event');
-    requireString(
-        eventWrite.workspaceKey,
-        'Client mutation computed.persistence.eventWrite.workspaceKey'
-    );
-    requireString(eventWrite.eventJson, 'Client mutation computed.persistence.eventWrite.eventJson');
-}
-
-function validateClientRuntimeWrite(value: ClientValidationValue, index: number): void {
-    const label = `Client mutation computed.persistence.runtimeWrites[${index}]`;
-    const write = decodeClientValidationRecord(value, label);
-    const commonKeys = ['kind', 'namespace', 'key', 'value', 'expireAtIsoTimestamp'];
-    requireExactKeys(write, [...commonKeys, 'expectedRevision'], label);
-    requireString(write.namespace, `${label}.namespace`);
-    requireString(write.key, `${label}.key`);
-    requireString(write.value, `${label}.value`);
-    requireString(write.expireAtIsoTimestamp, `${label}.expireAtIsoTimestamp`);
-    if (write.kind === 'insert' && write.expectedRevision === null) {
-        return;
-    }
-    if (
-        write.kind !== 'update' ||
-        !Number.isSafeInteger(write.expectedRevision) ||
-        (write.expectedRevision as number) < 0
-    ) {
-        rejectClientMutation(`${label} guard is invalid`);
-    }
+    validateClientPersistenceShape(value.persistence);
 }
 
 function validateConditionalCandidate<T>(

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-mutation.ts
@@ -15,7 +15,7 @@ import {
 } from './validate-client-mutation-authority-policy.ts';
 import { validateClientMutationRead } from './validate-client-mutation-read.ts';
 import { validateClientMutationResult } from './validate-client-mutation-result.ts';
-import { validateClientPersistence } from './validate-client-persistence.ts';
+import { validateExactClientPersistence } from './validate-client-persistence.ts';
 
 export class ClientMutationIdempotencyConflictError extends Error {
     readonly code = 'client-mutation-idempotency-conflict';
@@ -61,7 +61,7 @@ export function validateClientMutation(
         );
     }
     validateClientMutationReceiptIdentity(command, computed);
-    validateClientPersistence(computed);
+    validateExactClientPersistence(computed);
     if (computed.outcome !== 'write') {
         return;
     }

--- a/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-persistence.ts
+++ b/packages/shared-server/rallar-system/client-state/mutation/result-validation/validate-client-persistence.ts
@@ -1,4 +1,5 @@
 import { assertPersistableClientStateEvent } from '../../../state-events/postgres/client-state-event-row-codec.ts';
+import { validateClientEvent } from '../../client-state-contract-validation.ts';
 import { assertCanonicalClientStateIdempotencyRecord } from '../../persistence/client-state-repository-reads.ts';
 import {
     validatePersistedClientInstance,
@@ -6,13 +7,55 @@ import {
     validatePersistedClientSession
 } from '../../persistence/validate-persisted-client-state.ts';
 import { ClientMutationRejectedError } from '../../validation/client-mutation-rejection.ts';
+import {
+    decodeClientValidationRecord,
+    requireExactKeys,
+    type ClientValidationValue
+} from '../../validation/client-record-validation.ts';
+import { requireString } from '../../validation/client-string-validation.ts';
 import type {
     ClientMutationComputed,
     ClientMutationDomainWrite
 } from '../client-mutation-contracts.ts';
 import { computeClientPersistence } from '../compute/compute-client-persistence.ts';
 
-export function validateClientPersistence(
+export function validateClientPersistenceShape(value: ClientValidationValue): void {
+    const persistence = decodeClientValidationRecord(
+        value,
+        'Client mutation computed.persistence'
+    );
+    requireExactKeys(
+        persistence,
+        ['runtimeWrites', 'eventWrite'],
+        'Client mutation computed.persistence'
+    );
+    if (!Array.isArray(persistence.runtimeWrites)) {
+        throw new ClientMutationRejectedError(
+            'Client mutation computed.persistence.runtimeWrites must be an array'
+        );
+    }
+    persistence.runtimeWrites.forEach(validateClientRuntimeWriteShape);
+    if (persistence.eventWrite === null) {
+        return;
+    }
+    const eventWrite = decodeClientValidationRecord(
+        persistence.eventWrite,
+        'Client mutation computed.persistence.eventWrite'
+    );
+    requireExactKeys(
+        eventWrite,
+        ['event', 'workspaceKey', 'eventJson'],
+        'Client mutation computed.persistence.eventWrite'
+    );
+    validateClientEvent(eventWrite.event, 'Client mutation computed.persistence.eventWrite.event');
+    requireString(
+        eventWrite.workspaceKey,
+        'Client mutation computed.persistence.eventWrite.workspaceKey'
+    );
+    requireString(eventWrite.eventJson, 'Client mutation computed.persistence.eventWrite.eventJson');
+}
+
+export function validateExactClientPersistence(
     computed: Exclude<ClientMutationComputed, { outcome: 'idempotency-conflict'; }>
 ): void {
     if (
@@ -27,6 +70,30 @@ export function validateClientPersistence(
             JSON.stringify(computed.persistence)
     ) {
         throw new ClientMutationRejectedError('Client computed persistence differs');
+    }
+}
+
+function validateClientRuntimeWriteShape(value: ClientValidationValue, index: number): void {
+    const label = `Client mutation computed.persistence.runtimeWrites[${index}]`;
+    const write = decodeClientValidationRecord(value, label);
+    requireExactKeys(
+        write,
+        ['kind', 'namespace', 'key', 'value', 'expireAtIsoTimestamp', 'expectedRevision'],
+        label
+    );
+    requireString(write.namespace, `${label}.namespace`);
+    requireString(write.key, `${label}.key`);
+    requireString(write.value, `${label}.value`);
+    requireString(write.expireAtIsoTimestamp, `${label}.expireAtIsoTimestamp`);
+    if (write.kind === 'insert' && write.expectedRevision === null) {
+        return;
+    }
+    if (
+        write.kind !== 'update' ||
+        !Number.isSafeInteger(write.expectedRevision) ||
+        (write.expectedRevision as number) < 0
+    ) {
+        throw new ClientMutationRejectedError(`${label} guard is invalid`);
     }
 }
 


### PR DESCRIPTION
## Summary

- move client persistence shape checks beside their semantic and exact-projection checks
- give the two responsibilities explicit names under one canonical owner
- remove the duplicate local validator from the general mutation-result module

## Review

This is a behavior-preserving consolidation. `validateClientMutationResult` still validates the untrusted persistence shape in the same order. `validateClientMutation` then validates canonical persisted values and exact equality with the compute-owned persistence projection. There is one persistence-validation owner and no compatibility wrapper.

Navigability improves because persistence validation is found in one file. No new style, structure, navigation, or transaction-write findings were introduced.

## Validation

- client-state tests: 24 files, 94 tests passed
- focused result/purity tests: 5 passed
- shared-server TypeScript: pass
- governed test typecheck: 1026 files, zero debt/errors
- scoped transaction-write checker: pass
- changed-file style, structure, navigation, formatting, and diff checks: pass