### PR TITLE
test(black-box): document the hidden primitives, and gate expectations the runner ignores

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -246,7 +246,8 @@ Common fields:
   `compatible-complete`, `exact-structure`, `exact`); `compatible-complete` keeps
   extra object keys tolerated but rejects unexpected array elements, closing the
   vacuous-assertion gap where `compatible` matches an empty expected array
-  against anything
+  against anything. **No mode compares array order** — see _Array comparison is
+  unordered in every mode_ below before asserting on a sequence
 - `output`: optional output name for the step result
 - `outputPath`: optional path inside the result to store under `output`
 - `outputs`: optional map of output names to result paths
@@ -474,7 +475,8 @@ Common fields:
   `compatible-complete`, `exact-structure`, `exact`); `compatible-complete` keeps
   extra object keys tolerated but rejects unexpected array elements, closing the
   vacuous-assertion gap where `compatible` matches an empty expected array
-  against anything
+  against anything. **No mode compares array order** — see _Array comparison is
+  unordered in every mode_ below before asserting on a sequence
 - `expect.ignoreJsonKeys`: keys to ignore
 - `expect.ignoreJsonPaths`: paths to ignore
 
@@ -762,9 +764,119 @@ HTTP retry configuration lives under `request.resilience.retry` or
 WS and RTC waits use `expect.withinMs`. Message waits can also use
 `expect.consume` and `expect.ordered`.
 
-There is no separate poll step yet. Model polling with HTTP retry for transient
-status codes or with explicit repeated steps until a recipe needs a stronger
-generic polling primitive.
+For convergence, prefer the `http.poll-until` step documented above over HTTP
+retry: retry is for transient transport failures, polling is for state that has
+not converged yet. **`poll-until` is HTTP-only** — `assert`, `set` and `parallel`
+have no retry loop, so a recipe waiting on a durable row or a parallel outcome
+still has to sleep. Sleeping is a real cost: the api-v1 corpus carries 371
+seconds of unconditional `delayMs` across 59 steps, concentrated in five
+recipes, almost all of it hand-rolled polling.
+
+## Array Comparison Is Unordered In Every Mode
+
+Every comparison mode matches array elements by containment, not by position.
+Measured against `CompareJson` directly:
+
+| Mode                   | `['a','b','c']` vs `['c','b','a']` | `{events: []}` vs `{events: [{...},{...}]}` |
+| ---------------------- | ---------------------------------- | ------------------------------------------- |
+| `compatible` (default) | matches                            | **matches** — vacuous                       |
+| `compatible-structure` | matches                            | **matches** — vacuous                       |
+| `compatible-complete`  | matches                            | rejected                                    |
+| `exact-structure`      | matches                            | rejected                                    |
+| `exact`                | matches                            | rejected                                    |
+
+Two consequences worth internalising before writing an assertion.
+
+**Order is never checked, including under `exact`.** To assert a sequence, read
+positions explicitly — `body.0.eventType`, `body.1.eventType` — because both
+`[n]` and `.n` resolve in output paths. An expected array proves only that each
+element appears _somewhere_ in the actual array.
+
+**Because matching is unordered, enumerating permutations under `expect.anyOf`
+is dead code.** A race whose two outcomes are `[200, 409]` in either order needs
+one alternative, not two; the second can never be the one that matches. Five
+recipes in the api-v1 corpus carry this idiom today.
+
+**The default mode is the vacuous one.** `compatible` matching an empty expected
+array against a populated actual is exactly how an assertion ends up proving
+nothing. Set `compatible-complete` or stronger whenever the array's contents are
+the point of the assertion.
+
+## Primitives This Guide Previously Omitted
+
+Four working features had no documentation, which is why recipes hand-roll
+weaker substitutes for them.
+
+### `expect.missingActualValue` — assert on a value that may not exist
+
+An `assert` step whose `actual` placeholder cannot resolve normally throws
+`Cannot resolve placeholder {x}` and fails the step. Supplying
+`missingActualValue` substitutes that value instead of throwing, which is how a
+recipe asserts _absence_ of a captured output rather than crashing on it:
+
+```json
+{
+  "name": "noRejectionWasRecorded",
+  "type": "assert",
+  "actual": "{rejectionCode}",
+  "missingActualValue": "none",
+  "expect": { "body": "none" }
+}
+```
+
+Substitution applies recursively through arrays and objects, so a composite
+`actual` can carry several possibly-absent members.
+
+### `expect.monotonicPaths` — assert a series never regresses
+
+Each path must resolve to a non-empty array of finite numbers; the step fails on
+the first element smaller than its predecessor, reporting `regressionIndex`,
+`previous` and `current`. Use it for revisions, generations and epochs, where the
+product property is "never goes backwards" rather than any particular value:
+
+```json
+{
+  "name": "generationsAdvanced",
+  "type": "assert",
+  "actual": { "generations": ["{genA}", "{genB}", "{genC}"] },
+  "expect": { "monotonicPaths": ["generations"] }
+}
+```
+
+Equal neighbours pass — this is non-decreasing, not strictly increasing.
+
+### `set.state-write-evidence` — assert on durable queue rows
+
+Runs an SQL collector against the run's database and captures the matching
+`resource_inbox` / `resource_inbox_results` rows as a step output. This is the
+only way a recipe can observe what a mutation did _durably_ — `status`,
+`resultStatus`, `attempts`, `startAt`/`endAt`/`nextAt`, `outboxIds` and the
+decoded `durableResult`:
+
+```json
+{
+  "name": "exposeStateWriteEvidence",
+  "type": "set.state-write-evidence",
+  "output": "stateWriteEvidence",
+  "request": {
+    "stateWriteEvidence": {
+      "match": "bb-request-prune-{executionToken}",
+      "commandTypes": ["ADMIN_PRUNE_EXPIRED"],
+      "minimumMatchedRows": 1
+    }
+  }
+}
+```
+
+It has **no poll loop**, so a recipe waiting for a row to reach a terminal state
+has to sleep first. That is a real limitation, not a style choice — one corpus
+recipe pays a 65-second unconditional wait for it.
+
+### `anyOfMatchedIndex` — which alternative matched
+
+An `assert` using `expect.anyOf` reports the index of the alternative that
+matched in its success status. Read it to distinguish _which_ branch of an
+asymmetric race actually occurred, rather than only that one of them did.
 
 ## Post-run Assertions And Thresholds
 
