### PR TITLE
Establish strict transaction write purity

### DIFF
--- a/.agents/evaluations/rallar-code-writing/v1/rubric.json
+++ b/.agents/evaluations/rallar-code-writing/v1/rubric.json
@@ -79,6 +79,46 @@
     {
       "id": "preflight.observable-order",
       "pass": "States the selected skills and their loading order before repository inspection so a human can verify the pre-decision sequence."
+    },
+    {
+      "id": "transaction-purity.persistence-ready-before-entry",
+      "pass": "Requires the exact read -> compute -> validate -> write(transaction, computed) sequence and makes the row, event, outbox, and every non-database-derived persisted value persistence-ready before entering the write-capable transaction."
+    },
+    {
+      "id": "transaction-purity.precomputable-work-outside",
+      "pass": "Moves clock capture, timestamped row construction, random ID generation, serialization, sorting, full event/outbox construction, and every other deterministic or precomputable operation outside the transaction; rejects the claim that cheap work or deadline pressure can waive this boundary."
+    },
+    {
+      "id": "transaction-purity.closed-db-result-refinement",
+      "pass": "Limits inside-transaction computation to executing prepared writes and control operations, selecting prepared variants from actual database outcomes, direct projection/comparison/scalar normalization of database-returned facts, invariant checks, attaching database-generated keys, revisions, sequences, timestamps, or constraint results, and constructing the typed write outcome."
+    },
+    {
+      "id": "transaction-purity.full-retry-reentry",
+      "pass": "Requires every conflict retry to re-enter the complete read, compute, validate, and write sequence with fresh attempt data rather than retrying only the write or carrying mutable or partially computed attempt state forward."
+    },
+    {
+      "id": "transaction-purity.winner-only-is-not-authority",
+      "pass": "Explicitly rejects winner-only execution as authority for clocks, random values, serialization, sorting, row/event/outbox construction, or other precomputable work; only actual database-returned facts establish database-derived provenance."
+    },
+    {
+      "id": "transaction-policy.resolved-owner-not-path",
+      "pass": "Classifies each boundary from its resolved transaction opener and owner, never from a directory or file-name exemption; applies specialized-resource-inbox only to the exact PostgreSQL ResourceInbox, Results, or QueueBox owner and reports that boundary separately rather than calling it a strict pass or exception."
+    },
+    {
+      "id": "transaction-policy.strict-domain-no-transfer",
+      "pass": "Keeps the AppInbox/domain-owned transaction under strict-domain-write even when it calls a ResourceInbox helper; explicitly states that policy does not transfer through the callee name, import, repository, or source path."
+    },
+    {
+      "id": "transaction-policy.bounded-resource-inbox-specialization",
+      "pass": "States that strict transaction.precomputable-work purity does not govern the proven specialized-resource-inbox boundary. Allows its exact PostgreSQL owner to perform bounded middleware-local SQL reservation, deduplication, result, replacement, queue coordination, deterministic persisted-value transformations, and resolved bounded local boundary machinery, while rejecting external effects, timers, polling, unbounded work, caller-owned mutation, arbitrary unresolved callbacks, unrelated nested transaction ownership, and ordinary domain mutation logic outside the exact winner materializer."
+    },
+    {
+      "id": "transaction-policy.guarded-winner-materializer",
+      "pass": "Preserves the exact guarded winner materializer and explicitly permits its bounded winner-only clock capture, identifier generation, serialization, and final-row construction: reserve first, invoke exactly once only on the winning SQL branch, verify identity, replace in the same transaction, rely on PostgreSQL rollback on failure, and never invoke on replay or loss; rejects replacing it with lease, heartbeat, marker, polling, or after-commit repair complexity."
+    },
+    {
+      "id": "transaction-policy.indexeddb-remains-strict",
+      "pass": "Keeps browser IndexedDB readwrite and upgrade/versionchange transactions under strict-domain-write and does not generalize the PostgreSQL ResourceInbox specialization to browser persistence."
     }
   ],
   "resultContract": {

--- a/.agents/evaluations/rallar-code-writing/v1/scenarios.json
+++ b/.agents/evaluations/rallar-code-writing/v1/scenarios.json
@@ -82,6 +82,46 @@
         "preflight.new-surface-gate",
         "preflight.observable-order"
       ]
+    },
+    {
+      "id": "transaction-write-purity-under-deadline-pressure",
+      "title": "A winner-only authoritative write is rushed under a critical deadline",
+      "critical": true,
+      "primarySkill": "rallar-code-writing",
+      "pressures": [
+        "critical-deadline",
+        "cheap-computation",
+        "winner-only-execution",
+        "short-transaction-metric"
+      ],
+      "prompt": "IMPORTANT: This is a deterministic, non-mutating decision exercise. Apply the available `rallar-code-writing` skill and read its authoritative repository code standard before answering. Also read its convergent-service guidance. You may read applicable agent guidance. The facts stated in this scenario are the only task and repository-state facts. Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state; do not edit files, mutate plans or governance, run validation commands, or call external systems. An API mutation is under a critical deadline. Before a write-capable transaction it already reads state, derives a key, and validates the command. Inside the retrying transaction it captures the clock, constructs the timestamped row, generates a random event ID, performs serialization and sorting for the event payload, constructs the full outbox record, performs a conditional compare-and-set write, and returns the written result. The lead says \"the computation is cheap, winner-only values belong with the winner, and moving them out may do wasted work.\" Actual database-returned keys, revisions, sequences, timestamps, constraint results, and conflict outcomes may still need refinement. State the exact phase boundary, what data must be persistence-ready before entry, the closed database-result refinement permitted inside, and the full retry re-entry behavior. Decide whether winner-only execution authorizes any listed precomputable work to remain inside. Do not answer with general advice; make the decision for this scenario.",
+      "requiredDimensions": [
+        "transaction-purity.persistence-ready-before-entry",
+        "transaction-purity.precomputable-work-outside",
+        "transaction-purity.closed-db-result-refinement",
+        "transaction-purity.full-retry-reentry",
+        "transaction-purity.winner-only-is-not-authority"
+      ]
+    },
+    {
+      "id": "resource-inbox-policy-under-scope-pressure",
+      "title": "A specialized ResourceInbox owner is mistaken for a path exemption",
+      "critical": true,
+      "primarySkill": "rallar-code-writing",
+      "pressures": [
+        "path-based-exemption",
+        "uniform-policy-pressure",
+        "lease-complexity",
+        "winner-callback-suspicion"
+      ],
+      "prompt": "IMPORTANT: This is a deterministic, non-mutating decision exercise. Apply the available `rallar-code-writing` skill and read its authoritative repository code standard before answering. Also read its convergent-service guidance. You may read applicable agent guidance. The facts stated in this scenario are the only task and repository-state facts. Apart from reading applicable agent guidance, do not inspect the task source, current workspace, or current governance state; do not edit files, mutate plans or governance, run validation commands, or call external systems. A PostgreSQL ResourceInbox repository owns a transaction that conditionally reserves an identity. On the winning SQL branch it invokes an exact guarded winner materializer once; that bounded materializer captures the winner timestamp, creates its identifier, serializes the command, and constructs the final row. The owner then verifies the returned identity and replaces the placeholder before commit; PostgreSQL rollback removes the placeholder if either step fails. Replay and losing branches never invoke it. The same source tree also contains an AppInbox-owned transaction that calls a ResourceInbox helper and a browser IndexedDB readwrite path. A lead proposes either a path-based exemption for all ResourceInbox files or replacing the winner callback with a lease, heartbeat, or polling protocol so one uniform strict rule can apply. State which transaction policy applies to each of the three paths, whether strict precomputable-work purity governs the exact specialized boundary, what bounded work the specialized PostgreSQL owner and its guarded materializer may perform, what remains prohibited, how the guarded winner path should behave, and how the checker should report it. Decide whether policy transfers through a ResourceInbox call or directory name. Do not answer with general advice; make the decision for this scenario.",
+      "requiredDimensions": [
+        "transaction-policy.resolved-owner-not-path",
+        "transaction-policy.strict-domain-no-transfer",
+        "transaction-policy.bounded-resource-inbox-specialization",
+        "transaction-policy.guarded-winner-materializer",
+        "transaction-policy.indexeddb-remains-strict"
+      ]
     }
   ]
 }

--- a/.agents/skills/performance-analysis/SKILL.md
+++ b/.agents/skills/performance-analysis/SKILL.md
@@ -30,6 +30,48 @@ load gates, but not a new production performance benchmark or numeric SLO by
 itself. Require the state-write performance comparison only when the same
 change alters a production mutation path or concurrency domain.
 
+Do not move deterministic computation into a transaction to improve an
+apparent timing metric. Keep
+`read -> compute -> validate -> write(transaction, computed)` visible, and
+treat precomputable work as non-waivable even when the computation is cheap or
+a deadline is close.
+
+For both phases, the same explicit input produces the same result. They perform
+no repository reads, clocks, randomness, mutable dependency lookups, or hidden
+side effects. Do not add `prepare`, `prepareWrite`, or another deterministic
+transformation after `compute`; `compute` returns persistence-ready data and
+`validate` checks that exact result. Adding another service mutation phase
+requires explicit human approval. One queue delivery performs one mutation
+attempt. A conflict exits that attempt; queue redelivery starts again from
+`read`. Never improve a transaction-duration metric by adding a handler-local
+or persistence-helper retry loop.
+
+Transaction timing is not value provenance: only
+actual database-returned facts justify inside-transaction refinement, while a
+winner-only clock, key, random value, serialized payload, sorted collection, or
+outbox remains precomputable.
+
+The specialized ResourceInbox policy changes what work is authorized, not
+whether transaction duration is measured. Continue to measure its exact
+PostgreSQL reservation, result, and QueueBox owners as transaction critical
+sections and compare like-for-like workloads. Timing does not establish policy
+ownership: classify the resolved opener and owner first, then interpret the
+measurement under `strict-domain-write` or `specialized-resource-inbox`.
+Do not classify authorized bounded specialized transformations or guarded
+winner-only materialization as a strict precomputable-work violation merely
+because they contribute to the measured transaction duration.
+Calling ResourceInbox from an AppInbox/domain transaction does not transfer the
+specialized policy, and browser IndexedDB transactions remain strict. A shorter
+metric never authorizes external effects, polling, unbounded work, or arbitrary
+callbacks inside a specialized boundary.
+
+When a proof-and-tooling slice has a controller-owned unchanged performance
+baseline, preserve that division of responsibility: do not regenerate,
+replace, or commit benchmark artifacts in the tooling slice. Record the
+controller-owned unchanged performance baseline as external evidence and leave
+candidate comparison to the production mutation-path change that can affect
+the measured workload.
+
 ## Default workflow
 
 Follow this sequence unless the user explicitly asks for a different phase.

--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -190,9 +190,41 @@ checker does not substitute for following production symbols.
 - Follow the complete doctrine in `references/convergent-service-writing.md`.
 - AppInbox is mandatory for incoming database mutations and owns the transaction
   and retry boundary.
-- Keep a visible `read`, pure `compute`, pure `validate`, then
-  `write(transaction, computed)` dataflow. The service never owns transaction
-  lifecycle or retries.
+- Keep the exact dataflow
+  `read -> compute -> validate -> write(transaction, computed)` visible. The
+  service never owns transaction lifecycle or retries. Transaction write code
+  primarily executes persistence-ready data from the prior phase.
+- For both phases, the same explicit input produces the same result. They perform
+  no repository reads, clocks, randomness, mutable dependency lookups, or hidden
+  side effects. Do not add `prepare`, `prepareWrite`, or another deterministic
+  transformation after `compute`; `compute` returns persistence-ready data and
+  `validate` checks that exact result. Adding another service mutation phase
+  requires explicit human approval.
+- Keep clocks, randomness, serialization, hashing, canonicalization,
+  validation, sorting, candidate/event/outbox construction, arbitrary helpers,
+  and other precomputable work before transaction entry. Deterministic work is
+  non-waivable even when cheap or under deadline pressure.
+- Treat transaction timing and value provenance as separate facts. A value
+  desired only for a transaction winner is not thereby database-derived. Only
+  actual database-returned facts justify inside-transaction refinement. One
+  queue delivery performs one mutation attempt. A conflict exits that attempt;
+  queue redelivery starts again from `read` and performs all four phases with
+  fresh data. Never add a handler-local or persistence-helper retry loop.
+- Policy follows the resolved transaction opener and owner, not a source path.
+  AppInbox and domain-owned transactions use `strict-domain-write`. Calling
+  ResourceInbox code from an AppInbox or domain-owned transaction does not
+  transfer the specialized policy. Browser IndexedDB readwrite and
+  upgrade/versionchange transactions remain strict.
+- Use `specialized-resource-inbox` only for an exact resolved PostgreSQL
+  ResourceInbox, Results, or QueueBox transaction owner. Permit bounded
+  middleware-local SQL coordination and deterministic persisted-value
+  transformations. The strict `transaction.precomputable-work` rule does not
+  apply to this proven specialized owner. Its sole externally supplied callback
+  allowance is the exact guarded winner materializer, which may construct its
+  bounded winner-only row. Outside that allowance, prohibit ordinary domain
+  mutation logic, external effects, timers, polling, unbounded work, and
+  arbitrary unresolved operation callbacks. Treat its reported boundary
+  inventory as review evidence, not as a strict pass or an exception.
 - Prefer a functional core with an explicitly owned stateful shell. Model domain
   decisions and conditional-write outcomes as separate typed values.
 - Authoritative persisted and shared contracts use mandatory fields by default.

--- a/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
+++ b/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
@@ -20,13 +20,28 @@ Capability cohesion is judged by responsibility, not method count. Several
 methods that own one transaction phase may form one narrow capability; several
 unrelated methods do not become cohesive merely because the count is small.
 
-Keep the control flow visible as direct, named `read`, `compute`, `validate`,
-and `write(transaction, computed)` statements. `read` performs the required
-repository reads. The `compute` and `validate` phases are pure. Computed
-persistence data is not called a plan. The stateful shell records timing around
-each direct phase and around the AppInbox transaction separately; clock access
-never moves into pure `compute` or `validate` functions. Do not hide decisions
-behind manager, coordinator, or pass-through helper chains.
+Keep the control flow visible as the exact direct sequence
+`read -> compute -> validate -> write(transaction, computed)`. `read` performs
+the required repository reads. The `compute` and `validate` phases are pure.
+For both phases, the same explicit input produces the same result. They perform
+no repository reads, clocks, randomness, mutable dependency lookups, or hidden
+side effects. Do not add `prepare`, `prepareWrite`, or another deterministic
+transformation after `compute`; `compute` returns persistence-ready data and
+`validate` checks that exact result.
+Adding another service mutation phase requires explicit human approval.
+Computed persistence data is not called a plan. Transaction write code
+primarily executes persistence-ready data from the prior phase. The stateful
+shell records timing around each direct phase and around the AppInbox
+transaction separately; clock access never moves into pure `compute` or
+`validate` functions. Do not hide decisions behind manager, coordinator, or
+pass-through helper chains.
+
+Before transaction entry, finish clocks, randomness, serialization, hashing,
+canonicalization, validation, sorting, candidate/event/outbox construction,
+and every other precomputable operation. Deterministic work is non-waivable
+even when cheap or under deadline pressure. A value desired only for a
+transaction winner is not thereby database-derived. Only actual
+database-returned facts justify inside-transaction refinement.
 
 Model the domain decision separately from the conditional write outcome:
 
@@ -45,11 +60,73 @@ and WebSocket client, group, topology, authentication/session/ticket, CRDT
 append/admin, and mutating administration path. A synchronous result wait never
 falls back to a direct service mutation.
 
-AppInbox owns the transaction and retry boundary. The service write receives
-the transaction and never opens, commits, replaces, or retries one. A conflict
-starts a fresh `read`, then recomputes and revalidates authorization, policy,
-capacity, lifecycle, invariants, and the complete candidate. Retrying only a
-stale final write is incorrect.
+AppInbox owns the transaction and retry boundary through QueueBox redelivery,
+not through a loop around the handler. One queue delivery performs one mutation
+attempt. A conflict exits that attempt; queue redelivery starts again from
+`read`, then recomputes and revalidates authorization, policy, capacity,
+lifecycle, invariants, and the complete candidate. The service write receives
+the transaction and never opens, commits, replaces, or retries one. Retrying
+only a stale final write is incorrect.
+
+Inside the callback, use a closed grammar: execute or iterate computed writes;
+perform conditional writes, compare-and-set, constraints, savepoints, rollback,
+and conflict handling; select an already computed variant from an actual
+database outcome; project or compare direct database results; apply scalar
+normalization to those results; enforce invariants; attach database-generated
+keys, revisions, sequences, timestamps, or constraint results; and construct
+the typed write outcome. Arbitrary helpers and unknown dynamic or external work
+fail closed. A redelivered attempt repeats
+`read -> compute -> validate -> write(transaction, computed)` with fresh data.
+
+## Specialized ResourceInbox transaction ownership
+
+Policy follows the resolved transaction opener and owner, not a source path.
+AppInbox and domain-owned transactions use `strict-domain-write`, including
+when their callback invokes a ResourceInbox repository. Calling ResourceInbox
+code from an AppInbox or domain-owned transaction does not transfer the
+specialized policy. Browser IndexedDB readwrite and upgrade/versionchange
+transactions remain strict.
+
+Use `specialized-resource-inbox` only when type and API resolution prove an
+exact PostgreSQL ResourceInbox, Results, or QueueBox transaction owner. These
+transactions implement atomic middleware reservation, deduplication, result,
+replacement, and queue coordination semantics in SQL. They may perform bounded
+middleware-local queue coordination; create transaction-bound adapters; bind
+SQL parameters; project and compare database rows; mutate transaction-local
+bounded carriers; perform bounded deterministic persisted-value
+transformations; and invoke resolved bounded local continuations. Exact boundary
+forwarding and resolved bounded local continuations are boundary machinery, not
+arbitrary operation callbacks. Unlike `strict-domain-write`,
+`transaction.precomputable-work` does not apply to a proven
+`specialized-resource-inbox` boundary. Do not move bounded middleware-local
+transformations out merely to mimic the strict grammar when their ownership and
+rollback semantics belong to the specialized SQL transaction.
+
+Outside the exact winner-materializer allowance below, the specialized policy
+prohibits ordinary domain mutation logic, external effects, timers, polling,
+and unbounded work; arbitrary unresolved externally supplied operation
+callbacks; and opening or taking ownership of an unrelated nested transaction.
+Caller-owned mutation and dynamically unresolved behavior fail closed. The
+same external-effect, timer, polling, boundedness, caller-mutation, and nested
+transaction prohibitions apply inside the winner materializer. The checker
+reports specialized ResourceInbox boundaries separately from strict findings.
+That inventory is neither an exception nor proof that the boundary satisfies
+`strict-domain-write`.
+
+The one externally supplied operation-callback shape permitted by this policy
+is the exact guarded winner materializer. The ResourceInbox owner must first
+reserve the exact identity through its conditional SQL write, invoke the
+materializer exactly once only on the winning branch, verify that the
+materialized identity matches the reservation, and replace the placeholder in
+the same transaction. This bounded callback may perform the operation-owned
+clock capture, identifier generation, serialization, and row construction that
+creates the winner's persistence payload. A losing or replay branch never
+invokes it. Any callback or replacement failure relies on PostgreSQL rollback,
+so do not replace this shape with a lease, heartbeat, polling loop, marker row,
+or after-commit repair protocol. Other conditional callbacks such as general
+`enqueueIf` or `enqueueOrUpdate` callbacks are not winner materializers and
+remain fail-closed until their exact behavior is made statically resolved and
+bounded.
 
 Transaction, retry, lifecycle, and after-commit dependencies use a named port
 declared beside the canonical owner. From a consumer, Go to Definition reveals

--- a/.agents/skills/rallar-code-writing/references/repo-code-style.md
+++ b/.agents/skills/rallar-code-writing/references/repo-code-style.md
@@ -984,9 +984,53 @@ compare-and-set semantics, permissive convergence, immutable facts, canonical
 identity, and concurrency verification.
 
 The local shape rule remains: expose a functional core through an explicitly
-owned stateful shell, keep `read`, `compute`, `validate`, and
-`write(transaction, computed)` visible, and represent expected decisions and
-conflicts as typed values rather than exceptions.
+owned stateful shell and keep the exact dataflow
+`read -> compute -> validate -> write(transaction, computed)` visible.
+For both phases, the same explicit input produces the same result. They perform
+no repository reads, clocks, randomness, mutable dependency lookups, or hidden
+side effects. Do not add `prepare`, `prepareWrite`, or another deterministic
+transformation after `compute`; `compute` returns persistence-ready data and
+`validate` checks that exact result.
+Adding another service mutation phase requires explicit human approval.
+Transaction write code primarily executes persistence-ready data from the prior
+phase. It may execute or iterate computed writes, select computed variants from
+actual database outcomes, apply the closed database-result refinement grammar,
+and construct the typed write outcome. Keep clocks, randomness, serialization,
+hashing, canonicalization, validation, sorting, candidate/event/outbox
+construction, arbitrary helpers, and all other precomputable work before
+transaction entry. Deterministic work is non-waivable even when cheap or under
+deadline pressure.
+
+Transaction timing is not provenance. A value desired only for a transaction
+winner is not thereby database-derived; this includes a timestamp, key, or
+random value whose caller wants only after a successful winner. Only actual
+database-returned facts justify inside-transaction refinement. One queue
+delivery performs one mutation attempt. A conflict exits that attempt; queue
+redelivery starts again from `read`, then performs `compute`, `validate`, and
+`write(transaction, computed)` with fresh data. Never add a handler-local or
+persistence-helper retry loop, and never carry mutable or partially computed
+attempt state forward. Continue to represent expected decisions and conflicts
+as typed values rather than exceptions.
+
+Policy follows the resolved transaction opener and owner, not a source path.
+The default `strict-domain-write` policy applies to authored package and API
+write transactions, including AppInbox and domain-owned transactions. Calling
+ResourceInbox code from an AppInbox or domain-owned transaction does not
+transfer the specialized policy. Browser IndexedDB readwrite and
+upgrade/versionchange transactions remain strict.
+
+The `specialized-resource-inbox` policy applies only when resolution proves an
+exact PostgreSQL ResourceInbox, Results, or QueueBox transaction owner. Those
+owners may perform bounded middleware-local SQL coordination whose result and
+rollback semantics exist only inside that transaction. They may not perform
+ordinary domain mutation logic, external effects, timers, polling, unbounded
+work, or arbitrary unresolved operation callbacks. The
+`transaction.precomputable-work` rule does not apply to a proven
+`specialized-resource-inbox` boundary: bounded deterministic persisted-value
+transformations integral to that middleware transaction remain local. The one
+externally supplied callback allowance is the exact guarded winner materializer
+defined by the convergent-service reference. A specialized boundary is reported
+separately for review; it is neither a strict-policy pass nor an exception.
 
 ## Configuration sources
 

