### PR TITLE
docs+refactor(group-lifecycle): close what an audit of the merged result found

### DIFF
--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -103,10 +103,12 @@ transport valve asks the same two and adds no third.
 | `manager`     | A resolved lifecycle manager. No manager resolves → `lifecycle-manager-unavailable`; a non-manager → `forbidden-role`.                              |
 | `server-auto` | No principal, ever (`forbidden-role`), owner included. Among the presets only `drop-in-social` uses it, and its `immediate` formation never phases. |
 
-`validateGroupLifecyclePolicy` does not reject a custom `server-auto` policy with
-`formation: 'phased'`. Such a group is created forming without a principal who can advance it.
-General automatic planning/connect trigger evaluation is deferred; initial formation retries are the
-narrow existing exception.
+`validateGroupLifecyclePolicy` rejects the `server-auto` combinations that could never advance:
+`server-auto-requires-automatic-trigger` when a `phased` group's plan or connect trigger is
+`manual`, and `server-auto-requires-automatic-activation` when its `activation.mode` is. Both are
+the same deadlock — `server-auto` denies every principal, so a boundary only a principal could
+cross is one the group would wait at forever. A `phased` `server-auto` policy whose triggers and
+activation are all automatic is accepted, because the automation can advance it.
 
 `fail-formation` has no HTTP route. The `formation-criterion` authority permits only activate/fail
 with observed evidence. Retry plan/connect use `formation-automation`; topology publication cannot