@@ -1208,6 +1320,46 @@ Provider adapters may call Rallar facade methods internally. Recipes should
 still describe observable network behavior: HTTP calls, WS messages, RTC
 connect/send/wait/close, and assertions.
 
+## Identifiers
+
+**`{runId}` is per profile run, not per recipe.** It resolves from one
+environment variable that every recipe binds under the same name, so it is
+byte-identical in every recipe executing in that run. Recipes run sequentially
+against one server and one database for the whole run.
+
+That combination has one consequence that surprises everybody: **an identifier
+collision breaks the other recipe, not yours.** Two recipes sending the same
+`/requests/<id>` are one AppInbox replay — the second gets the first's receipt
+back, so it passes while the recipe it collided with fails somewhere unrelated.
+Nothing in the framework namespaces identifiers per recipe.
+
+**Every identifier a recipe invents must carry `{runId}`.** Request ids, message
+ids, resource ids, group ids, application and workspace ids, usernames. Request
+ids are additionally constrained to 20-128 characters of `[A-Za-z0-9_-]`, which
+bounds any naming scheme.
+
+**A replayed request id is permanent.** AppInbox rows are written to never
+expire, so a replay returns the first receipt verbatim — success _or_ the
+original failure — and `prune-expired` cannot reclaim them. A recipe with a fixed
+identifier therefore does not merely repeat itself on a second run against the
+same database: it goes **green while executing no new server logic**. That is the
+worst available failure mode, because nothing reports it.
+
+**Auth identifiers are scoped by identity, not by run.** A login request id is
+keyed on the normalized username, and `clientId` and `sessionId` are _derived
+from_ the request id — so a fixed login id collides across recipes even when
+everything downstream looks unique.
+
+**After cloning a recipe, re-derive every identifier literal.** Enumerate every
+`/requests/<id>` segment, `msgId`, `traceId`, `resourceId` and every id in
+`variables`, then diff against the rest of the corpus. Run the profile **with and
+without** your new matrix entry: a green new recipe is not evidence the suite is
+unbroken, because the recipe you broke is a different one.
+
+**`[201, 409]` on a register step is a smell, not a pattern to copy.** Accepting
+the conflict status usually means an identifier is being reused across runs and
+the recipe has stopped asserting what it was written to assert.
+
 ## Authoring Checklist
 
 - Start with the external behavior being tested.
