### PR TITLE
test(black-box): read the stage bucket across the cluster that writes it (slice 13b)

### DIFF
--- a/packages/shared-test/black-box-runner/recipe-matrix.json
+++ b/packages/shared-test/black-box-runner/recipe-matrix.json
@@ -1394,6 +1394,39 @@
       "description": "Three-server CRDT AppInbox gate for authenticated append, committed reply, durable fanout, and catch-up."
     },
     {
+      "id": "api-v1-group-lifecycle-stage-metrics",
+      "recipe": "tests/api-v1/api-v1-group-lifecycle-stage-metrics.json",
+      "category": "api-v1-black-box",
+      "mode": "run",
+      "tier": 1,
+      "profiles": ["api-v1-black-box-cluster"],
+      "expectedExitCode": 0,
+      "artifactName": "api-v1-group-lifecycle-stage-metrics",
+      "requires": {
+        "livePreflight": {
+          "timeoutMs": 10000
+        },
+        "httpServices": [
+          {
+            "name": "Rallar API primary",
+            "env": "RALLAR_API_BASE_URL",
+            "default": "http://127.0.0.1:18080"
+          },
+          {
+            "name": "Rallar API secondary",
+            "env": "RALLAR_API_BASE_URL_SECONDARY",
+            "default": "http://127.0.0.1:18081"
+          },
+          {
+            "name": "Rallar API tertiary",
+            "env": "RALLAR_API_BASE_URL_TERTIARY",
+            "default": "http://127.0.0.1:18082"
+          }
+        ]
+      },
+      "description": "Three-node reading of the stage-transition metrics bucket: a managed group is planned, dials itself on the connect trigger and is activated, with admin group-formation metrics read on every node before and after, because the counter is process-local and the AppInbox is claimed by any node."
+    },
+    {
       "id": "api-v1-crdt-append-history-small",
       "recipe": "tests/api-v1/api-v1-crdt-append-history.json",
       "category": "api-v1-black-box",

--- a/packages/shared-test/black-box-runner/tests/README.md
+++ b/packages/shared-test/black-box-runner/tests/README.md
@@ -53,9 +53,9 @@ black-box test. The convention: name the evidence source, not the topology.
   including all `api-v1-black-box-recipes` portability-profile rows.
 - **Tier 2 — convergence/durability proof (SQL evidence)**: additionally
   reads persisted state through `set.state-write-evidence`
-  (`resource_inbox`/outbox/receipts). Exactly five today:
-  `api-v1-admin-operations`, `api-v1-auth-session`, `api-v1-crdt-app-inbox`,
-  `api-v1-state-medium-scale-churn`, `api-v1-state-write-convergence`.
+  (`resource_inbox`/outbox/receipts). `recipe-matrix.test.ts` derives the tier
+  from that usage, so the list is whatever carries the evidence rather than a
+  number to keep in step here.
 - **Tier 3 — coordinator proof**: coordinator-owned flows that manage server
   processes themselves; not portable matrix recipes. Today this is the
   `api-v1-black-box-topology-replay` profile (`topology-replay/*.mts`), which

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
@@ -1,0 +1,635 @@
+{
+  "description": "The stage-transition metrics bucket read across the cluster that writes it: a managed group is planned, dials itself on the connect trigger and is activated, while the admin group-formation metrics are read on all three nodes before and after. The counter is process-local and the AppInbox is claimed by any node, so only the cluster sum is a sound reading.",
+  "variables": {
+    "apiPrimary": {
+      "env": "RALLAR_API_BASE_URL",
+      "default": "http://127.0.0.1:18080"
+    },
+    "apiSecondary": {
+      "env": "RALLAR_API_BASE_URL_SECONDARY",
+      "default": "http://127.0.0.1:18081"
+    },
+    "apiTertiary": {
+      "env": "RALLAR_API_BASE_URL_TERTIARY",
+      "default": "http://127.0.0.1:18082"
+    },
+    "applicationId": "stage-metrics-{runId}",
+    "workspaceId": "default-{runId}",
+    "groupId": "stage-metrics-room-{runId}",
+    "aliceUsername": {
+      "env": "RALLAR_ALICE_USERNAME",
+      "default": "alice"
+    },
+    "alicePassword": {
+      "env": "RALLAR_ALICE_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
+    "bobUsername": {
+      "env": "RALLAR_BOB_USERNAME",
+      "default": "bob"
+    },
+    "bobPassword": {
+      "env": "RALLAR_BOB_PASSWORD",
+      "default": "secret",
+      "secret": true
+    },
+    "adminUsername": {
+      "env": "RALLAR_BB_ADMIN_USERNAME",
+      "default": "admin"
+    },
+    "adminPassword": {
+      "env": "RALLAR_BB_ADMIN_PASSWORD",
+      "default": "admin",
+      "secret": true
+    },
+    "runId": {
+      "env": "RALLAR_BB_RUN_ID",
+      "default": "local"
+    }
+  },
+  "execution": {
+    "correlation": {
+      "injectHeaders": true,
+      "injectPayloads": false
+    }
+  },
+  "connections": {
+    "primary": {
+      "type": "http",
+      "baseUrl": "{apiPrimary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 15000
+    },
+    "secondary": {
+      "type": "http",
+      "baseUrl": "{apiSecondary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 15000
+    },
+    "tertiary": {
+      "type": "http",
+      "baseUrl": "{apiTertiary}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "timeoutMs": 15000
+    }
+  },
+  "steps": [
+    {
+      "name": "loginAlice",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login/requests/bb-login-alice-001-{runId}-group-lifecycle-stage-metrics",
+        "body": {
+          "username": "{aliceUsername}",
+          "password": "{alicePassword}"
+        },
+        "outputs": {
+          "aliceClientId": "body.clientId",
+          "aliceSessionId": "body.sessionId",
+          "aliceAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveAliceAuthHeader",
+      "type": "set",
+      "output": "aliceAuthHeader",
+      "secret": true,
+      "redactAs": "aliceAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.aliceAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "loginBob",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login/requests/bb-login-bob-002-{runId}-group-lifecycle-stage-metrics",
+        "body": {
+          "username": "{bobUsername}",
+          "password": "{bobPassword}"
+        },
+        "outputs": {
+          "bobClientId": "body.clientId",
+          "bobSessionId": "body.sessionId",
+          "bobAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveBobAuthHeader",
+      "type": "set",
+      "output": "bobAuthHeader",
+      "secret": true,
+      "redactAs": "bobAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.bobAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "loginAdmin",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/auth/login/requests/bb-login-admin-003-{runId}-group-lifecycle-stage-metrics",
+        "body": {
+          "username": "{adminUsername}",
+          "password": "{adminPassword}"
+        },
+        "outputs": {
+          "adminClientId": "body.clientId",
+          "adminAccessToken": {
+            "path": "body.accessToken",
+            "secret": true
+          }
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "deriveAdminAuthHeader",
+      "type": "set",
+      "output": "adminAuthHeader",
+      "secret": true,
+      "redactAs": "adminAuthHeader",
+      "transform": {
+        "concat": [
+          "Bearer ",
+          {
+            "path": "outputs.adminAccessToken"
+          }
+        ]
+      }
+    },
+    {
+      "name": "captureStageWritesBeforePrimary",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "beforeStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "captureStageWritesBeforeSecondary",
+      "type": "http",
+      "connection": "secondary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "beforeStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "captureStageWritesBeforeTertiary",
+      "type": "http",
+      "connection": "tertiary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "beforeStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "sumStageWritesBefore",
+      "type": "set",
+      "output": "beforeStageWritesTotal",
+      "transform": {
+        "add": [
+          {
+            "path": "outputs.beforeStageWritesPrimary"
+          },
+          {
+            "path": "outputs.beforeStageWritesSecondary"
+          },
+          {
+            "path": "outputs.beforeStageWritesTertiary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "createManagedGroup",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/requests/group-create-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "groupId": "{groupId}",
+          "displayName": "Stage metrics group {runId}",
+          "kind": "room",
+          "joinMode": "open",
+          "createdByPrincipalId": "{aliceClientId}",
+          "lifecyclePolicy": {
+            "preset": "managed",
+            "activation": {
+              "mode": "manual"
+            }
+          }
+        }
+      },
+      "expect": {
+        "status": 201,
+        "body": {
+          "group": {
+            "groupId": "{groupId}",
+            "lifecycleState": "forming",
+            "formationEpoch": 0
+          }
+        }
+      }
+    },
+    {
+      "name": "aliceInvitesBob",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/invites/{bobClientId}/requests/invite-bob-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {}
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "members": [
+            {
+              "principalId": "{bobClientId}",
+              "status": "invited"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "bobAcceptsTheInvite",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/invites/accept/requests/accept-bob-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "body": {}
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "members": [
+            {
+              "principalId": "{bobClientId}",
+              "status": "active"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "connectAlicePresence",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "PUT",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/sessions/{aliceSessionId}/requests/presence-alice-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {
+          "generationId": "generation-{runId}",
+          "principalId": "{aliceClientId}"
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "connectBobPresence",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "PUT",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/sessions/{bobSessionId}/requests/presence-bob-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{bobAuthHeader}",
+          "x-client-id": "{bobClientId}"
+        },
+        "body": {
+          "generationId": "generation-{runId}",
+          "principalId": "{bobClientId}"
+        }
+      },
+      "expect": {
+        "status": 200
+      }
+    },
+    {
+      "name": "managerPlansTheGroup",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/plan/requests/plan-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {}
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "planned",
+            "formationEpoch": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "thePlanPublishesALayout",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/topology",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 250,
+          "backoffMultiplier": 1.5
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "snapshot": {
+            "state": "active"
+          }
+        }
+      }
+    },
+    {
+      "name": "theConnectTriggerDialsIt",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/formation",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 20,
+          "maxDurationMs": 15000,
+          "backoffMs": 250,
+          "backoffMultiplier": 1.5
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "lifecycleState": "connecting",
+          "formationEpoch": 2
+        }
+      }
+    },
+    {
+      "name": "activateTheDialedLayout",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "POST",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}/lifecycle/activate/requests/activate-stage-metrics-{runId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "body": {}
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "lifecycleState": "active",
+            "formationEpoch": 3
+          }
+        }
+      }
+    },
+    {
+      "name": "captureStageWritesAfterPrimary",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "afterStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "captureStageWritesAfterSecondary",
+      "type": "http",
+      "connection": "secondary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "afterStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "captureStageWritesAfterTertiary",
+      "type": "http",
+      "connection": "tertiary",
+      "request": {
+        "method": "GET",
+        "path": "/api/admin/operations/realtime",
+        "headers": {
+          "Authorization": "{adminAuthHeader}",
+          "x-client-id": "{adminClientId}"
+        },
+        "outputs": {
+          "afterStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "groupFormation": {
+            "processLocal": true
+          }
+        }
+      }
+    },
+    {
+      "name": "sumStageWritesAfter",
+      "type": "set",
+      "output": "afterStageWritesTotal",
+      "transform": {
+        "add": [
+          {
+            "path": "outputs.afterStageWritesPrimary"
+          },
+          {
+            "path": "outputs.afterStageWritesSecondary"
+          },
+          {
+            "path": "outputs.afterStageWritesTertiary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "sumStageWritesExpected",
+      "type": "set",
+      "output": "expectedStageWritesTotal",
+      "transform": {
+        "add": [
+          {
+            "path": "outputs.beforeStageWritesTotal"
+          },
+          3
+        ]
+      }
+    },
+    {
+      "name": "thePlanConnectAndActivateCountInTheStageBucket",
+      "type": "assert",
+      "actual": {
+        "afterStageWritesTotal": "{afterStageWritesTotal}",
+        "expectedStageWritesTotal": "{expectedStageWritesTotal}"
+      },
+      "expect": {
+        "comparators": [
+          {
+            "path": "afterStageWritesTotal",
+            "gte": "{expectedStageWritesTotal}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
@@ -1,5 +1,5 @@
 {
-  "description": "The stage-transition metrics bucket read across the cluster that writes it: a managed group is planned, dials itself on the connect trigger and is activated, while the admin group-formation metrics are read on all three nodes before and after. The counter is process-local and the AppInbox is claimed by any node, so only the cluster sum is a sound reading, and the readings are asserted to come from three distinct servers. The floor is a floor because the counter is global to each process: it holds while no other recipe in this profile drives a lifecycle command. Re-running with a stale runId replays the request identities, which satisfy the state expectations from stored receipts without re-incrementing the counter.",
+  "description": "The stage-transition metrics bucket read across the cluster that writes it: a managed group is planned, dials itself on the connect trigger and is activated, while the admin group-formation metrics are read on all three nodes before and after. The counter is process-local and the AppInbox is claimed by any node, so only the cluster sum is a sound reading, and the readings are asserted to come from three distinct servers. The floor is a floor because the counter is global to each process: it holds while nothing else on these three processes drives a lifecycle transition, and the upper bound makes gross contamination visible rather than silently satisfying the floor. This recipe needs a fresh runId: two of its state expectations are live polls for a mid-formation stage, so a stale runId replays the receipts but then waits for a stage the group has already left.",
   "variables": {
     "apiPrimary": {
       "env": "RALLAR_API_BASE_URL",
@@ -523,11 +523,11 @@
       "type": "set",
       "output": "closingReadingSettle",
       "value": {
-        "delayMs": 1500,
+        "delayMs": 3000,
         "waitsFor": "the post-commit metric increment on the claiming node"
       },
       "request": {
-        "delayMs": 1500
+        "delayMs": 3000
       }
     },
     {
@@ -543,7 +543,8 @@
         },
         "outputs": {
           "afterStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
-          "afterFormationMetricsPrimary": "body.groupFormation.metrics"
+          "afterFormationMetricsPrimary": "body.groupFormation.metrics",
+          "afterServerIdPrimary": "body.serverId"
         }
       },
       "expect": {
@@ -568,7 +569,8 @@
         },
         "outputs": {
           "afterStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
-          "afterFormationMetricsSecondary": "body.groupFormation.metrics"
+          "afterFormationMetricsSecondary": "body.groupFormation.metrics",
+          "afterServerIdSecondary": "body.serverId"
         }
       },
       "expect": {
@@ -593,7 +595,8 @@
         },
         "outputs": {
           "afterStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
-          "afterFormationMetricsTertiary": "body.groupFormation.metrics"
+          "afterFormationMetricsTertiary": "body.groupFormation.metrics",
+          "afterServerIdTertiary": "body.serverId"
         }
       },
       "expect": {
@@ -633,6 +636,19 @@
             "path": "outputs.beforeStageWritesTotal"
           },
           3
+        ]
+      }
+    },
+    {
+      "name": "computeContaminationCeiling",
+      "type": "set",
+      "output": "stageWritesContaminationCeiling",
+      "transform": {
+        "add": [
+          {
+            "path": "outputs.beforeStageWritesTotal"
+          },
+          6
         ]
       }
     },
@@ -682,6 +698,67 @@
       }
     },
     {
+      "name": "compareServerIdSameProcessPrimary",
+      "type": "set",
+      "output": "serverIdPrimarySameProcess",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdPrimary"
+          },
+          {
+            "path": "outputs.afterServerIdPrimary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "compareServerIdSameProcessSecondary",
+      "type": "set",
+      "output": "serverIdSecondarySameProcess",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdSecondary"
+          },
+          {
+            "path": "outputs.afterServerIdSecondary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "compareServerIdSameProcessTertiary",
+      "type": "set",
+      "output": "serverIdTertiarySameProcess",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdTertiary"
+          },
+          {
+            "path": "outputs.afterServerIdTertiary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "eachReadingPairComesFromOneProcess",
+      "type": "assert",
+      "actual": {
+        "serverIdPrimarySameProcess": "{serverIdPrimarySameProcess}",
+        "serverIdSecondarySameProcess": "{serverIdSecondarySameProcess}",
+        "serverIdTertiarySameProcess": "{serverIdTertiarySameProcess}"
+      },
+      "expect": {
+        "body": {
+          "serverIdPrimarySameProcess": true,
+          "serverIdSecondarySameProcess": true,
+          "serverIdTertiarySameProcess": true
+        }
+      }
+    },
+    {
       "name": "theThreeReadingsComeFromThreeServers",
       "type": "assert",
       "actual": {
@@ -709,13 +786,18 @@
         "beforeStageWritesTertiary": "{beforeStageWritesTertiary}",
         "afterStageWritesPrimary": "{afterStageWritesPrimary}",
         "afterStageWritesSecondary": "{afterStageWritesSecondary}",
-        "afterStageWritesTertiary": "{afterStageWritesTertiary}"
+        "afterStageWritesTertiary": "{afterStageWritesTertiary}",
+        "stageWritesContaminationCeiling": "{stageWritesContaminationCeiling}"
       },
       "expect": {
         "comparators": [
           {
             "path": "afterStageWritesTotal",
             "gte": "{expectedStageWritesTotal}"
+          },
+          {
+            "path": "afterStageWritesTotal",
+            "lte": "{stageWritesContaminationCeiling}"
           }
         ]
       }

--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-lifecycle-stage-metrics.json
@@ -1,5 +1,5 @@
 {
-  "description": "The stage-transition metrics bucket read across the cluster that writes it: a managed group is planned, dials itself on the connect trigger and is activated, while the admin group-formation metrics are read on all three nodes before and after. The counter is process-local and the AppInbox is claimed by any node, so only the cluster sum is a sound reading.",
+  "description": "The stage-transition metrics bucket read across the cluster that writes it: a managed group is planned, dials itself on the connect trigger and is activated, while the admin group-formation metrics are read on all three nodes before and after. The counter is process-local and the AppInbox is claimed by any node, so only the cluster sum is a sound reading, and the readings are asserted to come from three distinct servers. The floor is a floor because the counter is global to each process: it holds while no other recipe in this profile drives a lifecycle command. Re-running with a stale runId replays the request identities, which satisfy the state expectations from stored receipts without re-incrementing the counter.",
   "variables": {
     "apiPrimary": {
       "env": "RALLAR_API_BASE_URL",
@@ -209,7 +209,9 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "beforeStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "beforeStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "beforeFormationMetricsPrimary": "body.groupFormation.metrics",
+          "serverIdPrimary": "body.serverId"
         }
       },
       "expect": {
@@ -233,7 +235,9 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "beforeStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "beforeStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "beforeFormationMetricsSecondary": "body.groupFormation.metrics",
+          "serverIdSecondary": "body.serverId"
         }
       },
       "expect": {
@@ -257,7 +261,9 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "beforeStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "beforeStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "beforeFormationMetricsTertiary": "body.groupFormation.metrics",
+          "serverIdTertiary": "body.serverId"
         }
       },
       "expect": {
@@ -464,7 +470,7 @@
       }
     },
     {
-      "name": "theConnectTriggerDialsIt",
+      "name": "theConnectTriggerDialsThePublishedLayout",
       "type": "http",
       "connection": "primary",
       "request": {
@@ -513,6 +519,18 @@
       }
     },
     {
+      "name": "settleBeforeTheClosingReading",
+      "type": "set",
+      "output": "closingReadingSettle",
+      "value": {
+        "delayMs": 1500,
+        "waitsFor": "the post-commit metric increment on the claiming node"
+      },
+      "request": {
+        "delayMs": 1500
+      }
+    },
+    {
       "name": "captureStageWritesAfterPrimary",
       "type": "http",
       "connection": "primary",
@@ -524,7 +542,8 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "afterStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "afterStageWritesPrimary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "afterFormationMetricsPrimary": "body.groupFormation.metrics"
         }
       },
       "expect": {
@@ -548,7 +567,8 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "afterStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "afterStageWritesSecondary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "afterFormationMetricsSecondary": "body.groupFormation.metrics"
         }
       },
       "expect": {
@@ -572,7 +592,8 @@
           "x-client-id": "{adminClientId}"
         },
         "outputs": {
-          "afterStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write"
+          "afterStageWritesTertiary": "body.groupFormation.metrics.groupMutationCount.stageTransition.write",
+          "afterFormationMetricsTertiary": "body.groupFormation.metrics"
         }
       },
       "expect": {
@@ -616,11 +637,79 @@
       }
     },
     {
+      "name": "compareServerIdPrimarySecondary",
+      "type": "set",
+      "output": "serverIdPrimaryIsSecondary",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdPrimary"
+          },
+          {
+            "path": "outputs.serverIdSecondary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "compareServerIdSecondaryTertiary",
+      "type": "set",
+      "output": "serverIdSecondaryIsTertiary",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdSecondary"
+          },
+          {
+            "path": "outputs.serverIdTertiary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "compareServerIdPrimaryTertiary",
+      "type": "set",
+      "output": "serverIdPrimaryIsTertiary",
+      "transform": {
+        "equals": [
+          {
+            "path": "outputs.serverIdPrimary"
+          },
+          {
+            "path": "outputs.serverIdTertiary"
+          }
+        ]
+      }
+    },
+    {
+      "name": "theThreeReadingsComeFromThreeServers",
+      "type": "assert",
+      "actual": {
+        "serverIdPrimaryIsSecondary": "{serverIdPrimaryIsSecondary}",
+        "serverIdSecondaryIsTertiary": "{serverIdSecondaryIsTertiary}",
+        "serverIdPrimaryIsTertiary": "{serverIdPrimaryIsTertiary}"
+      },
+      "expect": {
+        "body": {
+          "serverIdPrimaryIsSecondary": false,
+          "serverIdSecondaryIsTertiary": false,
+          "serverIdPrimaryIsTertiary": false
+        }
+      }
+    },
+    {
       "name": "thePlanConnectAndActivateCountInTheStageBucket",
       "type": "assert",
       "actual": {
+        "beforeStageWritesTotal": "{beforeStageWritesTotal}",
         "afterStageWritesTotal": "{afterStageWritesTotal}",
-        "expectedStageWritesTotal": "{expectedStageWritesTotal}"
+        "expectedStageWritesTotal": "{expectedStageWritesTotal}",
+        "beforeStageWritesPrimary": "{beforeStageWritesPrimary}",
+        "beforeStageWritesSecondary": "{beforeStageWritesSecondary}",
+        "beforeStageWritesTertiary": "{beforeStageWritesTertiary}",
+        "afterStageWritesPrimary": "{afterStageWritesPrimary}",
+        "afterStageWritesSecondary": "{afterStageWritesSecondary}",
+        "afterStageWritesTertiary": "{afterStageWritesTertiary}"
       },
       "expect": {
         "comparators": [
@@ -630,6 +719,13 @@
           }
         ]
       }
