### PR TITLE
Finalize computed mutation results

### DIFF
--- a/.agents/skills/rallar-code-writing/SKILL.md
+++ b/.agents/skills/rallar-code-writing/SKILL.md
@@ -226,8 +226,9 @@ checker does not substitute for following production symbols.
   allowance is the exact guarded winner materializer, which may construct its
   bounded winner-only row. Outside that allowance, prohibit ordinary domain
   mutation logic, external effects, timers, polling, unbounded work, and
-  arbitrary unresolved operation callbacks. Treat its reported boundary
-  inventory as review evidence, not as a strict pass or an exception.
+  arbitrary unresolved operation callbacks. Treat the checker's explicit file
+  inventory as review evidence, not as a strict pass or an exception. A new
+  file is strict by default until its exact specialized ownership is reviewed.
 - Prefer a functional core with an explicitly owned stateful shell. Model domain
   decisions and conditional-write outcomes as separate typed values.
 - Authoritative persisted and shared contracts use mandatory fields by default.

--- a/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
+++ b/.agents/skills/rallar-code-writing/references/convergent-service-writing.md
@@ -109,9 +109,9 @@ callbacks; and opening or taking ownership of an unrelated nested transaction.
 Caller-owned mutation and dynamically unresolved behavior fail closed. The
 same external-effect, timer, polling, boundedness, caller-mutation, and nested
 transaction prohibitions apply inside the winner materializer. The checker
-reports specialized ResourceInbox boundaries separately from strict findings.
-That inventory is neither an exception nor proof that the boundary satisfies
-`strict-domain-write`.
+keeps specialized ResourceInbox files in an explicit reviewed inventory and
+analyzes new files by default. Inventory membership is neither an exception nor
+proof that the boundary satisfies `strict-domain-write`.
 
 The one externally supplied operation-callback shape permitted by this policy
 is the exact guarded winner materializer. The ResourceInbox owner must first