@@ -1220,6 +1372,9 @@ connect/send/wait/close, and assertions.
 - Prefer explicit connection names for actors such as `aliceRtc`, `bobRtc`, and
   `serverWs`.
 - Use `--dry-run` before a live browser or network run when changing recipes.
+- Give every identifier you invent a `{runId}` suffix, and after cloning a recipe
+  re-derive every identifier literal — see _Identifiers_ above. A stale one breaks
+  the recipe you cloned from, not yours.
 
 ## Related Docs
 

--- a/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
+++ b/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
@@ -952,7 +952,95 @@ function validateStrictStep(step: JsonRecord, path: string): readonly BlackBoxRu
             });
         }
     }
+    issues.push(...validateStrictExpectIsHonoured(step, type, path));
+    issues.push(...validateStrictExpectIsNotVacuous(step, path));
     return issues;
+}
+
+/**
+ * Assertion keys a WebSocket send never reads. `sendWs` dispatches on
+ * `expect.messages` and `expect.message` only, so these two describe a check
+ * the runner will not perform. Wait plumbing (`connection`, `withinMs`,
+ * `consume`) is deliberately absent from this list: those are honoured
+ * elsewhere on the step and flagging them would be noise, not a finding.
+ */
+const WS_SEND_IGNORED_ASSERTION_KEYS = ['absent', 'close'];
+
+function validateStrictExpectIsHonoured(
+    step: JsonRecord,
+    type: string,
+    path: string
+): readonly BlackBoxRunnerPreflightIssue[] {
+    const expected = asRecord(step.expect || step.response);
+    const expectedKeys = Object.keys(expected);
+    if (expectedKeys.length <= 0) {
+        return [];
+    }
+
+    if (type === 'parallel') {
+        return [{
+            severity: 'error',
+            code: 'STRICT_EXPECT_IGNORED',
+            message: 'Parallel steps ignore expect entirely; assert on the group steps instead.',
+            path: `${path}.expect`
+        }];
+    }
+
+    const action = String(asRecord(step.request).action || '').toLowerCase();
+    const isWsSend = type.startsWith('ws') && (action === 'send' || action.length <= 0);
+    if (!isWsSend) {
+        return [];
+    }
+
+    return expectedKeys
+        .filter((key) => WS_SEND_IGNORED_ASSERTION_KEYS.includes(key))
+        .map((key): BlackBoxRunnerPreflightIssue => ({
+            severity: 'error',
+            code: 'STRICT_EXPECT_IGNORED',
+            message: `WebSocket send steps read only expect.message and expect.messages; expect.${key} is ignored. ` +
+                'Use a ws.wait step for it.',
+            path: `${path}.expect.${key}`
+        }));
+}
+
+/**
+ * `compatible` and `compatible-structure` match an empty expected array against
+ * any actual array, so an empty one asserts nothing at all. The stricter modes
+ * reject it, which is what makes the mode part of the check rather than the
+ * array alone.
+ */
+const VACUOUS_ARRAY_COMPARISONS = ['', 'compatible', 'compatible-structure'];
+
+function validateStrictExpectIsNotVacuous(
+    step: JsonRecord,
+    path: string
+): readonly BlackBoxRunnerPreflightIssue[] {
+    const expected = asRecord(step.expect || step.response);
+    const comparison = String(expected.comparison || '').toLowerCase();
+    if (!VACUOUS_ARRAY_COMPARISONS.includes(comparison)) {
+        return [];
+    }
+
+    return toEmptyArrayPaths(expected.body, `${path}.expect.body`)
+        .map((emptyPath): BlackBoxRunnerPreflightIssue => ({
+            severity: 'error',
+            code: 'STRICT_EXPECT_VACUOUS',
+            message: 'An empty expected array matches anything under compatible; ' +
+                'use compatible-complete or a non-empty expectation.',
+            path: emptyPath
+        }));
+}
+
+function toEmptyArrayPaths(value: unknown, path: string): readonly string[] {
+    if (Array.isArray(value)) {
+        return value.length <= 0
+            ? [path]
+            : value.flatMap((item, index) => toEmptyArrayPaths(item, `${path}[${index}]`));
+    }
+
+    return isRecord(value)
+        ? Object.entries(value).flatMap(([key, item]) => toEmptyArrayPaths(item, `${path}.${key}`))
+        : [];
 }
 
 function validateStrictSet(step: JsonRecord, path: string): readonly BlackBoxRunnerPreflightIssue[] {

--- a/packages/shared-test/black-box-runner/preflight/strict-expectation-debt.json
+++ b/packages/shared-test/black-box-runner/preflight/strict-expectation-debt.json
@@ -1,0 +1,17 @@
+{
+  "note": "Recipes with expectations the runner does not compare. New recipes must add none; these are pre-existing and each is a weakened assertion to be repaired.",
+  "debtByRecipe": {
+    "api-v1-admin-operations": 4,
+    "api-v1-admin-support": 4,
+    "api-v1-black-box-control-auth": 4,
+    "api-v1-crdt-append-history": 1,
+    "api-v1-cross-application-ws-isolation": 2,
+    "api-v1-cross-principal-client-state-isolation": 2,
+    "api-v1-drop-in-social-preset": 1,
+    "api-v1-group-data-policy": 2,
+    "api-v1-group-lifecycle-policy": 2,
+    "api-v1-group-manager-succession": 2,
+    "api-v1-ice-config": 3,
+    "api-v1-openapi-topology-auth": 20
+  }
+}

--- a/packages/tests/shared-test/recipe-matrix.test.ts
+++ b/packages/tests/shared-test/recipe-matrix.test.ts
@@ -57,7 +57,52 @@ function rtcProviders(recipe: Record<string, unknown>): string[] {
         .map((connection) => connection.provider ?? '');
 }
 
+const strictDebtPath = path.join(runnerRoot, 'preflight/strict-expectation-debt.json');
+
+/**
+ * Expectation keys the runner never compares. A recipe carrying one reads as
+ * though it asserts something and asserts nothing, which is the failure mode
+ * this ratchet exists to stop spreading: the debt file records what is already
+ * there, and a new finding fails.
+ */
+function readStrictExpectationFindings(recipeRelativePath: string): number {
+    // The runner prefixes its `-c` argument with './', so an absolute path
+    // becomes './/Users/...' and cannot be opened. Pass repo-relative paths.
+    const result = spawnSync('deno', [
+        'run',
+        '-A',
+        'packages/shared-test/black-box-runner/scenario-black-box.ts',
+        '-c',
+        path.posix.join('packages/shared-test/black-box-runner', recipeRelativePath),
+        '--validate',
+        '--strict'
+    ], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+
+    expect(result.stdout, `strict preflight produced no output for ${recipeRelativePath}: ${result.stderr}`)
+        .not.toBe('');
+    const issues = (JSON.parse(result.stdout) as {
+        issues?: Array<{ code: string; }>;
+    }).issues ?? [];
+
+    return issues.filter((issue) => issue.code === 'STRICT_EXPECT_VACUOUS' || issue.code === 'STRICT_EXPECT_IGNORED').length;
+}
+
 describe('black-box runner recipe matrix', () => {
+    it('adds no expectation the runner would silently ignore', () => {
+        const debt = (JSON.parse(readFileSync(strictDebtPath, 'utf8')) as {
+            debtByRecipe: Record<string, number>;
+        }).debtByRecipe;
+        const recipes = listJsonRecipes(path.join(testsRoot, 'api-v1'), 'tests/api-v1/');
+
+        const worsened = recipes
+            .map((recipe) => {
+                const name = path.basename(recipe, '.json');
+                return { name, found: readStrictExpectationFindings(recipe), allowed: debt[name] ?? 0 };
+            })
+            .filter((entry) => entry.found > entry.allowed);
+
+        expect(worsened).toEqual([]);
+    }, 240_000);
     it('has unique entry ids and artifact names', () => {
         const { entries } = readMatrix();
         const ids = entries.map((entry) => entry.id);


### PR DESCRIPTION
D1's first two prerequisites, from **Framework prerequisites** in `2026-09-05-black-box-coverage-plan.md` (relocated there by #505 — they were written into the browser plan by mistake). Both exist to stop the same thing: **an agent adapting a test into something weaker because the framework's real shape is undiscoverable.**

## Item 1 — the guide

**It contradicted itself.** `http.poll-until` is documented at line 292; line 765 said *"There is no separate poll step yet."* That paragraph now says what's true — and names the real limitation: `poll-until` is **HTTP-only**, so `assert`, `set` and `parallel` still have to sleep. The corpus pays **371 seconds of unconditional `delayMs` across 59 steps** for that, almost all hand-rolled polling.

**Four working primitives had zero mentions in 1,236 lines** — `missingActualValue`, `monotonicPaths`, `set.state-write-evidence`, `anyOfMatchedIndex` — each now documented from its implementation, with the limitation that matters (`set.state-write-evidence` has no poll loop, which is why one recipe pays a 65-second wait).

**Array comparison is unordered in every mode, including `exact`.** Measured against `CompareJson` rather than assumed:

| Mode | reordered array | empty expected array |
| --- | --- | --- |
| `compatible` (default) | matches | **matches — vacuous** |
| `compatible-structure` | matches | **matches — vacuous** |
| `compatible-complete` / `exact-structure` / `exact` | matches | rejected |

So order needs positional paths, and **enumerating both permutations of a race under `expect.anyOf` is dead code** — five recipes carry that idiom.

**Identifiers get a section**, because `grep -rn "runId" .agents/skills/` returns **zero** and the authoring checklist had no identifier rule. `{runId}` is per *profile run*, not per recipe — so a collision breaks the **other** recipe, which is why it's so hard to spot.

## Item 2 — the vacuity lint

Three strict checks in `plan-preflight.ts`: an `expect` on a `parallel` step (ignored entirely), `expect.absent`/`expect.close` on a `ws.send` (its dispatch reads only `message`/`messages`), and an empty expected array under a `compatible` mode.

**Its first catch is a real one.** `aliceNeverReceivesTheBlockedMessage` in `api-v1-group-data-policy.json` is a `ws.send` carrying `expect.absent` — so the assertion that blocked data never reaches Alice **has never run**.

Enforced as a **per-recipe ratchet against a recorded baseline**, not a hard zero: 47 findings across 12 recipes exist today, each a weakened assertion to repair, and a new one fails. This follows the repo's existing pattern (`check-tests-typecheck`'s debt baseline).

## What the checks deliberately do not flag

My first version flagged `expect.connection` and `expect.withinMs` on `ws.send` — **106 findings, almost all false positives**, because those are wait plumbing honoured elsewhere on the step. Narrowed to the two keys I verified the dispatch ignores. The `ws.open` rejection path is a capability gap, not a vacuous expectation, so it is out of scope here.

## Verification

- **The ratchet discriminates**: adding one violation to an unlisted recipe fails by name (`found: 1, allowed: 0`) and passes when removed.
- `recipe-matrix.test.ts` — 19 tests pass. Its own coverage test caught my first placement of the baseline file inside `tests/`, where it was read as an unregistered recipe.
- `test:repo-governance` — 429 pass. `test:deno` — 146 pass, 0 fail.
- `check-tests-typecheck` — 1049 files, 0 debt. `check:repo-style:changed`, `check-test-structure-coupling --changed` — PASS.

Items 3–7 (generalising `poll-until`, `expect.count`, path comparators, honouring `expect` on `parallel`, `ws.open` negatives) remain as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
