### PR TITLE
feat(group-state): dial the commanded replan out of reconfiguring (slice 11d)

### DIFF
--- a/apps/api-v1/prisma/migrations/20260903120000_connect_trigger_latch_supersedes/migration.sql
+++ b/apps/api-v1/prisma/migrations/20260903120000_connect_trigger_latch_supersedes/migration.sql
@@ -1,0 +1,7 @@
+-- Connect-trigger latches gain the candidate they wait to see replaced.
+-- Latches written before it existed were armed by a `plan`, which names no
+-- candidate, so they carry null; every reader requires the field from here on.
+UPDATE runtime_state_store
+SET store_value = (store_value::jsonb || '{"supersedesLayoutIdentity": null}'::jsonb)::text
+WHERE store_namespace = 'group-state:connect-trigger-latches'
+  AND NOT (store_value::jsonb ? 'supersedesLayoutIdentity');

--- a/apps/api-v1/src/db/in-memory-schema-bootstrap.ts
+++ b/apps/api-v1/src/db/in-memory-schema-bootstrap.ts
@@ -21,7 +21,8 @@ export const API_V1_IN_MEMORY_SCHEMA_URL = new URL(
 export const API_V1_PGLITE_SCHEMA_UPGRADE_URLS: readonly URL[] = [
     '../../prisma/migrations/20260714093000_resource_inbox_scoped_queue_keys/migration.sql',
     '../../prisma/migrations/20260902150000_coalesced_work_window_anchor/migration.sql',
-    '../../prisma/migrations/20260902200000_connect_trigger_latch_settle/migration.sql'
+    '../../prisma/migrations/20260902200000_connect_trigger_latch_settle/migration.sql',
+    '../../prisma/migrations/20260903120000_connect_trigger_latch_supersedes/migration.sql'
 ].map((path) => new URL(path, import.meta.url));
 
 export async function readApiV1InMemorySchemaSql(): Promise<string> {

--- a/apps/api-v1/test/db/connect-trigger-latch-supersedes-migration.test.ts
+++ b/apps/api-v1/test/db/connect-trigger-latch-supersedes-migration.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import { createApiV1TestPGliteDatabaseLifecycle } from './api-v1-test-pglite-database.ts';
+
+const MIGRATION_URL = new URL(
+    '../../prisma/migrations/20260903120000_connect_trigger_latch_supersedes/migration.sql',
+    import.meta.url
+);
+const NAMESPACE = 'group-state:connect-trigger-latches';
+
+interface StoredLayoutIdentity {
+    readonly groupRevision: number;
+    readonly presenceRevision: number;
+    readonly version: number;
+    readonly state: 'active' | 'removed';
+}
+
+/** A stored latch, before and after the superseded candidate existed. */
+interface StoredLatch {
+    readonly groupRef: { readonly applicationId: string; readonly workspaceId: string; readonly groupId: string; };
+    readonly formationEpoch: number;
+    readonly triggerGeneration: string;
+    readonly notBeforeEpochMs: number;
+    readonly supersedesLayoutIdentity?: StoredLayoutIdentity | null;
+    readonly state: 'awaiting-publication' | 'consumed';
+}
+
+const SUPERSEDED: StoredLayoutIdentity = {
+    groupRevision: 7,
+    presenceRevision: 3,
+    version: 4,
+    state: 'active'
+};
+
+function toStoredLatch(supersedes: StoredLayoutIdentity | null | undefined): string {
+    const latch: StoredLatch = {
+        groupRef: { applicationId: 'app', workspaceId: 'workspace', groupId: 'room' },
+        formationEpoch: 2,
+        triggerGeneration: 'plan-1',
+        notBeforeEpochMs: 0,
+        ...(supersedes === undefined ? {} : { supersedesLayoutIdentity: supersedes }),
+        state: 'awaiting-publication'
+    };
+    return JSON.stringify(latch);
+}
+
+Deno.test('the supersedes migration backfills latches written before the candidate existed', async () => {
+    const lifecycle = await createApiV1TestPGliteDatabaseLifecycle();
+    try {
+        const sql = lifecycle.database;
+        const rows = [
+            ['legacy', NAMESPACE, toStoredLatch(undefined)],
+            ['reconfigure', NAMESPACE, toStoredLatch(SUPERSEDED)],
+            ['other', 'group-state:other', toStoredLatch(undefined)]
+        ] as const;
+        for (const [key, namespace, value] of rows) {
+            await sql`
+                insert into runtime_state_store (store_namespace, store_key, store_value, expire_at_ts)
+                values (${namespace}, ${key}, ${value}, '9999-12-31 23:59:59+00')
+            `;
+        }
+
+        await sql.exec(await Deno.readTextFile(MIGRATION_URL));
+
+        const stored = await sql<{ store_key: string; store_value: string; }[]>`
+            select store_key, store_value from runtime_state_store order by store_key
+        `;
+        const byKey = new Map(stored.map((row) => [row.store_key, JSON.parse(row.store_value) as StoredLatch]));
+        // A plan-armed latch names no candidate, so any active planned layout
+        // still satisfies it -- the behaviour those rows were written under.
+        assert.equal(byKey.get('legacy')?.supersedesLayoutIdentity, null);
+        assert.equal(byKey.get('legacy')?.notBeforeEpochMs, 0);
+        assert.deepEqual(byKey.get('reconfigure')?.supersedesLayoutIdentity, SUPERSEDED);
+        assert.equal(byKey.get('other')?.supersedesLayoutIdentity, undefined);
+    }
+    finally {
+        await lifecycle.close();
+    }
+});

--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -183,9 +183,14 @@ instant: `immediate` may connect as soon as the layout publishes, `after` from i
 `connect` timer petitions the group's awaiting latches; `presence` from its fallback on, or sooner when its members hold live presence — the topology cycle
 that every presence change reaches petitions the latch as satisfied — and `manual` arms nothing. A
 re-plan behind a spent attempt latches regardless of trigger or formation mode, because it continues
-a series the application already started. The `reconfigure` that opens `reconfiguring` arms nothing:
-its own replan has not published, so `reconfiguring` still waits for an application `connect`. A deadline that finds no live planned layout in a dialing
-stage fails that attempt at once, with no layout to fence. A `forming` group's presence trigger plans through the same
+a series the application already started. The `reconfigure` that opens `reconfiguring` arms the same
+trigger, with one difference: it commands its own replan, so at arming time the planned slot still
+holds the candidate it means to replace. Its latch names that candidate
+(`supersedesLayoutIdentity`) and the petition refuses it, so the trigger dials the replan when it
+publishes and never the layout the reconfigure replaced; a `plan` names nothing, because its own
+replan may be skipped as unchanged and the standing candidate is then the one to dial. A deadline
+that finds no live planned layout in a dialing stage fails that attempt at once, with no layout to
+fence. A `forming` group's presence trigger plans through the same
 cycle, under `formation-automation`.
 
 `establishment.maxConcurrentEdgeSetups` reaches the browser as `Group.memberPolicy`, where each

--- a/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
@@ -191,9 +191,19 @@ function computeEstablishmentTimerEntries(
 }
 
 /**
+ * The commands that can land a group in a stage holding a planned candidate,
+ * and so arm the connect trigger: a `plan` from `forming` and the
+ * `reconfigure` that opens `reconfiguring`. The latch and its timer backstop
+ * must agree on this, or a trigger with a settle arms an intent nothing wakes.
+ */
+export function opensPlannedCandidateStage(operation: GroupMutationCommand['operation']): boolean {
+    return operation === 'planGroupLayout' || operation === 'reconfigureGroup';
+}
+
+/**
  * The stage triggers' time leg (product decision 8), phased groups only
  * (product decision 17): the first entry into `forming` — creation or
- * `start` — arms the plan trigger, and a plan that lands a candidate in a
+ * `start` — arms the plan trigger, and a command that lands a candidate in a
  * stage that holds one arms the connect trigger, each at the delay its kind
  * gives — a settle for `after`, a fallback for `presence`. A below-floor
  * return into `forming` is the retry leg's, and a repeated `plan` while
@@ -212,9 +222,9 @@ function computeStageTriggerTimerEntries(
     }
     const { connectTrigger } = policy.establishment;
     if (
-        input.command.operation !== 'planGroupLayout' || !holdsPlannedCandidateAt(next.lifecycleState) ||
-        // `immediate` needs no entry: the publication that follows the plan
-        // petitions the latch, which is sooner than any timer could be.
+        !opensPlannedCandidateStage(input.command.operation) || !holdsPlannedCandidateAt(next.lifecycleState) ||
+        // `immediate` needs no entry: the publication that follows petitions
+        // the latch, which is sooner than any timer could be.
         connectTrigger.kind === 'immediate'
     ) {
         return [];

--- a/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts
@@ -16,10 +16,11 @@ import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry
 import { AppOutboxType } from '../app-outbox/app-outbox-type.ts';
 import { requireOneOf } from '../protocol/exact-object-decoding.ts';
 import { decodeJsonWireValue, type JsonWireObject, type JsonWireValue } from '../protocol/json-wire-identity.ts';
-import type {
-    GroupLifecycleTransitionOperation,
-    GroupMutationCommand,
-    GroupMutationFacts
+import {
+    opensPlannedCandidateStage,
+    type GroupLifecycleTransitionOperation,
+    type GroupMutationCommand,
+    type GroupMutationFacts
 } from './mutation/group-mutation-contracts.ts';
 
 import { groupStateGroupStorageKey } from './persistence/aggregate/group-aggregate-storage-keys.ts';
@@ -188,16 +189,6 @@ function computeEstablishmentTimerEntries(
         ];
     }
     return [];
-}
-
-/**
- * The commands that can land a group in a stage holding a planned candidate,
- * and so arm the connect trigger: a `plan` from `forming` and the
- * `reconfigure` that opens `reconfiguring`. The latch and its timer backstop
- * must agree on this, or a trigger with a settle arms an intent nothing wakes.
- */
-export function opensPlannedCandidateStage(operation: GroupMutationCommand['operation']): boolean {
-    return operation === 'planGroupLayout' || operation === 'reconfigureGroup';
 }
 
 /**

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
@@ -1,10 +1,12 @@
 import { toStageTriggerTimerDelayMs } from '@shared/api/group-lifecycle/evaluate-group-stage-trigger.ts';
 import type { GroupLifecyclePolicy, GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import { type GroupLayoutIdentity, toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { holdsPlannedCandidateAt } from '@shared/api/group-lifecycle/resolve-formation-stage-entry.ts';
 import type { Group } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import type { RuntimeStateGuardedBatchEffect } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import { opensPlannedCandidateStage } from '../../formation-timer-outbox-entry.ts';
 import { computeGroupConnectTriggerEntry } from '../../group-connect-trigger-outbox-entry.ts';
 import { toGroupConnectTriggerLatchEffect } from '../../persistence/group-connect-trigger-latch-repository.ts';
 import type { GroupMutationCommand, GroupMutationFacts, GroupMutationRead } from '../group-mutation-contracts.ts';
@@ -76,21 +78,30 @@ export function computeGroupConnectTrigger(input: ComputeGroupConnectTriggerInpu
 }
 
 /**
- * A plan that lands a fresh candidate in a stage that holds one. The
- * reconfigure that opens `reconfiguring` is deliberately not an arming site:
- * its own replan has not published yet, so a latch armed there would petition
- * against the layout the reconfigure means to replace and freeze it by
- * dialing. `reconfiguring` still waits for an application `connect`; the
- * automatic boundary out of it needs the latch to name the publication it
- * waits for, which is the next slice's work.
+ * A command that lands the group in a stage holding a candidate: `plan` from
+ * `forming`, and the `reconfigure` that opens `reconfiguring`. Both arm; what
+ * separates them is which publication satisfies the latch. A `reconfigure`
+ * commands its own replan, so at arming time the planned slot still holds the
+ * layout it means to replace — the latch names that layout and waits for a
+ * different one (plan slice 11d). A `plan` names nothing, because its replan
+ * may be skipped as unchanged and the standing candidate is then the one to
+ * dial. The idempotent replan from `planned` is excluded by the stage change.
  */
 function entersHeldStage(
     command: GroupMutationCommand,
     previous: GroupLifecycleState | null,
     next: Group
 ): boolean {
-    return command.operation === 'planGroupLayout' &&
+    return opensPlannedCandidateStage(command.operation) &&
         holdsPlannedCandidateAt(next.lifecycleState) && previous !== next.lifecycleState;
+}
+
+/** The candidate a `reconfigure` supersedes: the one its own replan replaces. */
+function resolveSupersededLayoutIdentity(input: ComputeGroupConnectTriggerInput): GroupLayoutIdentity | null {
+    if (input.command.operation !== 'reconfigureGroup' || input.read.plannedLayoutRow === null) {
+        return null;
+    }
+    return toGroupLayoutIdentity(input.read.plannedLayoutRow.snapshot);
 }
 
 function latchAwaitingPublication(
@@ -103,6 +114,7 @@ function latchAwaitingPublication(
         formationEpoch: next.formationEpoch,
         triggerGeneration: command.commandId,
         notBeforeEpochMs,
+        supersedesLayoutIdentity: resolveSupersededLayoutIdentity(input),
         state: 'awaiting-publication'
     } as const;
     return {

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
@@ -1,6 +1,6 @@
 import { toStageTriggerTimerDelayMs } from '@shared/api/group-lifecycle/evaluate-group-stage-trigger.ts';
+import { toGroupLayoutIdentity, type GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { GroupLifecyclePolicy, GroupLifecycleState } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
-import { type GroupLayoutIdentity, toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { holdsPlannedCandidateAt } from '@shared/api/group-lifecycle/resolve-formation-stage-entry.ts';
 import type { Group } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';

--- a/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts
@@ -6,10 +6,14 @@ import type { Group } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import type { RuntimeStateGuardedBatchEffect } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
-import { opensPlannedCandidateStage } from '../../formation-timer-outbox-entry.ts';
 import { computeGroupConnectTriggerEntry } from '../../group-connect-trigger-outbox-entry.ts';
 import { toGroupConnectTriggerLatchEffect } from '../../persistence/group-connect-trigger-latch-repository.ts';
-import type { GroupMutationCommand, GroupMutationFacts, GroupMutationRead } from '../group-mutation-contracts.ts';
+import {
+    opensPlannedCandidateStage,
+    type GroupMutationCommand,
+    type GroupMutationFacts,
+    type GroupMutationRead
+} from '../group-mutation-contracts.ts';
 
 export interface GroupConnectTriggerComputed {
     readonly effect: RuntimeStateGuardedBatchEffect | null;

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -592,6 +592,16 @@ export function isGroupTransportOperation(
 }
 
 /** True exactly when the command names a planned layout its fence must match. */
+/**
+ * The commands that can land a group in a stage holding a planned candidate,
+ * and so arm the connect trigger: a `plan` from `forming` and the
+ * `reconfigure` that opens `reconfiguring`. The latch and its timer backstop
+ * must agree on this, or a trigger with a settle arms an intent nothing wakes.
+ */
+export function opensPlannedCandidateStage(operation: GroupMutationCommand['operation']): boolean {
+    return operation === 'planGroupLayout' || operation === 'reconfigureGroup';
+}
+
 export function isLayoutFencedGroupMutationCommand(command: GroupMutationCommand): boolean {
     return (
         (

--- a/packages/shared-server/rallar-system/group-state/mutation/read/group-mutation-read-scope.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/read/group-mutation-read-scope.ts
@@ -48,12 +48,16 @@ export function readsGroupActiveMemberPrincipalIds(
 /**
  * True when the command's compute consults the stored layout rows: every
  * activation reads them for the promotion effect (operator activations
- * included), and a layout-fenced command reads the planned row for its
- * fence and its commit-time re-assertion.
+ * included), a layout-fenced command reads the planned row for its fence and
+ * its commit-time re-assertion, and a `reconfigure` reads it to name the
+ * candidate its connect latch supersedes (plan slice 11d). The reconfigure
+ * takes no fence from it, so it adds a point read and no conflict surface —
+ * and only on a commanded path that already reads the stored policy.
  */
 export function readsGroupLayoutRows(command: GroupMutationCommand): boolean {
     return command.operation === 'activateGroup' ||
         command.operation === 'resetGroupFormation' ||
+        command.operation === 'reconfigureGroup' ||
         isLayoutFencedGroupMutationCommand(command);
 }
 

--- a/packages/shared-server/rallar-system/group-state/persistence/group-connect-trigger-latch-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-connect-trigger-latch-repository.ts
@@ -1,10 +1,15 @@
+import {
+    GROUP_LAYOUT_IDENTITY_KEYS,
+    GROUP_LAYOUT_IDENTITY_STATES,
+    type GroupLayoutIdentity
+} from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
 import type { RuntimeStateGuardedBatchEffect } from '../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { RuntimeStateEntry, RuntimeStateRepositoryLike } from '../../../runtime-state/runtime-state-repository.ts';
 import { serializeCanonicalJson } from '../../protocol/canonical-json.ts';
-import { decodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
+import { decodeJsonWireValue, type JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import { toExactJsonWireObject } from '../../protocol/to-json-wire-object.ts';
 import { groupStateGroupStorageKey } from './aggregate/group-aggregate-storage-keys.ts';
 
@@ -19,6 +24,13 @@ export interface GroupConnectTriggerIdentity {
 export interface GroupConnectTriggerLatch extends GroupConnectTriggerIdentity {
     /** The trigger's settle instant: a publication before it leaves the intent latched (plan slice 11a). */
     readonly notBeforeEpochMs: number;
+    /**
+     * The candidate this latch is waiting to see replaced, or `null` when any
+     * active planned layout satisfies it. A `reconfigure` commands its own
+     * replan, so at arming time the planned slot still holds the layout the
+     * reconfigure means to supersede (plan slice 11d).
+     */
+    readonly supersedesLayoutIdentity: GroupLayoutIdentity | null;
     readonly state: 'awaiting-publication' | 'consumed';
 }
 
@@ -100,8 +112,10 @@ export function decodeGroupConnectTriggerLatchRow(
             'formationEpoch',
             'triggerGeneration',
             'notBeforeEpochMs',
+            'supersedesLayoutIdentity',
             'state'
         ], 'Connect trigger latch');
+        const supersedesLayoutIdentity = toStoredSupersededLayoutIdentity(value.supersedesLayoutIdentity, entry.key);
         const groupRef = toExactJsonWireObject(
             value.groupRef,
             ['applicationId', 'workspaceId', 'groupId'],
@@ -120,13 +134,42 @@ export function decodeGroupConnectTriggerLatchRow(
             throw new GroupConnectTriggerLatchCorruptionError(entry.key);
         }
         return {
-            latch: { ...identity, notBeforeEpochMs: value.notBeforeEpochMs, state: value.state },
+            latch: {
+                ...identity,
+                notBeforeEpochMs: value.notBeforeEpochMs,
+                supersedesLayoutIdentity,
+                state: value.state
+            },
             revision: entry.revision
         };
     }
     catch {
         throw new GroupConnectTriggerLatchCorruptionError(entry.key);
     }
+}
+
+/** `null` or the exact wire shape of a layout identity; anything else is corruption. */
+function toStoredSupersededLayoutIdentity(value: JsonWireValue, key: string): GroupLayoutIdentity | null {
+    if (value === null) {
+        return null;
+    }
+    const identity = toExactJsonWireObject(value, GROUP_LAYOUT_IDENTITY_KEYS, 'Connect trigger superseded layout');
+    const state = identity.state;
+    if (
+        typeof identity.groupRevision !== 'number' || !Number.isSafeInteger(identity.groupRevision) ||
+        typeof identity.presenceRevision !== 'number' || !Number.isSafeInteger(identity.presenceRevision) ||
+        typeof identity.version !== 'number' || !Number.isSafeInteger(identity.version) ||
+        typeof state !== 'string' ||
+        !(GROUP_LAYOUT_IDENTITY_STATES as readonly string[]).includes(state)
+    ) {
+        throw new GroupConnectTriggerLatchCorruptionError(key);
+    }
+    return {
+        groupRevision: identity.groupRevision,
+        presenceRevision: identity.presenceRevision,
+        version: identity.version,
+        state: state as GroupLayoutIdentity['state']
+    };
 }
 
 export function toGroupConnectTriggerLatchEffect(

--- a/packages/shared-server/rallar-system/topology/replay/work/create-group-connect-trigger-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-group-connect-trigger-work-handler.ts
@@ -1,5 +1,5 @@
 import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
-import { toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import { isSameGroupLayoutIdentity, toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { holdsPlannedCandidateAt } from '@shared/api/group-lifecycle/resolve-formation-stage-entry.ts';
 import type { Group, GroupRef } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
@@ -104,10 +104,17 @@ export async function petitionGroupConnectTrigger(
         // Intent remains in the latch; publication creates fresh durable work.
         return;
     }
-    await port.submitCommand(
-        toAutomaticGroupConnectCommand(identity, toGroupLayoutIdentity(planned)),
-        port.nowEpochMs()
-    );
+    const publication = toGroupLayoutIdentity(planned);
+    if (
+        row.latch.supersedesLayoutIdentity !== null &&
+        isSameGroupLayoutIdentity(publication, row.latch.supersedesLayoutIdentity)
+    ) {
+        // The reconfigure's own replan has not published yet, so this is the
+        // candidate it means to replace. Dialing it would enter `reconnecting`
+        // on the stale layout and freeze the replan (plan slice 11d).
+        return;
+    }
+    await port.submitCommand(toAutomaticGroupConnectCommand(identity, publication), port.nowEpochMs());
 }
 
 export function toAutomaticGroupConnectCommand(

--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1067,7 +1067,7 @@
           }
         ]
       },
-      "description": "Automatic formation triggers on a phased group: the plan trigger plans after its settle and the connect trigger dials the planned layout after the next settle, with no application plan or connect command."
+      "description": "Automatic formation triggers on a phased group: the plan trigger plans after its settle, the connect trigger dials the planned layout after the next settle, and a reconfigure that opens RECONFIGURING is dialed by the same trigger once its own replan publishes -- never the candidate it replaced, and with no application plan or connect command."
     },
     {
       "id": "api-v1-presence-formation-trigger",

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-automatic-formation-triggers.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-automatic-formation-triggers.json
@@ -1,5 +1,5 @@
 {
-  "description": "The automatic formation triggers (product decision 8, plan slice 11a): a phased group whose plan and connect triggers are `after` settles plans itself once the settle elapses and dials the planned layout after the next settle, with no application plan or connect command; each automatic transition advances the epoch like its manual twin.",
+  "description": "The automatic formation triggers (product decision 8, plan slices 11a and 11d): a phased group whose plan and connect triggers are `after` settles plans itself once the settle elapses and dials the planned layout after the next settle, with no application plan or connect command; a `reconfigure` then opens RECONFIGURING and the same connect trigger dials the replan it commanded, never the candidate it replaced; each automatic transition advances the epoch like its manual twin.",
   "variables": {
     "apiPrimary": {
       "env": "RALLAR_API_BASE_URL",
@@ -364,6 +364,129 @@
             "state": "active"
           }
         }
+      }
+    },
+    {
+      "name": "activateTheDialedLayout",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/activate/requests/activate-automatic-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {}
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "active",
+            "formationEpoch": 3
+          }
+        }
+      }
+    },
+    {
+      "name": "reconfigureOpensReconfiguring",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/reconfigure/requests/reconfigure-automatic-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "landing": "hold"
+        },
+        "outputs": {
+          "supersededLayoutGroupRevision": "body.group.acceptedLayoutIdentity.groupRevision"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "reconfiguring",
+            "formationEpoch": 4
+          }
+        }
+      }
+    },
+    {
+      "name": "theConnectTriggerDialsTheCommandedReplan",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/formation",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 250,
+          "backoffMultiplier": 1.5
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "lifecycleState": "reconnecting",
+          "formationEpoch": 5
+        }
+      }
+    },
+    {
+      "name": "theDialedReplanIsNotTheSupersededCandidate",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 250,
+          "backoffMultiplier": 1.5
+        },
+        "outputs": {
+          "dialedLayoutGroupRevision": "body.snapshot.sourceGroupStateCausalRevision.groupRevision"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
+          }
+        }
+      }
+    },
+    {
+      "name": "theDialedReplanSupersedesTheCandidateTheLatchNamed",
+      "type": "assert",
+      "actual": {
+        "supersededLayoutGroupRevision": "{supersededLayoutGroupRevision}",
+        "dialedLayoutGroupRevision": "{dialedLayoutGroupRevision}"
+      },
+      "expect": {
+        "comparators": [
+          {
+            "path": "dialedLayoutGroupRevision",
+            "gt": "{supersededLayoutGroupRevision}"
+          }
+        ]
       }
     }
   ],

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json
@@ -724,7 +724,6 @@
           "landing": "hold"
         },
         "outputs": {
-          "reconfigureLifecycleEpoch": "body.group.formationEpoch",
           "reconfigureLifecycleGroupRevision": "body.causalRevision.groupRevision"
         }
       },
