### PR TITLE
fix(api-v1): publish every policy reason code, and couple the two lists

### DIFF
--- a/apps/api-v1/resources/api-v1-openapi.yaml
+++ b/apps/api-v1/resources/api-v1-openapi.yaml
@@ -3286,6 +3286,12 @@ components:
         - forbidden-role
         - last-owner
         - formation-attempts-exhausted
+        - lifecycle-transition-invalid
+        - lifecycle-manager-unavailable
+        - group-admission-closed
+        - group-admission-deadline-passed
+        - group-admission-capacity-reached
+        - group-data-blocked-until-active
 
     ErrorResponse:
       type: object

--- a/packages/tests/shared-web/rallar-group-public-contracts.test.ts
+++ b/packages/tests/shared-web/rallar-group-public-contracts.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { GROUP_POLICY_REASON_CODES } from '@shared/api/group-policy-types.ts';
+
 const repoRoot = process.cwd();
 
 const apiReference = readRepoFile('docs/rallar-api-reference.md');
@@ -36,6 +38,19 @@ describe('Rallar group public contracts', () => {
             'Room Switch Recovery',
             'RallarRoomSwitchPartialFailureError'
         ]);
+    });
+
+    /**
+     * Nothing coupled these two before, and the absence cost something real:
+     * an edge adding `formation-attempts-exhausted` to the enum was reverted
+     * twice by a blanket checkout after a formatting run, and both times the
+     * loss was silent -- no gate, no test, no type error, and once it shipped
+     * as a false claim in a delivery record.
+     */
+    it('publishes exactly the policy reason codes the const declares', () => {
+        const published = schema('GroupPolicyReasonCode').enum ?? [];
+
+        expect([...published].sort()).toEqual([...GROUP_POLICY_REASON_CODES].sort());
     });
 
     it('documents stable policy reasons and the strict read rollout switch', () => {


### PR DESCRIPTION
Slice 14's item carried from PR 9.

## The gap

The OpenAPI `GroupPolicyReasonCode` enum was **six codes behind** the TypeScript const — 16 against 22. A client generated from the contract could not name denials the server actually sends:

- `lifecycle-transition-invalid`
- `lifecycle-manager-unavailable`
- `group-admission-closed`
- `group-admission-deadline-passed`
- `group-admission-capacity-reached`
- `group-data-blocked-until-active`

The plan's "6 codes behind" figure was exact; I verified both lists in both directions before touching either.

## The six codes are the smaller half

**Nothing coupled the two lists**, and that absence had already cost an edit *twice*: adding `formation-attempts-exhausted` was reverted by a blanket `git checkout` after a formatting run — silently both times, with no gate, no test and no type error — and once it shipped as a false claim in a delivery record, caught only by review.

A test now asserts the published enum equals the const **exactly, in both directions**. Verified it works: deleting one code from the enum fails it by name.

```
× publishes exactly the policy reason codes the const declares
-   "group-data-blocked-until-active",
```

It lives beside the existing OpenAPI parsing in `rallar-group-public-contracts.test.ts`, reusing the machinery already there rather than adding a second reader.

## Verification

Full `typecheck` clean, `deno task check` clean on api-v1, `check:repo-style:changed` **0 findings**, 7 tests in that file passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)