+    }
+  ],
+  "postRunAssertions": [
+    {
+      "name": "no failed steps",
+      "path": "summary.failure",
+      "eq": 0
     }
   ]
 }

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -3096,16 +3096,42 @@ The same review found the seven transition literals living in a fourth place. Th
 typed guard delegating to a name-only sibling for callers holding an unvalidated string, and the
 metrics classifier calling that sibling.
 
-**Carried forward.** The artifact reading the section asked for needs a recipe that is cluster-wired
-_and_ drives lifecycle commands. None exists: the metrics-reading bursts drive none, and the
-transition-driving recipes are single-origin by design. Building one is the next piece of Slice 13's
-observability work, and it is what would let 12b's writer be measured rather than assumed.
+**Carried forward, and then built.** The artifact reading the section asked for needs a recipe that is
+cluster-wired _and_ drives lifecycle commands. None existed: the metrics-reading bursts drive none,
+and the transition-driving recipes are single-origin by design. Slice 13b is that recipe —
+`api-v1-group-lifecycle-stage-metrics`, the cluster profile's seventh.
 
 **Not here:** `activationStatus` counts nothing until the writer exists, deliberately — registering it
 now costs one artifact shape change instead of two. It is a zero counter on a diagnostic, not a wire
 contract with no producer, which is why it is treated differently from the
 `group-activation-status-changed` event I36 deferred; a test pins that no operation the group inbox
 can report reaches it. If 12b lands without a producer, the bucket should go.
