### PR TITLE
test(shared): pin the browser dial-selection and room transport matrices

### DIFF
--- a/packages/tests/shared-web/rtc-room-transport-state.test.ts
+++ b/packages/tests/shared-web/rtc-room-transport-state.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRtcRoomTransportState } from '@shared-web/browser/rtc/rtc-room-transport-status.ts';
+
+type TransportInput = Parameters<typeof resolveRtcRoomTransportState>[0];
+
+const fullyReady: TransportInput = {
+    mode: 'warm',
+    hasAcceptedLayout: true,
+    desiredPeerCount: 3,
+    knownPeerCount: 3,
+    activePeerCount: 3,
+    readyPeerCount: 3,
+    failedPeerCount: 0,
+    minReadyPeers: 0
+};
+
+describe('resolveRtcRoomTransportState', () => {
+    // Product decision 25: the transport valve is orthogonal to the stage, so
+    // a halt is not a degraded or failed room -- it outranks every other
+    // observation, including a room that is otherwise fully open.
+    it('reports a halt ahead of every other observation', () => {
+        expect(resolveRtcRoomTransportState({ ...fullyReady, transportState: 'halted' })).toBe('halted');
+        expect(resolveRtcRoomTransportState({
+            ...fullyReady,
+            transportState: 'halted',
+            mode: 'off',
+            hasAcceptedLayout: false,
+            readyPeerCount: 0,
+            failedPeerCount: 3
+        })).toBe('halted');
+    });
+
+    it('reports off ahead of everything but a halt', () => {
+        expect(resolveRtcRoomTransportState({ ...fullyReady, mode: 'off' })).toBe('off');
+    });
+
+    // The member-progress scenario's "reports nothing while no layout exists".
+    it('reports idle while no accepted layout exists, however many peers are ready', () => {
+        expect(resolveRtcRoomTransportState({ ...fullyReady, hasAcceptedLayout: false })).toBe('idle');
+    });
+
+    it('reports open at full readiness and for an empty desired set', () => {
+        expect(resolveRtcRoomTransportState(fullyReady)).toBe('open');
+        expect(resolveRtcRoomTransportState({
+            ...fullyReady,
+            desiredPeerCount: 0,
+            knownPeerCount: 0,
+            activePeerCount: 0,
+            readyPeerCount: 0
+        })).toBe('open');
+    });
+
+    it('reports partial once a declared floor is met', () => {
+        expect(resolveRtcRoomTransportState({
+            ...fullyReady,
+            readyPeerCount: 2,
+            minReadyPeers: 2
+        })).toBe('partial');
+    });
+
+    it('does not report partial without a declared floor', () => {
+        expect(resolveRtcRoomTransportState({
+            ...fullyReady,
+            readyPeerCount: 2,
+            minReadyPeers: 0
+        })).toBe('connecting');
+    });
+
+    it('separates a degraded room from a failed one by whether anything is ready', () => {
+        const exhausted = { ...fullyReady, readyPeerCount: 0, failedPeerCount: 3 };
+
+        expect(resolveRtcRoomTransportState(exhausted)).toBe('failed');
+        expect(resolveRtcRoomTransportState({ ...exhausted, readyPeerCount: 1, failedPeerCount: 2 }))
+            .toBe('degraded');
+    });
+
+    it('treats a failed or timed-out wait as terminal even with peers still connecting', () => {
+        const connecting = { ...fullyReady, readyPeerCount: 0, failedPeerCount: 0 };
+
+        expect(resolveRtcRoomTransportState({ ...connecting, waitStatus: 'failed' })).toBe('failed');
+        expect(resolveRtcRoomTransportState({ ...connecting, waitStatus: 'timeout' })).toBe('failed');
+        expect(resolveRtcRoomTransportState({ ...connecting, readyPeerCount: 1, waitStatus: 'timeout' }))
+            .toBe('degraded');
+    });
+
+    it('reports connecting while peers are known but none is ready yet', () => {
+        expect(resolveRtcRoomTransportState({ ...fullyReady, readyPeerCount: 0 })).toBe('connecting');
+    });
+
+    // A layout naming peers none of which has been seen at all is not
+    // "connecting" -- nothing is in flight to report progress on.
+    it('reports idle when the layout names peers none of which is known', () => {
+        expect(resolveRtcRoomTransportState({
+            ...fullyReady,
+            knownPeerCount: 0,
+            activePeerCount: 0,
+            readyPeerCount: 0
+        })).toBe('idle');
+    });
+});

