### PR TITLE
Make ingress validation time explicit

### DIFF
--- a/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
@@ -135,7 +135,7 @@ export class AppClientInboxService {
         authority: IssuedAuthSession
     ): Promise<Either<AppInboxFailure, ClientStateWritten>> {
         const ingress = readAuthenticatedClientMutationIngress(enqueue);
-        validateIssuedClientMutationIngress(authority, ingress);
+        validateIssuedClientMutationIngress(authority, ingress, Date.now());
         const result = await this.commandClient.enqueueAndWaitForResult(
             {
                 ...enqueue,

--- a/packages/shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts
@@ -109,14 +109,15 @@ export function readAuthenticatedClientMutationIngress(
 
 export function validateIssuedClientMutationIngress(
     authority: IssuedAuthSession,
-    ingress: AuthenticatedClientMutationIngress
+    ingress: AuthenticatedClientMutationIngress,
+    nowEpochMs: number
 ): void {
     if (
         !authority.accessToken ||
         !authority.sessionId ||
         !authority.clientId ||
         authority.issuedAtEpochMs >= authority.expiresAtEpochMs ||
-        authority.expiresAtEpochMs <= Date.now()
+        authority.expiresAtEpochMs <= nowEpochMs
     ) {
         throw new NonRetryableException(
             'Authenticated client mutation session is invalid or expired.'

--- a/packages/tests/shared-server/rallar-system/client-state/app-client-inbox-authentication.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/app-client-inbox-authentication.test.ts
@@ -10,7 +10,11 @@ import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persist
 import type { IssuedAuthSession } from '@shared-server/rallar-system/auth/persistence/auth-session-types.ts';
 import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import { AppClientInboxService } from '@shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts';
-import { toAuthenticatedClientMutationContextId } from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
+import {
+    readAuthenticatedClientMutationIngress,
+    toAuthenticatedClientMutationContextId,
+    validateIssuedClientMutationIngress
+} from '@shared-server/rallar-system/client-state/inbox/authenticated-client-mutation-ingress.ts';
 import { toClientMutationIssuedSessionAuthority } from '@shared-server/rallar-system/client-state/mutation/client-mutation-authority.ts';
 import { toClientMutationCommand } from '@shared-server/rallar-system/client-state/mutation/client-mutation-command.ts';
 import { toUpsertClientPrincipalMutationInput } from '@shared-server/rallar-system/client-state/mutation/command-input/to-upsert-client-principal-mutation-input.ts';
@@ -33,6 +37,47 @@ import { TestResourceInbox, TestResourceInboxResults } from './app-client-inbox-
 import { createClientStateServiceFixture } from './create-client-state-service-fixture.ts';
 
 describe('AppClientInbox authentication', () => {
+    it('validates issued authority from an explicit observation time without reading the clock', () => {
+        const authority = issuedSession('alice', 'alice-session');
+        const ingress = readAuthenticatedClientMutationIngress({
+            type: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
+            topicId: AppInboxType.CLIENT_PRINCIPAL_UPSERT,
+            resourceId: 'explicit-validation-time',
+            contextId: toAuthenticatedClientMutationContextId({
+                scope: SCOPE,
+                principalId: 'alice',
+                callerClientId: authority.clientId,
+                callerSessionId: authority.sessionId
+            }),
+            senderId: authority.clientId,
+            data: {
+                scope: SCOPE,
+                principalId: 'alice',
+                request: {
+                    requestId: 'explicit-validation-time',
+                    actorPrincipalId: authority.clientId,
+                    actorSessionId: authority.sessionId
+                }
+            }
+        });
+        const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => {
+            throw new Error('validation read the clock');
+        });
+
+        try {
+            expect(() =>
+                validateIssuedClientMutationIngress(
+                    authority,
+                    ingress,
+                    authority.issuedAtEpochMs + 1
+                )
+            ).not.toThrow();
+        }
+        finally {
+            dateNow.mockRestore();
+        }
+    });
+
     it('returns the exact terminal left for a malformed completed client result', async () => {
         const queue = new TestResourceInbox();
         const reader = new InboxQueueReader(queue);


### PR DESCRIPTION
## Summary
- pass the observation time into authenticated client mutation validation
- keep the validation function deterministic and free of hidden clock reads
- add a regression that fails if validation accesses `Date.now()`

## Validation
- 24 client-state test files / 95 tests passed
- shared-server TypeScript check passed
- governed test typecheck passed (1026 files, zero debt/errors)
- fresh-login-shell Deno checks passed
- transaction-write checker passed
- changed-file repository style check passed with zero new findings
- dprint and diff checks passed

## Review assessment
Small and direct. The stateful AppInbox service captures time; the pure validator consumes explicit values. No compatibility wrapper, extra phase, inner retry, or new abstraction.