### PR TITLE
docs(plans): say that the distributed activation design was superseded

### DIFF
--- a/plans/rallar-distributed-group-rtc-activation-design.md
+++ b/plans/rallar-distributed-group-rtc-activation-design.md
@@ -1,10 +1,27 @@
 # Distributed Group RTC Activation Design
 
-Status: approved design direction; implementation not started. Revised
-2026-08-07 after a full design review (activation-flow correctness,
+Status: **superseded as an implementation target; retained as design
+direction.** Group activation shipped between 2026-08 and 2026-09 by a
+different route — see `playground/rtc-design/2026-08-22-group-activation-product-plan.md`
+and `docs/rallar-group-formation-architecture.md` for what was actually
+built. Read this document for the reasoning it records, not for the machinery
+it specifies.
+
+The delivered design keeps this document's principles: no server owns a
+group, any server sharing the database may claim the work, and an accepted
+layout is never overwritten by an unconfirmed plan — the non-goal this
+document states and the delivered accepted/planned split enforces.
+
+It does **not** adopt this document's mechanism. `ASYNC_REMOTE_QUEUE`,
+`AWAITING_REMOTE` and the `group_batch` coordination row exist nowhere in the
+repository; the shipped lifecycle rides the existing AppInbox mutation
+doctrine with a stage machine on the group aggregate instead. Anything below
+that names those three is unbuilt by decision, not by omission.
+
+Revised 2026-08-07 after a full design review (activation-flow correctness,
 distributed-systems behavior, scalability at hundreds of sessions, security,
-and operational complexity). All review decisions are folded into this
-document.
+and operational complexity). All review decisions of that pass are folded into
+this document.
 
 Governance note: before implementation starts, this design must be reconciled
 with `plans/rallar-architecture-quality-and-rtc-program-roadmap.md`, which


### PR DESCRIPTION
Slice 14's mandate is that the repository agrees with itself. This is the one place it still doesn't.

## The trap

`plans/rallar-distributed-group-rtc-activation-design.md` opens with:

> Status: approved design direction; implementation not started.

After this workstream that reads as the opposite of the truth. Group activation **has** shipped — the stage machine, the accepted/planned split, the activation criterion, the observed status projection — and a reader arriving at the *governance* directory concludes it hasn't. The repository's own CLAUDE.md warns that "historical plans and deleted architecture notes are not current authority", but that only helps if the document says so.

## What is actually true

The delivered design **keeps this document's principles**: no server owns a group, any server sharing the database may claim the work, and an accepted layout is never overwritten by an unconfirmed plan — the non-goal this document states in its own words, and what the delivered accepted/planned split enforces.

It **does not adopt the mechanism**. Verified rather than assumed:

```
AWAITING_REMOTE            -> 0 files
group_batch                -> 0 files
ASYNC_REMOTE_QUEUE         -> 0 files
isAsyncRemoteTerminalStatus -> 0 files
```

The shipped lifecycle rides the existing AppInbox mutation doctrine with a stage machine on the group aggregate instead. So the status line now says which half survived and which did not, and points at `2026-08-22-group-activation-product-plan.md` and `docs/rallar-group-formation-architecture.md` for what was built — leaving the rest of the document readable for the reasoning it records.

The document is still cited as *direction* by the current product plan, which is why this supersedes rather than deletes it.

## Verification

- No test or script pins this document's content (grepped `packages/tests/` and `scripts/`).
- `check:repo-style:changed` — PASS.
- `repository-governance` and `legacy-review` — 18 tests pass.
- `dprint fmt` on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)