### PR TITLE
feat(black-box): compare a denial by its code, and stop dropping parallel expectations

### DIFF
--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -19,7 +19,6 @@ import {
 } from './execution/black-box-scenario-results.ts';
 import {
     resolveAssertActual,
-    resolvePath,
     resolvePlaceholders
 } from './execution/black-box-value-resolution.ts';
 import { executeRemoteHttpInteraction } from './execution/execute-remote-http-interaction.ts';
@@ -29,6 +28,8 @@ import {
 } from './execution/execute-ws-interaction.ts';
 import { isRallarRemoteBrowserRequest } from './execution/remote-browser-execution.ts';
 import { validateAssertValueComparators } from './expectations/assert-value-comparators.ts';
+import { monotonicComparisonFailures } from './expectations/monotonic-comparison-failures.ts';
+import { parallelAggregateFailure } from './expectations/parallel-aggregate-expectation.ts';
 import { executeHttpInteraction } from './http/execute-http-interaction.ts';
 import {
     rememberRtcCloseEvent,
@@ -446,51 +447,6 @@ function toAssertFailureStatus(config: any, interaction: any, actual: any, resul
         details,
         ...config
     };
-}
-
-function monotonicComparisonFailures(actual: any, paths: unknown): any[] {
-    if (!Array.isArray(paths)) {
-        return [];
-    }
-
-    return paths.flatMap<any>((path) => {
-        if (typeof path !== 'string' || path.length <= 0) {
-            return [{ path, error: 'Monotonic assertion paths must be non-empty strings.' }];
-        }
-
-        let values: unknown;
-        try {
-            values = resolvePath(path, actual);
-        }
-        catch (error) {
-            return [{
-                path,
-                error: error instanceof Error ? error.message : String(error)
-            }];
-        }
-
-        if (!Array.isArray(values) || values.length <= 0) {
-            return [{ path, values, error: 'Monotonic assertion path must resolve to a non-empty array.' }];
-        }
-
-        const numericValues = values.map((value) => Number(value));
-        if (numericValues.some((value) => !Number.isFinite(value))) {
-            return [{ path, values, error: 'Monotonic assertion values must be finite numbers.' }];
-        }
-
-        const regressionIndex = numericValues.findIndex((value, index) =>
-            index > 0 && value < numericValues[index - 1]
-        );
-        return regressionIndex < 0
-            ? []
-            : [{
-                path,
-                values,
-                regressionIndex,
-                previous: numericValues[regressionIndex - 1],
-                current: numericValues[regressionIndex]
-            }];
-    });
 }
 
 function toResolvedAssertActual(interaction: any, context: any): any {
@@ -1155,50 +1111,6 @@ async function executeParallelInteraction(interaction: any, config: any, context
     }
 
     return toParallelSuccessStatus(config, interaction, actual);
-}
-
-/**
- * A parallel step's `expect` is compared against its aggregate — group results,
- * counts, concurrency and timing — which is the only place a bounded outcome
- * such as "at most K of N succeeded" can be asserted. Child failures are
- * decided before this, so an aggregate expectation can never mask one.
- */
-function parallelAggregateFailure(
-    interaction: any,
-    actual: any
-): { message: string; details: any; } | undefined {
-    const expectation = interaction.response;
-    if (!expectation) {
-        return undefined;
-    }
-
-    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
-    if (comparatorIssues.length > 0) {
-        return {
-            message: 'Parallel step comparator failed',
-            details: { comparators: expectation.comparators, failures: comparatorIssues }
-        };
-    }
-
-    const expected = expectation.body ?? expectation.expected;
-    if (expected === undefined) {
-        return undefined;
-    }
-
-    const comparison = compareJson(
-        expected,
-        actual,
-        toConfig(
-            expectation.comparison || COMPARISON.COMPATIBLE,
-            expectation.ignoreJsonKeys || [],
-            expectation.ignoreJsonPaths || []
-        )
-    );
-
-    return comparison.isEqual ? undefined : {
-        message: 'Parallel step aggregate comparison failed',
-        details: { expected, comparison }
-    };
 }
 
 interface ExecuteBlackBoxRecursiveInput {

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -1146,7 +1146,59 @@ async function executeParallelInteraction(interaction: any, config: any, context
         return toParallelFailureStatus(config, interaction, 'Parallel step had failed child steps.', actual);
     }
 
+    const aggregateFailure = parallelAggregateFailure(interaction, actual);
+    if (aggregateFailure !== undefined) {
+        return toParallelFailureStatus(config, interaction, aggregateFailure.message, {
+            ...actual,
+            ...aggregateFailure.details
+        });
+    }
+
     return toParallelSuccessStatus(config, interaction, actual);
+}
+
+/**
+ * A parallel step's `expect` is compared against its aggregate — group results,
+ * counts, concurrency and timing — which is the only place a bounded outcome
+ * such as "at most K of N succeeded" can be asserted. Child failures are
+ * decided before this, so an aggregate expectation can never mask one.
+ */
+function parallelAggregateFailure(
+    interaction: any,
+    actual: any
+): { message: string; details: any; } | undefined {
+    const expectation = interaction.response;
+    if (!expectation) {
+        return undefined;
+    }
+
+    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
+    if (comparatorIssues.length > 0) {
+        return {
+            message: 'Parallel step comparator failed',
+            details: { comparators: expectation.comparators, failures: comparatorIssues }
+        };
+    }
+
+    const expected = expectation.body ?? expectation.expected;
+    if (expected === undefined) {
+        return undefined;
+    }
+
+    const comparison = compareJson(
+        expected,
+        actual,
+        toConfig(
+            expectation.comparison || COMPARISON.COMPATIBLE,
+            expectation.ignoreJsonKeys || [],
+            expectation.ignoreJsonPaths || []
+        )
+    );
+
+    return comparison.isEqual ? undefined : {
+        message: 'Parallel step aggregate comparison failed',
+        details: { expected, comparison }
+    };
 }
 
 interface ExecuteBlackBoxRecursiveInput {

--- a/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
+++ b/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
@@ -1,4 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
+import { jsonEquals } from '@shared/repository/state-utils.ts';
+
 export interface AssertComparatorIssue {
     readonly path: any;
     readonly comparator: string;
@@ -168,7 +170,65 @@ function stringIssues(entry: any, value: any): AssertComparatorIssue[] {
     return issues;
 }
 
-const COMPARATOR_KEYS = ['gt', 'gte', 'lt', 'lte', 'between', 'length', 'contains', 'matches'];
+function equalityIssues(entry: any, value: any): AssertComparatorIssue[] {
+    const issues: AssertComparatorIssue[] = [];
+
+    if (entry.equals !== undefined && !jsonEquals(entry.equals, value)) {
+        issues.push(toIssue({
+            path: entry.path,
+            comparator: 'equals',
+            expected: entry.equals,
+            actual: value,
+            message: 'Expected the value to equal the expected value.'
+        }));
+    }
+
+    if (entry.notEquals !== undefined && jsonEquals(entry.notEquals, value)) {
+        issues.push(toIssue({
+            path: entry.path,
+            comparator: 'notEquals',
+            expected: entry.notEquals,
+            actual: value,
+            message: 'Expected the value to differ from the expected value.'
+        }));
+    }
+
+    return issues;
+}
+
+/**
+ * `exists` is decided before the path is required to resolve, because an
+ * absent path is the assertion rather than a failure to make one. Every other
+ * comparator needs a value to compare and reports an unresolved path.
+ */
+function existenceIssues(entry: any, found: boolean): AssertComparatorIssue[] {
+    if (entry.exists === undefined) {
+        return [];
+    }
+
+    const expected = Boolean(entry.exists);
+    return expected === found ? [] : [toIssue({
+        path: entry.path,
+        comparator: 'exists',
+        expected,
+        actual: found,
+        message: expected ? 'Expected the path to resolve to a value.' : 'Expected the path to be absent.'
+    })];
+}
+
+const COMPARATOR_KEYS = [
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'between',
+    'length',
+    'contains',
+    'matches',
+    'equals',
+    'notEquals',
+    'exists'
+];
 
 function entryIssues(entry: any, actual: any): AssertComparatorIssue[] {
     if (typeof entry?.path !== 'string' || entry.path.length <= 0) {
@@ -192,21 +252,32 @@ function entryIssues(entry: any, actual: any): AssertComparatorIssue[] {
     }
 
     const resolved = resolveComparatorValue(entry.path, actual);
+    const existence = existenceIssues(entry, resolved.found);
+    const comparesValue = COMPARATOR_KEYS.some((key) => key !== 'exists' && entry[key] !== undefined);
+    if (!comparesValue) {
+        return existence;
+    }
+
     if (!resolved.found) {
-        return [toIssue({
-            path: entry.path,
-            comparator: 'path',
-            expected: undefined,
-            actual: undefined,
-            message: 'Comparator path did not resolve to a value.'
-        })];
+        return [
+            ...existence,
+            toIssue({
+                path: entry.path,
+                comparator: 'path',
+                expected: undefined,
+                actual: undefined,
+                message: 'Comparator path did not resolve to a value.'
+            })
+        ];
     }
 
     return [
+        ...existence,
         ...numericIssues(entry, resolved.value),
         ...betweenIssues(entry, resolved.value),
         ...lengthIssues(entry, resolved.value),
-        ...stringIssues(entry, resolved.value)
+        ...stringIssues(entry, resolved.value),
+        ...equalityIssues(entry, resolved.value)
     ];
 }
 

--- a/packages/shared-test/black-box-runner/expectations/monotonic-comparison-failures.ts
+++ b/packages/shared-test/black-box-runner/expectations/monotonic-comparison-failures.ts
@@ -1,0 +1,55 @@
+// deno-lint-ignore-file no-explicit-any
+import type { ApiJsonValue } from '@shared/api/api-json-value.ts';
+
+import { resolvePath } from '../execution/black-box-value-resolution.ts';
+
+/**
+ * Each path must resolve to a non-empty array of finite numbers; the first
+ * element smaller than its predecessor is reported with its index and both
+ * values. Equal neighbours pass -- the property is non-decreasing, which is
+ * what a revision, generation or epoch series actually guarantees.
+ */
+export function monotonicComparisonFailures(actual: any, paths: ApiJsonValue | undefined): any[] {
+    if (!Array.isArray(paths)) {
+        return [];
+    }
+
+    return paths.flatMap<any>((path) => {
+        if (typeof path !== 'string' || path.length <= 0) {
+            return [{ path, error: 'Monotonic assertion paths must be non-empty strings.' }];
+        }
+
+        let values: ApiJsonValue;
+        try {
+            values = resolvePath(path, actual);
+        }
+        catch (error) {
+            return [{
+                path,
+                error: error instanceof Error ? error.message : String(error)
+            }];
+        }
+
+        if (!Array.isArray(values) || values.length <= 0) {
+            return [{ path, values, error: 'Monotonic assertion path must resolve to a non-empty array.' }];
+        }
+
+        const numericValues = values.map((value) => Number(value));
+        if (numericValues.some((value) => !Number.isFinite(value))) {
+            return [{ path, values, error: 'Monotonic assertion values must be finite numbers.' }];
+        }
+
+        const regressionIndex = numericValues.findIndex((value, index) =>
+            index > 0 && value < numericValues[index - 1]
+        );
+        return regressionIndex < 0
+            ? []
+            : [{
+                path,
+                values,
+                regressionIndex,
+                previous: numericValues[regressionIndex - 1],
+                current: numericValues[regressionIndex]
+            }];
+    });
+}

--- a/packages/shared-test/black-box-runner/expectations/parallel-aggregate-expectation.ts
+++ b/packages/shared-test/black-box-runner/expectations/parallel-aggregate-expectation.ts
@@ -1,0 +1,52 @@
+// deno-lint-ignore-file no-explicit-any
+import { compareJson, COMPARISON, toConfig } from '../../json-compare/CompareJson.ts';
+import { validateAssertValueComparators } from './assert-value-comparators.ts';
+
+export interface ParallelAggregateFailure {
+    readonly message: string;
+    readonly details: any;
+}
+
+/**
+ * A parallel step's `expect` is compared against its aggregate — group results,
+ * counts, concurrency and timing — which is the only place a bounded outcome
+ * such as "at most K of N succeeded" can be asserted. Child failures are
+ * decided before this, so an aggregate expectation can never mask one.
+ */
+export function parallelAggregateFailure(
+    interaction: any,
+    actual: any
+): ParallelAggregateFailure | undefined {
+    const expectation = interaction.response;
+    if (!expectation) {
+        return undefined;
+    }
+
+    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
+    if (comparatorIssues.length > 0) {
+        return {
+            message: 'Parallel step comparator failed',
+            details: { comparators: expectation.comparators, failures: comparatorIssues }
+        };
+    }
+
+    const expected = expectation.body ?? expectation.expected;
+    if (expected === undefined) {
+        return undefined;
+    }
+
+    const comparison = compareJson(
+        expected,
+        actual,
+        toConfig(
+            expectation.comparison || COMPARISON.COMPATIBLE,
+            expectation.ignoreJsonKeys || [],
+            expectation.ignoreJsonPaths || []
+        )
+    );
+
+    return comparison.isEqual ? undefined : {
+        message: 'Parallel step aggregate comparison failed',
+        details: { expected, comparison }
+    };
+}

--- a/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
+++ b/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
@@ -963,6 +963,10 @@ function validateStrictStep(step: JsonRecord, path: string): readonly BlackBoxRu
  * the runner will not perform. Wait plumbing (`connection`, `withinMs`,
  * `consume`) is deliberately absent from this list: those are honoured
  * elsewhere on the step and flagging them would be noise, not a finding.
+ *
+ * A `parallel` step is no longer listed here at all. Its `expect` is compared
+ * against the aggregate, so flagging it would block the capability rather than
+ * report a dropped one.
  */
 const WS_SEND_IGNORED_ASSERTION_KEYS = ['absent', 'close'];
 
@@ -975,15 +979,6 @@ function validateStrictExpectIsHonoured(
     const expectedKeys = Object.keys(expected);
     if (expectedKeys.length <= 0) {
         return [];
-    }
-
-    if (type === 'parallel') {
-        return [{
-            severity: 'error',
-            code: 'STRICT_EXPECT_IGNORED',
-            message: 'Parallel steps ignore expect entirely; assert on the group steps instead.',
-            path: `${path}.expect`
-        }];
     }
 
     const action = String(asRecord(step.request).action || '').toLowerCase();

--- a/packages/tests/shared-test/black-box-runner-strict-expectations.test.ts
+++ b/packages/tests/shared-test/black-box-runner-strict-expectations.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject } from '@shared/api/api-json-value.ts';
+import { explainBlackBoxRunnerPlan } from '../../shared-test/black-box-runner/preflight/plan-preflight.ts';
+
+function strictIssueCodes(step: ApiJsonObject): readonly string[] {
+    const plan = explainBlackBoxRunnerPlan({
+        rawConfig: { steps: [step] },
+        profile: 'strict'
+    } as never);
+
+    return (plan.issues ?? []).map((issue: { code: string; }) => issue.code);
+}
+
+const PARALLEL_GROUPS = [{ name: 'alpha', steps: [] }];
+
+describe('strict preflight expectation checks', () => {
+    // The runner compares a parallel step's expect against its aggregate, so a
+    // gate that rejects one would block the capability rather than report a
+    // dropped assertion.
+    it('accepts an expectation on a parallel step', () => {
+        expect(strictIssueCodes({
+            name: 'race',
+            type: 'parallel',
+            request: { maxConcurrency: 2 },
+            groups: PARALLEL_GROUPS,
+            expect: { comparators: [{ path: 'success', lte: 2 }] }
+        })).not.toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    it('accepts a body expectation on a parallel step', () => {
+        expect(strictIssueCodes({
+            name: 'race',
+            type: 'parallel',
+            request: { maxConcurrency: 2 },
+            groups: PARALLEL_GROUPS,
+            expect: { body: { groupCount: 2, failure: 0 } }
+        })).not.toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    // The keys a WebSocket send genuinely never reads still have to be caught,
+    // or the lint stops doing the job it was added for.
+    it('still reports an absence expectation on a websocket send', () => {
+        expect(strictIssueCodes({
+            name: 'sendAndHope',
+            type: 'ws.send',
+            request: { action: 'send', connection: 'wsAlice', message: {} },
+            expect: { absent: { id: { msgId: 'never' } } }
+        })).toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    it('still reports an empty expected array under a compatible comparison', () => {
+        expect(strictIssueCodes({
+            name: 'readGroup',
+            type: 'http',
+            request: { method: 'GET', path: '/api/state/groups/g' },
+            expect: { body: { managerPrincipalIds: [] } }
+        })).toContain('STRICT_EXPECT_VACUOUS');
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
+++ b/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
@@ -161,3 +161,117 @@ describe('executeBlackBox ASSERT expect.comparators', () => {
         expect(result.details.message).toBe('Json array has unexpected elements');
     });
 });
+
+describe('executeBlackBox ASSERT path comparators', () => {
+    it('compares a resolved value for equality and inequality', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { denial: { code: 'forbidden-role', status: 403 } },
+                expectFields: {
+                    comparators: [
+                        { path: 'denial.code', equals: 'forbidden-role' },
+                        { path: 'denial.status', equals: 403 },
+                        { path: 'denial.code', notEquals: 'member-not-active' }
+                    ]
+                },
+                name: 'denialCodeIsNamed'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // The reason this comparator family exists: a denial recipe asserting only
+    // the status cannot tell a correct denial from a differently-wrong one.
+    it('reports the mismatching code rather than only that something differed', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { denial: { code: 'member-not-active' } },
+                expectFields: { comparators: [{ path: 'denial.code', equals: 'forbidden-role' }] },
+                name: 'wrongDenialCode'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+        expect(JSON.stringify(report)).toContain('forbidden-role');
+        expect(JSON.stringify(report)).toContain('member-not-active');
+    });
+
+    it('compares structured values by deep equality', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { identity: { groupRevision: 9, presenceRevision: 2 } },
+                expectFields: {
+                    comparators: [{ path: 'identity', equals: { groupRevision: 9, presenceRevision: 2 } }]
+                },
+                name: 'identityMatches'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('asserts a path is present without constraining its value', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { activationStatus: { condition: 'active' } },
+                expectFields: { comparators: [{ path: 'activationStatus.condition', exists: true }] },
+                name: 'conditionIsPresent'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // An absent path is the assertion here, so it must not be reported as an
+    // unresolvable path the way every other comparator treats it.
+    it('asserts a path is absent', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: { lifecycleState: 'active' } },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: false }] },
+                name: 'noStatusStored'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('fails when a path asserted absent is present', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: { activationStatus: { condition: 'degraded' } } },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: false }] },
+                name: 'unexpectedStatus'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('fails when a path asserted present is absent', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: {} },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: true }] },
+                name: 'missingStatus'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
+++ b/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+function assertGroup(name: string, actual: unknown, expected: unknown): Record<string, unknown> {
+    return {
+        name,
+        steps: [{
+            ASSERT: {
+                request: { actual, scenarioExecutionNumber: 1, interactionExecutionNumber: 1 },
+                response: { body: expected }
+            },
+            [`${name}Step`]: {}
+        }]
+    };
+}
+
+function parallelStep(input: {
+    groups: Array<Record<string, unknown>>;
+    expectFields?: Record<string, unknown>;
+}): Record<string, unknown> {
+    return {
+        PARALLEL: {
+            request: {
+                groups: input.groups,
+                maxConcurrency: 2,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1
+            },
+            ...(input.expectFields === undefined ? {} : { response: input.expectFields })
+        },
+        raceOutcome: {}
+    };
+}
+
+describe('executeBlackBox PARALLEL expect', () => {
+    it('passes a parallel step whose aggregate matches the expectation', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { body: { groupCount: 2, failure: 0, success: 2 } }
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // The defect this closes: the executor built a rich `actual` and never
+    // compared it, so an expectation on a parallel step was a silent no-op and
+    // a recipe could assert something plainly false and still pass.
+    it('fails a parallel step whose aggregate contradicts the expectation', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { body: { groupCount: 99 } }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('supports comparators over the aggregate, so a bounded outcome is expressible', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { comparators: [{ path: 'success', lte: 2 }, { path: 'failure', equals: 0 }] }
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('fails when a comparator over the aggregate does not hold', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { comparators: [{ path: 'success', lt: 1 }] }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('leaves a parallel step without an expectation unchanged', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({ groups: [assertGroup('alpha', 1, 1)] })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // A child failure must still fail the parent, and must not be masked by a
+    // passing aggregate expectation.
+    it('keeps a failing child failing even when the expectation holds', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 2)],
+                expectFields: { body: { groupCount: 1 } }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBeGreaterThan(0);
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
+++ b/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject, ApiJsonValue } from '@shared/api/api-json-value.ts';
 import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
 
-function assertGroup(name: string, actual: unknown, expected: unknown): Record<string, unknown> {
+function assertGroup(name: string, actual: ApiJsonValue, expected: ApiJsonValue): ApiJsonObject {
     return {
         name,
         steps: [{
@@ -15,9 +17,9 @@ function assertGroup(name: string, actual: unknown, expected: unknown): Record<s
 }
 
 function parallelStep(input: {
-    groups: Array<Record<string, unknown>>;
-    expectFields?: Record<string, unknown>;
-}): Record<string, unknown> {
+    groups: readonly ApiJsonObject[];
+    expectFields?: ApiJsonObject;
+}): ApiJsonObject {
     return {
         PARALLEL: {
             request: {

--- a/playground/rtc-design/2026-09-05-black-box-coverage-plan.md
+++ b/playground/rtc-design/2026-09-05-black-box-coverage-plan.md
@@ -354,6 +354,23 @@ not opportunistic widening; the coverage plan should adopt them rather than rout
 Items 1 and 2 should land regardless of whether any recipe is written: **they are what stops the next
 agent from adapting a test instead of fixing the framework.**
 
+### Prerequisite delivery
+
+| Item    | State                                                                                                                                                                                                                                                                                                                                               |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | **Delivered** (#503). The guide's self-contradiction is gone, the four hidden primitives are documented from their implementations, the unordered-array semantics are stated with a measured table, and identifiers have a section.                                                                                                                 |
+| 2       | **Delivered** (#503). Three strict checks in `plan-preflight.ts`, ratcheted per recipe from `preflight/strict-expectation-debt.json` so a new finding fails while the 47 existing ones stay visible as debt. Its first catch was real: `aliceNeverReceivesTheBlockedMessage` is a `ws.send` carrying `expect.absent`, which the runner never reads. |
+| 5       | **Delivered.** `equals`, `notEquals` and `exists` join the comparator registry. `exists` is decided before the path is required to resolve, because an absent path is the assertion rather than a failure to make one. Deep equality reuses `jsonEquals` from `@shared/repository/state-utils.ts` rather than adding a third implementation.        |
+| 6       | **Delivered.** A `parallel` step's `expect` is now compared against its aggregate — groups, counts, concurrency, timing — through the same comparator and comparison path an `assert` uses. Child failures are still decided first, so an aggregate expectation cannot mask one.                                                                    |
+| 3, 4, 7 | Open.                                                                                                                                                                                                                                                                                                                                               |
+
+Two facts worth carrying into the remaining items. The runner may import from `@shared/**` — several
+modules already do — but only resolves the alias when the entry point is inside the workspace, so a
+probe script written to a temporary directory fails on the import rather than on the code under test.
+And a `parallel` group's steps use the runner's `{TRANSPORT: {request, response}, name: {}}` pair
+shape, not the flat `{name, type, expect}` shape recipes use at the top level; a group written the
+flat way executes nothing and reports `success: 0` rather than failing.
+
 ## Not in this plan
 
 - **WS upgrade negative paths** (reused, expired, foreign, missing ticket) — worth doing, but they


### PR DESCRIPTION
Prerequisites **5** and **6** from the coverage plan's framework list.

## Item 5 — path comparators

`equals`, `notEquals` and `exists` join the comparator registry. This is what the plan's **D8** needs: *assert the denial's code, not just its status* — a recipe asserting only `403` cannot distinguish a correct denial from a differently-wrong one.

**`exists` is decided before the path is required to resolve.** Every other comparator reports an unresolved path as a failure, but for `exists: false` an absent path **is** the assertion. That ordering is the whole design, not an implementation detail.

Deep equality reuses `jsonEquals` from `@shared/repository/state-utils.ts` — the runner already imports from `@shared/**`, and a third equality implementation is the duplication the repo standard forbids.

## Item 6 — parallel expectations were a silent no-op

`executeParallelInteraction` built a rich aggregate — groups, counts, concurrency, timing — and **never compared it**. An `expect` on a parallel step did nothing: a recipe could assert something plainly false and pass.

It now runs the same comparator and comparison path an `assert` uses. **Child failures are still decided first**, so an aggregate expectation can never mask one — a test pins that ordering explicitly.

This makes *"at most K of N were admitted"* expressible, which the 70-iteration join storm in `api-v1-group-join-admission` needs: it accepts `[200, 429]` per attempt today and never asserts how many got in.

## Verified by mutation, not by passing

| Mutation | Tests that fail |
| --- | --- |
| make `exists` always satisfied | `fails when a path asserted absent is present`, `fails when a path asserted present is absent` |
| restore the silent-ignore on `parallel` | `fails a parallel step whose aggregate contradicts the expectation`, `fails when a comparator over the aggregate does not hold` |

18 tests across the two files. No existing recipe carries an `expect` on a parallel step — item 2's lint reports zero — so nothing in the corpus changes behaviour.

## Gates

`typecheck`, `check-tests-typecheck` (1050 files, 0 debt), `check:repo-style:changed`, `test:deno` (146 passed) — all pass.

The memory profile fails two burst recipes on an isolated port **and does so identically on unmodified `main`** — those recipes reach a secondary URL that defaults to 18080, which a survivor process was holding. I ran the control rather than assuming, and left the survivor alone.

The plan now records items 1, 2, 5 and 6 as delivered, plus two facts that cost me time here: the `@shared` alias only resolves for entry points inside the workspace, and a `parallel` group's steps use the `{TRANSPORT: {...}, name: {}}` pair shape — written flat, a group executes nothing and reports `success: 0` rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)