### PR TITLE
Consolidate IndexedDB admission transactions

### DIFF
--- a/packages/shared-web/browser/al-runtime/browser-al-runtime-cleanup.ts
+++ b/packages/shared-web/browser/al-runtime/browser-al-runtime-cleanup.ts
@@ -1,11 +1,14 @@
-import { decodeALAdmissionStoredValue } from '@shared/alm/al-admission-backend.ts';
-import { ALAdmissionCorruptionError, decodeALAdmissionValue } from '@shared/alm/al-admission-decoder.ts';
-import { decodeALAdmissionNumber } from '@shared/alm/al-admission-value-validation.ts';
 import { isIndexedDbALRuntimeStoreSupported } from '@shared/alm/al-runtime-stores.ts';
 import { ALAdmissionBackendConflictError } from '@shared/alm/ALAdmissionBackendConflictError.ts';
-import { AL_ADMISSION_REVISION_KEY } from '@shared/alm/indexed-db-admission-backend.ts';
+import {
+    AL_ADMISSION_REVISION_KEY,
+    computeIndexedDbAdmissionRevisionWrite,
+    listIndexedDbAdmissionSnapshot,
+    readIndexedDbAdmissionKeySnapshot,
+    writeIndexedDbAdmissionMutations,
+    type IndexedDbAdmissionMutation
+} from '@shared/alm/indexed-db-admission-storage.ts';
 import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
