### PR TITLE
Run activate through the real inbox phases

### DIFF
--- a/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-operation-matrix.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/inbox/group-state-inbox-operation-matrix.test.ts
@@ -22,7 +22,10 @@ import {
     type GroupTransportCommandAppInboxPayload,
     type GroupUpdateAppInboxPayload
 } from '@shared-server/rallar-system/group-state/inbox/group-state-inbox-contracts.ts';
-import { RtcTopologySnapshotRepository } from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
+import {
+    RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE,
+    RtcTopologySnapshotRepository
+} from '@shared-server/rallar-system/topology/persistence/rtc-topology-snapshot-repository.ts';
 import { toScopedOverlayId } from '@shared/api/api-type-utils.ts';
 import { describe, expect, it } from 'vitest';
 import { FakeRuntimeStateRepository } from '../../../runtime-state/test-support/fake-runtime-state-repository.ts';
@@ -43,9 +46,12 @@ import { createAuthorityHarness, processAuthenticated, SCOPE } from './group-sta
  * cannot stop an operation from being advertised and then silently going
  * unrun, which is what this list existing at all makes visible.
  *
- * `GROUP_CONNECT` runs after the matrix, against a stored plan and against a
- * missing one, so it is exercised by this file rather than by the array. The
- * other two predate this list and are covered elsewhere.
+ * Both entries reach their source stages only against a stored planned row,
+ * which the matrix harness does not have, so both run the real phases in this
+ * file's second test instead; `connect` also lands its denial against a
+ * missing row after the matrix. Nothing else is advertised and unrun: 8d
+ * retired the two legacy establishment commands and 6c gave `start` and
+ * `reset` their own cases.
  */
 const INBOX_TYPES_OUTSIDE_THE_CASE_ARRAY: readonly AppInboxType[] = [
     AppInboxType.GROUP_CONNECT,
@@ -761,8 +767,15 @@ describe('GroupStateInboxService authenticated authority', () => {
     );
 
     it(
-        'connects against a stored planned layout and commits its revision guard',
+        'connects against a stored planned layout, then activates the layout it dialed',
         async () => {
+            // `connect` and `activate` both succeed only against a stored planned
+            // row, so this runs its own harness with that row present. `connect`
+            // must land the stage, stamp the establishment clock, and commit the
+            // planned row's revision guard (the batch's fence against a replan
+            // landing between read and commit); `activate` is then the only
+            // command that promotes what `connect` dialed, and `connecting` is
+            // reachable no other way, which is why the two share a run.
             const groupId = 'connect-success-room';
             const plannedIdentity = {
                 groupRevision: 1,
@@ -870,15 +883,51 @@ describe('GroupStateInboxService authenticated authority', () => {
             const plannedAfter = await plannedSnapshots.findSnapshotEntry({ ...SCOPE, groupId });
             expect(plannedAfter?.entry.revision).toBe(plannedBefore + 1);
             expect(plannedAfter?.value).toEqual(connectPlannedSnapshot(groupId, plannedIdentity));
+
+            // Dialing left the accepted slot empty, so what activation adds is
+            // visible: the promotion writes it in the stage's own transaction
+            // (decisions 24/42).
+            const acceptedSnapshots = new RtcTopologySnapshotRepository(
+                runtimeRepository,
+                RTC_TOPOLOGY_ACCEPTED_SNAPSHOTS_NAMESPACE
+            );
+            expect(await acceptedSnapshots.findSnapshotEntry({ ...SCOPE, groupId })).toBeUndefined();
+
+            const activated = await processAuthenticated({
+                service: harness.service,
+                reader: harness.reader,
+                authority: harness.sessions.owner,
+                input: {
+                    type: AppInboxType.GROUP_ACTIVATE,
+                    resourceId: 'connect-activate',
+                    contextId,
+                    senderId: harness.sessions.owner.clientId,
+                    data: {
+                        scope: SCOPE,
+                        groupId,
+                        request: { ...ownerActor, requestId: 'connect-activate' }
+                    } satisfies GroupLifecycleTransitionAppInboxPayload
+                }
+            });
+
+            expect(activated.left).toBeUndefined();
+            const activeGroup = (await harness.repository.readSnapshot({ ...SCOPE, groupId }))?.group;
+            expect(activeGroup?.lifecycleState).toBe('active');
+            expect(activeGroup?.formationEpoch).toBe((group?.formationEpoch ?? 0) + 1);
+            // The group row names the accepted identity and the accepted slot
+            // holds the snapshot behind it: one promotion, not two sources of
+            // truth.
+            expect(activeGroup?.acceptedLayoutIdentity).toEqual(plannedIdentity);
+            const accepted = await acceptedSnapshots.findSnapshotEntry({ ...SCOPE, groupId });
+            expect(accepted?.value).toEqual(connectPlannedSnapshot(groupId, plannedIdentity));
+            // The promotion re-asserts the planned row too, so its guard
+            // advanced a second time in activation's batch.
+            const plannedAfterActivation = await plannedSnapshots.findSnapshotEntry({ ...SCOPE, groupId });
+            expect(plannedAfterActivation?.entry.revision).toBe(plannedBefore + 2);
         },
         30_000
     );
 });
-
-// `connect` succeeds only against a stored planned row, so this runs its own
-// harness with that row present: the executed request must land the stage,
-// stamp the establishment clock, and commit the planned row's revision guard
-// (the batch's fence against a replan landing between read and commit).
 
 function connectPlannedSnapshot(
     groupId: string,


### PR DESCRIPTION
## What this is

PR #371 added `INBOX_TYPES_OUTSIDE_THE_CASE_ARRAY` to the group-state inbox operation matrix — the declared list of advertised AppInbox operations the `cases` array does not carry, coupled to `AUTHENTICATED_GROUP_INBOX_TYPES` so an operation can no longer be advertised and then silently go unrun. Its note said the entries it did not add were "covered elsewhere". This checks that claim.

Slices 8d (#396) and 6c (#376) have since emptied most of the list: the two legacy establishment commands are retired, and `start` and `reset` have real matrix cases. What remains is `GROUP_CONNECT`, genuinely exercised after the matrix, and `GROUP_ACTIVATE` — which had **no AppInbox phase coverage anywhere in the Vitest suite**.

| Where `activate` appears | What it actually proves |
| --- | --- |
| `group-state-inbox-descriptor-contract.test.ts` | type → operation mapping only |
| `group-state/mutation/group-lifecycle-mutation.test.ts` | `computeGroupMutation` in isolation — the pure phase, not read → compute → validate → write |
| `apps/api-v1/test/group-state/group-lifecycle-transition-routes.test.ts` | route envelopes against a **stubbed** `processGroupAppInbox`; no phases run |
| `black-box-runner/tests/api-v1/api-v1-group-lifecycle-transitions.json` | a live server — the only real phase coverage, and not in this suite |

## What changed

**`activate` now runs the real phases.** It cannot join the `cases` array: it is legal only from `connecting`, which is reachable only through `connect`, which needs the stored planned row the shared matrix harness does not have. So it extends the test that already lands `connecting` against a real row — create → plan → connect → activate through `processAuthenticated` — asserting the stage, the epoch advance, the accepted slot (empty before, holding the dialed snapshot after), the group row's accepted identity, and the planned row's guard advancing a second time inside activation's own batch.

Two smaller repairs to the same region, both about where this coverage lives:

- The note above the list still counted "the other two" after 8d removed them. It now states why neither remaining entry can join the array.
- 8d's inlining of `runConnectAgainstStoredPlan` left its header comment orphaned between the `describe` and `connectPlannedSnapshot`. It moves into the test it describes.

## Validation

- `npx vitest run packages/tests/shared-server/rallar-system/group-state/inbox/` — 13 files, 52 tests passed, on the rebased base
- Falsifiability check on the new leg: mutating `toBe('active')` → `toBe('MUTANT')` fails with `expected 'active' to be 'MUTANT'`, confirming the activation path genuinely executes rather than passing vacuously. Reverted.
- `dprint check` on the file — clean

Not run: `test:ci`, `build` — left to branch CI.

## Follow-up

None. The list is now down to the two operations the array structurally cannot reach, and the note says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)