### PR TITLE
fix(rtc): distinguish coalesced publication wakes

### DIFF
--- a/docs/rallar-group-formation-architecture.md
+++ b/docs/rallar-group-formation-architecture.md
@@ -535,7 +535,8 @@ If no plan exists, the initial work acknowledges but intent remains. Every accep
 publication atomically writes a group-scoped publication wake. This wake discovers current
 epoch latches after commit, closing the race where publication prepared before latch creation but
 the initial intent check ran before publication committed. Publication work identity includes its
-source work and exact layout, using source audit timestamps so crash replay is immutable.
+canonical source execution ID—including the coalescing generation—and exact layout, using source
+audit timestamps so crash replay is immutable while later generations remain distinct.
 
 The worker reads current group, latch and planned identity, then petitions exact connect through
 AppInbox. A superseding publication yields a new command identity. The connect write consumes the

--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -71,15 +71,15 @@ focused corrections in PRs #499 and #510, and the Branch Release quiescence
 correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
 PR #519; its first default warmup exposed a distinct publication-wake identity
 collision between coalesced topology generations that share a queue key and
-layout. There is not yet a valid B06 E3 result. B07 remains held, and evidence
-ranking cannot start until a valid B06 primary and any required repeat are
-archived.
+layout. PR #520 contains the focused correction. There is not yet a valid B06
+E3 result. B07 remains held, and evidence ranking cannot start until a valid
+B06 primary and any required repeat are archived.
 
 ### Current execution horizon
 
 | Order | Slice                                          | Completion evidence                                                                                                                                                                                                                              |
 | ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Correct coalesced publication-wake identity    | The focused change keys each wake by the existing canonical topology execution ID, including coalescing generation, while retaining strict final-outbox collision handling; focused and relevant full-stack gates pass and the PR merges.        |
+| 1     | Correct coalesced publication-wake identity    | PR #520 keys each wake by the existing canonical topology execution ID, including coalescing generation, while retaining strict final-outbox collision handling; focused and relevant full-stack gates pass and the PR merges.                   |
 | 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
 
 After these two slices, Task 12 will choose the B05 observation window,
@@ -3901,7 +3901,7 @@ reported a final-outbox collision for one
 one queue key across generations, but publication wake identity used only that
 key and the selected layout. Two generations that legitimately selected the
 same layout therefore attempted the same final outbox identity. The focused
-correction passes the already-canonical topology execution ID, which includes
+correction in PR #520 passes the already-canonical topology execution ID, which includes
 coalescing generation, into publication wake identity; it does not weaken the
 strict final-outbox collision invariant or retain an alternate identity path.
 
@@ -3920,8 +3920,8 @@ strict final-outbox collision invariant or retain an alternate identity path.
       PR #517, then dispatch run 33991439486 from moving `main`.
 - [x] Verify and archive run 33991439486's failed primary through observation
       PR #519; do not accept its metrics or run a repeat.