-import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import { tryRunInIntervals } from '@shared/resilience/TryWith.ts';
 
 import {
@@ -19,17 +22,18 @@ export const BROWSER_AL_RUNTIME_EXPIRY_EVICTION_INTERVAL_MS = 60_000;
 
 interface BrowserALRuntimeCleanupRead {
     readonly revision: number;
-    readonly rows: readonly Readonly<{ key: string; value: unknown; }>[];
+    readonly rows: readonly Readonly<{ key: string; expireAtTimestamp: number | null; }>[];
 }
 
 interface BrowserALRuntimeCleanupComputed {
-    readonly deleteKeys: readonly string[];
+    readonly mutations: readonly IndexedDbAdmissionMutation[];
     readonly revisionWrite: Readonly<{
         key: typeof AL_ADMISSION_REVISION_KEY;
         value: number;
         expireAtTimestamp: number;
     }>;
     readonly scanned: number;
+    readonly deleted: number;
 }
 
 type BrowserALRuntimeDeletionPolicy =
@@ -137,10 +141,11 @@ async function deleteBrowserALRuntimeEntriesMatching(
     );
 
     try {
-        const read = await readBrowserALRuntimeCleanup(db, keyPrefixes);
+        const read = await readBrowserALRuntimeCleanup(db, keyPrefixes, options.deletionPolicy);
         const computed = computeBrowserALRuntimeCleanup(read, options.deletionPolicy);
+        validateBrowserALRuntimeCleanup(read, options.deletionPolicy, computed);
         await writeBrowserALRuntimeCleanup(db, read.revision, computed);
-        return toBrowserALRuntimeCleanupResult(keyPrefixes, computed.scanned, computed.deleteKeys.length);
+        return toBrowserALRuntimeCleanupResult(keyPrefixes, computed.scanned, computed.deleted);
     }
     finally {
         db.close();
@@ -149,51 +154,30 @@ async function deleteBrowserALRuntimeEntriesMatching(
 
 async function readBrowserALRuntimeCleanup(
     db: IDBDatabase,
-    keyPrefixes: readonly string[]
+    keyPrefixes: readonly string[],
+    policy: BrowserALRuntimeDeletionPolicy
 ): Promise<BrowserALRuntimeCleanupRead> {
-    const transaction = db.transaction(BROWSER_AL_RUNTIME_STORE_NAME, 'readonly');
-    const store = transaction.objectStore(BROWSER_AL_RUNTIME_STORE_NAME);
-    const rowsPromise = readBrowserALRuntimeCleanupRows(store, keyPrefixes);
-    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
-    const completed = transactionDone(transaction);
-    const [rows, revisionValue] = await Promise.all([rowsPromise, revisionPromise]);
-    await completed;
-    return { rows, revision: decodeBrowserALRuntimeRevision(revisionValue) };
-}
-
-function readBrowserALRuntimeCleanupRows(
-    store: IDBObjectStore,
-    keyPrefixes: readonly string[]
-): Promise<readonly Readonly<{ key: string; value: unknown; }>[]> {
-    return new Promise((resolve, reject) => {
-        const rows: Readonly<{ key: string; value: unknown; }>[] = [];
-        const request = store.openCursor();
-        request.onerror = () => reject(request.error ?? new Error('Browser AL runtime cleanup cursor failed'));
-        request.onsuccess = () => {
-            const cursor = request.result;
-            if (cursor === null) {
-                resolve(rows);
-                return;
-            }
-            const key = cursor.primaryKey;
-            if (typeof key !== 'string') {
-                reject(new TypeError('Browser AL runtime cleanup row key must be a string'));
-                return;
-            }
-            if (matchesAnyBrowserALRuntimePrefix(key, keyPrefixes)) {
-                rows.push({ key, value: cursor.value });
-            }
-            cursor.continue();
+    if (policy.kind === 'all') {
+        const snapshot = await readIndexedDbAdmissionKeySnapshot(
+            db,
+            BROWSER_AL_RUNTIME_STORE_NAME,
+            keyPrefixes
+        );
+        return {
+            revision: snapshot.revision,
+            rows: snapshot.keys.map((key) => ({ key, expireAtTimestamp: null }))
         };
-    });
-}
-
-function decodeBrowserALRuntimeRevision(value: unknown): number {
-    if (value === undefined) {
-        return 0;
     }
-    const stored = decodeALAdmissionValue(value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionStoredValue);
-    return decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+    const snapshot = await listIndexedDbAdmissionSnapshot(db, BROWSER_AL_RUNTIME_STORE_NAME, '');
+    return {
+        revision: snapshot.revision,
+        rows: snapshot.stored
+            .filter((stored) =>
+                stored.key !== AL_ADMISSION_REVISION_KEY &&
+                matchesAnyBrowserALRuntimePrefix(stored.key, keyPrefixes)
+            )
+            .map((stored) => ({ key: stored.key, expireAtTimestamp: stored.expireAtTimestamp }))
+    };
 }
 
 function computeBrowserALRuntimeCleanup(
@@ -202,19 +186,43 @@ function computeBrowserALRuntimeCleanup(
 ): BrowserALRuntimeCleanupComputed {
     const deleteKeys: string[] = [];
     for (const row of read.rows) {
-        if (shouldDeleteBrowserALRuntimeEntry(row.key, row.value, deletionPolicy)) {
+        if (
+            deletionPolicy.kind === 'all' ||
+            (row.expireAtTimestamp !== null && row.expireAtTimestamp <= deletionPolicy.nowMs)
+        ) {
             deleteKeys.push(row.key);
         }
     }
     return {
-        deleteKeys,
-        revisionWrite: {
-            key: AL_ADMISSION_REVISION_KEY,
-            value: read.revision + 1,
-            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
-        },
-        scanned: read.rows.length
+        mutations: deleteKeys.map((key) => ({ kind: 'remove', key })),
+        revisionWrite: computeIndexedDbAdmissionRevisionWrite(read.revision),
+        scanned: read.rows.length,
+        deleted: deleteKeys.length
     };
+}
+
+function validateBrowserALRuntimeCleanup(
+    read: BrowserALRuntimeCleanupRead,
+    deletionPolicy: BrowserALRuntimeDeletionPolicy,
+    computed: BrowserALRuntimeCleanupComputed
+): void {
+    const expected = computeBrowserALRuntimeCleanup(read, deletionPolicy);
+    if (
+        computed.scanned !== expected.scanned ||
+        computed.deleted !== expected.deleted ||
+        computed.revisionWrite.key !== expected.revisionWrite.key ||
+        computed.revisionWrite.value !== expected.revisionWrite.value ||
+        computed.revisionWrite.expireAtTimestamp !== expected.revisionWrite.expireAtTimestamp ||
+        computed.mutations.length !== expected.mutations.length ||
+        computed.mutations.some((mutation, index) => {
+            const expectedMutation = expected.mutations[index];
+            return mutation.kind !== 'remove' ||
+                expectedMutation?.kind !== 'remove' ||
+                mutation.key !== expectedMutation.key;
+        })
+    ) {
+        throw new TypeError('Browser AL runtime cleanup differs from its canonical computation');
+    }
 }
 
 async function writeBrowserALRuntimeCleanup(
@@ -222,62 +230,19 @@ async function writeBrowserALRuntimeCleanup(
     expectedRevision: number,
     computed: BrowserALRuntimeCleanupComputed
 ): Promise<void> {
-    if (computed.deleteKeys.length === 0) {
+    if (computed.mutations.length === 0) {
         return;
     }
-    const committed = await new Promise<boolean>((resolve, reject) => {
-        const transaction = db.transaction(BROWSER_AL_RUNTIME_STORE_NAME, 'readwrite');
-        const store = transaction.objectStore(BROWSER_AL_RUNTIME_STORE_NAME);
-        const revisionRequest = store.get(AL_ADMISSION_REVISION_KEY);
-        let conflict = false;
-
-        transaction.oncomplete = () => resolve(true);
-        transaction.onabort = () => {
-            if (conflict) {
-                resolve(false);
-                return;
-            }
-            reject(transaction.error ?? new Error('Browser AL runtime cleanup aborted'));
-        };
-        transaction.onerror = () => {
-            if (!conflict) {
-                reject(transaction.error ?? new Error('Browser AL runtime cleanup failed'));
-            }
-        };
-        revisionRequest.onerror = () =>
-            reject(revisionRequest.error ?? new Error('Browser AL runtime cleanup revision read failed'));
-        revisionRequest.onsuccess = () => {
-            const storedRevision = revisionRequest.result as { readonly value?: unknown; } | undefined;
-            const actualRevision = storedRevision?.value ?? 0;
-            if (actualRevision !== expectedRevision) {
-                conflict = true;
-                transaction.abort();
-                return;
-            }
-            for (const key of computed.deleteKeys) {
-                store.delete(key);
-            }
-            store.put(computed.revisionWrite);
-        };
+    const committed = await writeIndexedDbAdmissionMutations({
+        db,
+        storeName: BROWSER_AL_RUNTIME_STORE_NAME,
+        expectedRevision,
+        mutations: computed.mutations,
+        revisionWrite: computed.revisionWrite
     });
     if (!committed) {
         throw new ALAdmissionBackendConflictError('Browser AL runtime cleanup conflicted');
     }
-}
-
-function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error ?? new Error('Browser AL runtime cleanup request failed'));
-    });
-}
-
-function transactionDone(transaction: IDBTransaction): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        transaction.oncomplete = () => resolve();
-        transaction.onabort = () => reject(transaction.error ?? new Error('Browser AL runtime cleanup read aborted'));
-        transaction.onerror = () => reject(transaction.error ?? new Error('Browser AL runtime cleanup read failed'));
-    });
 }
 
 function toBrowserALRuntimeCleanupResult(
@@ -304,30 +269,4 @@ function matchesAnyBrowserALRuntimePrefix(
         }
     }
     return false;
-}
-
-function shouldDeleteBrowserALRuntimeEntry(
-    key: string,
-    value: unknown,
-    policy: BrowserALRuntimeDeletionPolicy
-): boolean {
-    if (policy.kind === 'all') {
-        return true;
-    }
-    if (value === null || typeof value !== 'object') {
-        throw new ALAdmissionCorruptionError(key, new TypeError('Browser AL runtime cleanup row must be an object'));
-    }
-    const expireAtTimestamp = (value as { readonly expireAtTimestamp?: unknown; }).expireAtTimestamp;
-    if (
-        typeof expireAtTimestamp !== 'number' ||
-        !Number.isSafeInteger(expireAtTimestamp) ||
-        expireAtTimestamp < 0 ||
-        Object.is(expireAtTimestamp, -0)
-    ) {
-        throw new ALAdmissionCorruptionError(
-            key,
-            new TypeError('Browser AL runtime cleanup expiry must be a non-negative safe integer')
-        );
-    }
-    return expireAtTimestamp <= policy.nowMs;
 }

--- a/packages/shared/alm/indexed-db-admission-backend.ts
+++ b/packages/shared/alm/indexed-db-admission-backend.ts
@@ -7,15 +7,20 @@ import {
     type ALAdmissionStoredValue,
     type ALAdmissionWriteContext
 } from './al-admission-backend.ts';
-import { ALAdmissionCorruptionError, decodeALAdmissionValue, type ALAdmissionDecoder } from './al-admission-decoder.ts';
+import { decodeALAdmissionValue, type ALAdmissionDecoder } from './al-admission-decoder.ts';
 import { decodeALAdmissionNumber } from './al-admission-value-validation.ts';
 import { ALAdmissionBackendConflictError } from './ALAdmissionBackendConflictError.ts';
-
-export const AL_ADMISSION_REVISION_KEY = '__rallar_al_admission_revision__';
-
-type IndexedDbAdmissionMutation =
-    | Readonly<{ kind: 'set'; stored: ALAdmissionStoredValue; }>
-    | Readonly<{ kind: 'remove'; key: string; }>;
+import {
+    AL_ADMISSION_REVISION_KEY,
+    computeIndexedDbAdmissionRevisionWrite,
+    listIndexedDbAdmissionSnapshot,
+    listIndexedDbAdmissionStoredValues,
+    readIndexedDbAdmissionRevision,
+    readIndexedDbAdmissionSnapshot,
+    readIndexedDbAdmissionStoredValue,
+    writeIndexedDbAdmissionMutations,
+    type IndexedDbAdmissionMutation
+} from './indexed-db-admission-storage.ts';
 
 export class IndexedDbAdmissionBackend implements ALAdmissionBackend {
     private dbPromise?: Promise<IDBDatabase>;
@@ -92,17 +97,12 @@ export class IndexedDbAdmissionBackend implements ALAdmissionBackend {
         const buffer = new IndexedDbAdmissionWriteBuffer(db, this.storeName, this.nowMs);
         const result = await fn(buffer);
         const mutations = buffer.mutations();
-        const revisionWrite: ALAdmissionStoredValue = {
-            key: AL_ADMISSION_REVISION_KEY,
-            value: expectedRevision + 1,
-            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
-        };
         const committed = await writeIndexedDbAdmissionMutations({
             db,
             storeName: this.storeName,
             expectedRevision,
             mutations,
-            revisionWrite
+            revisionWrite: computeIndexedDbAdmissionRevisionWrite(expectedRevision)
         });
         if (!committed) {
             throw new ALAdmissionBackendConflictError('IndexedDB AL admission write conflicted');
@@ -222,76 +222,6 @@ function decodeAdmissionValue<V>(
     return { value, expired: canonical.expireAtTimestamp <= nowMs };
 }
 
-interface IndexedDbAdmissionReadSnapshot {
-    readonly revision: number;
-    readonly stored: ALAdmissionStoredValue | undefined;
-}
-
-interface IndexedDbAdmissionListSnapshot {
-    readonly revision: number;
-    readonly stored: readonly ALAdmissionStoredValue[];
-}
-
-async function readIndexedDbAdmissionSnapshot(
-    db: IDBDatabase,
-    storeName: string,
-    key: string
-): Promise<IndexedDbAdmissionReadSnapshot> {
-    const transaction = db.transaction(storeName, 'readonly');
-    const store = transaction.objectStore(storeName);
-    const completed = transactionDone(transaction);
-    const valuePromise = requestToPromise<unknown>(store.get(key));
-    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
-    const [value, revisionValue] = await Promise.all([valuePromise, revisionPromise]);
-    await completed;
-    return {
-        revision: decodeIndexedDbAdmissionRevision(revisionValue),
-        stored: value === undefined
-            ? undefined
-            : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue)
-    };
-}
-
-async function listIndexedDbAdmissionSnapshot(
-    db: IDBDatabase,
-    storeName: string,
-    prefix: string
-): Promise<IndexedDbAdmissionListSnapshot> {
-    const transaction = db.transaction(storeName, 'readonly');
-    const store = transaction.objectStore(storeName);
-    const completed = transactionDone(transaction);
-    const valuesPromise = collectIndexedDbAdmissionStoredValues(store, prefix);
-    const revisionPromise = requestToPromise<unknown>(store.get(AL_ADMISSION_REVISION_KEY));
-    const [stored, revisionValue] = await Promise.all([valuesPromise, revisionPromise]);
-    await completed;
-    return { revision: decodeIndexedDbAdmissionRevision(revisionValue), stored };
-}
-
-function decodeIndexedDbAdmissionRevision(value: unknown): number {
-    if (value === undefined) {
-        return 0;
-    }
-    const stored = decodeALAdmissionValue(value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionStoredValue);
-    return decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
-}
-
-async function collectIndexedDbAdmissionStoredValues(
-    store: IDBObjectStore,
-    prefix: string
-): Promise<readonly ALAdmissionStoredValue[]> {
-    const values: ALAdmissionStoredValue[] = [];
-    await cursorEach(store, (cursor) => {
-        const key = cursor.primaryKey;
-        if (typeof key !== 'string') {
-            throw new ALAdmissionCorruptionError(String(key), new TypeError('Admission row key must be a string'));
-        }
-        if (key.startsWith(prefix)) {
-            values.push(decodeALAdmissionValue(cursor.value, key, decodeALAdmissionStoredValue));
-        }
-    });
-    return values;
-}
-
 interface RemoveExpiredIndexedDbAdmissionValuesInput {
     readonly db: IDBDatabase;
     readonly expectedRevision: number;
@@ -307,140 +237,9 @@ async function removeExpiredIndexedDbAdmissionValues(
         storeName: input.storeName,
         expectedRevision: input.expectedRevision,
         mutations: input.keys.map((key) => ({ kind: 'remove', key })),
-        revisionWrite: {
-            key: AL_ADMISSION_REVISION_KEY,
-            value: input.expectedRevision + 1,
-            expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
-        }
+        revisionWrite: computeIndexedDbAdmissionRevisionWrite(input.expectedRevision)
     });
     if (!committed) {
         throw new ALAdmissionBackendConflictError('IndexedDB AL admission expiry cleanup conflicted');
     }
-}
-
-async function readIndexedDbAdmissionRevision(db: IDBDatabase, storeName: string): Promise<number> {
-    const stored = await readIndexedDbAdmissionStoredValue(db, storeName, AL_ADMISSION_REVISION_KEY);
-    return stored === undefined
-        ? 0
-        : decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
-}
-
-async function readIndexedDbAdmissionStoredValue(
-    db: IDBDatabase,
-    storeName: string,
-    key: string
-): Promise<ALAdmissionStoredValue | undefined> {
-    const transaction = db.transaction(storeName, 'readonly');
-    const completed = transactionDone(transaction);
-    const value = await requestToPromise<unknown>(transaction.objectStore(storeName).get(key));
-    await completed;
-    return value === undefined
-        ? undefined
-        : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue);
-}
-
-async function listIndexedDbAdmissionStoredValues(
-    db: IDBDatabase,
-    storeName: string,
-    prefix: string
-): Promise<readonly ALAdmissionStoredValue[]> {
-    const transaction = db.transaction(storeName, 'readonly');
-    const completed = transactionDone(transaction);
-    const values = await collectIndexedDbAdmissionStoredValues(transaction.objectStore(storeName), prefix);
-    await completed;
-    return values;
-}
-
-interface WriteIndexedDbAdmissionMutationsInput {
-    readonly db: IDBDatabase;
-    readonly expectedRevision: number;
-    readonly mutations: readonly IndexedDbAdmissionMutation[];
-    readonly revisionWrite: ALAdmissionStoredValue;
-    readonly storeName: string;
-}
-
-async function writeIndexedDbAdmissionMutations(
-    input: WriteIndexedDbAdmissionMutationsInput
-): Promise<boolean> {
-    return await new Promise<boolean>((resolve, reject) => {
-        const transaction = input.db.transaction(input.storeName, 'readwrite');
-        const store = transaction.objectStore(input.storeName);
-        const revisionRequest = store.get(AL_ADMISSION_REVISION_KEY);
-        let conflict = false;
-
-        transaction.oncomplete = () => resolve(true);
-        transaction.onabort = () => {
-            if (conflict) {
-                resolve(false);
-                return;
-            }
-            reject(transaction.error ?? new Error('IndexedDB AL admission write aborted'));
-        };
-        transaction.onerror = () => {
-            if (!conflict) {
-                reject(transaction.error ?? new Error('IndexedDB AL admission write failed'));
-            }
-        };
-        revisionRequest.onerror = () =>
-            reject(revisionRequest.error ?? new Error('IndexedDB AL admission revision read failed'));
-        revisionRequest.onsuccess = () => {
-            const storedRevision = revisionRequest.result as ALAdmissionStoredValue | undefined;
-            const actualRevision = storedRevision?.value ?? 0;
-            if (actualRevision !== input.expectedRevision) {
-                conflict = true;
-                transaction.abort();
-                return;
-            }
-            for (const mutation of input.mutations) {
-                const request = mutation.kind === 'set'
-                    ? store.put(mutation.stored)
-                    : store.delete(mutation.key);
-                request.onerror = () => reject(request.error ?? new Error('IndexedDB AL admission mutation failed'));
-            }
-            if (input.mutations.length > 0) {
-                const request = store.put(input.revisionWrite);
-                request.onerror = () =>
-                    reject(request.error ?? new Error('IndexedDB AL admission revision write failed'));
-            }
-        };
-    });
-}
-
-async function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-    return await new Promise<T>((resolve, reject) => {
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
-    });
-}
-
-async function cursorEach(
-    store: IDBObjectStore,
-    handler: (cursor: IDBCursorWithValue) => void
-): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-        const request = store.openCursor();
-        request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'));
-        request.onsuccess = () => {
-            const cursor = request.result;
-            if (cursor === null) {
-                resolve();
-                return;
-            }
-            try {
-                handler(cursor);
-                cursor.continue();
-            }
-            catch (error) {
-                reject(error);
-            }
-        };
-    });
-}
-
-async function transactionDone(transaction: IDBTransaction): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-        transaction.oncomplete = () => resolve();
-        transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
-        transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
-    });
 }