+
+### Slice 13b start checkpoint — the stage bucket read across the cluster (2026-09-03)
+
+Stacked on 13a, which is the slice that has the bucket to read. 13a could not prove it end to end:
+its own census found no recipe that both drives a lifecycle command and reads
+`body.groupFormation.metrics`, and neither remedy fitted — a primary-only reading on the managed
+bursts is unsound because the AppInbox is claimed by any node, and a cluster-wide one breaks the
+single-origin property `api-v1-managed-formation-recipe-loading.test.ts` pins on exactly those two.
+
+`api-v1-group-lifecycle-stage-metrics` is the recipe that fits, and it is new rather than an
+amendment because none of the six existing cluster recipes drives a lifecycle command either. It
+logs in as its own admin, reads the stage-transition write count on all three nodes, drives a
+`managed` group through `plan` → the connect trigger's own dial → `activate`, reads all three nodes
+again, and asserts the **sum** rose by at least three. The sum is the point: the counter is
+process-local, the queue hands work to whichever node claims it, and two of those three transitions
+are worker- and timer-driven, so no single node's reading is a fact about the group.
+
+It sits in `api-v1-black-box-cluster`, which the routine Postgres profile already runs, so the proof
+is paid on every `bb:api-v1:postgres` rather than only in `formation-large`.
+
+**Two gates corrected the first draft.** The matrix's evidence tier is not decorative — `tier: 2`
+means the recipe carries SQL evidence, and this one does not, so copying a neighbour's entry made a
+dishonest claim the matrix test caught. And the request identities have to be at least twenty
+resolved characters and private to one recipe: `plan-{runId}` was too short, while `activate-{runId}`
+and `group-create-{runId}` collided with the lifecycle-transitions and state-read-convergence
+recipes, which would have replayed their receipts.
 
 ## Slice 14 — Finalisation
 


