### PR TITLE
Keep client mutation timing outside pure phases

### DIFF
--- a/packages/shared-server/rallar-system/client-state/client-state-service-timing.ts
+++ b/packages/shared-server/rallar-system/client-state/client-state-service-timing.ts
@@ -3,12 +3,38 @@ import {
     recordRallarTiming,
     timeRallarAsync,
     type RallarTimingEventInput,
-    type RallarTimingSink
+    type RallarTimingSink,
+    type RecordRallarTimingInput
 } from '../observability/timing.ts';
 import type { ClientStateService } from './client-state-service-contracts.ts';
-import type { ClientMutationCommand } from './mutation/client-mutation-contracts.ts';
+import type {
+    ClientMutationCommand,
+    ClientMutationComputedWrite
+} from './mutation/client-mutation-contracts.ts';
 
-type ClientStateServiceOperation = 'mutation.read' | 'mutation.compute' | 'mutation.validate' | 'mutation.write';
+type ClientStatePurePhase = 'mutation.compute' | 'mutation.validate';
+
+export interface ClientStateMutationTiming {
+    readonly sink: RallarTimingSink | undefined;
+    readonly serviceId: string;
+}
+
+interface ClientStatePhaseTimingInput {
+    readonly timing: ClientStateMutationTiming;
+    readonly operation: ClientStatePurePhase;
+    readonly command: ClientMutationCommand;
+}
+
+interface ClientStateMutationCommitTimingInput {
+    readonly timing: ClientStateMutationTiming;
+    readonly writes: readonly ClientMutationComputedWrite[];
+}
+
+interface RecordClientStateMutationCommitInput extends ClientStateMutationCommitTimingInput {
+    readonly status: 'ok' | 'error';
+    readonly durationMs: number;
+    readonly error?: RecordRallarTimingInput['error'];
+}
 
 interface CreateTimedClientStateServiceInput {
     readonly service: ClientStateService;
@@ -24,13 +50,7 @@ export function createTimedClientStateService(
     }
     return {
         ...input.service,
-        read: (command) => timeClientMutationRead(input, command, () => input.service.read(command)),
-        compute: (command, read) =>
-            timeClientMutationCompute(input, command, () => input.service.compute(command, read)),
-        validate: (command, read, computed) =>
-            timeClientMutationValidate(input, command, () => input.service.validate(command, read, computed)),
-        write: (transaction, computed) =>
-            timeClientMutationWrite(input, computed, () => input.service.write(transaction, computed))
+        read: (command) => timeClientMutationRead(input, command, () => input.service.read(command))
     };
 }
 
@@ -54,17 +74,19 @@ function timeClientMutationRead<T>(
     );
 }
 