-- [ ] Merge the focused coalesced publication-wake identity correction after
-      relevant unit, type, full-stack, and branch validation.
+- [ ] Merge the focused coalesced publication-wake identity correction in PR
+      #520 after relevant unit, type, full-stack, and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
       `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
@@ -4393,12 +4393,12 @@ metrics. PRs #499 and #510 corrected the fourth and fifth failures, while PR
 #517 corrected their Branch Release regression recipe's quiescence race. Run
 33991439486 and archive PR #519 exposed the sixth failure: publication-wake
 identity omitted the generation of its mutable coalesced topology source. The
-current focused slice threads the existing canonical execution ID into that
-wake identity without weakening final-outbox collision handling. After it
+focused correction in PR #520 threads the existing canonical execution ID into
+that wake identity without weakening final-outbox collision handling. After it
 merges, the next performance action is another manual Task 10 dispatch from
-moving `main`, followed by integrity-gated archive publication or
-evidence-led diagnosis of its first failed attempt. B07 remains held; Task 12
-remains blocked on valid B06 evidence.
+moving `main`, followed by integrity-gated archive publication or evidence-led
+diagnosis of its first failed attempt. B07 remains held; Task 12 remains blocked
+on valid B06 evidence.
 
 | Date       | Plan revision                                                                                                    | State                       | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Next action                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -65,21 +65,22 @@ observation stream, and B06 E3-memory observation tooling are merged. Five
 distinct valid B05 observations through 2026-09-05 are archived on `main`: PR
 #402 landed directly, and the four observations formerly published by PRs
 #405, #463, #474, and #494 landed through batch PRs #507 and #504 before the
-superseded PRs and branches were closed. Five B06 observations have failed with
-`acceptedMetrics: false`; the first four are archived on `main`, and the fifth
-is preserved by PR #509 pending human review. There is not yet a valid B06 E3
-result. That fifth observation ran after PR #499's post-activation delivery
-barrier and exposed a narrower topology-publication revision race. PR #510
-contains the focused fix and regression proof. B07 remains held, and evidence
+superseded PRs and branches were closed. Six B06 observations have failed with
+`acceptedMetrics: false` and are archived on `main`. The first five, their
+focused corrections in PRs #499 and #510, and the Branch Release quiescence
+correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
+PR #519; its first default warmup exposed a distinct publication-wake identity
+collision between coalesced topology generations that share a queue key and
+layout. There is not yet a valid B06 E3 result. B07 remains held, and evidence
 ranking cannot start until a valid B06 primary and any required repeat are
 archived.
 
 ### Current execution horizon
 
-| Order | Slice                                           | Completion evidence                                                                                                                                                                                                                    |
-| ----- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | Publish the failed evidence and its focused fix | Human review and green relevant gates allow failed-observation PR #509 and topology-publication barrier fix PR #510 to merge independently. The failed ZIP remains evidence and is not replaced by a later successful run.             |
-| 2     | Capture B06 E3-memory from moving `main`        | Manually dispatch `RTC-B06 Performance Observation` after #510 reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
+| Order | Slice                                          | Completion evidence                                                                                                                                                                                                                              |
+| ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1     | Correct coalesced publication-wake identity    | The focused change keys each wake by the existing canonical topology execution ID, including coalescing generation, while retaining strict final-outbox collision handling; focused and relevant full-stack gates pass and the PR merges.        |
+| 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
 
 After these two slices, Task 12 will choose the B05 observation window,
 revisit whether the candidate call path requires E4-pg, and reconcile the
@@ -3869,7 +3870,7 @@ performance-observations/rtc-b06/YYYY/MM/DD/<observation-id>.zip
 performance-observations/rtc-b06/index.jsonl
 ```
 
-Current evidence contains five failed B06 primaries and no accepted metrics.
+Current evidence contains six failed B06 primaries and no accepted metrics.
 The fourth archive is PR #498. Its first retained default attempt timed out
 receiving `messages.rtc` multicast on agent C after the warmup passed. That run
 exposed a post-activation readiness gap: the lifecycle driver proved readiness
@@ -3888,6 +3889,22 @@ selected layout identity, and the server-enforced formation-epoch fence; it
 adds regression coverage for that transition and does not retain the obsolete
 exact-revision behavior.
 
+PRs #509 and #510 merged, and PR #517 added the missing quiescence barrier to
+the Branch Release regression recipe that had raced an activation-status
+write. Run 33991439486 then observed commit
+`a9726f7a21ccac31ae91b3639613c9ebce504ad4`; its source guard, tooling checks,
+capture recovery, archive verification, publication, and observation-integrity
+gate all passed. PR #519 archived the failed result. The default warmup timed
+out waiting for agent A to observe both ready peers while the API repeatedly
+reported a final-outbox collision for one
+`app-outbox.group-connect-trigger` resource. The coalesced topology head keeps
+one queue key across generations, but publication wake identity used only that
+key and the selected layout. Two generations that legitimately selected the
+same layout therefore attempted the same final outbox identity. The focused
+correction passes the already-canonical topology execution ID, which includes
+coalescing generation, into publication wake identity; it does not weaken the
+strict final-outbox collision invariant or retain an alternate identity path.
+
 - [x] Merge the B06 E3-memory producer, recovery, verifier, and observation-PR
       publication path; configure `RTC_OBSERVATION_PR_TOKEN`.
 - [x] Preserve the first four unsuccessful primaries as failed evidence rather than
@@ -3898,9 +3915,15 @@ exact-revision behavior.
 - [x] Diagnose run 33983623186's first failure to the exact-revision race and
       publish its failed archive as PR #509 and its focused correction as PR
       #510.