### PR DESCRIPTION
## Goal

Slice 13b of the [group activation implementation plan](playground/rtc-design/2026-08-22-group-activation-implementation-plan.md), stacked on #467: read the stage-transition metrics bucket in an artifact, which is what the Slice 13 ordering note actually asks for and what #467 could not deliver on its own.

## Why a new recipe

#467's census found no recipe that both drives a lifecycle command and reads `body.groupFormation.metrics`, and neither way of amending an existing one was sound:

- **A primary-only reading misses the work.** The counter is recorded by whichever process executed the queued mutation — the AppInbox is claimed `for update skip locked` from a shared table — and two of the three transitions here are worker- and timer-driven with no affinity to the node that took the request.
- **Cluster connections break a pinned property.** `api-v1-managed-formation-recipe-loading.test.ts` holds every HTTP operation in the two managed bursts to the single configured API origin, which is what lets them drive one managed deployment.

None of the six existing cluster recipes drives a lifecycle command either, so this is a new one rather than an amendment.

## Changes

- **`api-v1-group-lifecycle-stage-metrics`**: its own admin identity, a stage-transition reading on all three nodes, a `managed` group driven through `plan` → the connect trigger's own dial → `activate`, a second three-node reading, and an assertion that the **summed** count rose by at least three. The sum is the point — no single node's reading is a fact about the group.
- **In `api-v1-black-box-cluster`**, which the routine Postgres profile already runs, so the proof is paid on every `bb:api-v1:postgres` rather than only in `formation-large`.

