### PR TITLE
ci: give the governance gate time to install its dependencies

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -15,7 +15,7 @@ jobs:
   governance-gate:
     name: Governance Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/packages/tests/repo/governance-gate/governance-gate-workflow.test.ts
+++ b/packages/tests/repo/governance-gate/governance-gate-workflow.test.ts
@@ -39,7 +39,7 @@ describe('governance gate workflow', () => {
                 'governance-gate': {
                     name: 'Governance Gate',
                     'runs-on': 'ubuntu-latest',
-                    'timeout-minutes': 2,
+                    'timeout-minutes': 10,
                     steps: [
                         {
                             uses: 'actions/checkout@v7',


### PR DESCRIPTION
## The problem

Every **Branch Release Gate** run in the repository is failing today, on every branch, always the same way: the `Governance Gate` job is killed inside `npm ci --ignore-scripts`. GitHub reports a timeout as *"cancelled"*, which is why it reads as if a human cancelled the run.

```
09:06:55.83  ##[group]Run npm ci --ignore-scripts
09:08:59.33  ##[error]The operation was canceled.
```

The install alone now runs past **2m03s** — longer than the entire job budget of two minutes, which also has to cover a `fetch-depth: 0` checkout, `setup-node`, and the three gate phases.

Because every other job in `branch-release-gate.yml` declares `needs: governance-gate`, one timeout skips the whole workflow and no pull request can reach a mergeable state.

## Why now

Nothing about the dependency graph changed. #467 finished this same job in **66 seconds** a day earlier on the same lockfile. What changed is the `setup-node` npm cache, which GitHub evicts on age or repository size — so the install is now cold.

## Why not just skip the install

`check:governance-gate` spawns `check:repo-structure`, `check:repo-style` and `check:retained-legacy`, and those need real dependencies. The install is genuinely required.

## What this changes

`timeout-minutes: 2` → `10` on that one job, and the pin in `governance-gate-workflow.test.ts` that asserts it.

This **weakens no check**: the gate still runs all three phases and still fails a PR on any of them. The only behavioural change is how long a genuinely hung job takes to give up. The two sibling two-minute jobs in `branch-release-gate.yml` run no install and keep their budgets.

## Evidence

Observed failing on unrelated branches by different authors:

| Branch | Governance Gate |
| --- | --- |
| `codex/group-activation-stage-metrics-recipe` | cancelled ×3, ~2m16s each |
| `codex/transaction-write-purity-1-foundation` … `-5-closure` | cancelled, 2m15s |
| `automation/rtc-b05-observation-*` | cancelled |

## Verification

`npx vitest run packages/tests/repo` — **1200 passed (96 files)**, including `governance-gate-workflow.test.ts` and `github-actions-runtime-governance.test.ts`.

This PR is `pull_request`-triggered against a local `uses:` path, so its own Governance Gate runs with the raised budget — a green gate here is the fix demonstrating itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)