-- [ ] Merge PRs #509 and #510 after relevant validation and human review.
+- [x] Merge PRs #509 and #510 after relevant validation and human review.
+- [x] Correct the Branch Release recipe's activation-status quiescence race in
+      PR #517, then dispatch run 33991439486 from moving `main`.
+- [x] Verify and archive run 33991439486's failed primary through observation
+      PR #519; do not accept its metrics or run a repeat.
+- [ ] Merge the focused coalesced publication-wake identity correction after
+      relevant unit, type, full-stack, and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
-      `main` after PR #510 merges.
+      `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
       integrity and merge the ZIP/index row. A valid primary must report
       `acceptedMetrics: true`; complete any controller-required repeat.
@@ -4363,16 +4386,19 @@ incomplete evidence milestone and do not mark this written plan complete.
 ## 13. Progress Record
 
 **2026-09-05 reconciliation:** Task 4B, B04, B05, both observation producers,
-and B06 E3-memory tooling are merged. Five valid B05 observation PRs remain
-open because each is a distinct append-only sample; merge #402, #405, #463,
-#474, and #494 chronologically, then delete their branches. Four B06 primaries
-are archived as failed evidence with no accepted metrics. The newest archive,
-PR #498, exposed the post-activation readiness gap corrected by PR #499.
-PR #496 independently restores main-wide typechecking. After #499 merges, the
-next performance action is a fresh manual Task 10 dispatch from moving `main`,
-followed by integrity-gated archive publication or evidence-led diagnosis of
-its first failed attempt. B07 remains held; Task 12 remains blocked on valid
-B06 evidence.
+and B06 E3-memory tooling are merged. Five valid B05 observations are archived
+on `main`; the overlapping source PRs and branches were consolidated and
+closed. Six B06 primaries are archived as failed evidence with no accepted
+metrics. PRs #499 and #510 corrected the fourth and fifth failures, while PR
+#517 corrected their Branch Release regression recipe's quiescence race. Run
+33991439486 and archive PR #519 exposed the sixth failure: publication-wake
+identity omitted the generation of its mutable coalesced topology source. The
+current focused slice threads the existing canonical execution ID into that
+wake identity without weakening final-outbox collision handling. After it
+merges, the next performance action is another manual Task 10 dispatch from
+moving `main`, followed by integrity-gated archive publication or
+evidence-led diagnosis of its first failed attempt. B07 remains held; Task 12
+remains blocked on valid B06 evidence.
 
 | Date       | Plan revision                                                                                                    | State                       | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Next action                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
@@ -113,6 +113,7 @@ interface ComputedRtcTopologyReplayWrite {
 export interface ComputeRtcTopologyWorkWriteInput {
     readonly accepted: AcceptedRtcTopologyWork;
     readonly entry: ResourceEntry;
+    readonly sourceWorkId: string;
     readonly reservationFinish: ResourceInboxReservationFinish;
     readonly formationAutomationEnabled: boolean;
     readonly serviceId: string | undefined;
@@ -152,6 +153,7 @@ export function computeRtcTopologyWorkWrite(
             connectWrites: computePublicationConnectTriggerRequests({
                 automationEnabled: input.formationAutomationEnabled,
                 target,
+                sourceWorkId: input.sourceWorkId,
                 entry
             }).map(computeAppOutboxInsert),
             fingerprint: computeFingerprintWrite(accepted),

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work.ts
@@ -175,6 +175,7 @@ function toRtcTopologyWorkWriteInput(
     return {
         accepted,
         entry: input.entry,
+        sourceWorkId: input.facts.workId,
         reservationFinish: input.reservationFinish,
         formationAutomationEnabled: input.formationAutomationEnabled,
         serviceId: input.serviceId,

--- a/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/create-rtc-topology-work-handler.ts
@@ -150,6 +150,7 @@ async function processRtcTopologyWork(input: ProcessRtcTopologyWorkInput): Promi
         const writeInput: ComputeRtcTopologyWorkWriteInput = {
             accepted: rttRefinementSkip,
             entry,
+            sourceWorkId: workId,
             reservationFinish,
             formationAutomationEnabled: options.formationAutomation !== undefined,
             serviceId: options.serviceId,

--- a/packages/shared-server/rallar-system/topology/replay/work/group-connect-trigger-requests.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/group-connect-trigger-requests.ts
@@ -9,6 +9,7 @@ import { serializeCanonicalJson } from '../../../protocol/canonical-json.ts';
 export interface PublicationConnectTriggerRequestsInput {
     readonly automationEnabled: boolean;
     readonly target: RallarOverlayTopologySnapshot | null;
+    readonly sourceWorkId: string;
     readonly entry: ResourceEntry;
 }
 
@@ -23,7 +24,10 @@ export function computePublicationConnectTriggerRequests(
         work: {
             kind: 'publication',
             groupRef: target.groupRef,
-            wakeIdentity: serializeCanonicalJson({ source: entry.key, expectedLayout: toGroupLayoutIdentity(target) })
+            wakeIdentity: serializeCanonicalJson({
+                sourceWorkId: input.sourceWorkId,
+                expectedLayout: toGroupLayoutIdentity(target)
+            })
         },
         senderId: entry.audit.createdBy,
         createdAtEpochMs: entry.audit.createdTs.toZonedDateTime('UTC').epochMilliseconds,

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts
@@ -333,7 +333,12 @@ describe('retry handoff commit races and replay', () => {
             createdAtEpochMs: 1000,
             expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
         });
-        const requests = computePublicationConnectTriggerRequests({ automationEnabled: true, target: PLANNED, entry: source });
+        const requests = computePublicationConnectTriggerRequests({
+            automationEnabled: true,
+            target: PLANNED,
+            sourceWorkId: 'source-work:1',
+            entry: source
+        });
         const writes = requests.map(computeAppOutboxInsert);
         expect(requests).toHaveLength(1);
         expect(decodeGroupConnectTriggerWork(requests[0]!.resource).kind).toBe('publication');
@@ -369,8 +374,18 @@ describe('retry handoff commit races and replay', () => {
             createdAtEpochMs: 1000,
             expireAtEpochMs: NEVER_EXPIRE_AT_TIMESTAMP
         });
-        const first = computePublicationConnectTriggerRequests({ automationEnabled: true, target: PLANNED, entry: source });
-        const next = computePublicationConnectTriggerRequests({ automationEnabled: true, target: { ...PLANNED, version: 2 }, entry: source });
+        const first = computePublicationConnectTriggerRequests({
+            automationEnabled: true,
+            target: PLANNED,
+            sourceWorkId: 'source-work:1',
+            entry: source
+        });
+        const next = computePublicationConnectTriggerRequests({
+            automationEnabled: true,
+            target: { ...PLANNED, version: 2 },
+            sourceWorkId: 'source-work:1',
+            entry: source
+        });
         const firstWrite = computeAppOutboxInsert(first[0]!);
         const nextWrite = computeAppOutboxInsert(next[0]!);
         expect(first[0]!.key).not.toEqual(next[0]!.key);

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
@@ -67,6 +67,30 @@ describe('RTC topology complete write computation', () => {
         expect(computeRtcTopologyWorkWrite(input)).toEqual(computed);
     });
 
+    it('gives each coalesced source generation a distinct publication wake identity', () => {
+        const firstInput = {
+            ...createWriteInput(),
+            sourceWorkId: 'rtc-topology:group-1:coalesced-work:1',
+            formationAutomationEnabled: true
+        };
+        const secondInput = {
+            ...firstInput,
+            sourceWorkId: 'rtc-topology:group-1:coalesced-work:2'
+        };
+
+        const first = computeRtcTopologyWorkWrite(firstInput);
+        const second = computeRtcTopologyWorkWrite(secondInput);
+        if (first.kind !== 'transaction' || second.kind !== 'transaction') {
+            throw new Error('Expected topology transaction fixtures');
+        }
+
+        expect(first.transaction.connectWrites).toHaveLength(1);
+        expect(second.transaction.connectWrites).toHaveLength(1);
+        expect(first.transaction.connectWrites[0]!.entry.key.resourceId).not.toBe(
+            second.transaction.connectWrites[0]!.entry.key.resourceId
+        );
+    });
+
     it('leaves durable replay checks to validation', () => {
         const snapshot = createTopologySnapshot(createGroupRef(), 1);
         const publication = createPublication(snapshot, 'work-1');
@@ -223,6 +247,7 @@ function createWriteInput(): ComputeRtcTopologyWorkWriteInput {
     return {
         accepted,
         entry,
+        sourceWorkId: 'rtc-topology:group-1:work-1:0',
         reservationFinish: {
             key: entry.key,
             expectedAttempts: entry.dequeueAudit.attempts,


### PR DESCRIPTION
## Summary

- key publication wakes by the existing canonical topology execution ID, including coalescing generation
- preserve strict final-outbox collision rollback for retries of the same generation
- add regression coverage and reconcile the RTC baseline plan with failed observation #519

## Root cause

Run 33991439486 reached two coalesced topology generations that selected the same layout. The mutable coalesced head preserves one queue key across generations, while the wake identity used only that key and layout, so the second generation collided with the first final outbox row and blocked peer readiness.

## Validation

- `npx vitest run packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts packages/tests/shared-server/rallar-system/group-state/mutation/group-connect-trigger-latch.test.ts` (29 passed)
- `npm run test:group-topology` (554 passed, 5 skipped)
- `npm run test:shared-server` (2186 passed, 12 skipped)
- `npm run typecheck`
- `npm run test:transaction-writes` (23 passed)
- `npm run test:rallar:full-stack:memory:live-rtc-3` (default matrix passed; two conditional tests skipped)
- changed-style, repository-structure, retained-legacy, transaction-write, targeted dprint, and diff checks passed

The full repository dprint check remains red on pre-existing `main` files and preserved untracked diagnostic output; every file changed by this PR passes dprint.

## Follow-up

After merge, dispatch a fresh RTC-B06 E3-memory observation from moving `main` and archive its result.