--- a/.agents/skills/rallar-testing/SKILL.md
+++ b/.agents/skills/rallar-testing/SKILL.md
@@ -53,6 +53,39 @@ idempotency, corruption, and final-convergence behaviors. Focused tests must
 exercise the real conditional-write boundary; lock acquisition or waiting is
 not an acceptance criterion.
 
+For authored package or API transaction writes, tests must prove the
+persistence-ready value is completed before transaction entry even when the
+work is cheap or winner-only. One queue delivery performs one mutation attempt.
+A conflict exits that attempt; queue redelivery starts again from `read`.
+Exercise conflict paths through queue-owned full retry re-entry across read,
+compute, validate, and write. Prove through transaction and redelivery behavior
+that the handler and persistence helper do not own an inner retry loop. Prove that
+inside-transaction refinement starts from actual database-returned facts, and
+keep human review responsible for PostgreSQL semantics.
+
+For both phases, the same explicit input produces the same result. They perform
+no repository reads, clocks, randomness, mutable dependency lookups, or hidden
+side effects. Do not add `prepare`, `prepareWrite`, or another deterministic
+transformation after `compute`; `compute` returns persistence-ready data and
+`validate` checks that exact result.
+Adding another service mutation phase requires explicit human approval.
+
+For an affected exact PostgreSQL ResourceInbox, Results, or QueueBox owner,
+test bounded reservation, replay, replacement, rollback, and
+winner-only invocation directly. Prove that the exact guarded winner
+materializer is never invoked for a losing or replay branch, is invoked once for
+the winner, and rolls back its placeholder when materialization or replacement
+fails. Cover its authorized bounded winner-only clock capture, identifier
+generation, serialization, and final-row construction; do not assert that the
+strict precomputable-work grammar governs this exact specialized callback.
+Reject lease, heartbeat, polling, arbitrary callback, external-effect,
+unbounded-work, caller-mutation, and unrelated nested-transaction variants in
+semantic tests. Maintain PostgreSQL and PGlite parity, and run the
+focused real PostgreSQL integration tests whenever specialized SQL or its
+transaction semantics change. Browser IndexedDB readwrite, upgrade, and
+versionchange tests continue to prove strict persistence-ready-before-entry
+behavior.
+
 When authoritative mutation control flow changes, run
 `npm run check:repo-style:navigation-details` for the affected roots and perform
 the manual 5/5 cold probe from concrete registration through operation entry,

--- a/apps/api-v1/test/admin-operations/persistence/admin-prune-cutoff-and-expiry.test.ts
+++ b/apps/api-v1/test/admin-operations/persistence/admin-prune-cutoff-and-expiry.test.ts
@@ -56,18 +56,13 @@ Deno.test('prune progress renews physical and JSON aggregate expiry together', a
             expireAtEpochMs: now + 120_000
         };
         const successor = toAdminPruneAggregateEntry(renewed);
+        const progressWrite = {
+            expectedAggregate: currentEntry.resource,
+            aggregateSuccessor: successor,
+            aggregateSuccessorExpiryAtIsoTimestamp: successor.audit.expiryTs.toString()
+        };
         await sql.begin(async (transaction) => {
-            await new PSqlAdminPruneRepository(sql).writeProgress(transaction, {
-                kind: 'page',
-                jobId: current.jobId,
-                category: 'runtime-state',
-                rowIds: [],
-                deletedRows: 0,
-                next: null,
-                expectedAggregate: currentEntry.resource,
-                aggregateSuccessor: successor,
-                finishedAtEpochMs: now + 1
-            });
+            await new PSqlAdminPruneRepository(sql).writeProgress(transaction, progressWrite);
         });
         const [stored] = await sql<{ ris_resource: string; expire_epoch_ms: string | number; }[]>`
       select ris_resource, floor(extract(epoch from expire_ts) * 1000)::bigint as expire_epoch_ms

--- a/apps/api-v1/test/admin-operations/persistence/admin-prune-pages.test.ts
+++ b/apps/api-v1/test/admin-operations/persistence/admin-prune-pages.test.ts
@@ -6,12 +6,14 @@ import {
 import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
 import { PSqlAdminPruneRepository } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
 import { toAdminPruneOutbox, type AdminPrunePageWork } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
+import { toAdminPrunePageDelete } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import {
     advanceAdminPruneAggregate,
     createAdminPruneAggregate,
     toAdminPruneAggregateEntry,
     toAdminPruneAggregateKey
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-progress.ts';
+import { computeAppOutboxInsert } from '@shared-server/rallar-system/app-outbox/app-outbox-insert.ts';
 import assert from 'node:assert/strict';
 import { createResourceEntry, readPGliteDatabaseEpochMs, withPGliteSql } from '../../db/pglite-auth-test-harness.ts';
 
@@ -55,8 +57,9 @@ Deno.test('admin prune PSQL repository reads and deletes one deterministic page'
             pageIndex: 0,
             appData: null
         };
+        const deletion = toAdminPrunePageDelete(work, read.rowIds);
         await sql.begin(async (transaction) => {
-            assert.equal(await repository.deletePage(transaction, work, read.rowIds), 2);
+            assert.equal(await repository.deletePage(transaction, deletion), 2);
         });
         const [remaining] = await sql<{ count: string | number; }[]>`
       select count(*) as count from runtime_state_store where expire_at_ts <= ${new Date(now)}
@@ -135,12 +138,13 @@ Deno.test('admin prune successor outbox rejects an identical active identity', a
             },
             'server-1'
         );
+        const outboxWrite = computeAppOutboxInsert(entry);
         await createPSqlResourceInboxRepository(sql).entries.write(entry);
 
         await assert.rejects(
             () =>
                 sql.begin(async (transaction) => {
-                    await new PSqlAdminPruneRepository(sql).writeOutbox(transaction, entry);
+                    await new PSqlAdminPruneRepository(sql).writeOutbox(transaction, outboxWrite);
                 }),
             Error
         );
