### PR TITLE
build(deno): let the cheap check cover what the expensive one already does

### DIFF
--- a/apps/api-v1/deno.json
+++ b/apps/api-v1/deno.json
@@ -18,7 +18,7 @@
     "dev": "deno run --watch --allow-net --allow-env --allow-read src/main.ts",
     "start": "deno run --allow-net --allow-env --allow-read src/main.ts",
     "start:memory": "RALLAR_API_CONFIGURATION_PROFILE=prod-in-memory deno run --allow-net --allow-env --allow-read src/main.ts",
-    "check": "deno check src/main.ts",
+    "check": "deno check src/main.ts test/",
     "lint": "deno lint",
     "test": "deno test --allow-env --allow-read --allow-write \"--allow-run=$(deno eval 'console.log(Deno.execPath())')\"",
     "db:up": "docker compose up -d",

--- a/apps/rallar-black-box-control-server/deno.json
+++ b/apps/rallar-black-box-control-server/deno.json
@@ -11,7 +11,7 @@
   "tasks": {
     "dev": "deno run --watch --allow-net --allow-env --allow-read --allow-write src/main.ts",
     "start": "deno run --allow-net --allow-env --allow-read --allow-write src/main.ts",
-    "check": "deno check src/main.ts test/control-service.test.ts test/control-service-group-assertions.test.ts test/control-retention.test.ts test/retention-cleanup.test.ts test/retention-main-wiring.test.ts test/retention-plan-token.test.ts test/retention-query.test.ts test/swagger-routes.test.ts test/control-artifacts.test.ts test/cors.test.ts test/control-run-artifact-api.test.ts test/control-distributed-api.test.ts test/control-retention-api.test.ts",
+    "check": "deno check src/main.ts test/",
     "test": "deno test --allow-run --allow-net --allow-env --allow-read --allow-write"
   },
   "deploy": {

--- a/apps/relic-hunter-server-v1/deno.json
+++ b/apps/relic-hunter-server-v1/deno.json
@@ -25,7 +25,7 @@
   "tasks": {
     "dev": "deno run --watch --allow-net --allow-env --allow-read src/main.ts",
     "start": "deno run --allow-net --allow-env --allow-read src/main.ts",
-    "check": "deno check src/main.ts",
+    "check": "deno check src/main.ts test/",
     "lint": "deno lint",
     "test": "deno test --allow-env --allow-read"
   },


### PR DESCRIPTION
Two PRs in the group-activation series (#484, #486) shipped with red CI for the same reason, and it is worth removing the trap rather than remembering it.

## The gap

`apps/api-v1/deno.json` and `apps/relic-hunter-server-v1/deno.json` define:

```
"check": "deno check src/main.ts"
```

That reaches only what `main.ts` imports, so **nothing under `apps/<app>/test/**` is type-checked by it**. Both PRs made a field required — which was the point of each change — and both had a hand-built test fixture that no longer compiled. `deno task check` passed on both.

`deno task test` and `npm run test:deno` *do* catch these (`deno test` type-checks by default), and CI's `test:ci` step is where both failures surfaced. But those take about two minutes per app, so the fast check is the one that actually gets run — and its green does not mean what it looks like.

`rallar-black-box-control-server` had the same gap in a different shape: its check named **thirteen** test files by hand, so a fourteenth escapes silently.

## The change

All three apps now check `src/main.ts test/`. Seconds rather than minutes, and it cannot fall behind the directory.

## Verification

Each app is clean under the widened task **on `main`** — checked before changing anything, so this adds a gate rather than a backlog:

```
api-v1: check OK
relic-hunter-server-v1: check OK
rallar-black-box-control-server: check OK
```

CI keeps its existing `deno task check` invocations in `release-gate.yml`; they simply cover more now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)