### PR TITLE
feat(black-box): count matching frames with expect.count

### DIFF
--- a/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
+++ b/packages/shared-test/black-box-runner/docs/black-box-runner-recipe-guide.md
@@ -772,6 +772,36 @@ still has to sleep. Sleeping is a real cost: the api-v1 corpus carries 371
 seconds of unconditional `delayMs` across 59 steps, concentrated in five
 recipes, almost all of it hand-rolled polling.
 
+## Counting Frames With `expect.count`
+
+`expect.message` resolves on its **first** match, so it cannot tell "exactly
+one" from "at least one". `expect.count` decides cardinality instead: it waits
+the full `withinMs` window and then counts every frame matching
+`expect.message`, for the same reason `expect.absent` waits the whole window — a
+count is only as strong as the time the runner kept listening.
+
+```json
+{
+  "name": "exactlyOneDecisionWasEmitted",
+  "type": "ws.wait",
+  "connection": "wsManager",
+  "expect": {
+    "withinMs": 4000,
+    "message": { "payload": { "typeId": "group-state.event" } },
+    "count": 1
+  }
+}
+```
+
+`count` accepts a non-negative integer, or a range with either end optional:
+`{ "min": 1 }`, `{ "max": 3 }`, `{ "min": 1, "max": 3 }`. `count: 0` is a
+stricter absence claim than `expect.absent`, because the failure also reports
+how many frames were observed while it waited.
+
+It works on `ws.wait`, `rtc.wait`, and on a `ws.send` step that wants to count
+what its own send produced. The result carries `matchedCount` and
+`observedMessageCount`.
+
 ## Array Comparison Is Unordered In Every Mode
 
 Every comparison mode matches array elements by containment, not by position.

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -19,7 +19,6 @@ import {
 } from './execution/black-box-scenario-results.ts';
 import {
     resolveAssertActual,
-    resolvePath,
     resolvePlaceholders
 } from './execution/black-box-value-resolution.ts';
 import { executeRemoteHttpInteraction } from './execution/execute-remote-http-interaction.ts';
@@ -29,6 +28,8 @@ import {
 } from './execution/execute-ws-interaction.ts';
 import { isRallarRemoteBrowserRequest } from './execution/remote-browser-execution.ts';
 import { validateAssertValueComparators } from './expectations/assert-value-comparators.ts';