@@ -844,33 +846,39 @@ The pure core is pinned in `packages/tests/shared/`: `group-lifecycle-policy.tes
 `group-formation-reading.test.ts`, `group-admission-decision.test.ts`, and
 `group-lifecycle-managers.test.ts`. The server side is pinned in `packages/tests/shared-server/`:
 `group-policy.test.ts`, `group-create-lifecycle-policy.test.ts`,
-`group-lifecycle-policy-repository.test.ts`, `group-state/group-lifecycle-command-policy.test.ts`,
-`group-state/group-lifecycle-safety-baseline.test.ts`,
-`group-state/mutation/group-lifecycle-mutation.test.ts`,
-`group-state/mutation/group-admission-mutation.test.ts`,
-`topology/replay/work/rtc-topology-work-handler.test.ts` (the
+`group-lifecycle-policy-repository.test.ts`, `rallar-system/group-state/group-lifecycle-command-policy.test.ts`,
+`rallar-system/group-state/group-lifecycle-safety-baseline.test.ts`,
+`rallar-system/group-state/mutation/group-lifecycle-mutation.test.ts`,
+`rallar-system/group-state/mutation/group-admission-mutation.test.ts`,
+`rallar-system/topology/replay/work/rtc-topology-work-handler.test.ts` (the
 damped edge-trigger; the criterion, formation timer and durable retry latch have focused semantic tests), and
 `rallar-system/topology/planning/group-topology-planning-service.test.ts` (the FORMING gate). The
 data gate is pinned in `apps/api-v1/test/services/ws-topic-room-authorizer.test.ts`.
 
 ### Recipes and profiles
 
-Every recipe exercising lifecycle behaviour names the policy it tests. The nine single-server
+Every recipe exercising lifecycle behaviour names the policy it tests. The fifteen single-server
 recipes live in `packages/shared-test/black-box-runner/tests/api-v1/` and sit in the
 `api-v1-black-box` and `api-v1-black-box-recipes` profiles of `recipe-matrix.json`, so the memory
 backend runs them in the fast loop and the Postgres CI job runs them in its base phase:
 
-| Recipe                               | Pins                                                                                                                                                                                                                           |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `api-v1-group-lifecycle-policy`      | a preset with overrides is accepted; absent ≡ explicit `optimistic`; the two validity `400`s                                                                                                                                   |
-| `api-v1-group-lifecycle-transitions` | the explicit lifecycle HTTP commands and their epoch advances (`fail-formation` is criterion-only and pinned by the criterion, windows, and match recipes), FORMING holds planning, non-manager and illegal-transition denials |
-| `api-v1-group-formation-criterion`   | threshold, deadline, degraded, and evidence-driven activation                                                                                                                                                                  |
-| `api-v1-group-manager-succession`    | assigned managers, succession on removal and on leave, the zero-manager fallback                                                                                                                                               |
-| `api-v1-group-admission-approval`    | parking, grant, decline, re-request, zero-manager recovery, epoch survival, park while active                                                                                                                                  |
-| `api-v1-group-admission-windows`     | the binding phases of capacity, deadline, and `closed`                                                                                                                                                                         |
-| `api-v1-group-data-policy`           | the data gate, the CRDT exemption, `allowed` and default-group flows, post-activation flow, and the forming allowed-group transport valve                                                                                      |
-| `api-v1-match-preset`                | the composed `match` preset, including all-or-nothing failure and lobby re-opening                                                                                                                                             |
-| `api-v1-drop-in-social-preset`       | the composed `drop-in-social` preset                                                                                                                                                                                           |
+| Recipe                                | Pins                                                                                                                                                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `api-v1-group-lifecycle-policy`       | a preset with overrides is accepted; absent ≡ explicit `optimistic`; the two validity `400`s                                                                                                                                   |
+| `api-v1-group-lifecycle-transitions`  | the explicit lifecycle HTTP commands and their epoch advances (`fail-formation` is criterion-only and pinned by the criterion, windows, and match recipes), FORMING holds planning, non-manager and illegal-transition denials |
+| `api-v1-group-formation-criterion`    | threshold, deadline, degraded, and evidence-driven activation                                                                                                                                                                  |
+| `api-v1-group-manager-succession`     | assigned managers, succession on removal and on leave, the zero-manager fallback                                                                                                                                               |
+| `api-v1-group-admission-approval`     | parking, grant, decline, re-request, zero-manager recovery, epoch survival, park while active                                                                                                                                  |
+| `api-v1-group-admission-windows`      | the binding phases of capacity, deadline, and `closed`                                                                                                                                                                         |
+| `api-v1-group-data-policy`            | the data gate, the CRDT exemption, `allowed` and default-group flows, post-activation flow, and the forming allowed-group transport valve                                                                                      |
+| `api-v1-match-preset`                 | the composed `match` preset, including all-or-nothing failure and lobby re-opening                                                                                                                                             |
+| `api-v1-drop-in-social-preset`        | the composed `drop-in-social` preset                                                                                                                                                                                           |
+| `api-v1-automatic-formation-triggers` | the `after` plan and connect triggers advancing a `phased` group with no application command, and a commanded replan dialing the layout it produced rather than the one it replaced                                            |
+| `api-v1-presence-formation-trigger`   | the `presence` trigger: a group holds in `forming` on one live member and plans and dials itself as the second arrives                                                                                                         |
+| `api-v1-commanded-replanning`         | `commanded` replanning holds the automatic replan, `layoutStale` latches, and promotion after `connect`/`activate` clears the obligation                                                                                       |
+| `api-v1-debounced-replanning`         | the replanning window: due time extends with a change inside it, stops extending at the maximum wait, and one replan carries the burst's last presence revision                                                                |
+| `api-v1-reconfiguration-fails`        | a reconnection below the floor returns the group to `active` with the accepted layout identity byte-identical across the failure                                                                                               |
+| `api-v1-group-status-lifecycle`       | the stored condition walking `inactive → initialising → active → failed`, read off the group row rather than the view's fallback                                                                                               |
 
 A recipe sits in exactly one of the profiles a single Postgres CI job runs: the job runs the base
 profile and then the cluster profile against the same servers under one run id, and a recipe in
@@ -977,8 +985,6 @@ writing this document:
   `400 app-inbox-malformed-command`; the issue codes never reach the response.
 - **Typed WS NACK reasons.** Every policy denial over WS is `unauthorized`; the admission codes are
   typed on HTTP only, and the data-gate code reaches no wire at all.
-- **A validity rule for `server-auto` with `phased` formation.** The combination is accepted at
-  creation and produces a group nothing can establish.
 - **Per-edge confirm-or-fail establishment.** `strictConfirmation: true` is rejected at creation.
   The `match` preset therefore has no per-edge audit trail — a disputed session has "we were at
   94%" rather than "edge (A, B) never confirmed at T" — and no server-controlled establishment

--- a/packages/shared/api/group-lifecycle/activation-status/compute-group-activation-condition.ts
+++ b/packages/shared/api/group-lifecycle/activation-status/compute-group-activation-condition.ts
@@ -7,15 +7,13 @@ import { resolveDialLayoutRoles } from '../resolve-dial-layout-roles.ts';
  * Server defaults settled once so no later slice invents values under
  * pressure (product decisions 7 and 41). Nothing in this file applies them:
  * the presence-summary worker floors a queued replan by the minimum layout
- * age, the status writer slice owns the dwell, the hysteresis band (exit
- * sitting one width below entry) and evidence expiry, and the browser
- * pacing slice owns the RTC setup timeout.
+ * age, and the status writer slice owns the dwell, the hysteresis band (exit
+ * sitting one width below entry) and evidence expiry.
  */
 export const GROUP_ACTIVATION_STATUS_DWELL_MS = 3_000;
 export const GROUP_ACTIVATION_HYSTERESIS_WIDTH = 0.05;
 export const GROUP_ACTIVATION_EVIDENCE_EXPIRY_MS = 30_000;
 export const GROUP_MINIMUM_LAYOUT_AGE_MS = 1_000;
-export const GROUP_RTC_SETUP_TIMEOUT_MS = 15_000;
 
 /** The business plane resolved to one liveness fact (status plus expiry). */
 export type GroupBusinessLiveness =

--- a/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
+++ b/packages/shared/api/group-lifecycle/group-lifecycle-policy.ts
@@ -4,9 +4,8 @@ import type { PrincipalId } from '../group-types.ts';
  * The stage registry. Every stage-keyed decision is a total function over this
  * array (product decision 41), and the runtime enum validators pass it
  * directly, so adding a stage is a compile error at every decision site and
- * never a silent fallthrough. `dormant`, `planned` and `reconnecting` are
- * unreachable until their producing transitions land; every current consumer
- * holds an explicit row for them.
+ * never a silent fallthrough. Every stage is produced by a delivered
+ * transition, and every current consumer holds an explicit row for each.
  */
 export const GROUP_LIFECYCLE_STATES = [
     'dormant',

--- a/packages/tests/repo/rallar-group-documentation.test.ts
+++ b/packages/tests/repo/rallar-group-documentation.test.ts
@@ -123,7 +123,7 @@ function toCitations(document: string): readonly string[] {
                 .map((match) => match[1])
                 .filter((token) =>
                     (SOURCE_ROOTS.test(token) && (token.endsWith('/') || SOURCE_FILENAME.test(path.basename(token)))) ||
-                    (!token.includes('/') && SOURCE_FILENAME.test(token))
+                    (!token.startsWith('@') && SOURCE_FILENAME.test(path.basename(token)))
                 )
         )
     ];
@@ -133,9 +133,17 @@ function isResolvedCitation(citation: string): boolean {
     if (citation.endsWith('/')) {
         return trackedPaths.some((tracked) => tracked.startsWith(citation));
     }
-    return citation.includes('/')
-        ? trackedPaths.includes(citation)
-        : trackedBasenames.has(citation);
+    if (!citation.includes('/')) {
+        return trackedBasenames.has(citation);
+    }
+    if (SOURCE_ROOTS.test(citation)) {
+        return trackedPaths.includes(citation);
+    }
+    // A relative fragment is cited under a root the prose established, so it
+    // resolves as a path suffix. These rot silently: a tree that gains a
+    // directory level leaves them naming nothing, and they are too long for
+    // the bare-filename check to see.
+    return trackedPaths.some((tracked) => tracked.endsWith(`/${citation}`));
 }
 
 function toBacktickedKebabTokens(section: string): readonly string[] {

--- a/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
+++ b/playground/rtc-design/2026-08-22-group-activation-implementation-plan.md
@@ -3330,8 +3330,17 @@ one was a live defect:
   derivations) and two are server-side gaps a recipe could close.
 - **`start-establishment` and `reopen-establishment` are gone** from every `.ts`, `.mts`, `.json`,
   `.yaml` and `.md` outside `playground/` — verified, nothing to remove.
-- `RtcTopologySnapshotRepository.findEntryRevision` **still has its caller** and was left alone, as
-  this section instructs; 6c owns it.
+- `RtcTopologySnapshotRepository.findEntryRevision` was **already gone**, so slice 14 correctly left
+  it alone but for the wrong reason: this checkpoint recorded it as still having a caller, when 6c
+  had removed it on 2026-08-30 (recorded above at slice 6c's own checkpoint). A repo-wide grep now
+  returns nothing.
+- **`GROUP_RTC_SETUP_TIMEOUT_MS` is deleted.** Slice 1c settled it at 15 000 ms and named the browser
+  pacing slice as its applier; that slice landed without applying it, so the constant had zero
+  consumers repo-wide while the browser's live establishment timeout is
+  `DEFAULT_WEB_RTC_PEER_ESTABLISHMENT_TIMEOUT_POLICY`'s 30 000 ms. An unreferenced constant whose
+  value disagrees with the live one is worse than dead — the next reader wires it up and halves the
+  timeout — so decision 14's no-retained-legacy rule applies. I24's claim that every settled constant
+  is "pinned by the policy and status matrices" was true of the other four and never of this one.
 
 **A correctness fix the slice's own review produced.** `resolveStoredCondition` on the formation view
 stated half the rule its comment describes: it compared the coverage basis but was never given the


### PR DESCRIPTION
> **Stacks on #496** (the typecheck fix that unbreaks `main`). Merge that first; this branch contains it.

Slice 14's mandate is that the repository agrees with itself — and that could only be checked properly once every slice was merged. An audit over the merged tree found five disagreements no branch-level gate could see, because each needs two slices present at once.

## 1. The architecture doc asserted the opposite of the shipped validator

It said `validateGroupLifecyclePolicy` **"does not reject"** a custom `server-auto` policy with `formation: 'phased'`, and repeated it under Not In V1 as an unbuilt gap.

The validator has rejected both stuck variants since #353 — `server-auto-requires-automatic-trigger` and `server-auto-requires-automatic-activation`. Both are the same deadlock: `server-auto` denies every principal, so a boundary only a principal could cross is one the group waits at forever. The fully automatic combination is accepted, and the document now says that.

## 2. `GROUP_RTC_SETUP_TIMEOUT_MS` is deleted

Slice 1c settled it at 15 000 ms and named the browser pacing slice as its applier. That slice landed without applying it. A repo-wide grep returns **exactly one occurrence — its own declaration** — while the browser's live establishment timeout is **30 000 ms**, from `DEFAULT_WEB_RTC_PEER_ESTABLISHMENT_TIMEOUT_POLICY`.

An unreferenced constant whose value disagrees with the live one is worse than dead: the next reader wires it up and halves the timeout. Decision 14's no-retained-legacy rule applies. The plan records the deletion and why, so the settled value isn't lost.

## 3. The recipe table said nine, and fifteen carry the profile pair

The six missing rows are this workstream's own: both trigger recipes, both replanning recipes, `reconfiguration-fails`, and `status-lifecycle`. Verified mechanically that all fifteen listed carry both `api-v1-black-box` and `api-v1-black-box-recipes`.

## 4. Four cited test paths named nothing

They lost the `rallar-system/` segment when that tree moved. **The citation check could not see them**: it only resolved paths rooted at a source directory, so a relative fragment like `group-state/mutation/group-lifecycle-mutation.test.ts` was invisible.

It now resolves fragments as path suffixes — **94 → 104 citations checked** — and excludes `@shared/...` aliases, which are imports rather than paths. Verified it discriminates on exactly the shape that slipped.

## 5. Two stale claims, one in source

The stage registry's TSDoc still said `dormant`, `planned` and `reconnecting` are *"unreachable until their producing transitions land"* — all seven stages are produced today. And slice 14's checkpoint recorded `findEntryRevision` as still having a caller; 6c removed it on 2026-08-30, which the plan already records two thousand lines earlier.

## Verification

- `npm run typecheck` — clean. `check-tests-typecheck` — 1030 files, 0 debt.
- `packages/tests/shared` + the docs gate — **5 654 tests pass**.
- `check:repo-style:changed`, `check-test-structure-coupling --changed`, `check:retained-legacy` — all PASS.
- `dprint fmt` on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)