### PR TITLE
test(api): wait for replanning quiescence

### DIFF
--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-debounced-replanning.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-debounced-replanning.json
@@ -1,5 +1,5 @@
 {
-  "description": "The debounced-replanning scenario (product decision 31, plan slice 10b): a managed group active on an accepted layout takes four replacing sessions about half a second apart under a 4 000 ms window with a 4 500 ms maximum wait; each read of the queued replan sees its own change (generation up by one), the due time extends with the second change, stops extending at the maximum wait, the one replan the burst yields carries its last presence revision, and nothing pends afterwards.",
+  "description": "The debounced-replanning scenario (product decision 31, plan slice 10b): a managed group reaches a quiescent active layout after its durable activation status and resulting topology work settle, then takes four replacing sessions about half a second apart under a 4 000 ms window with a 4 500 ms maximum wait; each read of the queued replan sees its own change (generation up by one), the due time extends with the second change, stops extending at the maximum wait, the one replan the burst yields carries its last presence revision, and nothing pends afterwards.",
   "variables": {
     "apiPrimary": {
       "env": "RALLAR_API_BASE_URL",
@@ -426,6 +426,35 @@
         "body": {
           "acceptedSnapshot": {
             "state": "active"
+          }
+        }
+      }
+    },
+    {
+      "name": "activationDwellWritesItsStatus",
+      "type": "http",
+      "connection": "primary",
+      "request": {
+        "method": "GET",
+        "path": "/api/state/apps/{applicationId}/workspaces/{workspaceId}/groups/{groupId}",
+        "headers": {
+          "Authorization": "{aliceAuthHeader}",
+          "x-client-id": "{aliceClientId}"
+        },
+        "poll": {
+          "maxAttempts": 40,
+          "maxDurationMs": 25000,
+          "backoffMs": 150,
+          "backoffMultiplier": 1.2
+        }
+      },
+      "expect": {
+        "status": 200,
+        "body": {
+          "group": {
+            "activationStatus": {
+              "condition": "failed"
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- wait for the durable activation-status writer before measuring the debounced replanning burst
- retain the existing barrier that requires the resulting topology work to settle
- keep the deadline-extension and maximum-wait assertions unchanged

## Root cause

The Release Gate on #510 observed activation-status dwell work land during the first measured churn interval. That independent group revision extended the coalescing window to its maximum before sample 1, so sample 2 correctly had the same due time and the recipe failed. The production debounce calculation behaved correctly; the recipe began measuring before the group was quiescent.

Failed evidence: https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/33986014566/job/101359714585

## Validation

- `npx dprint check packages/shared-test/black-box-runner/tests/api-v1/api-v1-debounced-replanning.json`
- `npx vitest run packages/tests/shared-test/recipe-matrix.test.ts` — 19 passed
- offline validation for `api-v1-debounced-replanning` — passed
- live PGlite recipe — 54/54 steps passed; due time extended by 500 ms and then held at the maximum wait
- `npm run check:repo-style:changed -- ecca3a46bca3f2959f5c3f840823cfdb0532b330 HEAD`
- `npm run check:repo-structure`
- `npm run check:test-structure-coupling -- --changed ecca3a46bca3f2959f5c3f840823cfdb0532b330 HEAD`
- `npm run check:retained-legacy`
- `git diff --check origin/main...HEAD`

The containing local PGlite profile completed the target successfully but later exposed an unrelated existing join-admission rate-limit failure. The Postgres Branch Release Gate is the authoritative broad confirmation for this PR.

## Compatibility

Test evidence only. No production API, persisted format, compatibility layer, or retained legacy behavior changes.