@@ -755,12 +754,6 @@
           "maxDurationMs": 15000,
           "backoffMs": 100,
           "backoffMultiplier": 2
-        },
-        "outputs": {
-          "reconfigureLifecycleLayoutGroupRevision": "body.snapshot.sourceGroupStateCausalRevision.groupRevision",
-          "reconfigureLifecycleLayoutPresenceRevision": "body.snapshot.sourceGroupStateCausalRevision.presenceRevision",
-          "reconfigureLifecycleLayoutVersion": "body.snapshot.version",
-          "reconfigureLifecycleLayoutState": "body.snapshot.state"
         }
       },
       "expect": {
@@ -780,30 +773,24 @@
       "type": "http",
       "connection": "primary",
       "request": {
-        "method": "POST",
-        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/lifecycle/connect/requests/connect-reconfigure-managed-group-{runId}",
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{managedGroupId}/formation",
         "headers": {
           "Authorization": "{aliceAuthHeader}",
           "x-client-id": "{aliceClientId}"
         },
-        "body": {
-          "expectedFormationEpoch": "{reconfigureLifecycleEpoch}",
-          "expectedLayout": {
-            "groupRevision": "{reconfigureLifecycleLayoutGroupRevision}",
-            "presenceRevision": "{reconfigureLifecycleLayoutPresenceRevision}",
-            "version": "{reconfigureLifecycleLayoutVersion}",
-            "state": "{reconfigureLifecycleLayoutState}"
-          }
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 250,
+          "backoffMultiplier": 1.5
         }
       },
       "expect": {
         "status": 200,
         "body": {
-          "group": {
-            "lifecycleState": "reconnecting",
-            "formationEpoch": 5,
-            "transportState": "halted"
-          }
+          "lifecycleState": "reconnecting",
+          "formationEpoch": 5
         }
       }
     },