-function timeClientMutationCompute<T>(
-    input: CreateTimedClientStateServiceInput,
-    command: ClientMutationCommand,
+export function timeClientStateMutationPhase<T>(
+    input: ClientStatePhaseTimingInput,
     action: () => T
 ): T {
+    if (!input.timing.sink) {
+        return action();
+    }
     const startedAtEpochMs = nowMs();
     try {
         const result = action();
         recordRallarTiming({
-            sink: input.timing,
-            event: toMutationTiming('mutation.compute', command, input.serviceId),
+            sink: input.timing.sink,
+            event: toMutationTiming(input.operation, input.command, input.timing.serviceId),
             status: 'ok',
             durationMs: nowMs() - startedAtEpochMs
         });
@@ -72,8 +94,8 @@ function timeClientMutationCompute<T>(
     }
     catch (error) {
         recordRallarTiming({
-            sink: input.timing,
-            event: toMutationTiming('mutation.compute', command, input.serviceId),
+            sink: input.timing.sink,
+            event: toMutationTiming(input.operation, input.command, input.timing.serviceId),
             status: 'error',
             durationMs: nowMs() - startedAtEpochMs,
             error
@@ -82,54 +104,54 @@ function timeClientMutationCompute<T>(
     }
 }
 
-function timeClientMutationValidate<T>(
-    input: CreateTimedClientStateServiceInput,
-    command: ClientMutationCommand,
-    action: () => T
-): T {
-    const startedAtEpochMs = nowMs();
-    try {
-        const result = action();
-        recordRallarTiming({
-            sink: input.timing,
-            event: toMutationTiming('mutation.validate', command, input.serviceId),
-            status: 'ok',
-            durationMs: nowMs() - startedAtEpochMs
-        });
-        return result;
-    }
-    catch (error) {
-        recordRallarTiming({
-            sink: input.timing,
-            event: toMutationTiming('mutation.validate', command, input.serviceId),
-            status: 'error',
-            durationMs: nowMs() - startedAtEpochMs,
-            error
-        });
-        throw error;
-    }
-}
-
-function timeClientMutationWrite<T>(
-    input: CreateTimedClientStateServiceInput,
-    computed: Parameters<ClientStateService['write']>[1],
+export async function timeClientStateMutationCommit<T>(
+    input: ClientStateMutationCommitTimingInput,
     action: () => Promise<T>
 ): Promise<T> {
-    return timeRallarAsync(
-        input.timing,
-        {
-            component: 'client-state-service',
-            operation: 'mutation.write',
-            serviceId: input.serviceId,
-            requestId: computed.receipt.requestId ?? undefined,
-            ...computed.receipt.aggregateRef
-        },
-        action
-    );
+    if (!input.timing.sink || input.writes.length === 0) {
+        return await action();
+    }
+    const startedAtEpochMs = nowMs();
+    try {
+        const result = await action();
+        recordClientStateMutationCommit({
+            ...input,
+            status: 'ok',
+            durationMs: nowMs() - startedAtEpochMs
+        });
+        return result;
+    }
+    catch (error) {
+        recordClientStateMutationCommit({
+            ...input,
+            status: 'error',
+            durationMs: nowMs() - startedAtEpochMs,
+            error
+        });
+        throw error;
+    }
+}
+
+function recordClientStateMutationCommit(input: RecordClientStateMutationCommitInput): void {
+    for (const write of input.writes) {
+        recordRallarTiming({
+            sink: input.timing.sink,
+            event: {
+                component: 'client-state-service',
+                operation: 'mutation.write',
+                serviceId: input.timing.serviceId,
+                requestId: write.receipt.requestId ?? undefined,
+                ...write.receipt.aggregateRef
+            },
+            status: input.status,
+            durationMs: input.durationMs,
+            error: input.error
+        });
+    }
 }
 
 function toMutationTiming(
-    operation: ClientStateServiceOperation,
+    operation: ClientStatePurePhase,
     command: ClientMutationCommand,
     serviceId: string
 ): RallarTimingEventInput {

--- a/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/app-client-inbox-service.ts
@@ -124,6 +124,7 @@ export class AppClientInboxService {
             expiryCandidates: dependencies.clientStateService,
             snapshotObserver: dependencies.clientStateService,
             transactionWriter: handlerRuntime.transactionWriter,
+            mutationTiming: { sink: config.timing, serviceId: config.serviceId },
             serviceId: config.serviceId
         });
         this.registerClientStateMessages();

--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -23,6 +23,11 @@ import {
     type ClientStateService,
     type ClientStateWritten
 } from '../client-state-service-contracts.ts';
+import {
+    timeClientStateMutationCommit,
+    timeClientStateMutationPhase,
+    type ClientStateMutationTiming
+} from '../client-state-service-timing.ts';
 import { toClientMutationCommand, type ClientMutationPersistedFacts } from '../mutation/client-mutation-command.ts';
 import type {
     ClientMutationCommand,
@@ -49,6 +54,7 @@ export interface ClientStateInboxHandlerDependencies {
     readonly expiryCandidates: Pick<ClientStateService, 'listExpiredSessionCandidates'>;
     readonly snapshotObserver: Pick<ClientStateService, 'observeSnapshot'>;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
+    readonly mutationTiming: ClientStateMutationTiming;
     readonly serviceId: string;
 }
 
@@ -73,8 +79,8 @@ export class ClientStateInboxHandler {
     ): Promise<ClientStateWritten> {
         const command = await this.toCommand(context, input);
         const read = await this.dependencies.mutationService.read(command);
-        const computed = this.dependencies.mutationService.compute(command, read);
-        this.dependencies.mutationService.validate(command, read, computed);
+        const computed = this.compute(command, read);
+        this.validate(command, read, computed);
         return await this.commitComputed(context, computed);
     }
 
@@ -122,8 +128,8 @@ export class ClientStateInboxHandler {
                 lifecycleComputed
             });
         }
-        const computed = this.dependencies.mutationService.compute(command, read);
-        this.dependencies.mutationService.validate(command, read, computed);
+        const computed = this.compute(command, read);
+        this.validate(command, read, computed);
         return await this.commitComputed(context, computed, lifecycleComputed);
     }
 
@@ -136,16 +142,19 @@ export class ClientStateInboxHandler {
         const durableResult = applied.map(toClientStateWritten);
         const committedSnapshots = applied.map((successor) => successor.snapshot);
         const completion = this.readComputeValidateCompletion(context, durableResult);
-        const result = await this.dependencies.transactionWriter.writeComputedMutation(
-            context,
-            completion,
-            async (transaction) => {
-                for (const successor of computed) {
-                    if (requiresClientWrite(successor)) {
-                        await this.dependencies.mutationService.write(transaction, successor);
+        const writes = computed.filter(requiresClientWrite);
+        const result = await timeClientStateMutationCommit(
+            { timing: this.dependencies.mutationTiming, writes },
+            async () =>
+                await this.dependencies.transactionWriter.writeComputedMutation(
+                    context,
+                    completion,
+                    async (transaction) => {
+                        for (const successor of writes) {
+                            await this.dependencies.mutationService.write(transaction, successor);
+                        }
                     }
-                }
-            }
+                )
         );
         await this.observeCommittedSnapshots(committedSnapshots);
         return result;
@@ -155,8 +164,8 @@ export class ClientStateInboxHandler {
         command: ClientMutationCommand
     ): Promise<ClientMutationComputed> {
         const read = await this.dependencies.mutationService.read(command);
-        const computed = this.dependencies.mutationService.compute(command, read);
-        this.dependencies.mutationService.validate(command, read, computed);
+        const computed = this.compute(command, read);
+        this.validate(command, read, computed);
         return computed;
     }
 
@@ -171,15 +180,41 @@ export class ClientStateInboxHandler {
         const durableResult = toClientStateWritten(computed);
         const committedSnapshots = [computed.snapshot];
         const completion = this.readComputeValidateCompletion(context, durableResult);
-        const result = await this.dependencies.transactionWriter.writeComputedMutation(
-            context,
-            completion,
-            async (transaction) => {
-                await this.writeClientMutation(transaction, computed, lifecycleComputed);
-            }
+        const writes = requiresClientWrite(computed) ? [computed] : [];
+        const result = await timeClientStateMutationCommit(
+            { timing: this.dependencies.mutationTiming, writes },
+            async () =>
+                await this.dependencies.transactionWriter.writeComputedMutation(
+                    context,
+                    completion,
+                    async (transaction) => {
+                        await this.writeClientMutation(transaction, computed, lifecycleComputed);
+                    }
+                )
         );
         await this.observeCommittedSnapshots(committedSnapshots);
         return result;
+    }
+
+    private compute(
+        command: ClientMutationCommand,
+        read: Awaited<ReturnType<ClientStateMutationService['read']>>
+    ): ClientMutationComputed {
+        return timeClientStateMutationPhase(
+            { timing: this.dependencies.mutationTiming, command, operation: 'mutation.compute' },
+            () => this.dependencies.mutationService.compute(command, read)
+        );
+    }
+
+    private validate(
+        command: ClientMutationCommand,
+        read: Awaited<ReturnType<ClientStateMutationService['read']>>,
+        computed: ClientMutationComputed
+    ): void {
+        timeClientStateMutationPhase(
+            { timing: this.dependencies.mutationTiming, command, operation: 'mutation.validate' },
+            () => this.dependencies.mutationService.validate(command, read, computed)
+        );
     }
 
     private async writeClientMutation(

--- a/packages/tests/shared-server/rallar-system/client-state/client-state-service-timing.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-state-service-timing.test.ts
@@ -1,18 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
-import { createTimedClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-timing.ts';
+import {
+    createTimedClientStateService,
+    timeClientStateMutationCommit
+} from '@shared-server/rallar-system/client-state/client-state-service-timing.ts';
 import type { RallarTimingEvent } from '@shared-server/rallar-system/observability/timing.ts';
 
 import type { ClientStateService } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
 import type { ClientMutationCommand } from '@shared-server/rallar-system/client-state/mutation/client-mutation-contracts.ts';
+import { toUpsertClientPrincipalMutationInput } from '@shared-server/rallar-system/client-state/mutation/command-input/to-upsert-client-principal-mutation-input.ts';
 
-import { FakeRuntimeStateRepository } from '../../runtime-state/test-support/fake-runtime-state-repository.ts';
-import { CLIENT_MUTATION_SERVICE_SCOPE } from './client-state-service-test-fixtures.ts';
-import { createClientStateTestDriver as createClientStateService } from './client-state-test-runtime.ts';
+import { createClientMutationTransactionBoundaryFixture } from './create-client-mutation-transaction-boundary-fixture.ts';
 
 describe('client-state service timing', () => {
-    it('preserves timed phase identities, results, rejections, and argument identities', async () => {
+    it('times reads without adding clock or sink effects to compute, validate, or write', async () => {
         const fixture = createTimedClientStateServiceFixture();
         const timed = createTimedClientStateService({
             service: fixture.service,
@@ -24,6 +26,9 @@ describe('client-state service timing', () => {
         });
 
         await expect(timed.read(TIMED_COMMAND)).resolves.toBe(fixture.readResult);
+        expect(timed.compute).toBe(fixture.service.compute);
+        expect(timed.validate).toBe(fixture.service.validate);
+        expect(timed.write).toBe(fixture.service.write);
         expect(timed.compute(TIMED_COMMAND, fixture.readResult as never)).toBe(fixture.computedResult);
         expect(() => timed.validate(TIMED_COMMAND, fixture.readResult as never, fixture.computedResult as never)).not.toThrow();
         await expect(timed.write(TIMED_TRANSACTION, TIMED_COMPUTED)).rejects.toBe(fixture.writeFailure);
@@ -32,19 +37,12 @@ describe('client-state service timing', () => {
             'read',
             'event:mutation.read:ok',
             'compute',
-            'event:mutation.compute:ok',
             'validate',
-            'event:mutation.validate:ok',
-            'write',
-            'event:mutation.write:error'
+            'write'
         ]);
         expect(fixture.events.map((event) => [event.operation, event.serviceId, event.status])).toEqual([
-            ['mutation.read', 'client-timing-service', 'ok'],
-            ['mutation.compute', 'client-timing-service', 'ok'],
-            ['mutation.validate', 'client-timing-service', 'ok'],
-            ['mutation.write', 'client-timing-service', 'error']
+            ['mutation.read', 'client-timing-service', 'ok']
         ]);
-        expect(fixture.events.at(-1)?.error?.message).toBe(fixture.writeFailure.message);
     });
 });
 
@@ -138,37 +136,59 @@ function createTimedClientStateServiceFixture(): TimedClientStateServiceFixture 
 }
 
 describe('client mutation service timing', () => {
-    it('records timing for client state service methods when a timing sink is supplied', async () => {
-        const timingEvents: RallarTimingEvent[] = [];
-        const service = createClientStateService({
-            runtimeRepository: new FakeRuntimeStateRepository(),
-            now: () => 1_000,
-            serviceId: 'client-service',
-            timing: (event) => timingEvents.push(event)
+    it('records compute and validate before transaction entry and write after commit', async () => {
+        const fixture = await createClientMutationTransactionBoundaryFixture({
+            recordMutationTiming: true
         });
 
-        await service.upsertPrincipal(CLIENT_MUTATION_SERVICE_SCOPE, 'alice', {
-            username: 'alice',
-            displayName: 'Alice',
-            actorPrincipalId: 'alice',
-            actorSessionId: 'alice-session',
-            requestId: 'upsert-alice-timed'
-        });
-
-        expect(timingEvents).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    component: 'client-state-service',
-                    operation: 'mutation.write',
-                    status: 'ok',
-                    serviceId: 'client-service',
-                    requestId: 'upsert-alice-timed',
-                    applicationId: CLIENT_MUTATION_SERVICE_SCOPE.applicationId,
-                    workspaceId: CLIENT_MUTATION_SERVICE_SCOPE.workspaceId,
-                    principalId: 'alice'
-                })
-            ])
+        await fixture.handler.processCommand(
+            fixture.context,
+            toUpsertClientPrincipalMutationInput({
+                scope: SCOPE,
+                principalId: 'alice',
+                request: { username: 'alice', requestId: 'upsert-alice-timed' },
+                defaultCommandId: 'upsert-alice-timed'
+            })
         );
-        expect(typeof timingEvents[0]?.durationMs).toBe('number');
+
+        expect(fixture.actions).toEqual([
+            'mutation.compute',
+            'mutation.validate',
+            'completion',
+            'write',
+            'commit',
+            'mutation.write',
+            'observe'
+        ]);
+    });
+
+    it('records a failed write only after the transaction action has exited', async () => {
+        const actions: string[] = [];
+        const failure = new Error('transaction failed');
+
+        await expect(timeClientStateMutationCommit(
+            {
+                timing: {
+                    serviceId: 'client-timing-service',
+                    sink: (event) => actions.push(`event:${event.operation}:${event.status}`)
+                },
+                writes: [TIMED_COMPUTED]
+            },
+            async () => {
+                actions.push('transaction');
+                try {
+                    throw failure;
+                }
+                finally {
+                    actions.push('transaction-exited');
+                }
+            }
+        )).rejects.toBe(failure);
+
+        expect(actions).toEqual([
+            'transaction',
+            'transaction-exited',
+            'event:mutation.write:error'
+        ]);
     });
 });

--- a/packages/tests/shared-server/rallar-system/client-state/client-state-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-state-test-runtime.ts
@@ -6,6 +6,11 @@ import {
     type ClientStateService,
     type ClientStateWritten
 } from '@shared-server/rallar-system/client-state/client-state-service-contracts.ts';
+import {
+    timeClientStateMutationCommit,
+    timeClientStateMutationPhase,
+    type ClientStateMutationTiming
+} from '@shared-server/rallar-system/client-state/client-state-service-timing.ts';
 import { createClientStateService } from '@shared-server/rallar-system/client-state/client-state-service.ts';
 import {
     toClientMutationIssuedSessionAuthority,
@@ -45,6 +50,7 @@ interface ClientStateTestExecutorInput {
     readonly serviceId: string;
     readonly nowEpochMs: () => number;
     readonly nextSequence: () => number;
+    readonly mutationTiming: ClientStateMutationTiming;
 }
 
 interface ClientStateTestDriverDependencies {
@@ -84,6 +90,7 @@ export function createClientStatePhaseTestDriver(
             service,
             serviceId,
             nowEpochMs,
+            mutationTiming: { sink: options.timing, serviceId },
             nextSequence: () => ++commandSequence
         }),
         nextId: () => `test-client-command-${++commandSequence}`
@@ -148,8 +155,14 @@ async function computeClientStateTestMutation(
         authority
     );
     const read = await context.service.read(command);
-    const computed = context.service.compute(command, read);
-    context.service.validate(command, read, computed);
+    const computed = timeClientStateMutationPhase(
+        { timing: context.mutationTiming, command, operation: 'mutation.compute' },
+        () => context.service.compute(command, read)
+    );
+    timeClientStateMutationPhase(
+        { timing: context.mutationTiming, command, operation: 'mutation.validate' },
+        () => context.service.validate(command, read, computed)
+    );
     return computed;
 }
 
@@ -157,26 +170,30 @@ async function writeClientStateTestMutation(
     context: ClientStateTestExecutorInput,
     computed: Parameters<ClientStateService['write']>[1]
 ): Promise<void> {
-    await context.runtimeRepository.begin(async (runtime) => {
-        const outboxBefore = captureClientStateTestOutbox(context.runtimeRepository);
-        const eventsBefore = [...context.eventStore.events];
-        try {
-            await context.service.write(
-                createClientStateTestTransaction({
-                    runtime,
-                    runtimeRepository: context.runtimeRepository,
-                    eventStore: context.eventStore
-                }),
-                computed
-            );
-        }
-        catch (error) {
-            restoreClientStateTestOutbox(context.runtimeRepository, outboxBefore);
-            context.eventStore.events.length = 0;
-            context.eventStore.events.push(...eventsBefore);
-            throw error;
-        }
-    });
+    await timeClientStateMutationCommit(
+        { timing: context.mutationTiming, writes: [computed] },
+        async () =>
+            await context.runtimeRepository.begin(async (runtime) => {
+                const outboxBefore = captureClientStateTestOutbox(context.runtimeRepository);
+                const eventsBefore = [...context.eventStore.events];
+                try {
+                    await context.service.write(
+                        createClientStateTestTransaction({
+                            runtime,
+                            runtimeRepository: context.runtimeRepository,
+                            eventStore: context.eventStore
+                        }),
+                        computed
+                    );
+                }
+                catch (error) {
+                    restoreClientStateTestOutbox(context.runtimeRepository, outboxBefore);
+                    context.eventStore.events.length = 0;
+                    context.eventStore.events.push(...eventsBefore);
+                    throw error;
+                }
+            })
+    );
 }
 
 async function toTestAuthority(

--- a/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
@@ -32,6 +32,7 @@ const SCOPE: StateScope = { applicationId: 'ar-eye-hunter', workspaceId: 'defaul
 
 interface ClientMutationTransactionBoundaryOptions {
     readonly failTransaction?: boolean;
+    readonly recordMutationTiming?: boolean;
     readonly rejectSnapshotReadInTransaction?: boolean;
 }
 
@@ -97,6 +98,12 @@ export async function createClientMutationTransactionBoundaryFixture(
                 return context.message.id.ts;
             }
         }),
+        mutationTiming: {
+            serviceId: 'client-inbox-service',
+            sink: options.recordMutationTiming
+                ? (event) => actions.push(event.operation)
+                : undefined
+        },
         serviceId: 'client-inbox-service'
     });
     return {


### PR DESCRIPTION
## Summary
- preserve exact client compute, validate, and write functions in the timing decorator
- record compute/validate timing in the AppInbox stateful shell
- record write timing only after the outer transaction has completed or failed
- keep the direct test mutation shell aligned with the same boundary

## Validation
- `npx vitest run packages/tests/shared-server/rallar-system/client-state --silent` (96 passed)
- `npx tsc -p packages/shared-server/tsconfig.json --noEmit --pretty false`
- `npm run typecheck:tests` (1027 files, zero errors)
- fresh login shell `deno check` for the three changed production modules
- `npm run check:transaction-writes`
- `npm run check:repo-style:changed -- origin/main`
- `npm run check:repo-structure`

## Review
The change adds one explicit timing descriptor and two shell-owned timing helpers. It does not add a mutation phase, retry loop, compatibility layer, or transaction work. The scoped style warnings are in untouched files; changed-file style and structure checks pass.