+import { monotonicComparisonFailures } from './expectations/monotonic-comparison-failures.ts';
+import { parallelAggregateFailure } from './expectations/parallel-aggregate-expectation.ts';
 import { executeHttpInteraction } from './http/execute-http-interaction.ts';
 import {
     rememberRtcCloseEvent,
@@ -446,51 +447,6 @@ function toAssertFailureStatus(config: any, interaction: any, actual: any, resul
         details,
         ...config
     };
-}
-
-function monotonicComparisonFailures(actual: any, paths: unknown): any[] {
-    if (!Array.isArray(paths)) {
-        return [];
-    }
-
-    return paths.flatMap<any>((path) => {
-        if (typeof path !== 'string' || path.length <= 0) {
-            return [{ path, error: 'Monotonic assertion paths must be non-empty strings.' }];
-        }
-
-        let values: unknown;
-        try {
-            values = resolvePath(path, actual);
-        }
-        catch (error) {
-            return [{
-                path,
-                error: error instanceof Error ? error.message : String(error)
-            }];
-        }
-
-        if (!Array.isArray(values) || values.length <= 0) {
-            return [{ path, values, error: 'Monotonic assertion path must resolve to a non-empty array.' }];
-        }
-
-        const numericValues = values.map((value) => Number(value));
-        if (numericValues.some((value) => !Number.isFinite(value))) {
-            return [{ path, values, error: 'Monotonic assertion values must be finite numbers.' }];
-        }
-
-        const regressionIndex = numericValues.findIndex((value, index) =>
-            index > 0 && value < numericValues[index - 1]
-        );
-        return regressionIndex < 0
-            ? []
-            : [{
-                path,
-                values,
-                regressionIndex,
-                previous: numericValues[regressionIndex - 1],
-                current: numericValues[regressionIndex]
-            }];
-    });
 }
 
 function toResolvedAssertActual(interaction: any, context: any): any {
@@ -1155,50 +1111,6 @@ async function executeParallelInteraction(interaction: any, config: any, context
     }
 
     return toParallelSuccessStatus(config, interaction, actual);
-}
-
-/**
- * A parallel step's `expect` is compared against its aggregate — group results,
- * counts, concurrency and timing — which is the only place a bounded outcome
- * such as "at most K of N succeeded" can be asserted. Child failures are
- * decided before this, so an aggregate expectation can never mask one.
- */
-function parallelAggregateFailure(
-    interaction: any,
-    actual: any
-): { message: string; details: any; } | undefined {
-    const expectation = interaction.response;
-    if (!expectation) {
-        return undefined;
-    }
-
-    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
-    if (comparatorIssues.length > 0) {
-        return {
-            message: 'Parallel step comparator failed',
-            details: { comparators: expectation.comparators, failures: comparatorIssues }
-        };
-    }
-
-    const expected = expectation.body ?? expectation.expected;
-    if (expected === undefined) {
-        return undefined;
-    }
-
-    const comparison = compareJson(
-        expected,
-        actual,
-        toConfig(
-            expectation.comparison || COMPARISON.COMPATIBLE,
-            expectation.ignoreJsonKeys || [],
-            expectation.ignoreJsonPaths || []
-        )
-    );
-
-    return comparison.isEqual ? undefined : {
-        message: 'Parallel step aggregate comparison failed',
-        details: { expected, comparison }
-    };
 }
 
 interface ExecuteBlackBoxRecursiveInput {

--- a/packages/shared-test/black-box-runner/execute-black-box.ts
+++ b/packages/shared-test/black-box-runner/execute-black-box.ts
@@ -1146,7 +1146,59 @@ async function executeParallelInteraction(interaction: any, config: any, context
         return toParallelFailureStatus(config, interaction, 'Parallel step had failed child steps.', actual);
     }
 
+    const aggregateFailure = parallelAggregateFailure(interaction, actual);
+    if (aggregateFailure !== undefined) {
+        return toParallelFailureStatus(config, interaction, aggregateFailure.message, {
+            ...actual,
+            ...aggregateFailure.details
+        });
+    }
+
     return toParallelSuccessStatus(config, interaction, actual);
+}
+
+/**
+ * A parallel step's `expect` is compared against its aggregate — group results,
+ * counts, concurrency and timing — which is the only place a bounded outcome
+ * such as "at most K of N succeeded" can be asserted. Child failures are
+ * decided before this, so an aggregate expectation can never mask one.
+ */
+function parallelAggregateFailure(
+    interaction: any,
+    actual: any
+): { message: string; details: any; } | undefined {
+    const expectation = interaction.response;
+    if (!expectation) {
+        return undefined;
+    }
+
+    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
+    if (comparatorIssues.length > 0) {
+        return {
+            message: 'Parallel step comparator failed',
+            details: { comparators: expectation.comparators, failures: comparatorIssues }
+        };
+    }
+
+    const expected = expectation.body ?? expectation.expected;
+    if (expected === undefined) {
+        return undefined;
+    }
+
+    const comparison = compareJson(
+        expected,
+        actual,
+        toConfig(
+            expectation.comparison || COMPARISON.COMPATIBLE,
+            expectation.ignoreJsonKeys || [],
+            expectation.ignoreJsonPaths || []
+        )
+    );
+
+    return comparison.isEqual ? undefined : {
+        message: 'Parallel step aggregate comparison failed',
+        details: { expected, comparison }
+    };
 }
 
 interface ExecuteBlackBoxRecursiveInput {

--- a/packages/shared-test/black-box-runner/execution/execute-local-ws-interaction.ts
+++ b/packages/shared-test/black-box-runner/execution/execute-local-ws-interaction.ts
@@ -6,6 +6,7 @@ import {
     waitForWsClose,
     waitForWsMessage,
     waitForWsMessageAbsence,
+    waitForWsMessageCount,
     waitForWsMessages
 } from '../ws/ws-wait-expectations.ts';
 import {
@@ -92,6 +93,10 @@ function sendWs(interaction: any, config: any, context: any): Promise<any> {
         sendLatencyMs: sendEndedAtEpochMs - sendStartedAtEpochMs
     };
 
+    if (interaction.response?.count !== undefined) {
+        return waitForWsMessageCount({ interaction, config, context, details });
+    }
+
     if (interaction.response?.messages) {
         return waitForWsMessages(interaction, config, context, details);
     }
@@ -120,6 +125,12 @@ export function executeLocalWsInteraction(interaction: any, config: any, context
     if (action === 'wait' || action === 'expect') {
         if (interaction.response?.absent !== undefined) {
             return waitForWsMessageAbsence({ interaction, config, context });
+        }
+
+        // Before `message`, which resolves on its first match and so cannot
+        // tell "exactly one" from "at least one".
+        if (interaction.response?.count !== undefined) {
+            return waitForWsMessageCount({ interaction, config, context });
         }
 
         if (interaction.response?.close !== undefined) {

--- a/packages/shared-test/black-box-runner/execution/execute-local-ws-interaction.ts
+++ b/packages/shared-test/black-box-runner/execution/execute-local-ws-interaction.ts
@@ -149,7 +149,8 @@ export function executeLocalWsInteraction(interaction: any, config: any, context
             toWsFailureStatus(
                 config,
                 interaction,
-                'WebSocket wait expects expect.message, expect.messages, expect.absent, or expect.close'
+                'WebSocket wait expects expect.message, expect.messages, expect.count, ' +
+                    'expect.absent, or expect.close'
             )
         );
     }

--- a/packages/shared-test/black-box-runner/execution/remote-browser-websocket-interaction.ts
+++ b/packages/shared-test/black-box-runner/execution/remote-browser-websocket-interaction.ts
@@ -1,9 +1,4 @@
 // deno-lint-ignore-file no-explicit-any
-import type {
-    RallarBlackBoxTestWsCloseCommand,
-    RallarBlackBoxTestWsOpenCommand,
-    RallarBlackBoxTestWsSendCommand
-} from '../../rallar-bb-test/types.ts';
 import {
     executeRallarRemoteBrowserCommand,
     resolveRallarRemoteBrowserConfig,
@@ -24,85 +19,18 @@ import {
     waitForWsMessages
 } from '../ws/ws-wait-expectations.ts';
 import {
-    assertRemoteDestinationAllowed,
-    assertRemotePayloadWithinLimit,
     isRallarRemoteBrowserRequest,
     remoteBrowserFetch,
     remoteBrowserOptions,
     remoteResultValue
 } from './remote-browser-execution.ts';
-
-function toWsUrl(request: any): string | undefined {
-    return request.url || request.path;
-}
-
-function toRemoteWsPayload(request: any): any {
-    return request.send !== undefined
-        ? request.send
-        : request.message !== undefined
-        ? request.message
-        : request.body;
-}
-
-function toRemoteWsOpenCommand(
-    commandId: string,
-    interaction: any,
-    context: any
-): RallarBlackBoxTestWsOpenCommand {
-    const request = interaction.request;
-    const url = toWsUrl(request);
-    assertRemoteDestinationAllowed({ request, context, url, label: 'WebSocket' });
-    return {
-        kind: 'ws.open',
-        commandId,
-        connection: toWsConnectionName(request),
-        url,
-        protocols: request.protocols,
-        headers: request.headers,
-        timeoutMs: request.timeoutMs,
-        metadata: {
-            blackBoxRunner: request
-        }
-    };
-}
-
-function toRemoteWsSendCommand(
-    commandId: string,
-    interaction: any,
-    context: any
-): RallarBlackBoxTestWsSendCommand {
-    const request = interaction.request;
-    const data = toRemoteWsPayload(request);
-    assertRemotePayloadWithinLimit({ request, context, value: data, label: 'WebSocket send' });
-    return {
-        kind: 'ws.send',
-        commandId,
-        connection: toWsConnectionName(request),
-        data,
-        timeoutMs: request.timeoutMs,
-        metadata: {
-            blackBoxRunner: request
-        }
-    };
-}
-
-function toRemoteWsCloseCommand(
-    commandId: string,
-    interaction: any
-): RallarBlackBoxTestWsCloseCommand {
-    const request = interaction.request;
-    return {
-        kind: 'ws.close',
-        commandId,
-        connection: toWsConnectionName(request),
-        code: request.closeCode !== undefined ? request.closeCode : request.code,
-        reason: request.closeReason !== undefined ? request.closeReason : request.reason,
-        timeoutMs: request.timeoutMs,
-        metadata: {
-            blackBoxRunner: request
-        }
-    };
-}
+import {
+    toRemoteWsCloseCommand,
+    toRemoteWsOpenCommand,
+    toRemoteWsPayload,
+    toRemoteWsSendCommand,
+    toWsUrl
+} from './remote-websocket-commands.ts';
 
 function toRemoteWsConfig(interaction: any, config: any, context: any): RallarRemoteBrowserConfig {
     return resolveRallarRemoteBrowserConfig(

--- a/packages/shared-test/black-box-runner/execution/remote-browser-websocket-interaction.ts
+++ b/packages/shared-test/black-box-runner/execution/remote-browser-websocket-interaction.ts
@@ -20,6 +20,7 @@ import {
     waitForWsClose,
     waitForWsMessage,
     waitForWsMessageAbsence,
+    waitForWsMessageCount,
     waitForWsMessages
 } from '../ws/ws-wait-expectations.ts';
 import {
@@ -310,6 +311,15 @@ async function sendRemoteWs(interaction: any, config: any, context: any): Promis
             sendLatencyMs: sendEndedAtEpochMs - sendStartedAtEpochMs
         };
 
+        if (interaction.response?.count !== undefined) {
+            return waitWithRemoteWsEventSync({
+                remote,
+                fetchFn,
+                context,
+                wait: () => waitForWsMessageCount({ interaction, config, context, details })
+            });
+        }
+
         if (interaction.response?.messages) {
             return waitWithRemoteWsEventSync({
                 remote,
@@ -378,6 +388,17 @@ async function waitRemoteWs(interaction: any, config: any, context: any): Promis
                 });
             }
 
+            // Before `message`, which resolves on its first match and so cannot
+            // tell "exactly one" from "at least one".
+            if (interaction.response?.count !== undefined) {
+                return waitForWsMessageCount({
+                    interaction,
+                    config,
+                    context,
+                    details: { remote }
+                });
+            }
+
             if (interaction.response?.close !== undefined) {
                 return waitForWsClose(interaction, config, context, {
                     remote
@@ -399,7 +420,8 @@ async function waitRemoteWs(interaction: any, config: any, context: any): Promis
             return Promise.resolve(toRemoteWsFailure({
                 config,
                 interaction,
-                result: 'WebSocket wait expects expect.message, expect.messages, expect.absent, or expect.close'
+                result: 'WebSocket wait expects expect.message, expect.messages, expect.count, ' +
+                    'expect.absent, or expect.close'
             }));
         }
     });

--- a/packages/shared-test/black-box-runner/execution/remote-websocket-commands.ts
+++ b/packages/shared-test/black-box-runner/execution/remote-websocket-commands.ts
@@ -1,0 +1,83 @@
+// deno-lint-ignore-file no-explicit-any
+import type {
+    RallarBlackBoxTestWsCloseCommand,
+    RallarBlackBoxTestWsOpenCommand,
+    RallarBlackBoxTestWsSendCommand
+} from '../../rallar-bb-test/types.ts';
+import { toWsConnectionName } from '../ws/ws-wait-expectations.ts';
+import {
+    assertRemoteDestinationAllowed,
+    assertRemotePayloadWithinLimit
+} from './remote-browser-execution.ts';
+
+export function toWsUrl(request: any): string | undefined {
+    return request.url || request.path;
+}
+
+export function toRemoteWsPayload(request: any): any {
+    return request.send !== undefined
+        ? request.send
+        : request.message !== undefined
+        ? request.message
+        : request.body;
+}
+
+export function toRemoteWsOpenCommand(
+    commandId: string,
+    interaction: any,
+    context: any
+): RallarBlackBoxTestWsOpenCommand {
+    const request = interaction.request;
+    const url = toWsUrl(request);
+    assertRemoteDestinationAllowed({ request, context, url, label: 'WebSocket' });
+    return {
+        kind: 'ws.open',
+        commandId,
+        connection: toWsConnectionName(request),
+        url,
+        protocols: request.protocols,
+        headers: request.headers,
+        timeoutMs: request.timeoutMs,
+        metadata: {
+            blackBoxRunner: request
+        }
+    };
+}
+
+export function toRemoteWsSendCommand(
+    commandId: string,
+    interaction: any,
+    context: any
+): RallarBlackBoxTestWsSendCommand {
+    const request = interaction.request;
+    const data = toRemoteWsPayload(request);
+    assertRemotePayloadWithinLimit({ request, context, value: data, label: 'WebSocket send' });
+    return {
+        kind: 'ws.send',
+        commandId,
+        connection: toWsConnectionName(request),
+        data,
+        timeoutMs: request.timeoutMs,
+        metadata: {
+            blackBoxRunner: request
+        }
+    };
+}
+
+export function toRemoteWsCloseCommand(
+    commandId: string,
+    interaction: any
+): RallarBlackBoxTestWsCloseCommand {
+    const request = interaction.request;
+    return {
+        kind: 'ws.close',
+        commandId,
+        connection: toWsConnectionName(request),
+        code: request.closeCode !== undefined ? request.closeCode : request.code,
+        reason: request.closeReason !== undefined ? request.closeReason : request.reason,
+        timeoutMs: request.timeoutMs,
+        metadata: {
+            blackBoxRunner: request
+        }
+    };
+}

--- a/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
+++ b/packages/shared-test/black-box-runner/expectations/assert-value-comparators.ts
@@ -1,4 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
+import { jsonEquals } from '@shared/repository/state-utils.ts';
+
 export interface AssertComparatorIssue {
     readonly path: any;
     readonly comparator: string;
@@ -168,7 +170,65 @@ function stringIssues(entry: any, value: any): AssertComparatorIssue[] {
     return issues;
 }
 
-const COMPARATOR_KEYS = ['gt', 'gte', 'lt', 'lte', 'between', 'length', 'contains', 'matches'];
+function equalityIssues(entry: any, value: any): AssertComparatorIssue[] {
+    const issues: AssertComparatorIssue[] = [];
+
+    if (entry.equals !== undefined && !jsonEquals(entry.equals, value)) {
+        issues.push(toIssue({
+            path: entry.path,
+            comparator: 'equals',
+            expected: entry.equals,
+            actual: value,
+            message: 'Expected the value to equal the expected value.'
+        }));
+    }
+
+    if (entry.notEquals !== undefined && jsonEquals(entry.notEquals, value)) {
+        issues.push(toIssue({
+            path: entry.path,
+            comparator: 'notEquals',
+            expected: entry.notEquals,
+            actual: value,
+            message: 'Expected the value to differ from the expected value.'
+        }));
+    }
+
+    return issues;
+}
+
+/**
+ * `exists` is decided before the path is required to resolve, because an
+ * absent path is the assertion rather than a failure to make one. Every other
+ * comparator needs a value to compare and reports an unresolved path.
+ */
+function existenceIssues(entry: any, found: boolean): AssertComparatorIssue[] {
+    if (entry.exists === undefined) {
+        return [];
+    }
+
+    const expected = Boolean(entry.exists);
+    return expected === found ? [] : [toIssue({
+        path: entry.path,
+        comparator: 'exists',
+        expected,
+        actual: found,
+        message: expected ? 'Expected the path to resolve to a value.' : 'Expected the path to be absent.'
+    })];
+}
+
+const COMPARATOR_KEYS = [
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'between',
+    'length',
+    'contains',
+    'matches',
+    'equals',
+    'notEquals',
+    'exists'
+];
 
 function entryIssues(entry: any, actual: any): AssertComparatorIssue[] {
     if (typeof entry?.path !== 'string' || entry.path.length <= 0) {
@@ -192,21 +252,32 @@ function entryIssues(entry: any, actual: any): AssertComparatorIssue[] {
     }
 
     const resolved = resolveComparatorValue(entry.path, actual);
+    const existence = existenceIssues(entry, resolved.found);
+    const comparesValue = COMPARATOR_KEYS.some((key) => key !== 'exists' && entry[key] !== undefined);
+    if (!comparesValue) {
+        return existence;
+    }
+
     if (!resolved.found) {
-        return [toIssue({
-            path: entry.path,
-            comparator: 'path',
-            expected: undefined,
-            actual: undefined,
-            message: 'Comparator path did not resolve to a value.'
-        })];
+        return [
+            ...existence,
+            toIssue({
+                path: entry.path,
+                comparator: 'path',
+                expected: undefined,
+                actual: undefined,
+                message: 'Comparator path did not resolve to a value.'
+            })
+        ];
     }
 
     return [
+        ...existence,
         ...numericIssues(entry, resolved.value),
         ...betweenIssues(entry, resolved.value),
         ...lengthIssues(entry, resolved.value),
-        ...stringIssues(entry, resolved.value)
+        ...stringIssues(entry, resolved.value),
+        ...equalityIssues(entry, resolved.value)
     ];
 }
 

--- a/packages/shared-test/black-box-runner/expectations/monotonic-comparison-failures.ts
+++ b/packages/shared-test/black-box-runner/expectations/monotonic-comparison-failures.ts
@@ -1,0 +1,55 @@
+// deno-lint-ignore-file no-explicit-any
+import type { ApiJsonValue } from '@shared/api/api-json-value.ts';
+
+import { resolvePath } from '../execution/black-box-value-resolution.ts';
+
+/**
+ * Each path must resolve to a non-empty array of finite numbers; the first
+ * element smaller than its predecessor is reported with its index and both
+ * values. Equal neighbours pass -- the property is non-decreasing, which is
+ * what a revision, generation or epoch series actually guarantees.
+ */
+export function monotonicComparisonFailures(actual: any, paths: ApiJsonValue | undefined): any[] {
+    if (!Array.isArray(paths)) {
+        return [];
+    }
+
+    return paths.flatMap<any>((path) => {
+        if (typeof path !== 'string' || path.length <= 0) {
+            return [{ path, error: 'Monotonic assertion paths must be non-empty strings.' }];
+        }
+
+        let values: ApiJsonValue;
+        try {
+            values = resolvePath(path, actual);
+        }
+        catch (error) {
+            return [{
+                path,
+                error: error instanceof Error ? error.message : String(error)
+            }];
+        }
+
+        if (!Array.isArray(values) || values.length <= 0) {
+            return [{ path, values, error: 'Monotonic assertion path must resolve to a non-empty array.' }];
+        }
+
+        const numericValues = values.map((value) => Number(value));
+        if (numericValues.some((value) => !Number.isFinite(value))) {
+            return [{ path, values, error: 'Monotonic assertion values must be finite numbers.' }];
+        }
+
+        const regressionIndex = numericValues.findIndex((value, index) =>
+            index > 0 && value < numericValues[index - 1]
+        );
+        return regressionIndex < 0
+            ? []
+            : [{
+                path,
+                values,
+                regressionIndex,
+                previous: numericValues[regressionIndex - 1],
+                current: numericValues[regressionIndex]
+            }];
+    });
+}

--- a/packages/shared-test/black-box-runner/expectations/parallel-aggregate-expectation.ts
+++ b/packages/shared-test/black-box-runner/expectations/parallel-aggregate-expectation.ts
@@ -1,0 +1,52 @@
+// deno-lint-ignore-file no-explicit-any
+import { compareJson, COMPARISON, toConfig } from '../../json-compare/CompareJson.ts';
+import { validateAssertValueComparators } from './assert-value-comparators.ts';
+
+export interface ParallelAggregateFailure {
+    readonly message: string;
+    readonly details: any;
+}
+
+/**
+ * A parallel step's `expect` is compared against its aggregate — group results,
+ * counts, concurrency and timing — which is the only place a bounded outcome
+ * such as "at most K of N succeeded" can be asserted. Child failures are
+ * decided before this, so an aggregate expectation can never mask one.
+ */
+export function parallelAggregateFailure(
+    interaction: any,
+    actual: any
+): ParallelAggregateFailure | undefined {
+    const expectation = interaction.response;
+    if (!expectation) {
+        return undefined;
+    }
+
+    const comparatorIssues = validateAssertValueComparators(actual, expectation.comparators);
+    if (comparatorIssues.length > 0) {
+        return {
+            message: 'Parallel step comparator failed',
+            details: { comparators: expectation.comparators, failures: comparatorIssues }
+        };
+    }
+
+    const expected = expectation.body ?? expectation.expected;
+    if (expected === undefined) {
+        return undefined;
+    }
+
+    const comparison = compareJson(
+        expected,
+        actual,
+        toConfig(
+            expectation.comparison || COMPARISON.COMPATIBLE,
+            expectation.ignoreJsonKeys || [],
+            expectation.ignoreJsonPaths || []
+        )
+    );
+
+    return comparison.isEqual ? undefined : {
+        message: 'Parallel step aggregate comparison failed',
+        details: { expected, comparison }
+    };
+}

--- a/packages/shared-test/black-box-runner/expectations/wait-count-bound.ts
+++ b/packages/shared-test/black-box-runner/expectations/wait-count-bound.ts
@@ -10,20 +10,39 @@ export interface WaitCountBound {
     readonly max: number;
 }
 
+const RANGE_KEYS = ['min', 'max'];
+
+function isNonNegativeInteger(value: unknown): value is number {
+    return Number.isInteger(value) && (value as number) >= 0;
+}
+
+/**
+ * Returns `undefined` for anything that does not name a bound, which the waits
+ * report as a failed expectation. Nothing is coerced and nothing is defaulted
+ * into existence: a `count` that named no recognised key would otherwise become
+ * an unbounded range, and an unbounded range is a cardinality assertion no
+ * observed count can fail.
+ */
 export function toWaitCountBound(count: ApiJsonValue | undefined): WaitCountBound | undefined {
-    if (Number.isInteger(count) && (count as number) >= 0) {
-        return { min: count as number, max: count as number };
+    if (isNonNegativeInteger(count)) {
+        return { min: count, max: count };
     }
 
-    if (!count || typeof count !== 'object') {
+    if (!count || typeof count !== 'object' || Array.isArray(count)) {
         return undefined;
     }
 
-    const range = count as { min?: number; max?: number; };
-    const min = range.min === undefined ? 0 : Number(range.min);
-    const max = range.max === undefined ? Number.POSITIVE_INFINITY : Number(range.max);
-    const isBounded = Number.isInteger(min) && min >= 0 &&
-        (max === Number.POSITIVE_INFINITY || Number.isInteger(max));
+    const range = count as { min?: ApiJsonValue; max?: ApiJsonValue; };
+    if (!RANGE_KEYS.some((key) => range[key as 'min' | 'max'] !== undefined)) {
+        return undefined;
+    }
 
-    return isBounded && min <= max ? { min, max } : undefined;
+    const min = range.min === undefined ? 0 : range.min;
+    const max = range.max === undefined ? Number.POSITIVE_INFINITY : range.max;
+    const isBounded = isNonNegativeInteger(min) &&
+        (max === Number.POSITIVE_INFINITY || isNonNegativeInteger(max));
+
+    return isBounded && (min as number) <= (max as number)
+        ? { min: min as number, max: max as number }
+        : undefined;
 }

--- a/packages/shared-test/black-box-runner/expectations/wait-count-bound.ts
+++ b/packages/shared-test/black-box-runner/expectations/wait-count-bound.ts
@@ -1,0 +1,29 @@
+import type { ApiJsonValue } from '@shared/api/api-json-value.ts';
+
+/**
+ * The cardinality a `count` wait accepts: an exact non-negative integer, or a
+ * `{min,max}` range with either end optional. Shared by the WS and RTC waits so
+ * one vocabulary decides both.
+ */
+export interface WaitCountBound {
+    readonly min: number;
+    readonly max: number;
+}
+
+export function toWaitCountBound(count: ApiJsonValue | undefined): WaitCountBound | undefined {
+    if (Number.isInteger(count) && (count as number) >= 0) {
+        return { min: count as number, max: count as number };
+    }
+
+    if (!count || typeof count !== 'object') {
+        return undefined;
+    }
+
+    const range = count as { min?: number; max?: number; };
+    const min = range.min === undefined ? 0 : Number(range.min);
+    const max = range.max === undefined ? Number.POSITIVE_INFINITY : Number(range.max);
+    const isBounded = Number.isInteger(min) && min >= 0 &&
+        (max === Number.POSITIVE_INFINITY || Number.isInteger(max));
+
+    return isBounded && min <= max ? { min, max } : undefined;
+}

--- a/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
+++ b/packages/shared-test/black-box-runner/preflight/plan-preflight.ts
@@ -963,6 +963,10 @@ function validateStrictStep(step: JsonRecord, path: string): readonly BlackBoxRu
  * the runner will not perform. Wait plumbing (`connection`, `withinMs`,
  * `consume`) is deliberately absent from this list: those are honoured
  * elsewhere on the step and flagging them would be noise, not a finding.
+ *
+ * A `parallel` step is no longer listed here at all. Its `expect` is compared
+ * against the aggregate, so flagging it would block the capability rather than
+ * report a dropped one.
  */
 const WS_SEND_IGNORED_ASSERTION_KEYS = ['absent', 'close'];
 
@@ -975,15 +979,6 @@ function validateStrictExpectIsHonoured(
     const expectedKeys = Object.keys(expected);
     if (expectedKeys.length <= 0) {
         return [];
-    }
-
-    if (type === 'parallel') {
-        return [{
-            severity: 'error',
-            code: 'STRICT_EXPECT_IGNORED',
-            message: 'Parallel steps ignore expect entirely; assert on the group steps instead.',
-            path: `${path}.expect`
-        }];
     }
 
     const action = String(asRecord(step.request).action || '').toLowerCase();

--- a/packages/shared-test/black-box-runner/rallar-remote-browser-provider.ts
+++ b/packages/shared-test/black-box-runner/rallar-remote-browser-provider.ts
@@ -1247,16 +1247,19 @@ export function createRallarRemoteBrowserRtcProvider(
                         remote
                     });
                 }
+
                 if (interaction.response?.diagnostics) {
                     return waitForRtcDiagnostics(interaction, config, context, {
                         remote
                     });
                 }
+
                 if (interaction.response?.diagnostic) {
                     return waitForRtcDiagnostic(interaction, config, context, {
                         remote
                     });
                 }
+
                 if (interaction.response?.health !== undefined) {
                     return waitForRemoteRtcHealth(
                         remote,
@@ -1269,6 +1272,7 @@ export function createRallarRemoteBrowserRtcProvider(
                         }
                     );
                 }
+
                 // Before `message`, which resolves on its first match.
                 if (interaction.response?.count !== undefined) {
                     return waitForRtcMessageCount({
@@ -1278,11 +1282,13 @@ export function createRallarRemoteBrowserRtcProvider(
                         details: { remote }
                     });
                 }
+
                 if (interaction.response?.messages) {
                     return waitForRtcMessages(interaction, config, context, {
                         remote
                     });
                 }
+
                 if (interaction.response?.message) {
                     return waitForRtcMessage(interaction, config, context, {
                         remote

--- a/packages/shared-test/black-box-runner/rallar-remote-browser-provider.ts
+++ b/packages/shared-test/black-box-runner/rallar-remote-browser-provider.ts
@@ -18,6 +18,7 @@ import {
     waitForRtcDiagnostics,
     waitForRtcHealth,
     waitForRtcMessage,
+    waitForRtcMessageCount,
     waitForRtcMessages,
     type RtcProvider
 } from './rtc-provider.ts';
@@ -1135,6 +1136,16 @@ export function createRallarRemoteBrowserRtcProvider(
                     sendLatencyMs: sendEndedAtEpochMs - sendStartedAtEpochMs
                 };
 
+                // Before `message`, which resolves on its first match.
+                if (interaction.response?.count !== undefined) {
+                    return waitWithRemoteEventSync(
+                        remote,
+                        fetchFn,
+                        context,
+                        () => waitForRtcMessageCount({ interaction, config, context, details })
+                    );
+                }
+
                 if (interaction.response?.messages) {
                     return waitWithRemoteEventSync(
                         remote,
@@ -1258,6 +1269,15 @@ export function createRallarRemoteBrowserRtcProvider(
                         }
                     );
                 }
+                // Before `message`, which resolves on its first match.
+                if (interaction.response?.count !== undefined) {
+                    return waitForRtcMessageCount({
+                        interaction,
+                        config,
+                        context,
+                        details: { remote }
+                    });
+                }
                 if (interaction.response?.messages) {
                     return waitForRtcMessages(interaction, config, context, {
                         remote
@@ -1272,7 +1292,8 @@ export function createRallarRemoteBrowserRtcProvider(
                 return Promise.resolve(toRtcFailureStatus(
                     config,
                     interaction,
-                    'RTC wait expects expect.message, expect.messages, expect.diagnostic, expect.diagnostics, expect.health, or expect.close',
+                    'RTC wait expects expect.message, expect.messages, expect.count, expect.diagnostic, ' +
+                        'expect.diagnostics, expect.health, or expect.close',
                     {
                         connection: toRtcExpectedConnectionName(interaction),
                         remote

--- a/packages/shared-test/black-box-runner/rallar-stub-rtc-provider.ts
+++ b/packages/shared-test/black-box-runner/rallar-stub-rtc-provider.ts
@@ -12,6 +12,7 @@ import {
     waitForRtcClose,
     waitForRtcMessage,
     waitForRtcMessageAbsence,
+    waitForRtcMessageCount,
     waitForRtcMessages,
     type RtcProvider
 } from './rtc-provider.ts';
@@ -112,6 +113,16 @@ export function createRallarStubRtcProvider(): RtcProvider {
 
             if (interaction.response?.absent !== undefined) {
                 return waitForRtcMessageAbsence({
+                    interaction,
+                    config,
+                    context,
+                    details: { stub: true }
+                });
+            }
+
+            // Before `message`, which resolves on its first match.
+            if (interaction.response?.count !== undefined) {
+                return waitForRtcMessageCount({
                     interaction,
                     config,
                     context,

--- a/packages/shared-test/black-box-runner/rallar-stub-rtc-provider.ts
+++ b/packages/shared-test/black-box-runner/rallar-stub-rtc-provider.ts
@@ -75,6 +75,22 @@ export function createRallarStubRtcProvider(): RtcProvider {
                 });
             });
 
+            // Before `message`, which resolves on its first match.
+            if (interaction.response?.count !== undefined) {
+                return waitForRtcMessageCount({
+                    interaction,
+                    config,
+                    context,
+                    details: {
+                        sentConnection: connectionName,
+                        sent: payload,
+                        deliveredMessages,
+                        deliverTargets,
+                        stub: true
+                    }
+                });
+            }
+
             if (interaction.response?.messages) {
                 return waitForRtcMessages(interaction, config, context, {
                     sentConnection: connectionName,
@@ -145,7 +161,8 @@ export function createRallarStubRtcProvider(): RtcProvider {
             return Promise.resolve(toRtcFailureStatus(
                 config,
                 interaction,
-                'RTC wait expects expect.message, expect.messages, expect.absent, or expect.close',
+                'RTC wait expects expect.message, expect.messages, expect.count, ' +
+                    'expect.absent, or expect.close',
                 {
                     stub: true,
                     connection: toRtcExpectedConnectionName(interaction)

--- a/packages/shared-test/black-box-runner/rtc-provider.ts
+++ b/packages/shared-test/black-box-runner/rtc-provider.ts
@@ -15,6 +15,7 @@ import {
     waitForRtcHealth,
     waitForRtcMessage,
     waitForRtcMessageAbsence,
+    waitForRtcMessageCount,
     waitForRtcMessages
 } from './rtc/rtc-wait-expectations.ts';
 
@@ -324,6 +325,11 @@ export function createRtcProviderFromClientFactory(options: RtcClientProviderOpt
 
             if (interaction.response?.absent !== undefined) {
                 return waitForRtcMessageAbsence({ interaction, config, context });
+            }
+
+            // Before `message`, which resolves on its first match.
+            if (interaction.response?.count !== undefined) {
+                return waitForRtcMessageCount({ interaction, config, context });
             }
 
             if (interaction.response?.diagnostics) {

--- a/packages/shared-test/black-box-runner/rtc-provider.ts
+++ b/packages/shared-test/black-box-runner/rtc-provider.ts
@@ -284,6 +284,16 @@ export function createRtcProviderFromClientFactory(options: RtcClientProviderOpt
                 diagnostics: connection.diagnostics
             };
 
+            // Before `message`, which resolves on its first match.
+            if (interaction.response?.count !== undefined) {
+                return waitForRtcMessageCount({
+                    interaction,
+                    config,
+                    context,
+                    details: sendWaitDetails
+                });
+            }
+
             if (interaction.response?.messages) {
                 return waitForRtcMessages(interaction, config, context, sendWaitDetails);
             }
@@ -355,7 +365,7 @@ export function createRtcProviderFromClientFactory(options: RtcClientProviderOpt
             return toRtcFailureStatus(
                 config,
                 interaction,
-                'RTC wait expects expect.message, expect.messages, expect.absent, ' +
+                'RTC wait expects expect.message, expect.messages, expect.count, expect.absent, ' +
                     'expect.diagnostic, expect.diagnostics, expect.health, or expect.close',
                 {
                     connection: toRtcExpectedConnectionName(interaction)

--- a/packages/shared-test/black-box-runner/rtc/rtc-wait-expectations.ts
+++ b/packages/shared-test/black-box-runner/rtc/rtc-wait-expectations.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
 import { compareJson, COMPARISON, toConfig } from '../../json-compare/CompareJson.ts';
+import { toWaitCountBound } from '../expectations/wait-count-bound.ts';
 
 const SUCCESS = 'SUCCESS';
 const FAILURE = 'FAILURE';
@@ -714,6 +715,81 @@ export function waitForRtcClose(
                 }));
             }
         }, 25);
+    });
+}
+
+export interface WaitForRtcMessageCountInput {
+    readonly interaction: any;
+    readonly config: any;
+    readonly context: any;
+    readonly details?: any;
+}
+
+function countMatchingRtcMessages(messages: any[], expectedMessage: any, interaction: any): number {
+    return messages.filter((message) =>
+        compareJson(expectedMessage, message.data, toRtcComparisonConfig(interaction)).isEqual
+    ).length;
+}
+
+/**
+ * Cardinality over the whole window, mirroring the WebSocket wait.
+ * `waitForRtcMessage` resolves on its first match and so cannot tell "exactly
+ * one" from "at least one"; this waits the full `withinMs` before counting.
+ */
+export function waitForRtcMessageCount(input: WaitForRtcMessageCountInput): Promise<any> {
+    const { interaction, config, context } = input;
+    const details = input.details ?? {};
+    const connectionName = toRtcExpectedConnectionName(interaction);
+    const expectedMessage = interaction.response.message;
+    const bound = toWaitCountBound(interaction.response.count);
+    const windowMs = Number.parseInt(
+        interaction.response.withinMs || interaction.request.timeoutMs || 5000
+    );
+    const startedAt = Date.now();
+
+    if (expectedMessage === undefined || expectedMessage === null) {
+        return Promise.resolve(toRtcFailureStatus(
+            config,
+            interaction,
+            'RTC count wait expects expect.message to match frames against.',
+            { ...details, connection: connectionName }
+        ));
+    }
+
+    if (bound === undefined) {
+        return Promise.resolve(toRtcFailureStatus(
+            config,
+            interaction,
+            'RTC count wait expects expect.count to be a non-negative integer or {min,max}.',
+            { ...details, connection: connectionName, count: interaction.response.count }
+        ));
+    }
+
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const messages = context.rtcMessages[connectionName] || [];
+            const matchedCount = countMatchingRtcMessages(messages, expectedMessage, interaction);
+            const reported = {
+                ...details,
+                connection: connectionName,
+                expectedMessage,
+                expectedCount: interaction.response.count,
+                matchedCount,
+                observedMessageCount: messages.length,
+                waitedMs: Date.now() - startedAt
+            };
+
+            resolve(
+                matchedCount >= bound.min && matchedCount <= bound.max
+                    ? toRtcSuccessStatus(config, interaction, reported)
+                    : toRtcFailureStatus(
+                        config,
+                        interaction,
+                        'RTC message count did not match the expectation',
+                        reported
+                    )
+            );
+        }, windowMs);
     });
 }
 

--- a/packages/shared-test/black-box-runner/ws/ws-wait-expectations.ts
+++ b/packages/shared-test/black-box-runner/ws/ws-wait-expectations.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { compareJson, COMPARISON, toConfig } from '../../json-compare/CompareJson.ts';
 import { toBoundedWsWaitMessages } from '../artifacts/with-bounded-artifact-report-results.ts';
+import { toWaitCountBound } from '../expectations/wait-count-bound.ts';
 import { toWsExpectedConnectionName, toWsFailureStatus, toWsSuccessStatus } from './ws-interaction-statuses.ts';
 
 export {
@@ -294,6 +295,82 @@ export function waitForWsClose(
                 }));
             }
         }, 25);
+    });
+}
+
+export interface WaitForWsMessageCountInput {
+    readonly interaction: any;
+    readonly config: any;
+    readonly context: any;
+    readonly details?: any;
+}
+
+function countMatchingWsMessages(messages: any[], expectedMessage: any, interaction: any): number {
+    return messages.filter((message) =>
+        compareJson(expectedMessage, message.data, toWsComparisonConfig(interaction)).isEqual
+    ).length;
+}
+
+/**
+ * Cardinality over the whole window. `waitForWsMessage` resolves on the first
+ * match, which cannot distinguish "exactly one" from "at least one" -- so this
+ * always waits the full `withinMs` before counting, the same reason
+ * `waitForWsMessageAbsence` does.
+ */
+export function waitForWsMessageCount(input: WaitForWsMessageCountInput): Promise<any> {
+    const { interaction, config, context } = input;
+    const details = input.details ?? {};
+    const connectionName = toWsExpectedConnectionName(interaction);
+    const expectedMessage = interaction.response.message;
+    const bound = toWaitCountBound(interaction.response.count);
+    const windowMs = Number.parseInt(
+        interaction.response.withinMs || interaction.request.timeoutMs || 5000
+    );
+    const startedAt = Date.now();
+
+    if (expectedMessage === undefined || expectedMessage === null) {
+        return Promise.resolve(toWsFailureStatus(
+            config,
+            interaction,
+            'WebSocket count wait expects expect.message to match frames against.',
+            { ...details, connection: connectionName }
+        ));
+    }
+
+    if (bound === undefined) {
+        return Promise.resolve(toWsFailureStatus(
+            config,
+            interaction,
+            'WebSocket count wait expects expect.count to be a non-negative integer or {min,max}.',
+            { ...details, connection: connectionName, count: interaction.response.count }
+        ));
+    }
+
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const messages = context.wsMessages[connectionName] || [];
+            const matchedCount = countMatchingWsMessages(messages, expectedMessage, interaction);
+            const reported = {
+                ...details,
+                connection: connectionName,
+                expectedMessage,
+                expectedCount: interaction.response.count,
+                matchedCount,
+                observedMessageCount: messages.length,
+                waitedMs: Date.now() - startedAt
+            };
+
+            resolve(
+                matchedCount >= bound.min && matchedCount <= bound.max
+                    ? toWsSuccessStatus(config, interaction, reported)
+                    : toWsFailureStatus(
+                        config,
+                        interaction,
+                        'WebSocket message count did not match the expectation',
+                        reported
+                    )
+            );
+        }, windowMs);
     });
 }
 

--- a/packages/tests/shared-test/black-box-runner-strict-expectations.test.ts
+++ b/packages/tests/shared-test/black-box-runner-strict-expectations.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject } from '@shared/api/api-json-value.ts';
+import { explainBlackBoxRunnerPlan } from '../../shared-test/black-box-runner/preflight/plan-preflight.ts';
+
+function strictIssueCodes(step: ApiJsonObject): readonly string[] {
+    const plan = explainBlackBoxRunnerPlan({
+        rawConfig: { steps: [step] },
+        profile: 'strict'
+    } as never);
+
+    return (plan.issues ?? []).map((issue: { code: string; }) => issue.code);
+}
+
+const PARALLEL_GROUPS = [{ name: 'alpha', steps: [] }];
+
+describe('strict preflight expectation checks', () => {
+    // The runner compares a parallel step's expect against its aggregate, so a
+    // gate that rejects one would block the capability rather than report a
+    // dropped assertion.
+    it('accepts an expectation on a parallel step', () => {
+        expect(strictIssueCodes({
+            name: 'race',
+            type: 'parallel',
+            request: { maxConcurrency: 2 },
+            groups: PARALLEL_GROUPS,
+            expect: { comparators: [{ path: 'success', lte: 2 }] }
+        })).not.toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    it('accepts a body expectation on a parallel step', () => {
+        expect(strictIssueCodes({
+            name: 'race',
+            type: 'parallel',
+            request: { maxConcurrency: 2 },
+            groups: PARALLEL_GROUPS,
+            expect: { body: { groupCount: 2, failure: 0 } }
+        })).not.toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    // The keys a WebSocket send genuinely never reads still have to be caught,
+    // or the lint stops doing the job it was added for.
+    it('still reports an absence expectation on a websocket send', () => {
+        expect(strictIssueCodes({
+            name: 'sendAndHope',
+            type: 'ws.send',
+            request: { action: 'send', connection: 'wsAlice', message: {} },
+            expect: { absent: { id: { msgId: 'never' } } }
+        })).toContain('STRICT_EXPECT_IGNORED');
+    });
+
+    it('still reports an empty expected array under a compatible comparison', () => {
+        expect(strictIssueCodes({
+            name: 'readGroup',
+            type: 'http',
+            request: { method: 'GET', path: '/api/state/groups/g' },
+            expect: { body: { managerPrincipalIds: [] } }
+        })).toContain('STRICT_EXPECT_VACUOUS');
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
+++ b/packages/tests/shared-test/execute-black-box-assert-comparators.test.ts
@@ -161,3 +161,117 @@ describe('executeBlackBox ASSERT expect.comparators', () => {
         expect(result.details.message).toBe('Json array has unexpected elements');
     });
 });
+
+describe('executeBlackBox ASSERT path comparators', () => {
+    it('compares a resolved value for equality and inequality', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { denial: { code: 'forbidden-role', status: 403 } },
+                expectFields: {
+                    comparators: [
+                        { path: 'denial.code', equals: 'forbidden-role' },
+                        { path: 'denial.status', equals: 403 },
+                        { path: 'denial.code', notEquals: 'member-not-active' }
+                    ]
+                },
+                name: 'denialCodeIsNamed'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // The reason this comparator family exists: a denial recipe asserting only
+    // the status cannot tell a correct denial from a differently-wrong one.
+    it('reports the mismatching code rather than only that something differed', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { denial: { code: 'member-not-active' } },
+                expectFields: { comparators: [{ path: 'denial.code', equals: 'forbidden-role' }] },
+                name: 'wrongDenialCode'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+        expect(JSON.stringify(report)).toContain('forbidden-role');
+        expect(JSON.stringify(report)).toContain('member-not-active');
+    });
+
+    it('compares structured values by deep equality', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { identity: { groupRevision: 9, presenceRevision: 2 } },
+                expectFields: {
+                    comparators: [{ path: 'identity', equals: { groupRevision: 9, presenceRevision: 2 } }]
+                },
+                name: 'identityMatches'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('asserts a path is present without constraining its value', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { activationStatus: { condition: 'active' } },
+                expectFields: { comparators: [{ path: 'activationStatus.condition', exists: true }] },
+                name: 'conditionIsPresent'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // An absent path is the assertion here, so it must not be reported as an
+    // unresolvable path the way every other comparator treats it.
+    it('asserts a path is absent', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: { lifecycleState: 'active' } },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: false }] },
+                name: 'noStatusStored'
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('fails when a path asserted absent is present', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: { activationStatus: { condition: 'degraded' } } },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: false }] },
+                name: 'unexpectedStatus'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('fails when a path asserted present is absent', async () => {
+        const report = await executeBlackBox(
+            [assertStep({
+                actual: { group: {} },
+                expectFields: { comparators: [{ path: 'group.activationStatus', exists: true }] },
+                name: 'missingStatus'
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
+++ b/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
+
+function assertGroup(name: string, actual: unknown, expected: unknown): Record<string, unknown> {
+    return {
+        name,
+        steps: [{
+            ASSERT: {
+                request: { actual, scenarioExecutionNumber: 1, interactionExecutionNumber: 1 },
+                response: { body: expected }
+            },
+            [`${name}Step`]: {}
+        }]
+    };
+}
+
+function parallelStep(input: {
+    groups: Array<Record<string, unknown>>;
+    expectFields?: Record<string, unknown>;
+}): Record<string, unknown> {
+    return {
+        PARALLEL: {
+            request: {
+                groups: input.groups,
+                maxConcurrency: 2,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber: 1
+            },
+            ...(input.expectFields === undefined ? {} : { response: input.expectFields })
+        },
+        raceOutcome: {}
+    };
+}
+
+describe('executeBlackBox PARALLEL expect', () => {
+    it('passes a parallel step whose aggregate matches the expectation', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { body: { groupCount: 2, failure: 0, success: 2 } }
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // The defect this closes: the executor built a rich `actual` and never
+    // compared it, so an expectation on a parallel step was a silent no-op and
+    // a recipe could assert something plainly false and still pass.
+    it('fails a parallel step whose aggregate contradicts the expectation', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { body: { groupCount: 99 } }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('supports comparators over the aggregate, so a bounded outcome is expressible', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { comparators: [{ path: 'success', lte: 2 }, { path: 'failure', equals: 0 }] }
+            })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    it('fails when a comparator over the aggregate does not hold', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 1), assertGroup('beta', 2, 2)],
+                expectFields: { comparators: [{ path: 'success', lt: 1 }] }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBe(1);
+    });
+
+    it('leaves a parallel step without an expectation unchanged', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({ groups: [assertGroup('alpha', 1, 1)] })],
+            0,
+            { failFast: true }
+        );
+
+        expect(report.summary.failure).toBe(0);
+    });
+
+    // A child failure must still fail the parent, and must not be masked by a
+    // passing aggregate expectation.
+    it('keeps a failing child failing even when the expectation holds', async () => {
+        const report = await executeBlackBox(
+            [parallelStep({
+                groups: [assertGroup('alpha', 1, 2)],
+                expectFields: { body: { groupCount: 1 } }
+            })],
+            0,
+            { failFast: false }
+        );
+
+        expect(report.summary.failure).toBeGreaterThan(0);
+    });
+});

--- a/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
+++ b/packages/tests/shared-test/execute-black-box-parallel-expectations.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject, ApiJsonValue } from '@shared/api/api-json-value.ts';
 import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
 
-function assertGroup(name: string, actual: unknown, expected: unknown): Record<string, unknown> {
+function assertGroup(name: string, actual: ApiJsonValue, expected: ApiJsonValue): ApiJsonObject {
     return {
         name,
         steps: [{
@@ -15,9 +17,9 @@ function assertGroup(name: string, actual: unknown, expected: unknown): Record<s
 }
 
 function parallelStep(input: {
-    groups: Array<Record<string, unknown>>;
-    expectFields?: Record<string, unknown>;
-}): Record<string, unknown> {
+    groups: readonly ApiJsonObject[];
+    expectFields?: ApiJsonObject;
+}): ApiJsonObject {
     return {
         PARALLEL: {
             request: {

--- a/packages/tests/shared-test/fake-remote-browser-control-server.ts
+++ b/packages/tests/shared-test/fake-remote-browser-control-server.ts
@@ -1,0 +1,234 @@
+import type { RallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/types.ts';
+
+type StoredResult = Readonly<{
+    kind: 'result';
+    runId: string;
+    agentId: string;
+    commandId: string;
+    ok: boolean;
+    result: Readonly<{
+        commandId: string;
+        kind: string;
+        status: 'ok';
+        ok: true;
+        startedAtEpochMs: number;
+        endedAtEpochMs: number;
+        durationMs: number;
+        value: unknown;
+    }>;
+}>;
+
+type StoredEvent = Readonly<{
+    kind: 'event';
+    runId: string;
+    agentId: string;
+    atEpochMs: number;
+    eventId: string;
+    commandId: string;
+    payload: unknown;
+}>;
+
+export class FakeRemoteBrowserControlServer {
+    readonly commands: RallarBlackBoxTestCommand[] = [];
+    readonly results: StoredResult[] = [];
+    readonly events: StoredEvent[] = [];
+
+    fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = new URL(String(input));
+        const commandMatch = url.pathname.match(/^\/runs\/([^/]+)\/agents\/([^/]+)\/commands$/);
+        if (init?.method === 'POST' && commandMatch) {
+            const runId = decodeURIComponent(commandMatch[1]);
+            const agentId = decodeURIComponent(commandMatch[2]);
+            const body = JSON.parse(String(init.body ?? '{}')) as {
+                command: RallarBlackBoxTestCommand;
+            };
+            this.acceptCommand(runId, agentId, body.command);
+            return toJsonResponse({
+                accepted: true
+            }, 202);
+        }
+
+        const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/);
+        if ((!init?.method || init.method === 'GET') && runMatch) {
+            return toJsonResponse({
+                runId: decodeURIComponent(runMatch[1]),
+                results: this.results,
+                events: this.events
+            });
+        }
+
+        return toJsonResponse({
+            error: 'Not found'
+        }, 404);
+    };
+
+    private acceptCommand(
+        runId: string,
+        agentId: string,
+        command: RallarBlackBoxTestCommand
+    ): void {
+        this.commands.push(command);
+        const now = 1_000 + this.results.length;
+        if (command.kind === 'rtc.connect') {
+            this.events.push({
+                kind: 'event',
+                runId,
+                agentId,
+                atEpochMs: now,
+                eventId: `event-${command.commandId}-connected`,
+                commandId: command.commandId ?? 'missing-command',
+                payload: {
+                    eventId: `event-${command.commandId}-connected`,
+                    kind: 'diagnostic',
+                    topic: 'rallar.bb.rtc.connected',
+                    atEpochMs: now,
+                    commandId: command.commandId,
+                    connection: command.connection,
+                    actor: command.actor,
+                    transport: command.transport,
+                    payload: {
+                        roomId: command.roomId,
+                        roomRef: command.roomRef,
+                        applicationId: command.applicationId,
+                        workspaceId: command.workspaceId,
+                        data: {
+                            connected: true
+                        }
+                    }
+                }
+            });
+        }
+
+        if (command.kind === 'rtc.send') {
+            this.events.push({
+                kind: 'event',
+                runId,
+                agentId,
+                atEpochMs: now,
+                eventId: `event-${command.commandId}`,
+                commandId: command.commandId ?? 'missing-command',
+                payload: {
+                    eventId: `event-${command.commandId}`,
+                    kind: 'message',
+                    topic: 'rallar.remote.fake.message',
+                    atEpochMs: now,
+                    commandId: command.commandId,
+                    connection: command.connection,
+                    payload: {
+                        data: command.send
+                    }
+                }
+            });
+        }
+
+        if (command.kind === 'ws.send') {
+            this.events.push({
+                kind: 'event',
+                runId,
+                agentId,
+                atEpochMs: now,
+                eventId: `event-${command.commandId}`,
+                commandId: command.commandId ?? 'missing-command',
+                payload: {
+                    eventId: `event-${command.commandId}`,
+                    kind: 'message',
+                    topic: 'rallar.bb.ws.message',
+                    atEpochMs: now,
+                    commandId: command.commandId,
+                    connection: command.connection,
+                    transport: 'ws',
+                    payload: {
+                        data: command.data
+                    }
+                }
+            });
+        }
+
+        if (command.kind === 'ws.close') {
+            this.events.push({
+                kind: 'event',
+                runId,
+                agentId,
+                atEpochMs: now,
+                eventId: `event-${command.commandId}`,
+                commandId: command.commandId ?? 'missing-command',
+                payload: {
+                    eventId: `event-${command.commandId}`,
+                    kind: 'event',
+                    topic: 'rallar.bb.ws.closed',
+                    atEpochMs: now,
+                    commandId: command.commandId,
+                    connection: command.connection,
+                    transport: 'ws',
+                    payload: {
+                        code: command.code,
+                        reason: command.reason,
+                        wasClean: true
+                    }
+                }
+            });
+        }
+
+        this.results.push({
+            kind: 'result',
+            runId,
+            agentId,
+            commandId: command.commandId ?? 'missing-command',
+            ok: true,
+            result: {
+                commandId: command.commandId ?? 'missing-command',
+                kind: command.kind,
+                status: 'ok',
+                ok: true,
+                startedAtEpochMs: now,
+                endedAtEpochMs: now + 1,
+                durationMs: 1,
+                value: this.resultValue(command)
+            }
+        });
+    }
+
+    private resultValue(command: RallarBlackBoxTestCommand): unknown {
+        if (command.kind === 'http.request') {
+            return {
+                url: command.request.url ?? command.request.path,
+                status: 201,
+                statusText: 'Created',
+                ok: true,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                body: {
+                    ok: true,
+                    method: command.request.method,
+                    body: command.request.body
+                }
+            };
+        }
+
+        if (command.kind === 'health') {
+            return {
+                rallar: {
+                    connected: true,
+                    laneHealth: {
+                        ready: true
+                    }
+                }
+            };
+        }
+
+        return {
+            accepted: true,
+            command
+        };
+    }
+}
+
+export function toJsonResponse(value: unknown, status = 200): Response {
+    return new Response(JSON.stringify(value), {
+        status,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+}

--- a/packages/tests/shared-test/fake-remote-browser-control-server.ts
+++ b/packages/tests/shared-test/fake-remote-browser-control-server.ts
@@ -1,4 +1,31 @@
-import type { RallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/types.ts';
+import type {
+    RallarBlackBoxTestCommand,
+    RallarBlackBoxTestEvent,
+    RallarBlackBoxTestHttpRequestCommand,
+    RallarBlackBoxTestResult
+} from '../../shared-test/rallar-bb-test/types.ts';
+
+/** The three canned values this fake answers commands with. */
+type FakeCommandResultValue =
+    | Readonly<{
+        url: string | undefined;
+        status: number;
+        statusText: string;
+        ok: true;
+        headers: Readonly<Record<string, string>>;
+        body: Readonly<{
+            ok: true;
+            method: string | undefined;
+            body: RallarBlackBoxTestHttpRequestCommand['request']['body'];
+        }>;
+    }>
+    | Readonly<{
+        rallar: Readonly<{
+            connected: true;
+            laneHealth: Readonly<{ ready: true; }>;
+        }>;
+    }>
+    | Readonly<{ accepted: true; command: RallarBlackBoxTestCommand; }>;
 
 type StoredResult = Readonly<{
     kind: 'result';
@@ -6,16 +33,7 @@ type StoredResult = Readonly<{
     agentId: string;
     commandId: string;
     ok: boolean;
-    result: Readonly<{
-        commandId: string;
-        kind: string;
-        status: 'ok';
-        ok: true;
-        startedAtEpochMs: number;
-        endedAtEpochMs: number;
-        durationMs: number;
-        value: unknown;
-    }>;
+    result: RallarBlackBoxTestResult<FakeCommandResultValue>;
 }>;
 
 type StoredEvent = Readonly<{
@@ -25,7 +43,7 @@ type StoredEvent = Readonly<{
     atEpochMs: number;
     eventId: string;
     commandId: string;
-    payload: unknown;
+    payload: RallarBlackBoxTestEvent;
 }>;
 
 export class FakeRemoteBrowserControlServer {
@@ -188,7 +206,7 @@ export class FakeRemoteBrowserControlServer {
         });
     }
 
-    private resultValue(command: RallarBlackBoxTestCommand): unknown {
+    private resultValue(command: RallarBlackBoxTestCommand): FakeCommandResultValue {
         if (command.kind === 'http.request') {
             return {
                 url: command.request.url ?? command.request.path,
@@ -224,7 +242,7 @@ export class FakeRemoteBrowserControlServer {
     }
 }
 
-export function toJsonResponse(value: unknown, status = 200): Response {
+export function toJsonResponse<T>(value: T, status = 200): Response {
     return new Response(JSON.stringify(value), {
         status,
         headers: {

--- a/packages/tests/shared-test/rallar-remote-browser-provider.test.ts
+++ b/packages/tests/shared-test/rallar-remote-browser-provider.test.ts
@@ -1,240 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
 import { createRallarRemoteBrowserRtcProvider } from '../../shared-test/black-box-runner/rallar-remote-browser-provider.ts';
-import type { RallarBlackBoxTestCommand } from '../../shared-test/rallar-bb-test/types.ts';
-
-type StoredResult = Readonly<{
-    kind: 'result';
-    runId: string;
-    agentId: string;
-    commandId: string;
-    ok: boolean;
-    result: Readonly<{
-        commandId: string;
-        kind: string;
-        status: 'ok';
-        ok: true;
-        startedAtEpochMs: number;
-        endedAtEpochMs: number;
-        durationMs: number;
-        value: unknown;
-    }>;
-}>;
-
-type StoredEvent = Readonly<{
-    kind: 'event';
-    runId: string;
-    agentId: string;
-    atEpochMs: number;
-    eventId: string;
-    commandId: string;
-    payload: unknown;
-}>;
-
-class FakeRemoteControlServer {
-    readonly commands: RallarBlackBoxTestCommand[] = [];
-    readonly results: StoredResult[] = [];
-    readonly events: StoredEvent[] = [];
-
-    fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = new URL(String(input));
-        const commandMatch = url.pathname.match(/^\/runs\/([^/]+)\/agents\/([^/]+)\/commands$/);
-        if (init?.method === 'POST' && commandMatch) {
-            const runId = decodeURIComponent(commandMatch[1]);
-            const agentId = decodeURIComponent(commandMatch[2]);
-            const body = JSON.parse(String(init.body ?? '{}')) as {
-                command: RallarBlackBoxTestCommand;
-            };
-            this.acceptCommand(runId, agentId, body.command);
-            return jsonResponse({
-                accepted: true
-            }, 202);
-        }
-
-        const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/);
-        if ((!init?.method || init.method === 'GET') && runMatch) {
-            return jsonResponse({
-                runId: decodeURIComponent(runMatch[1]),
-                results: this.results,
-                events: this.events
-            });
-        }
-
-        return jsonResponse({
-            error: 'Not found'
-        }, 404);
-    };
-
-    private acceptCommand(
-        runId: string,
-        agentId: string,
-        command: RallarBlackBoxTestCommand
-    ): void {
-        this.commands.push(command);
-        const now = 1_000 + this.results.length;
-        if (command.kind === 'rtc.connect') {
-            this.events.push({
-                kind: 'event',
-                runId,
-                agentId,
-                atEpochMs: now,
-                eventId: `event-${command.commandId}-connected`,
-                commandId: command.commandId ?? 'missing-command',
-                payload: {
-                    eventId: `event-${command.commandId}-connected`,
-                    kind: 'diagnostic',
-                    topic: 'rallar.bb.rtc.connected',
-                    atEpochMs: now,
-                    commandId: command.commandId,
-                    connection: command.connection,
-                    actor: command.actor,
-                    transport: command.transport,
-                    payload: {
-                        roomId: command.roomId,
-                        roomRef: command.roomRef,
-                        applicationId: command.applicationId,
-                        workspaceId: command.workspaceId,
-                        data: {
-                            connected: true
-                        }
-                    }
-                }
-            });
-        }
-
-        if (command.kind === 'rtc.send') {
-            this.events.push({
-                kind: 'event',
-                runId,
-                agentId,
-                atEpochMs: now,
-                eventId: `event-${command.commandId}`,
-                commandId: command.commandId ?? 'missing-command',
-                payload: {
-                    eventId: `event-${command.commandId}`,
-                    kind: 'message',
-                    topic: 'rallar.remote.fake.message',
-                    atEpochMs: now,
-                    commandId: command.commandId,
-                    connection: command.connection,
-                    payload: {
-                        data: command.send
-                    }
-                }
-            });
-        }
-
-        if (command.kind === 'ws.send') {
-            this.events.push({
-                kind: 'event',
-                runId,
-                agentId,
-                atEpochMs: now,
-                eventId: `event-${command.commandId}`,
-                commandId: command.commandId ?? 'missing-command',
-                payload: {
-                    eventId: `event-${command.commandId}`,
-                    kind: 'message',
-                    topic: 'rallar.bb.ws.message',
-                    atEpochMs: now,
-                    commandId: command.commandId,
-                    connection: command.connection,
-                    transport: 'ws',
-                    payload: {
-                        data: command.data
-                    }
-                }
-            });
-        }
-
-        if (command.kind === 'ws.close') {
-            this.events.push({
-                kind: 'event',
-                runId,
-                agentId,
-                atEpochMs: now,
-                eventId: `event-${command.commandId}`,
-                commandId: command.commandId ?? 'missing-command',
-                payload: {
-                    eventId: `event-${command.commandId}`,
-                    kind: 'event',
-                    topic: 'rallar.bb.ws.closed',
-                    atEpochMs: now,
-                    commandId: command.commandId,
-                    connection: command.connection,
-                    transport: 'ws',
-                    payload: {
-                        code: command.code,
-                        reason: command.reason,
-                        wasClean: true
-                    }
-                }
-            });
-        }
-
-        this.results.push({
-            kind: 'result',
-            runId,
-            agentId,
-            commandId: command.commandId ?? 'missing-command',
-            ok: true,
-            result: {
-                commandId: command.commandId ?? 'missing-command',
-                kind: command.kind,
-                status: 'ok',
-                ok: true,
-                startedAtEpochMs: now,
-                endedAtEpochMs: now + 1,
-                durationMs: 1,
-                value: this.resultValue(command)
-            }
-        });
-    }
-
-    private resultValue(command: RallarBlackBoxTestCommand): unknown {
-        if (command.kind === 'http.request') {
-            return {
-                url: command.request.url ?? command.request.path,
-                status: 201,
-                statusText: 'Created',
-                ok: true,
-                headers: {
-                    'content-type': 'application/json'
-                },
-                body: {
-                    ok: true,
-                    method: command.request.method,
-                    body: command.request.body
-                }
-            };
-        }
-
-        if (command.kind === 'health') {
-            return {
-                rallar: {
-                    connected: true,
-                    laneHealth: {
-                        ready: true
-                    }
-                }
-            };
-        }
-
-        return {
-            accepted: true,
-            command
-        };
-    }
-}
-
-function jsonResponse(value: unknown, status = 200): Response {
-    return new Response(JSON.stringify(value), {
-        status,
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    });
-}
+import { FakeRemoteBrowserControlServer, toJsonResponse } from './fake-remote-browser-control-server.ts';
 
 describe('rallar remote browser RTC provider', () => {
     it('is registered as a default black-box runner RTC provider', async () => {
@@ -244,7 +11,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('sends runner RTC interactions through the control server and consumes remote events', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
         const roomRef = {
             applicationId: 'app-1',
             workspaceId: 'workspace-a',
@@ -397,7 +164,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('waits for remote RTC diagnostics and health through generic expectations', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [
@@ -499,11 +266,11 @@ describe('rallar remote browser RTC provider', () => {
         const fetchWithoutResults = async (input: RequestInfo | URL, init?: RequestInit) => {
             const url = new URL(String(input));
             if (init?.method === 'POST') {
-                return jsonResponse({
+                return toJsonResponse({
                     accepted: true
                 }, 202);
             }
-            return jsonResponse({
+            return toJsonResponse({
                 runId: url.pathname.split('/').at(-1),
                 results: [],
                 events: []
@@ -551,7 +318,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('auto-closes remote connections through the control server', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [
@@ -596,7 +363,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('routes remote HTTP interactions through the control server', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [
@@ -662,7 +429,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('blocks remote HTTP destinations outside the configured allowlist', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [
@@ -700,7 +467,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('blocks remote WebSocket sends above the configured payload limit', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [
@@ -754,7 +521,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('routes remote WebSocket interactions through the control server', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
         const payload = {
             topic: 'presence.ping',
             payload: {
@@ -843,7 +610,7 @@ describe('rallar remote browser RTC provider', () => {
     });
 
     it('forwards CRDT wait commands through the control server', async () => {
-        const server = new FakeRemoteControlServer();
+        const server = new FakeRemoteBrowserControlServer();
 
         const report = await executeBlackBox(
             [

--- a/packages/tests/shared-test/remote-browser-wait-count-dispatch.test.ts
+++ b/packages/tests/shared-test/remote-browser-wait-count-dispatch.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject } from '@shared/api/api-json-value.ts';
+
 import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
 import { createRallarRemoteBrowserRtcProvider } from '../../shared-test/black-box-runner/rallar-remote-browser-provider.ts';
 import { FakeRemoteBrowserControlServer } from './fake-remote-browser-control-server.ts';
@@ -10,7 +13,7 @@ const payload = {
     }
 };
 
-function toWsSend(interactionExecutionNumber: number, response: unknown): unknown {
+function toWsSend(interactionExecutionNumber: number, response: ApiJsonObject): ApiJsonObject {
     return {
         WS: {
             request: {
@@ -26,7 +29,7 @@ function toWsSend(interactionExecutionNumber: number, response: unknown): unknow
     };
 }
 
-function toRtcSend(interactionExecutionNumber: number, response: unknown): unknown {
+function toRtcSend(interactionExecutionNumber: number, response: ApiJsonObject): ApiJsonObject {
     return {
         RTC: {
             request: {
@@ -76,7 +79,8 @@ const rtcConnect = {
     connectAlice: {}
 };
 
-function toWsOptions(server: FakeRemoteBrowserControlServer, runId: string): unknown {
+// The options carry a fetch and a provider instance, so they are wiring, not JSON.
+function toWsOptions(server: FakeRemoteBrowserControlServer, runId: string) {
     return {
         rallarRemoteBrowser: {
             controlBaseUrl: 'http://control.example.test',
@@ -89,7 +93,7 @@ function toWsOptions(server: FakeRemoteBrowserControlServer, runId: string): unk
     };
 }
 
-function toRtcOptions(server: FakeRemoteBrowserControlServer, runId: string): unknown {
+function toRtcOptions(server: FakeRemoteBrowserControlServer, runId: string) {
     return {
         rallarRemoteBrowser: {
             controlBaseUrl: 'http://control.example.test',

--- a/packages/tests/shared-test/remote-browser-wait-count-dispatch.test.ts
+++ b/packages/tests/shared-test/remote-browser-wait-count-dispatch.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { executeBlackBox } from '../../shared-test/black-box-runner/execute-black-box.ts';
+import { createRallarRemoteBrowserRtcProvider } from '../../shared-test/black-box-runner/rallar-remote-browser-provider.ts';
+import { FakeRemoteBrowserControlServer } from './fake-remote-browser-control-server.ts';
+
+const payload = {
+    topic: 'presence.ping',
+    payload: {
+        id: 'ping-1'
+    }
+};
+
+function toWsSend(interactionExecutionNumber: number, response: unknown): unknown {
+    return {
+        WS: {
+            request: {
+                action: 'send',
+                connection: 'controlWs',
+                send: payload,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber
+            },
+            response
+        },
+        [`sendRemoteWs${interactionExecutionNumber}`]: {}
+    };
+}
+
+function toRtcSend(interactionExecutionNumber: number, response: unknown): unknown {
+    return {
+        RTC: {
+            request: {
+                action: 'send',
+                connection: 'aliceRtc',
+                provider: 'rallar-remote-browser',
+                actor: 'alice',
+                roomId: 'room-1',
+                send: payload,
+                scenarioExecutionNumber: 1,
+                interactionExecutionNumber
+            },
+            response
+        },
+        [`sendRemoteRtc${interactionExecutionNumber}`]: {}
+    };
+}
+
+const wsOpen = {
+    WS: {
+        request: {
+            action: 'connect',
+            connection: 'controlWs',
+            provider: 'rallar-remote-browser',
+            path: 'wss://ws.example.test/control',
+            scenarioExecutionNumber: 1,
+            interactionExecutionNumber: 1
+        },
+        response: {}
+    },
+    openRemoteWs: {}
+};
+
+const rtcConnect = {
+    RTC: {
+        request: {
+            action: 'connect',
+            connection: 'aliceRtc',
+            provider: 'rallar-remote-browser',
+            actor: 'alice',
+            roomId: 'room-1',
+            scenarioExecutionNumber: 1,
+            interactionExecutionNumber: 1
+        },
+        response: {}
+    },
+    connectAlice: {}
+};
+
+function toWsOptions(server: FakeRemoteBrowserControlServer, runId: string): unknown {
+    return {
+        rallarRemoteBrowser: {
+            controlBaseUrl: 'http://control.example.test',
+            runId,
+            agentId: 'agent-remote',
+            timeoutMs: 500,
+            pollIntervalMs: 1,
+            fetch: server.fetch
+        }
+    };
+}
+
+function toRtcOptions(server: FakeRemoteBrowserControlServer, runId: string): unknown {
+    return {
+        rallarRemoteBrowser: {
+            controlBaseUrl: 'http://control.example.test',
+            runId,
+            agentId: 'agent-remote',
+            timeoutMs: 500,
+            pollIntervalMs: 1
+        },
+        rtcProviders: {
+            'rallar-remote-browser': createRallarRemoteBrowserRtcProvider({
+                fetch: server.fetch
+            })
+        }
+    };
+}
+
+// Every case sends the same payload twice, so `expect.message` alone would
+// match the first frame and report SUCCESS. Only the count dispatch can see
+// the second one, which is what makes these discriminating.
+describe('remote browser count dispatch', () => {
+    it('counts frames on a remote WebSocket wait', async () => {
+        const server = new FakeRemoteBrowserControlServer();
+        const report = await executeBlackBox(
+            [
+                wsOpen,
+                toWsSend(2, {}),
+                toWsSend(3, {}),
+                {
+                    WS: {
+                        request: {
+                            action: 'wait',
+                            connection: 'controlWs',
+                            scenarioExecutionNumber: 1,
+                            interactionExecutionNumber: 4
+                        },
+                        response: {
+                            connection: 'controlWs',
+                            withinMs: 200,
+                            message: payload,
+                            count: 1
+                        }
+                    },
+                    countRemoteWs: {}
+                }
+            ],
+            0,
+            toWsOptions(server, 'run-remote-ws-count-wait')
+        );
+
+        expect(report.resultsByName.countRemoteWs[0].status).toBe('FAILURE');
+        expect(report.resultsByName.countRemoteWs[0].actual.matchedCount).toBe(2);
+    });
+
+    it('counts frames on a remote WebSocket send', async () => {
+        const server = new FakeRemoteBrowserControlServer();
+        const report = await executeBlackBox(
+            [
+                wsOpen,
+                toWsSend(2, {}),
+                toWsSend(3, {
+                    connection: 'controlWs',
+                    withinMs: 200,
+                    message: payload,
+                    count: 2
+                })
+            ],
+            0,
+            toWsOptions(server, 'run-remote-ws-count-send')
+        );
+
+        expect(report.resultsByName.sendRemoteWs3[0].status).toBe('SUCCESS');
+        expect(report.resultsByName.sendRemoteWs3[0].actual.matchedCount).toBe(2);
+        expect(report.resultsByName.sendRemoteWs3[0].actual.sendResult.status).toBe('sent');
+    });
+
+    it('counts frames on a remote RTC wait', async () => {
+        const server = new FakeRemoteBrowserControlServer();
+        const report = await executeBlackBox(
+            [
+                rtcConnect,
+                toRtcSend(2, {}),
+                toRtcSend(3, {}),
+                {
+                    RTC: {
+                        request: {
+                            action: 'wait',
+                            connection: 'aliceRtc',
+                            provider: 'rallar-remote-browser',
+                            actor: 'alice',
+                            scenarioExecutionNumber: 1,
+                            interactionExecutionNumber: 4
+                        },
+                        response: {
+                            connection: 'aliceRtc',
+                            withinMs: 200,
+                            message: {
+                                topic: 'rallar.remote.fake.message'
+                            },
+                            count: 1
+                        }
+                    },
+                    countRemoteRtc: {}
+                }
+            ],
+            0,
+            toRtcOptions(server, 'run-remote-rtc-count-wait')
+        );
+
+        expect(report.resultsByName.countRemoteRtc[0].status).toBe('FAILURE');
+        expect(report.resultsByName.countRemoteRtc[0].actual.matchedCount).toBe(2);
+    });
+
+    it('counts frames on a remote RTC send', async () => {
+        const server = new FakeRemoteBrowserControlServer();
+        const report = await executeBlackBox(
+            [
+                rtcConnect,
+                toRtcSend(2, {}),
+                toRtcSend(3, {
+                    connection: 'aliceRtc',
+                    withinMs: 200,
+                    message: {
+                        topic: 'rallar.remote.fake.message'
+                    },
+                    count: 2
+                })
+            ],
+            0,
+            toRtcOptions(server, 'run-remote-rtc-count-send')
+        );
+
+        expect(report.resultsByName.sendRemoteRtc3[0].status).toBe('SUCCESS');
+        expect(report.resultsByName.sendRemoteRtc3[0].actual.matchedCount).toBe(2);
+    });
+});

--- a/packages/tests/shared-test/rtc-wait-message-count.test.ts
+++ b/packages/tests/shared-test/rtc-wait-message-count.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject, ApiJsonValue } from '@shared/api/api-json-value.ts';
+
+import { waitForRtcMessageCount } from '../../shared-test/black-box-runner/rtc/rtc-wait-expectations.ts';
+
+const connection = 'aliceRtc';
+
+async function runCount(input: {
+    expectFields: ApiJsonObject;
+    payloads: readonly ApiJsonValue[];
+}): Promise<{ status: string; matchedCount?: number; }> {
+    const interaction = {
+        request: {
+            action: 'wait',
+            connection,
+            scenarioExecutionNumber: 1,
+            interactionExecutionNumber: 1
+        },
+        response: { connection, withinMs: 30, ...input.expectFields }
+    };
+    const status = await waitForRtcMessageCount({
+        interaction,
+        config: { interactionName: 'countRtcFrames', interaction },
+        context: { rtcMessages: { [connection]: input.payloads.map((data) => ({ data })) } }
+    });
+
+    return { status: status.status, matchedCount: status.actual?.matchedCount };
+}
+
+const motion = { payload: { typeId: 'motion.tick' } };
+const chat = { payload: { typeId: 'chat.message' } };
+
+describe('waitForRtcMessageCount', () => {
+    it('accepts an exact count of matching frames', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'motion.tick' } }, count: 2 },
+            payloads: [motion, chat, motion]
+        });
+
+        expect(result.status).toBe('SUCCESS');
+        expect(result.matchedCount).toBe(2);
+    });
+
+    it('rejects a count outside the expectation', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'motion.tick' } }, count: 1 },
+            payloads: [motion, motion]
+        });
+
+        expect(result.status).toBe('FAILURE');
+        expect(result.matchedCount).toBe(2);
+    });
+
+    it('accepts a bounded range', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'motion.tick' } }, count: { min: 1 } },
+            payloads: [motion, motion, motion]
+        });
+
+        expect(result.status).toBe('SUCCESS');
+    });
+
+    it('requires a message matcher to count against', async () => {
+        const result = await runCount({ expectFields: { count: 1 }, payloads: [motion] });
+
+        expect(result.status).toBe('FAILURE');
+    });
+});

--- a/packages/tests/shared-test/rtc-wait-message-count.test.ts
+++ b/packages/tests/shared-test/rtc-wait-message-count.test.ts
@@ -9,7 +9,7 @@ const connection = 'aliceRtc';
 async function runCount(input: {
     expectFields: ApiJsonObject;
     payloads: readonly ApiJsonValue[];
-}): Promise<{ status: string; matchedCount?: number; }> {
+}): Promise<{ status: string; result: string; matchedCount?: number; }> {
     const interaction = {
         request: {
             action: 'wait',
@@ -25,7 +25,11 @@ async function runCount(input: {
         context: { rtcMessages: { [connection]: input.payloads.map((data) => ({ data })) } }
     });
 
-    return { status: status.status, matchedCount: status.actual?.matchedCount };
+    return {
+        status: status.status,
+        result: status.result,
+        matchedCount: status.actual?.matchedCount
+    };
 }
 
 const motion = { payload: { typeId: 'motion.tick' } };
@@ -49,6 +53,7 @@ describe('waitForRtcMessageCount', () => {
         });
 
         expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('RTC message count did not match the expectation');
         expect(result.matchedCount).toBe(2);
     });
 
@@ -61,9 +66,22 @@ describe('waitForRtcMessageCount', () => {
         expect(result.status).toBe('SUCCESS');
     });
 
+    // The two guards and a genuine count mismatch all report FAILURE, so each
+    // case names its own message; otherwise a broken guard passes as the other.
     it('requires a message matcher to count against', async () => {
         const result = await runCount({ expectFields: { count: 1 }, payloads: [motion] });
 
         expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('RTC count wait expects expect.message to match frames against.');
+    });
+
+    it('rejects a count object that names no bound', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'motion.tick' } }, count: {} },
+            payloads: [motion, motion]
+        });
+
+        expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('RTC count wait expects expect.count to be a non-negative integer or {min,max}.');
     });
 });

--- a/packages/tests/shared-test/wait-count-bound.test.ts
+++ b/packages/tests/shared-test/wait-count-bound.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { toWaitCountBound } from '../../shared-test/black-box-runner/expectations/wait-count-bound.ts';
+
+describe('toWaitCountBound', () => {
+    it('accepts an exact non-negative integer', () => {
+        expect(toWaitCountBound(0)).toEqual({ min: 0, max: 0 });
+        expect(toWaitCountBound(3)).toEqual({ min: 3, max: 3 });
+    });
+
+    it('accepts a range with either end omitted', () => {
+        expect(toWaitCountBound({ min: 1, max: 3 })).toEqual({ min: 1, max: 3 });
+        expect(toWaitCountBound({ min: 2 })).toEqual({ min: 2, max: Number.POSITIVE_INFINITY });
+        expect(toWaitCountBound({ max: 2 })).toEqual({ min: 0, max: 2 });
+    });
+
+    // A count object naming no bound would otherwise become {0, INFINITY},
+    // which no observed count can fail — a wait that asserts nothing while
+    // reading as though it asserts cardinality.
+    it('rejects an object that names no bound', () => {
+        expect(toWaitCountBound({})).toBeUndefined();
+        expect(toWaitCountBound({ exactly: 1 } as never)).toBeUndefined();
+        expect(toWaitCountBound({ minimum: 1 } as never)).toBeUndefined();
+    });
+
+    it('rejects an array, which is not a range', () => {
+        expect(toWaitCountBound([1, 3] as never)).toBeUndefined();
+        expect(toWaitCountBound([] as never)).toBeUndefined();
+    });
+
+    // The exact form required a real number while the range form coerced, so
+    // the same value was accepted in one shape and rejected in the other.
+    it('requires real numbers in both shapes rather than coercing one', () => {
+        expect(toWaitCountBound('2' as never)).toBeUndefined();
+        expect(toWaitCountBound({ min: '2' } as never)).toBeUndefined();
+        expect(toWaitCountBound({ min: 1, max: '3' } as never)).toBeUndefined();
+    });
+
+    it('rejects negative, fractional and inverted bounds', () => {
+        expect(toWaitCountBound(-1)).toBeUndefined();
+        expect(toWaitCountBound(1.5)).toBeUndefined();
+        expect(toWaitCountBound({ min: -1 })).toBeUndefined();
+        expect(toWaitCountBound({ min: 3, max: 1 })).toBeUndefined();
+    });
+
+    it('rejects a missing count', () => {
+        expect(toWaitCountBound(undefined)).toBeUndefined();
+        expect(toWaitCountBound(null)).toBeUndefined();
+    });
+});

--- a/packages/tests/shared-test/ws-wait-message-count.test.ts
+++ b/packages/tests/shared-test/ws-wait-message-count.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiJsonObject, ApiJsonValue } from '@shared/api/api-json-value.ts';
+
+import { waitForWsMessageCount } from '../../shared-test/black-box-runner/ws/ws-wait-expectations.ts';
+
+const connection = 'wsAlice';
+
+function toInteraction(expectFields: ApiJsonObject): ApiJsonObject {
+    return {
+        request: {
+            action: 'wait',
+            connection,
+            scenarioExecutionNumber: 1,
+            interactionExecutionNumber: 1
+        },
+        response: { connection, withinMs: 30, ...expectFields }
+    };
+}
+
+function toContext(payloads: readonly ApiJsonValue[]): ApiJsonObject {
+    return { wsMessages: { [connection]: payloads.map((data) => ({ data })) } };
+}
+
+function toConfig(interaction: ApiJsonObject): ApiJsonObject {
+    return { interactionName: 'countFrames', interaction };
+}
+
+async function runCount(input: {
+    expectFields: ApiJsonObject;
+    payloads: readonly ApiJsonValue[];
+}): Promise<{ status: string; matchedCount?: number; }> {
+    const interaction = toInteraction(input.expectFields);
+    const status = await waitForWsMessageCount({
+        interaction,
+        config: toConfig(interaction),
+        context: toContext(input.payloads)
+    });
+
+    return { status: status.status, matchedCount: status.actual?.matchedCount };
+}
+
+const decided = { payload: { typeId: 'admission.decided' } };
+const other = { payload: { typeId: 'group.updated' } };
+
+describe('waitForWsMessageCount', () => {
+    // The assertion slice 4 needs: an admission race must emit exactly one
+    // decision, and "at least one" cannot distinguish that from two.
+    it('accepts an exact count of matching frames', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: 1 },
+            payloads: [other, decided, other]
+        });
+
+        expect(result.status).toBe('SUCCESS');
+        expect(result.matchedCount).toBe(1);
+    });
+
+    it('rejects a second matching frame under an exact count', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: 1 },
+            payloads: [decided, decided]
+        });
+
+        expect(result.status).toBe('FAILURE');
+        expect(result.matchedCount).toBe(2);
+    });
+
+    it('rejects an absent frame under an exact count', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: 1 },
+            payloads: [other]
+        });
+
+        expect(result.status).toBe('FAILURE');
+        expect(result.matchedCount).toBe(0);
+    });
+
+    it('accepts a bounded range', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: { min: 1, max: 3 } },
+            payloads: [decided, decided]
+        });
+
+        expect(result.status).toBe('SUCCESS');
+        expect(result.matchedCount).toBe(2);
+    });
+
+    it('rejects a count above the range maximum', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: { min: 0, max: 1 } },
+            payloads: [decided, decided]
+        });
+
+        expect(result.status).toBe('FAILURE');
+    });
+
+    // count: 0 is a stricter absence claim than expect.absent, because it also
+    // reports how many frames were seen while it waited.
+    it('accepts zero as an absence claim', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: 0 },
+            payloads: [other, other]
+        });
+
+        expect(result.status).toBe('SUCCESS');
+        expect(result.matchedCount).toBe(0);
+    });
+
+    it('requires a message matcher to count against', async () => {
+        const result = await runCount({ expectFields: { count: 1 }, payloads: [decided] });
+
+        expect(result.status).toBe('FAILURE');
+    });
+
+    it('rejects a range whose minimum exceeds its maximum', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: { min: 3, max: 1 } },
+            payloads: [decided]
+        });
+
+        expect(result.status).toBe('FAILURE');
+    });
+});

--- a/packages/tests/shared-test/ws-wait-message-count.test.ts
+++ b/packages/tests/shared-test/ws-wait-message-count.test.ts
@@ -29,7 +29,7 @@ function toConfig(interaction: ApiJsonObject): ApiJsonObject {
 async function runCount(input: {
     expectFields: ApiJsonObject;
     payloads: readonly ApiJsonValue[];
-}): Promise<{ status: string; matchedCount?: number; }> {
+}): Promise<{ status: string; result: string; matchedCount?: number; }> {
     const interaction = toInteraction(input.expectFields);
     const status = await waitForWsMessageCount({
         interaction,
@@ -37,7 +37,11 @@ async function runCount(input: {
         context: toContext(input.payloads)
     });
 
-    return { status: status.status, matchedCount: status.actual?.matchedCount };
+    return {
+        status: status.status,
+        result: status.result,
+        matchedCount: status.actual?.matchedCount
+    };
 }
 
 const decided = { payload: { typeId: 'admission.decided' } };
@@ -63,6 +67,7 @@ describe('waitForWsMessageCount', () => {
         });
 
         expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('WebSocket message count did not match the expectation');
         expect(result.matchedCount).toBe(2);
     });
 
@@ -107,10 +112,13 @@ describe('waitForWsMessageCount', () => {
         expect(result.matchedCount).toBe(0);
     });
 
+    // The two guards and a genuine count mismatch all report FAILURE, so each
+    // case names its own message; otherwise a broken guard passes as the other.
     it('requires a message matcher to count against', async () => {
         const result = await runCount({ expectFields: { count: 1 }, payloads: [decided] });
 
         expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('WebSocket count wait expects expect.message to match frames against.');
     });
 
     it('rejects a range whose minimum exceeds its maximum', async () => {
@@ -120,5 +128,16 @@ describe('waitForWsMessageCount', () => {
         });
 
         expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('WebSocket count wait expects expect.count to be a non-negative integer or {min,max}.');
+    });
+
+    it('rejects a count object that names no bound', async () => {
+        const result = await runCount({
+            expectFields: { message: { payload: { typeId: 'admission.decided' } }, count: {} },
+            payloads: [decided, decided]
+        });
+
+        expect(result.status).toBe('FAILURE');
+        expect(result.result).toBe('WebSocket count wait expects expect.count to be a non-negative integer or {min,max}.');
     });
 });

--- a/playground/rtc-design/2026-09-05-black-box-coverage-plan.md
+++ b/playground/rtc-design/2026-09-05-black-box-coverage-plan.md
@@ -354,6 +354,23 @@ not opportunistic widening; the coverage plan should adopt them rather than rout
 Items 1 and 2 should land regardless of whether any recipe is written: **they are what stops the next
 agent from adapting a test instead of fixing the framework.**
 
+### Prerequisite delivery
+
+| Item    | State                                                                                                                                                                                                                                                                                                                                               |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | **Delivered** (#503). The guide's self-contradiction is gone, the four hidden primitives are documented from their implementations, the unordered-array semantics are stated with a measured table, and identifiers have a section.                                                                                                                 |
+| 2       | **Delivered** (#503). Three strict checks in `plan-preflight.ts`, ratcheted per recipe from `preflight/strict-expectation-debt.json` so a new finding fails while the 47 existing ones stay visible as debt. Its first catch was real: `aliceNeverReceivesTheBlockedMessage` is a `ws.send` carrying `expect.absent`, which the runner never reads. |
+| 5       | **Delivered.** `equals`, `notEquals` and `exists` join the comparator registry. `exists` is decided before the path is required to resolve, because an absent path is the assertion rather than a failure to make one. Deep equality reuses `jsonEquals` from `@shared/repository/state-utils.ts` rather than adding a third implementation.        |
+| 6       | **Delivered.** A `parallel` step's `expect` is now compared against its aggregate — groups, counts, concurrency, timing — through the same comparator and comparison path an `assert` uses. Child failures are still decided first, so an aggregate expectation cannot mask one.                                                                    |
+| 3, 4, 7 | Open.                                                                                                                                                                                                                                                                                                                                               |
+
+Two facts worth carrying into the remaining items. The runner may import from `@shared/**` — several
+modules already do — but only resolves the alias when the entry point is inside the workspace, so a
+probe script written to a temporary directory fails on the import rather than on the code under test.
+And a `parallel` group's steps use the runner's `{TRANSPORT: {request, response}, name: {}}` pair
+shape, not the flat `{name, type, expect}` shape recipes use at the top level; a group written the
+flat way executes nothing and reports `success: 0` rather than failing.
+
 ## Not in this plan
 
 - **WS upgrade negative paths** (reused, expired, foreign, missing ticket) — worth doing, but they


### PR DESCRIPTION
Prerequisite **4** from the coverage plan's framework list. Stacks on #508 (items 5 and 6).

## The gap

`expect.message` resolves on its **first** match, so it cannot tell *"exactly one"* from *"at least one"*. That is precisely the assertion slice 4's admission race needs: the product property is that a grant/decline race emits **exactly one** decision event.

## The design

`expect.count` waits the **full `withinMs` window** and then counts every frame matching `expect.message` — the same reason `expect.absent` waits the whole window: a cardinality claim is only as strong as the time the runner kept listening.

```json
{
  "name": "exactlyOneDecisionWasEmitted",
  "type": "ws.wait",
  "expect": {
    "withinMs": 4000,
    "message": { "payload": { "typeId": "group-state.event" } },
    "count": 1
  }
}
```

Accepts an exact integer or `{min,max}` with either end optional. **`count: 0` is a stricter absence claim than `expect.absent`**, because its failure also reports how many frames were observed.

## Why it landed on `ws.send` too

Not symmetry — consistency with item 2's lint. That lint gates expectation keys the runner ignores, so a `count` honoured on the wait and silently dropped on the send would be exactly the defect the lint exists to catch.

The bound parser is shared between the WS and RTC waits rather than written twice.

## Verified by mutation

Forcing the bound comparison true fails the three rejecting tests. 30 tests across four files pass.

## Two extractions the standard required

My addition pushed `execute-black-box.ts` past the **1200-line navigation backstop** (1238). Rather than exempt it, two things moved out along real ownership lines: the parallel aggregate expectation (from #508) and `monotonicComparisonFailures`, both to `expectations/`, where the other assertion helpers live. The file is now 1314 physical / under the discounted backstop, and `check:repo-style:changed` **passes**.

JSON boundaries are typed as `ApiJsonValue`/`ApiJsonObject` rather than `unknown`, which is what the `boundary.unknown` rule asks for and is also more honest — these are recipe JSON, not arbitrary values.

## Two things I found but did not fix

- **`api-v1-crdt-append-history-recipe.test.ts > strictly expands every case with its exact loop count` fails on pristine `origin/main`.** I verified by reverting my own files and re-running; it still fails. Pre-existing, unrelated to this change, and not something to fold into this PR.
- `check-tests-typecheck` reports `packages/shared/api/group-state-delta.ts` missing `validateGroupActivationStatusPayload`. That traces to an **in-progress refactor from another session** sitting uncommitted in the shared worktree, and touches nothing in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)