### PR TITLE
Make mutation phase inputs explicit

### DIFF
--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-worker.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-summary-worker.ts
@@ -85,11 +85,12 @@ export class GroupPresenceSummaryWork {
 
     public compute(
         work: GroupPresenceSummaryWorkData,
-        read: GroupPresenceSummaryWorkRead
+        read: GroupPresenceSummaryWorkRead,
+        nowEpochMs: number
     ): GroupPresenceSummaryComputedWork {
         return computeGroupPresenceSummaryWork(work, read, {
             serviceId: this.options.serviceId,
-            nowEpochMs: this.now(),
+            nowEpochMs,
             recomputeDebounceMs: this.options.recomputeDebounceMs
         });
     }
@@ -144,7 +145,7 @@ export class GroupPresenceSummaryWork {
         }
         const work = decodeCanonicalGroupPresenceSummaryWork(message, entry);
         const read = await this.read(work);
-        const computed = this.compute(work, read);
+        const computed = this.compute(work, read, this.now());
         this.validate(work, read, computed);
         const completedAt = new Date(this.now());
         await runInPSqlTransaction(this.options.database, async (transaction) => {

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-authority.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-authority.ts
@@ -46,7 +46,7 @@ export async function createAuthenticatedTopologyEnqueue(
     input: CreateAuthenticatedTopologyEnqueueInput
 ): Promise<AppInboxEnqueueInput> {
     const command = await readAuthenticatedTopologyCommand(input.enqueue, input.claimedAuthority);
-    const currentSession = await validateCurrentTopologySession({
+    const currentSession = await readAndValidateCurrentTopologySession({
         principalId: command.actor.principalId,
         claimedAuthority: input.claimedAuthority,
         groupStateService: input.groupStateService,
@@ -186,7 +186,7 @@ export function constantTimeTopologyProofEqual(left: string, right: string): boo
     return difference === 0;
 }
 
-export async function validateCurrentTopologySession(
+export async function readAndValidateCurrentTopologySession(
     input: ValidateCurrentTopologySessionInput
 ): Promise<PersistedAuthSession> {
     const session = await input.groupStateService.readIssuedAuthSession(

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -28,7 +28,7 @@ import {
     createAuthenticatedTopologyEnqueue,
     createAuthenticatedTopologyEnqueueFromValidatedSession,
     decodeTopologyAppInboxAuthority,
-    validateCurrentTopologySession,
+    readAndValidateCurrentTopologySession,
     verifyTopologyAppInboxAuthority
 } from './topology-app-inbox-authority.ts';
 import { toTopologyConfigMutationCommand } from './topology-app-inbox-command.ts';
@@ -152,11 +152,11 @@ export class TopologyAppInboxHandler {
         });
     }
 
-    async validateCurrentSession(
+    async readAndValidateCurrentSession(
         principalId: string,
         claimedAuthority: IssuedAuthSession
     ): Promise<PersistedAuthSession> {
-        return await validateCurrentTopologySession({
+        return await readAndValidateCurrentTopologySession({
             principalId,
             claimedAuthority,
             groupStateService: this.dependencies.groupStateService,

--- a/packages/shared-server/rallar-system/topology/inbox/topology-inbox-service.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-inbox-service.ts
@@ -144,7 +144,7 @@ export class TopologyInboxService {
         reservation: TopologyInboxService.HttpCommandReservation,
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, TopologyAppInboxResult>> {
-        const currentSession = await this.handler.validateCurrentSession(
+        const currentSession = await this.handler.readAndValidateCurrentSession(
             reservation.callerId,
             authority
         );

--- a/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
+++ b/packages/shared-server/rallar-system/topology/planning/group-topology-planning-service.ts
@@ -123,7 +123,7 @@ export class GroupTopologyPlanningService {
         return computeGroupTopologyFromAuthority(authority, previous, planning);
     }
 
-    async computeGroupTopology(
+    private async readAndComputeGroupTopology(
         group: GroupSnapshot,
         previous: RallarOverlayTopologySnapshot | undefined
     ): Promise<ReconcileGroupTopologyResult> {
@@ -193,7 +193,7 @@ export class GroupTopologyPlanningService {
             throw new TypeError('Persistent topology reconciliation requires APP_OUTBOX');
         }
         const previous = this.dependencies.topologyService.readSnapshot(group);
-        const result = await this.computeGroupTopology(group, previous);
+        const result = await this.readAndComputeGroupTopology(group, previous);
         if (result.action === 'frozen') {
             return result;
         }

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-concurrency.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-concurrency.test.ts
@@ -339,7 +339,8 @@ describe('group presence concurrency', () => {
                 work,
                 runtime,
                 ref,
-                commandId: `inactive-summary-${operation}-${order}`
+                commandId: `inactive-summary-${operation}-${order}`,
+                nowEpochMs: BASE_EPOCH_MS + 3_000
             });
             expect((await repository.findPresenceSummaryEntry(ref))?.value).toMatchObject({
                 activePrincipalIds: [],
@@ -360,7 +361,8 @@ describe('group presence concurrency', () => {
                 work,
                 runtime,
                 ref,
-                commandId: `reactivated-summary-${operation}-${order}`
+                commandId: `reactivated-summary-${operation}-${order}`,
+                nowEpochMs: BASE_EPOCH_MS + 3_000
             });
             expect((await repository.findPresenceSummaryEntry(ref))?.value).toMatchObject({
                 activePrincipalIds: [],

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-summary-delta-emission.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-summary-delta-emission.test.ts
@@ -171,7 +171,7 @@ async function computeSummaryWork(scenario: ConnectedScenario): Promise<Computed
         event
     };
     const read = await work.read(command);
-    const computed = work.compute(command, read);
+    const computed = work.compute(command, read, BASE_EPOCH_MS + 1_000);
     work.validate(command, read, computed);
     return { work, command, read, computed };
 }

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-summary-validation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-summary-validation.test.ts
@@ -68,7 +68,8 @@ describe('group presence summary validation', () => {
             work: summaryWork,
             runtime,
             ref,
-            commandId: 'inactive-summary-filter'
+            commandId: 'inactive-summary-filter',
+            nowEpochMs: BASE_EPOCH_MS + 3_000
         });
 
         expect((await repository.findPresenceSummaryEntry(ref))?.value).toMatchObject({
@@ -145,7 +146,8 @@ describe('group presence summary validation', () => {
                 work: summaryWork,
                 runtime,
                 ref: groupRef(`corrupt-summary-${namespace}`),
-                commandId: `corrupt-${namespace}`
+                commandId: `corrupt-${namespace}`,
+                nowEpochMs: BASE_EPOCH_MS + 3_000
             })
         ).rejects.toThrow(/scope|lifecycle|timestamp|unexpected|serialized|summary/i);
         expect(runtime.presenceSummaryGuards).toBe(0);

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-test-runtime.ts
@@ -48,13 +48,15 @@ interface ConvergeSummaryForTestInput {
     readonly runtime: GroupBarrierRepository;
     readonly ref: GroupRef;
     readonly commandId: string;
+    readonly nowEpochMs: number;
 }
 
 export async function convergeSummaryForTest({
     work,
     runtime,
     ref,
-    commandId
+    commandId,
+    nowEpochMs
 }: ConvergeSummaryForTestInput): Promise<void> {
     const repository = createTestGroupStateRepository(runtime);
     const event = (await repository.listEvents(ref)).at(-1);
@@ -71,7 +73,7 @@ export async function convergeSummaryForTest({
         event
     };
     const read = await work.read(command);
-    const computed = work.compute(command, read);
+    const computed = work.compute(command, read, nowEpochMs);
     work.validate(command, read, computed);
     await runtime.begin(async (transaction) => {
         if (computed.summary.outcome === 'no-op') {

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-state-delta-envelope.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-state-delta-envelope.test.ts
@@ -96,7 +96,8 @@ describe('group-state delta envelope construction', () => {
             work: createSummaryWorkService(runtime),
             runtime,
             ref: groupRef('delta-noop-group'),
-            commandId: 'delta-noop-converge'
+            commandId: 'delta-noop-converge',
+            nowEpochMs: BASE_EPOCH_MS + 1_000
         });
 
         const { computed } = await computeSummaryWork({
@@ -119,6 +120,43 @@ describe('group-state delta envelope construction', () => {
         expect(first.resource).toBe(second.resource);
         const envelope = readGroupStateEventRowEnvelope(first);
         expect(envelope.activeSessionIds).toEqual(['s-a', 's-b', 's-c', 's-trigger']);
+    });
+
+    it('computes from the explicit observation time without consulting a hidden clock', async () => {
+        const runtime = new GroupBarrierRepository();
+        const service = createService(runtime, BASE_EPOCH_MS);
+        await seedGroupWithBob(service, 'delta-explicit-time-group');
+        const ref = groupRef('delta-explicit-time-group');
+        const repository = createTestGroupStateRepository(runtime);
+        const event = (await repository.listEvents(ref)).find(
+            (candidate) => candidate.eventType === 'member-joined'
+        );
+        if (!event) {
+            throw new Error('Missing member-joined event');
+        }
+        const command: GroupPresenceSummaryWorkData = {
+            effectKind: 'group-presence-summary',
+            aggregateRef: ref,
+            commandId: 'delta-explicit-time-command',
+            createdAtEpochMs: event.occurredAtEpochMs,
+            expireAtEpochMs: 253_402_300_799_999,
+            acceptedCausalRevision: event.causalRevision,
+            event
+        };
+        const work = new GroupPresenceSummaryWork({
+            outboxQueueReader: new OutboxQueueReader(new InMemoryQueueBox()),
+            recomputeDebounceMs: 0,
+            runtimeRepository: runtime,
+            now: () => {
+                throw new Error('compute read the worker clock');
+            },
+            serviceId: 'summary-worker'
+        });
+        const read = await work.read(command);
+
+        const computed = work.compute(command, read, BASE_EPOCH_MS + 1_000);
+
+        expect(computed.summary.evaluatedAtEpochMs).toBe(BASE_EPOCH_MS + 1_000);
     });
 });
 
@@ -221,7 +259,7 @@ async function computeSummaryWork(input: SummaryWorkInput): Promise<ComputedSumm
         event
     };
     const read = await work.read(command);
-    const computed = work.compute(command, read);
+    const computed = work.compute(command, read, BASE_EPOCH_MS + 1_000);
     work.validate(command, read, computed);
     return { command, read, computed };
 }

--- a/packages/tests/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/snapshot/group-state-snapshot-read-through-cache.test.ts
@@ -219,7 +219,7 @@ async function convergePresenceSummaryForCacheTest(
         serviceId: 'cache-convergence-test'
     });
     const read = await work.read(command);
-    const computed = work.compute(command, read);
+    const computed = work.compute(command, read, 2_001);
     work.validate(command, read, computed);
     await runtime.begin(async (transaction) => {
         if (computed.summary.outcome === 'no-op') {


### PR DESCRIPTION
## Summary
- pass the presence-summary observation time explicitly into compute instead of reading a hidden clock
- name topology operations that perform reads as read-and-compute/read-and-validate
- update all verified consumers without compatibility wrappers

## Validation
- 20 focused files, 114 tests passed
- shared-server TypeScript check passed
- governed test typecheck passed (1026 files, zero debt)
- fresh-login-shell Deno checks passed
- transaction-write, changed-style, formatting, and diff checks passed

Stacked on #457.