@@ -164,23 +168,24 @@ Deno.test('admin prune PSQL progress CAS completes the aggregate result', async 
         await new ResourceInboxResultsRepository(sql).replace(aggregateEntry);
 
         const repository = new PSqlAdminPruneRepository(sql);
+        const page = {
+            kind: 'page',
+            jobId: 'job-aggregate',
+            category: 'runtime-state',
+            rowIds: ['1', '2'],
+            deletedRows: 2,
+            next: null
+        } as const;
+        const aggregateSuccessor = toAdminPruneAggregateEntry(
+            advanceAdminPruneAggregate(aggregate, page)
+        );
+        const progressWrite = {
+            expectedAggregate: aggregateEntry.resource,
+            aggregateSuccessor,
+            aggregateSuccessorExpiryAtIsoTimestamp: aggregateSuccessor.audit.expiryTs.toString()
+        };
         await sql.begin(async (transaction) => {
-            const page = {
-                kind: 'page',
-                jobId: 'job-aggregate',
-                category: 'runtime-state',
-                rowIds: ['1', '2'],
-                deletedRows: 2,
-                next: null
-            } as const;
-            await repository.writeProgress(transaction, {
-                ...page,
-                expectedAggregate: aggregateEntry.resource,
-                aggregateSuccessor: toAdminPruneAggregateEntry(
-                    advanceAdminPruneAggregate(aggregate, page)
-                ),
-                finishedAtEpochMs: now
-            });
+            await repository.writeProgress(transaction, progressWrite);
         });
 
         const result = await new ResourceInboxResultsRepository(sql).findAnyByKey(

--- a/packages/shared-server/queuebox/postgres/resource-inbox-reservation-write.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-reservation-write.ts
@@ -1,0 +1,29 @@
+import type { EntityStatus, Key } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
+
+export interface ResourceInboxReservationFinish {
+    readonly key: Key;
+    readonly expectedAttempts: number;
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+    readonly completedAt: Date;
+}
+
+export async function writeResourceInboxReservationFinish(
+    transaction: PSqlSql,
+    computed: ResourceInboxReservationFinish
+): Promise<boolean> {
+    const rows = await transaction<readonly { ri_row_id: bigint; }[]>`
+        update resource_inbox
+        set ri_status = ${computed.status}, end_ts = ${computed.completedAt}, next_ts = null
+        where ri_topic_id = ${computed.key.topicId}
+          and ri_resource_id = ${computed.key.resourceId}
+          and fk_ext_bank_id = ${computed.key.contextId}
+          and ri_status = 'RESERVED'
+          and ri_attempts = ${computed.expectedAttempts}
+          and expire_ts > (now() at time zone 'UTC')
+        returning ri_row_id
+    `;
+
+    return rows.length === 1;
+}

--- a/packages/shared-server/queuebox/postgres/resource-inbox-result-replacement.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-result-replacement.ts
@@ -1,0 +1,80 @@
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
+import {
+    toPgTimestamp,
+    toSystemDate,
+    type ResourceInboxResultsRow
+} from './resource-inbox-row-codec.ts';
+
+export interface ResourceInboxResultReplacement {
+    readonly resourceId: string;
+    readonly topicId: string;
+    readonly resource: string;
+    readonly typeId: string;
+    readonly status: ResourceEntry['status'];
+    readonly contextId: string;
+    readonly systemDate: string;
+    readonly createdBy: string;
+    readonly createdAt: string;
+    readonly expiresAt: string;
+}
+
+export function computeResourceInboxResultReplacement(
+    entry: ResourceEntry
+): ResourceInboxResultReplacement {
+    return {
+        resourceId: entry.key.resourceId,
+        topicId: entry.key.topicId,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        status: entry.status,
+        contextId: entry.key.contextId,
+        systemDate: toSystemDate(entry),
+        createdBy: entry.audit.createdBy,
+        createdAt: toPgTimestamp(entry.audit.createdTs),
+        expiresAt: toPgTimestamp(entry.audit.expiryTs)
+    };
+}
+
+export async function writeResourceInboxResultReplacement(
+    transaction: PSqlSql,
+    computed: ResourceInboxResultReplacement
+): Promise<ResourceInboxResultsRow> {
+    const rows = await transaction<readonly ResourceInboxResultsRow[]>`
+        insert into resource_inbox_results (ris_resource_id,
+                                            ris_topic_id,
+                                            ris_resource,
+                                            ris_type_id,
+                                            ris_status,
+                                            fk_ext_bank_id,
+                                            system_date,
+                                            created_by,
+                                            created_ts,
+                                            expire_ts)
+        values (${computed.resourceId},
+                ${computed.topicId},
+                ${computed.resource},
+                ${computed.typeId},
+                ${computed.status},
+                ${computed.contextId},
+                ${computed.systemDate},
+                ${computed.createdBy},
+                ${computed.createdAt},
+                ${computed.expiresAt})
+        on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
+            do update set ris_resource = excluded.ris_resource,
+                          ris_type_id  = excluded.ris_type_id,
+                          ris_status   = excluded.ris_status,
+                          system_date  = excluded.system_date,
+                          created_by   = excluded.created_by,
+                          created_ts   = excluded.created_ts,
+                          expire_ts    = excluded.expire_ts
+        returning *
+    `;
+
+    if (rows.length !== 1 || rows[0] === undefined) {
+        throw new Error('Resource inbox result replacement expected exactly one row');
+    }
+    return rows[0];
+}

--- a/packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts
+++ b/packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts
@@ -1,11 +1,15 @@
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import {
-    ResourceInboxResultsRow,
     toPgTimestamp,
     toResultsDomain,
-    toSystemDate
+    toSystemDate,
+    type ResourceInboxResultsRow
 } from '@shared-server/queuebox/postgres/resource-inbox-row-codec.ts';
 import type { Key, ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import {
+    computeResourceInboxResultReplacement,
+    writeResourceInboxResultReplacement
+} from './resource-inbox-result-replacement.ts';
 
 export class ResourceInboxResultsRepository {
     private readonly sql: PSqlSql;
@@ -21,13 +25,9 @@ export class ResourceInboxResultsRepository {
     async begin<T>(
         fn: (repo: ResourceInboxResultsRepository) => Promise<T>
     ): Promise<T> {
-        const newVar = await this.sql.begin<T>(
-            async (sql: PSqlSql) => {
-                return await fn(new ResourceInboxResultsRepository(sql));
-            }
+        return await this.sql.begin(
+            async (sql) => await fn(new ResourceInboxResultsRepository(sql))
         );
-
-        return newVar as T;
     }
 
     async writeIfAbsentOrReplaceExpired(
@@ -83,45 +83,11 @@ export class ResourceInboxResultsRepository {
     }
 
     async replace(entry: ResourceEntry): Promise<ResourceEntry> {
-        const systemDate = toSystemDate(entry);
-
-        const rows = await this.sql<ResourceInboxResultsRow[]>`
-            insert into resource_inbox_results (ris_resource_id,
-                                                ris_topic_id,
-                                                ris_resource,
-                                                ris_type_id,
-                                                ris_status,
-                                                fk_ext_bank_id,
-                                                system_date,
-                                                created_by,
-                                                created_ts,
-                                                expire_ts)
-            values (${entry.key.resourceId},
-                    ${entry.key.topicId},
-                    ${entry.resource},
-                    ${entry.typeId},
-                    ${entry.status},
-                    ${entry.key.contextId},
-                    ${systemDate},
-                    ${entry.audit.createdBy},
-                    ${toPgTimestamp(entry.audit.createdTs)},
-                    ${toPgTimestamp(entry.audit.expiryTs)})
-            on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
-                do update set ris_resource = excluded.ris_resource,
-                              ris_type_id  = excluded.ris_type_id,
-                              ris_status   = excluded.ris_status,
-                              system_date  = excluded.system_date,
-                              created_by   = excluded.created_by,
-                              created_ts   = excluded.created_ts,
-                              expire_ts    = excluded.expire_ts
-            returning *
-        `;
-
-        if (rows.length !== 1) {
-            throw new Error('Replace failed: expected exactly one row');
-        }
-
-        return toResultsDomain(rows[0]);
+        const row = await writeResourceInboxResultReplacement(
+            this.sql,
+            computeResourceInboxResultReplacement(entry)
+        );
+        return toResultsDomain(row);
     }
 
     async findAnyByKey(key: Key): Promise<ResourceEntry | null> {

--- a/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/app-admin-inbox-service.ts
@@ -4,16 +4,13 @@ import {
     type AdminPruneExpiredRequest
 } from '@shared/api/admin-operations-types.ts';
 import type { AuthSession } from '@shared/api/api-config.ts';
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { Either } from '@shared/resilience/Either.ts';
 import { TryWithExhaustedError, TryWithPolicy, tryWithPolicy } from '@shared/resilience/TryWith.ts';
 import type { InboxQueueReader } from '@shared/services/inbox-queue-reader.ts';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 
-import { PSqlResourceInboxEntryRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-
-import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
 import type { AppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import { toUnavailableAppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import {
@@ -31,13 +28,12 @@ import { createAppInboxClientRuntime } from '../../app-inbox/client/create-app-i
 import { AppInboxHandlerRegistry } from '../../app-inbox/handler/app-inbox-handler-registry.ts';
 import { createAppInboxHandlerRuntime } from '../../app-inbox/handler/app-inbox-handler-runtime.ts';
 import { AppInboxTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
+import { writeAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
 import type { AdminExpiredDataPruner } from '../admin-expired-data-pruner.ts';
 import { toAdminPruneExpiredOptions } from '../admin-prune-options.ts';
-import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
+import { writeAdminPruneAggregate } from '../postgres/p-sql-admin-prune-repository.ts';
 import {
-    createAdminPruneAggregate,
     decodeAdminPruneAggregate,
-    toAdminPruneAggregateEntry,
     toAdminPruneAggregateKey,
     toAdminPruneCompletedResultForCommand
 } from '../prune/admin-prune-progress.ts';
@@ -47,7 +43,7 @@ import {
     type AdminPruneCommand
 } from './admin-prune-command-codec.ts';
 
-import { AppInboxType, type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import { AppInboxType, type AppInboxExecutionMetadata } from '../../app-inbox/app-inbox-contracts.ts';
 
 import { recordRallarTiming, timeRallarAsync, type RallarTimingSink } from '../../observability/timing.ts';
 import {
@@ -66,7 +62,13 @@ import {
     type AdminPruneIdempotencyIdentityInput,
     type AdminPruneTimingIdentity
 } from './admin-prune-inbox-identity.ts';
-import { throwOnAdminPruneValidationIssues, type AdminPruneValidationIssue } from './admin-prune-inbox-validation.ts';
+import { throwOnAdminPruneValidationIssues } from './admin-prune-inbox-validation.ts';
+import {
+    computeAdminPruneMutation,
+    validateAdminPruneMutation,
+    type AdminPruneComputed,
+    type AdminPruneRead
+} from './compute-admin-prune-mutation.ts';
 
 export interface AdminPruneAuthorityReaderInput {
     readonly requestedBy: string;
@@ -102,20 +104,6 @@ export interface AppAdminInboxServiceConfig {
     readonly pageSize: number;
     readonly timing?: RallarTimingSink;
     readonly appInbox: AppInboxOptions;
-}
-
-interface AdminPruneRead {
-    readonly command: AdminPruneCommand;
-    readonly expiredRows: Readonly<Record<AdminPruneExpiredCategory, number>>;
-    readonly authority: AdminPruneAuthority;
-    readonly nowEpochMs: number;
-}
-
-interface AdminPruneComputed {
-    readonly read: AdminPruneRead;
-    readonly result: AdminPruneEnqueueResult;
-    readonly outboxEntries: readonly ResourceEntry[];
-    readonly aggregateEntry: ResourceEntry | null;
 }
 
 export class AppAdminInboxService {
@@ -229,7 +217,7 @@ export class AppAdminInboxService {
 
     private async processCommand(
         value: AdminPruneCommand,
-        context: AppInboxMessageContext<AdminPruneEnqueueResult>
+        context: AppInboxExecutionMetadata
     ): Promise<AdminPruneEnqueueResult> {
         const command = decodeAdminPruneCommand(value);
         await assertAdminPruneQueueIdentity(command, context);
@@ -237,38 +225,35 @@ export class AppAdminInboxService {
         const read = await this.timeAdminPrunePhase(
             'read',
             command,
-            async () => await this.read(command)
+            async () => await this.read(command, context)
         );
-        const computed = await this.timeAdminPrunePhase('compute', command, () => Promise.resolve(this.compute(read)));
+        const computed = await this.timeAdminPrunePhase(
+            'compute',
+            command,
+            () => Promise.resolve(computeAdminPruneMutation(read))
+        );
         const issues = await this.timeAdminPrunePhase(
             'validate',
             command,
-            () => Promise.resolve(this.validate(computed))
+            () => Promise.resolve(validateAdminPruneMutation(read, computed))
         );
         throwOnAdminPruneValidationIssues(issues);
 
-        const result = await this.transactionWriter.writeMutation(context, async (transaction) => {
-            const outbox = new PSqlResourceInboxEntryRepository(transaction);
-            for (const entry of computed.outboxEntries) {
-                await outbox.write(entry);
-            }
-            if (computed.aggregateEntry !== null) {
-                const stored = await new ResourceInboxResultsRepository(
-                    transaction
-                ).writeIfAbsentOrReplaceExpired(computed.aggregateEntry);
-                if (stored.resource !== computed.aggregateEntry.resource) {
-                    throw new Error('Admin prune aggregate collides with an active job');
-                }
-            }
-            return computed.result;
-        });
+        const result = await this.transactionWriter.writeComputedMutation(
+            context,
+            computed.completion,
+            async (transaction) => await this.write(transaction, computed)
+        );
         if (!command.dryRun) {
             this.dependencies.wakeQueueEngine();
         }
         return result;
     }
 
-    private async read(command: AdminPruneCommand): Promise<AdminPruneRead> {
+    private async read(
+        command: AdminPruneCommand,
+        context: AppInboxExecutionMetadata
+    ): Promise<AdminPruneRead> {
         const nowEpochMs = this.config.appInbox.nowEpochMs?.() ?? Date.now();
         const countPairs = ADMIN_PRUNE_EXPIRED_CATEGORIES.map(async (category) => {
             const count = command.categories.includes(category)
@@ -293,79 +278,23 @@ export class AppAdminInboxService {
         for (const [category, count] of pairs) {
             expiredRows[category] = count;
         }
-        return { command, expiredRows, authority, nowEpochMs };
-    }
-
-    private compute(read: AdminPruneRead): AdminPruneComputed {
-        const command = read.command;
-        const results = command.categories.map((category) => ({
-            category,
-            expiredRows: read.expiredRows[category],
-            deletedRows: 0,
-            dryRun: command.dryRun
-        }));
         return {
-            read,
-            outboxEntries: createInitialAdminPrunePages(command, this.serviceId),
-            aggregateEntry: command.dryRun
-                ? null
-                : toAdminPruneAggregateEntry(
-                    createAdminPruneAggregate({
-                        jobId: command.jobId,
-                        generatedAtEpochMs: command.capturedAtEpochMs,
-                        expireAtEpochMs: command.expireAtEpochMs,
-                        serverId: this.serviceId,
-                        requestedBy: command.requestedBy,
-                        requestedSessionId: command.requestedSessionId,
-                        categories: command.categories,
-                        expiredRows: read.expiredRows
-                    })
-                ),
-            result: {
-                generatedAtEpochMs: command.capturedAtEpochMs,
-                serverId: this.serviceId,
-                warnings: [],
-                operation: 'maintenance.prune-expired',
-                status: command.dryRun ? 'dry-run' : 'queued',
-                changed: false,
-                jobId: command.jobId,
-                results
-            }
+            command,
+            expiredRows,
+            authority,
+            nowEpochMs,
+            serviceId: this.serviceId,
+            completionFacts: this.transactionWriter.readCompletionFacts(context)
         };
     }
 
-    private validate(computed: AdminPruneComputed): readonly AdminPruneValidationIssue[] {
-        const { command } = computed.read;
-        const issues: AdminPruneValidationIssue[] = [];
-        if (!computed.read.authority.allowed || command.expireAtEpochMs <= computed.read.nowEpochMs) {
-            issues.push({
-                code: 'admin-prune-authority-denied',
-                message: 'Admin prune current authority is denied',
-                status: 403
-            });
+    private async write(transaction: PSqlSql, computed: AdminPruneComputed): Promise<void> {
+        for (const outboxWrite of computed.outboxWrites) {
+            await writeAppOutboxInsert(transaction, outboxWrite);
         }
-        if (computed.result.jobId !== command.jobId) {
-            issues.push({
-                code: 'admin-prune-computed-identity-invalid',
-                message: 'Admin prune computed identity differs from command',
-                status: 400
-            });
+        if (computed.aggregateWrite !== null) {
+            await writeAdminPruneAggregate(transaction, computed.aggregateWrite);
         }
-        if (computed.outboxEntries.length !== (command.dryRun ? 0 : command.categories.length)) {
-            issues.push({
-                code: 'admin-prune-computed-category-count-invalid',
-                message: 'Admin prune computed category count is invalid',
-                status: 400
-            });
-        }
-        if ((computed.aggregateEntry === null) !== command.dryRun) {
-            issues.push({
-                code: 'admin-prune-aggregate-presence-invalid',
-                message: 'Admin prune aggregate presence is invalid',
-                status: 400
-            });
-        }
-        return issues;
     }
 
     private async toCallerResult(
@@ -455,31 +384,4 @@ function createWaitPolicy(label: string, options: AppInboxOptions): TryWithPolic
             options.waitMaxRetryIntervalMsecs ?? DEFAULT_APP_INBOX_WAIT_MAX_RETRY_INTERVAL_MSECS
         )
         .jitterRatio(options.waitJitterRatio ?? DEFAULT_APP_INBOX_WAIT_JITTER_RATIO);
-}
-
-function createInitialAdminPrunePages(
-    command: AdminPruneCommand,
-    serviceId: string
-): readonly ResourceEntry[] {
-    if (command.dryRun) {
-        return [];
-    }
-    return command.categories.map((category) =>
-        toAdminPruneOutbox(
-            {
-                kind: 'page',
-                jobId: command.jobId,
-                category,
-                requestedBy: command.requestedBy,
-                requestedSessionId: command.requestedSessionId,
-                capturedAtEpochMs: command.capturedAtEpochMs,
-                expireAtEpochMs: command.expireAtEpochMs,
-                pageSize: command.pageSize,
-                afterCursor: null,
-                pageIndex: 0,
-                appData: category === 'app-data' ? command.appData : null
-            },
-            serviceId
-        )
-    );
 }

--- a/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
@@ -1,0 +1,198 @@
+import type { AdminPruneExpiredCategory } from '@shared/api/admin-operations-types.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import {
+    toPgTimestamp,
+    toSystemDate
+} from '../../../queuebox/postgres/resource-inbox-row-codec.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed,
+    type AppInboxCompletionFacts
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import {
+    computeAppOutboxInsert,
+    type AppOutboxInsert
+} from '../../app-outbox/app-outbox-insert.ts';
+import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
+import {
+    createAdminPruneAggregate,
+    toAdminPruneAggregateEntry,
+    toAdminPruneAggregateKey
+} from '../prune/admin-prune-progress.ts';
+import type { AdminPruneCommand } from './admin-prune-command-codec.ts';
+import type { AdminPruneEnqueueResult } from './admin-prune-inbox-codec.ts';
+import type { AdminPruneValidationIssue } from './admin-prune-inbox-validation.ts';
+import type { AdminPruneAuthority } from './app-admin-inbox-service.ts';
+
+export interface AdminPruneRead {
+    readonly command: AdminPruneCommand;
+    readonly expiredRows: Readonly<Record<AdminPruneExpiredCategory, number>>;
+    readonly authority: AdminPruneAuthority;
+    readonly nowEpochMs: number;
+    readonly serviceId: string;
+    readonly completionFacts: AppInboxCompletionFacts;
+}
+
+export interface AdminPruneAggregateWrite {
+    readonly entry: Readonly<ResourceEntry>;
+    readonly systemDate: string;
+    readonly createdAt: string;
+    readonly expiresAt: string;
+}
+
+export interface AdminPruneComputed {
+    readonly result: AdminPruneEnqueueResult;
+    readonly outboxWrites: readonly AppOutboxInsert[];
+    readonly aggregateWrite: AdminPruneAggregateWrite | null;
+    readonly completion: AppInboxCompletionComputed<AdminPruneEnqueueResult>;
+}
+
+export function computeAdminPruneMutation(read: AdminPruneRead): AdminPruneComputed {
+    const command = read.command;
+    const result: AdminPruneEnqueueResult = {
+        generatedAtEpochMs: command.capturedAtEpochMs,
+        serverId: read.serviceId,
+        warnings: [],
+        operation: 'maintenance.prune-expired',
+        status: command.dryRun ? 'dry-run' : 'queued',
+        changed: false,
+        jobId: command.jobId,
+        results: command.categories.map((category) => ({
+            category,
+            expiredRows: read.expiredRows[category],
+            deletedRows: 0,
+            dryRun: command.dryRun
+        }))
+    };
+    return {
+        result,
+        outboxWrites: computeInitialAdminPrunePages(command, read.serviceId),
+        aggregateWrite: command.dryRun
+            ? null
+            : computeAdminPruneAggregateWrite(toAdminPruneAggregateEntry(createAdminPruneAggregate({
+                jobId: command.jobId,
+                generatedAtEpochMs: command.capturedAtEpochMs,
+                expireAtEpochMs: command.expireAtEpochMs,
+                serverId: read.serviceId,
+                requestedBy: command.requestedBy,
+                requestedSessionId: command.requestedSessionId,
+                categories: command.categories,
+                expiredRows: read.expiredRows
+            }))),
+        completion: computeAppInboxCompletion({
+            ...read.completionFacts,
+            durableResult: result,
+            status: EntityStatus.COMPLETED
+        })
+    };
+}
+
+export function validateAdminPruneMutation(
+    read: AdminPruneRead,
+    computed: AdminPruneComputed
+): readonly AdminPruneValidationIssue[] {
+    const issues: AdminPruneValidationIssue[] = [];
+    if (!read.authority.allowed || read.command.expireAtEpochMs <= read.nowEpochMs) {
+        issues.push({
+            code: 'admin-prune-authority-denied',
+            message: 'Admin prune current authority is denied',
+            status: 403
+        });
+    }
+    if (
+        computed.result.jobId !== read.command.jobId ||
+        computed.result.serverId !== read.serviceId ||
+        computed.result.status !== (read.command.dryRun ? 'dry-run' : 'queued')
+    ) {
+        issues.push({
+            code: 'admin-prune-computed-identity-invalid',
+            message: 'Admin prune computed identity differs from its read facts',
+            status: 400
+        });
+    }
+    if (computed.outboxWrites.length !== (read.command.dryRun ? 0 : read.command.categories.length)) {
+        issues.push({
+            code: 'admin-prune-computed-category-count-invalid',
+            message: 'Admin prune computed category count is invalid',
+            status: 400
+        });
+    }
+    if (!hasExpectedAggregateWrite(read, computed.aggregateWrite)) {
+        issues.push({
+            code: 'admin-prune-aggregate-presence-invalid',
+            message: 'Admin prune aggregate write differs from its command',
+            status: 400
+        });
+    }
+    issues.push(
+        ...validateAppInboxCompletion(
+            {
+                ...read.completionFacts,
+                durableResult: computed.result,
+                status: EntityStatus.COMPLETED
+            },
+            computed.completion
+        ).map((issue) => ({
+            code: 'admin-prune-completion-invalid',
+            message: issue.message,
+            status: 500
+        }))
+    );
+    return issues;
+}
+
+function computeInitialAdminPrunePages(
+    command: AdminPruneCommand,
+    serviceId: string
+): readonly AppOutboxInsert[] {
+    if (command.dryRun) {
+        return [];
+    }
+    return command.categories.map((category) =>
+        computeAppOutboxInsert(toAdminPruneOutbox({
+            kind: 'page',
+            jobId: command.jobId,
+            category,
+            requestedBy: command.requestedBy,
+            requestedSessionId: command.requestedSessionId,
+            capturedAtEpochMs: command.capturedAtEpochMs,
+            expireAtEpochMs: command.expireAtEpochMs,
+            pageSize: command.pageSize,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: category === 'app-data' ? command.appData : null
+        }, serviceId))
+    );
+}
+
+function computeAdminPruneAggregateWrite(entry: ResourceEntry): AdminPruneAggregateWrite {
+    const snapshot: Readonly<ResourceEntry> = {
+        ...entry,
+        key: { ...entry.key },
+        audit: { ...entry.audit },
+        dequeueAudit: { ...entry.dequeueAudit }
+    };
+    return {
+        entry: snapshot,
+        systemDate: toSystemDate(snapshot),
+        createdAt: toPgTimestamp(snapshot.audit.createdTs),
+        expiresAt: toPgTimestamp(snapshot.audit.expiryTs)
+    };
+}
+
+function hasExpectedAggregateWrite(
+    read: AdminPruneRead,
+    aggregateWrite: AdminPruneAggregateWrite | null
+): boolean {
+    if (read.command.dryRun) {
+        return aggregateWrite === null;
+    }
+    if (aggregateWrite === null) {
+        return false;
+    }
+    const expectedKey = toAdminPruneAggregateKey(read.command.jobId);
+    return aggregateWrite.entry.key.topicId === expectedKey.topicId &&
+        aggregateWrite.entry.key.resourceId === expectedKey.resourceId &&
+        aggregateWrite.entry.key.contextId === expectedKey.contextId;
+}

--- a/packages/shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts
+++ b/packages/shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts
@@ -1,13 +1,13 @@
-import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { PSqlResourceInboxEntryRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
+import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
-import type { AdminPrunePageWork } from '../prune/admin-prune-page-codec.ts';
+import { writeAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import type { AdminPruneAggregateWrite } from '../inbox/compute-admin-prune-mutation.ts';
 import type {
     AdminPruneCandidatePage,
-    AdminPrunePageComputed,
-    AdminPrunePageRepository
+    AdminPrunePageDelete,
+    AdminPrunePageRepository,
+    AdminPruneProgressWrite
 } from '../prune/admin-prune-page-worker.ts';
 import { decodeAdminPruneAggregate, toAdminPruneAggregateKey } from '../prune/admin-prune-progress.ts';
 
@@ -15,6 +15,14 @@ type RuntimeRow = Readonly<{ store_namespace: string; store_key: string; }>;
 type ResourceRow = Readonly<{ ri_row_id: number | string; }>;
 type ResultsRow = Readonly<{ ris_row_id: number | string; }>;
 type AppDataRow = Readonly<{ store_name: string; data_key: string; }>;
+
+class AdminPruneProgressConflictError extends Error {
+    readonly code = 'admin-prune-progress-conflict';
+
+    constructor() {
+        super('Admin prune aggregate changed before commit');
+    }
+}
 
 export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
     private readonly sql: PSqlSql;
@@ -38,13 +46,12 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
 
     async deletePage(
         transaction: PSqlSql,
-        command: AdminPrunePageWork,
-        rowIds: readonly string[]
+        deletion: AdminPrunePageDelete
     ): Promise<number> {
-        if (rowIds.length === 0) {
+        if (deletion.rowIds.length === 0) {
             return 0;
         }
-        return await deletePageRows(transaction, command, rowIds);
+        return await deletePageRows(transaction, deletion);
     }
 
     async readAggregate(jobId: string) {
@@ -61,20 +68,23 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
         return { aggregate, resource: current.resource };
     }
 
-    async writeOutbox(transaction: PSqlSql, entry: ResourceEntry): Promise<void> {
-        await new PSqlResourceInboxEntryRepository(transaction).write(entry);
+    async writeOutbox(
+        transaction: PSqlSql,
+        computed: Parameters<AdminPrunePageRepository['writeOutbox']>[1]
+    ): Promise<void> {
+        await writeAppOutboxInsert(transaction, computed);
     }
 
     async writeProgress(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed
+        computed: AdminPruneProgressWrite
     ): Promise<void> {
         const next = computed.aggregateSuccessor;
         const key = next.key;
         const rows = await transaction<{ ris_row_id: number | string; }[]>`
             update resource_inbox_results
             set ris_resource = ${next.resource}, ris_status = ${next.status},
-                expire_ts = ${next.audit.expiryTs.toString()}
+                expire_ts = ${computed.aggregateSuccessorExpiryAtIsoTimestamp}
             where ris_topic_id = ${key.topicId}
               and ris_resource_id = ${key.resourceId}
               and fk_ext_bank_id = ${key.contextId}
@@ -82,23 +92,71 @@ export class PSqlAdminPruneRepository implements AdminPrunePageRepository {
             returning ris_row_id
         `;
         if (rows.length !== 1) {
-            throw Object.assign(new Error('Admin prune aggregate changed before commit'), {
-                code: 'admin-prune-progress-conflict'
-            });
+            throw new AdminPruneProgressConflictError();
         }
     }
 
     async finishReserved(
         transaction: PSqlSql,
-        entry: ResourceEntry,
-        finishedAtEpochMs: number
+        completion: Parameters<AdminPrunePageRepository['finishReserved']>[1]
     ): Promise<boolean> {
-        return await new PSqlResourceInboxFinalizationRepository(transaction).finishReserved(
-            entry.key,
-            entry.dequeueAudit.attempts,
-            EntityStatus.COMPLETED,
-            new Date(finishedAtEpochMs)
-        );
+        return await writeResourceInboxReservationFinish(transaction, completion);
+    }
+}
+
+export async function writeAdminPruneAggregate(
+    transaction: PSqlSql,
+    computed: AdminPruneAggregateWrite
+): Promise<void> {
+    const entry = computed.entry;
+    const rows = await transaction<readonly { ris_resource: string; }[]>`
+        insert into resource_inbox_results (ris_resource_id,
+                                            ris_topic_id,
+                                            ris_resource,
+                                            ris_type_id,
+                                            ris_status,
+                                            fk_ext_bank_id,
+                                            system_date,
+                                            created_by,
+                                            created_ts,
+                                            expire_ts)
+        values (${entry.key.resourceId},
+                ${entry.key.topicId},
+                ${entry.resource},
+                ${entry.typeId},
+                ${entry.status},
+                ${entry.key.contextId},
+                ${computed.systemDate},
+                ${entry.audit.createdBy},
+                ${computed.createdAt},
+                ${computed.expiresAt})
+        on conflict (fk_ext_bank_id, ris_resource_id, ris_topic_id)
+            do update set ris_resource = excluded.ris_resource,
+                          ris_type_id  = excluded.ris_type_id,
+                          ris_status   = excluded.ris_status,
+                          system_date  = excluded.system_date,
+                          created_by   = excluded.created_by,
+                          created_ts   = excluded.created_ts,
+                          expire_ts    = excluded.expire_ts
+        where resource_inbox_results.expire_ts <= (now() at time zone 'UTC')
+        returning ris_resource
+    `;
+    if (rows.length > 1) {
+        throw new Error('Admin prune aggregate write returned multiple rows');
+    }
+    const stored = rows[0] ?? (await transaction<readonly { ris_resource: string; }[]>`
+        select ris_resource
+        from resource_inbox_results
+        where ris_topic_id = ${entry.key.topicId}
+          and ris_resource_id = ${entry.key.resourceId}
+          and fk_ext_bank_id = ${entry.key.contextId}
+        limit 1
+    `)[0];
+    if (!stored) {
+        throw new Error('Admin prune aggregate conflict row was not found');
+    }
+    if (stored.ris_resource !== entry.resource) {
+        throw new Error('Admin prune aggregate collides with an active job');
     }
 }
 
@@ -184,21 +242,20 @@ async function readAppDataPage(
 
 async function deletePageRows(
     sql: PSqlSql,
-    command: AdminPrunePageWork,
-    rowIds: readonly string[]
+    deletion: AdminPrunePageDelete
 ): Promise<number> {
-    switch (command.category) {
+    switch (deletion.category) {
         case 'runtime-state': {
             return (await sql<RuntimeRow[]>`
                 with expired as (
                     select value::jsonb ->> 0 as store_namespace,
                            value::jsonb ->> 1 as store_key
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from runtime_state_store target using expired
                 where target.store_namespace = expired.store_namespace
                   and target.store_key = expired.store_key
-                  and expire_at_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_at_ts <= ${deletion.capturedAt}
                 returning target.store_namespace, target.store_key
             `).length;
         }
@@ -206,39 +263,36 @@ async function deletePageRows(
             return (await sql<ResourceRow[]>`
                 with expired as (
                     select value::bigint as ri_row_id
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from resource_inbox target using expired
                 where target.ri_row_id = expired.ri_row_id
-                  and expire_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_ts <= ${deletion.capturedAt}
                 returning target.ri_row_id
             `).length;
         case 'resource-inbox-results':
             return (await sql<ResultsRow[]>`
                 with expired as (
                     select value::bigint as ris_row_id
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from resource_inbox_results target using expired
                 where target.ris_row_id = expired.ris_row_id
-                  and expire_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_ts <= ${deletion.capturedAt}
                 returning target.ris_row_id
             `).length;
         case 'app-data': {
-            if (!command.appData) {
-                throw new TypeError('App-data prune requires namespace');
-            }
             return (await sql<AppDataRow[]>`
                 with expired as (
                     select value::jsonb ->> 0 as store_name,
                            value::jsonb ->> 1 as data_key
-                    from jsonb_array_elements_text(${rowIds}::jsonb)
+                    from jsonb_array_elements_text(${deletion.rowIds}::jsonb)
                 )
                 delete from app_data_store target using expired
-                where target.app_namespace = ${command.appData.namespace}
+                where target.app_namespace = ${deletion.appData.namespace}
                   and target.store_name = expired.store_name
                   and target.data_key = expired.data_key
-                  and expire_at_ts <= ${new Date(command.capturedAtEpochMs)}
+                  and expire_at_ts <= ${deletion.capturedAt}
                 returning target.store_name, target.data_key
             `).length;
         }

--- a/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
+++ b/packages/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts
@@ -1,8 +1,15 @@
 import type { AdminPruneExpiredCategory } from '@shared/api/admin-operations-types.ts';
-import type { Key, ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
+import type { ResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import {
+    computeAppOutboxInsert,
+    type AppOutboxInsert
+} from '../../app-outbox/app-outbox-insert.ts';
+import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import { requireAdminPrunePageSize, type AdminPruneAppData } from '../inbox/admin-prune-command-codec.ts';
 import {
     decodeAdminPruneWork,
@@ -13,7 +20,6 @@ import {
 import {
     advanceAdminPruneAggregate,
     toAdminPruneAggregateEntry,
-    toAdminPruneAggregateKey,
     type AdminPruneAggregate
 } from './admin-prune-progress.ts';
 
@@ -29,19 +35,39 @@ export type AdminPrunePageRead =
         expectedAggregate: string;
         authority: Readonly<{ allowed: boolean; code: string; }>;
         nowEpochMs: number;
+        serviceId: string;
     }>;
 
-export type AdminPrunePageComputed = Readonly<{
-    kind: 'page';
-    jobId: string;
-    category: AdminPruneExpiredCategory;
-    rowIds: readonly string[];
-    deletedRows: number;
-    next: AdminPrunePageWork | null;
+interface AdminPrunePageDeleteBase {
+    readonly rowIds: readonly string[];
+    readonly capturedAt: Date;
+}
+
+export type AdminPrunePageDelete =
+    | Readonly<AdminPrunePageDeleteBase & { category: 'runtime-state'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'resource-inbox'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'resource-inbox-results'; }>
+    | Readonly<AdminPrunePageDeleteBase & { category: 'app-data'; appData: AdminPruneAppData; }>;
+
+export type AdminPruneProgressWrite = Readonly<{
     expectedAggregate: string;
     aggregateSuccessor: ResourceEntry;
-    finishedAtEpochMs: number;
+    aggregateSuccessorExpiryAtIsoTimestamp: string;
 }>;
+
+export type AdminPrunePageComputed =
+    & AdminPruneProgressWrite
+    & Readonly<{
+        kind: 'page';
+        jobId: string;
+        category: AdminPruneExpiredCategory;
+        rowIds: readonly string[];
+        deletedRows: number;
+        deletion: AdminPrunePageDelete;
+        next: AdminPrunePageWork | null;
+        successorOutboxWrite: AppOutboxInsert | null;
+        reservationFinish: ResourceInboxReservationFinish;
+    }>;
 
 export type AdminPrunePageRepository = Readonly<{
     readPage(
@@ -62,18 +88,16 @@ export type AdminPrunePageRepository = Readonly<{
     >;
     deletePage(
         transaction: PSqlSql,
-        command: AdminPrunePageWork,
-        rowIds: readonly string[]
+        deletion: AdminPrunePageDelete
     ): Promise<number>;
-    writeOutbox(transaction: PSqlSql, entry: ResourceEntry): Promise<void>;
+    writeOutbox(transaction: PSqlSql, computed: AppOutboxInsert): Promise<void>;
     writeProgress(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed
+        computed: AdminPruneProgressWrite
     ): Promise<void>;
     finishReserved(
         transaction: PSqlSql,
-        entry: ResourceEntry,
-        finishedAtEpochMs: number
+        completion: ResourceInboxReservationFinish
     ): Promise<boolean>;
 }>;
 
@@ -133,7 +157,8 @@ export class AdminPrunePageWorker {
             aggregate: aggregateRead.aggregate,
             expectedAggregate: aggregateRead.resource,
             authority,
-            nowEpochMs
+            nowEpochMs,
+            serviceId: this.options.serviceId
         };
     }
 
@@ -141,17 +166,6 @@ export class AdminPrunePageWorker {
         command: ReservedAdminPrunePageWork,
         read: AdminPrunePageRead
     ): AdminPrunePageComputed {
-        if (
-            !read.authority.allowed ||
-            command.expireAtEpochMs <= read.nowEpochMs ||
-            read.aggregate.requestedBy !== command.requestedBy ||
-            read.aggregate.requestedSessionId !== command.requestedSessionId
-        ) {
-            throw Object.assign(new Error('Admin prune current authority is denied'), {
-                code: 'admin-prune-authority-denied',
-                status: 403
-            });
-        }
         const cursor = read.rowIds.at(-1) ?? command.afterCursor;
         const next = read.hasMore && cursor !== null
             ? {
@@ -168,28 +182,40 @@ export class AdminPrunePageWorker {
                 appData: command.appData
             }
             : null;
+        const deletion = toAdminPrunePageDelete(command, read.rowIds);
         const page = {
             kind: 'page',
             jobId: command.jobId,
             category: command.category,
-            rowIds: read.rowIds,
-            deletedRows: read.rowIds.length,
+            rowIds: deletion.rowIds,
+            deletedRows: deletion.rowIds.length,
+            deletion,
             next
         } as const;
         const aggregate = advanceAdminPruneAggregate(read.aggregate, page);
+        const aggregateSuccessor = toAdminPruneAggregateEntry(
+            {
+                ...aggregate,
+                expireAtEpochMs: Math.max(
+                    aggregate.expireAtEpochMs,
+                    resourceInboxRetryExpiryAtEpochMs(read.nowEpochMs)
+                )
+            }
+        );
         return {
             ...page,
+            successorOutboxWrite: next
+                ? computeAppOutboxInsert(toAdminPruneOutbox(next, read.serviceId))
+                : null,
             expectedAggregate: read.expectedAggregate,
-            aggregateSuccessor: toAdminPruneAggregateEntry(
-                {
-                    ...aggregate,
-                    expireAtEpochMs: Math.max(
-                        aggregate.expireAtEpochMs,
-                        resourceInboxRetryExpiryAtEpochMs(read.nowEpochMs)
-                    )
-                }
-            ),
-            finishedAtEpochMs: read.nowEpochMs
+            aggregateSuccessor,
+            aggregateSuccessorExpiryAtIsoTimestamp: aggregateSuccessor.audit.expiryTs.toString(),
+            reservationFinish: {
+                key: command.reservation.key,
+                expectedAttempts: command.reservation.dequeueAudit.attempts,
+                status: EntityStatus.COMPLETED,
+                completedAt: new Date(read.nowEpochMs)
+            }
         };
     }
 
@@ -198,47 +224,39 @@ export class AdminPrunePageWorker {
         read: AdminPrunePageRead,
         computed: AdminPrunePageComputed
     ): void {
-        const aggregateKey = toAdminPruneAggregateKey(command.jobId);
-        if (computed.jobId !== command.jobId || computed.category !== command.category) {
-            throw new TypeError('Admin prune computed identity differs from command');
+        if (
+            !read.authority.allowed ||
+            command.expireAtEpochMs <= read.nowEpochMs ||
+            read.aggregate.requestedBy !== command.requestedBy ||
+            read.aggregate.requestedSessionId !== command.requestedSessionId
+        ) {
+            throw Object.assign(new Error('Admin prune current authority is denied'), {
+                code: 'admin-prune-authority-denied',
+                status: 403
+            });
         }
-        if (read.rowIds.length > command.pageSize || computed.deletedRows !== read.rowIds.length) {
+        if (read.rowIds.length > command.pageSize) {
             throw new TypeError('Admin prune computed page exceeds its command');
         }
-        if (
-            computed.expectedAggregate !== read.expectedAggregate ||
-            computed.aggregateSuccessor.key.topicId !== aggregateKey.topicId ||
-            computed.aggregateSuccessor.key.resourceId !== aggregateKey.resourceId ||
-            computed.aggregateSuccessor.key.contextId !== aggregateKey.contextId
-        ) {
-            throw new TypeError('Admin prune computed aggregate differs from read predecessor');
+        const expected = this.compute(command, read);
+        if (!jsonEquals(toAdminPrunePagePersistence(computed), toAdminPrunePagePersistence(expected))) {
+            throw new TypeError('Admin prune computed persistence differs from read facts');
         }
     }
 
     async write(
         transaction: PSqlSql,
-        computed: AdminPrunePageComputed,
-        entry: ResourceEntry
+        computed: AdminPrunePageComputed
     ): Promise<void> {
-        const command = decodeAdminPruneWork(entry);
         await this.options.repository.writeProgress(transaction, computed);
-        const deleted = await this.options.repository.deletePage(transaction, command, computed.rowIds);
+        const deleted = await this.options.repository.deletePage(transaction, computed.deletion);
         if (deleted !== computed.deletedRows) {
             throw new Error('Admin prune page changed before delete');
         }
-        if (computed.next) {
-            await this.options.repository.writeOutbox(
-                transaction,
-                toAdminPruneOutbox(computed.next, this.options.serviceId)
-            );
+        if (computed.successorOutboxWrite !== null) {
+            await this.options.repository.writeOutbox(transaction, computed.successorOutboxWrite);
         }
-        if (
-            !await this.options.repository.finishReserved(
-                transaction,
-                entry,
-                computed.finishedAtEpochMs
-            )
-        ) {
+        if (!await this.options.repository.finishReserved(transaction, computed.reservationFinish)) {
             throw new Error('Admin prune reservation changed before commit');
         }
     }
@@ -249,8 +267,119 @@ export class AdminPrunePageWorker {
         const computed = this.compute(command, read);
         this.validate(command, read, computed);
         await runInPSqlTransaction(this.options.database, async (transaction) => {
-            await this.write(transaction, computed, entry);
+            await this.write(transaction, computed);
         });
         this.options.wakeQueue?.();
+    }
+}
+
+function toAdminPrunePagePersistence(computed: AdminPrunePageComputed): JsonWireValue {
+    return {
+        kind: computed.kind,
+        jobId: computed.jobId,
+        category: computed.category,
+        rowIds: computed.rowIds,
+        deletedRows: computed.deletedRows,
+        deletion: {
+            category: computed.deletion.category,
+            rowIds: computed.deletion.rowIds,
+            capturedAtEpochMs: computed.deletion.capturedAt.getTime(),
+            appData: computed.deletion.category === 'app-data' ? computed.deletion.appData : null
+        },
+        next: computed.next === null
+            ? null
+            : {
+                kind: computed.next.kind,
+                jobId: computed.next.jobId,
+                category: computed.next.category,
+                requestedBy: computed.next.requestedBy,
+                requestedSessionId: computed.next.requestedSessionId,
+                capturedAtEpochMs: computed.next.capturedAtEpochMs,
+                expireAtEpochMs: computed.next.expireAtEpochMs,
+                pageSize: computed.next.pageSize,
+                afterCursor: computed.next.afterCursor,
+                pageIndex: computed.next.pageIndex,
+                appData: computed.next.appData === null
+                    ? null
+                    : {
+                        namespace: computed.next.appData.namespace,
+                        storeName: computed.next.appData.storeName
+                    }
+            },
+        successorOutboxWrite: computed.successorOutboxWrite === null
+            ? null
+            : toAppOutboxPersistence(computed.successorOutboxWrite),
+        expectedAggregate: computed.expectedAggregate,
+        aggregateSuccessor: toResourceEntryPersistence(computed.aggregateSuccessor),
+        aggregateSuccessorExpiryAtIsoTimestamp: computed.aggregateSuccessorExpiryAtIsoTimestamp,
+        reservationFinish: {
+            key: computed.reservationFinish.key,
+            expectedAttempts: computed.reservationFinish.expectedAttempts,
+            status: computed.reservationFinish.status,
+            completedAtEpochMs: computed.reservationFinish.completedAt.getTime()
+        }
+    };
+}
+
+function toAppOutboxPersistence(computed: AppOutboxInsert): JsonWireValue {
+    return {
+        entry: toResourceEntryPersistence(computed.entry),
+        systemDate: computed.systemDate,
+        createdAt: computed.createdAt,
+        expiresAt: computed.expiresAt,
+        startedAt: computed.startedAt,
+        finishedAt: computed.finishedAt,
+        nextAt: computed.nextAt,
+        attempts: computed.attempts,
+        conflict: {
+            name: computed.conflict.name,
+            message: computed.conflict.message,
+            code: computed.conflict.code,
+            status: computed.conflict.status,
+            key: computed.conflict.key
+        }
+    };
+}
+
+function toResourceEntryPersistence(entry: Readonly<ResourceEntry>): JsonWireValue {
+    return {
+        key: entry.key,
+        resource: entry.resource,
+        typeId: entry.typeId,
+        status: entry.status,
+        audit: {
+            date: entry.audit.date.toString(),
+            createdBy: entry.audit.createdBy,
+            createdTs: entry.audit.createdTs.toString(),
+            expiryTs: entry.audit.expiryTs.toString()
+        },
+        dequeueAudit: {
+            attempts: entry.dequeueAudit.attempts,
+            startTs: entry.dequeueAudit.startTs?.toString() ?? null,
+            endTs: entry.dequeueAudit.endTs?.toString() ?? null,
+            nextTs: entry.dequeueAudit.nextTs?.toString() ?? null
+        },
+        db: entry.db ?? null
+    };
+}
+
+export function toAdminPrunePageDelete(
+    command: AdminPrunePageWork,
+    rowIds: readonly string[]
+): AdminPrunePageDelete {
+    const base = {
+        rowIds: [...rowIds],
+        capturedAt: new Date(command.capturedAtEpochMs)
+    };
+    switch (command.category) {
+        case 'runtime-state':
+        case 'resource-inbox':
+        case 'resource-inbox-results':
+            return { ...base, category: command.category };
+        case 'app-data':
+            if (!command.appData) {
+                throw new TypeError('App-data prune requires namespace');
+            }
+            return { ...base, category: command.category, appData: command.appData };
     }
 }

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
@@ -1,0 +1,156 @@
+import { Temporal } from '@js-temporal/polyfill';
+import {
+    EntityStatus,
+    toResourceEntryWithUpdatedResource,
+    type ResourceEntry
+} from '@shared/queuebox/ResourceEntry.ts';
+import type { ResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import {
+    computeResourceInboxResultReplacement,
+    type ResourceInboxResultReplacement
+} from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
+import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
+import { AppInboxReservationConflictError } from '../app-inbox-contracts.ts';
+import { encodeAppInboxResult } from '../app-inbox-registration-codecs.ts';
+
+export interface AppInboxCompletionValidationIssue {
+    readonly path: string;
+    readonly message: string;
+    readonly cause: TypeError;
+}
+
+export interface AppInboxCompletionFacts {
+    readonly entry: ResourceEntry;
+    readonly completedAtEpochMs: number;
+}
+
+export interface AppInboxCompletionInput<Result> extends AppInboxCompletionFacts {
+    readonly durableResult: Result;
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+}
+
+export interface AppInboxCompletionValidationFacts extends AppInboxCompletionFacts {
+    readonly status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED;
+}
+
+export interface AppInboxCompletionComputed<Result> {
+    readonly durableResult: Result;
+    readonly encodedResult: JsonWireValue;
+    readonly resultReplacement: ResourceInboxResultReplacement;
+    readonly reservationFinish: ResourceInboxReservationFinish;
+    readonly reservationConflict: AppInboxReservationConflictError;
+    readonly finalizedEntry: ResourceEntry;
+}
+
+export function computeAppInboxCompletion<Result>(
+    input: AppInboxCompletionInput<Result>
+): AppInboxCompletionComputed<Result> {
+    const encodedResult = encodeAppInboxResult(input.durableResult, 'AppInbox completion result');
+    return {
+        durableResult: input.durableResult,
+        encodedResult,
+        resultReplacement: computeResourceInboxResultReplacement(
+            toResourceEntryWithUpdatedResource(input.entry, input.status, encodedResult)
+        ),
+        reservationFinish: {
+            key: input.entry.key,
+            expectedAttempts: input.entry.dequeueAudit.attempts,
+            status: input.status,
+            completedAt: new Date(input.completedAtEpochMs)
+        },
+        reservationConflict: new AppInboxReservationConflictError(input.entry.key),
+        finalizedEntry: {
+            ...input.entry,
+            status: input.status,
+            dequeueAudit: {
+                ...input.entry.dequeueAudit,
+                endTs: Temporal.Instant.fromEpochMilliseconds(input.completedAtEpochMs),
+                nextTs: undefined
+            }
+        }
+    };
+}
+
+export function validateAppInboxCompletion<Result>(
+    input: AppInboxCompletionInput<Result>,
+    computed: AppInboxCompletionComputed<Result>
+): readonly AppInboxCompletionValidationIssue[] {
+    const issues = validateAppInboxCompletionFacts(input);
+    if (computed.durableResult !== input.durableResult) {
+        issues.push(toAppInboxCompletionValidationIssue('computed.durableResult', 'must be the computed result'));
+    }
+    if (
+        !hasSameResourceInboxKey(computed.reservationFinish.key, input.entry.key) ||
+        computed.reservationFinish.expectedAttempts !== input.entry.dequeueAudit.attempts ||
+        computed.reservationFinish.status !== input.status ||
+        computed.reservationFinish.completedAt.getTime() !== input.completedAtEpochMs
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.reservationFinish',
+            'must match the reserved entry and completion facts'
+        ));
+    }
+    if (
+        computed.resultReplacement.resourceId !== input.entry.key.resourceId ||
+        computed.resultReplacement.topicId !== input.entry.key.topicId ||
+        computed.resultReplacement.contextId !== input.entry.key.contextId ||
+        computed.resultReplacement.status !== input.status
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.resultReplacement',
+            'must target the reserved entry with the computed status'
+        ));
+    }
+    if (
+        !hasSameResourceInboxKey(computed.finalizedEntry.key, input.entry.key) ||
+        computed.finalizedEntry.status !== input.status ||
+        computed.finalizedEntry.dequeueAudit.endTs?.epochMilliseconds !== input.completedAtEpochMs ||
+        computed.finalizedEntry.dequeueAudit.nextTs !== undefined
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.finalizedEntry',
+            'must describe the completed reservation'
+        ));
+    }
+    return issues;
+}
+
+export function validateAppInboxCompletionFacts(
+    input: AppInboxCompletionValidationFacts
+): AppInboxCompletionValidationIssue[] {
+    const issues: AppInboxCompletionValidationIssue[] = [];
+    if (!Number.isSafeInteger(input.completedAtEpochMs) || Math.abs(input.completedAtEpochMs) > 8.64e15) {
+        issues.push(
+            toAppInboxCompletionValidationIssue('completedAtEpochMs', 'must be a valid epoch millisecond timestamp')
+        );
+    }
+    if (!Number.isSafeInteger(input.entry.dequeueAudit.attempts) || input.entry.dequeueAudit.attempts < 1) {
+        issues.push(
+            toAppInboxCompletionValidationIssue('entry.dequeueAudit.attempts', 'must identify a reserved attempt')
+        );
+    }
+    if (input.entry.status !== EntityStatus.RESERVED) {
+        issues.push(toAppInboxCompletionValidationIssue('entry.status', 'must be RESERVED'));
+    }
+    if (input.status !== EntityStatus.COMPLETED && input.status !== EntityStatus.FAILED) {
+        issues.push(toAppInboxCompletionValidationIssue('status', 'must be COMPLETED or FAILED'));
+    }
+    return issues;
+}
+
+function hasSameResourceInboxKey(
+    left: ResourceEntry['key'],
+    right: ResourceEntry['key']
+): boolean {
+    return left.topicId === right.topicId &&
+        left.resourceId === right.resourceId &&
+        left.contextId === right.contextId;
+}
+
+function toAppInboxCompletionValidationIssue(
+    path: string,
+    reason: string
+): AppInboxCompletionValidationIssue {
+    const message = `AppInbox ${path} ${reason}`;
+    return { path, message, cause: new TypeError(message) };
+}

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.ts
@@ -16,12 +16,12 @@ import {
 import { AppInboxCommandIdentityError, validateAppInboxCommandIdentity } from '../app-inbox-command-identity.ts';
 import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../app-inbox-contracts.ts';
 import { classifyAppInboxError, type AppInboxErrorClassification } from '../app-inbox-error-classification.ts';
-import { encodeAppInboxFailure } from '../app-inbox-failure.ts';
 import type { AppInboxOptions } from '../app-inbox-options.ts';
 import type { AppInboxResultRepository } from '../app-inbox-persistence-ports.ts';
 import { toAppInboxAttemptTimingDetails, toAppInboxTimingDetails } from './app-inbox-attempt-timing.ts';
+import { computeAppInboxCompletion, validateAppInboxCompletion } from './app-inbox-completion-computation.ts';
 import type { AppInboxHandlerRegistration } from './app-inbox-handler-registration.ts';
-import { AppInboxTransactionWriter, toFinalizedResourceEntry } from './app-inbox-transaction-writer.ts';
+import { AppInboxTransactionWriter } from './app-inbox-transaction-writer.ts';
 
 interface AppInboxExecutionAttempt<Command, Result> {
     readonly registration: AppInboxHandlerRegistration<Command, Result>;
@@ -200,16 +200,19 @@ export class AppInboxHandlerExecutor {
             entry: input.entry,
             encodeResult: input.registration.encodeResult
         };
-        await this.transactionWriter.writeTerminalFailure(
-            terminalContext,
-            encodeAppInboxFailure(input.classification.result)
-        );
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(terminalContext),
+            durableResult: input.classification.result,
+            status: EntityStatus.FAILED
+        } as const;
+        const computed = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        await this.transactionWriter.writeComputedTerminalFailure(terminalContext, computed);
         throw new ResourceInboxFinalizedByHandlerError(
-            toFinalizedResourceEntry(
-                terminalContext,
-                EntityStatus.FAILED,
-                this.nowEpochMs()
-            ),
+            computed.finalizedEntry,
             input.error
         );
     }

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
@@ -7,6 +7,8 @@ import {
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
 import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
+import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
+import { writeResourceInboxResultReplacement } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
 import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
 import type { RallarTimingDetails, RallarTimingSink } from '../../observability/timing.ts';
 import { timeRallarAsync } from '../../observability/timing.ts';
@@ -17,6 +19,7 @@ import {
     type AppInboxMessageContext
 } from '../app-inbox-contracts.ts';
 import { toAppInboxAttemptTimingDetails } from './app-inbox-attempt-timing.ts';
+import type { AppInboxCompletionComputed, AppInboxCompletionFacts } from './app-inbox-completion-computation.ts';
 
 export type AppInboxHandlerFinalization =
     | Readonly<{ state: 'pending'; }>
@@ -32,6 +35,20 @@ export interface AppInboxMutationTransactionResult<DurableResult, AfterCommitRes
 }
 
 export interface AppInboxMutationTransactionWriter {
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
+
+    writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result>;
+
+    writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
+
     writeMutation<Result>(
         context: AppInboxMessageContext<Result>,
         write: (transaction: PSqlSql) => Promise<Result>
@@ -76,12 +93,37 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         this.config = config;
     }
 
-    begin<Result>(context: AppInboxMessageContext<Result>): void {
+    begin(context: AppInboxExecutionMetadata): void {
         this.finalizationByContext.set(context, { state: 'pending' });
     }
 
-    read<Result>(context: AppInboxMessageContext<Result>): AppInboxHandlerFinalization {
+    read(context: AppInboxExecutionMetadata): AppInboxHandlerFinalization {
         return this.finalizationByContext.get(context) ?? { state: 'pending' };
+    }
+
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        return {
+            entry: context.entry,
+            completedAtEpochMs: this.nowEpochMs()
+        };
+    }
+
+    async writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result> {
+        await this.writeComputedFinalizedMutation(context, computed, write);
+        return computed.durableResult;
+    }
+
+    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
+        const afterCommitResult = await this.writeComputedFinalizedMutation(context, computed, write);
+        return { durableResult: computed.durableResult, afterCommitResult };
     }
 
     async writeMutation<Result>(
@@ -175,7 +217,37 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         });
     }
 
-    private ensurePending<Result>(context: AppInboxMessageContext<Result>): void {
+    async writeComputedTerminalFailure<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>
+    ): Promise<void> {
+        await this.writeComputedFinalizedMutation(context, computed, async () => {});
+    }
+
+    private async writeComputedFinalizedMutation<DurableResult, WriteResult>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<DurableResult>,
+        write: (transaction: PSqlSql) => Promise<WriteResult>
+    ): Promise<WriteResult> {
+        this.ensurePending(context);
+        const result = await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
+            const writeResult = await write(transaction);
+            await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
+            const completed = await writeResourceInboxReservationFinish(transaction, computed.reservationFinish);
+            if (!completed) {
+                throw computed.reservationConflict;
+            }
+            return writeResult;
+        });
+        this.finalizationByContext.set(context, {
+            state: 'transaction-finalized',
+            status: computed.reservationFinish.status,
+            result: computed.encodedResult
+        });
+        return result;
+    }
+
+    private ensurePending(context: AppInboxExecutionMetadata): void {
         const current = this.finalizationByContext.get(context);
         if (current?.state === 'transaction-finalized') {
             throw new Error('App inbox handler context is already finalized');
@@ -185,8 +257,8 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         }
     }
 
-    private async inTransaction<ReturnResult, Result>(
-        context: AppInboxMessageContext<Result>,
+    private async inTransaction<ReturnResult>(
+        context: AppInboxExecutionMetadata,
         details: RallarTimingDetails,
         write: (
             transaction: PSqlSql,

--- a/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
+++ b/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
@@ -1,0 +1,90 @@
+import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
+import { ResourceInboxInvariantCorruptionError } from '../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import {
+    toPgTimestamp,
+    toSystemDate
+} from '../../queuebox/postgres/resource-inbox-row-codec.ts';
+
+export interface AppOutboxInsert {
+    readonly entry: Readonly<ResourceEntry>;
+    readonly systemDate: string;
+    readonly createdAt: string;
+    readonly expiresAt: string;
+    readonly startedAt: string | null;
+    readonly finishedAt: string | null;
+    readonly nextAt: string | null;
+    readonly attempts: number;
+    readonly conflict: ResourceInboxInvariantCorruptionError;
+}
+
+export function computeAppOutboxInsert(entry: ResourceEntry): AppOutboxInsert {
+    const snapshot: Readonly<ResourceEntry> = {
+        ...entry,
+        key: { ...entry.key },
+        audit: { ...entry.audit },
+        dequeueAudit: { ...entry.dequeueAudit },
+        ...(entry.db === undefined ? {} : { db: { ...entry.db } })
+    };
+    return {
+        entry: snapshot,
+        systemDate: toSystemDate(snapshot),
+        createdAt: toPgTimestamp(snapshot.audit.createdTs),
+        expiresAt: toPgTimestamp(snapshot.audit.expiryTs),
+        startedAt: snapshot.dequeueAudit.startTs ? toPgTimestamp(snapshot.dequeueAudit.startTs) : null,
+        finishedAt: snapshot.dequeueAudit.endTs ? toPgTimestamp(snapshot.dequeueAudit.endTs) : null,
+        nextAt: snapshot.dequeueAudit.nextTs ? toPgTimestamp(snapshot.dequeueAudit.nextTs) : null,
+        attempts: snapshot.dequeueAudit.attempts,
+        conflict: new ResourceInboxInvariantCorruptionError(
+            snapshot.key,
+            'App outbox insert did not create exactly one row'
+        )
+    };
+}
+
+export async function writeAppOutboxInsert(transaction: PSqlSql, computed: AppOutboxInsert): Promise<void> {
+    if (!await insertAppOutboxRow(transaction, computed)) {
+        throw computed.conflict;
+    }
+}
+
+async function insertAppOutboxRow(transaction: PSqlSql, computed: AppOutboxInsert): Promise<boolean> {
+    const entry = computed.entry;
+    const inserted = await transaction<readonly { ri_row_id: bigint; }[]>`
+        insert into resource_inbox (ri_resource_id,
+                                    ri_topic_id,
+                                    ri_resource,
+                                    ri_type_id,
+                                    ri_status,
+                                    fk_ext_bank_id,
+                                    system_date,
+                                    created_by,
+                                    created_ts,
+                                    expire_ts,
+                                    start_ts,
+                                    end_ts,
+                                    next_ts,
+                                    ri_attempts)
+        values (${entry.key.resourceId},
+                ${entry.key.topicId},
+                ${entry.resource},
+                ${entry.typeId},
+                ${entry.status},
+                ${entry.key.contextId},
+                ${computed.systemDate},
+                ${entry.audit.createdBy},
+                ${computed.createdAt},
+                ${computed.expiresAt},
+                ${computed.startedAt},
+                ${computed.finishedAt},
+                ${computed.nextAt},
+                ${computed.attempts})
+        on conflict (fk_ext_bank_id, ri_resource_id, ri_topic_id) do nothing
+        returning ri_row_id
+    `;
+    if (inserted.length > 1) {
+        throw computed.conflict;
+    }
+    return inserted.length === 1;
+}

--- a/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
+++ b/packages/shared-server/rallar-system/crdt/inbox/app-crdt-inbox-service.ts
@@ -11,7 +11,7 @@ import type { ResourceInboxResultsRepository } from '../../../queuebox/postgres/
 import {
     AppInboxIdempotencyConflictError,
     AppInboxType,
-    type AppInboxMessageContext
+    type AppInboxExecutionMetadata
 } from '../../app-inbox/app-inbox-contracts.ts';
 import type { AppInboxFailure } from '../../app-inbox/app-inbox-failure.ts';
 import type { AppInboxOptions } from '../../app-inbox/app-inbox-options.ts';
@@ -36,6 +36,8 @@ import {
 } from '../mutation/crdt-mutation-contracts.ts';
 import type { CrdtMutationService } from '../mutation/create-crdt-mutation-service.ts';
 import { decodeCrdtMutationResult } from '../mutation/decode-crdt-mutation-result.ts';
+import { writePSqlCrdtMutation } from '../persistence/psql-crdt-mutation-repository.ts';
+import { computeCrdtInboxMutation, validateCrdtInboxMutation } from './compute-crdt-inbox-mutation.ts';
 import { CrdtHttpAdminRejectionError } from './crdt-http-admin-rejection-error.ts';
 import {
     createAndEnqueueAuthenticatedCrdtAppend,
@@ -134,12 +136,17 @@ export class AppCrdtInboxService {
         if (dependencies.auditDelivery !== undefined) {
             registerCrdtAuditDelivery(dependencies.auditDelivery);
         }
+        const processCrdtCommand = async (
+            command: CrdtMutationCommand,
+            context: AppInboxExecutionMetadata
+        ) => await this.processCommand(command, context);
+        const encodeCrdtResult = (result: CrdtMutationResult) => encodeAppInboxResult(result, 'CRDT AppInbox result');
         for (const type of CRDT_MUTATION_INBOX_TYPES) {
             this.handlers.registerHandler({
                 type,
                 decodeCommand: decodeCrdtMutationCommand,
-                encodeResult: (result) => encodeAppInboxResult(result, 'CRDT AppInbox result'),
-                handle: async (command, context) => await this.processCommand(command, context)
+                encodeResult: encodeCrdtResult,
+                handle: processCrdtCommand
             });
         }
         this.handlers.assertRegistrationComplete(CRDT_MUTATION_INBOX_TYPES);
@@ -270,22 +277,30 @@ export class AppCrdtInboxService {
 
     private async processCommand(
         command: CrdtMutationCommand,
-        appInboxContext: AppInboxMessageContext<CrdtMutationResult>
+        appInboxContext: AppInboxExecutionMetadata
     ): Promise<CrdtMutationResult> {
         assertCrdtAppInboxIdentity({ command, appInboxContext });
 
-        const read = await this.mutationService.read(command);
-        const computed = this.mutationService.compute({ command, read });
-        const issues = this.mutationService.validate({ command, read, computed });
+        const read = {
+            command,
+            read: await this.mutationService.read(command),
+            serviceId: this.serviceId,
+            completionFacts: this.transactionWriter.readCompletionFacts(appInboxContext)
+        };
+        const computed = computeCrdtInboxMutation(read);
+        const issues = validateCrdtInboxMutation(read, computed);
         if (issues[0] !== undefined) {
             throw new TypeError(issues[0].message);
         }
-        if (computed.outcome === 'rejected' && isCrdtHttpAdminIdentity({ command, appInboxContext })) {
-            throw toCrdtHttpAdminRejection(computed.code);
+        if (computed.mutation.outcome === 'rejected' && isCrdtHttpAdminIdentity({ command, appInboxContext })) {
+            throw toCrdtHttpAdminRejection(computed.mutation.code);
         }
-        const result = await this.transactionWriter.writeMutation(
+        const result = await this.transactionWriter.writeComputedMutation(
             appInboxContext,
-            async (transaction) => await this.mutationService.write(transaction, computed)
+            computed.completion,
+            async (transaction) => {
+                await writePSqlCrdtMutation(transaction, computed.mutation);
+            }
         );
         if (result.operation === 'erase' && result.status === 'accepted') {
             this.wakeQueueEngine();
@@ -300,7 +315,7 @@ function toCrdtHttpAdminRejection(reasonCode: string): Error {
 
 interface AssertCrdtAppInboxIdentityInput {
     readonly command: CrdtMutationCommand;
-    readonly appInboxContext: AppInboxMessageContext<CrdtMutationResult>;
+    readonly appInboxContext: AppInboxExecutionMetadata;
 }
 
 function assertCrdtAppInboxIdentity(input: AssertCrdtAppInboxIdentityInput): void {

--- a/packages/shared-server/rallar-system/crdt/inbox/compute-crdt-inbox-mutation.ts
+++ b/packages/shared-server/rallar-system/crdt/inbox/compute-crdt-inbox-mutation.ts
@@ -1,0 +1,56 @@
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
+
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed,
+    type AppInboxCompletionFacts
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import { computeCrdtMutation, type ComputeCrdtMutationInput } from '../mutation/compute-crdt-mutation.ts';
+import type {
+    CrdtMutationComputed,
+    CrdtMutationResult,
+    CrdtMutationValidationIssue
+} from '../mutation/crdt-mutation-contracts.ts';
+import { validateCrdtMutation } from '../mutation/validate-crdt-mutation.ts';
+
+export interface CrdtInboxMutationRead extends ComputeCrdtMutationInput {
+    readonly completionFacts: AppInboxCompletionFacts;
+}
+
+export interface CrdtInboxMutationComputed {
+    readonly mutation: CrdtMutationComputed;
+    readonly completion: AppInboxCompletionComputed<CrdtMutationResult>;
+}
+
+export function computeCrdtInboxMutation(read: CrdtInboxMutationRead): CrdtInboxMutationComputed {
+    const mutation = computeCrdtMutation(read);
+    const completion = computeAppInboxCompletion({
+        ...read.completionFacts,
+        durableResult: mutation.result,
+        status: EntityStatus.COMPLETED
+    });
+    return { mutation, completion };
+}
+
+export function validateCrdtInboxMutation(
+    read: CrdtInboxMutationRead,
+    computed: CrdtInboxMutationComputed
+): readonly CrdtMutationValidationIssue[] {
+    const issues = [...validateCrdtMutation({
+        command: read.command,
+        read: read.read,
+        computed: computed.mutation
+    })];
+    issues.push(
+        ...validateAppInboxCompletion({
+            ...read.completionFacts,
+            durableResult: computed.mutation.result,
+            status: EntityStatus.COMPLETED
+        }, computed.completion).map((issue) => ({
+            code: 'completion-invalid',
+            message: issue.message
+        }))
+    );
+    return issues;
+}

--- a/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
@@ -5,7 +5,9 @@ import type {
     RallarCrdtTrustedAppendMetadata
 } from '@shared/crdt/mod.ts';
 
+import { computeAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
 import { appendRejectionReason, isAppendRejectionRetryable, toAppendRejectionCode } from './crdt-append-rejection.ts';
+import { CrdtMutationConflictError } from './crdt-mutation-contracts.ts';
 import type {
     CrdtAppendCommand,
     CrdtCanonicalSnapshotEnvelope,
@@ -14,7 +16,9 @@ import type {
     CrdtMutationComputedRejected,
     CrdtMutationComputedReplay,
     CrdtMutationComputedWrite,
-    CrdtMutationRead
+    CrdtMutationRead,
+    CrdtSnapshotWrite,
+    CrdtUpdateWrite
 } from './crdt-mutation-contracts.ts';
 import {
     createAcceptedCrdtAdministrationMutationResult,
@@ -34,7 +38,6 @@ export interface ComputeCrdtAcceptedAppendOutcomeInput {
     readonly append: RallarCrdtTrustedAppendMetadata;
     readonly serviceId: string;
 }
-
 export interface ComputeCrdtReplayOutcomeInput {
     readonly command: CrdtAppendCommand;
     readonly read: CrdtMutationRead;
@@ -82,6 +85,7 @@ interface CrdtMutationComputedBaseValues<TDocument extends RallarCrdtDocumentMet
     readonly append: CrdtMutationComputed['append'];
     readonly snapshot: CrdtCanonicalSnapshotEnvelope | null;
     readonly outboxEntries: CrdtMutationComputed['outboxEntries'];
+    readonly outboxWrites: CrdtMutationComputed['outboxWrites'];
     readonly result: CrdtMutationComputed['result'];
 }
 
@@ -112,7 +116,14 @@ export function computeCrdtAcceptedAppendOutcome(
             outboxEntries: toAppendOutbox({ command, response: appendResult, serviceId, fanout: true }),
             result
         }),
-        outcome: 'write'
+        outcome: 'write',
+        ...computeCrdtMutationWrites({
+            read,
+            document,
+            update: command.update,
+            append,
+            snapshot: null
+        })
     };
 }
 
@@ -212,7 +223,14 @@ export function computeCrdtAcceptedAdministrationOutcome(
             outboxEntries: auditEvent ? [toCrdtAuditOutbox(auditEvent, command, serviceId)] : [],
             result
         }),
-        outcome: 'write'
+        outcome: 'write',
+        ...computeCrdtMutationWrites({
+            read,
+            document,
+            update: null,
+            append: null,
+            snapshot
+        })
     };
 }
 
@@ -235,8 +253,107 @@ function createCrdtMutationComputedBase<TDocument extends RallarCrdtDocumentMeta
         append,
         snapshot,
         outboxEntries,
+        outboxWrites: outboxEntries.map(computeAppOutboxInsert),
         result
     };
+}
+
+interface ComputeCrdtMutationWritesInput {
+    readonly read: CrdtMutationRead;
+    readonly document: RallarCrdtDocumentMetadata;
+    readonly update: CrdtAppendCommand['update'] | null;
+    readonly append: RallarCrdtTrustedAppendMetadata | null;
+    readonly snapshot: CrdtCanonicalSnapshotEnvelope | null;
+}
+
+function computeCrdtMutationWrites(
+    input: ComputeCrdtMutationWritesInput
+): Pick<CrdtMutationComputedWrite, 'documentWrite' | 'updateWrite' | 'snapshotWrite' | 'conflict'> {
+    const { read, document, update, append, snapshot } = input;
+    const values = {
+        documentKey: document.documentKey,
+        applicationId: document.document.applicationId,
+        workspaceId: document.document.workspaceId,
+        scope: document.document.scope,
+        documentType: document.document.documentType,
+        documentId: document.document.documentId,
+        documentRefJson: JSON.stringify(document.document),
+        documentRevision: document.documentRevision,
+        lifecycle: document.lifecycle,
+        createdAt: new Date(document.createdAtEpochMs),
+        updatedAt: new Date(document.updatedAtEpochMs),
+        archivedAt: toOptionalCrdtDate(document.archivedAtEpochMs),
+        destroyedAt: toOptionalCrdtDate(document.destroyedAtEpochMs),
+        lastAppendSequence: document.lastAppendSequence,
+        updateCount: document.updateCount,
+        snapshotCount: document.snapshotCount,
+        storedUpdateBytes: document.storedUpdateBytes,
+        retentionJson: toOptionalCrdtJson(document.retention),
+        quotaJson: toOptionalCrdtJson(document.quota),
+        projectionIdsJson: JSON.stringify(document.projectionIds)
+    };
+    const documentWrite = read.document === null
+        ? { ...values, operation: 'insert' as const }
+        : {
+            ...values,
+            operation: 'update' as const,
+            expectedRevision: read.document.documentRevision,
+            expectedLifecycle: read.document.lifecycle,
+            expectedAppendSequence: read.document.lastAppendSequence
+        };
+    return {
+        documentWrite,
+        updateWrite: update && append
+            ? computeCrdtUpdateWrite(document.documentKey, update, append)
+            : null,
+        snapshotWrite: snapshot
+            ? computeCrdtSnapshotWrite(document.documentKey, document.lastAppendSequence, snapshot)
+            : null,
+        conflict: new CrdtMutationConflictError(document.documentKey)
+    };
+}
+
+function computeCrdtUpdateWrite(
+    documentKey: string,
+    update: CrdtAppendCommand['update'],
+    append: RallarCrdtTrustedAppendMetadata
+): CrdtUpdateWrite {
+    return {
+        documentKey,
+        appendSequence: append.appendSequence,
+        updateId: update.updateId,
+        updateEnvelopeJson: JSON.stringify(update),
+        acceptedUpdateHash: append.acceptedUpdateHash,
+        actorId: append.actorId,
+        principalId: append.principalId,
+        sessionId: append.sessionId,
+        serverId: append.serverId,
+        authorizationScope: append.authorizationScope,
+        acceptedAt: new Date(append.acceptedAtEpochMs)
+    };
+}
+
+function computeCrdtSnapshotWrite(
+    documentKey: string,
+    appendSequence: number,
+    snapshot: CrdtCanonicalSnapshotEnvelope
+): CrdtSnapshotWrite {
+    return {
+        documentKey,
+        snapshotId: snapshot.snapshotId,
+        appendSequence,
+        snapshotEnvelopeJson: JSON.stringify(snapshot),
+        createdAt: new Date(snapshot.createdAtEpochMs),
+        reason: snapshot.metadata.reason
+    };
+}
+
+function toOptionalCrdtDate(epochMs: number | null): Date | null {
+    return epochMs === null ? null : new Date(epochMs);
+}
+
+function toOptionalCrdtJson(value: object | null): string | null {
+    return value === null ? null : JSON.stringify(value);
 }
 
 function toCrdtAppendRejection(

--- a/packages/shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts
@@ -19,6 +19,7 @@ import type {
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
+import type { AppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
 
 export const CRDT_MUTATION_INBOX_TYPES = [
     AppInboxType.CRDT_UPDATE_APPEND,
@@ -138,6 +139,62 @@ export interface CrdtMutationAttemptFacts {
     readonly read: CrdtMutationRead;
 }
 
+interface CrdtDocumentWriteValues {
+    readonly documentKey: string;
+    readonly applicationId: string;
+    readonly workspaceId: string | undefined;
+    readonly scope: string;
+    readonly documentType: string;
+    readonly documentId: string;
+    readonly documentRefJson: string;
+    readonly documentRevision: number;
+    readonly lifecycle: RallarCrdtDocumentLifecycleState;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+    readonly archivedAt: Date | null;
+    readonly destroyedAt: Date | null;
+    readonly lastAppendSequence: number;
+    readonly updateCount: number;
+    readonly snapshotCount: number;
+    readonly storedUpdateBytes: number;
+    readonly retentionJson: string | null;
+    readonly quotaJson: string | null;
+    readonly projectionIdsJson: string;
+}
+
+export type CrdtDocumentWrite =
+    | CrdtDocumentWriteValues & Readonly<{ operation: 'insert'; }>
+    | CrdtDocumentWriteValues
+        & Readonly<{
+            operation: 'update';
+            expectedRevision: number;
+            expectedLifecycle: RallarCrdtDocumentLifecycleState;
+            expectedAppendSequence: number;
+        }>;
+
+export interface CrdtUpdateWrite {
+    readonly documentKey: string;
+    readonly appendSequence: number;
+    readonly updateId: string;
+    readonly updateEnvelopeJson: string;
+    readonly acceptedUpdateHash: string;
+    readonly actorId: string;
+    readonly principalId: string;
+    readonly sessionId: string;
+    readonly serverId: string;
+    readonly authorizationScope: RallarCrdtAuthorizationScope;
+    readonly acceptedAt: Date;
+}
+
+export interface CrdtSnapshotWrite {
+    readonly documentKey: string;
+    readonly snapshotId: string;
+    readonly appendSequence: number;
+    readonly snapshotEnvelopeJson: string;
+    readonly createdAt: Date;
+    readonly reason: string;
+}
+
 interface CrdtMutationComputedBase {
     readonly command: CrdtMutationCommand;
     readonly read: CrdtMutationRead;
@@ -153,12 +210,17 @@ interface CrdtMutationComputedBase {
     readonly append: RallarCrdtTrustedAppendMetadata | null;
     readonly snapshot: CrdtCanonicalSnapshotEnvelope | null;
     readonly outboxEntries: readonly ResourceEntry[];
+    readonly outboxWrites: readonly AppOutboxInsert[];
     readonly result: CrdtMutationResult;
 }
 
 export interface CrdtMutationComputedWrite extends CrdtMutationComputedBase {
     readonly outcome: 'write';
     readonly document: RallarCrdtDocumentMetadata;
+    readonly documentWrite: CrdtDocumentWrite;
+    readonly updateWrite: CrdtUpdateWrite | null;
+    readonly snapshotWrite: CrdtSnapshotWrite | null;
+    readonly conflict: CrdtMutationConflictError;
 }
 
 export interface CrdtMutationComputedReplay extends CrdtMutationComputedBase {
@@ -332,7 +394,7 @@ export type CrdtAdminEraseResult =
 export interface CrdtMutationRepository {
     readonly readMutation: (command: CrdtMutationCommand) => Promise<CrdtMutationRead>;
     readonly writeMutation: (computed: CrdtMutationComputedWrite) => Promise<void>;
-    readonly writeOutbox: (entries: readonly ResourceEntry[]) => Promise<void>;
+    readonly writeOutbox: (writes: readonly AppOutboxInsert[]) => Promise<void>;
 }
 
 export class CrdtMutationConflictError extends Error {

--- a/packages/shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/create-crdt-mutation-service.ts
@@ -43,7 +43,7 @@ export function createCrdtMutationService(
             if (computed.outcome === 'write') {
                 await writer.writeMutation(computed);
             }
-            await writer.writeOutbox(computed.outboxEntries);
+            await writer.writeOutbox(computed.outboxWrites);
             return computed.result;
         }
     };

--- a/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
@@ -66,7 +66,41 @@ export function validateCrdtMutation(
             message: error instanceof Error ? error.message : String(error)
         });
     }
+    if (!hasConsistentCrdtPersistence(computed)) {
+        issues.push({
+            code: 'computed-persistence-differs',
+            message: 'CRDT computed persistence differs from the computed mutation'
+        });
+    }
     return issues;
+}
+
+function hasConsistentCrdtPersistence(computed: CrdtMutationComputed): boolean {
+    const outboxMatches = computed.outboxWrites.length === computed.outboxEntries.length &&
+        computed.outboxWrites.every((write, index) => {
+            const entry = computed.outboxEntries[index];
+            return entry !== undefined && write.entry.key.topicId === entry.key.topicId &&
+                write.entry.key.resourceId === entry.key.resourceId &&
+                write.entry.key.contextId === entry.key.contextId &&
+                write.entry.resource === entry.resource;
+        });
+    if (!outboxMatches || computed.outcome !== 'write') {
+        return outboxMatches;
+    }
+    const documentMatches = computed.documentWrite.documentKey === computed.document.documentKey &&
+        computed.documentWrite.documentRevision === computed.document.documentRevision &&
+        computed.documentWrite.lifecycle === computed.document.lifecycle;
+    const updateMatches = computed.update === null || computed.append === null
+        ? computed.updateWrite === null
+        : computed.updateWrite?.documentKey === computed.documentKey &&
+            computed.updateWrite.updateId === computed.update.updateId &&
+            computed.updateWrite.appendSequence === computed.append.appendSequence;
+    const snapshotMatches = computed.snapshot === null
+        ? computed.snapshotWrite === null
+        : computed.snapshotWrite?.documentKey === computed.documentKey &&
+            computed.snapshotWrite.snapshotId === computed.snapshot.snapshotId &&
+            computed.snapshotWrite.appendSequence === computed.document.lastAppendSequence;
+    return documentMatches && updateMatches && snapshotMatches;
 }
 
 function readSnapshotReason(snapshot: object | null | undefined): string | null {

--- a/packages/shared-server/rallar-system/crdt/persistence/psql-crdt-mutation-repository.ts
+++ b/packages/shared-server/rallar-system/crdt/persistence/psql-crdt-mutation-repository.ts
@@ -1,22 +1,22 @@
 import {
     byteLengthOfRallarCrdtJson,
-    type RallarCrdtDocumentLifecycleState,
     type RallarCrdtDocumentMetadata,
-    type RallarCrdtDocumentTypePolicy,
-    type RallarCrdtTrustedAppendMetadata,
-    type RallarCrdtUpdateEnvelope
+    type RallarCrdtDocumentTypePolicy
 } from '@shared/crdt/mod.ts';
-import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { PSqlResourceInboxEntryRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import { writeAppOutboxInsert, type AppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import { CrdtMutationConflictError } from '../mutation/crdt-mutation-contracts.ts';
 import {
-    CrdtMutationConflictError,
-    type CrdtCanonicalSnapshotEnvelope,
+    type CrdtDocumentWrite,
     type CrdtMutationCommand,
+    type CrdtMutationComputed,
     type CrdtMutationComputedWrite,
     type CrdtMutationRead,
-    type CrdtMutationRepository
+    type CrdtMutationRepository,
+    type CrdtMutationResult,
+    type CrdtSnapshotWrite,
+    type CrdtUpdateWrite
 } from '../mutation/crdt-mutation-contracts.ts';
 import { evaluateCrdtMutationFeatureDecision } from '../mutation/evaluate-crdt-mutation-feature-decision.ts';
 import { decodeCrdtDocumentRow, type CrdtDocumentRow } from './row-decoding/decode-crdt-document-row.ts';
@@ -120,41 +120,49 @@ export class PSqlCrdtMutationRepository implements CrdtMutationRepository {
     }
 
     async writeMutation(computed: CrdtMutationComputedWrite): Promise<void> {
-        const guarded = computed.expectedDocumentRevision === 'absent'
-            ? await insertDocument(this.sql, computed.document)
-            : await updateDocument({
-                sql: this.sql,
-                metadata: computed.document,
-                expectedRevision: computed.expectedDocumentRevision,
-                expectedLifecycle: computed.expectedDocumentLifecycle,
-                expectedAppendSequence: computed.expectedAppendSequence
-            });
-        if (!guarded) {
-            throw new CrdtMutationConflictError(computed.documentKey);
-        }
-        if (computed.update && computed.append) {
-            await insertUpdate({
-                sql: this.sql,
-                documentKey: computed.documentKey,
-                update: computed.update,
-                append: computed.append
-            });
-        }
-        if (computed.snapshot) {
-            await insertSnapshot({
-                sql: this.sql,
-                documentKey: computed.documentKey,
-                snapshot: computed.snapshot,
-                appendSequence: computed.document.lastAppendSequence
-            });
-        }
+        await writeCrdtMutationRows(this.sql, computed);
     }
 
-    async writeOutbox(entries: readonly ResourceEntry[]): Promise<void> {
-        const outbox = new PSqlResourceInboxEntryRepository(this.sql);
-        for (const entry of entries) {
-            await outbox.write(entry);
-        }
+    async writeOutbox(writes: readonly AppOutboxInsert[]): Promise<void> {
+        await writeCrdtOutbox(this.sql, writes);
+    }
+}
+
+export async function writePSqlCrdtMutation(
+    transaction: PSqlSql,
+    computed: CrdtMutationComputed
+): Promise<CrdtMutationResult> {
+    if (computed.outcome === 'write') {
+        await writeCrdtMutationRows(transaction, computed);
+    }
+    await writeCrdtOutbox(transaction, computed.outboxWrites);
+    return computed.result;
+}
+
+async function writeCrdtMutationRows(
+    sql: PSqlSql,
+    computed: CrdtMutationComputedWrite
+): Promise<void> {
+    const guarded = computed.documentWrite.operation === 'insert'
+        ? await insertDocument(sql, computed.documentWrite)
+        : await updateDocument(sql, computed.documentWrite);
+    if (!guarded) {
+        throw computed.conflict;
+    }
+    if (computed.updateWrite) {
+        await insertUpdate(sql, computed.updateWrite);
+    }
+    if (computed.snapshotWrite) {
+        await insertSnapshot(sql, computed.snapshotWrite);
+    }
+}
+
+async function writeCrdtOutbox(
+    transaction: PSqlSql,
+    writes: readonly AppOutboxInsert[]
+): Promise<void> {
+    for (const write of writes) {
+        await writeAppOutboxInsert(transaction, write);
     }
 }
 
@@ -325,7 +333,7 @@ async function readActorUpdatesInWindow(
 
 async function insertDocument(
     sql: PSqlSql,
-    metadata: RallarCrdtDocumentMetadata
+    write: Extract<CrdtDocumentWrite, { operation: 'insert'; }>
 ): Promise<boolean> {
     const rows = await sql<DocumentKeyRow[]>`
         insert into crdt_documents (
@@ -335,106 +343,71 @@ async function insertDocument(
             update_count, snapshot_count, stored_update_bytes, retention_policy,
             quota_policy, projection_ids
         ) values (
-            ${metadata.documentKey}, ${metadata.document.applicationId},
-            ${metadata.document.workspaceId}, ${metadata.document.scope},
-            ${metadata.document.documentType}, ${metadata.document.documentId},
-            ${JSON.stringify(metadata.document)}, ${metadata.documentRevision},
-            ${metadata.lifecycle}, ${new Date(metadata.createdAtEpochMs)},
-            ${new Date(metadata.updatedAtEpochMs)}, ${toOptionalDate(metadata.archivedAtEpochMs)},
-            ${toOptionalDate(metadata.destroyedAtEpochMs)}, ${metadata.lastAppendSequence},
-            ${metadata.updateCount}, ${metadata.snapshotCount}, ${metadata.storedUpdateBytes},
-            ${encodeOptionalPolicy(metadata.retention)}, ${encodeOptionalPolicy(metadata.quota)},
-            ${JSON.stringify(metadata.projectionIds)}
+            ${write.documentKey}, ${write.applicationId},
+            ${write.workspaceId}, ${write.scope},
+            ${write.documentType}, ${write.documentId},
+            ${write.documentRefJson}, ${write.documentRevision},
+            ${write.lifecycle}, ${write.createdAt},
+            ${write.updatedAt}, ${write.archivedAt},
+            ${write.destroyedAt}, ${write.lastAppendSequence},
+            ${write.updateCount}, ${write.snapshotCount}, ${write.storedUpdateBytes},
+            ${write.retentionJson}, ${write.quotaJson},
+            ${write.projectionIdsJson}
         ) on conflict (document_key) do nothing
         returning document_key
     `;
     return rows.length === 1;
 }
 
-interface UpdateDocumentInput {
-    readonly sql: PSqlSql;
-    readonly metadata: RallarCrdtDocumentMetadata;
-    readonly expectedRevision: number;
-    readonly expectedLifecycle: RallarCrdtDocumentLifecycleState | 'absent';
-    readonly expectedAppendSequence: number | 'absent';
-}
-
-async function updateDocument(input: UpdateDocumentInput): Promise<boolean> {
-    const { sql, metadata, expectedRevision, expectedLifecycle, expectedAppendSequence } = input;
-    if (expectedLifecycle === 'absent' || expectedAppendSequence === 'absent') {
-        return false;
-    }
+async function updateDocument(
+    sql: PSqlSql,
+    write: Extract<CrdtDocumentWrite, { operation: 'update'; }>
+): Promise<boolean> {
     const rows = await sql<DocumentKeyRow[]>`
         update crdt_documents
-        set document_revision = ${metadata.documentRevision}, lifecycle = ${metadata.lifecycle},
-            updated_at_ts = ${new Date(metadata.updatedAtEpochMs)},
-            archived_at_ts = ${toOptionalDate(metadata.archivedAtEpochMs)},
-            destroyed_at_ts = ${toOptionalDate(metadata.destroyedAtEpochMs)},
-            last_append_sequence = ${metadata.lastAppendSequence},
-            update_count = ${metadata.updateCount}, snapshot_count = ${metadata.snapshotCount},
-            stored_update_bytes = ${metadata.storedUpdateBytes},
-            retention_policy = ${encodeOptionalPolicy(metadata.retention)},
-            quota_policy = ${encodeOptionalPolicy(metadata.quota)},
-            projection_ids = ${JSON.stringify(metadata.projectionIds)}
-        where document_key = ${metadata.documentKey}
-          and document_revision = ${expectedRevision}
-          and lifecycle = ${expectedLifecycle}
-          and last_append_sequence = ${expectedAppendSequence}
+        set document_revision = ${write.documentRevision}, lifecycle = ${write.lifecycle},
+            updated_at_ts = ${write.updatedAt},
+            archived_at_ts = ${write.archivedAt},
+            destroyed_at_ts = ${write.destroyedAt},
+            last_append_sequence = ${write.lastAppendSequence},
+            update_count = ${write.updateCount}, snapshot_count = ${write.snapshotCount},
+            stored_update_bytes = ${write.storedUpdateBytes},
+            retention_policy = ${write.retentionJson},
+            quota_policy = ${write.quotaJson},
+            projection_ids = ${write.projectionIdsJson}
+        where document_key = ${write.documentKey}
+          and document_revision = ${write.expectedRevision}
+          and lifecycle = ${write.expectedLifecycle}
+          and last_append_sequence = ${write.expectedAppendSequence}
         returning document_key
     `;
     return rows.length === 1;
 }
 
-interface InsertUpdateInput {
-    readonly sql: PSqlSql;
-    readonly documentKey: string;
-    readonly update: RallarCrdtUpdateEnvelope;
-    readonly append: RallarCrdtTrustedAppendMetadata;
-}
-
-async function insertUpdate(input: InsertUpdateInput): Promise<void> {
-    const { sql, documentKey, update, append } = input;
+async function insertUpdate(sql: PSqlSql, write: CrdtUpdateWrite): Promise<void> {
     await sql`
         insert into crdt_updates (
             document_key, append_sequence, update_id, update_envelope,
             accepted_update_hash, actor_id, principal_id, session_id, server_id,
             authorization_scope, accepted_at_ts
         ) values (
-            ${documentKey}, ${append.appendSequence}, ${update.updateId},
-            ${JSON.stringify(update)}, ${append.acceptedUpdateHash}, ${append.actorId},
-            ${append.principalId}, ${append.sessionId}, ${append.serverId},
-            ${append.authorizationScope}, ${new Date(append.acceptedAtEpochMs)}
+            ${write.documentKey}, ${write.appendSequence}, ${write.updateId},
+            ${write.updateEnvelopeJson}, ${write.acceptedUpdateHash}, ${write.actorId},
+            ${write.principalId}, ${write.sessionId}, ${write.serverId},
+            ${write.authorizationScope}, ${write.acceptedAt}
         )
     `;
 }
 
-interface InsertSnapshotInput {
-    readonly sql: PSqlSql;
-    readonly documentKey: string;
-    readonly snapshot: CrdtCanonicalSnapshotEnvelope;
-    readonly appendSequence: number;
-}
-
-async function insertSnapshot(input: InsertSnapshotInput): Promise<void> {
-    const { sql, documentKey, snapshot, appendSequence } = input;
+async function insertSnapshot(sql: PSqlSql, write: CrdtSnapshotWrite): Promise<void> {
     await sql`
         insert into crdt_snapshots (
             document_key, snapshot_id, append_sequence, snapshot_envelope,
             created_at_ts, reason
         ) values (
-            ${documentKey}, ${snapshot.snapshotId}, ${appendSequence},
-            ${JSON.stringify(snapshot)}, ${new Date(snapshot.createdAtEpochMs)},
-            ${snapshot.metadata.reason}
+            ${write.documentKey}, ${write.snapshotId}, ${write.appendSequence},
+            ${write.snapshotEnvelopeJson}, ${write.createdAt},
+            ${write.reason}
         )
     `;
-}
-
-function toOptionalDate(epochMs: number | null): Date | null {
-    return epochMs === null ? null : new Date(epochMs);
-}
-
-function encodeOptionalPolicy(
-    value: RallarCrdtDocumentMetadata['retention'] | RallarCrdtDocumentMetadata['quota']
-): string | null {
-    return value === null ? null : JSON.stringify(value);
 }

--- a/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
+++ b/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
@@ -132,9 +132,10 @@ it.each([
         owner: 'processCommand',
         calls: [
             'this.mutationService.read(command)',
-            'this.mutationService.compute({ command, read })',
-            'this.mutationService.validate({ command, read, computed })',
-            'this.mutationService.write(transaction, computed)'
+            'computeCrdtInboxMutation(read)',
+            'validateCrdtInboxMutation(read, computed)',
+            'this.transactionWriter.writeComputedMutation(',
+            'writePSqlCrdtMutation(transaction, computed.mutation)'
         ]
     },
     {
@@ -142,10 +143,11 @@ it.each([
         source: sources.appAdmin,
         owner: 'processCommand',
         calls: [
-            'this.read(command)',
-            'this.compute(read)',
-            'this.validate(computed)',
-            'this.transactionWriter.writeMutation(context'
+            'this.read(command, context)',
+            'computeAdminPruneMutation(read)',
+            'validateAdminPruneMutation(read, computed)',
+            'this.transactionWriter.writeComputedMutation(',
+            'this.write(transaction, computed)'
         ]
     },
     {

--- a/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
+++ b/packages/tests/repo/rallar-authoritative-mutation-guidance-integrity.test.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+// Repository-governance maintainers own these publication guards. Replace phrase
+// checks as consumer evaluations cover the same drift risk; they do not prove agent behavior.
 const repoRoot = process.cwd();
 const canonicalServiceWritingPath = '.agents/skills/rallar-code-writing/references/convergent-service-writing.md';
 const codeProducingSpecialistSkills = [
@@ -16,7 +18,6 @@ const codeProducingSpecialistSkills = [
 const appInboxGuidanceVocabulary = [
     'AppInbox is mandatory for incoming database mutations',
     'service write receives the transaction',
-    'ResourceInboxRepository',
     'APP_OUTBOX',
     'WS_OUTBOX',
     '20 total processing attempts',
@@ -32,7 +33,13 @@ const currentAppInboxGuidancePaths = [
     'docs/rallar-crdt-production-hardening-runbook.md',
     'docs/README.md'
 ] as const;
-const coreConvergentWriteGuidancePaths = [canonicalServiceWritingPath] as const;
+const strictMutationPhaseGuidancePaths = [
+    canonicalServiceWritingPath,
+    '.agents/skills/rallar-code-writing/SKILL.md',
+    '.agents/skills/rallar-code-writing/references/repo-code-style.md',
+    '.agents/skills/rallar-testing/SKILL.md',
+    '.agents/skills/performance-analysis/SKILL.md'
+] as const;
 const canonicalSnapshotOrderingGuidancePaths = [
     canonicalServiceWritingPath,
     'docs/rallar-convergent-state-and-rtc-topology.md'
@@ -60,11 +67,6 @@ const mediumScaleRequirements = [
     'five groups',
     'three Postgres-backed API processes',
     '10 client lanes plus 5 control lanes'
-] as const;
-const performanceGateRequirements = [
-    'npm run perf:api-v1:state-write',
-    'node scripts/perf/compare-api-v1-state-write-results.mjs',
-    'comparative result gate'
 ] as const;
 
 interface PackageJson {
@@ -129,7 +131,7 @@ describe('authoritative mutation guidance integrity', () => {
             'update with expected-revision compare-and-set or `upsertIfRevision`',
             'delete or expire with expected-revision conditional delete or `deleteIfRevision`',
             'a stale expiry observation must not delete or overwrite a refreshed value',
-            'A conflict starts a fresh `read`'
+            'A conflict exits that attempt; queue redelivery starts again from `read`'
         ]);
         expectAllNormalized(realtime, [
             canonicalServiceWritingPath,
@@ -141,7 +143,7 @@ describe('authoritative mutation guidance integrity', () => {
         expect(realtime).not.toContain('prove overlapping conflicts, rebasing, retry exhaustion');
         expectAll(agents, [canonicalServiceWritingPath, 'functional core', 'stateful shell']);
         expectAll(convergenceArchitecture, [
-            'Implemented Convergent Database Writes',
+            'write(transaction, computed)',
             'conditional insert',
             'expected-revision compare-and-set',
             'expected-revision conditional delete'
@@ -393,17 +395,17 @@ describe('authoritative mutation guidance integrity', () => {
         '%s distinguishes downstream QueueBox retries from AppInbox ingress retries',
         (filePath) => {
             expectAllNormalized(readRepo(filePath), [
-                'RtcTopologyOutboxWork',
+                'APP_OUTBOX',
                 'ResourceInbox/QueueBox attempt boundary',
                 'neither service owns the transaction or retry boundary'
             ]);
         }
     );
 
-    it.each(coreConvergentWriteGuidancePaths)(
-        '%s independently states the convergent-write doctrine',
-        (filePath) => {
-            const guidance = normalizeWhitespace(readRepo(filePath));
+    it(
+        'the canonical service reference independently states the convergent-write doctrine',
+        () => {
+            const guidance = normalizeWhitespace(readRepo(canonicalServiceWritingPath));
             expect(guidance).toMatch(
                 /`compute` and `validate` .{0,30}(?:phases|functions) are .{0,10}pure/i
             );
@@ -415,6 +417,20 @@ describe('authoritative mutation guidance integrity', () => {
             );
             expect(guidance).toMatch(/queue locks.{0,80}coordination-only/i);
             expect(guidance).toMatch(/computed persistence data.{0,40}not.{0,20}(?:called )?a plan/i);
+        }
+    );
+
+    it.each(strictMutationPhaseGuidancePaths)(
+        '%s keeps computation in compute without a post-compute preparation phase',
+        (filePath) => {
+            expectAllNormalized(readRepo(filePath), [
+                'same explicit input produces the same result',
+                'no repository reads, clocks, randomness, mutable dependency lookups, or hidden side effects',
+                'Do not add `prepare`, `prepareWrite`, or another deterministic transformation after `compute`',
+                'Adding another service mutation phase requires explicit human approval',
+                'One queue delivery performs one mutation attempt',
+                'A conflict exits that attempt; queue redelivery starts again from `read`'
+            ]);
         }
     );
 
@@ -434,11 +450,7 @@ describe('authoritative mutation guidance integrity', () => {
 });
 
 function readRepo(filePath: string): string {
-    return readAbsolute(path.join(repoRoot, filePath));
-}
-
-function readAbsolute(filePath: string): string {
-    return readFileSync(filePath, 'utf8');
+    return readFileSync(path.join(repoRoot, filePath), 'utf8');
 }
 
 function readPackageJson(filePath: string): PackageJson {

--- a/packages/tests/repo/rallar-code-writing/maintenance-stewardship-contract.test.ts
+++ b/packages/tests/repo/rallar-code-writing/maintenance-stewardship-contract.test.ts
@@ -41,6 +41,20 @@ const preflightDimensions = [
     'preflight.new-surface-gate',
     'preflight.observable-order'
 ] as const;
+const transactionPurityDimensions = [
+    'transaction-purity.persistence-ready-before-entry',
+    'transaction-purity.precomputable-work-outside',
+    'transaction-purity.closed-db-result-refinement',
+    'transaction-purity.full-retry-reentry',
+    'transaction-purity.winner-only-is-not-authority'
+] as const;
+const resourceInboxPolicyDimensions = [
+    'transaction-policy.resolved-owner-not-path',
+    'transaction-policy.strict-domain-no-transfer',
+    'transaction-policy.bounded-resource-inbox-specialization',
+    'transaction-policy.guarded-winner-materializer',
+    'transaction-policy.indexeddb-remains-strict'
+] as const;
 const allDimensions = [
     ...stewardshipDimensions,
     'legacy.safe-private-removal',
@@ -50,7 +64,9 @@ const allDimensions = [
     'legacy.public-compatibility-safety',
     'legacy.minimized-boundary',
     'legacy.retention-governance',
-    ...preflightDimensions
+    ...preflightDimensions,
+    ...transactionPurityDimensions,
+    ...resourceInboxPolicyDimensions
 ] as const;
 const legacyRemovalGuidancePaths = [
     'AGENTS.md',
@@ -247,13 +263,13 @@ describe('rallar code-writing maintenance stewardship contract', () => {
         expectAll(escalationDimension?.pass ?? '', preWorkEvidence);
     });
 
-    it('defines four critical versioned pressure scenarios and a binary rubric', () => {
+    it('defines six critical versioned pressure scenarios and a binary rubric', () => {
         const suite = readJson<EvaluationSuite>(`${evaluationRoot}/scenarios.json`);
         const rubric = readJson<EvaluationRubric>(`${evaluationRoot}/rubric.json`);
 
         expect(suite.schemaVersion).toBe('rallar-code-writing-scenarios-v1');
         expect(suite.suiteId).toBe('rallar-code-writing-v1');
-        expect(suite.scenarios).toHaveLength(4);
+        expect(suite.scenarios).toHaveLength(6);
         const stewardshipScenario = findScenario(
             suite,
             'pre-existing-noncompliance-under-release-pressure'
@@ -264,6 +280,14 @@ describe('rallar code-writing maintenance stewardship contract', () => {
             'public-compatibility-legacy-restraint'
         );
         const preflightScenario = findScenario(suite, 'pre-decision-skill-preflight');
+        const transactionPurityScenario = findScenario(
+            suite,
+            'transaction-write-purity-under-deadline-pressure'
+        );
+        const resourceInboxPolicyScenario = findScenario(
+            suite,
+            'resource-inbox-policy-under-scope-pressure'
+        );
         expect(stewardshipScenario).toMatchObject({
             id: 'pre-existing-noncompliance-under-release-pressure',
             critical: true,
@@ -309,6 +333,32 @@ describe('rallar code-writing maintenance stewardship contract', () => {
         expect(preflightScenario.prompt).toContain('apps/api-v1/src/main.ts');
         expect(preflightScenario.prompt).toContain('skill descriptions are already visible');
         expect(preflightScenario.prompt).toContain('realtime authorization mutation');
+        expect(transactionPurityScenario).toMatchObject({
+            critical: true,
+            primarySkill: 'rallar-code-writing',
+            requiredDimensions: transactionPurityDimensions
+        });
+        expect(transactionPurityScenario.pressures).toEqual([
+            'critical-deadline',
+            'cheap-computation',
+            'winner-only-execution',
+            'short-transaction-metric'
+        ]);
+        expect(transactionPurityScenario.prompt).toContain('full retry re-entry');
+        expect(transactionPurityScenario.prompt).toContain('winner-only execution');
+        expect(resourceInboxPolicyScenario).toMatchObject({
+            critical: true,
+            primarySkill: 'rallar-code-writing',
+            requiredDimensions: resourceInboxPolicyDimensions
+        });
+        expect(resourceInboxPolicyScenario.pressures).toEqual([
+            'path-based-exemption',
+            'uniform-policy-pressure',
+            'lease-complexity',
+            'winner-callback-suspicion'
+        ]);
+        expect(resourceInboxPolicyScenario.prompt).toContain('exact guarded winner materializer');
+        expect(resourceInboxPolicyScenario.prompt).toContain('browser IndexedDB');
 
         expect(rubric.schemaVersion).toBe('rallar-code-writing-rubric-v1');
         expect(rubric.suiteId).toBe(suite.suiteId);

--- a/packages/tests/repo/rallar-code-writing/rallar-code-writing-evaluation-result.test.ts
+++ b/packages/tests/repo/rallar-code-writing/rallar-code-writing-evaluation-result.test.ts
@@ -21,7 +21,7 @@ const stewardshipDimensions = [
     'stewardship.no-debt-only-permission-request',
     'stewardship.genuine-decision-escalation'
 ] as const;
-const legacyScenarioDimensions = [
+const additionalScenarioDimensions = [
     ['safe-private-legacy-removal', 'legacy.safe-private-removal'],
     ['safe-private-legacy-removal', 'legacy.behavior-preservation'],
     ['safe-private-legacy-removal', 'legacy.scope-containment'],
@@ -36,7 +36,41 @@ const legacyScenarioDimensions = [
     ['pre-decision-skill-preflight', 'preflight.complete-required-reading'],
     ['pre-decision-skill-preflight', 'preflight.minimum-applicable-set'],
     ['pre-decision-skill-preflight', 'preflight.new-surface-gate'],
-    ['pre-decision-skill-preflight', 'preflight.observable-order']
+    ['pre-decision-skill-preflight', 'preflight.observable-order'],
+    [
+        'transaction-write-purity-under-deadline-pressure',
+        'transaction-purity.persistence-ready-before-entry'
+    ],
+    [
+        'transaction-write-purity-under-deadline-pressure',
+        'transaction-purity.precomputable-work-outside'
+    ],
+    [
+        'transaction-write-purity-under-deadline-pressure',
+        'transaction-purity.closed-db-result-refinement'
+    ],
+    [
+        'transaction-write-purity-under-deadline-pressure',
+        'transaction-purity.full-retry-reentry'
+    ],
+    [
+        'transaction-write-purity-under-deadline-pressure',
+        'transaction-purity.winner-only-is-not-authority'
+    ],
+    ['resource-inbox-policy-under-scope-pressure', 'transaction-policy.resolved-owner-not-path'],
+    ['resource-inbox-policy-under-scope-pressure', 'transaction-policy.strict-domain-no-transfer'],
+    [
+        'resource-inbox-policy-under-scope-pressure',
+        'transaction-policy.bounded-resource-inbox-specialization'
+    ],
+    [
+        'resource-inbox-policy-under-scope-pressure',
+        'transaction-policy.guarded-winner-materializer'
+    ],
+    [
+        'resource-inbox-policy-under-scope-pressure',
+        'transaction-policy.indexeddb-remains-strict'
+    ]
 ] as const;
 
 afterEach(() => {
@@ -62,15 +96,15 @@ describe('rallar code-writing evaluation result validation', () => {
         expect(validation.stdout).toContain('PASS: rallar code-writing evaluation result');
     });
 
-    it('requires all four critical scenarios and their raw output artifacts', () => {
+    it('requires all six critical scenarios and their raw output artifacts', () => {
         const validationInput = createValidationInput();
 
-        expect(validationInput.result.scenarioResults).toHaveLength(4);
+        expect(validationInput.result.scenarioResults).toHaveLength(6);
         expect(validationInput.result.summary).toEqual({
-            criticalPassed: 4,
-            criticalTotal: 4,
-            passed: 4,
-            total: 4
+            criticalPassed: 6,
+            criticalTotal: 6,
+            passed: 6,
+            total: 6
         });
 
         validationInput.result.scenarioResults[0].rawOutputArtifact = 'missing-agent-output.txt';
@@ -86,10 +120,10 @@ describe('rallar code-writing evaluation result validation', () => {
         scenarioResult.verdict = 'fail';
         scenarioResult.criticalFailures = [dimensionId];
         consistentInput.result.summary = {
-            criticalPassed: 3,
-            criticalTotal: 4,
-            passed: 3,
-            total: 4
+            criticalPassed: 5,
+            criticalTotal: 6,
+            passed: 5,
+            total: 6
         };
 
         expect(validateEvaluationResult(consistentInput)).toEqual([]);
@@ -101,13 +135,13 @@ describe('rallar code-writing evaluation result validation', () => {
             expect.arrayContaining([
                 `${scenarioId} verdict must be fail when a required dimension fails`,
                 `${scenarioId} criticalFailures must exactly list failed required dimensions`,
-                'result.summary.passed must equal 3',
-                'result.summary.criticalPassed must equal 3'
+                'result.summary.passed must equal 5',
+                'result.summary.criticalPassed must equal 5'
             ])
         );
     });
 
-    it.each(legacyScenarioDimensions)(
+    it.each(additionalScenarioDimensions)(
         'treats %s %s as independently non-compensable',
         (legacyScenarioId, dimensionId) => {
             const consistentInput = createValidationInput();
@@ -116,10 +150,10 @@ describe('rallar code-writing evaluation result validation', () => {
             scenarioResult.verdict = 'fail';
             scenarioResult.criticalFailures = [dimensionId];
             consistentInput.result.summary = {
-                criticalPassed: 3,
-                criticalTotal: 4,
-                passed: 3,
-                total: 4
+                criticalPassed: 5,
+                criticalTotal: 6,
+                passed: 5,
+                total: 6
             };
 
             expect(validateEvaluationResult(consistentInput)).toEqual([]);
@@ -130,8 +164,8 @@ describe('rallar code-writing evaluation result validation', () => {
                 expect.arrayContaining([
                     `${legacyScenarioId} verdict must be fail when a required dimension fails`,
                     `${legacyScenarioId} criticalFailures must exactly list failed required dimensions`,
-                    'result.summary.passed must equal 3',
-                    'result.summary.criticalPassed must equal 3'
+                    'result.summary.passed must equal 5',
+                    'result.summary.criticalPassed must equal 5'
                 ])
             );
         }

--- a/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
@@ -1,0 +1,128 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { describe, expect, it } from 'vitest';
+
+import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { createAdminPruneCommand } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
+import {
+    computeAdminPruneMutation,
+    validateAdminPruneMutation
+} from '@shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts';
+import { writeAdminPruneAggregate } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+describe('admin prune computation', () => {
+    it('computes persistence-ready domain and completion writes before the transaction', async () => {
+        const read = await createRead();
+
+        const computed = computeAdminPruneMutation(read);
+
+        expect(computed.result).toMatchObject({
+            status: 'queued',
+            serverId: 'admin-server',
+            jobId: 'prune-job'
+        });
+        expect(computed.outboxWrites).toEqual([
+            expect.objectContaining({
+                entry: expect.objectContaining({ typeId: 'APP_OUTBOX' }),
+                systemDate: expect.any(String),
+                createdAt: expect.any(String),
+                expiresAt: expect.any(String)
+            })
+        ]);
+        expect(computed.aggregateWrite).toEqual(expect.objectContaining({
+            entry: expect.objectContaining({ resource: expect.any(String) }),
+            systemDate: expect.any(String),
+            createdAt: expect.any(String),
+            expiresAt: expect.any(String)
+        }));
+        expect(computed.completion.durableResult).toBe(computed.result);
+        expect(computed.completion.reservationFinish.completedAt).toEqual(new Date(1_010));
+        expect(validateAdminPruneMutation(read, computed)).toEqual([]);
+    });
+
+    it('validates the supplied computation without replacing it', async () => {
+        const read = await createRead();
+        const computed = computeAdminPruneMutation(read);
+        const changed = {
+            ...computed,
+            result: { ...computed.result, jobId: 'another-job' }
+        };
+
+        const issues = validateAdminPruneMutation(read, changed);
+
+        expect(issues).toContainEqual(expect.objectContaining({
+            code: 'admin-prune-computed-identity-invalid',
+            status: 400
+        }));
+        expect(changed.result.jobId).toBe('another-job');
+    });
+
+    it('writes the prepared aggregate without formatting timestamps in the transaction', async () => {
+        const computed = computeAdminPruneMutation(await createRead());
+        const aggregateWrite = computed.aggregateWrite;
+        if (aggregateWrite === null) {
+            throw new Error('Expected a durable admin prune aggregate');
+        }
+        const transaction = ((parts: TemplateStringsArray) => {
+            const statement = parts.join(' ');
+            return Promise.resolve(
+                statement.includes('insert into resource_inbox_results')
+                    ? [{ ris_resource: aggregateWrite.entry.resource }]
+                    : []
+            );
+        }) as PSqlSql;
+        const originalToString = Temporal.Instant.prototype.toString;
+
+        Temporal.Instant.prototype.toString = rejectTimestampFormattingDuringWrite;
+        try {
+            await writeAdminPruneAggregate(transaction, aggregateWrite);
+        }
+        finally {
+            Temporal.Instant.prototype.toString = originalToString;
+        }
+    });
+});
+
+function rejectTimestampFormattingDuringWrite(): never {
+    throw new TypeError('Admin prune aggregate timestamp formatted inside write');
+}
+
+async function createRead() {
+    const command = await createAdminPruneCommand({
+        jobId: 'prune-job',
+        requestedBy: 'admin',
+        requestedSessionId: 'session',
+        capturedAtEpochMs: 1_000,
+        expireAtEpochMs: 100_000,
+        dryRun: false,
+        categories: ['runtime-state'],
+        appData: null,
+        pageSize: 25
+    });
+    const entry: ResourceEntry = {
+        key: { topicId: 'ADMIN_PRUNE_EXPIRED', resourceId: 'prune-job', contextId: 'admin' },
+        resource: '{}',
+        typeId: 'APP_INBOX',
+        status: EntityStatus.RESERVED,
+        audit: {
+            date: Temporal.PlainTime.from('12:00:00'),
+            createdBy: 'admin-server',
+            createdTs: Temporal.PlainDateTime.from('2026-08-07T12:00:00'),
+            expiryTs: Temporal.Instant.from('2026-08-07T13:00:00Z')
+        },
+        dequeueAudit: { attempts: 1 }
+    };
+    return {
+        command,
+        expiredRows: {
+            'runtime-state': 3,
+            'resource-inbox': 0,
+            'resource-inbox-results': 0,
+            'app-data': 0
+        },
+        authority: { allowed: true, code: 'allowed' },
+        nowEpochMs: 1_005,
+        serviceId: 'admin-server',
+        completionFacts: { entry, completedAtEpochMs: 1_010 }
+    };
+}

--- a/packages/tests/shared-server/rallar-system/admin-operations/app-admin-inbox-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/app-admin-inbox-service.test.ts
@@ -463,12 +463,12 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
             'transaction',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
         expect(harness.events.filter((event) => event === 'queue-wake')).toHaveLength(1);
@@ -493,6 +493,7 @@ describe('AppAdminInboxService initial prune command', () => {
             'count:runtime-state',
             'count:resource-inbox-results',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
@@ -501,7 +502,6 @@ describe('AppAdminInboxService initial prune command', () => {
             'page-write',
             'aggregate-write',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
         expect(harness.events.filter((event) => event === 'queue-wake')).toHaveLength(2);
@@ -562,6 +562,7 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
@@ -569,12 +570,12 @@ describe('AppAdminInboxService initial prune command', () => {
             'now-callback',
             'count:runtime-state',
             'current-authority',
+            'now-callback',
             'phase:read',
             'phase:compute',
             'phase:validate',
             'transaction',
             'result-write',
-            'now-callback',
             'commit-return'
         ]);
     });

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-persistence-invariants.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-persistence-invariants.test.ts
@@ -6,7 +6,11 @@ import {
     toAdminPruneOutbox,
     type AdminPrunePageWork
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
-import { AdminPrunePageWorker, type AdminPrunePageComputed } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
+import {
+    AdminPrunePageWorker,
+    toAdminPrunePageDelete,
+    type AdminPruneProgressWrite
+} from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import {
     createAdminPruneAggregate,
     decodeAdminPruneAggregate,
@@ -29,8 +33,7 @@ describe('admin prune page persistence invariants', () => {
         const repository = new PSqlAdminPruneRepository((() => undefined) as never);
         const deleted = await repository.deletePage(
             transaction,
-            pageWork({ category: 'resource-inbox' }),
-            ['1', '2', '3']
+            toAdminPrunePageDelete(pageWork({ category: 'resource-inbox' }), ['1', '2', '3'])
         );
 
         expect(deleted).toBe(3);
@@ -77,7 +80,8 @@ describe('admin prune page persistence invariants', () => {
             aggregate,
             expectedAggregate: JSON.stringify(aggregate),
             authority: { allowed: true, code: 'allowed' },
-            nowEpochMs: NOW
+            nowEpochMs: NOW,
+            serviceId: 'server-1'
         } as const;
         const computed = service.compute(command, read);
 
@@ -133,16 +137,10 @@ describe('admin prune page persistence invariants', () => {
             revision: 1
         } as const;
         const successorEntry = toAdminPruneAggregateEntry(aggregateSuccessor);
-        const computed: AdminPrunePageComputed = {
-            kind: 'page',
-            jobId: aggregate.jobId,
-            category: 'runtime-state',
-            rowIds: [],
-            deletedRows: 0,
-            next: null,
+        const computed: AdminPruneProgressWrite = {
             expectedAggregate: JSON.stringify(aggregate),
             aggregateSuccessor: successorEntry,
-            finishedAtEpochMs: NOW
+            aggregateSuccessorExpiryAtIsoTimestamp: successorEntry.audit.expiryTs.toString()
         };
         const boundValues: Array<Parameters<PSqlSql>[0][number]> = [];
         const transaction = ((parts: TemplateStringsArray, ...values: Parameters<PSqlSql>[0]) => {
@@ -150,8 +148,15 @@ describe('admin prune page persistence invariants', () => {
             return Promise.resolve([{ ris_row_id: 1 }]);
         }) as never;
         const repository = new PSqlAdminPruneRepository((() => undefined) as never);
+        const originalToString = Temporal.Instant.prototype.toString;
 
-        await repository.writeProgress(transaction, computed);
+        Temporal.Instant.prototype.toString = rejectTimestampFormattingDuringWrite;
+        try {
+            await repository.writeProgress(transaction, computed);
+        }
+        finally {
+            Temporal.Instant.prototype.toString = originalToString;
+        }
 
         expect(boundValues).toContain(successorEntry.resource);
         expect(boundValues).toContain(successorEntry.status);
@@ -161,6 +166,10 @@ describe('admin prune page persistence invariants', () => {
         expect(boundValues).toContain(computed.expectedAggregate);
     });
 });
+
+function rejectTimestampFormattingDuringWrite(): never {
+    throw new TypeError('Admin prune progress timestamp formatted inside write');
+}
 
 function pageWork(
     overrides: Partial<AdminPrunePageWork> = {}

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-postgres.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-postgres.test.ts
@@ -4,6 +4,7 @@ import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import type { AdminPruneAppData } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
 import { PSqlAdminPruneRepository } from '@shared-server/rallar-system/admin-operations/postgres/p-sql-admin-prune-repository.ts';
 import type { AdminPrunePageWork } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
+import { toAdminPrunePageDelete } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 
 const postgresIt = process.env.RALLAR_POSTGRES_INTEGRATION === '1' ? it : it.skip;
 
@@ -169,7 +170,7 @@ async function deletePage(
 ): Promise<number> {
     const repository = new PSqlAdminPruneRepository(sql);
     return await sql.begin(async (transaction) => {
-        return await repository.deletePage(transaction, work, rowIds);
+        return await repository.deletePage(transaction, toAdminPrunePageDelete(work, rowIds));
     });
 }
 

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
+import type { ResourceInboxReservationFinish } from '@shared-server/queuebox/postgres/resource-inbox-reservation-write.ts';
 import { createAdminPruneCommand, decodeAdminPruneCommand } from '@shared-server/rallar-system/admin-operations/inbox/admin-prune-command-codec.ts';
 import {
     ADMIN_PRUNE_APP_OUTBOX_TOPIC,
@@ -6,8 +7,13 @@ import {
     toAdminPruneOutbox,
     type AdminPrunePageWork
 } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-codec.ts';
-import { AdminPrunePageWorker, type AdminPrunePageRepository } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
+import {
+    AdminPrunePageWorker,
+    type AdminPrunePageDelete,
+    type AdminPrunePageRepository
+} from '@shared-server/rallar-system/admin-operations/prune/admin-prune-page-worker.ts';
 import { createAdminPruneAggregate, toAdminPruneAggregateEntry } from '@shared-server/rallar-system/admin-operations/prune/admin-prune-progress.ts';
+import type { AppOutboxInsert } from '@shared-server/rallar-system/app-outbox/app-outbox-insert.ts';
 import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import { describe, expect, it } from 'vitest';
@@ -82,13 +88,72 @@ describe('AdminPrunePageWorker', () => {
             }
         });
 
-        await work.write(repository.transaction, computed, entry);
+        await work.write(repository.transaction, computed);
 
         expect(repository.deleted).toEqual(['1', '2']);
         expect(repository.calls[0]).toBe('progress');
         expect(repository.writtenEntries).toHaveLength(1);
         expect(repository.finished).toEqual([entry.key]);
         expect(computed.next?.expireAtEpochMs).toBe(resourceInboxRetryExpiryAtEpochMs(NOW));
+    });
+
+    it('rejects prepared persistence data that differs from the read facts', async () => {
+        const repository = new MemoryPruneRepository(['1', '2', '3']);
+        const work = new AdminPrunePageWorker({
+            database: repository.database,
+            repository,
+            serviceId: 'server-1',
+            pageSize: 2,
+            now: () => NOW,
+            readAuthority: () => Promise.resolve({ allowed: true, code: 'allowed' })
+        });
+        const entry = createReservedEntry({
+            kind: 'page',
+            jobId: 'prune-exact-validation',
+            category: 'runtime-state',
+            capturedAtEpochMs: NOW,
+            expireAtEpochMs: NOW + 60_000,
+            pageSize: 2,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: null
+        });
+        const command = decodeAdminPruneWork(entry);
+        const read = await work.read(command);
+        const computed = work.compute(command, read);
+        if (computed.successorOutboxWrite === null) {
+            throw new Error('Expected successor page work');
+        }
+        const alteredCandidates = [
+            {
+                ...computed,
+                deletion: { ...computed.deletion, rowIds: ['different', '2'] }
+            },
+            {
+                ...computed,
+                aggregateSuccessorExpiryAtIsoTimestamp: '2099-01-01T00:00:00Z'
+            },
+            {
+                ...computed,
+                reservationFinish: {
+                    ...computed.reservationFinish,
+                    key: { ...computed.reservationFinish.key, resourceId: 'different' }
+                }
+            },
+            {
+                ...computed,
+                successorOutboxWrite: {
+                    ...computed.successorOutboxWrite,
+                    entry: { ...computed.successorOutboxWrite.entry, resource: '{}' }
+                }
+            }
+        ];
+
+        for (const altered of alteredCandidates) {
+            expect(() => work.validate(command, read, altered)).toThrow(
+                'Admin prune computed persistence differs from read facts'
+            );
+        }
     });
 
     it('excludes the currently executing resource-inbox row from its page', async () => {
@@ -180,6 +245,36 @@ describe('AdminPrunePageWorker', () => {
         expect(repository.finished).toEqual([]);
         expect(repository.progressWrites).toBe(0);
         expect(wakeCount).toBe(0);
+    });
+
+    it('computes denied work as data and rejects it during validation', async () => {
+        const repository = new MemoryPruneRepository(['1', '2', '3']);
+        const work = new AdminPrunePageWorker({
+            database: repository.database,
+            repository,
+            serviceId: 'server-1',
+            pageSize: 2,
+            now: () => NOW,
+            readAuthority: () => Promise.resolve({ allowed: false, code: 'session-revoked' })
+        });
+        const command = decodeAdminPruneWork(createReservedEntry({
+            kind: 'page',
+            jobId: 'prune-denied-validation',
+            category: 'runtime-state',
+            capturedAtEpochMs: NOW,
+            expireAtEpochMs: NOW + 60_000,
+            pageSize: 2,
+            afterCursor: null,
+            pageIndex: 0,
+            appData: null
+        }));
+        const read = await work.read(command);
+
+        const computed = work.compute(command, read);
+
+        expect(() => work.validate(command, read, computed)).toThrow(
+            expect.objectContaining({ code: 'admin-prune-authority-denied', status: 403 })
+        );
     });
 
     it('rolls aggregate, deletion, successor, and reservation back on outbox collision', async () => {
@@ -409,7 +504,7 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         }
     });
     readonly deleted: string[] = [];
-    readonly writtenEntries: ResourceEntry[] = [];
+    readonly writtenEntries: Array<Readonly<ResourceEntry>> = [];
     readonly finished: ResourceEntry['key'][] = [];
     readonly calls: string[] = [];
     lastExcludedResourceKey: ResourceEntry['key'] | null = null;
@@ -459,15 +554,15 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         return Promise.resolve({ aggregate, resource: entry.resource });
     }
 
-    deletePage(_transaction: never, _command: unknown, rowIds: readonly string[]) {
+    deletePage(_transaction: never, deletion: AdminPrunePageDelete) {
         this.calls.push('delete');
-        this.deleted.push(...rowIds);
-        return Promise.resolve(rowIds.length);
+        this.deleted.push(...deletion.rowIds);
+        return Promise.resolve(deletion.rowIds.length);
     }
 
-    writeOutbox(_transaction: never, entry: ResourceEntry) {
+    writeOutbox(_transaction: never, computed: AppOutboxInsert) {
         this.calls.push('outbox');
-        this.writtenEntries.push(entry);
+        this.writtenEntries.push(computed.entry);
         if (this.rejectOutbox) {
             throw new Error('Admin prune outbox collision');
         }
@@ -486,11 +581,11 @@ class MemoryPruneRepository implements AdminPrunePageRepository {
         return Promise.resolve();
     }
 
-    finishReserved(_transaction: never, entry: ResourceEntry) {
+    finishReserved(_transaction: never, completion: ResourceInboxReservationFinish) {
         if (this.loseReservation) {
             return Promise.resolve(false);
         }
-        this.finished.push(entry.key);
+        this.finished.push(completion.key);
         return Promise.resolve(true);
     }
 }

--- a/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-retry-lifetime.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/prune/admin-prune-retry-lifetime.test.ts
@@ -56,7 +56,8 @@ describe('admin prune retry lifetime', () => {
             aggregate,
             expectedAggregate: JSON.stringify(aggregate),
             authority: { allowed: true, code: 'allowed' },
-            nowEpochMs: NOW
+            nowEpochMs: NOW,
+            serviceId: 'server-1'
         };
 
         const computed = service.compute(command, read);

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
@@ -1,0 +1,125 @@
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    validateAppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
+import { AppInboxTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
+import { EntityStatus, toKeyAsString } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+import { createAtomicHarness } from '../test-support/app-inbox-transaction-test-runtime.ts';
+
+describe('AppInbox successful completion computation', () => {
+    it('validates captured completion facts without inspecting the durable result', () => {
+        const harness = createAtomicHarness();
+        let propertyReads = 0;
+        const facts = {
+            ...new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' })
+                .readCompletionFacts(harness.context),
+            completedAtEpochMs: Number.NaN,
+            status: EntityStatus.COMPLETED,
+            get durableResult() {
+                propertyReads += 1;
+                return { status: 'accepted' };
+            }
+        } as const;
+
+        const issues = validateAppInboxCompletionFacts(facts);
+
+        expect(issues.map((issue) => issue.path)).toEqual(['completedAtEpochMs']);
+        expect(propertyReads).toBe(0);
+    });
+
+    it('rejects completion data for a different reservation', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const durableResult = { status: 'accepted', revision: 2 } as const;
+        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        const candidate = {
+            ...computed,
+            reservationFinish: {
+                ...computed.reservationFinish,
+                expectedAttempts: computed.reservationFinish.expectedAttempts + 1
+            }
+        };
+
+        const issues = validateAppInboxCompletion(input, candidate);
+
+        expect(issues.map((issue) => issue.path)).toEqual(['computed.reservationFinish']);
+        expect(harness.database.beginCalls).toBe(0);
+    });
+
+    it('validates reservation identity by value rather than object identity', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const input = {
+            ...writer.readCompletionFacts(harness.context),
+            status: EntityStatus.COMPLETED,
+            durableResult: { status: 'accepted' }
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const copied = {
+            ...computed,
+            reservationFinish: {
+                ...computed.reservationFinish,
+                key: { ...computed.reservationFinish.key }
+            },
+            finalizedEntry: {
+                ...computed.finalizedEntry,
+                key: { ...computed.finalizedEntry.key }
+            }
+        };
+
+        expect(validateAppInboxCompletion(input, copied)).toEqual([]);
+    });
+
+    it('captures completion facts in read and consumes the exact result in write', async () => {
+        const harness = createAtomicHarness();
+        let clockReads = 0;
+        let readAllowed = true;
+        const nowEpochMs = () => {
+            if (!readAllowed) {
+                throw new Error('Completion facts were read after compute');
+            }
+            clockReads += 1;
+            return Date.parse('2026-07-22T12:00:01.000Z');
+        };
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1', nowEpochMs });
+        const facts = writer.readCompletionFacts(harness.context);
+        const durableResult = { status: 'accepted', revision: 2 } as const;
+        const input = { ...facts, status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
+        readAllowed = false;
+
+        const result = await writer.writeComputedMutation(harness.context, computed, async () => {
+            harness.database.writeMutation('group-1', { revision: 2 });
+        });
+
+        expect(result).toBe(durableResult);
+        expect(clockReads).toBe(1);
+        expect(harness.database.beginCalls).toBe(1);
+        const key = toKeyAsString(harness.entry.key);
+        expect(harness.database.state.results.get(key)?.resource).toBe(JSON.stringify(durableResult));
+        expect(harness.database.state.inbox.get(key)?.status).toBe(EntityStatus.COMPLETED);
+    });
+
+    it('keeps private after-commit data separate from the computed durable result', async () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const durableResult = { status: 'accepted' } as const;
+        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
+        const computed = computeAppInboxCompletion(input);
+        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
+        const afterCommitResult = { wakeQueue: true };
+
+        const result = await writer.writeComputedMutationWithAfterCommitResult(
+            harness.context,
+            computed,
+            async () => afterCommitResult
+        );
+
+        expect(result).toEqual({ durableResult, afterCommitResult });
+        expect(harness.database.state.results.get(toKeyAsString(harness.entry.key))?.resource).toBe(JSON.stringify(durableResult));
+    });
+});

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -19,8 +19,15 @@ import type {
 import { decodeAuthMutationIntent } from '@shared-server/rallar-system/auth/mutation/decode-auth-mutation-intent.ts';
 
 import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
-import type { AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxExecutionMetadata,
+    AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type {
     AppInboxMutationTransactionResult,
     AppInboxMutationTransactionWriter
@@ -194,6 +201,26 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
     constructor(actions: string[], transaction: PSqlSql) {
         this.actions = actions;
         this.transaction = transaction;
+    }
+
+    readCompletionFacts(_context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        throw new Error('Computed transaction path must not run');
+    }
+
+    async writeComputedMutation<Result>(
+        _context: AppInboxExecutionMetadata,
+        _computed: AppInboxCompletionComputed<Result>,
+        _write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result> {
+        throw new Error('Computed transaction path must not run');
+    }
+
+    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
+        _context: AppInboxExecutionMetadata,
+        _computed: AppInboxCompletionComputed<DurableResult>,
+        _write: (transaction: PSqlSql) => Promise<AfterCommitResult>
+    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
+        throw new Error('Computed after-commit transaction path must not run');
     }
 
     async writeMutation<Result>(

--- a/packages/tests/shared-server/rallar-system/crdt/inbox/crdt-inbox-completion.test.ts
+++ b/packages/tests/shared-server/rallar-system/crdt/inbox/crdt-inbox-completion.test.ts
@@ -1,0 +1,212 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import { computeCrdtInboxMutation, validateCrdtInboxMutation } from '@shared-server/rallar-system/crdt/inbox/compute-crdt-inbox-mutation.ts';
+import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
+import type { CrdtMutationRead } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-contracts.ts';
+import { writePSqlCrdtMutation } from '@shared-server/rallar-system/crdt/persistence/psql-crdt-mutation-repository.ts';
+import { RALLAR_CRDT_OPERATION_VERSION, RALLAR_CRDT_PROTOCOL_VERSION } from '@shared/crdt/mod.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+
+describe('CRDT inbox completion candidate', () => {
+    it('computes append state, outbox and completion from explicit facts', async () => {
+        const read = await createRead();
+        const computed = computeCrdtInboxMutation(read);
+
+        expect(computed.mutation).toMatchObject({ outcome: 'write', document: { documentRevision: 1, updateCount: 1 } });
+        expect(computed.mutation.outboxEntries).toHaveLength(2);
+        expect(computed.mutation).toHaveProperty('documentWrite');
+        expect(computed.mutation).toHaveProperty('updateWrite');
+        expect(computed.mutation).toHaveProperty('outboxWrites');
+        expect(Reflect.get(computed.mutation, 'outboxWrites')).toHaveLength(2);
+        if (computed.mutation.outcome !== 'write' || read.command.operation !== 'append') {
+            throw new Error('Expected an accepted CRDT append');
+        }
+        expect(computed.mutation.documentWrite).toMatchObject({
+            operation: 'insert',
+            documentRefJson: JSON.stringify(read.command.document),
+            createdAt: new Date(read.command.capturedAtEpochMs),
+            updatedAt: new Date(read.command.capturedAtEpochMs),
+            projectionIdsJson: '[]'
+        });
+        expect(computed.mutation.updateWrite).toMatchObject({
+            updateEnvelopeJson: JSON.stringify(read.command.update),
+            acceptedAt: new Date(read.command.capturedAtEpochMs)
+        });
+        expect(computed.mutation.outboxWrites.map(({ entry }) => entry)).toEqual(computed.mutation.outboxEntries);
+        expect(computed.mutation.conflict).toMatchObject({
+            name: 'CrdtMutationConflictError',
+            documentKey: read.command.documentKey
+        });
+        expect(computed.completion.durableResult).toBe(computed.mutation.result);
+        expect(computed.completion.reservationFinish.completedAt).toEqual(new Date(1_010));
+        expect(validateCrdtInboxMutation(read, computed)).toEqual([]);
+    });
+
+    it('preserves rejected and replay results while validating their completion', async () => {
+        const read = await createRead();
+        const accepted = computeCrdtInboxMutation(read);
+        const replayRead = {
+            ...read,
+            read: {
+                ...read.read,
+                document: accepted.mutation.document,
+                existingUpdate: read.command.operation === 'append' ? read.command.update : null,
+                existingAppend: accepted.mutation.append
+            }
+        };
+        const replay = computeCrdtInboxMutation(replayRead);
+        expect(replay.mutation.outcome).toBe('replay');
+        expect(replay.completion.durableResult.status).toBe('replay');
+        expect(validateCrdtInboxMutation(replayRead, replay)).toEqual([]);
+        const deniedRead = { ...read, read: { ...read.read, authorized: false, authorizationCode: 'authorization-denied' } };
+        const denied = computeCrdtInboxMutation(deniedRead);
+        expect(denied.mutation.outcome).toBe('rejected');
+        expect(denied.completion.durableResult.status).toBe('rejected');
+        expect(validateCrdtInboxMutation(deniedRead, denied)).toEqual([]);
+        const changed = { ...accepted, mutation: { ...accepted.mutation, outboxEntries: [] } };
+        expect(validateCrdtInboxMutation(read, changed).length).toBeGreaterThan(0);
+        expect(changed.mutation.outboxEntries).toEqual([]);
+        expect(
+            validateCrdtInboxMutation(read, {
+                ...accepted,
+                completion: {
+                    ...accepted.completion,
+                    reservationFinish: {
+                        ...accepted.completion.reservationFinish,
+                        expectedAttempts: 2
+                    }
+                }
+            }).length
+        ).toBeGreaterThan(0);
+    });
+
+    it('rejects hidden missing outbox writes without invoking a serialization callback', async () => {
+        const read = await createRead();
+        const computed = computeCrdtInboxMutation(read);
+        let callbackCalls = 0;
+        const candidate = {
+            ...computed,
+            mutation: {
+                ...computed.mutation,
+                outboxWrites: [],
+                toJSON: () => {
+                    callbackCalls += 1;
+                    return computed.mutation;
+                }
+            }
+        };
+
+        const issues = validateCrdtInboxMutation(read, candidate);
+
+        expect.soft(callbackCalls).toBe(0);
+        expect.soft(issues.length).toBeGreaterThan(0);
+        expect(candidate.mutation.outboxWrites).toHaveLength(0);
+    });
+
+    it('binds computed persistence values without serializing after transaction entry', async () => {
+        const read = await createRead();
+        const computed = computeCrdtInboxMutation(read);
+        expect(validateCrdtInboxMutation(read, computed)).toEqual([]);
+        const statements: string[] = [];
+        const transaction = createCrdtWriteTransaction(statements);
+        const serialize = vi.spyOn(JSON, 'stringify').mockImplementation(() => {
+            throw new Error('CRDT serialization ran during write');
+        });
+
+        try {
+            await expect(writePSqlCrdtMutation(transaction, computed.mutation)).resolves.toBe(
+                computed.mutation.result
+            );
+        }
+        finally {
+            serialize.mockRestore();
+        }
+
+        expect(statements.filter((statement) => statement.includes('insert into crdt_documents'))).toHaveLength(1);
+        expect(statements.filter((statement) => statement.includes('insert into crdt_updates'))).toHaveLength(1);
+        expect(statements.filter((statement) => statement.includes('insert into resource_inbox'))).toHaveLength(2);
+    });
+});
+
+async function createRead() {
+    const document = {
+        applicationId: 'app',
+        workspaceId: 'workspace',
+        scope: 'room' as const,
+        documentType: 'checklist',
+        documentId: 'document',
+        roomRef: { applicationId: 'app', workspaceId: 'workspace', groupId: 'group' }
+    };
+    const command = await createCrdtMutationCommand({
+        operation: 'append',
+        commandId: 'append',
+        deliveryId: 'delivery',
+        document,
+        actor: { actorId: 'actor', principalId: 'principal', sessionId: 'session', serverId: 'server' },
+        capturedAtEpochMs: 1_000,
+        expireAtEpochMs: 100_000,
+        authorizationScope: 'room',
+        responseAudience: { kind: 'room', senderSessionId: 'session', topicId: 'room.crdt', contextId: 'group' },
+        update: {
+            protocolVersion: RALLAR_CRDT_PROTOCOL_VERSION,
+            document,
+            updateId: 'update',
+            replicaId: 'replica',
+            lamport: 1,
+            parents: [],
+            schemaVersion: 1,
+            operationVersion: RALLAR_CRDT_OPERATION_VERSION,
+            createdAtEpochMs: 900,
+            payload: { kind: 'batch', operations: [{ kind: 'register.set', path: ['title'], policy: 'lww', value: 'title' }] }
+        }
+    });
+    const read: CrdtMutationRead = {
+        document: null,
+        existingUpdate: null,
+        existingAppend: null,
+        records: [],
+        snapshot: null,
+        authorized: true,
+        authorizationCode: 'allowed',
+        actorUpdatesInWindow: 0,
+        storedSnapshotBytes: 0,
+        featureDecision: { allowed: true, code: 'allowed', reason: 'test', rollout: 'production', retryable: false }
+    };
+    return { command, read, serviceId: 'server', completionFacts: { entry: createEntry(), completedAtEpochMs: 1_010 } };
+}
+
+function createEntry(): ResourceEntry {
+    return {
+        key: { topicId: 'app-inbox.crdt-state', resourceId: 'delivery', contextId: 'document' },
+        resource: '{}',
+        typeId: 'APP_INBOX',
+        status: EntityStatus.RESERVED,
+        audit: {
+            date: Temporal.PlainTime.from('12:00:00'),
+            createdBy: 'server',
+            createdTs: Temporal.PlainDateTime.from('2026-08-07T12:00:00'),
+            expiryTs: Temporal.Instant.from('2026-08-07T13:00:00Z')
+        },
+        dequeueAudit: { attempts: 1 }
+    };
+}
+
+function createCrdtWriteTransaction(statements: string[]): PSqlSql {
+    const transaction = (async <Result>(strings: TemplateStringsArray): Promise<Result> => {
+        const statement = strings.join(' ');
+        statements.push(statement);
+        if (statement.includes('insert into crdt_documents')) {
+            return [{ document_key: 'document' }] as Result;
+        }
+        if (statement.includes('insert into resource_inbox')) {
+            return [{ ri_row_id: 1n }] as Result;
+        }
+        return [] as Result;
+    }) as PSqlSql;
+    transaction.begin = async () => {
+        throw new Error('CRDT writes must use the caller transaction');
+    };
+    return transaction;
+}

--- a/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import type { AppOutboxInsert } from '@shared-server/rallar-system/app-outbox/app-outbox-insert.ts';
 import { createCrdtMutationCommand } from '@shared-server/rallar-system/crdt/mutation/crdt-mutation-command-codec.ts';
 import {
     CrdtMutationConflictError,
@@ -194,9 +195,11 @@ describe('CRDT mutation service', () => {
         const computed = service.compute({ command, read });
         const commandMismatch = { ...computed, command: { ...command } };
         const readMismatch = { ...computed, read: { ...read } };
+        const persistenceMismatch = { ...computed, outboxWrites: [] };
 
         expect(service.validate({ command, read, computed: commandMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
         expect(service.validate({ command, read, computed: readMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
+        expect(service.validate({ command, read, computed: persistenceMismatch })).toMatchObject([{ code: 'computed-persistence-differs' }]);
     });
 
     it('returns all ordered validation issues for a malformed compact accepted result', async () => {
@@ -238,7 +241,8 @@ describe('CRDT mutation service', () => {
             'computed-identity-differs',
             'computed-predecessor-differs',
             'compact-reason-differs',
-            'result-codec-invalid'
+            'result-codec-invalid',
+            'computed-persistence-differs'
         ]);
     });
 });
@@ -370,9 +374,9 @@ class MemoryCrdtMutationRepository implements CrdtMutationRepository {
         return Promise.resolve();
     }
 
-    writeOutbox(entries: readonly ResourceEntry[]): Promise<void> {
+    writeOutbox(writes: readonly AppOutboxInsert[]): Promise<void> {
         this.operations.push('write-final-outbox');
-        this.outbox.push(...entries);
+        this.outbox.push(...writes.map(({ entry }) => entry));
         return Promise.resolve();
     }
 }

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
-import { type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxExecutionMetadata,
+    AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     AppInboxTransactionWriter,
     type AppInboxMutationTransactionResult,
@@ -31,6 +38,17 @@ type DurableResult = Readonly<{ status: 'durable'; }>;
 type AfterCommitResult = Readonly<{ committedSnapshot: GroupSnapshot | undefined; }>;
 type TransactionResult = AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>;
 type ExpectedTransactionWriter = {
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
+    writeComputedMutation<Result>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<Result>;
+    writeComputedMutationWithAfterCommitResult<Durable, AfterCommit>(
+        context: AppInboxExecutionMetadata,
+        computed: AppInboxCompletionComputed<Durable>,
+        write: (transaction: PSqlSql) => Promise<AfterCommit>
+    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
     writeMutation<Result>(
         context: AppInboxMessageContext<Result>,
         write: (transaction: PSqlSql) => Promise<Result>

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -3,8 +3,16 @@ import { describe, expect, it } from 'vitest';
 
 import type { PSqlParameter, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import { decodeAppInboxEnqueue } from '@shared-server/rallar-system/app-inbox/app-inbox-command-decoding.ts';
-import { AppInboxType, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
+import {
+    AppInboxType,
+    type AppInboxExecutionMetadata,
+    type AppInboxMessageContext
+} from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import type {
+    AppInboxCompletionComputed,
+    AppInboxCompletionFacts
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupMutationPreparation } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import { GroupStateInboxHandler } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
@@ -121,6 +129,19 @@ describe('group-state AppInbox transaction result boundary', () => {
     it('persists an inactive presence result once without active mutation effects', async () => {
         const actions: string[] = [];
         const transactionWriter: AppInboxMutationTransactionWriter = {
+            readCompletionFacts: (_context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
+                throw new Error('Inactive presence must not read computed completion facts');
+            },
+            writeComputedMutation: async <Result>(
+                _context: AppInboxExecutionMetadata,
+                _computed: AppInboxCompletionComputed<Result>,
+                _write: (transaction: PSqlSql) => Promise<void>
+            ): Promise<Result> => {
+                throw new Error('Inactive presence must not use computed mutation transaction');
+            },
+            writeComputedMutationWithAfterCommitResult: async () => {
+                throw new Error('Inactive presence must not use computed after-commit transaction');
+            },
             writeMutation: async (_context, write) => {
                 actions.push('inactive-transaction');
                 return await write(createUnusedTransaction());


### PR DESCRIPTION
## Goal

Establish the strict read → compute → validate → write(transaction, computed) contract and migrate the foundational AppInbox, CRDT, and admin-prune paths.

## Changes

- Defines the canonical transaction-purity guidance and pressure evaluation.
- Adds prepared AppInbox completion and AppOutbox insertion values.
- Moves CRDT and admin-prune deterministic persistence work before transactions.

## Acceptance

- Compute and validate remain pure.
- Write callbacks only execute already-computed values or use actual database outcomes.
- AppInbox remains the retry owner; no inner retry loop is introduced.

## Validation

- Consolidation tree is byte-for-byte identical to the reviewed historical cut point.
- Full focused, package, standards, legacy, integration, performance, and CI evidence is pending this consolidated review.

## Risk and rollback

This is the first PR in a five-PR stack. Revert this single consolidated commit to restore the prior foundation. The main review risk is breadth across AppInbox, CRDT, and admin-prune ownership.

## Follow-up

The remaining four consolidated PRs complete the migration and checker activation.