--- a/packages/tests/shared-server/rallar-system/group-state/formation-stage-trigger-timers.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/formation-stage-trigger-timers.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@shared-server/rallar-system/topology/replay/work/create-group-connect-trigger-work-handler.ts';
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
-import { type GroupLayoutIdentity, toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import { toGroupLayoutIdentity, type GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupLifecyclePolicy, GroupLifecycleState, GroupStageTrigger } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { Group } from '@shared/api/group-types.ts';

--- a/packages/tests/shared-server/rallar-system/group-state/formation-stage-trigger-timers.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/formation-stage-trigger-timers.test.ts
@@ -8,7 +8,7 @@ import {
     type GroupFormationTimerWork
 } from '@shared-server/rallar-system/group-state/formation-timer-outbox-entry.ts';
 import { computeGroupConnectTrigger } from '@shared-server/rallar-system/group-state/mutation/aggregate/compute-group-connect-trigger.ts';
-import type { GroupMutationCommand } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
+import type { GroupMutationCommand, GroupMutationRead } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import {
     GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
     GroupConnectTriggerLatchRepository,
@@ -22,6 +22,7 @@ import {
 } from '@shared-server/rallar-system/topology/replay/work/create-group-connect-trigger-work-handler.ts';
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
+import { type GroupLayoutIdentity, toGroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
 import type { GroupLifecyclePolicy, GroupLifecycleState, GroupStageTrigger } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { Group } from '@shared/api/group-types.ts';
@@ -153,15 +154,19 @@ describe('stage trigger timer arming', () => {
         })).toEqual([]);
     });
 
