### PR TITLE
fix(topology): a commanded reconfigure must not be frozen as automatic

### DIFF
--- a/apps/api-v1/test/db/pglite-topology-test-runtime.ts
+++ b/apps/api-v1/test/db/pglite-topology-test-runtime.ts
@@ -249,6 +249,8 @@ async function persistAndReserveTopologyWork(
             groupSnapshot,
             effectKind: 'rtc-topology-recompute',
             payloadKind: 'group-revision',
+            // A plain recompute, not a commanded reconfigure.
+            origin: 'automatic',
             createdAtEpochMs: nowEpochMs,
             expireAtEpochMs: FUTURE_MS,
             senderId: 'owner',

--- a/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
+++ b/packages/shared-server/rallar-system/topology/config/mutation/topology-config-mutation-receipt.ts
@@ -186,6 +186,10 @@ function createTopologyConfigOutbox(
         groupSnapshot: topologyWrite.read.groupSnapshot,
         effectKind: 'rtc-topology-recompute',
         payloadKind: 'group-revision',
+        // Unchanged: a config write asks for different settings, not for a
+        // replan now, so `commanded` still holds its follow-up. Making this
+        // commanded is a product decision, not a mechanical one.
+        origin: 'automatic',
         expireAtEpochMs: 253_402_300_799_999,
         senderId: topologyWrite.command.input.updatedByPrincipalId,
         resourceId: outboxResourceId,

--- a/packages/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/topology/mutation/rtc-topology-outbox-entry.ts
@@ -37,6 +37,13 @@ export type ComputedRtcTopologyOutbox =
         & ComputedRtcTopologyOutboxBase
         & Readonly<{
             payloadKind: 'group-revision';
+            /**
+             * Who asked. The planner freezes `automatic` work under
+             * `commanded` and `corrupt` replanning, so an application command
+             * that arrives stamped `automatic` is discarded by exactly the
+             * mode that exists to honour it (product decision 4).
+             */
+            origin: 'automatic' | 'commanded';
         }>
     )
     | (
@@ -113,7 +120,7 @@ export function computeRtcTopologyEntry(computed: ComputedRtcTopologyOutbox): Re
             ...commonWork,
             kind: 'group-revision',
             sourceGroupStateCausalRevision,
-            origin: 'automatic'
+            origin: computed.origin
         };
     const envelope: RtcTopologyWorkEnvelope = {
         type: AppOutboxType.RTC_TOPOLOGY_RECOMPUTE,

--- a/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts
+++ b/packages/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.ts
@@ -75,6 +75,9 @@ export class GroupTopologyReconfigureMutation {
             groupSnapshot: snapshot,
             effectKind: 'rtc-topology-recompute',
             payloadKind: 'group-revision',
+            // The route exists to command a replan, so it must not be frozen
+            // by the replanning mode that only runs commanded work.
+            origin: 'commanded',
             createdAtEpochMs: command.capturedAtEpochMs,
             expireAtEpochMs: 253_402_300_799_999,
             senderId: command.actorPrincipalId,

--- a/packages/tests/shared-server/integration/postgres/topology-app-outbox-concurrency.test.ts
+++ b/packages/tests/shared-server/integration/postgres/topology-app-outbox-concurrency.test.ts
@@ -50,6 +50,7 @@ describe('Postgres topology APP_OUTBOX concurrency', () => {
                     groupSnapshot,
                     effectKind: 'rtc-topology-recompute',
                     payloadKind: 'group-revision',
+                    origin: 'automatic',
                     createdAtEpochMs: atEpochMs + index,
                     expireAtEpochMs: atEpochMs + 60_000 + index,
                     senderId: 'postgres-topology-concurrency',

--- a/packages/tests/shared-server/integration/postgres/topology-frozen-work.test.ts
+++ b/packages/tests/shared-server/integration/postgres/topology-frozen-work.test.ts
@@ -153,6 +153,7 @@ async function runTopologyWork(input: RunTopologyWorkInput): Promise<void> {
         groupSnapshot,
         effectKind: 'rtc-topology-recompute',
         payloadKind: 'group-revision',
+        origin: 'automatic',
         createdAtEpochMs: atEpochMs,
         expireAtEpochMs: atEpochMs + 60_000,
         senderId: 'topology-frozen-test',

--- a/packages/tests/shared-server/rallar-system/app-outbox/direct-resource-outbox.test.ts
+++ b/packages/tests/shared-server/rallar-system/app-outbox/direct-resource-outbox.test.ts
@@ -401,6 +401,7 @@ describe('direct resource outbox writes', () => {
             groupSnapshot,
             effectKind: 'rtc-topology-recompute',
             payloadKind: 'group-revision',
+            origin: 'automatic',
             senderId: 'server-1',
             resourceId: 'group-command-1:rtc-topology-recompute:group-revision:group=4;presence=3',
             requestOptions: toCanonicalGroupTopologyConfigPatch({}),
@@ -478,6 +479,7 @@ describe('direct resource outbox writes', () => {
         const computed = {
             ...createComputedRtcTopologyOutbox(),
             payloadKind: 'group-revision',
+            origin: 'automatic',
             requestOptions
         };
 
@@ -794,6 +796,7 @@ function createComputedRtcTopologyOutbox(): ComputedRtcTopologyOutbox {
         groupSnapshot,
         effectKind: 'rtc-topology-recompute' as const,
         payloadKind: 'group-revision' as const,
+        origin: 'automatic',
         senderId: 'server-1',
         resourceId: 'group-command-1:rtc-topology-recompute:group-revision:group=4;presence=3',
         requestOptions: toCanonicalGroupTopologyConfigPatch({}),

--- a/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/inbox/topology-app-inbox-handler.test.ts
@@ -487,6 +487,7 @@ function topologyOutbox(resourceId: string): ComputedRtcTopologyOutbox {
         groupSnapshot: groupSnapshot(),
         effectKind: 'rtc-topology-recompute',
         payloadKind: 'group-revision',
+        origin: 'automatic',
         createdAtEpochMs: NOW_EPOCH_MS,
         expireAtEpochMs: 2_000,
         senderId: 'owner',

--- a/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/reconfigure/group-topology-reconfigure-mutation.test.ts
@@ -21,6 +21,11 @@ describe('GroupTopologyReconfigureMutation', () => {
         expect(computed).toMatchObject({
             commandId: 'reconfigure-request',
             resourceId: 'reconfigure-request:rtc-topology-recompute:explicit',
+            // The route commands a replan, so its work must not be stamped
+            // automatic: the planner freezes automatic work under `commanded`
+            // and `corrupt`, which would discard the command in exactly the
+            // mode that exists to honour it (product decision 4).
+            origin: 'commanded',
             aggregateRef: createTopologyTestGroupRef(),
             acceptedCausalRevision: { groupRevision: 1, presenceRevision: 0 },
             effectKind: 'rtc-topology-recompute',

--- a/packages/tests/shared-server/rallar-system/topology/reconfigure/reconfigure-work-origin.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/reconfigure/reconfigure-work-origin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    resolveTopologyPlanAction,
+    type ResolveTopologyPlanActionInput
+} from '@shared-server/rallar-system/topology/planning/resolve-topology-plan-action.ts';
+
+const ACTIVE_LAYOUT = { state: 'active' } as ResolveTopologyPlanActionInput['previous'];
+
+/**
+ * Product decision 4: commanded groups advance on application commands. The
+ * `reconfigure` route exists to command a replan, so the work it enqueues must
+ * carry a commanded origin -- it was stamped `automatic`, which is precisely
+ * what `commanded` and `corrupt` replanning freeze, so the one mode that
+ * exists to honour the command was the mode that discarded it.
+ */
+describe('an application command is not frozen by the mode that honours it', () => {
+    it('plans commanded work under every replanning mode', () => {
+        for (const replanning of ['auto', 'debounced', 'commanded', 'corrupt'] as const) {
+            expect(planActionFor(replanning, 'commanded'), replanning).toBe('plan');
+        }
+    });
+
+    it('freezes automatic work only where the policy holds it', () => {
+        expect(planActionFor('auto', 'automatic')).toBe('plan');
+        expect(planActionFor('debounced', 'automatic')).toBe('plan');
+        expect(planActionFor('commanded', 'automatic')).toBe('freeze');
+        // A policy that cannot be read replans no more than `commanded` does.
+        expect(planActionFor('corrupt', 'automatic')).toBe('freeze');
+    });
+});
+
+function planActionFor(
+    replanning: ResolveTopologyPlanActionInput['replanning'],
+    workOrigin: ResolveTopologyPlanActionInput['workOrigin']
+): string {
+    return resolveTopologyPlanAction({
+        lifecycleState: 'active',
+        replanning,
+        workOrigin,
+        previous: ACTIVE_LAYOUT
+    });
+}

--- a/packages/tests/shared-server/rallar-system/topology/rtc-topology-test-fixtures.ts
+++ b/packages/tests/shared-server/rallar-system/topology/rtc-topology-test-fixtures.ts
@@ -122,6 +122,7 @@ export function createComputedRtcTopologyOutbox(): ComputedRtcTopologyOutbox {
         groupSnapshot,
         effectKind: 'rtc-topology-recompute',
         payloadKind: 'group-revision',
+        origin: 'automatic',
         senderId: 'server-1',
         resourceId: 'command-1:rtc-topology-recompute:group-revision:group=1;presence=0',
         requestOptions: toCanonicalGroupTopologyConfigPatch({}),


### PR DESCRIPTION
Slice 10a's carried-forward item. It is a **correctness bug**, not tidying.

## The bug

`computeRtcTopologyEntry` stamped **every** group-revision work item `automatic`, with no way for a producer to say otherwise:

```ts
kind: 'group-revision',
sourceGroupStateCausalRevision,
origin: 'automatic'      // hardcoded
```

And `resolveTopologyPlanAction` freezes automatic work when replanning is `commanded` or `corrupt`:

```ts
const automaticHeld = input.replanning === 'commanded' || input.replanning === 'corrupt';
return automaticHeld && input.workOrigin === 'automatic' ? 'freeze' : 'plan';
```

So an operator's **explicit reconfigure was discarded by exactly the mode that exists to honour it** — product decision 4: *"commanded groups advance on application commands."* The reconfigure producer builds `resourceId: '…:explicit'` with an `actorPrincipalId` sender, and it was being treated as background work.

The enqueue-side hold already read the origin correctly (`workOrigin === 'commanded'` short-circuits to enqueue), so the two halves of one rule disagreed.

## The fix

`origin` travels on the computed outbox and **each producer states it**, so the compiler names every site rather than one literal deciding for all of them:

- **reconfigure → `commanded`.** The route exists to command a replan.
- **config-write receipt → `automatic`, unchanged, with the reason recorded.** A config write asks for different settings, not for a replan *now*. Making it commanded is a product decision, not a mechanical one, so I left it and said so rather than changing two behaviours under one heading.
- **RTT refresh** is a different payload kind and is untouched.

## Verification

Pinned **where the bug lived** — on the producer, not the rule. The rule was already correct, so a test of it would have passed before and after. Restoring `automatic` on the reconfigure fails the compute test.

- `shared-server`: **2141 passing**; topology suites 544
- Full `typecheck` clean (five test fixtures needed the new required field), `deno task check` clean, `check:repo-style:changed` **0 findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)