### PR TITLE
feat(admin-support): report the lifecycle plane in explainGroup (slice 13)

### DIFF
--- a/apps/api-v1/src/composition/create-api-v1-admin-services.ts
+++ b/apps/api-v1/src/composition/create-api-v1-admin-services.ts
@@ -22,6 +22,7 @@ import type { RallarServerWsStatus } from '@shared-server/rallar-system/websocke
 import type { RallarCrdtAdminReadRepository } from '@shared/crdt/mod.ts';
 import type { JsonWebSocketServer } from '@shared/websocket/JsonWebSocketServer.ts';
 
+import type { GroupAdminSupportDependencies } from '@shared-server/rallar-system/admin-support/admin-support-contracts.ts';
 import {
     createApiV1AdminOperationUseCases,
     type CreateApiV1AdminOperationUseCasesInput
@@ -31,6 +32,7 @@ import type { CrdtAdminMutations } from '../crdt/create-crdt-admin-mutations.ts'
 
 export interface CreateApiV1AdminServicesInput extends CreateApiV1AdminOperationUseCasesInput {
     readonly topologyQuery: AdminSupportTopologyQuery;
+    readonly readLifecyclePolicy: GroupAdminSupportDependencies['readLifecyclePolicy'];
     readonly clientStateService: Pick<ClientStateService, 'readSnapshot' | 'readPresenceSnapshot' | 'listRecentEvents'>;
     readonly groupStateService: Pick<
         CachedGroupStateService,
@@ -62,6 +64,7 @@ export function createApiV1AdminServices(
             clientStateService: input.clientStateService,
             groupStateService: input.groupStateService,
             topologyQuery: input.topologyQuery,
+            readLifecyclePolicy: input.readLifecyclePolicy,
             wsStatus: readWebSocketStatus,
             crdtAdminRepository: input.crdtAdminRepository,
             timing: input.timing

--- a/apps/api-v1/src/composition/create-default-rallar-server.ts
+++ b/apps/api-v1/src/composition/create-default-rallar-server.ts
@@ -134,6 +134,9 @@ function constructDefaultRallarServer(
         serviceId: myServerId,
         timing,
         readWebSocketStatus: () => readApiV1WebSocketStatus(runtime.wsQBoxServerService.socket),
+        // Durable, never the snapshot cache: an operator explanation must not
+        // read a policy that lags a cross-server write.
+        readLifecyclePolicy: (ref) => topology.groupStateRepository.readLifecyclePolicy(ref),
         readRtcTopologyMetrics: topology.readRtcTopologyMetrics,
         resetRtcTopologyMetrics: topology.resetRtcTopologyMetrics,
         readGroupFormationMetrics: runtime.groupFormationMetrics.readMetrics,

--- a/apps/api-v1/test/composition/create-api-v1-admin-services.test.ts
+++ b/apps/api-v1/test/composition/create-api-v1-admin-services.test.ts
@@ -120,6 +120,7 @@ function createInput(
         topologyQuery: {
             readTopologyView: rejectUnusedOperation
         },
+        readLifecyclePolicy: rejectUnusedOperation,
         clientStateService: {
             readSnapshot: () => Promise.resolve(undefined),
             readPresenceSnapshot: () => Promise.resolve(undefined),

--- a/packages/shared-server/rallar-system/admin-support/admin-support-contracts.ts
+++ b/packages/shared-server/rallar-system/admin-support/admin-support-contracts.ts
@@ -13,6 +13,7 @@ import type { RallarCrdtAdminReadRepository } from '@shared/crdt/mod.ts';
 import type { Key } from '@shared/queuebox/ResourceEntry.ts';
 import type { ClientStateService } from '../client-state/client-state-service-contracts.ts';
 import type { GroupStateService } from '../group-state/group-state-service-contracts.ts';
+import type { GroupLifecyclePolicyRead } from '../group-state/persistence/group-lifecycle-policy-repository.ts';
 import type { RallarTimingSink } from '../observability/timing.ts';
 import type { RallarServerWsStatus } from '../websocket/router/rallar-server-ws-status.ts';
 
@@ -73,6 +74,13 @@ export interface ClientAdminSupportDependencies extends AdminSupportExecutionDep
 export interface GroupAdminSupportDependencies extends AdminSupportExecutionDependencies {
     readonly groupStateService?: AdminSupportGroupStateService;
     readonly topologyQuery?: AdminSupportTopologyQuery;
+    /**
+     * The stored lifecycle policy, which the remediation axis, the data gate
+     * and the real exhaustion predicate all need. Optional like the other two
+     * readers: an unconfigured one degrades the facts it feeds rather than
+     * failing the explanation.
+     */
+    readonly readLifecyclePolicy?: (groupRef: GroupRef) => Promise<GroupLifecyclePolicyRead>;
 }
 
 export interface CrdtAdminSupportDependencies extends AdminSupportExecutionDependencies {

--- a/packages/shared-server/rallar-system/admin-support/group-admin-support.ts
+++ b/packages/shared-server/rallar-system/admin-support/group-admin-support.ts
@@ -2,6 +2,7 @@ import type {
     AdminSupportExplainGroupRequest,
     AdminSupportNarrativeResponse
 } from '@shared/api/admin-support/admin-support-types.ts';
+import { toReadGroupLifecyclePolicy } from '../group-state/persistence/group-lifecycle-policy-repository.ts';
 import type { AdminSupportWriteInput, GroupAdminSupportDependencies } from './admin-support-contracts.ts';
 import { projectGroupAdminSupportNarrative } from './narratives/project-group-admin-support-narrative.ts';
 import { readAdminSupportRecentEventLimit } from './read-admin-support-recent-event-limit.ts';
@@ -29,10 +30,12 @@ export class GroupAdminSupport {
                 const limit = readAdminSupportRecentEventLimit(
                     input.request.limitRecentEvents
                 );
-                const [snapshot, recentEvents, topologyView] = await Promise.all([
+                const readPolicy = this.dependencies.readLifecyclePolicy;
+                const [snapshot, recentEvents, topologyView, policyRead] = await Promise.all([
                     service?.readSnapshot(groupRef),
                     service?.listRecentEvents?.(groupRef, { limit }) ?? Promise.resolve([]),
-                    topologyQuery?.readTopologyView(groupRef)
+                    topologyQuery?.readTopologyView(groupRef),
+                    readPolicy?.(groupRef)
                 ]);
                 return projectGroupAdminSupportNarrative({
                     request: input.request,
@@ -42,7 +45,9 @@ export class GroupAdminSupport {
                     hasTopologyQuery: Boolean(topologyQuery),
                     snapshot,
                     recentEvents,
-                    topologyView
+                    topologyView,
+                    hasLifecyclePolicyReader: Boolean(readPolicy),
+                    policy: policyRead === undefined ? null : toReadGroupLifecyclePolicy(policyRead)
                 });
             }
         });

--- a/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
@@ -1,6 +1,7 @@
 import type { AdminSupportFact } from '@shared/api/admin-support/admin-support-types.ts';
-import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import { toGroupLayoutIdentity, type GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { Group } from '@shared/api/group-types.ts';
+import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
 /**
  * The lifecycle plane an operator actually asks about: which stage the group
@@ -14,9 +15,20 @@ import type { Group } from '@shared/api/group-types.ts';
  * certainty until the writer has stored one, rather than inventing a band no
  * clock has observed.
  */
-export function groupLifecycleFacts(group: Group): readonly AdminSupportFact[] {
+export function groupLifecycleFacts(
+    group: Group,
+    plannedSnapshot: RallarOverlayTopologySnapshot | null
+): readonly AdminSupportFact[] {
     const status = group.activationStatus;
-    const statusCertainty = status === null ? 'unavailable' : 'exact';
+    // A status from a spent series describes a layout the group has moved
+    // past. The formation view refuses to publish one; a support surface
+    // should still show it -- that staleness is often the thing being
+    // debugged -- but must not call it exact.
+    const statusCertainty = status === null
+        ? 'unavailable'
+        : status.formationEpoch === group.formationEpoch
+        ? 'exact'
+        : 'inferred';
     return [
         { label: 'group.lifecycleState', source: 'group-state', value: group.lifecycleState, certainty: 'exact' },
         { label: 'group.formationEpoch', source: 'group-state', value: group.formationEpoch, certainty: 'exact' },
@@ -34,6 +46,17 @@ export function groupLifecycleFacts(group: Group): readonly AdminSupportFact[] {
             certainty: group.acceptedLayoutIdentity === null ? 'unavailable' : 'exact'
         },
         {
+            // The candidate waiting to be dialed. A held one sitting beside a
+            // different accepted identity is what a `hold` reconfigure landing
+            // looks like, and it is otherwise invisible to an operator.
+            label: 'group.plannedLayoutIdentity',
+            source: 'group-topology',
+            value: plannedSnapshot === null || plannedSnapshot.state !== 'active'
+                ? 'none'
+                : toLayoutIdentitySummary(toGroupLayoutIdentity(plannedSnapshot)),
+            certainty: plannedSnapshot === null ? 'unavailable' : 'exact'
+        },
+        {
             label: 'group.activationCondition',
             source: 'group-state',
             value: status?.condition ?? 'unconfirmed',
@@ -49,6 +72,18 @@ export function groupLifecycleFacts(group: Group): readonly AdminSupportFact[] {
             label: 'group.activationCoverageBasis',
             source: 'group-state',
             value: toLayoutIdentitySummary(status?.coverageBasisLayoutIdentity ?? null),
+            certainty: statusCertainty
+        },
+        {
+            label: 'group.activationStatusEpoch',
+            source: 'group-state',
+            value: status?.formationEpoch ?? 'unconfirmed',
+            certainty: statusCertainty
+        },
+        {
+            label: 'group.activationConfirmedAtEpochMs',
+            source: 'group-state',
+            value: status?.confirmedAtEpochMs ?? 'unconfirmed',
             certainty: statusCertainty
         }
     ];

--- a/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
@@ -1,29 +1,40 @@
 import type { AdminSupportFact } from '@shared/api/admin-support/admin-support-types.ts';
-import { toGroupLayoutIdentity, type GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import {
+    resolveGroupActivationRemediation,
+    resolveGroupBusinessLiveness
+} from '@shared/api/group-lifecycle/activation-status/compute-group-activation-condition.ts';
+import { computeGroupDataGate } from '@shared/api/group-lifecycle/compute-group-data-gate.ts';
+import {
+    isSameGroupLayoutIdentity,
+    toGroupLayoutIdentity,
+    type GroupLayoutIdentity
+} from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
+import { isFormationAttemptBudgetExhausted } from '@shared/api/group-lifecycle/group-lifecycle-transitions.ts';
 import type { Group } from '@shared/api/group-types.ts';
 import type { RallarOverlayTopologySnapshot } from '@shared/api/overlay-topology.ts';
 
+export interface GroupLifecycleFactsInput {
+    readonly group: Group;
+    readonly plannedSnapshot: RallarOverlayTopologySnapshot | null;
+    readonly acceptedSnapshot: RallarOverlayTopologySnapshot | null;
+    readonly replanQueued: boolean;
+    readonly policy: GroupLifecyclePolicy | null;
+    readonly nowEpochMs: number;
+}
+
 /**
- * The lifecycle plane an operator actually asks about: which stage the group
- * is in, which series it is on, which layout carries traffic, whether
- * application data is flowing (product decision 25 keeps the valve off the
- * routing plane), and what the group is telling its members about its own
- * connectivity.
+ * The lifecycle plane, for an operator.
  *
  * The status half is derived, non-authoritative state that no policy or gate
- * reads (product decision 3). It is reported as unconfirmed with unavailable
- * certainty until the writer has stored one, rather than inventing a band no
- * clock has observed.
+ * reads (product decision 3). It is reported as stored rather than recomputed,
+ * because a stale band is often the thing being debugged -- but a status from
+ * a series the group has left is marked `inferred` rather than `exact`, and
+ * carries the epoch and instant that make the staleness checkable.
  */
-export function groupLifecycleFacts(
-    group: Group,
-    plannedSnapshot: RallarOverlayTopologySnapshot | null
-): readonly AdminSupportFact[] {
+export function groupLifecycleFacts(input: GroupLifecycleFactsInput): readonly AdminSupportFact[] {
+    const { group, policy } = input;
     const status = group.activationStatus;
-    // A status from a spent series describes a layout the group has moved
-    // past. The formation view refuses to publish one; a support surface
-    // should still show it -- that staleness is often the thing being
-    // debugged -- but must not call it exact.
     const statusCertainty = status === null
         ? 'unavailable'
         : status.formationEpoch === group.formationEpoch
@@ -38,7 +49,28 @@ export function groupLifecycleFacts(
             value: group.formationAttemptCount,
             certainty: 'exact'
         },
+        {
+            // The denominator, so a live group's distance from exhaustion is
+            // visible rather than inferred from the numerator alone.
+            label: 'group.maxFormationAttempts',
+            source: 'group-lifecycle-policy',
+            value: policy?.activation.maxFormationAttempts ?? 'unreadable',
+            certainty: policy === null ? 'unavailable' : 'exact'
+        },
         { label: 'group.transportState', source: 'group-state', value: group.transportState, certainty: 'exact' },
+        {
+            // The valve is only half the gate: the forward gate composes with
+            // it under `blocked-until-active` (product decision 25), so
+            // `flowing` alone does not mean application data flows.
+            label: 'group.dataGate',
+            source: 'group-lifecycle-policy',
+            value: policy === null ? 'unreadable' : computeGroupDataGate({
+                lifecycleState: group.lifecycleState,
+                transportState: group.transportState,
+                preActivationAppData: policy.data.preActivationAppData
+            }),
+            certainty: policy === null ? 'unavailable' : 'exact'
+        },
         {
             label: 'group.acceptedLayoutIdentity',
             source: 'group-state',
@@ -51,16 +83,34 @@ export function groupLifecycleFacts(
             // looks like, and it is otherwise invisible to an operator.
             label: 'group.plannedLayoutIdentity',
             source: 'group-topology',
-            value: plannedSnapshot === null || plannedSnapshot.state !== 'active'
-                ? 'none'
-                : toLayoutIdentitySummary(toGroupLayoutIdentity(plannedSnapshot)),
-            certainty: plannedSnapshot === null ? 'unavailable' : 'exact'
+            value: toLayoutIdentitySummary(toActiveLayoutIdentity(input.plannedSnapshot)),
+            certainty: input.plannedSnapshot === null ? 'unavailable' : 'exact'
         },
         {
             label: 'group.activationCondition',
             source: 'group-state',
             value: status?.condition ?? 'unconfirmed',
             certainty: statusCertainty
+        },
+        {
+            label: 'group.activationRemediation',
+            source: 'group-lifecycle-policy',
+            value: policy === null ? 'unreadable' : resolveGroupActivationRemediation({
+                business: resolveGroupBusinessLiveness(group, input.nowEpochMs),
+                lifecycleState: group.lifecycleState,
+                attemptBudgetExhausted: isFormationAttemptBudgetExhausted({
+                    activation: policy.activation,
+                    formationAttemptCount: group.formationAttemptCount
+                }),
+                replanQueued: input.replanQueued,
+                layoutStale: toIdentityLayoutStale(input),
+                replanning: policy.topology.replanning
+            }),
+            // The staleness input is the identity half of `computeLayoutStale`
+            // only: this surface has no planning fingerprint, so a layout that
+            // is stale solely because its topology inputs moved -- an expired
+            // temporary override, say -- reads as current here.
+            certainty: policy === null ? 'unavailable' : 'inferred'
         },
         {
             label: 'group.activationCoverageRate',
@@ -87,6 +137,35 @@ export function groupLifecycleFacts(
             certainty: statusCertainty
         }
     ];
+}
+
+/** True when the series is spent, which is what denies a fresh `start`. */
+export function isGroupFormationSeriesParked(group: Group, policy: GroupLifecyclePolicy | null): boolean {
+    return group.lifecycleState === 'dormant' &&
+        policy !== null &&
+        isFormationAttemptBudgetExhausted({
+            activation: policy.activation,
+            formationAttemptCount: group.formationAttemptCount
+        });
+}
+
+/**
+ * The identity half of `computeLayoutStale`, which is all this surface can
+ * answer: it decides the accepted-versus-planned comparison exactly and
+ * cannot see the planning fingerprint, so it passes equal fingerprints and
+ * under-reports staleness rather than inventing it.
+ */
+function toIdentityLayoutStale(input: GroupLifecycleFactsInput): boolean {
+    const accepted = input.group.acceptedLayoutIdentity;
+    if (accepted === null) {
+        return false;
+    }
+    const planned = toActiveLayoutIdentity(input.plannedSnapshot);
+    return planned === null || !isSameGroupLayoutIdentity(accepted, planned);
+}
+
+function toActiveLayoutIdentity(snapshot: RallarOverlayTopologySnapshot | null): GroupLayoutIdentity | null {
+    return snapshot === null || snapshot.state !== 'active' ? null : toGroupLayoutIdentity(snapshot);
 }
 
 /**

--- a/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/group-lifecycle-facts.ts
@@ -1,0 +1,65 @@
+import type { AdminSupportFact } from '@shared/api/admin-support/admin-support-types.ts';
+import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
+import type { Group } from '@shared/api/group-types.ts';
+
+/**
+ * The lifecycle plane an operator actually asks about: which stage the group
+ * is in, which series it is on, which layout carries traffic, whether
+ * application data is flowing (product decision 25 keeps the valve off the
+ * routing plane), and what the group is telling its members about its own
+ * connectivity.
+ *
+ * The status half is derived, non-authoritative state that no policy or gate
+ * reads (product decision 3). It is reported as unconfirmed with unavailable
+ * certainty until the writer has stored one, rather than inventing a band no
+ * clock has observed.
+ */
+export function groupLifecycleFacts(group: Group): readonly AdminSupportFact[] {
+    const status = group.activationStatus;
+    const statusCertainty = status === null ? 'unavailable' : 'exact';
+    return [
+        { label: 'group.lifecycleState', source: 'group-state', value: group.lifecycleState, certainty: 'exact' },
+        { label: 'group.formationEpoch', source: 'group-state', value: group.formationEpoch, certainty: 'exact' },
+        {
+            label: 'group.formationAttemptCount',
+            source: 'group-state',
+            value: group.formationAttemptCount,
+            certainty: 'exact'
+        },
+        { label: 'group.transportState', source: 'group-state', value: group.transportState, certainty: 'exact' },
+        {
+            label: 'group.acceptedLayoutIdentity',
+            source: 'group-state',
+            value: toLayoutIdentitySummary(group.acceptedLayoutIdentity),
+            certainty: group.acceptedLayoutIdentity === null ? 'unavailable' : 'exact'
+        },
+        {
+            label: 'group.activationCondition',
+            source: 'group-state',
+            value: status?.condition ?? 'unconfirmed',
+            certainty: statusCertainty
+        },
+        {
+            label: 'group.activationCoverageRate',
+            source: 'group-state',
+            value: status?.coverageRate ?? 'unconfirmed',
+            certainty: statusCertainty
+        },
+        {
+            label: 'group.activationCoverageBasis',
+            source: 'group-state',
+            value: toLayoutIdentitySummary(status?.coverageBasisLayoutIdentity ?? null),
+            certainty: statusCertainty
+        }
+    ];
+}
+
+/**
+ * A layout identity is the tuple, never a bare version (product decision 29),
+ * so an operator comparing two of them can tell a re-plan from a re-publish.
+ */
+function toLayoutIdentitySummary(identity: GroupLayoutIdentity | null): string {
+    return identity === null
+        ? 'none'
+        : `${identity.state} r${identity.groupRevision}/${identity.presenceRevision} v${identity.version}`;
+}

--- a/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
@@ -10,6 +10,7 @@ import type { GroupTopologyManagementView } from '@shared/api/graph-topology-man
 import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { GroupEvent, GroupPresenceSession, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { adminSupportNarrativeBase, type AdminSupportNarrativeBase } from './admin-support-narrative-base.ts';
+import { groupLifecycleFacts } from './group-lifecycle-facts.ts';
 
 interface ProjectGroupAdminSupportInput extends AdminSupportNarrativeBase {
     readonly request: AdminSupportExplainGroupRequest;
@@ -123,66 +124,9 @@ function groupFacts(input: GroupFactsInput): readonly AdminSupportFact[] {
                 source: 'group-state',
                 value: input.snapshot.activeSessions.length,
                 certainty: 'exact'
-            },
-            // The lifecycle plane an operator actually asks about: which stage
-            // the group is in, which series it is on, which layout carries
-            // traffic, and whether application data is flowing (product
-            // decision 25 keeps the valve off the routing plane).
-            {
-                label: 'group.lifecycleState',
-                source: 'group-state',
-                value: input.snapshot.group.lifecycleState,
-                certainty: 'exact'
-            },
-            {
-                label: 'group.formationEpoch',
-                source: 'group-state',
-                value: input.snapshot.group.formationEpoch,
-                certainty: 'exact'
-            },
-            {
-                label: 'group.formationAttemptCount',
-                source: 'group-state',
-                value: input.snapshot.group.formationAttemptCount,
-                certainty: 'exact'
-            },
-            {
-                label: 'group.transportState',
-                source: 'group-state',
-                value: input.snapshot.group.transportState,
-                certainty: 'exact'
-            },
-            {
-                label: 'group.acceptedLayoutIdentity',
-                source: 'group-state',
-                value: summarizeLayoutIdentity(input.snapshot.group.acceptedLayoutIdentity),
-                certainty: input.snapshot.group.acceptedLayoutIdentity === null ? 'unavailable' : 'exact'
-            },
-            // Derived, non-authoritative, and read by no policy or gate
-            // (product decision 3) -- reported so an operator can see what the
-            // group is telling its members, and `unavailable` until the writer
-            // has confirmed one rather than invented a band no clock observed.
-            {
-                label: 'group.activationCondition',
-                source: 'group-state',
-                value: input.snapshot.group.activationStatus?.condition ?? 'unconfirmed',
-                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
-            },
-            {
-                label: 'group.activationCoverageRate',
-                source: 'group-state',
-                value: input.snapshot.group.activationStatus?.coverageRate ?? 'unconfirmed',
-                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
-            },
-            {
-                label: 'group.activationCoverageBasis',
-                source: 'group-state',
-                value: summarizeLayoutIdentity(
-                    input.snapshot.group.activationStatus?.coverageBasisLayoutIdentity ?? null
-                ),
-                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
             }
         );
+        facts.push(...groupLifecycleFacts(input.snapshot.group));
         if (input.principalId) {
             const member = input.snapshot.members.find(
                 (candidate) => candidate.principalId === input.principalId
@@ -237,11 +181,6 @@ function groupTimeline(events: readonly GroupEvent[]): readonly AdminSupportTime
  * A layout identity is the tuple, never a bare version (product decision 29),
  * so an operator comparing two of them can tell a re-plan from a re-publish.
  */
-function summarizeLayoutIdentity(identity: GroupLayoutIdentity | null): string {
-    return identity === null
-        ? 'none'
-        : `${identity.state} r${identity.groupRevision}/${identity.presenceRevision} v${identity.version}`;
-}
 
 function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[] {
     const warnings: AdminSupportWarning[] = [];

--- a/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
@@ -7,6 +7,7 @@ import type {
     AdminSupportWarning
 } from '@shared/api/admin-support/admin-support-types.ts';
 import type { GroupTopologyManagementView } from '@shared/api/graph-topology-management-types.ts';
+import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { GroupEvent, GroupPresenceSession, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { adminSupportNarrativeBase, type AdminSupportNarrativeBase } from './admin-support-narrative-base.ts';
 
@@ -122,6 +123,64 @@ function groupFacts(input: GroupFactsInput): readonly AdminSupportFact[] {
                 source: 'group-state',
                 value: input.snapshot.activeSessions.length,
                 certainty: 'exact'
+            },
+            // The lifecycle plane an operator actually asks about: which stage
+            // the group is in, which series it is on, which layout carries
+            // traffic, and whether application data is flowing (product
+            // decision 25 keeps the valve off the routing plane).
+            {
+                label: 'group.lifecycleState',
+                source: 'group-state',
+                value: input.snapshot.group.lifecycleState,
+                certainty: 'exact'
+            },
+            {
+                label: 'group.formationEpoch',
+                source: 'group-state',
+                value: input.snapshot.group.formationEpoch,
+                certainty: 'exact'
+            },
+            {
+                label: 'group.formationAttemptCount',
+                source: 'group-state',
+                value: input.snapshot.group.formationAttemptCount,
+                certainty: 'exact'
+            },
+            {
+                label: 'group.transportState',
+                source: 'group-state',
+                value: input.snapshot.group.transportState,
+                certainty: 'exact'
+            },
+            {
+                label: 'group.acceptedLayoutIdentity',
+                source: 'group-state',
+                value: summarizeLayoutIdentity(input.snapshot.group.acceptedLayoutIdentity),
+                certainty: input.snapshot.group.acceptedLayoutIdentity === null ? 'unavailable' : 'exact'
+            },
+            // Derived, non-authoritative, and read by no policy or gate
+            // (product decision 3) -- reported so an operator can see what the
+            // group is telling its members, and `unavailable` until the writer
+            // has confirmed one rather than invented a band no clock observed.
+            {
+                label: 'group.activationCondition',
+                source: 'group-state',
+                value: input.snapshot.group.activationStatus?.condition ?? 'unconfirmed',
+                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
+            },
+            {
+                label: 'group.activationCoverageRate',
+                source: 'group-state',
+                value: input.snapshot.group.activationStatus?.coverageRate ?? 'unconfirmed',
+                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
+            },
+            {
+                label: 'group.activationCoverageBasis',
+                source: 'group-state',
+                value: summarizeLayoutIdentity(
+                    input.snapshot.group.activationStatus?.coverageBasisLayoutIdentity ?? null
+                ),
+                certainty: input.snapshot.group.activationStatus === null ? 'unavailable' : 'exact'
             }
         );
         if (input.principalId) {
@@ -174,6 +233,16 @@ function groupTimeline(events: readonly GroupEvent[]): readonly AdminSupportTime
     }));
 }
 
+/**
+ * A layout identity is the tuple, never a bare version (product decision 29),
+ * so an operator comparing two of them can tell a re-plan from a re-publish.
+ */
+function summarizeLayoutIdentity(identity: GroupLayoutIdentity | null): string {
+    return identity === null
+        ? 'none'
+        : `${identity.state} r${identity.groupRevision}/${identity.presenceRevision} v${identity.version}`;
+}
+
 function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[] {
     const warnings: AdminSupportWarning[] = [];
     if (!input.hasGroupStateService) {
@@ -194,6 +263,27 @@ function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[
         warnings.push({
             code: 'group-session-missing',
             message: 'No active group presence session matched the requested principal or session id.',
+            source: 'group-state'
+        });
+    }
+    const group = input.snapshot?.group;
+    if (group?.lifecycleState === 'dormant' && group.formationAttemptCount > 0) {
+        // Decision 38: the parked series keeps its admission posture, so the
+        // lobby looks open while nothing will dial. That is the state an
+        // operator is most likely to be paged about and least likely to guess.
+        warnings.push({
+            code: 'group-formation-series-parked',
+            message: `Formation parked in dormant after ${group.formationAttemptCount} attempt(s); ` +
+                'a reset clears the series before another can start.',
+            source: 'group-state'
+        });
+    }
+    if (group?.transportState === 'halted') {
+        // The valve is orthogonal to the stage (product decision 25), so an
+        // active group can be carrying no application data at all.
+        warnings.push({
+            code: 'group-transport-halted',
+            message: 'Application data is paused; the routing plane is unaffected and resume restores it.',
             source: 'group-state'
         });
     }

--- a/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
@@ -7,9 +7,10 @@ import type {
     AdminSupportWarning
 } from '@shared/api/admin-support/admin-support-types.ts';
 import type { GroupTopologyManagementView } from '@shared/api/graph-topology-management-types.ts';
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupEvent, GroupPresenceSession, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { adminSupportNarrativeBase, type AdminSupportNarrativeBase } from './admin-support-narrative-base.ts';
-import { groupLifecycleFacts } from './group-lifecycle-facts.ts';
+import { groupLifecycleFacts, isGroupFormationSeriesParked } from './group-lifecycle-facts.ts';
 
 interface ProjectGroupAdminSupportInput extends AdminSupportNarrativeBase {
     readonly request: AdminSupportExplainGroupRequest;
@@ -18,6 +19,9 @@ interface ProjectGroupAdminSupportInput extends AdminSupportNarrativeBase {
     readonly snapshot: GroupSnapshot | undefined;
     readonly recentEvents: readonly GroupEvent[];
     readonly topologyView: GroupTopologyManagementView | undefined;
+    readonly hasLifecyclePolicyReader: boolean;
+    /** Null when unreadable or unconfigured; the facts it feeds degrade rather than lie. */
+    readonly policy: GroupLifecyclePolicy | null;
 }
 
 export function projectGroupAdminSupportNarrative(
@@ -29,6 +33,8 @@ export function projectGroupAdminSupportNarrative(
         input.request.sessionId
     );
     const facts = groupFacts({
+        policy: input.policy,
+        nowEpochMs: input.generatedAtEpochMs,
         snapshot: input.snapshot,
         recentEvents: input.recentEvents,
         topologyView: input.topologyView,
@@ -37,6 +43,8 @@ export function projectGroupAdminSupportNarrative(
         session
     });
     const warnings = groupWarnings({
+        policy: input.policy,
+        nowEpochMs: input.generatedAtEpochMs,
         hasGroupStateService: input.hasGroupStateService,
         hasTopologyQuery: input.hasTopologyQuery,
         snapshot: input.snapshot,
@@ -70,6 +78,8 @@ export function projectGroupAdminSupportNarrative(
 }
 
 interface GroupFactsInput {
+    readonly policy: GroupLifecyclePolicy | null;
+    readonly nowEpochMs: number;
     readonly snapshot: GroupSnapshot | undefined;
     readonly recentEvents: readonly GroupEvent[];
     readonly topologyView: GroupTopologyManagementView | undefined;
@@ -86,6 +96,8 @@ interface GroupWarningsInput {
     readonly sessionId: string | undefined;
     readonly session: GroupPresenceSession | undefined;
     readonly topologyView: GroupTopologyManagementView | undefined;
+    readonly policy: GroupLifecyclePolicy | null;
+    readonly nowEpochMs: number;
 }
 
 function groupFacts(input: GroupFactsInput): readonly AdminSupportFact[] {
@@ -125,7 +137,14 @@ function groupFacts(input: GroupFactsInput): readonly AdminSupportFact[] {
                 certainty: 'exact'
             }
         );
-        facts.push(...groupLifecycleFacts(input.snapshot.group, input.topologyView?.snapshot ?? null));
+        facts.push(...groupLifecycleFacts({
+            group: input.snapshot.group,
+            plannedSnapshot: input.topologyView?.snapshot ?? null,
+            acceptedSnapshot: input.topologyView?.acceptedSnapshot ?? null,
+            replanQueued: input.topologyView?.pending != null,
+            policy: input.policy,
+            nowEpochMs: input.nowEpochMs
+        }));
         if (input.principalId) {
             const member = input.snapshot.members.find(
                 (candidate) => candidate.principalId === input.principalId
@@ -200,11 +219,13 @@ function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[
         });
     }
     const group = input.snapshot?.group;
-    if (group?.lifecycleState === 'dormant' && group.formationAttemptCount > 0) {
-        // The series is spent: `start` is denied until a `reset` clears it
-        // (product decision 37). Nothing is claimed here about admission --
-        // decision 38 keeps whatever posture the policy asked for, so a closed
-        // lobby stays closed, and this narrative cannot read that policy.
+    if (group !== undefined && isGroupFormationSeriesParked(group, input.policy)) {
+        // The series is spent, so `start` is denied until a `reset` clears it
+        // (product decision 37). Keyed on the budget rather than on a non-zero
+        // attempt count, which stops describing exhaustion the moment someone
+        // raises `maxFormationAttempts` on a parked group. Nothing is claimed
+        // about admission: decision 38 keeps whatever posture the policy asked
+        // for, so a closed lobby stays closed.
         warnings.push({
             code: 'group-formation-series-parked',
             message: `Formation parked in dormant after ${group.formationAttemptCount} attempt(s); ` +

--- a/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
+++ b/packages/shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts
@@ -7,7 +7,6 @@ import type {
     AdminSupportWarning
 } from '@shared/api/admin-support/admin-support-types.ts';
 import type { GroupTopologyManagementView } from '@shared/api/graph-topology-management-types.ts';
-import type { GroupLayoutIdentity } from '@shared/api/group-lifecycle/group-layout-identity.ts';
 import type { GroupEvent, GroupPresenceSession, GroupRef, GroupSnapshot } from '@shared/api/group-types.ts';
 import { adminSupportNarrativeBase, type AdminSupportNarrativeBase } from './admin-support-narrative-base.ts';
 import { groupLifecycleFacts } from './group-lifecycle-facts.ts';
@@ -126,7 +125,7 @@ function groupFacts(input: GroupFactsInput): readonly AdminSupportFact[] {
                 certainty: 'exact'
             }
         );
-        facts.push(...groupLifecycleFacts(input.snapshot.group));
+        facts.push(...groupLifecycleFacts(input.snapshot.group, input.topologyView?.snapshot ?? null));
         if (input.principalId) {
             const member = input.snapshot.members.find(
                 (candidate) => candidate.principalId === input.principalId
@@ -177,11 +176,6 @@ function groupTimeline(events: readonly GroupEvent[]): readonly AdminSupportTime
     }));
 }
 
-/**
- * A layout identity is the tuple, never a bare version (product decision 29),
- * so an operator comparing two of them can tell a re-plan from a re-publish.
- */
-
 function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[] {
     const warnings: AdminSupportWarning[] = [];
     if (!input.hasGroupStateService) {
@@ -207,9 +201,10 @@ function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[
     }
     const group = input.snapshot?.group;
     if (group?.lifecycleState === 'dormant' && group.formationAttemptCount > 0) {
-        // Decision 38: the parked series keeps its admission posture, so the
-        // lobby looks open while nothing will dial. That is the state an
-        // operator is most likely to be paged about and least likely to guess.
+        // The series is spent: `start` is denied until a `reset` clears it
+        // (product decision 37). Nothing is claimed here about admission --
+        // decision 38 keeps whatever posture the policy asked for, so a closed
+        // lobby stays closed, and this narrative cannot read that policy.
         warnings.push({
             code: 'group-formation-series-parked',
             message: `Formation parked in dormant after ${group.formationAttemptCount} attempt(s); ` +
@@ -218,11 +213,14 @@ function groupWarnings(input: GroupWarningsInput): readonly AdminSupportWarning[
         });
     }
     if (group?.transportState === 'halted') {
-        // The valve is orthogonal to the stage (product decision 25), so an
-        // active group can be carrying no application data at all.
+        // The valve is orthogonal to the stage (product decision 25), but it is
+        // only half the data gate: `resume` clears the halt and the forward
+        // gate can still refuse data before activation. `reset` also halts
+        // (product decision 36), so a halt is not evidence of a pause.
         warnings.push({
             code: 'group-transport-halted',
-            message: 'Application data is paused; the routing plane is unaffected and resume restores it.',
+            message: 'Transport is halted, so application data is refused; a reset halts as well as a pause. ' +
+                'Resume clears the halt, which is not sufficient on its own before activation.',
             source: 'group-state'
         });
     }

--- a/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
@@ -27,6 +27,9 @@ describe('the group narrative reports the lifecycle plane', () => {
 
         expect(facts['group.lifecycleState']).toBe('active');
         expect(facts['group.formationEpoch']).toBe(4);
+        // The input the parked warning branches on; unasserted it could be
+        // deleted without failing anything.
+        expect(facts['group.formationAttemptCount']).toBe(1);
         expect(facts['group.transportState']).toBe('flowing');
         // The tuple, never a bare version (product decision 29), so two
         // identities can be told apart by a reader.
@@ -34,15 +37,58 @@ describe('the group narrative reports the lifecycle plane', () => {
     });
 
     it('reports an unconfirmed status as unavailable rather than inventing a band', () => {
-        const narrative = narrativeFor({ activationStatus: null });
+        const narrative = narrativeFor({ activationStatus: null, acceptedLayoutIdentity: null });
+        const byLabel = Object.fromEntries(narrative.facts.map((f) => [f.label, f]));
+
+        for (
+            const label of [
+                'group.activationCondition',
+                'group.activationCoverageRate',
+                'group.activationStatusEpoch',
+                'group.activationConfirmedAtEpochMs'
+            ]
+        ) {
+            expect(byLabel[label]?.value).toBe('unconfirmed');
+            expect(byLabel[label]?.certainty).toBe('unavailable');
+        }
+        expect(byLabel['group.activationCoverageBasis']?.value).toBe('none');
+        // An absent accepted layout is authoritatively absent, not a failed
+        // lookup, but it is reported the same way the file already reports a
+        // missing member or topology view.
+        expect(byLabel['group.acceptedLayoutIdentity']?.value).toBe('none');
+        expect(byLabel['group.acceptedLayoutIdentity']?.certainty).toBe('unavailable');
+    });
+
+    // A status from a spent series describes a layout the group has moved
+    // past; it is still shown, because that staleness is often the thing
+    // being debugged, but it must not be called exact.
+    it('downgrades a status whose series the group has left', () => {
+        const narrative = narrativeFor({
+            formationEpoch: 6,
+            activationStatus: {
+                condition: 'active',
+                coverageRate: 1,
+                coverageBasisLayoutIdentity: {
+                    groupRevision: 9,
+                    presenceRevision: 2,
+                    version: 3,
+                    state: 'active'
+                },
+                formationEpoch: 4,
+                evidenceWatermark: null,
+                confirmedAtEpochMs: NOW - 900
+            }
+        });
         const condition = narrative.facts.find((f) => f.label === 'group.activationCondition');
 
-        expect(condition?.value).toBe('unconfirmed');
-        expect(condition?.certainty).toBe('unavailable');
+        expect(condition?.value).toBe('active');
+        expect(condition?.certainty).toBe('inferred');
     });
 
     it('reports the confirmed status the writer stored', () => {
         const narrative = narrativeFor({
+            // Same series as the status, so it is current rather than stale.
+            formationEpoch: 4,
             activationStatus: {
                 condition: 'degraded',
                 coverageRate: 0.6,

--- a/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { projectGroupAdminSupportNarrative } from '@shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts';
+import type { AdminSupportJsonValue } from '@shared/api/admin-support/admin-support-types.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { createTestGroup } from '../../../create-test-group.ts';
@@ -107,7 +108,9 @@ function narrativeFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>)
     });
 }
 
-function factsFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>): Record<string, unknown> {
+function factsFor(
+    overrides: Partial<Parameters<typeof createTestGroup>[0]>
+): Record<string, AdminSupportJsonValue> {
     return Object.fromEntries(narrativeFor(overrides).facts.map((f) => [f.label, f.value]));
 }
 

--- a/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { projectGroupAdminSupportNarrative } from '@shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts';
 import type { AdminSupportJsonValue } from '@shared/api/admin-support/admin-support-types.ts';
+import { resolveGroupLifecyclePolicyPreset } from '@shared/api/group-lifecycle/group-lifecycle-policy-presets.ts';
+import type { GroupLifecyclePolicy } from '@shared/api/group-lifecycle/group-lifecycle-policy.ts';
 import type { GroupSnapshot } from '@shared/api/group-types.ts';
 
 import { createTestGroup } from '../../../create-test-group.ts';
@@ -111,17 +113,56 @@ describe('the group narrative reports the lifecycle plane', () => {
         expect(byLabel['group.activationCoverageBasis']?.value).toBe('active r9/2 v3');
     });
 
-    // Product decision 38: a parked series keeps its admission posture, so the
-    // lobby looks open while nothing will dial. That is the state an operator
-    // is least likely to guess.
-    it('warns that a parked series looks open but will not dial', () => {
-        const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 2 });
+    // The valve is only half the gate: under `blocked-until-active` the
+    // forward gate composes with it, so `flowing` alone does not mean data
+    // flows (product decision 25).
+    it('reports the data gate, not just the valve', () => {
+        const match = resolveGroupLifecyclePolicyPreset('match');
+
+        expect(factsFor({ lifecycleState: 'connecting', transportState: 'flowing' }, match)['group.dataGate'])
+            .toBe('blocked');
+        expect(factsFor({ lifecycleState: 'active', transportState: 'flowing' }, match)['group.dataGate'])
+            .toBe('flows');
+        expect(factsFor({ lifecycleState: 'active', transportState: 'halted' }, match)['group.dataGate'])
+            .toBe('halted');
+    });
+
+    it('reports the remediation axis as inferred, because it cannot see the planning fingerprint', () => {
+        const narrative = narrativeFor({ lifecycleState: 'dormant', formationAttemptCount: 3 });
+        const remediation = narrative.facts.find((f) => f.label === 'group.activationRemediation');
+
+        // An exhausted series in dormant is the application's move.
+        expect(remediation?.value).toBe('awaiting-application');
+        expect(remediation?.certainty).toBe('inferred');
+    });
+
+    it('degrades the policy-fed facts rather than lying when the policy is unreadable', () => {
+        const facts = factsFor({ lifecycleState: 'active' }, null);
+
+        for (const label of ['group.dataGate', 'group.activationRemediation', 'group.maxFormationAttempts']) {
+            expect(facts[label]).toBe('unreadable');
+        }
+    });
+
+    // Decision 37: the spent series denies a fresh `start` until a reset. No
+    // claim is made about admission -- decision 38 keeps the policy's posture,
+    // so a closed lobby stays closed.
+    it('warns that a spent series will not dial until a reset', () => {
+        const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 3 });
 
         expect(codes).toContain('group-formation-series-parked');
     });
 
     it('does not call a never-started group parked', () => {
         const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 0 });
+
+        expect(codes).not.toContain('group-formation-series-parked');
+    });
+
+    // Keyed on the budget, not on a non-zero count: a group part-way through
+    // its attempts is dormant with attempts spent but is not parked.
+    it('does not call a group with budget left parked', () => {
+        const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 1 });
 
         expect(codes).not.toContain('group-formation-series-parked');
     });
@@ -134,7 +175,10 @@ describe('the group narrative reports the lifecycle plane', () => {
     });
 });
 
-function narrativeFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>) {
+function narrativeFor(
+    overrides: Partial<Parameters<typeof createTestGroup>[0]>,
+    policy: GroupLifecyclePolicy | null = resolveGroupLifecyclePolicyPreset('managed')
+) {
     const snapshot: GroupSnapshot = {
         causalRevision: { groupRevision: 7, presenceRevision: 3 },
         group: createTestGroup({ ...GROUP_REF, displayName: 'Room 1', ...overrides }),
@@ -150,16 +194,22 @@ function narrativeFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>)
         topologyView: undefined,
         hasGroupStateService: true,
         hasTopologyQuery: true,
+        hasLifecyclePolicyReader: true,
+        policy,
         generatedAtEpochMs: NOW
     });
 }
 
 function factsFor(
-    overrides: Partial<Parameters<typeof createTestGroup>[0]>
+    overrides: Partial<Parameters<typeof createTestGroup>[0]>,
+    policy?: GroupLifecyclePolicy | null
 ): Record<string, AdminSupportJsonValue> {
-    return Object.fromEntries(narrativeFor(overrides).facts.map((f) => [f.label, f.value]));
+    return Object.fromEntries(narrativeFor(overrides, policy).facts.map((f) => [f.label, f.value]));
 }
 
-function warningCodesFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>): readonly string[] {
-    return narrativeFor(overrides).warnings.map((w) => w.code);
+function warningCodesFor(
+    overrides: Partial<Parameters<typeof createTestGroup>[0]>,
+    policy?: GroupLifecyclePolicy | null
+): readonly string[] {
+    return narrativeFor(overrides, policy).warnings.map((w) => w.code);
 }

--- a/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
+++ b/packages/tests/shared-server/rallar-system/admin-support/group-lifecycle-narrative.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectGroupAdminSupportNarrative } from '@shared-server/rallar-system/admin-support/narratives/project-group-admin-support-narrative.ts';
+import type { GroupSnapshot } from '@shared/api/group-types.ts';
+
+import { createTestGroup } from '../../../create-test-group.ts';
+
+const GROUP_REF = { applicationId: 'ar-eye-hunter', workspaceId: 'default', groupId: 'room-1' };
+const NOW = 1_000_000;
+
+/**
+ * The operator surface for the lifecycle plane (slice 13). These are the facts
+ * a support engineer cannot get any other way: which stage the group is in,
+ * which layout carries traffic, whether application data is flowing, and what
+ * the group is telling its members about its own connectivity.
+ */
+describe('the group narrative reports the lifecycle plane', () => {
+    it('names the stage, series, valve and accepted layout', () => {
+        const facts = factsFor({
+            lifecycleState: 'active',
+            formationEpoch: 4,
+            formationAttemptCount: 1,
+            transportState: 'flowing',
+            acceptedLayoutIdentity: { groupRevision: 9, presenceRevision: 2, version: 3, state: 'active' }
+        });
+
+        expect(facts['group.lifecycleState']).toBe('active');
+        expect(facts['group.formationEpoch']).toBe(4);
+        expect(facts['group.transportState']).toBe('flowing');
+        // The tuple, never a bare version (product decision 29), so two
+        // identities can be told apart by a reader.
+        expect(facts['group.acceptedLayoutIdentity']).toBe('active r9/2 v3');
+    });
+
+    it('reports an unconfirmed status as unavailable rather than inventing a band', () => {
+        const narrative = narrativeFor({ activationStatus: null });
+        const condition = narrative.facts.find((f) => f.label === 'group.activationCondition');
+
+        expect(condition?.value).toBe('unconfirmed');
+        expect(condition?.certainty).toBe('unavailable');
+    });
+
+    it('reports the confirmed status the writer stored', () => {
+        const narrative = narrativeFor({
+            activationStatus: {
+                condition: 'degraded',
+                coverageRate: 0.6,
+                coverageBasisLayoutIdentity: {
+                    groupRevision: 9,
+                    presenceRevision: 2,
+                    version: 3,
+                    state: 'active'
+                },
+                formationEpoch: 4,
+                evidenceWatermark: { version: 11, createdAtEpochMs: NOW - 500 },
+                confirmedAtEpochMs: NOW - 100
+            }
+        });
+        const byLabel = Object.fromEntries(narrative.facts.map((f) => [f.label, f]));
+
+        expect(byLabel['group.activationCondition']?.value).toBe('degraded');
+        expect(byLabel['group.activationCondition']?.certainty).toBe('exact');
+        expect(byLabel['group.activationCoverageRate']?.value).toBe(0.6);
+        expect(byLabel['group.activationCoverageBasis']?.value).toBe('active r9/2 v3');
+    });
+
+    // Product decision 38: a parked series keeps its admission posture, so the
+    // lobby looks open while nothing will dial. That is the state an operator
+    // is least likely to guess.
+    it('warns that a parked series looks open but will not dial', () => {
+        const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 2 });
+
+        expect(codes).toContain('group-formation-series-parked');
+    });
+
+    it('does not call a never-started group parked', () => {
+        const codes = warningCodesFor({ lifecycleState: 'dormant', formationAttemptCount: 0 });
+
+        expect(codes).not.toContain('group-formation-series-parked');
+    });
+
+    // The valve is orthogonal to the stage (product decision 25), so an active
+    // group can be carrying no application data at all.
+    it('warns that a halted group carries no application data', () => {
+        expect(warningCodesFor({ transportState: 'halted' })).toContain('group-transport-halted');
+        expect(warningCodesFor({ transportState: 'flowing' })).not.toContain('group-transport-halted');
+    });
+});
+
+function narrativeFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>) {
+    const snapshot: GroupSnapshot = {
+        causalRevision: { groupRevision: 7, presenceRevision: 3 },
+        group: createTestGroup({ ...GROUP_REF, displayName: 'Room 1', ...overrides }),
+        members: [],
+        activeSessions: [],
+        memberCount: 0,
+        onlineMemberCount: 0
+    };
+    return projectGroupAdminSupportNarrative({
+        request: { groupRef: GROUP_REF },
+        snapshot,
+        recentEvents: [],
+        topologyView: undefined,
+        hasGroupStateService: true,
+        hasTopologyQuery: true,
+        generatedAtEpochMs: NOW
+    });
+}
+
+function factsFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>): Record<string, unknown> {
+    return Object.fromEntries(narrativeFor(overrides).facts.map((f) => [f.label, f.value]));
+}
+
+function warningCodesFor(overrides: Partial<Parameters<typeof createTestGroup>[0]>): readonly string[] {
+    return narrativeFor(overrides).warnings.map((w) => w.code);
+}


### PR DESCRIPTION
An operator asking about a group could see its status, members and topology — but nothing about the plane the last several slices built. `explainGroup` now carries it.

## Facts

- `group.lifecycleState`, `group.formationEpoch`, `group.formationAttemptCount` — which stage, which series, how far into its attempt budget
- `group.transportState` — whether application data is flowing
- `group.acceptedLayoutIdentity` — the layout carrying traffic
- `group.activationCondition`, `group.activationCoverageRate`, `group.activationCoverageBasis` — what the group is telling its members about its own connectivity

Layout identities render as the **tuple, never a bare version** (product decision 29), so a reader can tell a re-plan from a re-publish. The status reads `unconfirmed` with `certainty: 'unavailable'` until the writer has stored one, rather than inventing a band no clock has observed.

## Warnings

Two states an operator is unlikely to guess:

- **`group-formation-series-parked`** — a series parked in `dormant` keeps its admission posture (product decision 38), so the lobby looks open while nothing will dial. Guarded on `formationAttemptCount > 0` so a never-started group isn't called parked.
- **`group-transport-halted`** — the valve is orthogonal to the stage (product decision 25), so an `active` group can be carrying no application data at all.

**A third warning was written and removed.** An active group with no confirmed status is the normal transient right after activation — warning on it would cry wolf on every activation. The fact already reports it with `unavailable` certainty, which is the honest signal without implying something is wrong.

## Verification

- 6 new tests, and they **discriminate**: stubbing the identity summary back to a bare version and dropping the parked warning fails 3 of the 6
- `admin-support` suite 20/20; `shared` + `shared-server` + `repo`: 6803 passing
- Full `typecheck` clean, `check:repo-style:changed` clean (0 findings)
- Three failures in the broad run are unrelated: the two known `listen EPERM` sandbox port-bind files, and `al-indexeddb-runtime-stores` which passes 3/3 in isolation (a flake under parallel load, and it references nothing this branch touches)

Remaining in slice 13: the `group-lifecycle-stages` workbench collection and the rooms-diagnostic stage column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)