--- a/packages/tests/shared/webrtc-group-dial-policy.test.ts
+++ b/packages/tests/shared/webrtc-group-dial-policy.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OverlayInfo } from '@shared/api/api-config.ts';
+import type { GroupRef } from '@shared/api/group-types.ts';
+import { selectGroupDialPeerIds } from '@shared/services/webrtc-group-dial-policy.ts';
+
+const groupRef: GroupRef = { applicationId: 'app', workspaceId: 'workspace', groupId: 'lobby' };
+const localSessionId = 'session-local';
+
+describe('selectGroupDialPeerIds', () => {
+    // The discovery-holds-dials acceptance scenario: a presence-connected
+    // `forming` lobby writes a bootstrap star as RTT evidence, and two
+    // independent gates must each keep it from becoming a dial.
+    it('dials nothing in a forming lobby holding a bootstrap star', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'forming',
+            localSessionId,
+            planned: createOverlay({ provenance: 'bootstrap', nextHopSessionIds: ['session-a', 'session-b'] }),
+            accepted: undefined
+        })).toEqual([]);
+    });
+
+    it('dials nothing in a forming lobby even when a server layout exists', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'forming',
+            localSessionId,
+            planned: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-a'] }),
+            accepted: undefined
+        })).toEqual([]);
+    });
+
+    // The provenance gate alone, with the stage gate open: a bootstrap
+    // overlay never substitutes for a missing server layout.
+    it('refuses a bootstrap star as a substitute for the planned layout', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'connecting',
+            localSessionId,
+            planned: createOverlay({ provenance: 'bootstrap', nextHopSessionIds: ['session-a', 'session-b'] }),
+            accepted: undefined
+        })).toEqual([]);
+    });
+
+    it('dials the planned server layout while connecting', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'connecting',
+            localSessionId,
+            planned: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-a', localSessionId, 'session-b'] }),
+            accepted: undefined
+        })).toEqual(['session-a', 'session-b']);
+    });
+
+    it('dials the accepted layout and not the planned one while active', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'active',
+            localSessionId,
+            planned: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-planned'] }),
+            accepted: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-accepted'] })
+        })).toEqual(['session-accepted']);
+    });
+
+    it('dials both layouts once each while reconnecting', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'reconnecting',
+            localSessionId,
+            planned: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-shared', 'session-planned'] }),
+            accepted: createOverlay({ provenance: 'server', nextHopSessionIds: ['session-shared', 'session-accepted'] })
+        })).toEqual(['session-shared', 'session-accepted', 'session-planned']);
+    });
+
+    // A retired layout is a tombstone, not a peer set.
+    it('refuses a removed server layout', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'active',
+            localSessionId,
+            planned: undefined,
+            accepted: createOverlay({ provenance: 'server', state: 'removed', nextHopSessionIds: ['session-a'] })
+        })).toEqual([]);
+    });
+
+    it('dials nothing when no layout is stored', () => {
+        expect(selectGroupDialPeerIds({
+            lifecycleState: 'active',
+            localSessionId,
+            planned: undefined,
+            accepted: undefined
+        })).toEqual([]);
+    });
+});
+
+function createOverlay(
+    overrides: Partial<OverlayInfo> & Pick<OverlayInfo, 'provenance' | 'nextHopSessionIds'>
+): OverlayInfo {
+    return {
+        sourceGroupStateCausalRevision: { groupRevision: 4, presenceRevision: 2 },
+        state: 'active',
+        overlayId: 'app:workspace:lobby',
+        groupRef,
+        topology: 'star',
+        name: 'Lobby',
+        createdByClientId: 'creator',
+        createdAtEpochMs: 1_000,
+        degreeLimit: 8,
+        overlayVersion: 1,
+        updatedAtEpochMs: 1_000,
+        ...overrides
+    };
+}


### PR DESCRIPTION
Continuing the plan past slice 14: closing two acceptance scenarios its coverage table records as unpinned browser-side work.

I had recorded both as needing infrastructure this workstream doesn't own. **That was wrong** — both are pure functions, and the plan's own verification model lists exactly this kind of thing under its unit matrices.

## 1. `discovery-holds-dials` — `selectGroupDialPeerIds`

The function describes itself as **"the browser's complete missing-peer selection policy"** and had no tests. It is what makes the scenario true: *a presence-connected `forming` lobby of a `phased` group makes zero bootstrap dials.*

A `forming` lobby **does** write a bootstrap star — deliberately, as RTT evidence. Two independent gates stop it becoming a dial:

- **The stage gate.** `resolveDialLayoutRoles` returns `none` for `dormant`, `forming` and `planned`.
- **The provenance gate.** `serverLayoutPeerIds` rejects any overlay that is not a `server` layout in `active` state — so the bootstrap star can never substitute for a missing server layout, **even once the stage gate opens.**

The stage table was already pinned by `group-lifecycle-stage-matrices.test.ts`; the provenance gate was pinned nowhere.

| Mutation | Test that fails |
| --- | --- |
| drop `provenance !== 'server'` | `refuses a bootstrap star as a substitute for the planned layout` |
| stage gate `case 'none'` returns planned peers | `dials nothing in a forming lobby even when a server layout exists` |

Neither mutation is caught by the other's test — which is why both are covered.

Also pinned: what the stage table means for *peers* rather than roles — `active` dials the accepted layout and not the planned one, `reconnecting` dials the union once each, a `removed` layout is a tombstone, and the local session is never dialed.

## 2. `member-progress` — `resolveRtcRoomTransportState`

A nine-branch precedence ladder, also untested. A ladder's bugs are **reorderings**, so the matrix is written to catch those rather than to enumerate outputs. Two orderings carry product meaning:

- **A halt outranks every other observation**, because the transport valve is orthogonal to the stage (product decision 25). A halted room is not degraded or failed, and stays halted with every peer ready.
- **No accepted layout reports `idle`** regardless of how many peers are ready — the scenario's "reports nothing while no layout exists".

| Mutation | Test that fails |
| --- | --- |
| demote the halt below `off` | `reports a halt ahead of every other observation` |
| demote the no-layout check below `open` | `reports idle while no accepted layout exists` |

The remaining rows separate the bands: `partial` needs a declared floor (without one the same readiness is `connecting`), `degraded` and `failed` differ only by whether anything is ready, a failed or timed-out wait is terminal even with peers in flight, and a layout whose peers are entirely unseen is `idle`, not `connecting`.

## Verification

- 18 tests across the two files; all four mutations above fail by name.
- `check-tests-typecheck` — 1026 files enforced, 0 debt. (It caught `mode: 'auto'`, which is not a `RallarRtcRoomMode`.)
- `check:repo-style:changed` — PASS. `check-test-structure-coupling --changed` — PASS.
- shared-web public API snapshots and bundle boundaries — 15 tests pass.

Once this and #488 are both in, the coverage table's `discovery-holds-dials` and `member-progress` rows should say they are pinned at the policy level here, with end-to-end browser behaviour still uncovered — dropping the unpinned count further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)