## Two gates corrected the first draft

- **Evidence tier.** `tier: 2` asserts the recipe carries SQL evidence; copying a neighbour's entry made that claim falsely, and `recipe-matrix.test.ts` caught it. Corrected to `tier: 1`.
- **Request identities.** They must be at least twenty resolved characters and private to one recipe. `plan-{runId}` was too short, and `activate-{runId}` / `group-create-{runId}` collided with `api-v1-group-lifecycle-transitions` and `api-v1-state-read-convergence` — which would have replayed those recipes' receipts instead of running.

## Acceptance

- The group reaches `active` through a plan, an automatic connect and an activate, each pinned by stage and epoch.
- The summed stage-transition write count across all three nodes rises by at least three; a regression that reclassified those mutations to `other` leaves the sum flat and fails the step.
- The recipe declares all three API services and resolves every operation against a declared connection.

## Validation

Passed locally on the final head: dprint on the touched files, `check:repo-style:changed` against 13a's head (no new findings), `check-test-structure-coupling --changed`, the governed test typecheck (1 019 files, 0 debt), `typecheck`, `test:repo-governance` (27 files, 413 tests), and the full `packages/tests/shared-test` suite (103 files, 1 031 tests).

Black-box: the Postgres profile **36 of 36** with the cluster profile now **7 of 7**, the new recipe passing 25 steps. The in-memory profile is unchanged at 36 — the recipe is cluster-only by design.

## Risk and rollback

A new test-only recipe and its matrix entry. No production code, no stored shape, no behaviour change. Rollback is a revert of the branch.

## Follow-up

Slice 12b — the status writer with dwell, hysteresis, durable clocks and I4's key-list edit — is next, and this recipe is what will let its write volume be measured rather than assumed. The rest of Slice 13 is the `explainGroup` admin-support surface and the `group-lifecycle-stages` workbench collection. 10a's per-command `automatic` origin item is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