--- a/apps/api-v1/src/composition/create-api-v1-mutation-runtime.ts
+++ b/apps/api-v1/src/composition/create-api-v1-mutation-runtime.ts
@@ -136,6 +136,7 @@ interface ApiV1MutationResources {
 
 interface CreateGroupStateInboxServiceFactoryInput extends ApiV1StateMutationDependencies {
     readonly groupStateService: ReturnType<typeof createCachedGroupStateService>;
+    readonly resultReader: ApiV1MutationResources['groupsRepository'];
     readonly groupFormationRecomputeDebounceMs: number;
 }
 
@@ -200,6 +201,7 @@ export function createApiV1MutationRuntime(
         createGroupStateInboxService: createGroupStateInboxServiceFactory({
             ...stateDependencies,
             groupStateService,
+            resultReader: resources.groupsRepository,
             groupFormationRecomputeDebounceMs: input.groupFormationRecomputeDebounceMs
         }),
         createAppClientInboxService: createAppClientInboxServiceFactory(stateDependencies),
@@ -323,7 +325,8 @@ function createGroupStateInboxServiceFactory(
                 resourceInboxRepository: input.resourceInboxRepository.entries,
                 resourceInboxResultsRepository: input.resourceInboxResultsRepository,
                 database: input.database,
-                groupStateService: input.groupStateService
+                groupStateService: input.groupStateService,
+                resultReader: input.resultReader
             },
             {
                 serviceId: input.serviceId,

--- a/apps/api-v1/test/db/pglite-group-state-and-auth.test.ts
+++ b/apps/api-v1/test/db/pglite-group-state-and-auth.test.ts
@@ -229,11 +229,13 @@ Deno.test(
             for (const joiningAuthority of joiningAuthorities) {
                 await authSessions.putSession(joiningAuthority);
             }
+            const groupEvents = new PSqlGroupStateEventRepository(sql);
+            const groups = new GroupStateRepository(runtime, groupEvents);
             const groupState = createGroupStateService({
                 readPlannedLayoutRow: () => Promise.resolve(null),
                 readAcceptedLayoutRow: () => Promise.resolve(null),
                 runtimeRepository: runtime,
-                groupStateEventStore: new PSqlGroupStateEventRepository(sql),
+                groupStateEventStore: groupEvents,
                 authSessionRepository: authSessions,
                 serviceId: 'pglite-group-service',
                 now: () => nowEpochMs
@@ -244,7 +246,8 @@ Deno.test(
                     resourceInboxRepository: resourceInbox.entries,
                     resourceInboxResultsRepository: resourceResults,
                     database: sql,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: groups
                 },
                 {
                     serviceId: 'pglite-group-service',
@@ -360,7 +363,7 @@ Deno.test(
                 groupId: 'vertical-group'
             };
             assert.equal(
-                (await new GroupStateRepository(runtime, new PSqlGroupStateEventRepository(runtime.sql)).findGroup(ref))?.displayName,
+                (await groups.findGroup(ref))?.displayName,
                 'Vertical Group'
             );
             assert.equal((await new PSqlGroupStateEventRepository(sql).listGroupEvents(ref)).length, 3);
@@ -437,11 +440,13 @@ Deno.test(
             };
             const authSessions = new AuthSessionRepository(runtime);
             await authSessions.putSession(authority);
+            const groupEvents = new PSqlGroupStateEventRepository(sql);
+            const groups = new GroupStateRepository(runtime, groupEvents);
             const groupState = createGroupStateService({
                 readPlannedLayoutRow: () => Promise.resolve(null),
                 readAcceptedLayoutRow: () => Promise.resolve(null),
                 runtimeRepository: runtime,
-                groupStateEventStore: new PSqlGroupStateEventRepository(sql),
+                groupStateEventStore: groupEvents,
                 authSessionRepository: authSessions,
                 serviceId: 'pglite-summary-fence',
                 now: () => nowEpochMs
@@ -452,7 +457,8 @@ Deno.test(
                     resourceInboxRepository: resourceInbox.entries,
                     resourceInboxResultsRepository: resourceResults,
                     database: sql,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: groups
                 },
                 {
                     serviceId: 'pglite-summary-fence',
@@ -519,8 +525,7 @@ Deno.test(
                 workspaceId: 'main',
                 groupId: 'fence-group'
             };
-            const repository = new GroupStateRepository(runtime, new PSqlGroupStateEventRepository(runtime.sql));
-            const summaryBefore = await repository.findPresenceSummaryEntry(ref);
+            const summaryBefore = await groups.findPresenceSummaryEntry(ref);
             const work = new GroupPresenceSummaryWork({
                 outboxQueueReader: new OutboxQueueReader(
                     new PSqlQueueBox(createPSqlResourceInboxRepository(sql))
@@ -541,7 +546,7 @@ Deno.test(
                 /reservation changed before commit/
             );
 
-            assert.deepEqual(await repository.findPresenceSummaryEntry(ref), summaryBefore);
+            assert.deepEqual(await groups.findPresenceSummaryEntry(ref), summaryBefore);
             const stillReserved = await resourceInbox.entries.findAnyByKey(key);
             assert.equal(stillReserved?.status, EntityStatus.RESERVED);
             assert.equal(stillReserved?.dequeueAudit.attempts, 1);

--- a/apps/api-v1/test/db/pglite-runtime-state-and-collisions.test.ts
+++ b/apps/api-v1/test/db/pglite-runtime-state-and-collisions.test.ts
@@ -18,6 +18,7 @@ import { createGroupTopologyMutationOwners } from '@shared-server/rallar-system/
 import { RtcTopologyOutboxWriter } from '@shared-server/rallar-system/topology/mutation/rtc-topology-outbox-writer.ts';
 import { createGroupTopologyRuntimeOwners } from '@shared-server/rallar-system/topology/runtime/create-group-topology-runtime-owners.ts';
 import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/runtime/rallar-rtc-topology-service.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { decodePersistedALMessage } from '@shared/al-contracts/al-message-persistence-validation.ts';
@@ -234,8 +235,9 @@ Deno.test(
                 }]
             };
 
+            const insertWrite = computeRuntimeStateGuardedBatchWrite(insertBatch);
             const insertResult = await repository.begin(async (transactionRepository) => {
-                return await transactionRepository.executeGuardedBatch(insertBatch);
+                return await transactionRepository.writeGuardedBatch(insertWrite);
             });
 
             assert.deepEqual(insertResult, {
@@ -306,9 +308,10 @@ Deno.test(
                     expireAtTimestamp: FUTURE_MS
                 }]
             };
+            const updateWrite = computeRuntimeStateGuardedBatchWrite(updateBatch);
             assert.deepEqual(
                 await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch(updateBatch);
+                    return await transactionRepository.writeGuardedBatch(updateWrite);
                 }),
                 {
                     guard: {
@@ -345,9 +348,10 @@ Deno.test(
                     expireAtTimestamp: FUTURE_MS
                 }]
             };
+            const deleteWrite = computeRuntimeStateGuardedBatchWrite(deleteBatch);
             assert.deepEqual(
                 await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch(deleteBatch);
+                    return await transactionRepository.writeGuardedBatch(deleteWrite);
                 }),
                 {
                     guard: {
@@ -404,8 +408,9 @@ Deno.test(
                 }]
             };
 
+            const computed = computeRuntimeStateGuardedBatchWrite(batch);
             const result = await repository.begin(async (transactionRepository) => {
-                return await transactionRepository.executeGuardedBatch(batch);
+                return await transactionRepository.writeGuardedBatch(computed);
             });
 
             assert.deepEqual(result, {
@@ -459,24 +464,25 @@ Deno.test(
                 fractionalEpochMs
             );
 
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'insert',
+                    namespace: 'guarded-expiry',
+                    key: 'guarded-future',
+                    value: 'future',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'fractional',
+                    operation: 'insert',
+                    namespace: 'guarded-expiry',
+                    key: 'guarded-fractional',
+                    value: 'fractional',
+                    expireAtTimestamp: fractionalEpochMs
+                }]
+            });
             await repository.begin(async (transactionRepository) => {
-                await transactionRepository.executeGuardedBatch({
-                    guard: {
-                        operation: 'insert',
-                        namespace: 'guarded-expiry',
-                        key: 'guarded-future',
-                        value: 'future',
-                        expireAtTimestamp: FUTURE_MS
-                    },
-                    effects: [{
-                        effectId: 'fractional',
-                        operation: 'insert',
-                        namespace: 'guarded-expiry',
-                        key: 'guarded-fractional',
-                        value: 'fractional',
-                        expireAtTimestamp: fractionalEpochMs
-                    }]
-                });
+                await transactionRepository.writeGuardedBatch(computed);
             });
 
             const rows = await sql<RuntimeStateExpiryRow[]>`
@@ -506,36 +512,37 @@ Deno.test(
         await withPGliteSql(async (sql) => {
             const repository = new PSqlRuntimeStateRepository(sql);
             await repository.insertIfAbsent('guarded-rollback', 'root', 'before', FUTURE_MS);
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'update',
+                    namespace: 'guarded-rollback',
+                    key: 'root',
+                    expectedRevision: 0,
+                    value: 'after',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'sibling',
+                    operation: 'insert',
+                    namespace: 'guarded-rollback',
+                    key: 'sibling',
+                    value: 'inserted',
+                    expireAtTimestamp: FUTURE_MS
+                }, {
+                    effectId: 'conflict',
+                    operation: 'update',
+                    namespace: 'guarded-rollback',
+                    key: 'missing',
+                    expectedRevision: 0,
+                    value: 'never',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             await assert.rejects(
                 async () => {
                     await repository.begin(async (transactionRepository) => {
-                        const observedResult = await transactionRepository.executeGuardedBatch({
-                            guard: {
-                                operation: 'update',
-                                namespace: 'guarded-rollback',
-                                key: 'root',
-                                expectedRevision: 0,
-                                value: 'after',
-                                expireAtTimestamp: FUTURE_MS
-                            },
-                            effects: [{
-                                effectId: 'sibling',
-                                operation: 'insert',
-                                namespace: 'guarded-rollback',
-                                key: 'sibling',
-                                value: 'inserted',
-                                expireAtTimestamp: FUTURE_MS
-                            }, {
-                                effectId: 'conflict',
-                                operation: 'update',
-                                namespace: 'guarded-rollback',
-                                key: 'missing',
-                                expectedRevision: 0,
-                                value: 'never',
-                                expireAtTimestamp: FUTURE_MS
-                            }]
-                        });
+                        const observedResult = await transactionRepository.writeGuardedBatch(computed);
                         assert.deepEqual(observedResult, {
                             guard: {
                                 status: 'applied',

--- a/apps/api-v1/test/db/pglite-state-event-validation.test.ts
+++ b/apps/api-v1/test/db/pglite-state-event-validation.test.ts
@@ -46,6 +46,7 @@ Deno.test('PSql group event reads fail closed on a wrong-scope payload', async (
 
         for (
             const read of [
+                () => repository.readGroupEvent(expectedRef, corruptEvent.eventId),
                 () => repository.listGroupEvents(expectedRef),
                 () => repository.listRecentGroupEvents(expectedRef),
                 () => repository.listGroupEventPage(expectedRef, { limit: 10 })
@@ -93,6 +94,7 @@ Deno.test(
 
             for (
                 const read of [
+                    () => repository.readGroupEvent(ref, incompleteEvent.eventId),
                     () => repository.listGroupEvents(ref),
                     () => repository.listRecentGroupEvents(ref),
                     () => repository.listGroupEventPage(ref, { limit: 1 })

--- a/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts
+++ b/packages/shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts
@@ -3,6 +3,7 @@ import { EntityStatus, type Key, type ResourceEntry } from '@shared/queuebox/Res
 import { Either } from '@shared/resilience/Either.ts';
 import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
 import type { StartProcessingEntitySkipped } from './p-sql-resource-inbox-reservation-repository.ts';
+import { writeResourceInboxReservationFinish } from './resource-inbox-reservation-write.ts';
 import { rowsToMap, toDomain, type ResourceInboxRow } from './resource-inbox-row-codec.ts';
 
 export class PSqlResourceInboxFinalizationRepository {
@@ -111,18 +112,11 @@ export class PSqlResourceInboxFinalizationRepository {
             );
         }
 
-        const rows = await this.sql<{ ri_row_id: bigint; }[]>`
-            update resource_inbox
-            set ri_status = ${status}, end_ts = ${completedAt}, next_ts = null
-            where ri_topic_id = ${key.topicId}
-              and ri_resource_id = ${key.resourceId}
-              and fk_ext_bank_id = ${key.contextId}
-              and ri_status = 'RESERVED'
-              and ri_attempts = ${expectedAttempts}
-              and expire_ts > (now() at time zone 'UTC')
-            returning ri_row_id
-        `;
-
-        return rows.length === 1;
+        return await writeResourceInboxReservationFinish(this.sql, {
+            key,
+            expectedAttempts,
+            status,
+            completedAt
+        });
     }
 }

--- a/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
+++ b/packages/shared-server/rallar-system/admin-operations/inbox/compute-admin-prune-mutation.ts
@@ -12,13 +12,13 @@ import {
 } from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     computeAppOutboxInsert,
+    isExactAppOutboxInsert,
     type AppOutboxInsert
 } from '../../app-outbox/app-outbox-insert.ts';
 import { toAdminPruneOutbox } from '../prune/admin-prune-page-codec.ts';
 import {
     createAdminPruneAggregate,
-    toAdminPruneAggregateEntry,
-    toAdminPruneAggregateKey
+    toAdminPruneAggregateEntry
 } from '../prune/admin-prune-progress.ts';
 import type { AdminPruneCommand } from './admin-prune-command-codec.ts';
 import type { AdminPruneEnqueueResult } from './admin-prune-inbox-codec.ts';
@@ -93,6 +93,7 @@ export function validateAdminPruneMutation(
     computed: AdminPruneComputed
 ): readonly AdminPruneValidationIssue[] {
     const issues: AdminPruneValidationIssue[] = [];
+    const expected = computeAdminPruneMutation(read);
     if (!read.authority.allowed || read.command.expireAtEpochMs <= read.nowEpochMs) {
         issues.push({
             code: 'admin-prune-authority-denied',
@@ -118,10 +119,10 @@ export function validateAdminPruneMutation(
             status: 400
         });
     }
-    if (!hasExpectedAggregateWrite(read, computed.aggregateWrite)) {
+    if (!hasExactAdminPrunePersistence(computed, expected)) {
         issues.push({
-            code: 'admin-prune-aggregate-presence-invalid',
-            message: 'Admin prune aggregate write differs from its command',
+            code: 'admin-prune-computed-persistence-invalid',
+            message: 'Admin prune prepared persistence differs from its computed mutation',
             status: 400
         });
     }
@@ -140,6 +141,41 @@ export function validateAdminPruneMutation(
         }))
     );
     return issues;
+}
+
+function hasExactAdminPrunePersistence(
+    computed: AdminPruneComputed,
+    expected: AdminPruneComputed
+): boolean {
+    if (
+        computed.outboxWrites.length !== expected.outboxWrites.length ||
+        !computed.outboxWrites.every((write, index) => {
+            const expectedWrite = expected.outboxWrites[index];
+            return expectedWrite !== undefined && isExactAppOutboxInsert(expectedWrite.entry, write);
+        })
+    ) {
+        return false;
+    }
+    return hasSameAdminPruneAggregateWrite(computed.aggregateWrite, expected.aggregateWrite);
+}
+
+function hasSameAdminPruneAggregateWrite(
+    left: AdminPruneAggregateWrite | null,
+    right: AdminPruneAggregateWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.entry.key.topicId === right.entry.key.topicId &&
+        left.entry.key.resourceId === right.entry.key.resourceId &&
+        left.entry.key.contextId === right.entry.key.contextId &&
+        left.entry.resource === right.entry.resource &&
+        left.entry.typeId === right.entry.typeId &&
+        left.entry.status === right.entry.status &&
+        left.entry.audit.createdBy === right.entry.audit.createdBy &&
+        left.systemDate === right.systemDate &&
+        left.createdAt === right.createdAt &&
+        left.expiresAt === right.expiresAt;
 }
 
 function computeInitialAdminPrunePages(
@@ -179,20 +215,4 @@ function computeAdminPruneAggregateWrite(entry: ResourceEntry): AdminPruneAggreg
         createdAt: toPgTimestamp(snapshot.audit.createdTs),
         expiresAt: toPgTimestamp(snapshot.audit.expiryTs)
     };
-}
-
-function hasExpectedAggregateWrite(
-    read: AdminPruneRead,
-    aggregateWrite: AdminPruneAggregateWrite | null
-): boolean {
-    if (read.command.dryRun) {
-        return aggregateWrite === null;
-    }
-    if (aggregateWrite === null) {
-        return false;
-    }
-    const expectedKey = toAdminPruneAggregateKey(read.command.jobId);
-    return aggregateWrite.entry.key.topicId === expectedKey.topicId &&
-        aggregateWrite.entry.key.resourceId === expectedKey.resourceId &&
-        aggregateWrite.entry.key.contextId === expectedKey.contextId;
 }

--- a/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
+++ b/packages/shared-server/rallar-system/app-inbox/app-inbox-retry-finalization.ts
@@ -1,21 +1,20 @@
-import { Temporal } from '@js-temporal/polyfill';
 import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '@shared-server/postgres/run-in-p-sql-transaction.ts';
-import { PSqlResourceInboxFinalizationRepository } from '@shared-server/queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
-import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres/resource-inbox-results-repository.ts';
+import { writeResourceInboxReservationFinish } from '@shared-server/queuebox/postgres/resource-inbox-reservation-write.ts';
+import { writeResourceInboxResultReplacement } from '@shared-server/queuebox/postgres/resource-inbox-result-replacement.ts';
 import type {
     ResourceInboxRetryExhaustion,
     ResourceInboxRetryExhaustionRecovery
 } from '@shared/queuebox/DequeueResourceEntryController.ts';
-import {
-    EntityStatus,
-    toResourceEntryWithUpdatedResource,
-    type ResourceEntry
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import { timeRallarAsync, type RallarTimingDetails, type RallarTimingSink } from '../observability/timing.ts';
 import { validateAppInboxCommandIdentity } from './app-inbox-command-identity.ts';
-import { AppInboxReservationConflictError } from './app-inbox-contracts.ts';
 import type { AppInboxFailure } from './app-inbox-failure.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from './handler/app-inbox-completion-computation.ts';
 
 export type AppInboxRetryFinalization =
     | ResourceInboxRetryExhaustion
@@ -27,10 +26,7 @@ export interface AppInboxRetryFinalizerDependencies {
 }
 
 interface AppInboxRetryFinalizationWork {
-    readonly finalization: AppInboxRetryFinalization;
-    readonly finalizedAtEpochMs: number;
-    readonly finalizedAt: Date;
-    readonly diagnostics: AppInboxFailure;
+    readonly completion: AppInboxCompletionComputed<AppInboxFailure>;
     readonly timingDetails: RallarTimingDetails;
 }
 
@@ -61,11 +57,19 @@ function createAppInboxRetryFinalizationWork(
     finalization: AppInboxRetryFinalization
 ): AppInboxRetryFinalizationWork {
     const finalizedAtEpochMs = toFinalizedAtEpochMs(finalization);
+    const completionInput = {
+        entry: finalization.entry,
+        completedAtEpochMs: finalizedAtEpochMs,
+        durableResult: toDiagnostics(finalization),
+        status: EntityStatus.FAILED
+    } as const;
+    const completion = computeAppInboxCompletion(completionInput);
+    const issues = validateAppInboxCompletion(completionInput, completion);
+    if (issues[0] !== undefined) {
+        throw issues[0].cause;
+    }
     return {
-        finalization,
-        finalizedAtEpochMs,
-        finalizedAt: new Date(finalizedAtEpochMs),
-        diagnostics: toDiagnostics(finalization),
+        completion,
         timingDetails: {
             processingAttempts: finalization.processingAttempts,
             reservationAttempt: finalization.reservationAttempt,
@@ -83,56 +87,20 @@ async function finalizeAppInboxRetry(
     dependencies: AppInboxRetryFinalizerDependencies,
     work: AppInboxRetryFinalizationWork
 ): Promise<ResourceEntry> {
-    return await runInPSqlTransaction(dependencies.database, async (transaction) => {
-        await writeAppInboxRetryFinalization(dependencies.timing, transaction, work);
-        return toFinalizedAppInboxEntry(work);
+    await runInPSqlTransaction(dependencies.database, async (transaction) => {
+        await writeAppInboxRetryFinalization(transaction, work.completion);
     });
+    return work.completion.finalizedEntry;
 }
 
 async function writeAppInboxRetryFinalization(
-    timing: RallarTimingSink | undefined,
     transaction: PSqlSql,
-    work: AppInboxRetryFinalizationWork
+    computed: AppInboxCompletionComputed<AppInboxFailure>
 ): Promise<void> {
-    const finalizationRepository = new PSqlResourceInboxFinalizationRepository(transaction);
-    const results = new ResourceInboxResultsRepository(transaction);
-    await timeRallarAsync(
-        timing,
-        {
-            component: 'app-inbox-phase',
-            operation: 'write',
-            requestId: work.finalization.entry.key.resourceId,
-            details: work.timingDetails
-        },
-        async () => {
-            await results.replace(toResourceEntryWithUpdatedResource(
-                work.finalization.entry,
-                EntityStatus.FAILED,
-                work.diagnostics
-            ));
-            const finished = await finalizationRepository.finishReserved(
-                work.finalization.entry.key,
-                work.finalization.reservationAttempt,
-                EntityStatus.FAILED,
-                work.finalizedAt
-            );
-            if (!finished) {
-                throw new AppInboxReservationConflictError(work.finalization.entry.key);
-            }
-        }
-    );
-}
-
-function toFinalizedAppInboxEntry(work: AppInboxRetryFinalizationWork): ResourceEntry {
-    return {
-        ...work.finalization.entry,
-        status: EntityStatus.FAILED,
-        dequeueAudit: {
-            ...work.finalization.entry.dequeueAudit,
-            endTs: Temporal.Instant.fromEpochMilliseconds(work.finalizedAtEpochMs),
-            nextTs: undefined
-        }
-    };
+    await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
+    if (!await writeResourceInboxReservationFinish(transaction, computed.reservationFinish)) {
+        throw computed.reservationConflict;
+    }
 }
 
 function toDiagnostics(exhaustion: AppInboxRetryFinalization): AppInboxFailure {

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts
@@ -9,6 +9,7 @@ import {
     computeResourceInboxResultReplacement,
     type ResourceInboxResultReplacement
 } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
+import { serializeCanonicalJson } from '../../protocol/canonical-json.ts';
 import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import { AppInboxReservationConflictError } from '../app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '../app-inbox-registration-codecs.ts';
@@ -76,8 +77,18 @@ export function validateAppInboxCompletion<Result>(
     computed: AppInboxCompletionComputed<Result>
 ): readonly AppInboxCompletionValidationIssue[] {
     const issues = validateAppInboxCompletionFacts(input);
+    if (issues.length > 0) {
+        return issues;
+    }
+    const expected = computeAppInboxCompletion(input);
     if (computed.durableResult !== input.durableResult) {
         issues.push(toAppInboxCompletionValidationIssue('computed.durableResult', 'must be the computed result'));
+    }
+    if (!hasSameJsonWireValue(computed.encodedResult, expected.encodedResult)) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.encodedResult',
+            'must encode the computed durable result'
+        ));
     }
     if (
         !hasSameResourceInboxKey(computed.reservationFinish.key, input.entry.key) ||
@@ -91,10 +102,7 @@ export function validateAppInboxCompletion<Result>(
         ));
     }
     if (
-        computed.resultReplacement.resourceId !== input.entry.key.resourceId ||
-        computed.resultReplacement.topicId !== input.entry.key.topicId ||
-        computed.resultReplacement.contextId !== input.entry.key.contextId ||
-        computed.resultReplacement.status !== input.status
+        !hasSameResultReplacement(computed.resultReplacement, expected.resultReplacement)
     ) {
         issues.push(toAppInboxCompletionValidationIssue(
             'computed.resultReplacement',
@@ -102,14 +110,20 @@ export function validateAppInboxCompletion<Result>(
         ));
     }
     if (
-        !hasSameResourceInboxKey(computed.finalizedEntry.key, input.entry.key) ||
-        computed.finalizedEntry.status !== input.status ||
-        computed.finalizedEntry.dequeueAudit.endTs?.epochMilliseconds !== input.completedAtEpochMs ||
-        computed.finalizedEntry.dequeueAudit.nextTs !== undefined
+        !hasSameFinalizedEntry(computed.finalizedEntry, expected.finalizedEntry)
     ) {
         issues.push(toAppInboxCompletionValidationIssue(
             'computed.finalizedEntry',
             'must describe the completed reservation'
+        ));
+    }
+    if (
+        !(computed.reservationConflict instanceof AppInboxReservationConflictError) ||
+        !hasSameResourceInboxKey(computed.reservationConflict.key, input.entry.key)
+    ) {
+        issues.push(toAppInboxCompletionValidationIssue(
+            'computed.reservationConflict',
+            'must describe the reserved entry'
         ));
     }
     return issues;
@@ -145,6 +159,56 @@ function hasSameResourceInboxKey(
     return left.topicId === right.topicId &&
         left.resourceId === right.resourceId &&
         left.contextId === right.contextId;
+}
+
+function hasSameJsonWireValue(left: JsonWireValue, right: JsonWireValue): boolean {
+    try {
+        return serializeCanonicalJson(left) === serializeCanonicalJson(right);
+    }
+    catch {
+        return false;
+    }
+}
+
+function hasSameResultReplacement(
+    left: ResourceInboxResultReplacement,
+    right: ResourceInboxResultReplacement
+): boolean {
+    return left.resourceId === right.resourceId &&
+        left.topicId === right.topicId &&
+        left.resource === right.resource &&
+        left.typeId === right.typeId &&
+        left.status === right.status &&
+        left.contextId === right.contextId &&
+        left.systemDate === right.systemDate &&
+        left.createdBy === right.createdBy &&
+        left.createdAt === right.createdAt &&
+        left.expiresAt === right.expiresAt;
+}
+
+function hasSameFinalizedEntry(left: ResourceEntry, right: ResourceEntry): boolean {
+    return hasSameResourceInboxKey(left.key, right.key) &&
+        left.resource === right.resource &&
+        left.typeId === right.typeId &&
+        left.status === right.status &&
+        left.audit.date.equals(right.audit.date) &&
+        left.audit.createdBy === right.audit.createdBy &&
+        left.audit.createdTs.equals(right.audit.createdTs) &&
+        left.audit.expiryTs.equals(right.audit.expiryTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.startTs, right.dequeueAudit.startTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.endTs, right.dequeueAudit.endTs) &&
+        hasSameOptionalInstant(left.dequeueAudit.nextTs, right.dequeueAudit.nextTs) &&
+        left.dequeueAudit.attempts === right.dequeueAudit.attempts &&
+        left.db?.id === right.db?.id;
+}
+
+function hasSameOptionalInstant(
+    left: Temporal.Instant | undefined,
+    right: Temporal.Instant | undefined
+): boolean {
+    return left === undefined || right === undefined
+        ? left === right
+        : left.equals(right);
 }
 
 function toAppInboxCompletionValidationIssue(

--- a/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
+++ b/packages/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts
@@ -1,22 +1,13 @@
-import { Temporal } from '@js-temporal/polyfill';
-import {
-    EntityStatus,
-    toResourceEntryWithUpdatedResource,
-    type ResourceEntry
-} from '@shared/queuebox/ResourceEntry.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { runInPSqlTransaction } from '../../../postgres/run-in-p-sql-transaction.ts';
-import { PSqlResourceInboxFinalizationRepository } from '../../../queuebox/postgres/p-sql-resource-inbox-finalization-repository.ts';
 import { writeResourceInboxReservationFinish } from '../../../queuebox/postgres/resource-inbox-reservation-write.ts';
 import { writeResourceInboxResultReplacement } from '../../../queuebox/postgres/resource-inbox-result-replacement.ts';
-import { ResourceInboxResultsRepository } from '../../../queuebox/postgres/resource-inbox-results-repository.ts';
 import type { RallarTimingDetails, RallarTimingSink } from '../../observability/timing.ts';
 import { timeRallarAsync } from '../../observability/timing.ts';
 import type { JsonWireValue } from '../../protocol/json-wire-identity.ts';
 import {
-    AppInboxReservationConflictError,
-    type AppInboxExecutionMetadata,
-    type AppInboxMessageContext
+    type AppInboxExecutionMetadata
 } from '../app-inbox-contracts.ts';
 import { toAppInboxAttemptTimingDetails } from './app-inbox-attempt-timing.ts';
 import type { AppInboxCompletionComputed, AppInboxCompletionFacts } from './app-inbox-completion-computation.ts';
@@ -29,11 +20,6 @@ export type AppInboxHandlerFinalization =
         result: JsonWireValue;
     }>;
 
-export interface AppInboxMutationTransactionResult<DurableResult, AfterCommitResult> {
-    readonly durableResult: DurableResult;
-    readonly afterCommitResult: AfterCommitResult;
-}
-
 export interface AppInboxMutationTransactionWriter {
     readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
 
@@ -42,29 +28,6 @@ export interface AppInboxMutationTransactionWriter {
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result>;
-
-    writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
-
-    writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result>;
-
-    writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>;
-}
-
-interface AppInboxMutationFinalization<DurableResult, ReturnResult> {
-    readonly durableResult: DurableResult;
-    readonly returnResult: ReturnResult;
 }
 
 export namespace AppInboxTransactionWriter {
@@ -113,138 +76,36 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result> {
-        await this.writeComputedFinalizedMutation(context, computed, write);
+        await this.writeFinalizedMutation(context, computed, write);
         return computed.durableResult;
-    }
-
-    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        const afterCommitResult = await this.writeComputedFinalizedMutation(context, computed, write);
-        return { durableResult: computed.durableResult, afterCommitResult };
-    }
-
-    async writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result> {
-        return await this.writeFinalizedMutation(context, async (transaction) => {
-            const durableResult = await write(transaction);
-            return { durableResult, returnResult: durableResult };
-        });
-    }
-
-    async writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        return await this.writeFinalizedMutation(context, async (transaction) => {
-            const result = await write(transaction);
-            return { durableResult: result.durableResult, returnResult: result };
-        });
-    }
-
-    private async writeFinalizedMutation<DurableResult, ReturnResult>(
-        context: AppInboxMessageContext<DurableResult>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationFinalization<DurableResult, ReturnResult>>
-    ): Promise<ReturnResult> {
-        this.ensurePending(context);
-        const finalized = await this.inTransaction(
-            context,
-            this.toTimingDetails(context),
-            async (transaction, repositories) => {
-                const result = await this.timeWrite(
-                    context,
-                    this.toTimingDetails(context),
-                    async () => await write(transaction)
-                );
-                await repositories.results.replace(
-                    toResourceEntryWithUpdatedResource(
-                        context.entry,
-                        EntityStatus.COMPLETED,
-                        context.encodeResult(result.durableResult)
-                    )
-                );
-                await this.finish(
-                    context,
-                    repositories.finalization,
-                    EntityStatus.COMPLETED,
-                    this.nowEpochMs()
-                );
-                return result;
-            }
-        );
-        this.finalizationByContext.set(context, {
-            state: 'transaction-finalized',
-            status: EntityStatus.COMPLETED,
-            result: context.encodeResult(finalized.durableResult)
-        });
-        return finalized.returnResult;
-    }
-
-    async writeTerminalFailure<Result>(
-        context: AppInboxMessageContext<Result>,
-        result: JsonWireValue
-    ): Promise<void> {
-        this.ensurePending(context);
-        const details = {
-            ...this.toTimingDetails(context),
-            classification: 'terminal'
-        };
-        await this.inTransaction(context, details, async (_transaction, repositories) => {
-            await this.timeWrite(context, details, async () => {
-                await repositories.results.replace(
-                    toResourceEntryWithUpdatedResource(context.entry, EntityStatus.FAILED, result)
-                );
-                await this.finish(
-                    context,
-                    repositories.finalization,
-                    EntityStatus.FAILED,
-                    this.nowEpochMs()
-                );
-            });
-        });
-        this.finalizationByContext.set(context, {
-            state: 'transaction-finalized',
-            status: EntityStatus.FAILED,
-            result
-        });
     }
 
     async writeComputedTerminalFailure<Result>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<Result>
     ): Promise<void> {
-        await this.writeComputedFinalizedMutation(context, computed, async () => {});
+        await this.writeFinalizedMutation(context, computed, async () => {});
     }
 
-    private async writeComputedFinalizedMutation<DurableResult, WriteResult>(
+    private async writeFinalizedMutation<DurableResult>(
         context: AppInboxExecutionMetadata,
         computed: AppInboxCompletionComputed<DurableResult>,
-        write: (transaction: PSqlSql) => Promise<WriteResult>
-    ): Promise<WriteResult> {
+        write: (transaction: PSqlSql) => Promise<void>
+    ): Promise<void> {
         this.ensurePending(context);
-        const result = await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
-            const writeResult = await write(transaction);
+        await this.inTransaction(context, this.toTimingDetails(context), async (transaction) => {
+            await write(transaction);
             await writeResourceInboxResultReplacement(transaction, computed.resultReplacement);
             const completed = await writeResourceInboxReservationFinish(transaction, computed.reservationFinish);
             if (!completed) {
                 throw computed.reservationConflict;
             }
-            return writeResult;
         });
         this.finalizationByContext.set(context, {
             state: 'transaction-finalized',
             status: computed.reservationFinish.status,
             result: computed.encodedResult
         });
-        return result;
     }
 
     private ensurePending(context: AppInboxExecutionMetadata): void {
@@ -260,13 +121,7 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
     private async inTransaction<ReturnResult>(
         context: AppInboxExecutionMetadata,
         details: RallarTimingDetails,
-        write: (
-            transaction: PSqlSql,
-            repositories: Readonly<{
-                finalization: PSqlResourceInboxFinalizationRepository;
-                results: ResourceInboxResultsRepository;
-            }>
-        ) => Promise<ReturnResult>
+        write: (transaction: PSqlSql) => Promise<ReturnResult>
     ): Promise<ReturnResult> {
         return await timeRallarAsync(
             this.config.timing,
@@ -280,30 +135,8 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
             async () =>
                 await runInPSqlTransaction(
                     this.database,
-                    async (transaction) =>
-                        await write(transaction, {
-                            finalization: new PSqlResourceInboxFinalizationRepository(transaction),
-                            results: new ResourceInboxResultsRepository(transaction)
-                        })
+                    async (transaction) => await write(transaction)
                 )
-        );
-    }
-
-    private async timeWrite<ReturnResult, Result>(
-        context: AppInboxMessageContext<Result>,
-        details: RallarTimingDetails,
-        write: () => Promise<ReturnResult>
-    ): Promise<ReturnResult> {
-        return await timeRallarAsync(
-            this.config.timing,
-            {
-                component: 'app-inbox-phase',
-                operation: 'write',
-                serviceId: this.config.serviceId,
-                requestId: context.enqueue.resourceId,
-                details
-            },
-            write
         );
     }
 
@@ -318,37 +151,4 @@ export class AppInboxTransactionWriter implements AppInboxMutationTransactionWri
     private nowEpochMs(): number {
         return this.config.nowEpochMs?.() ?? Date.now();
     }
-
-    private async finish(
-        context: AppInboxExecutionMetadata,
-        finalization: PSqlResourceInboxFinalizationRepository,
-        status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED,
-        completedAtEpochMs: number
-    ): Promise<void> {
-        const completed = await finalization.finishReserved(
-            context.entry.key,
-            context.entry.dequeueAudit.attempts,
-            status,
-            new Date(completedAtEpochMs)
-        );
-        if (!completed) {
-            throw new AppInboxReservationConflictError(context.entry.key);
-        }
-    }
-}
-
-export function toFinalizedResourceEntry(
-    context: AppInboxExecutionMetadata,
-    status: typeof EntityStatus.COMPLETED | typeof EntityStatus.FAILED,
-    completedAtEpochMs: number
-): ResourceEntry {
-    return {
-        ...context.entry,
-        status,
-        dequeueAudit: {
-            ...context.entry.dequeueAudit,
-            endTs: Temporal.Instant.fromEpochMilliseconds(completedAtEpochMs),
-            nextTs: undefined
-        }
-    };
 }

--- a/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
+++ b/packages/shared-server/rallar-system/app-outbox/app-outbox-insert.ts
@@ -43,6 +43,27 @@ export function computeAppOutboxInsert(entry: ResourceEntry): AppOutboxInsert {
     };
 }
 
+export function isExactAppOutboxInsert(
+    entry: ResourceEntry,
+    computed: AppOutboxInsert
+): boolean {
+    const expected = computeAppOutboxInsert(entry);
+    return computed.entry.key.topicId === expected.entry.key.topicId &&
+        computed.entry.key.resourceId === expected.entry.key.resourceId &&
+        computed.entry.key.contextId === expected.entry.key.contextId &&
+        computed.entry.resource === expected.entry.resource &&
+        computed.entry.typeId === expected.entry.typeId &&
+        computed.entry.status === expected.entry.status &&
+        computed.entry.audit.createdBy === expected.entry.audit.createdBy &&
+        computed.systemDate === expected.systemDate &&
+        computed.createdAt === expected.createdAt &&
+        computed.expiresAt === expected.expiresAt &&
+        computed.startedAt === expected.startedAt &&
+        computed.finishedAt === expected.finishedAt &&
+        computed.nextAt === expected.nextAt &&
+        computed.attempts === expected.attempts;
+}
+
 export async function writeAppOutboxInsert(transaction: PSqlSql, computed: AppOutboxInsert): Promise<void> {
     if (!await insertAppOutboxRow(transaction, computed)) {
         throw computed.conflict;

--- a/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/auth/inbox/auth-inbox-handler.ts
@@ -1,7 +1,12 @@
 import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 
 import { toAppQueueKey } from '@shared/queuebox/AppQueueIdentity.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AuthMutationService } from '../auth-mutation-service.ts';
 import type { AuthCredentialIssuer } from '../credentials/auth-credential-issuer.ts';
 import type { AuthMutationIntent, AuthMutationResult } from '../mutation/auth-mutation-contracts.ts';
@@ -47,9 +52,22 @@ export class AuthInboxHandler {
         const read = await this.dependencies.mutationService.read(command);
         const computed = this.dependencies.mutationService.compute(command, read, materialized.facts);
         this.dependencies.mutationService.validate(command, read, computed);
-        return await this.dependencies.transactionWriter.writeMutation(
+        const completionInput = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult: computed.result,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const completionIssues = validateAppInboxCompletion(completionInput, completion);
+        if (completionIssues[0] !== undefined) {
+            throw completionIssues[0].cause;
+        }
+        return await this.dependencies.transactionWriter.writeComputedMutation(
             context,
-            async (transaction) => await this.dependencies.mutationService.write(transaction, computed)
+            completion,
+            async (transaction) => {
+                await this.dependencies.mutationService.write(transaction, computed);
+            }
         );
     }
 }

--- a/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/client-state/inbox/client-state-inbox-handler.ts
@@ -1,6 +1,13 @@
+import type { ClientSnapshot } from '@shared/api/client-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
 import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import type { AppInboxExecutionMetadata, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import {
     validateWsSessionConnectGuard,
@@ -45,10 +52,6 @@ export interface ClientStateInboxHandlerDependencies {
     readonly serviceId: string;
 }
 
-export interface ClientStateInboxAfterCommitResult {
-    readonly committedSnapshots: readonly import('@shared/api/client-types.ts').ClientSnapshot[];
-}
-
 interface WriteMissingSessionDisconnectInput {
     readonly context: AppInboxMessageContext<AuthorisedWsClientMutationResult>;
     readonly disconnect: ClientAuthorisedWsSessionDisconnectAppInboxPayload;
@@ -87,7 +90,7 @@ export class ClientStateInboxHandler {
             return await this.writeInactiveGeneration(context, connection);
         }
         const command = await this.toAuthorisedWsConnectCommand(context, connection);
-        const computed = await this.computeValidatedMutation(command);
+        const computed = await this.readComputeValidateMutation(command);
         const lifecycleGuardFacts = {
             ...lifecycleFacts,
             expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(
@@ -107,7 +110,7 @@ export class ClientStateInboxHandler {
         input: ClientAuthorisedWsSessionDisconnectAppInboxPayload,
         context: AppInboxMessageContext<AuthorisedWsClientMutationResult>
     ): Promise<AuthorisedWsClientMutationResult> {
-        const lifecycleComputed = await this.computeAuthorisedWsDisconnectLifecycle(input);
+        const lifecycleComputed = await this.readComputeValidateAuthorisedWsDisconnectLifecycle(input);
         const command = await this.toAuthorisedWsDisconnectCommand(context, input);
         const read = await this.dependencies.mutationService.read(command);
         if (!read.session) {
@@ -128,28 +131,27 @@ export class ClientStateInboxHandler {
         context: AppInboxMessageContext<readonly ClientStateWritten[]>,
         atEpochMs: number
     ): Promise<readonly ClientStateWritten[]> {
-        const computed = await this.computeExpiredSessionMutations(context, atEpochMs);
+        const computed = await this.readComputeValidateExpiredSessionMutations(context, atEpochMs);
         const applied = computed.filter((successor) => successor.outcome === 'write');
         const durableResult = applied.map(toClientStateWritten);
-        const result = await this.dependencies.transactionWriter.writeMutationWithAfterCommitResult(
+        const committedSnapshots = applied.map((successor) => successor.snapshot);
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
                 for (const successor of computed) {
                     if (requiresClientWrite(successor)) {
                         await this.dependencies.mutationService.write(transaction, successor);
                     }
                 }
-                return {
-                    durableResult,
-                    afterCommitResult: { committedSnapshots: applied.map((successor) => successor.snapshot) }
-                };
             }
         );
-        await this.observeCommittedSnapshots(result.afterCommitResult);
-        return result.durableResult;
+        await this.observeCommittedSnapshots(committedSnapshots);
+        return result;
     }
 
-    private async computeValidatedMutation(
+    private async readComputeValidateMutation(
         command: ClientMutationCommand
     ): Promise<ClientMutationComputed> {
         const read = await this.dependencies.mutationService.read(command);
@@ -167,21 +169,20 @@ export class ClientStateInboxHandler {
             throw new Error('Validated client idempotency conflict is unreachable');
         }
         const durableResult = toClientStateWritten(computed);
-        const result = await this.dependencies.transactionWriter.writeMutationWithAfterCommitResult(
+        const committedSnapshots = [computed.snapshot];
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
-                await this.writeComputedMutation(transaction, computed, lifecycleComputed);
-                return {
-                    durableResult,
-                    afterCommitResult: { committedSnapshots: [computed.snapshot] }
-                };
+                await this.writeClientMutation(transaction, computed, lifecycleComputed);
             }
         );
-        await this.observeCommittedSnapshots(result.afterCommitResult);
-        return result.durableResult;
+        await this.observeCommittedSnapshots(committedSnapshots);
+        return result;
     }
 
-    private async writeComputedMutation(
+    private async writeClientMutation(
         transaction: PSqlSql,
         computed: Exclude<ClientMutationComputed, { outcome: 'idempotency-conflict'; }>,
         lifecycleComputed: WsSessionGenerationLifecycleComputed | undefined
@@ -194,10 +195,8 @@ export class ClientStateInboxHandler {
         }
     }
 
-    private async observeCommittedSnapshots(
-        result: ClientStateInboxAfterCommitResult
-    ): Promise<void> {
-        for (const snapshot of result.committedSnapshots) {
+    private async observeCommittedSnapshots(snapshots: readonly ClientSnapshot[]): Promise<void> {
+        for (const snapshot of snapshots) {
             await this.dependencies.snapshotObserver.observeSnapshot(snapshot);
         }
     }
@@ -217,14 +216,20 @@ export class ClientStateInboxHandler {
         context: AppInboxMessageContext<InactiveAuthorisedWsSessionResult>,
         connection: ClientAuthorisedWsSessionConnectAppInboxPayload
     ): Promise<InactiveAuthorisedWsSessionResult> {
-        return await this.dependencies.transactionWriter.writeMutation(context, async () => ({
+        const durableResult = {
             status: 'inactive',
             sessionId: connection.authSession.sessionId,
             generationId: connection.generationId
-        }));
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            completion,
+            async () => {}
+        );
     }
 
-    private async computeAuthorisedWsDisconnectLifecycle(
+    private async readComputeValidateAuthorisedWsDisconnectLifecycle(
         input: ClientAuthorisedWsSessionDisconnectAppInboxPayload
     ): Promise<WsSessionGenerationLifecycleComputed> {
         const connection = input.connection;
@@ -254,14 +259,36 @@ export class ClientStateInboxHandler {
         lifecycleComputed
     }: WriteMissingSessionDisconnectInput): Promise<InactiveAuthorisedWsSessionResult> {
         validateClientMutationAuthorityPolicy(command, read);
-        return await this.dependencies.transactionWriter.writeMutation(context, async (transaction) => {
-            await this.dependencies.sessionGenerationLifecycle.write(transaction, lifecycleComputed);
-            return {
-                status: 'inactive',
-                sessionId: disconnect.connection.authSession.sessionId,
-                generationId: disconnect.connection.generationId
-            };
-        });
+        const durableResult = {
+            status: 'inactive',
+            sessionId: disconnect.connection.authSession.sessionId,
+            generationId: disconnect.connection.generationId
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            completion,
+            async (transaction) => {
+                await this.dependencies.sessionGenerationLifecycle.write(transaction, lifecycleComputed);
+            }
+        );
+    }
+
+    private readComputeValidateCompletion<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionComputed<Result> {
+        const input = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues.length > 0) {
+            throw issues[0].cause;
+        }
+        return computed;
     }
 
     private async toAuthorisedWsConnectCommand(
@@ -327,7 +354,7 @@ export class ClientStateInboxHandler {
         );
     }
 
-    private async computeExpiredSessionMutations(
+    private async readComputeValidateExpiredSessionMutations(
         context: AppInboxExecutionMetadata,
         atEpochMs: number
     ): Promise<readonly ClientMutationComputed[]> {
@@ -341,7 +368,7 @@ export class ClientStateInboxHandler {
                 context,
                 toExpireClientSessionMutationInput(candidate)
             );
-            computed.push(await this.computeValidatedMutation(command));
+            computed.push(await this.readComputeValidateMutation(command));
         }
         return computed;
     }

--- a/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/compute-crdt-mutation-outcome.ts
@@ -258,7 +258,7 @@ function createCrdtMutationComputedBase<TDocument extends RallarCrdtDocumentMeta
     };
 }
 
-interface ComputeCrdtMutationWritesInput {
+export interface ComputeCrdtMutationWritesInput {
     readonly read: CrdtMutationRead;
     readonly document: RallarCrdtDocumentMetadata;
     readonly update: CrdtAppendCommand['update'] | null;
@@ -266,7 +266,7 @@ interface ComputeCrdtMutationWritesInput {
     readonly snapshot: CrdtCanonicalSnapshotEnvelope | null;
 }
 
-function computeCrdtMutationWrites(
+export function computeCrdtMutationWrites(
     input: ComputeCrdtMutationWritesInput
 ): Pick<CrdtMutationComputedWrite, 'documentWrite' | 'updateWrite' | 'snapshotWrite' | 'conflict'> {
     const { read, document, update, append, snapshot } = input;

--- a/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
+++ b/packages/shared-server/rallar-system/crdt/mutation/validate-crdt-mutation.ts
@@ -1,8 +1,13 @@
+import { isExactAppOutboxInsert } from '../../app-outbox/app-outbox-insert.ts';
+import { computeCrdtMutationWrites } from './compute-crdt-mutation-outcome.ts';
 import type {
+    CrdtDocumentWrite,
     CrdtMutationCommand,
     CrdtMutationComputed,
     CrdtMutationRead,
     CrdtMutationValidationIssue,
+    CrdtSnapshotWrite,
+    CrdtUpdateWrite,
     ValidateCrdtMutationInput
 } from './crdt-mutation-contracts.ts';
 import { decodeCrdtMutationResult } from './decode-crdt-mutation-result.ts';
@@ -79,28 +84,98 @@ function hasConsistentCrdtPersistence(computed: CrdtMutationComputed): boolean {
     const outboxMatches = computed.outboxWrites.length === computed.outboxEntries.length &&
         computed.outboxWrites.every((write, index) => {
             const entry = computed.outboxEntries[index];
-            return entry !== undefined && write.entry.key.topicId === entry.key.topicId &&
-                write.entry.key.resourceId === entry.key.resourceId &&
-                write.entry.key.contextId === entry.key.contextId &&
-                write.entry.resource === entry.resource;
+            return entry !== undefined && isExactAppOutboxInsert(entry, write);
         });
     if (!outboxMatches || computed.outcome !== 'write') {
         return outboxMatches;
     }
-    const documentMatches = computed.documentWrite.documentKey === computed.document.documentKey &&
-        computed.documentWrite.documentRevision === computed.document.documentRevision &&
-        computed.documentWrite.lifecycle === computed.document.lifecycle;
-    const updateMatches = computed.update === null || computed.append === null
-        ? computed.updateWrite === null
-        : computed.updateWrite?.documentKey === computed.documentKey &&
-            computed.updateWrite.updateId === computed.update.updateId &&
-            computed.updateWrite.appendSequence === computed.append.appendSequence;
-    const snapshotMatches = computed.snapshot === null
-        ? computed.snapshotWrite === null
-        : computed.snapshotWrite?.documentKey === computed.documentKey &&
-            computed.snapshotWrite.snapshotId === computed.snapshot.snapshotId &&
-            computed.snapshotWrite.appendSequence === computed.document.lastAppendSequence;
-    return documentMatches && updateMatches && snapshotMatches;
+    try {
+        const expected = computeCrdtMutationWrites({
+            read: computed.read,
+            document: computed.document,
+            update: computed.update,
+            append: computed.append,
+            snapshot: computed.snapshot
+        });
+        return sameDocumentWrite(computed.documentWrite, expected.documentWrite) &&
+            sameOptionalUpdateWrite(computed.updateWrite, expected.updateWrite) &&
+            sameOptionalSnapshotWrite(computed.snapshotWrite, expected.snapshotWrite);
+    }
+    catch {
+        return false;
+    }
+}
+
+function sameDocumentWrite(left: CrdtDocumentWrite, right: CrdtDocumentWrite): boolean {
+    return left.operation === right.operation &&
+        left.documentKey === right.documentKey &&
+        left.applicationId === right.applicationId &&
+        left.workspaceId === right.workspaceId &&
+        left.scope === right.scope &&
+        left.documentType === right.documentType &&
+        left.documentId === right.documentId &&
+        left.documentRefJson === right.documentRefJson &&
+        left.documentRevision === right.documentRevision &&
+        left.lifecycle === right.lifecycle &&
+        sameDate(left.createdAt, right.createdAt) &&
+        sameDate(left.updatedAt, right.updatedAt) &&
+        sameOptionalDate(left.archivedAt, right.archivedAt) &&
+        sameOptionalDate(left.destroyedAt, right.destroyedAt) &&
+        left.lastAppendSequence === right.lastAppendSequence &&
+        left.updateCount === right.updateCount &&
+        left.snapshotCount === right.snapshotCount &&
+        left.storedUpdateBytes === right.storedUpdateBytes &&
+        left.retentionJson === right.retentionJson &&
+        left.quotaJson === right.quotaJson &&
+        left.projectionIdsJson === right.projectionIdsJson &&
+        (left.operation === 'insert' || right.operation === 'insert' || (
+            left.expectedRevision === right.expectedRevision &&
+            left.expectedLifecycle === right.expectedLifecycle &&
+            left.expectedAppendSequence === right.expectedAppendSequence
+        ));
+}
+
+function sameOptionalUpdateWrite(
+    left: CrdtUpdateWrite | null,
+    right: CrdtUpdateWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.documentKey === right.documentKey &&
+        left.appendSequence === right.appendSequence &&
+        left.updateId === right.updateId &&
+        left.updateEnvelopeJson === right.updateEnvelopeJson &&
+        left.acceptedUpdateHash === right.acceptedUpdateHash &&
+        left.actorId === right.actorId &&
+        left.principalId === right.principalId &&
+        left.sessionId === right.sessionId &&
+        left.serverId === right.serverId &&
+        left.authorizationScope === right.authorizationScope &&
+        sameDate(left.acceptedAt, right.acceptedAt);
+}
+
+function sameOptionalSnapshotWrite(
+    left: CrdtSnapshotWrite | null,
+    right: CrdtSnapshotWrite | null
+): boolean {
+    if (left === null || right === null) {
+        return left === right;
+    }
+    return left.documentKey === right.documentKey &&
+        left.snapshotId === right.snapshotId &&
+        left.appendSequence === right.appendSequence &&
+        left.snapshotEnvelopeJson === right.snapshotEnvelopeJson &&
+        sameDate(left.createdAt, right.createdAt) &&
+        left.reason === right.reason;
+}
+
+function sameDate(left: Date, right: Date): boolean {
+    return left instanceof Date && right instanceof Date && left.getTime() === right.getTime();
+}
+
+function sameOptionalDate(left: Date | null, right: Date | null): boolean {
+    return left === null || right === null ? left === right : sameDate(left, right);
 }
 
 function readSnapshotReason(snapshot: object | null | undefined): string | null {

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts
@@ -1,28 +1,47 @@
+import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import type { GroupFormationMutationOutcome } from '@shared/rtc/group-formation-metrics.ts';
 import { type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed,
+    type AppInboxCompletionInput
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupFormationGroupMutationSink } from '../../observability/formation-metrics.ts';
 import type { WsSessionGenerationLifecycleComputed } from '../../websocket/ws-session-generation-computation.ts';
+import { validateWsSessionConnectGuard } from '../../websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '../../websocket/ws-session-generation-lifecycle.ts';
 import type {
     AuthorizedGroupMutation,
     GroupMutationAuthority,
     GroupMutationPreparation,
     GroupStateMutationCommand,
-    GroupStateMutationService,
-    GroupStateService
+    GroupStateMutationService
 } from '../group-state-service-contracts.ts';
-import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
+import type { GroupMutationComputed, GroupMutationRead } from '../mutation/group-mutation-contracts.ts';
 import { toGroupMutationRejectionError } from '../mutation/group-mutation-result.ts';
-import { createTransactionBoundGroupStateRepository } from '../persistence/group-state-repository.ts';
-import { processGroupPresenceConnect, type InactiveGroupPresenceResult } from '../presence/group-presence-service.ts';
+import {
+    readAndComputeGroupPresenceConnect,
+    type InactiveGroupPresenceResult
+} from '../presence/group-presence-service.ts';
 import { decodeGroupStateInboxAuthority } from './decode-group-state-inbox-authority.ts';
-import { readGroupStateInboxResult, type GroupStateInboxDurableResult } from './group-state-inbox-result.ts';
+import {
+    computeGroupStateInboxResult,
+    validateGroupStateInboxResult,
+    type GroupStateInboxDurableResult
+} from './group-state-inbox-result.ts';
+
+export interface GroupStateInboxResultReader {
+    readSnapshot(ref: GroupRef): Promise<GroupSnapshot | undefined>;
+    readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined>;
+}
 
 export interface GroupStateInboxHandlerDependencies {
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
-    readonly snapshotObserver: Pick<GroupStateService, 'observeSnapshot'>;
+    readonly resultReader: GroupStateInboxResultReader;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly wakeQueue?: () => void;
     readonly formationMetrics?: GroupFormationGroupMutationSink;
@@ -39,8 +58,16 @@ export interface GroupStateInboxHandlerDependencies {
 interface CommitGroupStateMutationInput {
     readonly context: AppInboxMessageContext<GroupStateInboxDurableResult>;
     readonly command: GroupStateMutationCommand;
-    readonly computed: GroupMutationComputed;
+    readonly computed: Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>;
+    readonly durableResult: GroupStateInboxDurableResult;
+    readonly completion: AppInboxCompletionComputed<GroupStateInboxDurableResult>;
     readonly lifecycleGuard?: WsSessionGenerationLifecycleComputed;
+}
+
+interface GroupStateInboxResultRead {
+    readonly mutationRead: GroupMutationRead;
+    readonly currentSnapshot: GroupSnapshot | undefined;
+    readonly recordedEvent: GroupEvent | undefined;
 }
 
 export class GroupStateInboxHandler {
@@ -64,30 +91,88 @@ export class GroupStateInboxHandler {
             }
         };
         if (command.command.operation === 'connectPresence') {
-            const outcome = await processGroupPresenceConnect({
+            const outcome = await readAndComputeGroupPresenceConnect({
                 command,
                 mutationService: this.dependencies.mutationService,
                 sessionGenerationLifecycle: this.dependencies.sessionGenerationLifecycle
             });
             if (outcome.status === 'inactive') {
-                const durableResult = await this.dependencies.transactionWriter.writeMutation(
+                const completionInput = this.readCompletionInput(context, outcome);
+                const completion = computeAppInboxCompletion(completionInput);
+                this.validateCompletion(completionInput, completion);
+                const durableResult = await this.dependencies.transactionWriter.writeComputedMutation(
                     context,
-                    () => Promise.resolve(outcome)
+                    completion,
+                    async () => {}
                 );
                 this.recordGroupMutation(command, 'rejected');
                 return durableResult;
             }
+            if (!isCommittableMutation(outcome.computed)) {
+                this.dependencies.mutationService.validate(command, outcome.read, outcome.computed);
+                validateWsSessionConnectGuard(
+                    outcome.lifecycleGuardFacts,
+                    outcome.lifecycleRead,
+                    outcome.lifecycleGuard
+                );
+                throwNonCommittableMutation(outcome.computed);
+            }
+            const computed = outcome.computed;
+            const durableResult = computed.receipt;
+            const completionInput = this.readCompletionInput(context, durableResult);
+            const completion = computeAppInboxCompletion(completionInput);
+            this.dependencies.mutationService.validate(command, outcome.read, computed);
+            validateWsSessionConnectGuard(
+                outcome.lifecycleGuardFacts,
+                outcome.lifecycleRead,
+                outcome.lifecycleGuard
+            );
+            this.validateCompletion(completionInput, completion);
             return await this.commitMutation({
                 context,
                 command,
-                computed: outcome.computed,
+                computed,
+                durableResult,
+                completion,
                 lifecycleGuard: outcome.lifecycleGuard
             });
         }
-        const read = await this.dependencies.mutationService.read(command);
-        const computed = this.dependencies.mutationService.compute(command, read);
-        this.dependencies.mutationService.validate(command, read, computed);
-        return await this.commitMutation({ context, command, computed });
+        const resultRead = await this.readResultFacts(command);
+        const computed = this.dependencies.mutationService.compute(command, resultRead.mutationRead);
+        if (!isCommittableMutation(computed)) {
+            this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed);
+            throwNonCommittableMutation(computed);
+        }
+        const resultInput = {
+            command,
+            read: resultRead.mutationRead,
+            computed,
+            currentSnapshot: resultRead.currentSnapshot,
+            recordedEvent: resultRead.recordedEvent
+        } as const;
+        const durableResult = computeGroupStateInboxResult(resultInput);
+        const completionInput = this.readCompletionInput(context, durableResult);
+        const completion = computeAppInboxCompletion(completionInput);
+        this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed);
+        validateGroupStateInboxResult(resultInput, durableResult);
+        this.validateCompletion(completionInput, completion);
+        return await this.commitMutation({ context, command, computed, durableResult, completion });
+    }
+
+    private async readResultFacts(command: GroupStateMutationCommand): Promise<GroupStateInboxResultRead> {
+        const readsSnapshot = !isPresenceOperation(command.command.operation);
+        const [mutationRead, currentSnapshot] = await Promise.all([
+            this.dependencies.mutationService.read(command),
+            readsSnapshot
+                ? this.dependencies.resultReader.readSnapshot(command.command.aggregateRef)
+                : Promise.resolve(undefined)
+        ]);
+        const receipt = mutationRead.idempotency?.value.receipt;
+        const recordedEvent =
+            readsSnapshot && receipt?.commandHash === command.facts.commandHash && receipt.eventId !== null
+                ? await this.dependencies.resultReader.readEvent(command.command.aggregateRef, receipt.eventId)
+                : undefined;
+        return { mutationRead, currentSnapshot, recordedEvent };
     }
 
     private async readOrPrepareGroupMutation(
@@ -108,12 +193,10 @@ export class GroupStateInboxHandler {
     private async commitMutation(
         input: CommitGroupStateMutationInput
     ): Promise<GroupStateInboxDurableResult> {
-        if (input.computed.outcome === 'rejected') {
-            throw toGroupMutationRejectionError(input.computed);
-        }
-        const { durableResult, afterCommitResult } = await this.dependencies.transactionWriter
-            .writeMutationWithAfterCommitResult(
+        const durableResult = await this.dependencies.transactionWriter
+            .writeComputedMutation(
                 input.context,
+                input.completion,
                 async (transaction) => {
                     if (input.lifecycleGuard) {
                         await this.dependencies.sessionGenerationLifecycle.write(
@@ -121,27 +204,11 @@ export class GroupStateInboxHandler {
                             input.lifecycleGuard
                         );
                     }
-                    if (input.computed.outcome === 'idempotency-conflict') {
-                        throw new TypeError('Validated group idempotency conflict is unreachable');
-                    }
                     if (input.computed.outcome === 'write') {
                         await this.dependencies.mutationService.write(transaction, input.computed);
                     }
-                    const inboxResult = await readGroupStateInboxResult({
-                        repository: createTransactionBoundGroupStateRepository(transaction),
-                        command: input.command,
-                        receipt: input.computed.receipt
-                    });
-                    return {
-                        durableResult: inboxResult.durableResult,
-                        afterCommitResult: { committedSnapshot: inboxResult.committedSnapshot }
-                    };
                 }
             );
-        const { committedSnapshot } = afterCommitResult;
-        if (committedSnapshot) {
-            await this.dependencies.snapshotObserver.observeSnapshot(committedSnapshot);
-        }
         this.dependencies.wakeQueue?.();
         this.recordGroupMutation(
             input.command,
@@ -150,6 +217,27 @@ export class GroupStateInboxHandler {
                 : 'noOp'
         );
         return durableResult;
+    }
+
+    private readCompletionInput<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionInput<Result> {
+        return {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+    }
+
+    private validateCompletion<Result>(
+        input: AppInboxCompletionInput<Result>,
+        computed: AppInboxCompletionComputed<Result>
+    ): void {
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
     }
 
     private recordGroupMutation(
@@ -166,4 +254,23 @@ export class GroupStateInboxHandler {
             // Recording must never affect group mutation behavior.
         }
     }
+}
+
+function isCommittableMutation(
+    computed: GroupMutationComputed
+): computed is Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }> {
+    return computed.outcome !== 'idempotency-conflict' && computed.outcome !== 'rejected';
+}
+
+function throwNonCommittableMutation(
+    computed: Extract<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>
+): never {
+    if (computed.outcome === 'idempotency-conflict') {
+        throw new TypeError('Validated group idempotency conflict is unreachable');
+    }
+    throw toGroupMutationRejectionError(computed);
+}
+
+function isPresenceOperation(operation: GroupStateMutationCommand['command']['operation']): boolean {
+    return operation === 'connectPresence' || operation === 'heartbeatPresence' || operation === 'disconnectPresence';
 }

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts
@@ -1,24 +1,66 @@
-import type { GroupEvent, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import type { GroupEvent, GroupMember, GroupSnapshot } from '@shared/api/group-types.ts';
+import { jsonEquals } from '@shared/repository/state-utils.ts';
 
 import type { GroupStateMutationCommand } from '../group-state-service-contracts.ts';
 import type { GroupJoinCodeWritten, GroupStateWritten } from '../group-state-service-contracts.ts';
-import type { GroupMutationReceipt } from '../mutation/group-mutation-contracts.ts';
-import type { GroupStateRepository } from '../persistence/group-state-repository.ts';
+import type {
+    GroupMutationComputed,
+    GroupMutationRead,
+    GroupMutationReceipt
+} from '../mutation/group-mutation-contracts.ts';
+import { assembleGroupStateSnapshot } from '../persistence/assemble-group-state-snapshot.ts';
+import { GroupStateRepositoryInvariantCorruptionError } from '../persistence/group-state-persistence-contracts.ts';
+import { groupStateMemberStorageKey } from '../persistence/membership/group-membership-storage-key.ts';
 import type { InactiveGroupPresenceResult } from '../presence/group-presence-service.ts';
 
 export type GroupPresenceInboxDurableResult = GroupMutationReceipt | InactiveGroupPresenceResult;
 
 export type GroupStateInboxDurableResult = GroupPresenceInboxDurableResult | GroupJoinCodeWritten | GroupStateWritten;
 
-export interface GroupStateInboxResult {
-    readonly durableResult: GroupStateInboxDurableResult;
-    readonly committedSnapshot: GroupSnapshot | undefined;
+export interface ComputeGroupStateInboxResultInput {
+    readonly command: GroupStateMutationCommand;
+    readonly read: GroupMutationRead;
+    readonly computed: Exclude<GroupMutationComputed, { outcome: 'idempotency-conflict' | 'rejected'; }>;
+    readonly currentSnapshot: GroupSnapshot | undefined;
+    readonly recordedEvent: GroupEvent | undefined;
 }
 
-export interface ReadGroupStateInboxResultInput {
-    readonly repository: GroupStateRepository;
-    readonly command: GroupStateMutationCommand;
-    readonly receipt: GroupMutationReceipt;
+export class GroupStateInboxResultReadConflictError extends Error {
+    readonly code = 'runtime-state-write-conflict';
+
+    constructor() {
+        super('Group state result snapshot no longer matches the mutation read.');
+        this.name = 'GroupStateInboxResultReadConflictError';
+    }
+}
+
+export function computeGroupStateInboxResult(input: ComputeGroupStateInboxResultInput): GroupStateInboxDurableResult {
+    if (isPresenceOperation(input.command.command.operation)) {
+        return input.computed.receipt;
+    }
+    assertSnapshotMatchesRead(input.currentSnapshot, input.read);
+    const snapshot = input.computed.outcome === 'write'
+        ? assembleCommittedSnapshot(input, input.computed)
+        : input.currentSnapshot;
+    if (snapshot === undefined) {
+        throw new GroupStateInboxResultReadConflictError();
+    }
+    const event = input.computed.outcome === 'write'
+        ? input.computed.event
+        : readRecordedEvent(input.recordedEvent, input.computed.receipt);
+    return input.command.command.operation === 'rotateGroupJoinCode'
+        ? toJoinCodeResult(input.computed.receipt, snapshot, event)
+        : toGroupMutationResult({ command: input.command, receipt: input.computed.receipt, snapshot, event });
+}
+
+export function validateGroupStateInboxResult(
+    input: ComputeGroupStateInboxResultInput,
+    computed: GroupStateInboxDurableResult
+): void {
+    const expected = computeGroupStateInboxResult(input);
+    if (JSON.stringify(computed) !== JSON.stringify(expected)) {
+        throw new TypeError('Computed group-state inbox result does not match its inputs.');
+    }
 }
 
 interface ToGroupMutationResultInput {
@@ -28,25 +70,81 @@ interface ToGroupMutationResultInput {
     readonly event: GroupEvent | null;
 }
 
-export async function readGroupStateInboxResult(
-    input: ReadGroupStateInboxResultInput
-): Promise<GroupStateInboxResult> {
-    const snapshot = await input.repository.readSnapshot(input.command.command.aggregateRef);
-    if (isPresenceOperation(input.command.command.operation)) {
-        return { durableResult: input.receipt, committedSnapshot: snapshot };
+function assertSnapshotMatchesRead(
+    snapshot: GroupSnapshot | undefined,
+    read: GroupMutationRead
+): void {
+    if (read.group === null) {
+        if (snapshot !== undefined) {
+            throw new GroupStateInboxResultReadConflictError();
+        }
+        return;
     }
-    if (!snapshot) {
-        throw new TypeError(`Group snapshot not found after ${input.command.command.operation}`);
+    const presenceRevision = read.presenceSummary?.value.causalRevision.presenceRevision ?? 0;
+    const expectedSnapshotGroup = {
+        ...read.group.value,
+        presenceVersion: presenceRevision
+    };
+    if (
+        snapshot === undefined ||
+        !jsonEquals(snapshot.group, expectedSnapshotGroup) ||
+        snapshot.causalRevision.groupRevision !== read.group.value.snapshotVersion ||
+        snapshot.causalRevision.presenceRevision !== presenceRevision
+    ) {
+        throw new GroupStateInboxResultReadConflictError();
     }
-    const event = await readReceiptEvent(
-        input.repository,
-        input.command.command.aggregateRef,
-        input.receipt
+}
+
+function assembleCommittedSnapshot(
+    input: ComputeGroupStateInboxResultInput,
+    computed: Extract<GroupMutationComputed, { outcome: 'write'; }>
+): GroupSnapshot {
+    if (computed.guard.kind !== 'group') {
+        throw new TypeError('Presence mutations do not assemble group snapshots.');
+    }
+    return assembleGroupStateSnapshot(
+        {
+            group: computed.guard.value,
+            members: mergeMembers(input.currentSnapshot?.members ?? [], computed.members),
+            summary: computed.initialPresenceSummary?.value ?? input.read.presenceSummary?.value,
+            authoritativeSessions: input.currentSnapshot?.activeSessions ?? [],
+            groupRevision: computed.guard.value.snapshotVersion,
+            observedAtEpochMs: input.command.facts.nowEpochMs,
+            sessionLeaseFields: 'authoritative'
+        },
+        (storageKey, message) => new GroupStateRepositoryInvariantCorruptionError(storageKey, message)
     );
-    const durableResult = input.command.command.operation === 'rotateGroupJoinCode'
-        ? toJoinCodeResult(input.receipt, snapshot, event)
-        : toGroupMutationResult({ command: input.command, receipt: input.receipt, snapshot, event });
-    return { durableResult, committedSnapshot: snapshot };
+}
+
+function mergeMembers(
+    current: readonly GroupMember[],
+    changed: readonly GroupMember[]
+): readonly GroupMember[] {
+    const members = new Map(current.map((member) => [groupStateMemberStorageKey(member), member]));
+    for (const member of changed) {
+        members.set(groupStateMemberStorageKey(member), member);
+    }
+    return [...members.entries()]
+        .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+        .map(([, member]) => member);
+}
+
+function readRecordedEvent(
+    event: GroupEvent | undefined,
+    receipt: GroupMutationReceipt
+): GroupEvent | null {
+    if (receipt.eventId === null) {
+        return null;
+    }
+    if (
+        event === undefined ||
+        event.eventId !== receipt.eventId ||
+        event.snapshotVersion !== receipt.snapshotVersion ||
+        event.requestId !== receipt.requestId
+    ) {
+        throw new TypeError(`Group mutation event not found: ${receipt.eventId}`);
+    }
+    return event;
 }
 
 function isPresenceOperation(
@@ -57,23 +155,6 @@ function isPresenceOperation(
         operation === 'heartbeatPresence' ||
         operation === 'disconnectPresence'
     );
-}
-
-async function readReceiptEvent(
-    repository: GroupStateRepository,
-    ref: GroupRef,
-    receipt: GroupMutationReceipt
-): Promise<GroupEvent | null> {
-    if (receipt.eventId === null) {
-        return null;
-    }
-    const event = (await repository.listEvents(ref)).find(
-        (candidate) => candidate.eventId === receipt.eventId
-    );
-    if (!event) {
-        throw new TypeError(`Group mutation event not found: ${receipt.eventId}`);
-    }
-    return event;
 }
 
 function toJoinCodeResult(

--- a/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
+++ b/packages/shared-server/rallar-system/group-state/inbox/group-state-inbox-service.ts
@@ -39,7 +39,10 @@ import {
     isAuthenticatedGroupMutationEnqueue,
     type AuthenticatedGroupMutationEnqueue
 } from './group-state-inbox-contracts.ts';
-import { GroupStateInboxHandler } from './group-state-inbox-handler.ts';
+import {
+    GroupStateInboxHandler,
+    type GroupStateInboxResultReader
+} from './group-state-inbox-handler.ts';
 import { decodeGroupStateInboxDurableResult } from './group-state-inbox-result-codec.ts';
 import type { GroupStateInboxDurableResult } from './group-state-inbox-result.ts';
 import { toGroupMutationDescriptor } from './to-group-mutation-descriptor.ts';
@@ -51,6 +54,7 @@ export namespace GroupStateInboxService {
         readonly resourceInboxResultsRepository: AppInboxResultRepository;
         readonly database: PSqlSql;
         readonly groupStateService: GroupStateService;
+        readonly resultReader: GroupStateInboxResultReader;
     }
 
     export interface Config {
@@ -107,7 +111,7 @@ export class GroupStateInboxService {
         this.groupStateInboxHandler = new GroupStateInboxHandler({
             mutationService: this.groupStateService,
             sessionGenerationLifecycle: this.groupStateService.sessionGenerationLifecycle,
-            snapshotObserver: this.groupStateService,
+            resultReader: dependencies.resultReader,
             transactionWriter: this.transactionWriter,
             wakeQueue: this.wakeQueue,
             formationMetrics: config.formationMetrics,
@@ -243,8 +247,9 @@ export class GroupStateInboxService {
                 await processGroupSessionCleanup({
                     facts: payload,
                     attemptCount: context.entry.dequeueAudit.attempts,
+                    context,
                     groupStateService: this.groupStateService,
-                    writeMutation: async (write) => await this.transactionWriter.writeMutation(context, write),
+                    transactionWriter: this.transactionWriter,
                     wakeQueue: this.wakeQueue
                 })
         });

--- a/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts
@@ -21,8 +21,8 @@ import type {
 } from '@shared/api/group-types.ts';
 import type { ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
 import type {
-    RuntimeStateGuardedBatch,
-    RuntimeStateGuardedBatchEffect
+    RuntimeStateGuardedBatchEffect,
+    RuntimeStateGuardedBatchWrite
 } from '../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { GroupConnectTriggerLatchRow } from '../persistence/group-connect-trigger-latch-repository.ts';
 import type {
@@ -516,7 +516,7 @@ export type GroupMutationDomainWrite = Readonly<{
 }>;
 
 export type GroupMutationPersistence = Readonly<{
-    guardedBatch: RuntimeStateGuardedBatch;
+    guardedBatch: RuntimeStateGuardedBatchWrite;
     lifecyclePolicyWrite:
         | Readonly<{
             namespace: string;

--- a/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/orchestration/compute-group-mutation-persistence.ts
@@ -1,6 +1,8 @@
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 
+import { computeRuntimeStateGuardedBatchWrite } from '../../../../runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import {
+    type RuntimeStateGuardedBatch,
     type RuntimeStateGuardedBatchEffect,
     type RuntimeStateGuardedBatchGuard
 } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
@@ -40,7 +42,9 @@ export function computeGroupMutationPersistence(
     computed: GroupMutationDomainWrite
 ): GroupMutationPersistence {
     return {
-        guardedBatch: computeGroupMutationGuardedBatch(computed),
+        guardedBatch: computeRuntimeStateGuardedBatchWrite(
+            computeGroupMutationGuardedBatch(computed)
+        ),
         lifecyclePolicyWrite: computed.lifecyclePolicy === null
             ? null
             : {
@@ -64,7 +68,7 @@ export function computeGroupMutationPersistence(
 
 function computeGroupMutationGuardedBatch(
     computed: GroupMutationDomainWrite
-): GroupMutationPersistence['guardedBatch'] {
+): RuntimeStateGuardedBatch {
     const effects: RuntimeStateGuardedBatchEffect[] = [];
     effects.push(...computePresenceAndMembershipEffects(computed));
     if (computed.acceptedLayoutPromotion) {

--- a/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
+++ b/packages/shared-server/rallar-system/group-state/mutation/write/write-group-mutation.ts
@@ -1,8 +1,8 @@
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
 import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
-import type { RuntimeStateGuardedBatch } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import type { RuntimeStateGuardedBatchWrite } from '../../../../runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { RuntimeStateWriteConflictError } from '../../../../runtime-state/optimistic-runtime-state-write.ts';
-import { executeComputedRuntimeStateGuardedBatch } from '../../../../runtime-state/postgres/execute-runtime-state-guarded-batch.ts';
+import { writeRuntimeStateGuardedBatch } from '../../../../runtime-state/postgres/write-runtime-state-guarded-batch.ts';
 import { GroupStateEventCollisionError } from '../../../state-events/group-state-event-store.ts';
 import type { GroupStateEventCollisionRow } from '../../../state-events/postgres/group-state-event-row-codec.ts';
 import type {
@@ -29,9 +29,9 @@ export async function writeGroupMutation(
 
 async function executeGuardedGroupMutationBatch(
     transaction: PSqlSql,
-    batch: RuntimeStateGuardedBatch
+    computed: RuntimeStateGuardedBatchWrite
 ): Promise<void> {
-    const result = await executeComputedRuntimeStateGuardedBatch(transaction, batch);
+    const result = await writeRuntimeStateGuardedBatch(transaction, computed);
     if (result.guard.status === 'conflict') {
         throw new RuntimeStateWriteConflictError();
     }

--- a/packages/shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/aggregate/group-aggregate-repository.ts
@@ -92,6 +92,10 @@ export class GroupAggregateRepository extends RuntimeStateJsonStore {
         return await this.events.listGroupEvents(ref);
     }
 
+    async readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return await this.events.readGroupEvent(ref, eventId);
+    }
+
     async listRecentEvents(
         ref: GroupRef,
         query: StateEventListQuery = {}

--- a/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
+++ b/packages/shared-server/rallar-system/group-state/persistence/group-state-repository.ts
@@ -143,6 +143,10 @@ export class GroupStateRepository extends GroupStateRepositoryReads {
         return await this.aggregate.listEvents(ref);
     }
 
+    async readEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return await this.aggregate.readEvent(ref, eventId);
+    }
+
     async listRecentEvents(
         ref: GroupRef,
         query: StateEventListQuery = {}

--- a/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
+++ b/packages/shared-server/rallar-system/group-state/presence/group-presence-service.ts
@@ -1,14 +1,21 @@
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { resourceInboxRetryExpiryAtEpochMs } from '@shared/queuebox/ResourceInboxRetryPolicy.ts';
-import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
+import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
 import { AppInboxType } from '../../app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxCommand } from '../../app-inbox/app-inbox-registration-codecs.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import { decodeJsonWireValue } from '../../protocol/json-wire-identity.ts';
 import {
     validateWsSessionConnectGuard,
     validateWsSessionGenerationClosed,
     type WsSessionGenerationCloseFacts,
+    type WsSessionGenerationGuardFacts,
     type WsSessionGenerationLifecycleComputed,
+    type WsSessionGenerationLifecycleRead,
     type WsSessionHighWaterIdentity
 } from '../../websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '../../websocket/ws-session-generation-lifecycle.ts';
@@ -19,11 +26,8 @@ import type {
     GroupStateService
 } from '../group-state-service-contracts.ts';
 import type { GroupMutationComputed } from '../mutation/group-mutation-contracts.ts';
+import type { GroupMutationRead } from '../mutation/group-mutation-contracts.ts';
 import type { GroupPresenceSessionCleanupAppInboxPayload } from './group-presence-session-cleanup-app-inbox-payload.ts';
-
-type WriteMutation = <Result>(
-    write: (transaction: PSqlSql) => Promise<Result>
-) => Promise<Result>;
 
 export interface InactiveGroupPresenceResult {
     readonly status: 'inactive';
@@ -36,10 +40,13 @@ export type GroupPresenceConnectOutcome =
     | Readonly<{
         status: 'ready-to-commit';
         computed: GroupMutationComputed;
+        read: GroupMutationRead;
+        lifecycleGuardFacts: WsSessionGenerationGuardFacts;
+        lifecycleRead: WsSessionGenerationLifecycleRead;
         lifecycleGuard: WsSessionGenerationLifecycleComputed;
     }>;
 
-interface ProcessGroupPresenceConnectInput {
+interface ReadAndComputeGroupPresenceConnectInput {
     readonly command: GroupStateMutationCommand;
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
@@ -83,8 +90,8 @@ export function toExpiredPresenceEnqueue(
     };
 }
 
-export async function processGroupPresenceConnect(
-    input: ProcessGroupPresenceConnectInput
+export async function readAndComputeGroupPresenceConnect(
+    input: ReadAndComputeGroupPresenceConnectInput
 ): Promise<GroupPresenceConnectOutcome> {
     const operation = input.command.command;
     if (operation.operation !== 'connectPresence') {
@@ -107,7 +114,6 @@ export async function processGroupPresenceConnect(
     }
     const read = await input.mutationService.read(input.command);
     const computed = input.mutationService.compute(input.command, read);
-    input.mutationService.validate(input.command, read, computed);
     const lifecycleGuardFacts = {
         ...identity,
         generationId: operation.input.generationId,
@@ -115,16 +121,16 @@ export async function processGroupPresenceConnect(
         expireAtEpochMs: resourceInboxRetryExpiryAtEpochMs(observedAtEpochMs)
     };
     const lifecycleGuard = lifecycle.computeConnectGuard(lifecycleGuardFacts, lifecycleRead);
-    validateWsSessionConnectGuard(lifecycleGuardFacts, lifecycleRead, lifecycleGuard);
-    return { status: 'ready-to-commit', computed, lifecycleGuard };
+    return { status: 'ready-to-commit', computed, read, lifecycleGuardFacts, lifecycleRead, lifecycleGuard };
 }
 
 export async function processGroupSessionCleanup(
     input: Readonly<{
         facts: GroupPresenceSessionCleanupAppInboxPayload;
         attemptCount: number;
+        context: AppInboxMessageContext<GroupSessionCleanupResult>;
         groupStateService: GroupStateService;
-        writeMutation: WriteMutation;
+        transactionWriter: Pick<AppInboxMutationTransactionWriter, 'readCompletionFacts' | 'writeComputedMutation'>;
         wakeQueue?: () => void;
     }>
 ): Promise<GroupSessionCleanupResult> {
@@ -132,7 +138,6 @@ export async function processGroupSessionCleanup(
     const lifecycle = input.groupStateService.sessionGenerationLifecycle;
     const lifecycleRead = await lifecycle.read(closeFacts);
     const lifecycleComputed = lifecycle.computeClosed(closeFacts, lifecycleRead);
-    validateWsSessionGenerationClosed(closeFacts, lifecycleRead, lifecycleComputed);
     const preparations = await input.groupStateService.prepareSessionCleanupMutations({
         scope: input.facts.connection.scope,
         authSession: input.facts.connection.authSession,
@@ -149,24 +154,41 @@ export async function processGroupSessionCleanup(
             };
             const read = await input.groupStateService.read(command);
             const computed = input.groupStateService.compute(command, read);
-            input.groupStateService.validate(command, read, computed);
-            return computed;
+            return { command, read, computed };
         })
     );
-    const result = await input.writeMutation(async (transaction) => {
-        await lifecycle.write(transaction, lifecycleComputed);
-        for (const computed of mutations) {
-            if (computed.outcome === 'write') {
-                await input.groupStateService.write(transaction, computed);
+    const durableResult = {
+        status: 'inactive',
+        sessionId: input.facts.connection.authSession.sessionId,
+        generationId: input.facts.connection.generationId,
+        affectedGroups: mutations.length
+    } as const;
+    const completionInput = {
+        ...input.transactionWriter.readCompletionFacts(input.context),
+        durableResult,
+        status: EntityStatus.COMPLETED
+    } as const;
+    const completion = computeAppInboxCompletion(completionInput);
+    validateWsSessionGenerationClosed(closeFacts, lifecycleRead, lifecycleComputed);
+    for (const mutation of mutations) {
+        input.groupStateService.validate(mutation.command, mutation.read, mutation.computed);
+    }
+    const completionIssues = validateAppInboxCompletion(completionInput, completion);
+    if (completionIssues[0] !== undefined) {
+        throw completionIssues[0].cause;
+    }
+    const result = await input.transactionWriter.writeComputedMutation(
+        input.context,
+        completion,
+        async (transaction) => {
+            await lifecycle.write(transaction, lifecycleComputed);
+            for (const mutation of mutations) {
+                if (mutation.computed.outcome === 'write') {
+                    await input.groupStateService.write(transaction, mutation.computed);
+                }
             }
         }
-        return {
-            status: 'inactive',
-            sessionId: input.facts.connection.authSession.sessionId,
-            generationId: input.facts.connection.generationId,
-            affectedGroups: mutations.length
-        } as const;
-    });
+    );
     input.wakeQueue?.();
     return result;
 }

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-app-inbox-handler.ts
@@ -1,6 +1,11 @@
-import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
-import { type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
-import { type AppInboxEnqueueInput } from '../../app-inbox/app-inbox-contracts.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
+import type { AppInboxEnqueueInput, AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
+import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { GroupStateService } from '../../group-state/group-state-service-contracts.ts';
 import { computeRtcRttMutation } from '../mutation/compute-rtc-rtt-mutation.ts';
 import { readRtcRttMutation } from '../mutation/read-rtc-rtt-mutation.ts';
@@ -13,17 +18,13 @@ import {
 } from './rtc-rtt-app-inbox-authority.ts';
 import type {
     CreateRtcRttAppInboxEnqueueInput,
-    RtcRttAppInboxCommand,
     RtcRttAppInboxDependencies
 } from './rtc-rtt-app-inbox-contracts.ts';
 import { toRtcRttAppInboxResult, type RtcRttAppInboxResult } from './rtc-rtt-app-inbox-result.ts';
 
 export interface RtcRttAppInboxHandlerDependencies {
     readonly groupStateService: GroupStateService;
-    readonly writeMutation: (
-        context: AppInboxMessageContext<RtcRttAppInboxResult>,
-        write: (transaction: PSqlSql) => Promise<RtcRttAppInboxResult>
-    ) => Promise<RtcRttAppInboxResult>;
+    readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly nowEpochMs: () => number;
     readonly wakeQueue?: () => void;
 }
@@ -82,9 +83,20 @@ export class RtcRttAppInboxHandler {
         };
         const computed = computeRtcRttMutation({ command, read, facts });
         validateRtcRttMutation({ command, read, facts, computed });
+        const durableResult = toRtcRttAppInboxResult(computed, authority.command.requestId);
+        const completionInput = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const completionIssues = validateAppInboxCompletion(completionInput, completion);
+        if (completionIssues[0] !== undefined) {
+            throw completionIssues[0].cause;
+        }
         const result = await this.commitMutation({
             context,
-            command: authority.command,
+            completion,
             computed,
             mutationDependencies: rtcRttDependencies
         });
@@ -105,23 +117,26 @@ export class RtcRttAppInboxHandler {
     }
 
     private async commitMutation(input: CommitRtcRttMutationInput): Promise<RtcRttAppInboxResult> {
-        const { context, command, computed } = input;
-        return await this.dependencies.writeMutation(context, async (transaction) => {
-            if (computed.outcome === 'write') {
-                await writeRtcRttMutation({
-                    transaction,
-                    computed,
-                    outboxWriter: input.mutationDependencies.outboxWriter
-                });
+        const { context, computed } = input;
+        return await this.dependencies.transactionWriter.writeComputedMutation(
+            context,
+            input.completion,
+            async (transaction) => {
+                if (computed.outcome === 'write') {
+                    await writeRtcRttMutation({
+                        transaction,
+                        computed,
+                        outboxWriter: input.mutationDependencies.outboxWriter
+                    });
+                }
             }
-            return toRtcRttAppInboxResult(computed, command.requestId);
-        });
+        );
     }
 }
 
 interface CommitRtcRttMutationInput {
     readonly context: AppInboxMessageContext<RtcRttAppInboxResult>;
-    readonly command: RtcRttAppInboxCommand;
+    readonly completion: AppInboxCompletionComputed<RtcRttAppInboxResult>;
     readonly computed: ReturnType<typeof computeRtcRttMutation>;
     readonly mutationDependencies: RtcRttAppInboxDependencies;
 }

--- a/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-inbox-service.ts
+++ b/packages/shared-server/rallar-system/rtc-rtt/inbox/rtc-rtt-inbox-service.ts
@@ -64,8 +64,7 @@ export class RtcRttInboxService {
         const handlers = handlerRuntime.registry;
         this.handler = new RtcRttAppInboxHandler({
             groupStateService: dependencies.groupStateService,
-            writeMutation: async (context, write) =>
-                await handlerRuntime.transactionWriter.writeMutation(context, write),
+            transactionWriter: handlerRuntime.transactionWriter,
             nowEpochMs: config.options?.nowEpochMs ?? Date.now,
             wakeQueue: config.wakeOwningQueue
         });

--- a/packages/shared-server/rallar-system/state-events/group-state-event-store.ts
+++ b/packages/shared-server/rallar-system/state-events/group-state-event-store.ts
@@ -5,6 +5,7 @@ import type { StateEventListQuery } from './state-event-listing.ts';
 
 export interface GroupStateEventStore {
     appendGroupEvent(event: GroupEvent): Promise<void>;
+    readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined>;
     listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]>;
     listRecentGroupEvents(
         ref: GroupRef,

--- a/packages/shared-server/rallar-system/state-events/in-memory-group-state-event-store.ts
+++ b/packages/shared-server/rallar-system/state-events/in-memory-group-state-event-store.ts
@@ -19,6 +19,10 @@ export class InMemoryGroupStateEventStore implements GroupStateEventStore {
         }
     }
 
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return this.events.find((event) => isGroupEventForRef(event, ref) && event.eventId === eventId);
+    }
+
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         return this.events
             .filter((event) => isGroupEventForRef(event, ref))

--- a/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-queries.ts
+++ b/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-queries.ts
@@ -71,6 +71,22 @@ export async function readAllPSqlGroupStateEventRows(
     `;
 }
 
+export async function readPSqlGroupStateEventRow(
+    sql: PSqlSql,
+    ref: GroupRef,
+    eventId: string
+): Promise<GroupStateEventRow | undefined> {
+    const [row] = await sql<GroupStateEventRow[]>`
+        select event_id, event_type, snapshot_version, occurred_at_epoch_ms, event_json
+        from group_state_events
+        where application_id = ${ref.applicationId}
+          and workspace_key = ${groupStateEventWorkspaceKey(ref.workspaceId)}
+          and group_id = ${ref.groupId}
+          and event_id = ${eventId}
+    `;
+    return row;
+}
+
 export async function readRecentPSqlGroupStateEventRows(
     input: GroupStateEventRowsQuery
 ): Promise<readonly GroupStateEventRow[]> {

--- a/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts
+++ b/packages/shared-server/rallar-system/state-events/postgres/p-sql-group-state-event-repository.ts
@@ -15,6 +15,7 @@ import {
     readAllPSqlGroupStateEventRows,
     readPSqlGroupStateEventCollision,
     readPSqlGroupStateEventPageRows,
+    readPSqlGroupStateEventRow,
     readRecentPSqlGroupStateEventRows
 } from './p-sql-group-state-event-queries.ts';
 
@@ -40,6 +41,11 @@ export class PSqlGroupStateEventRepository implements GroupStateEventStore {
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         const rows = await readAllPSqlGroupStateEventRows(this.sql, ref);
         return rows.map((row) => toValidatedGroupStateEvent(row, ref));
+    }
+
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        const row = await readPSqlGroupStateEventRow(this.sql, ref, eventId);
+        return row === undefined ? undefined : toValidatedGroupStateEvent(row, ref);
     }
 
     async listRecentGroupEvents(

--- a/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
+++ b/packages/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.ts
@@ -1,6 +1,12 @@
 import { fromCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 
 import { type AppInboxEnqueueInput, type AppInboxMessageContext } from '../../app-inbox/app-inbox-contracts.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion,
+    type AppInboxCompletionComputed
+} from '../../app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxMutationTransactionWriter } from '../../app-inbox/handler/app-inbox-transaction-writer.ts';
 import type { IssuedAuthSession } from '../../auth/persistence/auth-session-types.ts';
 import type { PersistedAuthSession } from '../../auth/persistence/persisted-auth-session.ts';
@@ -30,7 +36,10 @@ import type { TopologyReconfigureAppInboxAuthority } from './topology-app-inbox-
 
 export interface TopologyAppInboxHandlerDependencies {
     readonly groupStateService: Pick<GroupStateService, 'readIssuedAuthSession'>;
-    readonly transactionWriter: Pick<AppInboxMutationTransactionWriter, 'writeMutation'>;
+    readonly transactionWriter: Pick<
+        AppInboxMutationTransactionWriter,
+        'readCompletionFacts' | 'writeComputedMutation'
+    >;
     readonly nowEpochMs: () => number;
     readonly wakeQueue?: () => void;
 }
@@ -193,13 +202,15 @@ export class TopologyAppInboxHandler {
                 computed.receivedCommandHash
             );
         }
-        const result = await this.dependencies.transactionWriter.writeMutation(
+        const durableResult = toTopologyConfigMutationResult(computed);
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
                 if (computed.outcome === 'write' || computed.outcome === 'claim') {
                     await owners.configMutationService.write(transaction, computed);
                 }
-                return toTopologyConfigMutationResult(computed);
             }
         );
         if (computed.outcome === 'write') {
@@ -230,20 +241,39 @@ export class TopologyAppInboxHandler {
         const read = await mutation.read(command);
         const computed = mutation.compute(command, read);
         mutation.validate(command, read, computed);
-        const result = await this.dependencies.transactionWriter.writeMutation(
+        const durableResult = {
+            status: 'queued',
+            groupRef: command.groupRef,
+            requestId: command.commandId,
+            outboxId: computed.resourceId
+        } as const;
+        const completion = this.readComputeValidateCompletion(context, durableResult);
+        const result = await this.dependencies.transactionWriter.writeComputedMutation(
             context,
+            completion,
             async (transaction) => {
                 await mutation.write(transaction, computed);
-                return {
-                    status: 'queued',
-                    groupRef: command.groupRef,
-                    requestId: command.commandId,
-                    outboxId: computed.resourceId
-                } as const;
             }
         );
         mutation.recordCommittedWrite();
         this.dependencies.wakeQueue?.();
         return result;
+    }
+
+    private readComputeValidateCompletion<Result>(
+        context: AppInboxMessageContext<Result>,
+        durableResult: Result
+    ): AppInboxCompletionComputed<Result> {
+        const input = {
+            ...this.dependencies.transactionWriter.readCompletionFacts(context),
+            durableResult,
+            status: EntityStatus.COMPLETED
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+        const issues = validateAppInboxCompletion(input, computed);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        return computed;
     }
 }

--- a/packages/shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts
+++ b/packages/shared-server/rallar-system/topology/persistence/rtc-topology-execution-repository.ts
@@ -1,5 +1,4 @@
 import {
-    hashRtcTopologyExecutionCommand,
     RTC_TOPOLOGY_PUBLICATION_WORK_INDEX_NAMESPACE,
     RTC_TOPOLOGY_PUBLICATIONS_NAMESPACE,
     RtcTopologyPublicationCollisionError
@@ -12,12 +11,7 @@ import type { PSqlSql } from '../../../postgres/p-sql-sql.ts';
 import { RuntimeStateWriteConflictError } from '../../../runtime-state/optimistic-runtime-state-write.ts';
 import type { RuntimeStateOptimisticTransactionalRepositoryLike } from '../../../runtime-state/runtime-state-repository.ts';
 import type { RtcTopologyPersistenceComputed } from '../mutation/compute-rtc-topology-persistence.ts';
-import {
-    computeTopologyMutation,
-    validateTopologyMutation,
-    type RtcTopologyMutationComputed,
-    type RtcTopologyMutationRead
-} from '../mutation/rtc-topology-mutations.ts';
+import type { RtcTopologyMutationComputed, RtcTopologyMutationRead } from '../mutation/rtc-topology-mutations.ts';
 import { RTC_TOPOLOGY_REPLAY_RETENTION_MS } from '../replay/consumer/rtc-topology-replay-policy.ts';
 import {
     RTC_TOPOLOGY_INPUT_FINGERPRINTS_NAMESPACE,
@@ -25,26 +19,10 @@ import {
     type RtcTopologyInputFingerprintWrite
 } from '../replay/work/rtc-topology-input-fingerprint.ts';
 import { RtcTopologyRepositoryInvariantCorruptionError } from './rtc-topology-errors.ts';
-import { rtcTopologySemanticEqual } from './rtc-topology-semantic-equal.ts';
 import {
     RTC_TOPOLOGY_SNAPSHOTS_NAMESPACE,
     RtcTopologySnapshotRepository
 } from './rtc-topology-snapshot-repository.ts';
-
-export type RtcTopologyExecutionCommitResult =
-    | Readonly<{
-        status: 'committed' | 'loaded';
-        snapshot: RallarOverlayTopologySnapshot;
-        publication: RtcTopologyPublication;
-    }>
-    | Readonly<{
-        status: 'retry';
-        current?: RallarOverlayTopologySnapshot;
-    }>
-    | Readonly<{
-        status: 'superseded';
-        current: RallarOverlayTopologySnapshot;
-    }>;
 
 export class RtcTopologyExecutionRepository {
     readonly runtimeRepository: RuntimeStateOptimisticTransactionalRepositoryLike;
@@ -151,68 +129,6 @@ export class RtcTopologyExecutionRepository {
         return 'committed';
     }
 
-    async commit(
-        input: Readonly<{
-            expected?: RallarOverlayTopologySnapshot;
-            candidate: RallarOverlayTopologySnapshot;
-            publication: RtcTopologyPublication;
-        }>
-    ): Promise<RtcTopologyExecutionCommitResult> {
-        const read = await this.readTopologyMutation(
-            input.candidate.groupRef,
-            input.publication.workId
-        );
-        if (
-            !read.publicationClaim &&
-            !sameSnapshot(read.snapshot?.value, input.expected)
-        ) {
-            return { status: 'retry', current: read.snapshot?.value };
-        }
-        const candidate = read.publicationClaim ? null : input.candidate;
-        const facts = read.publicationClaim
-            ? {
-                publicationExpireAtTimestamp: null,
-                commandHash: null,
-                attemptCount: null
-            } as const
-            : {
-                publicationExpireAtTimestamp: this.publicationExpireAtTimestamp(),
-                commandHash: await hashRtcTopologyExecutionCommand(
-                    input.publication
-                ),
-                attemptCount: 1
-            } as const;
-        const computed = computeTopologyMutation({
-            read,
-            candidate,
-            publication: read.publicationClaim ? null : input.publication,
-            facts
-        });
-        validateTopologyMutation({
-            read,
-            candidate,
-            publication: read.publicationClaim ? null : input.publication,
-            facts,
-            computed
-        });
-        if (computed.outcome === 'retry') {
-            return { status: 'retry', current: read.snapshot?.value };
-        }
-        if (computed.outcome === 'loaded') {
-            return {
-                status: 'loaded',
-                snapshot: computed.snapshot,
-                publication: computed.publication
-            };
-        }
-        if (computed.outcome === 'superseded') {
-            return { status: 'superseded', current: computed.current };
-        }
-        throw new TypeError(
-            'RTC topology commits require an AppInbox or APP_OUTBOX transaction'
-        );
-    }
-
     publicationExpireAtTimestamp(): number {
         return this.now() + this.publicationRetentionMs;
     }
@@ -290,11 +206,4 @@ async function writeRtcTopologyPublication(
     if (!publications[0]) {
         throw new RtcTopologyPublicationCollisionError(publication.key);
     }
-}
-
-function sameSnapshot(
-    left: RallarOverlayTopologySnapshot | undefined,
-    right: RallarOverlayTopologySnapshot | undefined
-): boolean {
-    return left === right || rtcTopologySemanticEqual(left, right);
 }

--- a/packages/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts
@@ -8,10 +8,7 @@ import { GROUP_MUTATION_QUEUE_EXPIRE_AT_EPOCH_MS } from '@shared-server/rallar-s
 import type { GroupLifecyclePolicyRead } from '@shared-server/rallar-system/group-state/persistence/group-lifecycle-policy-repository.ts';
 import { computeTopologyPromotionEntry } from '@shared-server/rallar-system/group-state/topology-promotion-outbox-entry.ts';
 import type { PSqlSql } from '../../../../postgres/p-sql-sql.ts';
-import {
-    PSqlResourceInboxEntryRepository,
-    ResourceInboxInvariantCorruptionError
-} from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import { PSqlResourceInboxEntryRepository } from '../../../../queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
 
 /**
  * The route-less promotion producer's read surface (decision 27): present
@@ -95,16 +92,5 @@ export async function writeTopologyPromotionRequest(
     if (requestEntry === null) {
         return;
     }
-    try {
-        await new PSqlResourceInboxEntryRepository(transaction).writeIfAbsentOrMatch(requestEntry);
-    }
-    catch (error) {
-        // A same-identity request with different audit bytes already exists:
-        // the promotion is already durably requested, which is this write's
-        // whole goal — swallow the mismatch instead of wedging the
-        // publication transaction.
-        if (!(error instanceof ResourceInboxInvariantCorruptionError)) {
-            throw error;
-        }
-    }
+    await new PSqlResourceInboxEntryRepository(transaction).writeIfAbsentOrMatch(requestEntry);
 }

--- a/packages/shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts
+++ b/packages/shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts
@@ -1,0 +1,34 @@
+import type {
+    RuntimeStateGuardedBatch,
+    RuntimeStateGuardedBatchEffect,
+    RuntimeStateGuardedBatchSqlDescriptor,
+    RuntimeStateGuardedBatchWrite
+} from './runtime-state-guarded-batch.ts';
+
+export function computeRuntimeStateGuardedBatchWrite(
+    batch: RuntimeStateGuardedBatch
+): RuntimeStateGuardedBatchWrite {
+    return {
+        ...batch,
+        guardSqlDescriptor: computeSqlDescriptor(batch.guard),
+        effectSqlDescriptors: batch.effects.map(computeSqlDescriptor)
+    };
+}
+
+function computeSqlDescriptor(
+    input: RuntimeStateGuardedBatch['guard'] | RuntimeStateGuardedBatchEffect
+): RuntimeStateGuardedBatchSqlDescriptor {
+    return {
+        ...('effectId' in input ? { effectId: input.effectId } : {}),
+        operation: input.operation,
+        namespace: input.namespace,
+        key: input.key,
+        ...('expectedRevision' in input
+            ? { expectedRevision: input.expectedRevision }
+            : {}),
+        ...('value' in input ? { value: input.value } : {}),
+        ...('expireAtTimestamp' in input
+            ? { expireAtTimestamp: new Date(input.expireAtTimestamp).toISOString() }
+            : {})
+    };
+}

--- a/packages/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts
+++ b/packages/shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts
@@ -54,6 +54,21 @@ export interface RuntimeStateGuardedBatch {
     readonly effects: readonly RuntimeStateGuardedBatchEffect[];
 }
 
+export interface RuntimeStateGuardedBatchSqlDescriptor {
+    readonly effectId?: string;
+    readonly operation: RuntimeStateGuardedBatchEffect['operation'];
+    readonly namespace: string;
+    readonly key: string;
+    readonly expectedRevision?: number;
+    readonly value?: string;
+    readonly expireAtTimestamp?: string;
+}
+
+export interface RuntimeStateGuardedBatchWrite extends RuntimeStateGuardedBatch {
+    readonly guardSqlDescriptor: RuntimeStateGuardedBatchSqlDescriptor;
+    readonly effectSqlDescriptors: readonly RuntimeStateGuardedBatchSqlDescriptor[];
+}
+
 export type RuntimeStateGuardedBatchGuardResult =
     | Readonly<{
         status: 'applied';
@@ -117,7 +132,7 @@ export interface RuntimeStateGuardedBatchResult {
 }
 
 export interface RuntimeStateGuardedBatchTransaction {
-    executeGuardedBatch(
-        batch: RuntimeStateGuardedBatch
+    writeGuardedBatch(
+        computed: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult>;
 }

--- a/packages/shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts
+++ b/packages/shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts
@@ -1,7 +1,7 @@
 import type {
-    RuntimeStateGuardedBatch,
     RuntimeStateGuardedBatchResult,
-    RuntimeStateGuardedBatchTransaction
+    RuntimeStateGuardedBatchTransaction,
+    RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type {
     RuntimeStateConditionalDeleteResult,
@@ -19,7 +19,7 @@ import type {
     RuntimeStateReadBatchSelection,
     RuntimeStateReadBatchSelector
 } from '../read-batch/runtime-state-read-batch.ts';
-import { executeRuntimeStateGuardedBatch } from './execute-runtime-state-guarded-batch.ts';
+import { writeRuntimeStateGuardedBatch } from './write-runtime-state-guarded-batch.ts';
 import { readRuntimeStateBatch } from './read-runtime-state-batch.ts';
 import {
     decodeRuntimeStateRevision,
@@ -89,15 +89,15 @@ export class PSqlRuntimeStateRepository
         });
     }
 
-    async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    async writeGuardedBatch(
+        computed: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.sqlState.kind !== 'transaction') {
             throw new Error(
                 'Guarded runtime state batches require a transaction-scoped repository.'
             );
         }
-        return await executeRuntimeStateGuardedBatch(this.sql, input);
+        return await writeRuntimeStateGuardedBatch(this.sql, computed);
     }
 
     async findEntry(

--- a/packages/shared-server/runtime-state/postgres/write-runtime-state-guarded-batch.ts
+++ b/packages/shared-server/runtime-state/postgres/write-runtime-state-guarded-batch.ts
@@ -1,37 +1,18 @@
 import type { PSqlSql } from '../../postgres/p-sql-sql.ts';
 import type {
-    RuntimeStateGuardedBatch,
-    RuntimeStateGuardedBatchEffect,
-    RuntimeStateGuardedBatchResult
+    RuntimeStateGuardedBatchResult,
+    RuntimeStateGuardedBatchWrite
 } from '../guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatch } from '../guarded-batch/validate-runtime-state-guarded-batch.ts';
 import {
     decodeComputedRuntimeStateGuardedBatchRows,
     type RuntimeStateGuardedBatchDatabaseRow
 } from './decode-runtime-state-guarded-batch-rows.ts';
 
-interface RuntimeStateGuardedBatchSqlDescriptor {
-    readonly effectId?: string;
-    readonly operation: RuntimeStateGuardedBatchEffect['operation'];
-    readonly namespace: string;
-    readonly key: string;
-    readonly expectedRevision?: number;
-    readonly value?: string;
-    readonly expireAtTimestamp?: string;
-}
-
-export async function executeRuntimeStateGuardedBatch(
+export async function writeRuntimeStateGuardedBatch(
     sql: PSqlSql,
-    input: RuntimeStateGuardedBatch
+    computed: RuntimeStateGuardedBatchWrite
 ): Promise<RuntimeStateGuardedBatchResult> {
-    const batch = validateRuntimeStateGuardedBatch(input);
-    return await executeComputedRuntimeStateGuardedBatch(sql, batch);
-}
-
-export async function executeComputedRuntimeStateGuardedBatch(
-    sql: PSqlSql,
-    batch: RuntimeStateGuardedBatch
-): Promise<RuntimeStateGuardedBatchResult> {
+    const batch = computed;
     const rows = await sql<RuntimeStateGuardedBatchDatabaseRow[]>`
         with guard_input as (
             select descriptor ->> 'operation' as operation,
@@ -40,7 +21,7 @@ export async function executeComputedRuntimeStateGuardedBatch(
                    descriptor ->> 'value' as store_value,
                    (descriptor ->> 'expireAtTimestamp')::timestamptz as expire_at_ts,
                    (descriptor ->> 'expectedRevision')::bigint as expected_revision
-            from (select ${toSqlDescriptor(batch.guard)}::jsonb as descriptor) guard_json
+            from (select ${computed.guardSqlDescriptor}::jsonb as descriptor) guard_json
         ),
         effect_input as (
             select descriptor ->> 'effectId' as effect_id,
@@ -50,7 +31,7 @@ export async function executeComputedRuntimeStateGuardedBatch(
                    descriptor ->> 'value' as store_value,
                    (descriptor ->> 'expireAtTimestamp')::timestamptz as expire_at_ts,
                    (descriptor ->> 'expectedRevision')::bigint as expected_revision
-            from jsonb_array_elements(${batch.effects.map(toSqlDescriptor)}::jsonb) descriptor
+            from jsonb_array_elements(${computed.effectSqlDescriptors}::jsonb) descriptor
         ),
         guard_insert as (
             insert into runtime_state_store (store_namespace,
@@ -270,26 +251,4 @@ export async function executeComputedRuntimeStateGuardedBatch(
     `;
 
     return decodeComputedRuntimeStateGuardedBatchRows(batch, rows);
-}
-
-function toSqlDescriptor(
-    input: RuntimeStateGuardedBatch['guard'] | RuntimeStateGuardedBatchEffect
-): RuntimeStateGuardedBatchSqlDescriptor {
-    const effectId = 'effectId' in input ? input.effectId : undefined;
-    const expectedRevision = 'expectedRevision' in input
-        ? input.expectedRevision
-        : undefined;
-    const value = 'value' in input ? input.value : undefined;
-    const expireAtTimestamp = 'expireAtTimestamp' in input
-        ? new Date(input.expireAtTimestamp).toISOString()
-        : undefined;
-    return {
-        effectId,
-        operation: input.operation,
-        namespace: input.namespace,
-        key: input.key,
-        expectedRevision,
-        value,
-        expireAtTimestamp
-    };
 }

--- a/packages/shared-test/shared-server/test-group-state-event-store.ts
+++ b/packages/shared-test/shared-server/test-group-state-event-store.ts
@@ -25,6 +25,10 @@ export class TestGroupStateEventStore implements GroupStateEventStore {
         }
     }
 
+    async readGroupEvent(ref: GroupRef, eventId: string): Promise<GroupEvent | undefined> {
+        return this.events.find((event) => isEventForRef(event, ref) && event.eventId === eventId);
+    }
+
     async listGroupEvents(ref: GroupRef): Promise<readonly GroupEvent[]> {
         return this.events
             .filter((event) => isEventForRef(event, ref))

--- a/packages/shared/queuebox/indexed-db-queue-box-entry.ts
+++ b/packages/shared/queuebox/indexed-db-queue-box-entry.ts
@@ -188,56 +188,25 @@ export function isStoredQueueEntryTimedOut(
     return Temporal.Instant.compare(now, startTs.add(duration)) >= 0;
 }
 
-function temporalText(value: string | object, fallback: string): string {
-    if (typeof value === 'string' && value.length > 0 && value !== '[object Object]') {
-        return value;
-    }
-
-    if (
-        value &&
-        typeof value === 'object' &&
-        'toString' in value &&
-        typeof value.toString === 'function'
-    ) {
-        const text = value.toString();
-        if (text.length > 0 && text !== '[object Object]') {
-            return text;
-        }
-    }
-
-    return fallback;
-}
-
 function toPlainTime(value: string | Temporal.PlainTime): Temporal.PlainTime {
-    const fallback = Temporal.Now.plainTimeISO();
-    try {
-        return Temporal.PlainTime.from(temporalText(value, fallback.toString()));
+    if (typeof value !== 'string' && !(value instanceof Temporal.PlainTime)) {
+        throw new TypeError('IndexedDB queue audit date must be a plain time');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.PlainTime.from(value);
 }
 
 function toPlainDateTime(value: string | Temporal.PlainDateTime): Temporal.PlainDateTime {
-    const fallback = Temporal.Now.plainDateTimeISO();
-    try {
-        return Temporal.PlainDateTime.from(temporalText(value, fallback.toString()));
+    if (typeof value !== 'string' && !(value instanceof Temporal.PlainDateTime)) {
+        throw new TypeError('IndexedDB queue creation timestamp must be a plain date-time');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.PlainDateTime.from(value);
 }
 
-function toInstant(
-    value: string | Temporal.Instant,
-    fallback: Temporal.Instant = NEVER_EXPIRE_TS
-): Temporal.Instant {
-    try {
-        return Temporal.Instant.from(temporalText(value, fallback.toString()));
+function toInstant(value: string | Temporal.Instant): Temporal.Instant {
+    if (typeof value !== 'string' && !(value instanceof Temporal.Instant)) {
+        throw new TypeError('IndexedDB queue timestamp must be an instant');
     }
-    catch {
-        return fallback;
-    }
+    return Temporal.Instant.from(value);
 }
 
 function toOptionalInstant(
@@ -247,10 +216,5 @@ function toOptionalInstant(
         return undefined;
     }
 
-    try {
-        return Temporal.Instant.from(temporalText(value, ''));
-    }
-    catch {
-        return undefined;
-    }
+    return toInstant(value);
 }

--- a/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
+++ b/packages/tests/repo/mutation-route-ownership/authoritative/authoritative-mutation-read-compute-validate-write.test.ts
@@ -122,7 +122,7 @@ it.each([
             'this.dependencies.mutationService.read(command)',
             'this.dependencies.mutationService.compute(command, read, materialized.facts)',
             'this.dependencies.mutationService.validate(command, read, computed)',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'this.dependencies.mutationService.write(transaction, computed)'
         ]
     },
@@ -166,10 +166,14 @@ it.each([
         source: sources.groupHandler,
         owner: 'processGroupStateMutation',
         calls: [
-            'this.dependencies.mutationService.read(command)',
-            'this.dependencies.mutationService.compute(command, read)',
-            'this.dependencies.mutationService.validate(command, read, computed)',
-            'this.commitMutation({ context, command, computed })'
+            'this.readResultFacts(command)',
+            'this.dependencies.mutationService.compute(command, resultRead.mutationRead)',
+            'computeGroupStateInboxResult(resultInput)',
+            'computeAppInboxCompletion(completionInput)',
+            'this.dependencies.mutationService.validate(command, resultRead.mutationRead, computed)',
+            'validateGroupStateInboxResult(resultInput, durableResult)',
+            'this.validateCompletion(completionInput, completion)',
+            'this.commitMutation({ context, command, computed, durableResult, completion })'
         ]
     },
     {
@@ -180,7 +184,7 @@ it.each([
             'owners.configMutationService.read(',
             'owners.configMutationService.compute(',
             'owners.configMutationService.validate(',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'owners.configMutationService.write('
         ]
     },
@@ -192,7 +196,7 @@ it.each([
             'mutation.read(command)',
             'mutation.compute(command, read)',
             'mutation.validate(command, read, computed)',
-            'this.dependencies.transactionWriter.writeMutation(',
+            'this.dependencies.transactionWriter.writeComputedMutation(',
             'mutation.write(transaction, computed)'
         ]
     },
@@ -244,8 +248,8 @@ it('keeps AppInbox as the only retry and transaction owner for HTTP and WS mutat
         expect(source).not.toMatch(/waitForRuntimeStateWriteRetry/);
         expect(source).not.toMatch(/for\s*\([^)]*attempt/);
     }
-    expect(sources.topologyHandler).toContain('this.dependencies.transactionWriter.writeMutation(');
-    expect(sources.rtcHandler).toContain('this.dependencies.writeMutation(');
+    expect(sources.topologyHandler).toContain('this.dependencies.transactionWriter.writeComputedMutation(');
+    expect(sources.rtcHandler).toContain('this.dependencies.transactionWriter.writeComputedMutation(');
     expect(sources.rtcInbox).toContain('AppInboxType.RTC_RTT_SUBMIT');
     expect(sources.topologyInbox).toContain('AppInboxType.TOPOLOGY_RECONFIGURE');
 });
@@ -254,39 +258,41 @@ it('keeps transport boundaries free of direct mutators and persistence owners', 
     expect(findMutationBoundaryViolations()).toEqual([]);
 }, 15_000);
 
-it('writes topology config state, receipt, authority fence, and APP_OUTBOX atomically', () => {
+it('executes prepared topology config runtime writes before prepared APP_OUTBOX', () => {
     const seam = readFunctionBody(sources.topologyConfig, 'writeTopologyConfigMutation');
     expectInOrder(seam, [
-        'writeTopologyConfigAuthorityFence(',
-        'writeTopologyConfigState(',
-        'insertMutationRecord(',
-        'input.outboxWriter.write(transaction, computed.outboxWrite)'
+        'for (const write of input.computed.runtimeWrites)',
+        'executeTopologyConfigRuntimeWrite(input.transaction, write)',
+        'input.outboxWriter.write(input.transaction, input.computed.outboxWrite)'
     ]);
-    expectInOrder(readFunctionBody(sources.topologyConfig, 'writeTopologyConfigAuthorityFence'), [
-        'advanceGroupStateAuthorityFence(',
-        'computed.groupAuthorityGuard',
+    expectInOrder(readFunctionBody(sources.topologyConfig, 'executeTopologyConfigRuntimeWrite'), [
+        'switch (write.operation)',
+        'requireExpectedRevision('
+    ]);
+    expect(readFunctionBody(sources.topologyConfig, 'requireExpectedRevision')).toContain(
         'throw new RuntimeStateWriteConflictError()'
-    ]);
+    );
     expect(seam).not.toContain('StateMutation' + 'Outbox');
 });
 
 it('fences explicit reconfigure authority before inserting APP_OUTBOX', () => {
     const seam = readMethodBody(sources.topologyReconfigure, 'write');
     expectInOrder(seam, [
-        'advanceGroupStateAuthorityFence(',
-        'computed.authorityGuard',
+        'const write = computed.authorityWrite',
+        'where store_namespace = ${write.namespace}',
+        'decodeRuntimeStateRevision(rows[0].revision) !== write.expectedResultRevision',
         'throw new RuntimeStateWriteConflictError()',
         'this.dependencies.outboxWriter.write(transaction, computed.outboxWrite)'
     ]);
 });
 
-it('writes RTT admission, measurement, receipt, and direct APP_OUTBOX rows atomically', () => {
+it('executes prepared RTT runtime and APP_OUTBOX writes atomically', () => {
     const seam = readFunctionBody(sources.rtt, 'writeRtcRttMutation');
     expectInOrder(seam, [
-        'commitEndpointAdmission(',
-        'commitMeasurement(',
-        'insertMutationReceipt(',
-        'input.outboxWriter.write(transaction,'
+        'for (const write of input.computed.runtimeWrites)',
+        'executeRuntimeWrite(input.transaction, write)',
+        'for (const outboxWrite of input.computed.outboxWrites)',
+        'input.outboxWriter.write(input.transaction, outboxWrite)'
     ]);
     expect(seam).not.toContain('insertRecomputeIntent');
     expect(seam).not.toContain('StateMutation' + 'Outbox');

--- a/packages/tests/repo/transaction-write-check.test.ts
+++ b/packages/tests/repo/transaction-write-check.test.ts
@@ -45,6 +45,33 @@ describe('transaction write check', () => {
         expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
     });
 
+    it('inspects AppInbox domain write callbacks', () => {
+        const findings = analyzeFixture(`
+            interface PSqlSql { query(value: unknown): Promise<void>; }
+            interface AppInboxMutationTransactionWriter {
+                writeComputedMutation<Result>(
+                    context: object,
+                    computed: Result,
+                    write: (transaction: PSqlSql) => Promise<void>
+                ): Promise<Result>;
+            }
+            declare const transactionWriter: AppInboxMutationTransactionWriter;
+            declare const context: object;
+            declare const computed: { value: number };
+            export async function process(): Promise<void> {
+                await transactionWriter.writeComputedMutation(
+                    context,
+                    computed,
+                    async (transaction) => {
+                        await transaction.query(JSON.stringify(computed));
+                    }
+                );
+            }
+        `);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['JSON.stringify']);
+    });
+
     it('inspects inferred object-property write implementations', () => {
         const findings = analyzeFixture(`
             interface PSqlSql { query(value: unknown): Promise<void>; }
@@ -209,6 +236,18 @@ describe('transaction write check', () => {
             path: 'packages/shared/queuebox/indexed-db-queue-box-write.ts',
             operation: 'JSON.stringify'
         });
+    });
+
+    it('does not exempt new files merely because they are in the ResourceInbox directory', () => {
+        const project = new Project({ useInMemoryFileSystem: true });
+        const source = project.createSourceFile(
+            '/packages/shared-server/queuebox/postgres/unreviewed-domain-write.ts',
+            transactionSource('Date.now()')
+        );
+
+        const findings = analyzeTransactionWrites(project, [source]);
+
+        expect(findings.map((finding) => finding.operation)).toEqual(['Date.now']);
     });
 });
 

--- a/packages/tests/shared-server/integration/postgres/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/integration/postgres/runtime-state-guarded-batch.test.ts
@@ -17,6 +17,7 @@ import {
     RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE,
     RtcTopologySnapshotRepository
 } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
@@ -51,28 +52,27 @@ describe('Postgres runtime-state guarded batches', () => {
             const sql = await createRuntimeStatePostgresSql(requireDatabaseUrl());
             const repository = new PSqlRuntimeStateRepository(sql);
             const namespace = `guarded-batch-${crypto.randomUUID()}`;
+            const computed = computeRuntimeStateGuardedBatchWrite({
+                guard: {
+                    operation: 'insert',
+                    namespace,
+                    key: 'guard',
+                    value: 'guard-value',
+                    expireAtTimestamp: FUTURE_MS
+                },
+                effects: [{
+                    effectId: 'insert-effect',
+                    operation: 'insert',
+                    namespace,
+                    key: 'effect',
+                    value: 'effect-value',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             try {
                 const result = await repository.begin(async (transactionRepository) => {
-                    return await transactionRepository.executeGuardedBatch({
-                        guard: {
-                            operation: 'insert',
-                            namespace,
-                            key: 'guard',
-                            value: 'guard-value',
-                            expireAtTimestamp: FUTURE_MS
-                        },
-                        effects: [
-                            {
-                                effectId: 'insert-effect',
-                                operation: 'insert',
-                                namespace,
-                                key: 'effect',
-                                value: 'effect-value',
-                                expireAtTimestamp: FUTURE_MS
-                            }
-                        ]
-                    });
+                    return await transactionRepository.writeGuardedBatch(computed);
                 });
 
                 expect(result).toEqual({
@@ -134,20 +134,21 @@ describe('Postgres runtime-state guarded batches', () => {
                 ...outboxEntry,
                 resource: `${outboxEntry.resource}mismatch`
             };
+            const seedWrite = computeRuntimeStateGuardedBatchWrite({
+                guard: groupStateInsertGroupDescriptor(read.group!.value),
+                effects: [{
+                    effectId: 'reset-rollback-seed',
+                    operation: 'insert',
+                    namespace: seedNamespace,
+                    key: 'seed',
+                    value: 'seed',
+                    expireAtTimestamp: FUTURE_MS
+                }]
+            });
 
             try {
                 await runtime.begin(async (transactionRuntime) => {
-                    await transactionRuntime.executeGuardedBatch({
-                        guard: groupStateInsertGroupDescriptor(read.group!.value),
-                        effects: [{
-                            effectId: 'reset-rollback-seed',
-                            operation: 'insert',
-                            namespace: seedNamespace,
-                            key: 'seed',
-                            value: 'seed',
-                            expireAtTimestamp: FUTURE_MS
-                        }]
-                    });
+                    await transactionRuntime.writeGuardedBatch(seedWrite);
                     await new RtcTopologySnapshotRepository(transactionRuntime).commitSnapshotGuard(snapshot, null);
                     await new RtcTopologySnapshotRepository(
                         transactionRuntime,

--- a/packages/tests/shared-server/integration/postgres/test-support/postgres-app-inbox-worker-services.ts
+++ b/packages/tests/shared-server/integration/postgres/test-support/postgres-app-inbox-worker-services.ts
@@ -74,9 +74,10 @@ export function createPostgresAppInboxWorkerServices(
         clientStateEventStore: new PSqlClientStateEventRepository(input.sql),
         serviceId: input.serviceId
     });
+    const groupEventStore = new PSqlGroupStateEventRepository(input.sql);
     const groupState = createGroupStateService({
         runtimeRepository,
-        groupStateEventStore: new PSqlGroupStateEventRepository(input.sql),
+        groupStateEventStore: groupEventStore,
         authSessionRepository: authSessions,
         now: () => input.atEpochMs,
         serviceId: input.serviceId,
@@ -103,7 +104,8 @@ export function createPostgresAppInboxWorkerServices(
             resourceInboxRepository: resourceInbox.entries,
             resourceInboxResultsRepository: resourceInboxResults,
             database: input.transactionSql,
-            groupStateService: groupState
+            groupStateService: groupState,
+            resultReader: createTestGroupStateRepository(runtimeRepository, groupEventStore)
         },
         {
             serviceId: input.serviceId,
@@ -113,7 +115,7 @@ export function createPostgresAppInboxWorkerServices(
     );
     const topologyGroupStateRepository = createTestGroupStateRepository(
         runtimeRepository,
-        new PSqlGroupStateEventRepository(input.sql)
+        groupEventStore
     );
     const topologyConfigRepository = new GroupTopologyConfigRepository(topologyRuntimeRepository);
     const topologyRuntimeOwners = createGroupTopologyRuntimeOwners({

--- a/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-operations/admin-prune-computation.test.ts
@@ -57,6 +57,42 @@ describe('admin prune computation', () => {
         expect(changed.result.jobId).toBe('another-job');
     });
 
+    it('rejects prepared admin prune rows that differ from the computed mutation', async () => {
+        const read = await createRead();
+        const computed = computeAdminPruneMutation(read);
+        const firstOutboxWrite = computed.outboxWrites[0];
+        if (firstOutboxWrite === undefined || computed.aggregateWrite === null) {
+            throw new TypeError('Expected prepared admin prune writes');
+        }
+        const tampered = [
+            {
+                ...computed,
+                outboxWrites: [{ ...firstOutboxWrite, expiresAt: '2000-01-01T00:00:00.000Z' }]
+            },
+            {
+                ...computed,
+                aggregateWrite: {
+                    ...computed.aggregateWrite,
+                    createdAt: '2000-01-01T00:00:00.000Z'
+                }
+            },
+            {
+                ...computed,
+                aggregateWrite: {
+                    ...computed.aggregateWrite,
+                    entry: { ...computed.aggregateWrite.entry, resource: '{"jobId":"tampered"}' }
+                }
+            }
+        ];
+
+        for (const candidate of tampered) {
+            expect(validateAdminPruneMutation(read, candidate)).toContainEqual(expect.objectContaining({
+                code: 'admin-prune-computed-persistence-invalid',
+                status: 400
+            }));
+        }
+    });
+
     it('writes the prepared aggregate without formatting timestamps in the transaction', async () => {
         const computed = computeAdminPruneMutation(await createRead());
         const aggregateWrite = computed.aggregateWrite;

--- a/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-expired-row-replacement.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/app-inbox-expired-row-replacement.test.ts
@@ -240,7 +240,11 @@ describe('AppInbox expired row replacement', () => {
                     resourceInboxRepository: queue,
                     resourceInboxResultsRepository: results,
                     database: database,
-                    groupStateService: groupState
+                    groupStateService: groupState,
+                    resultReader: {
+                        readSnapshot: (ref) => groupState.readSnapshot(ref),
+                        readEvent: (ref, eventId) => database.groupEventStore.readGroupEvent(ref, eventId)
+                    }
                 },
                 {
                     serviceId: 'expired-group-service'

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.test.ts
@@ -49,6 +49,37 @@ describe('AppInbox successful completion computation', () => {
         expect(harness.database.beginCalls).toBe(0);
     });
 
+    it('rejects completion projections that do not match the durable result', () => {
+        const harness = createAtomicHarness();
+        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
+        const input = {
+            ...writer.readCompletionFacts(harness.context),
+            status: EntityStatus.COMPLETED,
+            durableResult: { status: 'accepted', revision: 2 }
+        } as const;
+        const computed = computeAppInboxCompletion(input);
+
+        const issues = validateAppInboxCompletion(input, {
+            ...computed,
+            encodedResult: { status: 'substituted' },
+            resultReplacement: {
+                ...computed.resultReplacement,
+                resource: JSON.stringify({ status: 'substituted' })
+            },
+            finalizedEntry: {
+                ...computed.finalizedEntry,
+                resource: 'substituted request'
+            }
+        });
+
+        expect(issues.map((issue) => issue.path)).toEqual([
+            'computed.encodedResult',
+            'computed.resultReplacement',
+            'computed.finalizedEntry'
+        ]);
+        expect(harness.database.beginCalls).toBe(0);
+    });
+
     it('validates reservation identity by value rather than object identity', () => {
         const harness = createAtomicHarness();
         const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
@@ -102,24 +133,5 @@ describe('AppInbox successful completion computation', () => {
         const key = toKeyAsString(harness.entry.key);
         expect(harness.database.state.results.get(key)?.resource).toBe(JSON.stringify(durableResult));
         expect(harness.database.state.inbox.get(key)?.status).toBe(EntityStatus.COMPLETED);
-    });
-
-    it('keeps private after-commit data separate from the computed durable result', async () => {
-        const harness = createAtomicHarness();
-        const writer = new AppInboxTransactionWriter({ database: harness.database.sql }, { serviceId: 'server-1' });
-        const durableResult = { status: 'accepted' } as const;
-        const input = { ...writer.readCompletionFacts(harness.context), status: EntityStatus.COMPLETED, durableResult };
-        const computed = computeAppInboxCompletion(input);
-        expect(validateAppInboxCompletion(input, computed)).toEqual([]);
-        const afterCommitResult = { wakeQueue: true };
-
-        const result = await writer.writeComputedMutationWithAfterCommitResult(
-            harness.context,
-            computed,
-            async () => afterCommitResult
-        );
-
-        expect(result).toEqual({ durableResult, afterCommitResult });
-        expect(harness.database.state.results.get(toKeyAsString(harness.entry.key))?.resource).toBe(JSON.stringify(durableResult));
     });
 });

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-handler-executor.test.ts
@@ -33,10 +33,11 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
         harness.service.onStateMessage(
             AppInboxType.GROUP_CREATE,
             async (_data, context) =>
-                await harness.service.commit(context, async () => ({
-                    status: 'accepted',
-                    source: 'transaction'
-                }))
+                await harness.service.commit(
+                    context,
+                    { status: 'accepted', source: 'transaction' },
+                    async () => {}
+                )
         );
 
         const pending = harness.service.enqueueAndWait(harness.enqueue);
@@ -58,10 +59,11 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
             timing: (event) => timing.push(event)
         });
         harness.service.onStateMessage(AppInboxType.GROUP_CREATE, async (_data, context) => {
-            await harness.service.commit(context, async () => ({
-                status: 'accepted',
-                source: 'transaction'
-            }));
+            await harness.service.commit(
+                context,
+                { status: 'accepted', source: 'transaction' },
+                async () => {}
+            );
             throw new Error('secret-after-commit');
         });
 
@@ -245,9 +247,8 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
             });
             let acceptedMutationExecutions = 0;
             const handler = async (_data: JsonWireValue, context: Parameters<typeof harness.service.commit>[0]) =>
-                await harness.service.commit(context, async () => {
+                await harness.service.commit(context, { status: 'accepted' }, async () => {
                     acceptedMutationExecutions += 1;
-                    return { status: 'accepted' };
                 });
             harness.service.onStateMessage(outerType as AppInboxType, handler);
             harness.service.enqueueWithoutWaiting(harness.enqueue);
@@ -298,9 +299,8 @@ describe('AppInboxHandlerExecutor registered handler finalization', () => {
         const harness = createRegisteredHandlerHarness();
         let mutationCommitted = false;
         const handler = async (_data: JsonWireValue, context: Parameters<typeof harness.service.commit>[0]) =>
-            await harness.service.commit(context, async () => {
+            await harness.service.commit(context, { status: 'accepted' }, async () => {
                 mutationCommitted = true;
-                return { status: 'accepted' };
             });
         harness.service.onStateMessage(AppInboxType.GROUP_UPDATE, handler);
         harness.service.enqueueWithoutWaiting(harness.enqueue);

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-p-sql-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-p-sql-transaction.test.ts
@@ -18,6 +18,10 @@ import { ResourceInboxResultsRepository } from '@shared-server/queuebox/postgres
 
 import { AppInboxType, type AppInboxMessageContext } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
 import { encodeAppInboxResult } from '@shared-server/rallar-system/app-inbox/app-inbox-registration-codecs.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import { AppInboxTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import { PSqlRuntimeStateRepository } from '@shared-server/runtime-state/postgres/p-sql-runtime-state-repository.ts';
 
@@ -141,17 +145,24 @@ describe('Postgres transaction write boundary', () => {
             encodeResult: (result) => encodeAppInboxResult(result, 'Postgres transaction test result')
         };
 
-        const result = await transactionWriter.writeMutation(context, async (transaction) => {
+        const durableResult = { status: 'accepted' };
+        const completionInput = {
+            ...transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.COMPLETED,
+            durableResult
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        expect(validateAppInboxCompletion(completionInput, completion)).toEqual([]);
+        const result = await transactionWriter.writeComputedMutation(context, completion, async (transaction) => {
             await new PSqlRuntimeStateRepository(transaction).insertIfAbsent(
                 'app-inbox-transaction',
                 'aggregate-1',
                 JSON.stringify({ state: 'accepted' }),
                 NEVER_EXPIRE_AT_TIMESTAMP
             );
-            return { status: 'accepted' };
         });
 
-        expect(result).toEqual({ status: 'accepted' });
+        expect(result).toEqual(durableResult);
         expect(database.beginCalls).toBe(1);
         expect(new Set(database.statementTransactions).size).toBe(1);
         expect(database.committed.inbox.get(toKey(incomingEntry.key))?.ri_status).toBe(

--- a/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.test.ts
@@ -13,11 +13,10 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness();
         const receipt = { status: 'accepted', revision: 2 } as const;
 
-        const result = await harness.service.commit(harness.context, async (transaction) => {
+        const result = await harness.service.commit(harness.context, receipt, async (transaction) => {
             expect(transaction).toBe(harness.database.activeTransaction);
             harness.database.writeMutation('group-1', { revision: 2 });
             harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-            return receipt;
         });
 
         expect(result).toEqual(receipt);
@@ -38,7 +37,7 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
             const harness = createAtomicHarness();
 
             await expect(
-                harness.service.commit(harness.context, async () => {
+                harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                     harness.database.writeMutation('group-1', { revision: 2 });
                     if (failurePhase === 'dependent-write') {
                         throw new Error('dependent write failed');
@@ -61,10 +60,9 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness({ failResultWrite: true });
 
         await expect(
-            harness.service.commit(harness.context, async () => {
+            harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                 harness.database.writeMutation('group-1', { revision: 2 });
                 harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-                return { status: 'accepted' };
             })
         ).rejects.toThrow('result write failed');
 
@@ -77,14 +75,13 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         const harness = createAtomicHarness({ loseReservation: true });
 
         await expect(
-            harness.service.commit(harness.context, async () => {
+            harness.service.commit(harness.context, { status: 'accepted' }, async () => {
                 harness.database.writeMutation('group-1', { revision: 2 });
                 harness.database.writeOutbox('outbox-1', { groupId: 'group-1' });
-                return { status: 'accepted' };
             })
         ).rejects.toBeInstanceOf(AppInboxReservationConflictError);
         await expect(
-            harness.service.commit(harness.context, async () => null)
+            harness.service.commit(harness.context, null, async () => {})
         ).rejects.toMatchObject({ code: 'app-inbox-reservation-conflict' });
 
         expect(harness.database.state.mutations.size).toBe(0);
@@ -145,14 +142,13 @@ describe('AppInboxTransactionWriter atomic finalization', () => {
         });
     });
 
-    it('records transaction and write timing for the winning attempt', async () => {
+    it('records transaction timing for the winning attempt', async () => {
         const timing: RallarTimingEvent[] = [];
         const harness = createAtomicHarness({ timing: (event) => timing.push(event) });
 
-        await harness.service.commit(harness.context, async () => ({ status: 'accepted' }));
+        await harness.service.commit(harness.context, { status: 'accepted' }, async () => {});
 
         expect(timing.filter((event) => event.operation === 'transaction')).toHaveLength(1);
-        expect(timing.filter((event) => event.operation === 'write')).toHaveLength(1);
         for (const event of timing) {
             expect(event.details).toMatchObject({ attempt: 7 });
             expect(event.details).not.toHaveProperty('plan');

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-runtime-state-mutation.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-runtime-state-mutation.ts
@@ -1,4 +1,5 @@
 import { decodeJsonWireValue, type JsonWireObject, type JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch, type RuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
 import type { RuntimeStateGuardedBatchDatabaseRow } from '@shared-server/runtime-state/postgres/decode-runtime-state-guarded-batch-rows.ts';
@@ -15,7 +16,8 @@ export async function tryExecuteRuntimeStateGuardedBatch(
         throw new Error('Guarded runtime-state SQL requires a transaction runtime');
     }
     const batch = decodeRuntimeStateGuardedBatchSqlValues(values);
-    return toRuntimeStateGuardedBatchRows(await runtime.executeGuardedBatch(batch));
+    const computed = computeRuntimeStateGuardedBatchWrite(batch);
+    return toRuntimeStateGuardedBatchRows(await runtime.writeGuardedBatch(computed));
 }
 
 export async function tryExecuteRuntimeStateConditionalMutation(

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-transaction-test-runtime.ts
@@ -14,6 +14,10 @@ import type { AppInboxEntryRepository, AppInboxResultRepository } from '@shared-
 import type { AppInboxCommandClient } from '@shared-server/rallar-system/app-inbox/client/app-inbox-command-client.ts';
 import type { AppInboxQueueEntryWriter } from '@shared-server/rallar-system/app-inbox/client/app-inbox-queue-entry-writer.ts';
 import { createAppInboxClientRuntime } from '@shared-server/rallar-system/app-inbox/client/create-app-inbox-client-runtime.ts';
+import {
+    computeAppInboxCompletion,
+    validateAppInboxCompletion
+} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import type { AppInboxHandlerRegistration } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-registration.ts';
 import { AppInboxHandlerRegistry } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-registry.ts';
 import { createAppInboxHandlerRuntime } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-handler-runtime.ts';
@@ -136,13 +140,34 @@ class AtomicAppInboxService {
 
     async commit<R>(
         context: AppInboxMessageContext<R>,
-        write: (transaction: PSqlSql) => Promise<R>
+        durableResult: R,
+        write: (transaction: PSqlSql) => Promise<void>
     ): Promise<R> {
-        return await this.transactionWriter.writeMutation(context, write);
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.COMPLETED,
+            durableResult
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, completion);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        return await this.transactionWriter.writeComputedMutation(context, completion, write);
     }
 
     async fail(context: AppInboxMessageContext<JsonWireValue>, error: JsonWireValue): Promise<void> {
-        await this.transactionWriter.writeTerminalFailure(context, error);
+        const completionInput = {
+            ...this.transactionWriter.readCompletionFacts(context),
+            status: EntityStatus.FAILED,
+            durableResult: error
+        } as const;
+        const completion = computeAppInboxCompletion(completionInput);
+        const issues = validateAppInboxCompletion(completionInput, completion);
+        if (issues[0] !== undefined) {
+            throw issues[0].cause;
+        }
+        await this.transactionWriter.writeComputedTerminalFailure(context, completion);
     }
 
     onStateMessage<Result>(

--- a/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-ws-close-test-harness.ts
+++ b/packages/tests/shared-server/rallar-system/app-inbox/test-support/app-inbox-ws-close-test-harness.ts
@@ -150,7 +150,14 @@ function installWsCloseReader(
             { serviceId: 'server-12345678' }
         ),
         group: new GroupStateInboxService(
-            { ...shared, groupStateService: dependencies.groupState },
+            {
+                ...shared,
+                groupStateService: dependencies.groupState,
+                resultReader: {
+                    readSnapshot: (ref) => dependencies.groupState.readSnapshot(ref),
+                    readEvent: (ref, eventId) => dependencies.database.groupEventStore.readGroupEvent(ref, eventId)
+                }
+            },
             { serviceId: 'server-12345678' }
         )
     };

--- a/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
+++ b/packages/tests/shared-server/rallar-system/auth/auth-inbox-phase-order.test.ts
@@ -28,10 +28,7 @@ import type {
     AppInboxCompletionComputed,
     AppInboxCompletionFacts
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
-import type {
-    AppInboxMutationTransactionResult,
-    AppInboxMutationTransactionWriter
-} from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
+import type { AppInboxMutationTransactionWriter } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import { materializeAuthMutationIntent } from '@shared-server/rallar-system/auth/mutation/materialize-auth-mutation-intent.ts';
 
 const decodeOrderCase = 'decodes before queue identity validation and exits before mutation phases on mismatch';
@@ -89,6 +86,7 @@ describe('auth inbox mutation phase order', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write'
         ]);
@@ -204,41 +202,19 @@ class RecordingTransactionWriter implements AppInboxMutationTransactionWriter {
         this.transaction = transaction;
     }
 
-    readCompletionFacts(_context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
-        throw new Error('Computed transaction path must not run');
+    readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts {
+        this.actions.push('completion');
+        return { entry: context.entry, completedAtEpochMs: context.message.id.ts };
     }
 
     async writeComputedMutation<Result>(
         _context: AppInboxExecutionMetadata,
-        _computed: AppInboxCompletionComputed<Result>,
-        _write: (transaction: PSqlSql) => Promise<void>
-    ): Promise<Result> {
-        throw new Error('Computed transaction path must not run');
-    }
-
-    async writeComputedMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        _context: AppInboxExecutionMetadata,
-        _computed: AppInboxCompletionComputed<DurableResult>,
-        _write: (transaction: PSqlSql) => Promise<AfterCommitResult>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        throw new Error('Computed after-commit transaction path must not run');
-    }
-
-    async writeMutation<Result>(
-        _context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
+        computed: AppInboxCompletionComputed<Result>,
+        write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result> {
         this.actions.push('transaction');
-        return await write(this.transaction);
-    }
-
-    async writeMutationWithAfterCommitResult<DurableResult, AfterCommitResult>(
-        _context: AppInboxMessageContext<DurableResult>,
-        _write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>>
-    ): Promise<AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>> {
-        throw new Error('After-commit transaction must not run');
+        await write(this.transaction);
+        return computed.durableResult;
     }
 }
 

--- a/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/client-mutation-transaction-and-outbox.test.ts
@@ -29,7 +29,7 @@ import { createClientMutationTransactionBoundaryFixture } from './create-client-
 const SCOPE = { applicationId: 'ar-eye-hunter', workspaceId: 'default' } as const;
 
 describe('client mutation transaction and outbox', () => {
-    it('persists durable JSON bytes before observing the exact committed snapshot', async () => {
+    it('serializes durable completion before the transaction and observes after commit', async () => {
         const harness = await createClientMutationTransactionBoundaryFixture();
 
         const result = await harness.handler.processCommand(
@@ -62,7 +62,7 @@ describe('client mutation transaction and outbox', () => {
             'status',
             'result'
         ]);
-        expect(harness.actions).toEqual(['write', 'commit', 'observe']);
+        expect(harness.actions).toEqual(['completion', 'write', 'commit', 'observe']);
         expect(harness.observedSnapshots).toHaveLength(1);
         expect(harness.observedSnapshots[0]).toBe(harness.computedSnapshots[0]);
         expect(result.result?.snapshot).toBe(harness.computedSnapshots[0]);
@@ -88,9 +88,34 @@ describe('client mutation transaction and outbox', () => {
             )
         ).rejects.toThrow('injected transaction failure');
 
-        expect(harness.actions).toEqual([]);
+        expect(harness.actions).toEqual(['completion']);
         expect(harness.observedSnapshots).toEqual([]);
         expect(await harness.results.findByKey(harness.context.entry.key)).toBeUndefined();
+    });
+
+    it('selects the after-commit snapshot before opening the transaction', async () => {
+        const harness = await createClientMutationTransactionBoundaryFixture({
+            rejectSnapshotReadInTransaction: true
+        });
+
+        await expect(
+            harness.handler.processCommand(
+                harness.context,
+                toUpsertClientPrincipalMutationInput({
+                    scope: SCOPE,
+                    principalId: 'alice',
+                    request: {
+                        username: 'alice',
+                        actorPrincipalId: 'alice',
+                        actorSessionId: 'alice-session',
+                        requestId: 'client-snapshot-selection'
+                    },
+                    defaultCommandId: 'client-snapshot-selection'
+                })
+            )
+        ).resolves.toBeDefined();
+
+        expect(harness.observedSnapshots).toHaveLength(1);
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/client-state/create-client-mutation-transaction-boundary-fixture.ts
@@ -32,6 +32,7 @@ const SCOPE: StateScope = { applicationId: 'ar-eye-hunter', workspaceId: 'defaul
 
 interface ClientMutationTransactionBoundaryOptions {
     readonly failTransaction?: boolean;
+    readonly rejectSnapshotReadInTransaction?: boolean;
 }
 
 interface ClientMutationTransactionBoundaryFixture {
@@ -53,6 +54,7 @@ export async function createClientMutationTransactionBoundaryFixture(
     const results = new TestResourceInboxResults();
     const runtimeRepository = new FakeRuntimeStateRepository();
     const context = createReservedClientContext();
+    let transactionActive = false;
     await queue.enqueue(context.entry);
     const database = createAppInboxTestDatabase(queue, results, {
         runtimeRepository,
@@ -60,14 +62,25 @@ export async function createClientMutationTransactionBoundaryFixture(
             if (options.failTransaction) {
                 throw new Error('injected transaction failure');
             }
-            const result = await write();
-            actions.push('commit');
-            return result;
+            transactionActive = true;
+            try {
+                const result = await write();
+                actions.push('commit');
+                return result;
+            }
+            finally {
+                transactionActive = false;
+            }
         }
     });
     const durable = createAutoAuthorizingClientStateService(runtimeRepository, database);
     const handler = new ClientStateInboxHandler({
-        mutationService: observeMutationWrites(durable, { actions, computedSnapshots }),
+        mutationService: observeMutationWrites(durable, {
+            actions,
+            computedSnapshots,
+            rejectSnapshotReadInTransaction: options.rejectSnapshotReadInTransaction === true,
+            isTransactionActive: () => transactionActive
+        }),
         sessionGenerationLifecycle: durable.sessionGenerationLifecycle,
         expiryCandidates: durable,
         snapshotObserver: {
@@ -79,16 +92,28 @@ export async function createClientMutationTransactionBoundaryFixture(
         },
         transactionWriter: new AppInboxTransactionWriter({ database }, {
             serviceId: 'client-inbox-service',
-            nowEpochMs: () => context.message.id.ts
+            nowEpochMs: () => {
+                actions.push('completion');
+                return context.message.id.ts;
+            }
         }),
         serviceId: 'client-inbox-service'
     });
-    return { actions, computedSnapshots, context, handler, observedSnapshots, results };
+    return {
+        actions,
+        computedSnapshots,
+        context,
+        handler,
+        observedSnapshots,
+        results
+    };
 }
 
 interface ObservedMutationEffects {
     readonly actions: string[];
     readonly computedSnapshots: ClientSnapshot[];
+    readonly rejectSnapshotReadInTransaction: boolean;
+    readonly isTransactionActive: () => boolean;
 }
 
 function observeMutationWrites(
@@ -101,6 +126,16 @@ function observeMutationWrites(
             const computed = durable.compute(command, read);
             if (computed.outcome !== 'idempotency-conflict') {
                 effects.computedSnapshots.push(computed.snapshot);
+                if (effects.rejectSnapshotReadInTransaction) {
+                    return Object.defineProperty({ ...computed }, 'snapshot', {
+                        get: () => {
+                            if (effects.isTransactionActive()) {
+                                throw new Error('snapshot selection must finish before the transaction');
+                            }
+                            return computed.snapshot;
+                        }
+                    });
+                }
             }
             return computed;
         },

--- a/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
+++ b/packages/tests/shared-server/rallar-system/crdt/mutation/crdt-mutation-service.test.ts
@@ -80,8 +80,8 @@ describe('CRDT mutation service', () => {
         });
         await applyCrdtMutation(service, repository, await createAppendCommand('append-first', 'update-1'));
 
-        const replay = await computeCrdtMutation(service, await createAppendCommand('append-replay', 'update-1'));
-        const collision = await computeCrdtMutation(service, await createAppendCommand('append-collision', 'update-1', 'different'));
+        const replay = await readComputeValidateCrdtMutation(service, await createAppendCommand('append-replay', 'update-1'));
+        const collision = await readComputeValidateCrdtMutation(service, await createAppendCommand('append-collision', 'update-1', 'different'));
 
         expect(replay.outcome).toBe('replay');
         expect(collision).toMatchObject({
@@ -99,7 +99,7 @@ describe('CRDT mutation service', () => {
             serviceId: 'server-1'
         });
         const command = await createAppendCommand('append-conflict', 'update-1');
-        const first = await computeCrdtMutation(service, command);
+        const first = await readComputeValidateCrdtMutation(service, command);
         repository.failNextConflict = true;
 
         await expect(service.write(repository.transaction, first)).rejects.toBeInstanceOf(CrdtMutationConflictError);
@@ -108,7 +108,7 @@ describe('CRDT mutation service', () => {
             documentRevision: 1,
             archivedAtEpochMs: 1_000
         });
-        const retried = await computeCrdtMutation(service, command);
+        const retried = await readComputeValidateCrdtMutation(service, command);
 
         expect(retried).toMatchObject({
             outcome: 'rejected',
@@ -200,6 +200,86 @@ describe('CRDT mutation service', () => {
         expect(service.validate({ command, read, computed: commandMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
         expect(service.validate({ command, read, computed: readMismatch })).toMatchObject([{ code: 'computed-identity-differs' }]);
         expect(service.validate({ command, read, computed: persistenceMismatch })).toMatchObject([{ code: 'computed-persistence-differs' }]);
+    });
+
+    it('rejects prepared CRDT persistence that differs from the computed domain result', async () => {
+        const repository = new MemoryCrdtMutationRepository();
+        const service = createCrdtMutationService({
+            repository,
+            createWriter: () => repository,
+            serviceId: 'server-1'
+        });
+        const command = await createAppendCommand('append-persistence-validation', 'update-persistence-validation');
+        const read = await service.read(command);
+        const computed = service.compute({ command, read });
+        if (computed.outcome !== 'write' || computed.updateWrite === null) {
+            throw new TypeError('Expected an accepted append mutation');
+        }
+        const firstOutboxWrite = computed.outboxWrites[0];
+        if (firstOutboxWrite === undefined) {
+            throw new TypeError('Expected an append outbox write');
+        }
+        const tampered = [
+            {
+                ...computed,
+                documentWrite: { ...computed.documentWrite, retentionJson: '{"kind":"tampered"}' }
+            },
+            {
+                ...computed,
+                updateWrite: { ...computed.updateWrite, updateEnvelopeJson: '{"kind":"tampered"}' }
+            },
+            {
+                ...computed,
+                outboxWrites: [
+                    { ...firstOutboxWrite, createdAt: '2000-01-01T00:00:00.000Z' },
+                    ...computed.outboxWrites.slice(1)
+                ]
+            }
+        ];
+
+        for (const candidate of tampered) {
+            expect(service.validate({ command, read, computed: candidate })).toMatchObject([
+                { code: 'computed-persistence-differs' }
+            ]);
+        }
+    });
+
+    it('rejects a prepared CRDT snapshot row that differs from the computed snapshot', async () => {
+        const repository = new MemoryCrdtMutationRepository();
+        repository.metadata = createMetadata();
+        const service = createCrdtMutationService({
+            repository,
+            createWriter: () => repository,
+            serviceId: 'server-1'
+        });
+        const command = await createCrdtMutationCommand({
+            operation: 'compact',
+            commandId: 'compact-persistence-validation',
+            actor: createActor(),
+            capturedAtEpochMs: 1_000,
+            expireAtEpochMs: 61_000,
+            document: DOCUMENT,
+            snapshotId: 'snapshot-persistence-validation',
+            snapshot: null,
+            reason: 'persistence-validation',
+            responseAudience: createAudience()
+        });
+        const read = await service.read(command);
+        const computed = service.compute({ command, read });
+        if (computed.outcome !== 'write' || computed.snapshotWrite === null) {
+            throw new TypeError('Expected an accepted compact mutation');
+        }
+        const tampered = {
+            ...computed,
+            snapshotWrite: {
+                ...computed.snapshotWrite,
+                snapshotEnvelopeJson: '{"kind":"tampered"}'
+            }
+        };
+
+        expect(service.validate({ command, read, computed: tampered })).toMatchObject([
+            { code: 'computed-persistence-differs' }
+        ]);
     });
 
     it('returns all ordered validation issues for a malformed compact accepted result', async () => {
@@ -392,7 +472,7 @@ function createUnusedTransaction(): PSqlSql {
     return transaction;
 }
 
-async function computeCrdtMutation(
+async function readComputeValidateCrdtMutation(
     service: ReturnType<typeof createCrdtMutationService>,
     command: Awaited<ReturnType<typeof createAppendCommand>>
 ) {
@@ -407,6 +487,6 @@ async function applyCrdtMutation(
     repository: MemoryCrdtMutationRepository,
     command: Awaited<ReturnType<typeof createAppendCommand>>
 ) {
-    const computed = await computeCrdtMutation(service, command);
+    const computed = await readComputeValidateCrdtMutation(service, command);
     return await service.write(repository.transaction, computed);
 }

--- a/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/group-state-test-mutation-executor.ts
@@ -23,7 +23,7 @@ import { GroupStateRepository } from '@shared-server/rallar-system/group-state/p
 import { decodeJsonWireValue, hashMutationCommand } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 import type { GroupStateEventStore } from '@shared-server/rallar-system/state-events/group-state-event-store.ts';
 import type { RuntimeStateGuardedBatchTransaction } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
-import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
+import { validateComputedRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { RuntimeStateRetryExhaustedError, RuntimeStateWriteConflictError } from '@shared-server/runtime-state/optimistic-runtime-state-write.ts';
 import type {
     RuntimeStateGuardedBatchTransactionalRepositoryLike,
@@ -229,9 +229,9 @@ export class GroupStateTestMutationExecutor {
 
 async function writeGuardedBatch(transaction: RuntimeStateGuardedBatchTransaction, computed: GroupMutationComputedWrite): Promise<void> {
     const materialized = computed.persistence.guardedBatch;
-    const result = validateRuntimeStateGuardedBatchResult(
+    const result = validateComputedRuntimeStateGuardedBatchResult(
         materialized,
-        await transaction.executeGuardedBatch(materialized)
+        await transaction.writeGuardedBatch(materialized)
     );
     if (result.guard.status === 'conflict' || result.effects.some((effect) => effect.status !== 'applied')) {
         throw new RuntimeStateWriteConflictError();

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-authority.test.ts
@@ -9,6 +9,7 @@ import { createAppInboxTestDatabase, type AppInboxTestDatabase } from '../../app
 import { AuthSessionRepository } from '@shared-server/rallar-system/auth/persistence/auth-session-repository.ts';
 
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
+import { groupStateUpdatePresenceSummaryDescriptor } from '@shared-server/rallar-system/group-state/persistence/presence/group-presence-write-descriptors.ts';
 import type { JsonWireValue } from '@shared-server/rallar-system/protocol/json-wire-identity.ts';
 
 import { AppInboxType } from '@shared-server/rallar-system/app-inbox/app-inbox-contracts.ts';
@@ -111,6 +112,56 @@ describe('GroupStateInboxService authenticated authority', () => {
             }
         });
         expect(requireGroupStateResult(joined).status).toBe('ok');
+    });
+
+    it('writes a group mutation after presence advances the projected snapshot revision', async () => {
+        const harness = await createAuthorityHarness(['owner']);
+        const groupId = 'presence-revision-room';
+        await createRoom(harness, groupId, 'Before presence');
+        const summaryWrite = groupStateUpdatePresenceSummaryDescriptor({
+            ...SCOPE,
+            groupId,
+            causalRevision: { groupRevision: 1, presenceRevision: 1 },
+            activePrincipalIds: [],
+            activeSessionIds: [],
+            activeSessions: [],
+            activePrincipalCount: 0,
+            activeSessionCount: 0,
+            computedAtEpochMs: harness.nowEpochMs
+        }, 0);
+        await harness.runtimeRepository.upsert(
+            summaryWrite.namespace,
+            summaryWrite.key,
+            summaryWrite.value,
+            summaryWrite.expireAtTimestamp
+        );
+
+        const updated = await processAuthenticated({
+            service: harness.service,
+            reader: harness.reader,
+            authority: harness.sessions.owner,
+            input: {
+                type: AppInboxType.GROUP_UPDATE,
+                resourceId: 'update-after-presence-revision',
+                contextId: `${SCOPE.applicationId}:${SCOPE.workspaceId}:${groupId}`,
+                senderId: 'owner',
+                data: {
+                    scope: SCOPE,
+                    groupId,
+                    request: {
+                        displayName: 'After presence',
+                        actorPrincipalId: 'owner',
+                        actorSessionId: 'owner-session',
+                        requestId: 'update-after-presence-revision'
+                    }
+                }
+            }
+        });
+
+        expect(requireGroupStateResult(updated).result.snapshot).toMatchObject({
+            causalRevision: { groupRevision: 2, presenceRevision: 1 },
+            group: { displayName: 'After presence', presenceVersion: 1 }
+        });
     });
 
     it('rejects a dequeued user command whose authority proof has extra fields', async () => {
@@ -247,6 +298,8 @@ describe('GroupStateInboxService authenticated authority', () => {
         const queue = new TestResourceInbox();
         const reader = new InboxQueueReader(queue);
         const results = new TestResourceInboxResults();
+        const eventStore = new InMemoryGroupStateEventStore();
+        const database = createAppInboxTestDatabase(queue, results, { runtimeRepository });
         const groupStateService = createGroupStateService(
             {
                 runtimeRepository,
@@ -254,7 +307,7 @@ describe('GroupStateInboxService authenticated authority', () => {
                 readPlannedLayoutRow: async () => null,
                 readAcceptedLayoutRow: async () => null,
                 now: () => nowEpochMs,
-                groupStateEventStore: new InMemoryGroupStateEventStore(),
+                groupStateEventStore: eventStore,
                 authSessionRepository: authSessions
             } as
                 & Parameters<typeof createGroupStateService>[0]
@@ -267,8 +320,12 @@ describe('GroupStateInboxService authenticated authority', () => {
                 inboxQueueReader: reader,
                 resourceInboxRepository: queue,
                 resourceInboxResultsRepository: results,
-                database: createAppInboxTestDatabase(queue, results, { runtimeRepository }),
-                groupStateService: groupStateService
+                database,
+                groupStateService,
+                resultReader: {
+                    readSnapshot: (ref) => groupStateService.readSnapshot(ref),
+                    readEvent: (ref, eventId) => eventStore.readGroupEvent(ref, eventId)
+                }
             },
             {
                 serviceId: 'server-12345678'

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-construction.test.ts
@@ -11,32 +11,31 @@ import type {
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-completion-computation.ts';
 import {
     AppInboxTransactionWriter,
-    type AppInboxMutationTransactionResult,
     type AppInboxMutationTransactionWriter
 } from '@shared-server/rallar-system/app-inbox/handler/app-inbox-transaction-writer.ts';
 import type {
     GroupMutationAuthority,
     GroupMutationDescriptor,
     GroupMutationPreparation,
-    GroupStateMutationService,
-    GroupStateService
+    GroupStateMutationService
 } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import { createGroupStateService as createDurableGroupStateService } from '@shared-server/rallar-system/group-state/group-state-service.ts';
 import type { AuthenticatedGroupMutationEnqueue } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
-import { GroupStateInboxHandler, type GroupStateInboxHandlerDependencies } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
+import {
+    GroupStateInboxHandler,
+    type GroupStateInboxHandlerDependencies,
+    type GroupStateInboxResultReader
+} from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-handler.ts';
 import type { GroupStateInboxDurableResult } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-result.ts';
 import { toGroupMutationDescriptor } from '@shared-server/rallar-system/group-state/inbox/to-group-mutation-descriptor.ts';
 import type { GroupMutationComputed } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
 import { computeGroupMutationWriteResult, type GroupMutationWriteInput } from '@shared-server/rallar-system/group-state/mutation/group-mutation-result.ts';
 import type { GroupFormationGroupMutationSink } from '@shared-server/rallar-system/observability/formation-metrics.ts';
 import type { WsSessionGenerationLifecycleService } from '@shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts';
-import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { GroupBarrierRepository } from '../group-state-concurrency-test-runtime.ts';
 
 type DurableResult = Readonly<{ status: 'durable'; }>;
-type AfterCommitResult = Readonly<{ committedSnapshot: GroupSnapshot | undefined; }>;
-type TransactionResult = AppInboxMutationTransactionResult<DurableResult, AfterCommitResult>;
 type ExpectedTransactionWriter = {
     readCompletionFacts(context: AppInboxExecutionMetadata): AppInboxCompletionFacts;
     writeComputedMutation<Result>(
@@ -44,26 +43,11 @@ type ExpectedTransactionWriter = {
         computed: AppInboxCompletionComputed<Result>,
         write: (transaction: PSqlSql) => Promise<void>
     ): Promise<Result>;
-    writeComputedMutationWithAfterCommitResult<Durable, AfterCommit>(
-        context: AppInboxExecutionMetadata,
-        computed: AppInboxCompletionComputed<Durable>,
-        write: (transaction: PSqlSql) => Promise<AfterCommit>
-    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
-    writeMutation<Result>(
-        context: AppInboxMessageContext<Result>,
-        write: (transaction: PSqlSql) => Promise<Result>
-    ): Promise<Result>;
-    writeMutationWithAfterCommitResult<Durable, AfterCommit>(
-        context: AppInboxMessageContext<Durable>,
-        write: (
-            transaction: PSqlSql
-        ) => Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>
-    ): Promise<AppInboxMutationTransactionResult<Durable, AfterCommit>>;
 };
 type ExpectedHandlerDependencies = {
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
-    readonly snapshotObserver: Pick<GroupStateService, 'observeSnapshot'>;
+    readonly resultReader: GroupStateInboxResultReader;
     readonly transactionWriter: AppInboxMutationTransactionWriter;
     readonly wakeQueue?: () => void;
     readonly formationMetrics?: GroupFormationGroupMutationSink;
@@ -88,22 +72,8 @@ describe('convergent group and presence state', () => {
         ).toThrow(/auth.*required/i);
     });
 
-    it('returns immutable committed snapshot data through the named transaction result', () => {
-        expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
-        expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
-        expectTypeOf<ReturnType<AppInboxMutationTransactionWriter['writeMutationWithAfterCommitResult']>>().toMatchTypeOf<
-            Promise<AppInboxMutationTransactionResult<unknown, unknown>>
-        >();
-    });
-
-    it('requires distinct durable and after-commit transaction results', () => {
-        expectTypeOf<TransactionResult>().toEqualTypeOf<Readonly<{ durableResult: DurableResult; afterCommitResult: AfterCommitResult; }>>();
-        expectTypeOf<TransactionResult['durableResult']>().toEqualTypeOf<DurableResult>();
-        expectTypeOf<TransactionResult['afterCommitResult']>().toEqualTypeOf<AfterCommitResult>();
+    it('returns the computed durable result after the transaction commits', () => {
         expectTypeOf<AppInboxMutationTransactionWriter>().toEqualTypeOf<ExpectedTransactionWriter>();
-        expectTypeOf<AppInboxMutationTransactionWriter['writeMutationWithAfterCommitResult']>().toEqualTypeOf<
-            ExpectedTransactionWriter['writeMutationWithAfterCommitResult']
-        >();
         expectTypeOf<AppInboxTransactionWriter>().toMatchTypeOf<AppInboxMutationTransactionWriter>();
     });
 
@@ -119,7 +89,7 @@ describe('convergent group and presence state', () => {
         expectTypeOf<GroupStateInboxHandlerDependencies>().toEqualTypeOf<ExpectedHandlerDependencies>();
         expectTypeOf<GroupStateInboxHandlerDependencies['mutationService']>().toEqualTypeOf<GroupStateMutationService>();
         expectTypeOf<GroupStateInboxHandlerDependencies['sessionGenerationLifecycle']>().toEqualTypeOf<WsSessionGenerationLifecycleService>();
-        expectTypeOf<GroupStateInboxHandlerDependencies['snapshotObserver']>().toEqualTypeOf<Pick<GroupStateService, 'observeSnapshot'>>();
+        expectTypeOf<GroupStateInboxHandlerDependencies['resultReader']>().toEqualTypeOf<GroupStateInboxResultReader>();
         expectTypeOf<GroupStateInboxHandlerDependencies['transactionWriter']>().toEqualTypeOf<AppInboxMutationTransactionWriter>();
         expectTypeOf<GroupStateInboxHandlerDependencies['wakeQueue']>().toEqualTypeOf<(() => void) | undefined>();
         expectTypeOf<ConstructorParameters<typeof GroupStateInboxHandler>>().toEqualTypeOf<[GroupStateInboxHandlerDependencies]>();

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-retry.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-retry.test.ts
@@ -54,16 +54,19 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                     commandMac: 'a'.repeat(64)
                 },
                 descriptor: {
-                    operation: 'updateGroup' as const,
+                    operation: 'heartbeatPresence' as const,
                     scope: SCOPE,
                     groupId: 'outer-retry-room',
                     targetPrincipalId: null,
-                    sessionId: null,
+                    sessionId: 'owner-session',
                     request: {
-                        displayName: 'Must Not Apply',
                         actorPrincipalId: 'owner',
                         actorSessionId: 'owner-session',
-                        requestId: 'outer-retry-authority-change'
+                        requestId: 'outer-retry-authority-change',
+                        principalId: 'owner',
+                        generationId: 'owner-generation',
+                        lastHeartbeatAtEpochMs: nowEpochMs,
+                        expiresAtEpochMs: nowEpochMs + 60_000
                     }
                 }
             };
@@ -72,27 +75,20 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                 prepareAppInboxMutation: async () => ({
                     ...authorizedMutation,
                     command: {
-                        operation: 'updateGroup',
+                        operation: 'heartbeatPresence',
                         aggregateRef: { ...SCOPE, groupId: 'outer-retry-room' },
                         commandId: 'outer-retry-authority-change',
                         requestId: 'outer-retry-authority-change',
+                        sessionId: 'owner-session',
                         input: {
                             actorPrincipalId: 'owner',
                             actorSessionId: 'owner-session',
                             reason: null,
                             traceId: null,
-                            slug: null,
-                            displayName: 'Must Not Apply',
-                            description: null,
-                            kind: null,
-                            status: null,
-                            joinMode: null,
-                            maxMembers: null,
-                            maxSessionsPerMember: null,
-                            metadata: null,
-                            expiresAtEpochMs: null,
-                            emptySinceEpochMs: null,
-                            purgeAfterEpochMs: null
+                            principalId: 'owner',
+                            generationId: 'owner-generation',
+                            lastHeartbeatAtEpochMs: nowEpochMs,
+                            expiresAtEpochMs: nowEpochMs + 60_000
                         }
                     },
                     facts: {
@@ -169,7 +165,11 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
                     resourceInboxRepository: queue,
                     resourceInboxResultsRepository: results,
                     database: createAppInboxTestDatabase(queue, results),
-                    groupStateService: phaseService as never
+                    groupStateService: phaseService as never,
+                    resultReader: {
+                        readSnapshot: async () => undefined,
+                        readEvent: async () => undefined
+                    }
                 },
                 {
                     serviceId: 'server-12345678'
@@ -183,18 +183,22 @@ describe('GroupStateInboxService authenticated authority', { timeout: 30_000 }, 
             });
             const pending = service.processAuthenticatedGroupEntryUntilCompletion(
                 {
-                    type: AppInboxType.GROUP_UPDATE,
+                    type: AppInboxType.GROUP_PRESENCE_HEARTBEAT,
                     resourceId: 'outer-retry-authority-change',
                     contextId: 'ar-eye-hunter:default:outer-retry-room',
                     senderId: 'owner',
                     data: {
                         scope: SCOPE,
                         groupId: 'outer-retry-room',
+                        sessionId: 'owner-session',
                         request: {
-                            displayName: 'Must Not Apply',
                             actorPrincipalId: 'owner',
                             actorSessionId: 'owner-session',
-                            requestId: 'outer-retry-authority-change'
+                            requestId: 'outer-retry-authority-change',
+                            principalId: 'owner',
+                            generationId: 'owner-generation',
+                            lastHeartbeatAtEpochMs: nowEpochMs,
+                            expiresAtEpochMs: nowEpochMs + 60_000
                         }
                     }
                 },

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-test-runtime.ts
@@ -148,7 +148,11 @@ function createAuthorityAppInboxService(
             resourceInboxRepository: input.queue,
             resourceInboxResultsRepository: input.results,
             database: input.database,
-            groupStateService: input.groupStateService
+            groupStateService: input.groupStateService,
+            resultReader: {
+                readSnapshot: (ref) => input.groupStateService.readSnapshot(ref),
+                readEvent: (ref, eventId) => input.database.groupEventStore.readGroupEvent(ref, eventId)
+            }
         },
         {
             serviceId: 'server-12345678',

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-transaction-result.test.ts
@@ -61,7 +61,7 @@ const EXPECTED_CREATE_GROUP_DURABLE_JSON = '{"status":"created","result":{"snaps
     '"traceId":null,"requestId":"create-transaction-boundary-room","payload":{}}}}';
 
 describe('group-state AppInbox transaction result boundary', () => {
-    it('persists the real durable result before exposing the committed snapshot', async () => {
+    it('persists the exact durable result without an inbox-owned cache observation', async () => {
         const harness = await createGroupStateTransactionBoundaryHarness();
 
         const created = await harness.handler.processGroupStateMutation(harness.context);
@@ -85,9 +85,7 @@ describe('group-state AppInbox transaction result boundary', () => {
             status: EntityStatus.COMPLETED,
             result: created
         });
-        expect(harness.observedSnapshots).toHaveLength(1);
-        expect(harness.observedSnapshots[0]).toEqual(created.result.snapshot);
-        expect(harness.observedSnapshots[0]).toBe(created.result.snapshot);
+        expect(harness.observedSnapshots).toEqual([]);
         expect(harness.readWakeCount()).toBe(1);
         expect(harness.outboxEntries.size).toBe(1);
     });
@@ -129,27 +127,19 @@ describe('group-state AppInbox transaction result boundary', () => {
     it('persists an inactive presence result once without active mutation effects', async () => {
         const actions: string[] = [];
         const transactionWriter: AppInboxMutationTransactionWriter = {
-            readCompletionFacts: (_context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
-                throw new Error('Inactive presence must not read computed completion facts');
+            readCompletionFacts: (context: AppInboxExecutionMetadata): AppInboxCompletionFacts => {
+                actions.push('completion');
+                return { entry: context.entry, completedAtEpochMs: context.message.id.ts };
             },
             writeComputedMutation: async <Result>(
                 _context: AppInboxExecutionMetadata,
-                _computed: AppInboxCompletionComputed<Result>,
-                _write: (transaction: PSqlSql) => Promise<void>
+                computed: AppInboxCompletionComputed<Result>,
+                write: (transaction: PSqlSql) => Promise<void>
             ): Promise<Result> => {
-                throw new Error('Inactive presence must not use computed mutation transaction');
-            },
-            writeComputedMutationWithAfterCommitResult: async () => {
-                throw new Error('Inactive presence must not use computed after-commit transaction');
-            },
-            writeMutation: async (_context, write) => {
                 actions.push('inactive-transaction');
-                return await write(createUnusedTransaction());
-            },
-            writeMutationWithAfterCommitResult: () =>
-                Promise.reject(
-                    new Error('Inactive presence must not enter the active mutation transaction')
-                )
+                await write(createUnusedTransaction());
+                return computed.durableResult;
+            }
         };
         const handler = new GroupStateInboxHandler({
             prepareMutation: async () => {
@@ -192,9 +182,12 @@ describe('group-state AppInbox transaction result boundary', () => {
                     throw new Error('Inactive presence must not write lifecycle state');
                 }
             },
-            snapshotObserver: {
-                observeSnapshot: async () => {
-                    throw new Error('Inactive presence must not observe a snapshot');
+            resultReader: {
+                readSnapshot: async () => {
+                    throw new Error('Inactive presence must not read a snapshot');
+                },
+                readEvent: async () => {
+                    throw new Error('Inactive presence must not read an event');
                 }
             },
             transactionWriter,
@@ -202,33 +195,7 @@ describe('group-state AppInbox transaction result boundary', () => {
         });
         const result = await handler.processGroupStateMutation(inactiveConnectContext());
         expect(JSON.stringify(result)).toBe('{"status":"inactive","sessionId":"inactive-session","generationId":"inactive-generation"}');
-        expect(actions).toEqual(['inactive-transaction']);
-    });
-
-    it('keeps the existing durable-only writer result and serialization unchanged', async () => {
-        const harness = await createGroupStateTransactionBoundaryHarness();
-        const durableResult = {
-            status: 'durable-only',
-            result: { value: 0, omitted: null }
-        } as const;
-        const durableContext = {
-            ...harness.context,
-            encodeResult: (result: typeof durableResult) => encodeAppInboxResult(result, 'Durable-only transaction test result')
-        };
-
-        const returned = await harness.transactionWriter.writeMutation(
-            durableContext,
-            async () => durableResult
-        );
-        const persisted = await harness.results.findByKey(harness.context.entry.key);
-
-        expect(returned).toBe(durableResult);
-        expect(persisted?.resource).toBe('{"status":"durable-only","result":{"value":0,"omitted":null}}');
-        expect(harness.transactionWriter.read(durableContext)).toEqual({
-            state: 'transaction-finalized',
-            status: EntityStatus.COMPLETED,
-            result: durableResult
-        });
+        expect(actions).toEqual(['completion', 'inactive-transaction']);
     });
 });
 

--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-transaction-boundary-fixture.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-transaction-boundary-fixture.ts
@@ -166,7 +166,10 @@ function createTransactionBoundaryExecution(
             throw new Error('A reserved transaction-boundary command must already be prepared.');
         },
         sessionGenerationLifecycle: groupState.service.sessionGenerationLifecycle,
-        snapshotObserver: groupState.service,
+        resultReader: createTestGroupStateRepository(
+            storage.runtimeRepository,
+            storage.database.groupEventStore
+        ),
         transactionWriter,
         wakeQueue: () => {
             wakeCount += 1;

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-mutation-test-runtime.ts
@@ -11,7 +11,8 @@ import {
     type RuntimeStateGuardedBatchEffectResult,
     type RuntimeStateGuardedBatchGuard,
     type RuntimeStateGuardedBatchGuardResult,
-    type RuntimeStateGuardedBatchResult
+    type RuntimeStateGuardedBatchResult,
+    type RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -336,13 +337,16 @@ export class ApplyingGuardedBatchRepository extends FakeRuntimeStateRepository {
         return result;
     }
 
-    override async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    override async writeGuardedBatch(
+        input: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.transactionDepth === 0) {
             throw new Error('Guarded batch requires an active transaction');
         }
-        const batch = validateRuntimeStateGuardedBatch(input);
+        const batch = validateRuntimeStateGuardedBatch({
+            guard: input.guard,
+            effects: input.effects
+        });
         this.batches.push(batch);
         this.readCountsBeforeBatch.push(this.outsideTransactionReadCount);
         this.transactionOrder.push('batch');

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-mutation-behavior.test.ts
@@ -69,9 +69,13 @@ describe('GroupStateService guarded batch write boundary', () => {
         });
         expect(guardedBatch.effects.map(({ effectId }) => effectId)).toEqual(['receipt']);
         expect(computed.outboxEntries).toHaveLength(1);
-        expect(computed.outboxEntries[0]?.typeId).toBe('APP_OUTBOX');
-        expect(() =>
-            group.durable.validate(command, read, {
+        const outboxEntry = computed.outboxEntries[0];
+        expect(outboxEntry?.typeId).toBe('APP_OUTBOX');
+        if (outboxEntry === undefined) {
+            throw new TypeError('Expected a prepared group outbox entry');
+        }
+        const tampered = [
+            {
                 ...computed,
                 persistence: {
                     ...computed.persistence,
@@ -83,8 +87,25 @@ describe('GroupStateService guarded batch write boundary', () => {
                         }
                     }
                 }
-            })
-        ).toThrow('differs from its canonical deterministic projection');
+            },
+            {
+                ...computed,
+                persistence: {
+                    ...computed.persistence,
+                    eventWrite: {
+                        ...computed.persistence.eventWrite,
+                        eventJson: '{"eventId":"tampered"}'
+                    }
+                }
+            },
+            {
+                ...computed,
+                outboxEntries: [{ ...outboxEntry, resource: '{"kind":"tampered"}' }]
+            }
+        ];
+        for (const candidate of tampered) {
+            expect(() => group.durable.validate(command, read, candidate)).toThrow();
+        }
 
         const stringify = vi.spyOn(JSON, 'stringify').mockImplementation(() => {
             throw new Error('group serialization must finish during compute');

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-state-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/write-group-state-mutation.test.ts
@@ -5,7 +5,7 @@ import { groupStateGroupStorageKey } from '@shared-server/rallar-system/group-st
 import { GroupStateRepository } from '@shared-server/rallar-system/group-state/persistence/group-state-repository.ts';
 import { groupStateIdempotencyStorageKey } from '@shared-server/rallar-system/group-state/persistence/idempotency/group-idempotency-storage-key.ts';
 import { groupStateMemberStorageKey } from '@shared-server/rallar-system/group-state/persistence/membership/group-membership-storage-key.ts';
-import type { RuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
+import type { RuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import type { GroupMember, GroupRef } from '@shared/api/group-types.ts';
 import { NEVER_EXPIRE_AT_TIMESTAMP } from '@shared/persistence/PersistenceProvider.ts';
 import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
@@ -17,7 +17,7 @@ const BATCH_SELECTED = new Error('guarded group batch selected');
 class RejectingGuardedBatchRepository extends FakeRuntimeStateRepository {
     batchCalls = 0;
 
-    executeGuardedBatch(_batch: RuntimeStateGuardedBatch): Promise<never> {
+    writeGuardedBatch(_batch: RuntimeStateGuardedBatchWrite): Promise<never> {
         this.batchCalls += 1;
         return Promise.reject(BATCH_SELECTED);
     }

--- a/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/presence/group-presence-connect-decision.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import type { GroupStateMutationCommand, GroupStateMutationService } from '@shared-server/rallar-system/group-state/group-state-service-contracts.ts';
 import type { GroupMutationComputed, GroupMutationRead } from '@shared-server/rallar-system/group-state/mutation/group-mutation-contracts.ts';
-import { processGroupPresenceConnect } from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
+import { readAndComputeGroupPresenceConnect } from '@shared-server/rallar-system/group-state/presence/group-presence-service.ts';
 import type {
     WsSessionGenerationLifecycleComputed,
     WsSessionGenerationLifecycleRead
 } from '@shared-server/rallar-system/websocket/ws-session-generation-computation.ts';
 import type { WsSessionGenerationLifecycleService } from '@shared-server/rallar-system/websocket/ws-session-generation-lifecycle.ts';
 
-describe('group presence connect decision', () => {
+describe('group presence connect read and compute', () => {
     it('returns inactive without reading or computing a group mutation', async () => {
         const phases: string[] = [];
         const dependencies = createDecisionDependencies({
@@ -17,7 +17,7 @@ describe('group presence connect decision', () => {
             closedAtObservation: true
         });
 
-        const outcome = await processGroupPresenceConnect({
+        const outcome = await readAndComputeGroupPresenceConnect({
             command: dependencies.command,
             mutationService: dependencies.mutationService,
             sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle
@@ -34,7 +34,7 @@ describe('group presence connect decision', () => {
             closedAtObservation: false
         });
 
-        const outcome = await processGroupPresenceConnect({
+        const outcome = await readAndComputeGroupPresenceConnect({
             command: dependencies.command,
             mutationService: dependencies.mutationService,
             sessionGenerationLifecycle: dependencies.sessionGenerationLifecycle
@@ -43,19 +43,27 @@ describe('group presence connect decision', () => {
         expect(outcome).toEqual({
             status: 'ready-to-commit',
             computed: dependencies.computed,
+            read: dependencies.read,
+            lifecycleGuardFacts: {
+                ...dependencies.lifecycleRead.identity,
+                generationId: 'generation-1',
+                generationStartedAtEpochMs: 1_000,
+                expireAtEpochMs: 422_240
+            },
+            lifecycleRead: dependencies.lifecycleRead,
             lifecycleGuard: dependencies.lifecycleGuard
         });
         if (outcome.status !== 'ready-to-commit') {
             throw new Error('Expected a ready-to-commit presence decision');
         }
         expect(outcome.computed).toBe(dependencies.computed);
+        expect(outcome.read).toBe(dependencies.read);
         expect(outcome.lifecycleGuard).toBe(dependencies.lifecycleGuard);
         expect(phases).toEqual([
             'lifecycle-read',
             'lifecycle-closed-check',
             'mutation-read',
             'mutation-compute',
-            'mutation-validate',
             'lifecycle-compute-guard'
         ]);
     });
@@ -69,6 +77,8 @@ interface CreateDecisionDependenciesInput {
 interface DecisionDependencies {
     readonly command: GroupStateMutationCommand;
     readonly computed: GroupMutationComputed;
+    readonly read: GroupMutationRead;
+    readonly lifecycleRead: WsSessionGenerationLifecycleRead;
     readonly lifecycleGuard: WsSessionGenerationLifecycleComputed;
     readonly mutationService: GroupStateMutationService;
     readonly sessionGenerationLifecycle: WsSessionGenerationLifecycleService;
@@ -76,11 +86,13 @@ interface DecisionDependencies {
 
 interface MutationServiceFixture {
     readonly computed: GroupMutationComputed;
+    readonly read: GroupMutationRead;
     readonly service: GroupStateMutationService;
 }
 
 interface LifecycleServiceFixture {
     readonly lifecycleGuard: WsSessionGenerationLifecycleComputed;
+    readonly lifecycleRead: WsSessionGenerationLifecycleRead;
     readonly service: WsSessionGenerationLifecycleService;
 }
 
@@ -91,6 +103,8 @@ function createDecisionDependencies(input: CreateDecisionDependenciesInput): Dec
     return {
         command,
         computed: mutation.computed,
+        read: mutation.read,
+        lifecycleRead: lifecycle.lifecycleRead,
         lifecycleGuard: lifecycle.lifecycleGuard,
         mutationService: mutation.service,
         sessionGenerationLifecycle: lifecycle.service
@@ -125,7 +139,7 @@ function createMutationServiceFixture(command: GroupStateMutationCommand, phases
             throw new Error('The presence decision must not own the transaction write');
         }
     };
-    return { computed, service };
+    return { computed, read, service };
 }
 
 function createLifecycleServiceFixture(input: CreateDecisionDependenciesInput): LifecycleServiceFixture {
@@ -163,7 +177,7 @@ function createLifecycleServiceFixture(input: CreateDecisionDependenciesInput): 
             throw new Error('The presence decision must not own the lifecycle write');
         }
     };
-    return { lifecycleGuard, service };
+    return { lifecycleGuard, lifecycleRead, service };
 }
 
 function lifecycleReadFixture(): WsSessionGenerationLifecycleRead {

--- a/packages/tests/shared-server/rallar-system/middleware/rallar-middleware-test-runtime.ts
+++ b/packages/tests/shared-server/rallar-system/middleware/rallar-middleware-test-runtime.ts
@@ -110,7 +110,8 @@ export function createRallarMiddlewareTestRuntime(
                     resourceInboxRepository: inbox,
                     resourceInboxResultsRepository: results,
                     database,
-                    groupStateService
+                    groupStateService,
+                    resultReader: groupsRepository
                 },
                 {
                     serviceId: TEST_SERVICE_ID,

--- a/packages/tests/shared-server/rallar-system/state-events/in-memory-group-state-event-collision.test.ts
+++ b/packages/tests/shared-server/rallar-system/state-events/in-memory-group-state-event-collision.test.ts
@@ -22,6 +22,10 @@ describe('in-memory group state event identity', () => {
         await store.appendGroupEvent(event);
         await store.appendGroupEvent(structuredClone(event));
 
+        await expect(store.readGroupEvent(event, event.eventId)).resolves.toBe(event);
+        await expect(
+            store.readGroupEvent({ ...event, groupId: 'another-group' }, event.eventId)
+        ).resolves.toBeUndefined();
         await expect(store.listGroupEvents(event)).resolves.toEqual([event]);
     });
 });

--- a/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/group-topology-reconfigure-mutation.test.ts
@@ -9,7 +9,7 @@ import {
     createTopologyTestAuthorityGuard,
     createTopologyTestGroupRef,
     createTopologyTestGroupSnapshot
-} from '../config/mutation/group-topology-config-mutation-test-fixtures.ts';
+} from './config/mutation/group-topology-config-mutation-test-fixtures.ts';
 
 describe('GroupTopologyReconfigureMutation', () => {
     it('computes the deterministic explicit outbox intent from the captured command', () => {
@@ -105,12 +105,10 @@ describe('GroupTopologyReconfigureMutation', () => {
 });
 
 function createSuccessfulTransaction(): PSqlSql {
-    function sql<Result>(
-        strings: TemplateStringsArray,
+    const sql = (
+        stringsOrValues: TemplateStringsArray | readonly PSqlParameter[],
         ..._values: readonly PSqlParameter[]
-    ): Promise<Result>;
-    function sql(_values: readonly PSqlParameter[]): object;
-    function sql(stringsOrValues: TemplateStringsArray | readonly PSqlParameter[]): Promise<unknown> | object {
+    ): Promise<readonly object[]> | object => {
         if (Array.isArray(stringsOrValues) && !Object.hasOwn(stringsOrValues, 'raw')) {
             return {};
         }
@@ -118,12 +116,12 @@ function createSuccessfulTransaction(): PSqlSql {
         return Promise.resolve(
             query.includes('returning ri_row_id') ? [{ ri_row_id: 1n }] : [{ revision: 1 }]
         );
-    }
+    };
     return Object.assign(sql, {
         begin: async <T>(_write: (transaction: PSqlSql) => Promise<T>): Promise<T> => {
             throw new Error('Reconfigure write must not open a transaction');
         }
-    });
+    }) as PSqlSql;
 }
 
 function createMutation(

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -6,6 +6,7 @@ import type { PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
 import type { EffectiveGroupTopologyConfig, StoredGroupTopologyConfig } from '@shared/api/graph-topology-management-types.ts';
 import { toCanonicalGroupTopologyConfigPatch } from '@shared/api/group-topology-config-canonical.ts';
 import type { GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
 
 import type { PersistedAuthSession } from '@shared-server/rallar-system/auth/persistence/persisted-auth-session.ts';
@@ -118,11 +119,15 @@ describe('TopologyAppInboxHandler', () => {
             nowEpochMs: () => NOW_EPOCH_MS,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => {
+                readCompletionFacts: (context) => {
+                    phases.push('completion');
+                    return { entry: context.entry, completedAtEpochMs: NOW_EPOCH_MS };
+                },
+                writeComputedMutation: async (_context, computed, write) => {
                     phases.push('transaction');
-                    const result = await write({} as PSqlSql);
+                    await write({} as PSqlSql);
                     phases.push('commit');
-                    return result;
+                    return computed.durableResult;
                 }
             }
         });
@@ -132,6 +137,7 @@ describe('TopologyAppInboxHandler', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write',
             'commit',
@@ -143,7 +149,7 @@ describe('TopologyAppInboxHandler', () => {
     it('rejects idempotency conflict before transaction or wake', async () => {
         const phases: string[] = [];
         const context = await topologyContext(phases);
-        const writeMutation = async () => {
+        const unreachableTransaction = (): never => {
             phases.push('transaction');
             throw new Error('Idempotency conflicts must not open a transaction');
         };
@@ -170,7 +176,10 @@ describe('TopologyAppInboxHandler', () => {
         const handler = new TopologyAppInboxHandler({
             groupStateService: sessionReader(phases),
             nowEpochMs: () => NOW_EPOCH_MS,
-            transactionWriter: { writeMutation },
+            transactionWriter: {
+                readCompletionFacts: unreachableTransaction,
+                writeComputedMutation: async () => unreachableTransaction()
+            },
             wakeQueue
         });
 
@@ -209,11 +218,15 @@ describe('TopologyAppInboxHandler', () => {
             nowEpochMs: () => NOW_EPOCH_MS,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => {
+                readCompletionFacts: (context) => {
+                    phases.push('completion');
+                    return { entry: context.entry, completedAtEpochMs: NOW_EPOCH_MS };
+                },
+                writeComputedMutation: async (_context, computed, write) => {
                     phases.push('transaction');
-                    const result = await write({} as PSqlSql);
+                    await write({} as PSqlSql);
                     phases.push('commit');
-                    return result;
+                    return computed.durableResult;
                 }
             }
         });
@@ -227,6 +240,7 @@ describe('TopologyAppInboxHandler', () => {
             'read',
             'compute',
             'validate',
+            'completion',
             'transaction',
             'write',
             'commit',
@@ -325,6 +339,7 @@ function createMessageContext(
         encodeResult: (result) => encodeAppInboxResult(result, 'Topology handler test result'),
         entry: {
             ...entry,
+            status: EntityStatus.RESERVED,
             dequeueAudit: { ...entry.dequeueAudit, attempts: 7 }
         }
     };

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-transaction.test.ts
@@ -34,6 +34,7 @@ import { RallarRtcTopologyService } from '@shared-server/rallar-system/topology/
 import { newALRoute, newALUntargetedMessage } from '@shared/al-contracts/al-contract.ts';
 import { EnqueuedType } from '@shared/api/api-config.ts';
 import type { GroupRef } from '@shared/api/group-types.ts';
+import { EntityStatus } from '@shared/queuebox/ResourceEntry.ts';
 import { InboxQueueReader } from '@shared/services/inbox-queue-reader.ts';
 import { QueueBoxUtilities } from '@shared/services/QueueBoxUtilities.ts';
 
@@ -389,7 +390,14 @@ describe('topology AppInbox transaction and idempotency', () => {
             nowEpochMs: () => harness.nowEpochMs,
             wakeQueue,
             transactionWriter: {
-                writeMutation: async (_context, write) => await harness.database.begin(write)
+                readCompletionFacts: (context) => ({
+                    entry: context.entry,
+                    completedAtEpochMs: harness.nowEpochMs
+                }),
+                writeComputedMutation: async (_context, computed, write) => {
+                    await harness.database.begin(write);
+                    return computed.durableResult;
+                }
             }
         });
 
@@ -398,7 +406,11 @@ describe('topology AppInbox transaction and idempotency', () => {
                 {
                     enqueue: wireEnqueue,
                     message,
-                    entry: { ...entry, dequeueAudit: { ...entry.dequeueAudit, attempts: 1 } },
+                    entry: {
+                        ...entry,
+                        status: EntityStatus.RESERVED,
+                        dequeueAudit: { ...entry.dequeueAudit, attempts: 1 }
+                    },
                     encodeResult: (result) => encodeAppInboxResult(result, 'Topology transaction test result')
                 } satisfies AppInboxMessageContext<TopologyAppInboxResult>,
                 management.mutationOwners

--- a/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/publication/rtc-topology-publication-repository.test.ts
@@ -199,34 +199,6 @@ describe('RTC topology publication repository', () => {
         });
     });
 
-    it('requests recomputation when the topology predecessor moves before commit', async () => {
-        const runtimeRepository = new FakeRuntimeStateRepository();
-        const snapshots = new RtcTopologySnapshotRepository(runtimeRepository);
-        const current = createTopologySnapshot(createGroupRef(), 4);
-        await expect(snapshots.commitSnapshotGuard(current, null)).resolves.toMatchObject({
-            status: 'accepted'
-        });
-        const repository = new RtcTopologyExecutionRepository(runtimeRepository);
-        const candidate = createTopologySnapshot(createGroupRef(), 3);
-
-        await expect(
-            repository.commit({
-                expected: undefined,
-                candidate,
-                publication: createPublication(candidate, 'work-stale')
-            })
-        ).resolves.toEqual({
-            status: 'retry',
-            current
-        });
-        expect(
-            await new RtcTopologyPublicationRepository(runtimeRepository).findPublicationForWork(
-                candidate.groupRef,
-                'work-stale'
-            )
-        ).toBeUndefined();
-    });
-
     it('validates publication and work direct, list, and page rows before expiry', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(10_000);

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.test.ts
@@ -1,0 +1,62 @@
+import { Temporal } from '@js-temporal/polyfill';
+import type {
+    PSqlParameter,
+    PSqlSql
+} from '@shared-server/postgres/p-sql-sql.ts';
+import {
+    ResourceInboxInvariantCorruptionError
+} from '@shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts';
+import { writeTopologyPromotionRequest } from '@shared-server/rallar-system/topology/replay/work/write-topology-promotion-request.ts';
+import { EntityStatus, type ResourceEntry } from '@shared/queuebox/ResourceEntry.ts';
+import { describe, expect, it } from 'vitest';
+
+describe('topology promotion request write', () => {
+    it('rejects an immutable ResourceInbox collision', async () => {
+        const entry = promotionEntry();
+
+        await expect(
+            writeTopologyPromotionRequest(createConflictingTransaction(), entry)
+        ).rejects.toBeInstanceOf(ResourceInboxInvariantCorruptionError);
+    });
+});
+
+function promotionEntry(): ResourceEntry {
+    const createdTs = Temporal.PlainDateTime.from('2026-01-02T03:04:05');
+    return {
+        key: {
+            topicId: 'topology-promotion',
+            resourceId: 'promotion-1',
+            contextId: 'group-1'
+        },
+        resource: '{"promotion":1}',
+        typeId: 'APP_OUTBOX',
+        status: EntityStatus.NEW,
+        audit: {
+            date: createdTs.toPlainTime(),
+            createdBy: 'topology-service',
+            createdTs,
+            expiryTs: Temporal.Instant.from('9999-12-31T23:59:59.999Z')
+        },
+        dequeueAudit: { attempts: 0 }
+    };
+}
+
+function createConflictingTransaction(): PSqlSql {
+    function sql<Result>(
+        _strings: TemplateStringsArray,
+        ..._values: readonly PSqlParameter[]
+    ): Promise<Result>;
+    function sql(_values: readonly PSqlParameter[]): object;
+    function sql(
+        stringsOrValues: TemplateStringsArray | readonly PSqlParameter[]
+    ): Promise<readonly object[]> | object {
+        return Array.isArray(stringsOrValues) && !Object.hasOwn(stringsOrValues, 'raw')
+            ? {}
+            : Promise.resolve([]);
+    }
+    return Object.assign(sql, {
+        begin: async <T>(_write: (transaction: PSqlSql) => Promise<T>): Promise<T> => {
+            throw new Error('Topology promotion write must not open a transaction');
+        }
+    });
+}

--- a/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
+++ b/packages/tests/shared-server/runtime-state/runtime-state-guarded-batch.test.ts
@@ -1,4 +1,9 @@
-import type { PSqlParameter, PSqlRows, PSqlSql } from '@shared-server/postgres/p-sql-sql.ts';
+import type {
+    PSqlParameter,
+    PSqlRows,
+    PSqlSql
+} from '@shared-server/postgres/p-sql-sql.ts';
+import { computeRuntimeStateGuardedBatchWrite } from '@shared-server/runtime-state/guarded-batch/compute-runtime-state-guarded-batch-write.ts';
 import { type RuntimeStateGuardedBatch, type RuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -8,6 +13,60 @@ import { describe, expect, it } from 'vitest';
 const FUTURE_MS = Date.parse('9999-12-31T23:59:59.999Z');
 
 describe('runtime-state guarded batches', () => {
+    it('computes SQL persistence values before entering a transaction', () => {
+        const batch = createBatch();
+
+        expect(computeRuntimeStateGuardedBatchWrite(batch)).toEqual({
+            ...batch,
+            guardSqlDescriptor: {
+                ...batch.guard,
+                expireAtTimestamp: new Date(FUTURE_MS).toISOString()
+            },
+            effectSqlDescriptors: batch.effects.map((effect) =>
+                'expireAtTimestamp' in effect
+                    ? {
+                        ...effect,
+                        expireAtTimestamp: new Date(effect.expireAtTimestamp).toISOString()
+                    }
+                    : effect
+            )
+        });
+    });
+
+    it('does not recompute persistence values while writing', async () => {
+        let expiryReads = 0;
+        const batch: RuntimeStateGuardedBatch = {
+            guard: {
+                operation: 'insert',
+                namespace: 'guard',
+                key: 'root',
+                value: 'value',
+                get expireAtTimestamp() {
+                    expiryReads += 1;
+                    if (expiryReads > 1) {
+                        throw new Error('expiry recomputed during write');
+                    }
+                    return FUTURE_MS;
+                }
+            },
+            effects: [{
+                effectId: 'delete',
+                operation: 'delete',
+                namespace: 'effect',
+                key: 'missing',
+                expectedRevision: 0
+            }]
+        };
+        const computed = computeRuntimeStateGuardedBatchWrite(batch);
+        const repository = new PSqlRuntimeStateRepository(createTransactionalSql([], []));
+
+        await repository.begin(async (transactionRepository) => {
+            await transactionRepository.writeGuardedBatch(computed);
+        });
+
+        expect(expiryReads).toBe(1);
+    });
+
     it('accepts dense mandatory descriptors at operation-specific revision bounds', () => {
         const batch = createBatch();
 
@@ -302,12 +361,13 @@ describe('runtime-state guarded batches', () => {
         const sql = createTransactionalSql(captured, []);
         const repository = new PSqlRuntimeStateRepository(sql);
 
-        await expect(repository.executeGuardedBatch(createBatch())).rejects.toThrow(
+        const computed = computeRuntimeStateGuardedBatchWrite(createBatch());
+        await expect(repository.writeGuardedBatch(computed)).rejects.toThrow(
             /transaction/iu
         );
 
         await repository.begin(async (transactionRepository) => {
-            await transactionRepository.executeGuardedBatch(createBatch());
+            await transactionRepository.writeGuardedBatch(computed);
         });
         expect(captured).toHaveLength(1);
     });
@@ -342,8 +402,9 @@ describe('runtime-state guarded batches', () => {
         }]);
         const repository = new PSqlRuntimeStateRepository(sql);
 
+        const computed = computeRuntimeStateGuardedBatchWrite(batch);
         const result = await repository.begin(async (transactionRepository) => {
-            return await transactionRepository.executeGuardedBatch(batch);
+            return await transactionRepository.writeGuardedBatch(computed);
         });
 
         expect(result).toEqual({
@@ -449,8 +510,9 @@ describe('runtime-state guarded batches', () => {
             createTransactionalSql([], rows)
         );
 
+        const computed = computeRuntimeStateGuardedBatchWrite(createBatch());
         await expect(repository.begin(async (transactionRepository) => {
-            return await transactionRepository.executeGuardedBatch(createBatch());
+            return await transactionRepository.writeGuardedBatch(computed);
         })).rejects.toThrow(/guarded batch database result/iu);
     });
 });

--- a/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
+++ b/packages/tests/shared-server/runtime-state/test-support/fake-runtime-state-repository.ts
@@ -4,7 +4,8 @@ import type {
     RuntimeStateGuardedBatchEffectResult,
     RuntimeStateGuardedBatchGuard,
     RuntimeStateGuardedBatchGuardResult,
-    RuntimeStateGuardedBatchResult
+    RuntimeStateGuardedBatchResult,
+    RuntimeStateGuardedBatchWrite
 } from '@shared-server/runtime-state/guarded-batch/runtime-state-guarded-batch.ts';
 import { validateRuntimeStateGuardedBatchResult } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch-result.ts';
 import { validateRuntimeStateGuardedBatch } from '@shared-server/runtime-state/guarded-batch/validate-runtime-state-guarded-batch.ts';
@@ -246,13 +247,16 @@ export class FakeRuntimeStateRepository
         return { status: 'applied' };
     }
 
-    async executeGuardedBatch(
-        input: RuntimeStateGuardedBatch
+    async writeGuardedBatch(
+        input: RuntimeStateGuardedBatchWrite
     ): Promise<RuntimeStateGuardedBatchResult> {
         if (this.activeTransactionCount === 0) {
             throw new Error('Guarded runtime state batch requires an active transaction');
         }
-        const batch = validateRuntimeStateGuardedBatch(input);
+        const batch = validateRuntimeStateGuardedBatch({
+            guard: input.guard,
+            effects: input.effects
+        });
         const guard = await applyGuardedBatchGuard(this, batch.guard);
         if (guard.status === 'conflict') {
             return validateRuntimeStateGuardedBatchResult(batch, {

--- a/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox-computed-write.test.ts
@@ -4,7 +4,11 @@ import '../setup-browser-indexeddb.ts';
 
 import { Temporal } from '@js-temporal/polyfill';
 import { openIndexedDbWithStore } from '@shared/persistence/openIndexedDb.ts';
-import { encodeStoredResourceEntry } from '@shared/queuebox/indexed-db-queue-box-entry.ts';
+import {
+    decodeStoredResourceEntry,
+    encodeStoredResourceEntry,
+    type StoredResourceEntry
+} from '@shared/queuebox/indexed-db-queue-box-entry.ts';
 import { computeIndexedDbFairnessReservation } from '@shared/queuebox/indexed-db-queue-box-fairness.ts';
 import { readStoredQueueEntry } from '@shared/queuebox/indexed-db-queue-box-store.ts';
 import { writeComputedIndexedDbQueueMutations } from '@shared/queuebox/indexed-db-queue-box-write.ts';
@@ -12,6 +16,30 @@ import { EntityStatus, NEVER_EXPIRE_TS, ResourceEntry, toKeyAsString } from '@sh
 import { describe, expect, it, vi } from 'vitest';
 
 describe('IndexedDbQueueBox computed writes', () => {
+    it.each(
+        [
+            ['audit.date', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, date: 'not-a-time' } })],
+            ['audit.createdTs', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, createdTs: 'not-a-time' } })],
+            ['audit.expiryTs', (stored: StoredResourceEntry) => ({ ...stored, audit: { ...stored.audit, expiryTs: 'not-a-time' } })],
+            ['dequeueAudit.startTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, startTs: 'not-a-time' }
+            })],
+            ['dequeueAudit.endTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, endTs: 'not-a-time' }
+            })],
+            ['dequeueAudit.nextTs', (stored: StoredResourceEntry) => ({
+                ...stored,
+                dequeueAudit: { ...stored.dequeueAudit, nextTs: 'not-a-time' }
+            })]
+        ] as const
+    )('rejects malformed persisted %s instead of substituting a fallback', (_field, corrupt) => {
+        const stored = encodeStoredResourceEntry(createEntry('malformed-timestamp'), 0);
+
+        expect(() => decodeStoredResourceEntry(corrupt(stored))).toThrow();
+    });
+
     it('allows only one writer to commit a computed revision', async () => {
         const storeName = 'entries';
         const db = await openIndexedDbWithStore(

--- a/packages/tests/shared/indexeddb-queuebox.test.ts
+++ b/packages/tests/shared/indexeddb-queuebox.test.ts
@@ -27,8 +27,18 @@ describe('IndexedDbQueueBox', () => {
                 dbName: `indexeddb-summary-finalized-${crypto.randomUUID()}`
             });
             const { reserved, current } = entries();
-            await queue.enqueue(current);
-            // IndexedDB serialization normalizes malformed inputs; release must still fence a malformed runtime row.
+            const persistedCurrent = {
+                ...current,
+                audit: {
+                    ...current.audit,
+                    date: current.audit.date instanceof Temporal.PlainTime ||
+                            typeof current.audit.date === 'string'
+                        ? current.audit.date
+                        : reserved.audit.date
+                }
+            };
+            await queue.enqueue(persistedCurrent);
+            // Inject malformed runtime data at the release boundary without relying on persistence normalization.
             vi.spyOn(queue as unknown as IndexedDbRuntimeDecoder, 'toResourceEntry')
                 .mockReturnValue(current);
 

--- a/scripts/perf/create-state-write-service-runtime.ts
+++ b/scripts/perf/create-state-write-service-runtime.ts
@@ -83,6 +83,7 @@ export function createStateWriteServiceRuntime({
     const authSessionRepository = new AuthSessionRepository(runtimeRepository);
     const clientStateEventStore = new PSqlClientStateEventRepository(instrumentedSql);
     const groupStateEventStore = new PSqlGroupStateEventRepository(instrumentedSql);
+    const groupStateRepository = new GroupStateRepository(runtimeRepository, groupStateEventStore);
     const groupState = createGroupStateService({
         runtimeRepository,
         groupStateEventStore,
@@ -122,7 +123,8 @@ export function createStateWriteServiceRuntime({
             resourceInboxRepository: resourceInbox.entries,
             resourceInboxResultsRepository: results,
             database: instrumentedSql,
-            groupStateService: groupState
+            groupStateService: groupState,
+            resultReader: groupStateRepository
         },
         {
             serviceId,
@@ -130,17 +132,16 @@ export function createStateWriteServiceRuntime({
             options: STATE_WRITE_BENCHMARK_APP_INBOX_OPTIONS.group
         }
     );
-    const topologyGroupStateRepository = new GroupStateRepository(runtimeRepository, groupStateEventStore);
     const topologyConfigRepository = new GroupTopologyConfigRepository(runtimeRepository);
     const topologyRuntimeOwners = createGroupTopologyRuntimeOwners({
         findGroupSnapshotByRef: (ref) => groupState.readSnapshot(ref),
-        readCurrentGroupSnapshot: async (ref) => await topologyGroupStateRepository.readSnapshot(ref),
+        readCurrentGroupSnapshot: async (ref) => await groupStateRepository.readSnapshot(ref),
         readRttMeasurements: () => [],
         configRepository: topologyConfigRepository,
         topologyService: new RallarRtcTopologyService()
     });
     const topologyMutationOwners = createGroupTopologyMutationOwners({
-        groupStateRepository: topologyGroupStateRepository,
+        groupStateRepository,
         configRepository: topologyConfigRepository,
         planning: topologyRuntimeOwners.planning,
         nowEpochMs: () => Date.now(),

--- a/scripts/transaction-write-check/README.md
+++ b/scripts/transaction-write-check/README.md
@@ -14,15 +14,17 @@ The checker reports:
 
 It recognizes PostgreSQL/PGlite `begin` and `transaction` callbacks, the
 `runInPSqlTransaction` wrapper, IndexedDB `readwrite` transactions, IndexedDB
-upgrade callbacks, and callback identifiers that resolve to authored source.
+upgrade callbacks, AppInbox computed-write callbacks, and callback identifiers
+that resolve to authored source.
 It inspects the lexical transaction body rather than expanding arbitrary helper
 graphs; suspiciously named compute/prepare/serialize/hash helpers still fail at
 their call site. Readonly IndexedDB transactions, tests, fixtures,
 generated/vendor code, `packages/shared-test/**`, and
 `packages/shared-rtc-bench/**` are excluded.
-Exact PostgreSQL ResourceInbox owners under
-`packages/shared-server/queuebox/postgres/**` are governed by their specialized
-SQL review and semantic tests instead.
+The explicitly inventoried PostgreSQL ResourceInbox owners in the analyzer are
+governed by their specialized SQL review and semantic tests instead. Directory
+placement alone grants no specialization: a new file is analyzed by default
+until its exact ownership is reviewed and added to that inventory.
 
 This is intentionally a narrow check. It does not attempt whole-program
 provenance, arbitrary helper-body expansion, SQL semantic proof, dynamic

--- a/scripts/transaction-write-check/analyze-transaction-writes.mjs
+++ b/scripts/transaction-write-check/analyze-transaction-writes.mjs
@@ -15,7 +15,15 @@ const PRECOMPUTABLE_METHODS = new Set(['sort', 'toSorted']);
 const PRECOMPUTABLE_NAME = /^(?:compute|prepare|serialize|canonicalize|hash|encode)(?:$|[A-Z_])/u;
 const TRANSACTION_TYPE = /(?:PSqlSql|IDBTransaction)/u;
 const DATABASE_RECEIVER_TYPE = /(?:Sql|Database|Repository|Runtime|PGlite)/u;
-const SPECIALIZED_RESOURCE_INBOX_ROOT = 'packages/shared-server/queuebox/postgres/';
+const APP_INBOX_TRANSACTION_WRITER_TYPE = /AppInbox(?:Mutation)?TransactionWriter/u;
+const APP_INBOX_WRITE_METHOD = 'writeComputedMutation';
+const SPECIALIZED_RESOURCE_INBOX_FILES = new Set([
+    'packages/shared-server/queuebox/postgres/create-p-sql-resource-inbox-repository.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-queue-box.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-resource-inbox-entry-repository.ts',
+    'packages/shared-server/queuebox/postgres/p-sql-results-queue-box.ts',
+    'packages/shared-server/queuebox/postgres/resource-inbox-results-repository.ts'
+]);
 
 export function analyzeTransactionWrites(project, sourceFiles = project.getSourceFiles()) {
     const findings = new Map();
@@ -26,7 +34,7 @@ export function analyzeTransactionWrites(project, sourceFiles = project.getSourc
         if (!isAnalyzedSource(path)) {
             continue;
         }
-        const specialized = path.startsWith(SPECIALIZED_RESOURCE_INBOX_ROOT);
+        const specialized = SPECIALIZED_RESOURCE_INBOX_FILES.has(path);
         for (const declaration of sourceFile.getDescendants().filter(isFunctionDeclaration)) {
             if (!specialized && isTransactionWriteDeclaration(declaration)) {
                 roots.push(analysisRoot(declaration));
@@ -41,6 +49,12 @@ export function analyzeTransactionWrites(project, sourceFiles = project.getSourc
             }
         }
         for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+            const appInboxWrite = appInboxWriteBoundary(call);
+            if (!specialized && appInboxWrite) {
+                for (const callback of resolveCallbackBodies(appInboxWrite, project)) {
+                    roots.push(analysisRoot(callback));
+                }
+            }
             const boundary = transactionBoundary(call);
             if (!boundary) {
                 continue;
@@ -148,6 +162,18 @@ function precomputableOperation(call, operation) {
         return undefined;
     }
     return PRECOMPUTABLE_NAME.test(name) ? name : undefined;
+}
+
+function appInboxWriteBoundary(call) {
+    const expression = call.getExpression();
+    if (!Node.isPropertyAccessExpression(expression) || expression.getName() !== APP_INBOX_WRITE_METHOD) {
+        return undefined;
+    }
+    const receiver = expression.getExpression();
+    if (!APP_INBOX_TRANSACTION_WRITER_TYPE.test(receiver.getType().getText(receiver))) {
+        return undefined;
+    }
+    return call.getArguments()[2];
 }
 
 function transactionBoundary(call) {


### PR DESCRIPTION
## Goal

Make durable AppInbox results and exact persistence validation part of computation, then remove remaining compute-in-write and duplicate transaction infrastructure.

## Changes

- Finalizes client, auth, RTC RTT, topology, group-state, and presence completion before transactions.
- Adds exact computed-projection validation for CRDT, admin, group, and AppOutbox writes.
- Removes replaced AppInbox and topology commit APIs and consolidates reservation and guarded-batch write ownership.
- Bounds the checker exemption to specialized ResourceInbox SQL ownership.

## Acceptance

- Writes consume validated computed projections and do not construct candidate rows or durable results.
- ResourceInbox middleware remains behaviorally unchanged and separately governed.
- Replaced production entry points and duplicate implementations are removed.

## Validation

- Consolidation tree is byte-for-byte identical to the reviewed historical cut point.
- Full focused, package, standards, legacy, integration, performance, and CI evidence is pending this consolidated review.

## Risk and rollback

This is PR 4 of a five-PR stack. Revert its single commit to restore the earlier completion and transaction APIs. Main risks are exact-projection validation compatibility and reservation finalization semantics.

## Follow-up

PR 5 completes topology, IndexedDB, phase-input, authority, timing, and AL closure.