### PR TITLE
fix(postgres): name timestamp type contract

### DIFF
--- a/packages/shared-server/postgres/postgres-timestamp-without-time-zone.ts
+++ b/packages/shared-server/postgres/postgres-timestamp-without-time-zone.ts
@@ -1,6 +1,13 @@
 export const POSTGRES_TIMESTAMP_WITHOUT_TIME_ZONE_OID = 1114;
 
-export function createPostgresTimestampWithoutTimeZoneTextType() {
+export interface PostgresTimestampWithoutTimeZoneTextType {
+    readonly to: number;
+    readonly from: number[];
+    readonly serialize: (value: string) => string;
+    readonly parse: (value: string) => string;
+}
+
+export function createPostgresTimestampWithoutTimeZoneTextType(): PostgresTimestampWithoutTimeZoneTextType {
     return {
         to: POSTGRES_TIMESTAMP_WITHOUT_TIME_ZONE_OID,
         from: [POSTGRES_TIMESTAMP_WITHOUT_TIME_ZONE_OID],


### PR DESCRIPTION
## Summary

- add the explicit named output contract required for the PostgreSQL timestamp-without-time-zone type descriptor
- preserve the exact runtime behavior merged in #479
- add no migration, compatibility, legacy, wrapper, or schema behavior

## Why

PR #479's final timestamp-precision correction returned a three-field object without a named output interface. The changed-file repository-style gate correctly rejected that shape with `function.output-contract` after #479 was merged. This follow-up addresses that exact finding without changing behavior.

## Validation

- exact changed-range repository-style gate: PASS, zero findings
- governance gate: PASS, all four phases
- test type-check: PASS, 1,049 files, zero errors/debt
- shared-server TypeScript: PASS
- API-v1 Deno checks: PASS
- fresh PostgreSQL shared-server integration: 14 files, 33/33 tests PASS
- fresh PostgreSQL presence-expiry integration: 10/10 tests PASS
- formatting and diff checks: PASS

The PostgreSQL runs used a freshly initialized disposable database, removed after validation.