-    it('arms nothing on the reconfigure that opens reconfiguring: its own replan has not published', () => {
+    // The latch a reconfigure arms names the candidate it supersedes, so its
+    // settle needs the same timer backstop a plan's does (plan slice 11d).
+    it('arms the connect settle on the reconfigure that opens reconfiguring', () => {
         const policy = policyWith({ kind: 'manual' }, { kind: 'after', settleMs: 700 });
-        expect(computeFormationTimerEntries({
+        const entries = computeFormationTimerEntries({
             command: transitionCommand('reconfigureGroup'),
             previous: 'active',
             next: createTestGroup({ lifecycleState: 'reconfiguring', formationEpoch: 4 }),
             policy,
             facts: createGroupAuthorityFacts()
-        })).toEqual([]);
+        });
+        expect(timerKinds(entries).map((work) => [work.kind, work.notBeforeEpochMs, work.formationEpoch]))
+            .toEqual([['connect', NOW_EPOCH_MS + 700, 4]]);
     });
 
     it('arms nothing for a group whose formation is immediate', () => {
@@ -223,6 +228,25 @@ describe('connect trigger latching by policy', () => {
         return computed.effect && 'value' in computed.effect ? JSON.parse(computed.effect.value).notBeforeEpochMs : null;
     }
 
+    function reconfigureLatchFor(plannedLayoutRow: GroupMutationRead['plannedLayoutRow']) {
+        return computeGroupConnectTrigger({
+            command: transitionCommand('reconfigureGroup'),
+            read: { ...createGroupAuthorityRead({ lifecycleState: 'active', formationEpoch: 2 }), plannedLayoutRow },
+            facts: createGroupAuthorityFacts(),
+            next: createTestGroup({ lifecycleState: 'reconfiguring', formationEpoch: 3 }),
+            policy: policyWith({ kind: 'manual' }, { kind: 'immediate' }),
+            previous: 'active'
+        });
+    }
+
+    function latchedSupersedes(
+        computed: ReturnType<typeof computeGroupConnectTrigger>
+    ): GroupLayoutIdentity | null {
+        return computed.effect && 'value' in computed.effect
+            ? JSON.parse(computed.effect.value).supersedesLayoutIdentity
+            : null;
+    }
+
     it('latches an application plan under an immediate connect trigger, settled at the plan', () => {
         const computed = latchFor({ kind: 'immediate' }, 'forming');
         expect(computed.effect?.operation).toBe('insert');
@@ -254,17 +278,17 @@ describe('connect trigger latching by policy', () => {
         expect(latchedNotBefore(computed)).toBe(0);
     });
 
-    it('latches nothing on the reconfigure that opens reconfiguring', () => {
-        const command = transitionCommand('reconfigureGroup');
-        const computed = computeGroupConnectTrigger({
-            command,
-            read: createGroupAuthorityRead({ lifecycleState: 'active', formationEpoch: 2 }),
-            facts: createGroupAuthorityFacts(),
-            next: createTestGroup({ lifecycleState: 'reconfiguring', formationEpoch: 3 }),
-            policy: policyWith({ kind: 'manual' }, { kind: 'immediate' }),
-            previous: 'active'
-        });
-        expect(computed).toEqual({ effect: null, outboxEntries: [] });
+    // The reconfigure commands its own replan, so the planned slot still holds
+    // the candidate it means to replace: the latch names that candidate and
+    // waits for a different one (plan slice 11d).
+    it('latches the superseded candidate on the reconfigure that opens reconfiguring', () => {
+        const computed = reconfigureLatchFor({ snapshot: PLANNED, revision: 5 });
+        expect(computed.effect?.operation).toBe('insert');
+        expect(latchedSupersedes(computed)).toEqual(toGroupLayoutIdentity(PLANNED));
+    });
+
+    it('names no candidate when the reconfigure finds an empty planned slot', () => {
+        expect(latchedSupersedes(reconfigureLatchFor(null))).toBeNull();
     });
 
     it('latches nothing for a group whose formation is immediate: the vocabulary is phased-only', () => {
@@ -310,13 +334,19 @@ async function createAutomationPort(
         planned: RallarOverlayTopologySnapshot | null;
         notBeforeEpochMs: number;
         nowEpochMs: number;
+        supersedesLayoutIdentity?: GroupLayoutIdentity | null;
     }>
 ): Promise<GroupFormationAutomationPort & { readonly commands: GroupMutationCommand[]; }> {
     const runtime = new FakeRuntimeStateRepository();
     await runtime.upsert(
         GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
         toGroupConnectTriggerStorageKey(IDENTITY),
-        JSON.stringify({ ...IDENTITY, notBeforeEpochMs: input.notBeforeEpochMs, state: 'awaiting-publication' }),
+        JSON.stringify({
+            ...IDENTITY,
+            notBeforeEpochMs: input.notBeforeEpochMs,
+            supersedesLayoutIdentity: input.supersedesLayoutIdentity ?? null,
+            state: 'awaiting-publication'
+        }),
         NEVER_EXPIRE_AT_TIMESTAMP
     );
     const commands: GroupMutationCommand[] = [];
@@ -353,6 +383,39 @@ describe('connect trigger settle', () => {
         const handler = createTimerHandler({ group: plannedGroup, planned: PLANNED, port, nowEpochMs: 5_000 });
         await handler.onMessage(timerMessage(), timerEntry({ kind: 'connect', formationEpoch: 3, notBeforeEpochMs: 5_000 }, plannedGroup));
         expect(port.commands.map((command) => command.operation)).toEqual(['connectGroup']);
+    });
+
+    // A reconfigure's latch names the candidate its own replan replaces, so
+    // the standing publication is exactly the one it must not dial.
+    it('leaves a latch naming the standing candidate latched', async () => {
+        const reconfiguring = createTestGroup({ lifecycleState: 'reconfiguring', formationEpoch: 3 });
+        const port = await createAutomationPort({
+            group: reconfiguring,
+            planned: PLANNED,
+            notBeforeEpochMs: 0,
+            nowEpochMs: 5_000,
+            supersedesLayoutIdentity: toGroupLayoutIdentity(PLANNED)
+        });
+        await petitionGroupConnectTrigger(port, IDENTITY, { kind: 'clock', atEpochMs: port.nowEpochMs() });
+        expect(port.commands).toEqual([]);
+        expect((await port.latches.read(IDENTITY))?.latch.state).toBe('awaiting-publication');
+    });
+
+    it('connects on the replan that replaces the candidate the latch names', async () => {
+        const reconfiguring = createTestGroup({ lifecycleState: 'reconfiguring', formationEpoch: 3 });
+        const replanned = { ...PLANNED, version: PLANNED.version + 1 };
+        const port = await createAutomationPort({
+            group: reconfiguring,
+            planned: replanned,
+            notBeforeEpochMs: 0,
+            nowEpochMs: 5_000,
+            supersedesLayoutIdentity: toGroupLayoutIdentity(PLANNED)
+        });
+        await petitionGroupConnectTrigger(port, IDENTITY, { kind: 'clock', atEpochMs: port.nowEpochMs() });
+        expect(port.commands.map((command) => command.operation)).toEqual(['connectGroup']);
+        expect(
+            port.commands.map((command) => command.operation === 'connectGroup' ? command.input.expectedLayout : null)
+        ).toEqual([toGroupLayoutIdentity(replanned)]);
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
@@ -62,6 +62,7 @@ describe('automatic retry connect intent', () => {
             formationEpoch: 3,
             triggerGeneration: command.commandId,
             notBeforeEpochMs: 0,
+            supersedesLayoutIdentity: null,
             state: 'awaiting-publication'
         });
         expect(computed.outboxEntries.some((entry) => JSON.parse(entry.resource).payload.typeId === 'GROUP_CONNECT_TRIGGER')).toBe(true);
@@ -96,7 +97,7 @@ function automaticRead(): GroupMutationRead {
         actorMember: null,
         actorMemberEntry: null,
         plannedLayoutRow: { snapshot: PLANNED, revision: 1 },
-        connectTriggerLatch: { latch: { ...IDENTITY, notBeforeEpochMs: 0, state: 'awaiting-publication' }, revision: 1 }
+        connectTriggerLatch: { latch: { ...IDENTITY, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'awaiting-publication' }, revision: 1 }
     };
 }
 
@@ -107,7 +108,7 @@ describe('connect intent handoff', () => {
         await runtime.upsert(
             GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
             toGroupConnectTriggerStorageKey(IDENTITY),
-            JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, state: 'awaiting-publication' }),
+            JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'awaiting-publication' }),
             NEVER_EXPIRE_AT_TIMESTAMP
         );
         const commands: GroupMutationCommand[] = [];
@@ -162,7 +163,7 @@ describe('connect intent handoff', () => {
                 ? { snapshot: { ...PLANNED, version: 2 }, revision: 2 }
                 : original.plannedLayoutRow,
             connectTriggerLatch: state === 'consumed'
-                ? { latch: { ...IDENTITY, notBeforeEpochMs: 0, state: 'consumed' }, revision: 2 }
+                ? { latch: { ...IDENTITY, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'consumed' }, revision: 2 }
                 : original.connectTriggerLatch,
             group: state === 'reset' ? createGroupAuthorityRead({ lifecycleState: 'dormant', formationEpoch: 4 }).group : original.group
         };
@@ -188,7 +189,7 @@ describe('connect intent handoff', () => {
             await runtime.upsert(
                 GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
                 toGroupConnectTriggerStorageKey(IDENTITY),
-                JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, state: 'awaiting-publication', ...patch }),
+                JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'awaiting-publication', ...patch }),
                 NEVER_EXPIRE_AT_TIMESTAMP
             );
             await expect(latches.read(IDENTITY)).rejects.toBeInstanceOf(GroupConnectTriggerLatchCorruptionError);
@@ -299,7 +300,7 @@ describe('retry handoff commit races and replay', () => {
         await harness.runtimeRepository.upsert(
             GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
             toGroupConnectTriggerStorageKey(IDENTITY),
-            JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, state: 'awaiting-publication' }),
+            JSON.stringify({ ...IDENTITY, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'awaiting-publication' }),
             NEVER_EXPIRE_AT_TIMESTAMP
         );
         await createGroupConnectTriggerWorkHandler(port).onMessage(JSON.parse(source.resource) as ALMessage, source);

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-sql.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-sql.test.ts
@@ -128,7 +128,7 @@ async function seedConnectWrite(sql: PSqlSql, applicationId: string) {
     };
     const base = createGroupAuthorityRead({ ...groupRef, lifecycleState: 'planned', formationEpoch: 3 });
     const group = { ...base.group!, entry: { ...base.group!.entry, key: groupStateGroupStorageKey(groupRef) } };
-    const latch = { ...identity, notBeforeEpochMs: 0, state: 'awaiting-publication' } as const;
+    const latch = { ...identity, notBeforeEpochMs: 0, supersedesLayoutIdentity: null, state: 'awaiting-publication' } as const;
     const read = {
         ...base,
         group,

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-observer.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/formation-criterion-observer.test.ts
@@ -246,7 +246,12 @@ async function createStageTriggerHarness(
         await runtime.upsert(
             GROUP_CONNECT_TRIGGER_LATCHES_NAMESPACE,
             toGroupConnectTriggerStorageKey(identity),
-            JSON.stringify({ ...identity, notBeforeEpochMs: input.awaitingLatchNotBeforeEpochMs, state: 'awaiting-publication' }),
+            JSON.stringify({
+                ...identity,
+                notBeforeEpochMs: input.awaitingLatchNotBeforeEpochMs,
+                supersedesLayoutIdentity: null,
+                state: 'awaiting-publication'
+            }),
             NEVER_EXPIRE_AT_TIMESTAMP
         );
     }

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -2654,6 +2654,12 @@ Split 11a (`immediate`/`after` via the durable timer path) from 11b (the `presen
 construction restructure and its own state-write verdict). **Write the first unit tests this surface has
 ever had in 11a.**
 
+_Delivered 2026-09-02/03 across four checkpoints: 11a (`immediate`/`after` on the durable timer),
+11b (the `presence` trigger), 11c (the exhausted series parks in `dormant`, I34) and 11d (the
+`reconfiguring → reconnecting` boundary, I35). What this section describes as outstanding is
+historical from here on; the only item it names that is still open is 10a's per-command `automatic`
+origin._
+
 **Gates:** baseline, both profiles, **medium-scale**, **state-write**, `formation-large`.
 
 ### Slice 11a start checkpoint — plan and connect triggers on the durable timer path (2026-09-02)

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -400,6 +400,8 @@ Decisions I21–I25 were taken while delivering and reviewing PR 2 (1b + 1c) on 
 | I33 | **The presence trigger is answered where the presence evidence already lands** (2026-09-02, Slice 11b): its threshold half is evaluated in the topology work cycle beside the criterion petition — every presence change reaches that cycle, because the topology input fingerprint hashes the live session set — and its fallback half stays with the durable timer the stage entry armed, so `presence` arms `plan`/`connect` at `fallbackMs` and fires sooner when the members arrive. The one evaluator answers all four kinds; a caller whose elapsed half belongs to the timer passes no stage-entry instant. A met threshold petitions the connect latch as satisfied rather than by the clock, so the settle gate cannot hold back a trigger the policy says has fired.                                                                                                                                                              |
 | I34 | **The exhaustion landing moves the stage and nothing else** (2026-09-03, Slice 11c): the mutation owner asks the attempt budget about the attempt the failure is recording, so a series' last failure parks in `dormant` instead of following the transition table. It clears no layout identity and closes no transport valve — decision 36 assigns both to `reset`, and the `dormant` row of the dial, topology-disposition and closed-admission tables already makes a parked group inert. _Alternative rejected:_ clearing `acceptedLayoutIdentity` here too, which would give one field two owners for the sake of a stage description decision 35 states as how the group arrives, not as an invariant the stage enforces.                                                                                                                                                                                                             |
 
+| I35 | **The connect latch names the candidate it supersedes** (2026-09-03, Slice 11d): a `reconfigure` commands its own replan, so at arming time the planned slot still holds the layout it means to replace; the latch carries that identity and the petition refuses it, which is what makes `reconfiguring → reconnecting` automatic without dialing the stale candidate and freezing the replan. A `plan` names nothing, and deliberately: only `reconfigure` and `reset` enqueue commanded-origin replan work, and a `plan`'s automatic-origin work can be skipped as unchanged, so requiring a different publication there would strand a group in `planned` whenever its inputs did not move. _Alternative rejected:_ a publication instant on the latch, which a lagging node's clock could strand exactly as the settle could before I31. |
+
 The held-layout capability is the next milestone under current evidence, but every checkpoint selects
 only its next two independently reviewable PRs. Later labels below are capability-analysis anchors used
 for dependencies and navigation; I20 permits their owners, boundaries, grouping, order and even their
@@ -2819,6 +2821,54 @@ plus a two-row test that the retry leg arms behind an unexhausted failure and no
 one. Two condition-axis branches written for this landing, `failed` in
 `computeGroupActivationCondition` and `awaiting-application` in `resolveGroupActivationRemediation`,
 become reachable in production; both stay unread until Slice 12's status projection.
+
+### Slice 11d start checkpoint — the reconfigure boundary (2026-09-03)
+
+Stacked on 11c. The remaining Slice 11 automation item, carried since 11a reverted its first attempt
+and recorded the reason: arming the connect latch on the `reconfigure` that opens `reconfiguring`
+made the publication-driven petition dial the layout the reconfigure meant to replace, entering
+`reconnecting` on the stale candidate and freezing the reconfigure's own replan behind the 4b stage
+freeze. The latch named an epoch and a generation but no publication, so it could not tell the
+candidate it was waiting to see replaced from the one that satisfied it.
+
+What 11d lands:
+
+- **`GroupConnectTriggerLatch.supersedesLayoutIdentity`** (I35), the candidate the latch waits to see
+  replaced, `null` when any active planned layout satisfies it. `computeGroupConnectTrigger` fills it
+  from the planned slot the reconfigure's own read already loaded; the petition compares the
+  publication against it with `isSameGroupLayoutIdentity` and leaves the intent latched on a match.
+  Migration `20260903120000_connect_trigger_latch_supersedes` backfills `null` onto stored latches —
+  every one of them was armed by a `plan` — and the PGlite bootstrap replays it.
+- **Why only the reconfigure names one.** `toGroupEventPayload` marks exactly `reconfigureGroup` and
+  `resetGroupFormation` as commanded-origin replan work, and the fingerprint skip
+  (`readFingerprintSkip`) applies only to change-gated automatic group-revision work. So a
+  reconfigure always republishes and a fresh identity is guaranteed, while a `plan`'s own replan can
+  be skipped as unchanged — requiring a different publication there would strand a group in `planned`
+  whenever its topology inputs did not move, which is the ordinary case for a retry.
+- **One predicate for the latch and its timer.** `opensPlannedCandidateStage` is now shared by
+  `entersHeldStage` and `computeStageTriggerTimerEntries`. They must agree: the timer's arming gate
+  still read `planGroupLayout` only, so a reconfigure under an `after` or `presence` connect trigger
+  would have armed an intent whose settle no timer ever crossed — the publication petition runs on
+  the arming node's clock and returns before the settle, with nothing left to wake it.
+- **Recipe**: `api-v1-automatic-formation-triggers` continues past `connecting` — it activates the
+  dialed layout, reconfigures under the `hold` landing, polls for the automatic `reconnecting`, and
+  asserts the dialed layout's version is greater than the accepted one the latch named.
+
+- **The planned row is now read for a `reconfigure`.** The first head armed the latch from
+  `read.plannedLayoutRow`, which `readsGroupLayoutRows` does not load for that command, so the
+  identity was silently `null` and the latch fired on the stale candidate exactly as in 11a — the
+  lifecycle-transitions recipe caught it as a topology poll stuck at the pre-reconfigure revision.
+  The reconfigure takes no fence from the row, so it adds one point read and no conflict surface, on
+  a commanded path that already reads the stored policy.
+- **Blast radius in the recipes.** Under the `managed` preset the connect trigger is `immediate`, so
+  `api-v1-group-lifecycle-transitions` no longer drives the reconfigure's connect by hand: its manual
+  `connect` POST becomes a formation poll for `reconnecting`, the same conversion 11a made for that
+  recipe's first connect, and the four layout outputs the POST consumed go with it.
+
+**Accepted rather than changed.** A reconfigure whose replan publishes nothing leaves the group in
+`reconfiguring` with its latch armed, exactly as before this slice; the application `connect` still
+works, and no commanded replan is silently dropped, because commanded-origin work is not
+change-gated. The `apply` landing arms nothing, because it does not change the stage.
 
 ## Slice 12 — The living observed status
 


### PR DESCRIPTION
## Goal

Slice 11d of the [group activation implementation plan](playground/rtc-design/2026-08-22-group-activation-implementation-plan.md), stacked on #464: the automatic `reconfiguring → reconnecting` boundary, the last of Slice 11's automation work. 11a tried arming the connect latch on the `reconfigure` and reverted it, because the publication-driven petition dialed the layout the reconfigure meant to replace — entering `reconnecting` on the stale candidate and freezing the reconfigure's own replan behind the 4b stage freeze. The latch named an epoch and a generation, but nothing about the publication it was waiting for.

## Changes

- **`GroupConnectTriggerLatch.supersedesLayoutIdentity`** (implementation decision I35): the candidate the latch waits to see replaced, `null` when any active planned layout satisfies it. The arming site fills it from the planned slot; the petition compares the publication with `isSameGroupLayoutIdentity` and leaves the intent latched on a match, so the trigger dials the commanded replan and never the layout it replaced.
- **Only the reconfigure names one, and the reason is mechanical.** `toGroupEventPayload` marks exactly `reconfigureGroup` and `resetGroupFormation` as commanded-origin replan work, and `readFingerprintSkip` applies only to change-gated *automatic* group-revision work. A reconfigure therefore always republishes, while a `plan`'s own replan can be skipped as unchanged — requiring a different publication there would strand a group in `planned` whenever its topology inputs had not moved, which is the ordinary case for a retry.
- **One predicate for the latch and its timer.** `opensPlannedCandidateStage` now lives with the other command-shape predicates in `group-mutation-contracts.ts` and is used by both `entersHeldStage` and `computeStageTriggerTimerEntries`. They must agree: the timer's gate still read `planGroupLayout` alone, so a reconfigure under an `after` or `presence` connect trigger would have armed an intent whose settle no timer ever crossed — the publication petition runs on the arming node's clock and returns before the settle, with nothing left to wake it.
- **`readsGroupLayoutRows` now covers `reconfigureGroup`.** The first head armed from `read.plannedLayoutRow`, which that predicate does not load for a reconfigure, so the identity was silently `null` and the latch fired on the stale candidate — reproducing 11a's failure exactly. The reconfigure takes no fence from the row, so this is one point read and no new conflict surface, on a commanded path that already reads the stored policy.
- **Migration `20260903120000_connect_trigger_latch_supersedes`** backfills `null` onto stored latches — every one of them was armed by a `plan` — with a PGlite test, and the bootstrap replays it.
- **Recipes**: `api-v1-automatic-formation-triggers` continues past `connecting` — it activates the dialed layout, reconfigures under the `hold` landing, polls for the automatic `reconnecting`, and asserts the dialed layout's causal revision is greater than the accepted one the latch named. Under the `managed` preset the connect trigger is `immediate`, so `api-v1-group-lifecycle-transitions` no longer drives the reconfigure's connect by hand: its manual `connect` POST becomes a formation poll, the same conversion 11a made for that recipe's first connect, and the four layout outputs it consumed go with it.
- **Docs**: the formation architecture's automation paragraph, the plan's Slice 11d checkpoint and decision I35.

## Acceptance

- A `reconfigure` that opens `reconfiguring` arms the connect trigger under `immediate`, `after` and `presence`, and names the planned slot's candidate; it names nothing when that slot is empty, and arms nothing under `manual` or on the `apply` landing.
- The petition leaves the intent latched while the planned slot still holds the named candidate, and dials the first different active publication.
- An `after` or `presence` reconfigure arms the connect timer that crosses its settle.
- A stored latch without the field is corrupt after the migration; a plan-armed latch reads `null` and behaves as it did.

## Review

The in-memory profile caught the first head twice, and both were real. First the arming read a row `readsGroupLayoutRows` never loads, so the latch dialed the stale candidate — the exact 11a regression, visible as a topology poll stuck at the pre-reconfigure revision. Then the new recipe assertion compared layout *versions*, which the planner reuses; re-keyed on the causal revision, which is what moves when a reconfigure republishes.

## Validation

Passed locally on the final head: dprint on the touched files, `check:repo-style:changed` (no new findings), `check-test-structure-coupling --changed`, `check:repo-structure`, `check:retained-legacy`, the governed test typecheck (1 019 files, 0 debt), `typecheck`, `build`, `test:deno` (546, 84 and 146 tests), and `test:unit` unsandboxed (1 045 files, 9 089 tests, no failures).

Black-box on the same head: the in-memory profile 36 of 36, the Postgres profile 36 of 36 plus the six-recipe cluster profile, the medium-scale convergence gate, the `formation-large` profile 4 of 4, and the topology replay proof (verified by its fresh proof JSON).

Not run: the state-write A-B-B-A comparison, still blocked by a foreign perf-bench container holding the pinned port. The reconfigure gains one point read; no other path changes its read set.

## Risk and rollback

The latch gains a required field, so a server from before this change rejects the backfilled shape: the rollout follows the stop-drain-deploy runbook, as 11a's settle migration did. The behavioural change is visible to any group whose connect trigger is not `manual` — a reconfigure now dials its own replan instead of waiting for an application `connect`, which is what product decision 8's stage table asks for. Rollback is a revert of the branch plus dropping the key from stored latches.

## Follow-up

A reconfigure whose replan publishes nothing leaves the group in `reconfiguring` with its latch armed, exactly as before this slice; the application `connect` still works, and no commanded replan is silently dropped, because commanded-origin work is not change-gated. 10a's per-command `automatic` origin item remains open. Slice 11's automation is otherwise complete; Slice 12 is the living observed status. No GitHub Issues were created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