--- a/packages/shared/alm/indexed-db-admission-storage.ts
+++ b/packages/shared/alm/indexed-db-admission-storage.ts
@@ -1,0 +1,266 @@
+import { NEVER_EXPIRE_AT_TIMESTAMP } from '../persistence/PersistenceProvider.ts';
+import {
+    decodeALAdmissionStoredValue,
+    type ALAdmissionStoredValue
+} from './al-admission-backend.ts';
+import { ALAdmissionCorruptionError, decodeALAdmissionValue } from './al-admission-decoder.ts';
+import { decodeALAdmissionNumber } from './al-admission-value-validation.ts';
+
+export const AL_ADMISSION_REVISION_KEY = '__rallar_al_admission_revision__';
+
+export type IndexedDbAdmissionMutation =
+    | Readonly<{ kind: 'set'; stored: ALAdmissionStoredValue; }>
+    | Readonly<{ kind: 'remove'; key: string; }>;
+
+export interface IndexedDbAdmissionReadSnapshot {
+    readonly revision: number;
+    readonly stored: ALAdmissionStoredValue | undefined;
+}
+
+export interface IndexedDbAdmissionListSnapshot {
+    readonly revision: number;
+    readonly stored: readonly ALAdmissionStoredValue[];
+}
+
+export interface IndexedDbAdmissionKeySnapshot {
+    readonly revision: number;
+    readonly keys: readonly string[];
+}
+
+export interface IndexedDbAdmissionRevisionWrite {
+    readonly key: typeof AL_ADMISSION_REVISION_KEY;
+    readonly value: number;
+    readonly expireAtTimestamp: number;
+}
+
+export interface WriteIndexedDbAdmissionMutationsInput {
+    readonly db: IDBDatabase;
+    readonly expectedRevision: number;
+    readonly mutations: readonly IndexedDbAdmissionMutation[];
+    readonly revisionWrite: ALAdmissionStoredValue;
+    readonly storeName: string;
+}
+
+export function computeIndexedDbAdmissionRevisionWrite(
+    expectedRevision: number
+): IndexedDbAdmissionRevisionWrite {
+    return {
+        key: AL_ADMISSION_REVISION_KEY,
+        value: expectedRevision + 1,
+        expireAtTimestamp: NEVER_EXPIRE_AT_TIMESTAMP
+    };
+}
+
+export async function readIndexedDbAdmissionSnapshot(
+    db: IDBDatabase,
+    storeName: string,
+    key: string
+): Promise<IndexedDbAdmissionReadSnapshot> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const store = transaction.objectStore(storeName);
+    const completed = transactionDone(transaction);
+    const valuePromise = requestToPromise(store.get(key));
+    const revisionPromise = requestToPromise(store.get(AL_ADMISSION_REVISION_KEY));
+    const [value, revisionValue] = await Promise.all([valuePromise, revisionPromise]);
+    await completed;
+    return {
+        revision: decodeIndexedDbAdmissionRevision(revisionValue),
+        stored: value === undefined
+            ? undefined
+            : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue)
+    };
+}
+
+export async function listIndexedDbAdmissionSnapshot(
+    db: IDBDatabase,
+    storeName: string,
+    prefix: string
+): Promise<IndexedDbAdmissionListSnapshot> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const store = transaction.objectStore(storeName);
+    const completed = transactionDone(transaction);
+    const valuesPromise = collectIndexedDbAdmissionStoredValues(store, prefix);
+    const revisionPromise = requestToPromise(store.get(AL_ADMISSION_REVISION_KEY));
+    const [stored, revisionValue] = await Promise.all([valuesPromise, revisionPromise]);
+    await completed;
+    return { revision: decodeIndexedDbAdmissionRevision(revisionValue), stored };
+}
+
+export async function readIndexedDbAdmissionKeySnapshot(
+    db: IDBDatabase,
+    storeName: string,
+    keyPrefixes: readonly string[]
+): Promise<IndexedDbAdmissionKeySnapshot> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const store = transaction.objectStore(storeName);
+    const completed = transactionDone(transaction);
+    const keysPromise = collectIndexedDbAdmissionKeys(store, keyPrefixes);
+    const revisionPromise = requestToPromise(store.get(AL_ADMISSION_REVISION_KEY));
+    const [keys, revisionValue] = await Promise.all([keysPromise, revisionPromise]);
+    await completed;
+    return { revision: decodeIndexedDbAdmissionRevision(revisionValue), keys };
+}
+
+export async function readIndexedDbAdmissionRevision(
+    db: IDBDatabase,
+    storeName: string
+): Promise<number> {
+    const stored = await readIndexedDbAdmissionStoredValue(db, storeName, AL_ADMISSION_REVISION_KEY);
+    return stored === undefined
+        ? 0
+        : decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+}
+
+export async function readIndexedDbAdmissionStoredValue(
+    db: IDBDatabase,
+    storeName: string,
+    key: string
+): Promise<ALAdmissionStoredValue | undefined> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const completed = transactionDone(transaction);
+    const value = await requestToPromise(transaction.objectStore(storeName).get(key));
+    await completed;
+    return value === undefined
+        ? undefined
+        : decodeALAdmissionValue(value, key, decodeALAdmissionStoredValue);
+}
+
+export async function listIndexedDbAdmissionStoredValues(
+    db: IDBDatabase,
+    storeName: string,
+    prefix: string
+): Promise<readonly ALAdmissionStoredValue[]> {
+    const transaction = db.transaction(storeName, 'readonly');
+    const completed = transactionDone(transaction);
+    const values = await collectIndexedDbAdmissionStoredValues(transaction.objectStore(storeName), prefix);
+    await completed;
+    return values;
+}
+
+export async function writeIndexedDbAdmissionMutations(
+    input: WriteIndexedDbAdmissionMutationsInput
+): Promise<boolean> {
+    return await new Promise<boolean>((resolve, reject) => {
+        const transaction = input.db.transaction(input.storeName, 'readwrite');
+        const store = transaction.objectStore(input.storeName);
+        const revisionRequest = store.get(AL_ADMISSION_REVISION_KEY);
+        let conflict = false;
+
+        transaction.oncomplete = () => resolve(true);
+        transaction.onabort = () => {
+            if (conflict) {
+                resolve(false);
+                return;
+            }
+            reject(transaction.error ?? new Error('IndexedDB AL admission write aborted'));
+        };
+        transaction.onerror = () => {
+            if (!conflict) {
+                reject(transaction.error ?? new Error('IndexedDB AL admission write failed'));
+            }
+        };
+        revisionRequest.onerror = () =>
+            reject(revisionRequest.error ?? new Error('IndexedDB AL admission revision read failed'));
+        revisionRequest.onsuccess = () => {
+            const actualRevision = decodeIndexedDbAdmissionRevision(revisionRequest.result);
+            if (actualRevision !== input.expectedRevision) {
+                conflict = true;
+                transaction.abort();
+                return;
+            }
+            for (const mutation of input.mutations) {
+                const request = mutation.kind === 'set'
+                    ? store.put(mutation.stored)
+                    : store.delete(mutation.key);
+                request.onerror = () => reject(request.error ?? new Error('IndexedDB AL admission mutation failed'));
+            }
+            if (input.mutations.length > 0) {
+                const request = store.put(input.revisionWrite);
+                request.onerror = () =>
+                    reject(request.error ?? new Error('IndexedDB AL admission revision write failed'));
+            }
+        };
+    });
+}
+
+function decodeIndexedDbAdmissionRevision(value: IDBRequest['result']): number {
+    if (value === undefined) {
+        return 0;
+    }
+    const stored = decodeALAdmissionValue(value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionStoredValue);
+    return decodeALAdmissionValue(stored.value, AL_ADMISSION_REVISION_KEY, decodeALAdmissionNumber);
+}
+
+async function collectIndexedDbAdmissionStoredValues(
+    store: IDBObjectStore,
+    prefix: string
+): Promise<readonly ALAdmissionStoredValue[]> {
+    const values: ALAdmissionStoredValue[] = [];
+    await cursorEach(store, (cursor) => {
+        const key = requireStringKey(cursor.primaryKey);
+        if (key.startsWith(prefix)) {
+            values.push(decodeALAdmissionValue(cursor.value, key, decodeALAdmissionStoredValue));
+        }
+    });
+    return values;
+}
+
+async function collectIndexedDbAdmissionKeys(
+    store: IDBObjectStore,
+    keyPrefixes: readonly string[]
+): Promise<readonly string[]> {
+    const keys: string[] = [];
+    await cursorEach(store, (cursor) => {
+        const key = requireStringKey(cursor.primaryKey);
+        if (keyPrefixes.some((prefix) => key.startsWith(prefix))) {
+            keys.push(key);
+        }
+    });
+    return keys;
+}
+
+function requireStringKey(key: IDBValidKey): string {
+    if (typeof key !== 'string') {
+        throw new ALAdmissionCorruptionError(String(key), new TypeError('Admission row key must be a string'));
+    }
+    return key;
+}
+
+async function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+    return await new Promise<T>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+    });
+}
+
+async function cursorEach(
+    store: IDBObjectStore,
+    handler: (cursor: IDBCursorWithValue) => void
+): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        const request = store.openCursor();
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'));
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor === null) {
+                resolve();
+                return;
+            }
+            try {
+                handler(cursor);
+                cursor.continue();
+            }
+            catch (error) {
+                reject(error);
+            }
+        };
+    });
+}
+
+async function transactionDone(transaction: IDBTransaction): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+        transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    });
+}


### PR DESCRIPTION
## Summary

- centralize IndexedDB admission readonly snapshots, revision decoding, and prepared CAS writes in one shared storage owner
- keep browser cleanup policy in shared-web while removing its duplicate IndexedDB transaction machinery
- materialize cleanup mutations in compute, validate the exact result, and pass it unchanged to write

## Review

The low-level write opens one short readwrite transaction, compares the actual stored revision, executes prepared set/remove operations, and writes the precomputed successor revision. It performs no candidate construction or serialization in the transaction. Browser cleanup preserves key-only session purge, so corrupt session rows remain removable without value decoding.

Navigability improves through one shared storage owner. The former 333-line browser cleanup and 446-line backend are now 272 and 245 lines; the extracted storage owner is 266 lines. None triggers a changed cognitive-load, unknown-boundary, structure, or navigation finding.

## Validation

- shared ALM and shared-web AL runtime tests: 10 files, 144 tests passed
- shared and shared-web TypeScript: pass
- governed test typecheck: 1026 files, zero debt/errors
- scoped transaction-write checker: pass
- changed-file style, structure, navigation, formatting, and diff checks: pass