### PR TITLE
feat(workbench): drive the lifecycle stages by hand (slice 13)

### DIFF
--- a/apps/rallar-black-box/src/rallar-server-workbench/create-rallar-server-rest-collection-templates.ts
+++ b/apps/rallar-black-box/src/rallar-server-workbench/create-rallar-server-rest-collection-templates.ts
@@ -95,6 +95,149 @@ export function createRallarServerRestCollectionTemplates(
             ]
         },
         {
+            collectionId: 'group-lifecycle-stages',
+            name: 'Group lifecycle stages',
+            description: 'Drive a phased group through plan, connect and activate by hand, then pause and ' +
+                'resume its transport, reading the stage and observed condition at each step.',
+            variables: baseVariables,
+            steps: [
+                {
+                    stepId: 'create-phased-group',
+                    label: 'Create phased group',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json',
+                        body: {
+                            groupId: '{{groupId}}',
+                            displayName: '{{groupId}}',
+                            description: 'Created by rallar-black-box lifecycle collection',
+                            kind: 'room',
+                            joinMode: 'open',
+                            createdByPrincipalId: '{{principalId}}',
+                            // `manual` triggers throughout: the point of this
+                            // collection is that an operator drives each
+                            // boundary by hand, so nothing may auto-advance
+                            // between the steps (product decision 8).
+                            lifecyclePolicy: {
+                                preset: 'managed',
+                                establishment: {
+                                    planTrigger: { kind: 'manual' },
+                                    connectTrigger: { kind: 'manual' }
+                                },
+                                activation: { mode: 'manual' },
+                                admission: { mode: 'open' }
+                            }
+                        }
+                    },
+                    expect: {
+                        status: [200, 201, 409],
+                        body: [
+                            {
+                                path: '$.group.lifecycleState',
+                                equals: 'forming'
+                            }
+                        ]
+                    }
+                },
+                {
+                    stepId: 'plan-layout',
+                    label: 'Plan layout',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/{{groupId}}/plan/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json'
+                    },
+                    expect: {
+                        status: [200, 201]
+                    }
+                },
+                {
+                    stepId: 'connect-layout',
+                    label: 'Connect the planned layout',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/{{groupId}}/connect/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json'
+                    },
+                    expect: {
+                        status: [200, 201]
+                    }
+                },
+                {
+                    stepId: 'read-formation',
+                    label: 'Read formation view',
+                    request: {
+                        method: 'GET',
+                        path: stateCollectionPath('/groups/{{groupId}}/formation'),
+                        attachAuth: true,
+                        responseBodyMode: 'json'
+                    },
+                    expect: {
+                        status: 200
+                    },
+                    extract: [
+                        {
+                            name: 'observedLifecycleState',
+                            path: '$.lifecycleState'
+                        },
+                        {
+                            name: 'observedCondition',
+                            path: '$.condition'
+                        },
+                        {
+                            name: 'observedFormationEpoch',
+                            path: '$.formationEpoch'
+                        }
+                    ]
+                },
+                {
+                    stepId: 'pause-transport',
+                    label: 'Pause transport',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/{{groupId}}/transport/pause/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json'
+                    },
+                    expect: {
+                        status: [200, 201],
+                        body: [
+                            {
+                                // The valve is orthogonal to the stage
+                                // (product decision 25): pausing must not move
+                                // the group off the stage it reached.
+                                path: '$.group.transportState',
+                                equals: 'halted'
+                            }
+                        ]
+                    }
+                },
+                {
+                    stepId: 'resume-transport',
+                    label: 'Resume transport',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/{{groupId}}/transport/resume/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json'
+                    },
+                    expect: {
+                        status: [200, 201],
+                        body: [
+                            {
+                                path: '$.group.transportState',
+                                equals: 'flowing'
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
             collectionId: 'client-presence-lifecycle',
             name: 'Client presence lifecycle',
             description: 'Upsert client state, connect presence, and list client/group events.',

--- a/apps/rallar-black-box/src/rallar-server-workbench/create-rallar-server-rest-collection-templates.ts
+++ b/apps/rallar-black-box/src/rallar-server-workbench/create-rallar-server-rest-collection-templates.ts
@@ -98,8 +98,17 @@ export function createRallarServerRestCollectionTemplates(
             collectionId: 'group-lifecycle-stages',
             name: 'Group lifecycle stages',
             description: 'Drive a phased group through plan, connect and activate by hand, then pause and ' +
-                'resume its transport, reading the stage and observed condition at each step.',
-            variables: baseVariables,
+                'resume its transport, reading the stage and observed condition at each step. ' +
+                'The layout read between plan and connect is not optional: connect is fenced on ' +
+                'the exact identity of the candidate it means to dial, and the workbench does ' +
+                'not poll, so re-run that step until the snapshot reads active.',
+            variables: {
+                ...baseVariables,
+                // Its own group: sharing one with the membership collection
+                // would 409 the create and leave the operator driving whatever
+                // policy that group already had.
+                groupId: `${variables.groupId}-lifecycle`
+            },
             steps: [
                 {
                     stepId: 'create-phased-group',
@@ -116,10 +125,10 @@ export function createRallarServerRestCollectionTemplates(
                             kind: 'room',
                             joinMode: 'open',
                             createdByPrincipalId: '{{principalId}}',
-                            // `manual` triggers throughout: the point of this
-                            // collection is that an operator drives each
-                            // boundary by hand, so nothing may auto-advance
-                            // between the steps (product decision 8).
+                            // `managed` is the one preset with a mixed manual
+                            // plan and immediate connect, so both triggers are
+                            // pinned manual here: an operator driving each
+                            // boundary must not race the server to it.
                             lifecyclePolicy: {
                                 preset: 'managed',
                                 establishment: {
@@ -132,13 +141,10 @@ export function createRallarServerRestCollectionTemplates(
                         }
                     },
                     expect: {
-                        status: [200, 201, 409],
-                        body: [
-                            {
-                                path: '$.group.lifecycleState',
-                                equals: 'forming'
-                            }
-                        ]
+                        // No body assertion beside the 409: a conflict returns
+                        // a mutation failure with no `group`, so asserting the
+                        // stage here would fail every re-run.
+                        status: [200, 201, 409]
                     }
                 },
                 {
@@ -146,25 +152,86 @@ export function createRallarServerRestCollectionTemplates(
                     label: 'Plan layout',
                     request: {
                         method: 'POST',
-                        path: stateCollectionPath('/groups/{{groupId}}/plan/requests/{{requestId}}'),
+                        path: stateCollectionPath('/groups/{{groupId}}/lifecycle/plan/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json',
+                        body: {}
+                    },
+                    expect: {
+                        status: 200
+                    },
+                    extract: [
+                        {
+                            name: 'plannedFormationEpoch',
+                            path: '$.group.formationEpoch'
+                        }
+                    ]
+                },
+                {
+                    stepId: 'read-planned-layout',
+                    label: 'Read planned layout',
+                    request: {
+                        method: 'GET',
+                        path: stateCollectionPath('/groups/{{groupId}}/topology'),
                         attachAuth: true,
                         responseBodyMode: 'json'
                     },
                     expect: {
-                        status: [200, 201]
-                    }
+                        status: 200,
+                        body: [
+                            {
+                                path: '$.snapshot.state',
+                                equals: 'active'
+                            }
+                        ]
+                    },
+                    extract: [
+                        {
+                            name: 'plannedGroupRevision',
+                            path: '$.snapshot.sourceGroupStateCausalRevision.groupRevision'
+                        },
+                        {
+                            name: 'plannedPresenceRevision',
+                            path: '$.snapshot.sourceGroupStateCausalRevision.presenceRevision'
+                        },
+                        { name: 'plannedVersion', path: '$.snapshot.version' },
+                        { name: 'plannedState', path: '$.snapshot.state' }
+                    ]
                 },
                 {
                     stepId: 'connect-layout',
                     label: 'Connect the planned layout',
                     request: {
                         method: 'POST',
-                        path: stateCollectionPath('/groups/{{groupId}}/connect/requests/{{requestId}}'),
+                        path: stateCollectionPath('/groups/{{groupId}}/lifecycle/connect/requests/{{requestId}}'),
                         attachAuth: true,
-                        responseBodyMode: 'json'
+                        responseBodyMode: 'json',
+                        body: {
+                            expectedFormationEpoch: '{{plannedFormationEpoch}}',
+                            expectedLayout: {
+                                groupRevision: '{{plannedGroupRevision}}',
+                                presenceRevision: '{{plannedPresenceRevision}}',
+                                version: '{{plannedVersion}}',
+                                state: '{{plannedState}}'
+                            }
+                        }
                     },
                     expect: {
-                        status: [200, 201]
+                        status: 200
+                    }
+                },
+                {
+                    stepId: 'activate-layout',
+                    label: 'Activate the dialed layout',
+                    request: {
+                        method: 'POST',
+                        path: stateCollectionPath('/groups/{{groupId}}/lifecycle/activate/requests/{{requestId}}'),
+                        attachAuth: true,
+                        responseBodyMode: 'json',
+                        body: {}
+                    },
+                    expect: {
+                        status: 200
                     }
                 },
                 {
@@ -180,18 +247,9 @@ export function createRallarServerRestCollectionTemplates(
                         status: 200
                     },
                     extract: [
-                        {
-                            name: 'observedLifecycleState',
-                            path: '$.lifecycleState'
-                        },
-                        {
-                            name: 'observedCondition',
-                            path: '$.condition'
-                        },
-                        {
-                            name: 'observedFormationEpoch',
-                            path: '$.formationEpoch'
-                        }
+                        { name: 'observedLifecycleState', path: '$.lifecycleState' },
+                        { name: 'observedCondition', path: '$.condition' },
+                        { name: 'observedFormationEpoch', path: '$.formationEpoch' }
                     ]
                 },
                 {
@@ -199,17 +257,15 @@ export function createRallarServerRestCollectionTemplates(
                     label: 'Pause transport',
                     request: {
                         method: 'POST',
-                        path: stateCollectionPath('/groups/{{groupId}}/transport/pause/requests/{{requestId}}'),
+                        path: stateCollectionPath('/groups/{{groupId}}/lifecycle/pause/requests/{{requestId}}'),
                         attachAuth: true,
-                        responseBodyMode: 'json'
+                        responseBodyMode: 'json',
+                        body: {}
                     },
                     expect: {
-                        status: [200, 201],
+                        status: 200,
                         body: [
                             {
-                                // The valve is orthogonal to the stage
-                                // (product decision 25): pausing must not move
-                                // the group off the stage it reached.
                                 path: '$.group.transportState',
                                 equals: 'halted'
                             }
@@ -221,12 +277,13 @@ export function createRallarServerRestCollectionTemplates(
                     label: 'Resume transport',
                     request: {
                         method: 'POST',
-                        path: stateCollectionPath('/groups/{{groupId}}/transport/resume/requests/{{requestId}}'),
+                        path: stateCollectionPath('/groups/{{groupId}}/lifecycle/resume/requests/{{requestId}}'),
                         attachAuth: true,
-                        responseBodyMode: 'json'
+                        responseBodyMode: 'json',
+                        body: {}
                     },
                     expect: {
-                        status: [200, 201],
+                        status: 200,
                         body: [
                             {
                                 path: '$.group.transportState',

--- a/docs/test-structure-coupling-exceptions.md
+++ b/docs/test-structure-coupling-exceptions.md
@@ -128,6 +128,14 @@ moved or changed test.
       "coverageRelation": "The named schema test parses and validates the exact published fixture, application example, compatibility corpus, or guide example represented by this filesystem occurrence."
     },
     {
+      "id": "workbench-collection-served-paths",
+      "domain": "Rallar server workbench collection addressing",
+      "owner": "Shared Test maintainers",
+      "summary": "Every workbench REST collection step addresses a path and method the API actually serves. Executable assertion: \u201caddresses paths the API actually serves\u201d.",
+      "semanticCoverage": "packages/tests/rallar-black-box/rallar-server-workbench.test.ts#addresses paths the API actually serves",
+      "coverageRelation": "The collections are hand-written HTTP paths that nothing executes in CI, so a wrong one is invisible until an operator clicks it and receives a 404. This assertion reads the shipped OpenAPI document \u2014 the published contract, not an internal structure \u2014 and requires a served path and method for every step. No behavioural test can substitute: the collections are operator inputs, never executed by the suite."
+    },
+    {
       "id": "control-protocol-browser-boundary",
       "domain": "Distributed monitor production ownership",
       "owner": "Shared Test maintainers",
@@ -1496,6 +1504,17 @@ moved or changed test.
     }
   ],
   "entries": [
+    {
+      "id": "test-structure-coupling-7f88b9c9cc3c1256",
+      "path": "packages/tests/rallar-black-box/rallar-server-workbench.test.ts",
+      "kind": "production-source-read",
+      "contract": "workbench-collection-served-paths",
+      "disposition": "durable-boundary",
+      "boundary": "public",
+      "owner": "Shared Test maintainers",
+      "rationale": "Reads the shipped OpenAPI document so a workbench collection cannot ship a path the API does not serve; the collections are operator inputs that no suite executes.",
+      "semanticCoverage": "packages/tests/rallar-black-box/rallar-server-workbench.test.ts#addresses paths the API actually serves"
+    },
     {
       "id": "test-structure-coupling-a5d5fdeb1214727a",
       "path": "packages/shared-rtc-bench/tests/architecture/rtc-benchmark-navigation-contract.test.ts",

--- a/packages/tests/rallar-black-box/rallar-server-workbench.test.ts
+++ b/packages/tests/rallar-black-box/rallar-server-workbench.test.ts
@@ -336,7 +336,7 @@ describe('rallar-black-box Rallar Server workbench helpers', () => {
         const collectionMutationSteps = createRallarServerRestCollectionTemplates(
             defaultRallarServerWorkbenchVariables({})
         ).flatMap((collection) => collection.steps.filter((step) => step.request.method !== 'GET'));
-        expect(collectionMutationSteps).toHaveLength(9);
+        expect(collectionMutationSteps).toHaveLength(14);
         for (const step of collectionMutationSteps) {
             expect(step.request.path, step.stepId).toMatch(/\/requests\/\{\{requestId\}\}$/u);
             expect(step.request.body).not.toMatchObject({ requestId: expect.anything() });
@@ -526,5 +526,43 @@ describe('rallar-black-box Rallar Server workbench helpers', () => {
         });
         expect(recipe.commands[0].metadata?.restCollection?.attachAuth).toBe(true);
         expect(recipe.commands[2].metadata?.restCollection?.expect).toBeDefined();
+    });
+    // Slice 13: the cheapest way to drive the stage machine by hand before the
+    // live-RTC specs exist.
+    it('drives every lifecycle boundary manually in the stage collection', () => {
+        const collection = createRallarServerRestCollectionTemplates(
+            defaultRallarServerWorkbenchVariables({})
+        ).find((entry) => entry.collectionId === 'group-lifecycle-stages');
+
+        expect(collection).toBeDefined();
+        expect(collection!.steps.map((step) => step.stepId)).toEqual([
+            'create-phased-group',
+            'plan-layout',
+            'connect-layout',
+            'read-formation',
+            'pause-transport',
+            'resume-transport'
+        ]);
+
+        // Nothing may auto-advance between the steps, or the operator is
+        // reading a stage the server reached on its own (product decision 8).
+        expect(collection!.steps[0]!.request.body).toMatchObject({
+            lifecyclePolicy: {
+                establishment: {
+                    planTrigger: { kind: 'manual' },
+                    connectTrigger: { kind: 'manual' }
+                },
+                activation: { mode: 'manual' }
+            }
+        });
+
+        // The valve is orthogonal to the stage (product decision 25): the
+        // pause and resume steps assert the transport moved and say nothing
+        // about the lifecycle state.
+        const valveSteps = collection!.steps.filter((step) => step.stepId.endsWith('-transport'));
+        expect(valveSteps.flatMap((step) => step.expect?.body ?? [])).toEqual([
+            { path: '$.group.transportState', equals: 'halted' },
+            { path: '$.group.transportState', equals: 'flowing' }
+        ]);
     });
 });

--- a/packages/tests/rallar-black-box/rallar-server-workbench.test.ts
+++ b/packages/tests/rallar-black-box/rallar-server-workbench.test.ts
@@ -1,3 +1,6 @@
+import { load as loadYaml } from 'js-yaml';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
     applyRallarServerEndpointPreset,
@@ -336,7 +339,7 @@ describe('rallar-black-box Rallar Server workbench helpers', () => {
         const collectionMutationSteps = createRallarServerRestCollectionTemplates(
             defaultRallarServerWorkbenchVariables({})
         ).flatMap((collection) => collection.steps.filter((step) => step.request.method !== 'GET'));
-        expect(collectionMutationSteps).toHaveLength(14);
+        expect(collectionMutationSteps).toHaveLength(15);
         for (const step of collectionMutationSteps) {
             expect(step.request.path, step.stepId).toMatch(/\/requests\/\{\{requestId\}\}$/u);
             expect(step.request.body).not.toMatchObject({ requestId: expect.anything() });
@@ -538,7 +541,11 @@ describe('rallar-black-box Rallar Server workbench helpers', () => {
         expect(collection!.steps.map((step) => step.stepId)).toEqual([
             'create-phased-group',
             'plan-layout',
+            // Connect is fenced on the exact planned identity, so the layout
+            // read between them is load-bearing, not a convenience.
+            'read-planned-layout',
             'connect-layout',
+            'activate-layout',
             'read-formation',
             'pause-transport',
             'resume-transport'
@@ -565,4 +572,39 @@ describe('rallar-black-box Rallar Server workbench helpers', () => {
             { path: '$.group.transportState', equals: 'flowing' }
         ]);
     });
+    /**
+     * The collections are hand-written HTTP paths that nothing executes in
+     * CI, so a wrong one is invisible until an operator clicks it. This
+     * checks every step against the served contract instead.
+     */
+    it('addresses paths the API actually serves', () => {
+        const openApi = loadYaml(
+            readFileSync(path.join(process.cwd(), 'apps/api-v1/resources/api-v1-openapi.yaml'), 'utf8')
+        ) as OpenApiPaths;
+        const served = new Set(Object.keys(openApi.paths));
+
+        const steps = createRallarServerRestCollectionTemplates(
+            defaultRallarServerWorkbenchVariables({})
+        ).flatMap((collection) => collection.steps);
+
+        for (const step of steps) {
+            const templated = step.request.path.replaceAll(/\{\{(\w+)\}\}/gu, '{$1}');
+            const candidates = [...served].filter((servedPath) => toPathShape(servedPath) === toPathShape(templated));
+            expect(candidates, `${step.stepId} -> ${step.request.path}`).not.toHaveLength(0);
+            const methods = served.has(candidates[0]!)
+                ? Object.keys(openApi.paths[candidates[0]!]!)
+                : [];
+            expect(methods, `${step.stepId} method`).toContain(step.request.method.toLowerCase());
+        }
+    });
 });
+
+/** Path parameter names differ between the workbench and the spec; shapes do not. */
+function toPathShape(value: string): string {
+    return value.replaceAll(/\{[^}]+\}/gu, '{}');
+}
+
+/** Only the path keys and their method keys are read here. */
+interface OpenApiPaths {
+    readonly paths: Record<string, object>;
+}


### PR DESCRIPTION
The last operator surface slice 13 names. An engineer can walk a phased group through **plan → connect → activate**, read the stage and observed condition, then **pause and resume** its transport — the cheapest way to exercise a held reconfiguration or a paused valve before the live-RTC specs exist.

## Design points that are load-bearing

**Every trigger is manual.** Under any other preset the group advances itself between the steps (product decision 8), and the operator ends up reading a stage the *server* reached rather than one they drove. The test pins this, because a preset change would silently turn the collection into a spectator.

**The valve steps assert transport and say nothing about the stage.** The valve is orthogonal to the stage (product decision 25); asserting a lifecycle state there would encode the opposite of what the decision says.

**No request-id suffixes.** The workbench pins every collection mutation to a path ending exactly in `/requests/{{requestId}}`, and identity is already scoped per route — which is why the existing collections reuse one id across steps. My first attempt used `-plan`/`-connect` suffixes and the strict-path test caught it.

## Verification

- `rallar-server-workbench.test.ts` — 16 passing, including a new test that pins the step order, the manual triggers, and the valve-only assertions
- Full `typecheck` clean; `check:repo-style:changed` **0 findings**
- `rallar-black-box` + `repo`: 2791 passing; the two failures are the known sandbox `/tmp` and live-RTC files, which reference nothing here

One thing worth noting: my new test initially tripped `boundary.unknown` **twice** — once for my own cast (removed in favour of `toMatchObject`) and once for *pre-existing* code whose line number my insertion had shifted, re-keying it as a new finding. Moving the test to the end of the file left the existing findings where they were.

This completes slice 13 alongside #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)