### PR TITLE
fix(rtc): distinguish topology promotion requests

### DIFF
--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -58,28 +58,31 @@ GitHub Actions, and ignored JSON evidence under `tmp/perf/rtc-baseline/**`.
 
 **Created:** 2026-08-06
 
-**Updated:** 2026-09-05
+**Updated:** 2026-09-06
 
 **Status:** Tasks 4A/4B, B04, native-browser B05 capture, the continuous B05
 observation stream, and B06 E3-memory observation tooling are merged. Five
 distinct valid B05 observations through 2026-09-05 are archived on `main`: PR
 #402 landed directly, and the four observations formerly published by PRs
 #405, #463, #474, and #494 landed through batch PRs #507 and #504 before the
-superseded PRs and branches were closed. Six B06 observations have failed with
+superseded PRs and branches were closed. Seven B06 observations have failed with
 `acceptedMetrics: false` and are archived on `main`. The first five, their
 focused corrections in PRs #499 and #510, and the Branch Release quiescence
 correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
-PR #519; its first default warmup exposed a distinct publication-wake identity
-collision between coalesced topology generations that share a queue key and
-layout. PR #520 contains the focused correction. There is not yet a valid B06
-E3 result. B07 remains held, and evidence ranking cannot start until a valid
-B06 primary and any required repeat are archived.
+PR #519; its focused publication-wake identity correction merged in PR #520.
+Run 33997173287 then produced the seventh failed archive in PR #522. Its first
+default warmup exposed the same missing source-generation dimension in the
+separate topology-promotion outbox identity. The current focused slice keys
+each promotion request by the existing canonical topology execution ID while
+leaving the fenced promotion command unchanged. There is not yet a valid B06 E3
+result. B07 remains held, and evidence ranking cannot start until a valid B06
+primary and any required repeat are archived.
 
 ### Current execution horizon
 
 | Order | Slice                                          | Completion evidence                                                                                                                                                                                                                              |
 | ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Correct coalesced publication-wake identity    | PR #520 keys each wake by the existing canonical topology execution ID, including coalescing generation, while retaining strict final-outbox collision handling; focused and relevant full-stack gates pass and the PR merges.                   |
+| 1     | Correct topology-promotion request identity    | The focused PR keys each promotion outbox event by the existing canonical topology execution ID, including coalescing generation, without changing the convergent fenced command; focused and relevant full-stack gates pass and the PR merges.  |
 | 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
 
 After these two slices, Task 12 will choose the B05 observation window,
@@ -3870,7 +3873,7 @@ performance-observations/rtc-b06/YYYY/MM/DD/<observation-id>.zip
 performance-observations/rtc-b06/index.jsonl
 ```
 
-Current evidence contains six failed B06 primaries and no accepted metrics.
+Current evidence contains seven failed B06 primaries and no accepted metrics.
 The fourth archive is PR #498. Its first retained default attempt timed out
 receiving `messages.rtc` multicast on agent C after the warmup passed. That run
 exposed a post-activation readiness gap: the lifecycle driver proved readiness
@@ -3905,6 +3908,17 @@ correction in PR #520 passes the already-canonical topology execution ID, which 
 coalescing generation, into publication wake identity; it does not weaken the
 strict final-outbox collision invariant or retain an alternate identity path.
 
+PR #520 merged, and run 33997173287 observed resulting `main` commit
+`021e10aa153e17a2695d31302768269582972d3a`. PR #522 archives its failed
+primary. The first default warmup again timed out before agent A observed both
+ready peers, but the causal server error moved to
+`app-outbox.topology-promotion`: two distinct topology source generations that
+selected the same formation epoch and layout attempted one immutable promotion
+outbox key. The focused follow-up includes the canonical topology execution ID
+in the outbox event identity. It intentionally leaves the decoded
+`applyPlannedLayout` work unchanged so multiple source events converge on the
+same fenced command, and it retains no old identity overload or fallback.
+
 - [x] Merge the B06 E3-memory producer, recovery, verifier, and observation-PR
       publication path; configure `RTC_OBSERVATION_PR_TOKEN`.
 - [x] Preserve the first four unsuccessful primaries as failed evidence rather than
@@ -3920,8 +3934,14 @@ strict final-outbox collision invariant or retain an alternate identity path.
       PR #517, then dispatch run 33991439486 from moving `main`.
 - [x] Verify and archive run 33991439486's failed primary through observation
       PR #519; do not accept its metrics or run a repeat.
-- [ ] Merge the focused coalesced publication-wake identity correction in PR
+- [x] Merge the focused coalesced publication-wake identity correction in PR
       #520 after relevant unit, type, full-stack, and branch validation.
+- [x] Dispatch run 33997173287 from the then-current `main` after PR #520
+      merges.
+- [x] Verify and archive run 33997173287's failed primary through observation
+      PR #522; do not accept its metrics or run a repeat.
+- [ ] Merge the focused topology-promotion request identity correction after
+      relevant unit, type, full-stack, and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
       `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
@@ -4385,20 +4405,22 @@ incomplete evidence milestone and do not mark this written plan complete.
 
 ## 13. Progress Record
 
-**2026-09-05 reconciliation:** Task 4B, B04, B05, both observation producers,
+**2026-09-06 reconciliation:** Task 4B, B04, B05, both observation producers,
 and B06 E3-memory tooling are merged. Five valid B05 observations are archived
 on `main`; the overlapping source PRs and branches were consolidated and
-closed. Six B06 primaries are archived as failed evidence with no accepted
+closed. Seven B06 primaries are archived as failed evidence with no accepted
 metrics. PRs #499 and #510 corrected the fourth and fifth failures, while PR
 #517 corrected their Branch Release regression recipe's quiescence race. Run
 33991439486 and archive PR #519 exposed the sixth failure: publication-wake
 identity omitted the generation of its mutable coalesced topology source. The
-focused correction in PR #520 threads the existing canonical execution ID into
-that wake identity without weakening final-outbox collision handling. After it
-merges, the next performance action is another manual Task 10 dispatch from
-moving `main`, followed by integrity-gated archive publication or evidence-led
-diagnosis of its first failed attempt. B07 remains held; Task 12 remains blocked
-on valid B06 evidence.
+focused correction merged in PR #520. Run 33997173287 and archive PR #522 then
+exposed the same omitted generation in the separate topology-promotion outbox
+identity. The current focused slice threads the existing canonical execution ID
+into that event identity while preserving the unchanged convergent command and
+strict collision handling. After it merges, the next performance action is
+another manual Task 10 dispatch from moving `main`, followed by
+integrity-gated archive publication or evidence-led diagnosis of its first
+failed attempt. B07 remains held; Task 12 remains blocked on valid B06 evidence.
 
 | Date       | Plan revision                                                                                                    | State                       | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Next action                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -72,7 +72,7 @@ correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
 PR #519; its focused publication-wake identity correction merged in PR #520.
 Run 33997173287 then produced the seventh failed archive in PR #522. Its first
 default warmup exposed the same missing source-generation dimension in the
-separate topology-promotion outbox identity. The current focused slice keys
+separate topology-promotion outbox identity. PR #523 keys
 each promotion request by the existing canonical topology execution ID while
 leaving the fenced promotion command unchanged. There is not yet a valid B06 E3
 result. B07 remains held, and evidence ranking cannot start until a valid B06
@@ -82,7 +82,7 @@ primary and any required repeat are archived.
 
 | Order | Slice                                          | Completion evidence                                                                                                                                                                                                                              |
 | ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Correct topology-promotion request identity    | The focused PR keys each promotion outbox event by the existing canonical topology execution ID, including coalescing generation, without changing the convergent fenced command; focused and relevant full-stack gates pass and the PR merges.  |
+| 1     | Correct topology-promotion request identity    | PR #523 keys each promotion outbox event by the existing canonical topology execution ID, including coalescing generation, without changing the convergent fenced command; focused and relevant full-stack gates pass and the PR merges.         |
 | 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
 
 After these two slices, Task 12 will choose the B05 observation window,
@@ -3914,8 +3914,8 @@ primary. The first default warmup again timed out before agent A observed both
 ready peers, but the causal server error moved to
 `app-outbox.topology-promotion`: two distinct topology source generations that
 selected the same formation epoch and layout attempted one immutable promotion
-outbox key. The focused follow-up includes the canonical topology execution ID
-in the outbox event identity. It intentionally leaves the decoded
+outbox key. The focused follow-up in PR #523 includes the canonical topology
+execution ID in the outbox event identity. It intentionally leaves the decoded
 `applyPlannedLayout` work unchanged so multiple source events converge on the
 same fenced command, and it retains no old identity overload or fallback.
 
@@ -3940,8 +3940,8 @@ same fenced command, and it retains no old identity overload or fallback.
       merges.
 - [x] Verify and archive run 33997173287's failed primary through observation
       PR #522; do not accept its metrics or run a repeat.
-- [ ] Merge the focused topology-promotion request identity correction after
-      relevant unit, type, full-stack, and branch validation.
+- [ ] Merge the focused topology-promotion request identity correction in PR
+      #523 after relevant unit, type, full-stack, and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
       `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
@@ -4415,7 +4415,7 @@ metrics. PRs #499 and #510 corrected the fourth and fifth failures, while PR
 identity omitted the generation of its mutable coalesced topology source. The
 focused correction merged in PR #520. Run 33997173287 and archive PR #522 then
 exposed the same omitted generation in the separate topology-promotion outbox
-identity. The current focused slice threads the existing canonical execution ID
+identity. PR #523 threads the existing canonical execution ID
 into that event identity while preserving the unchanged convergent command and
 strict collision handling. After it merges, the next performance action is
 another manual Task 10 dispatch from moving `main`, followed by

--- a/packages/shared-server/rallar-system/group-state/topology-promotion-outbox-entry.ts
+++ b/packages/shared-server/rallar-system/group-state/topology-promotion-outbox-entry.ts
@@ -28,6 +28,7 @@ export interface GroupTopologyPromotionWork {
 
 export interface ComputeTopologyPromotionEntryInput {
     readonly work: GroupTopologyPromotionWork;
+    readonly sourceWorkId: string;
     readonly senderId: string;
     readonly createdAtEpochMs: number;
     readonly expireAtEpochMs: number;
@@ -52,9 +53,16 @@ export function computeTopologyPromotionEntry(
         expectedLayout: input.work.expectedLayout
     };
     const contextId = groupStateGroupStorageKey(work.groupRef);
-    // Same 36-char discipline as the formation timers: the layout identity
-    // rides the fnv hash of its canonical spelling.
-    const identity = fnv1a64(contextId + serializeCanonicalJson(work.expectedLayout));
+    // Same 36-char discipline as the formation timers: the source generation
+    // and layout fence ride the fnv hash of their canonical spelling. Distinct
+    // topology work can request the same fence; retries of one work item retain
+    // one durable identity.
+    const identity = fnv1a64(
+        contextId + serializeCanonicalJson({
+            sourceWorkId: input.sourceWorkId,
+            expectedLayout: work.expectedLayout
+        })
+    );
     const key = toAppQueueKey({
         topicId: APP_OUTBOX_TOPOLOGY_PROMOTION_TOPIC,
         resourceId: `tp-${work.formationEpoch}-${identity}`,

--- a/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.ts
@@ -148,6 +148,7 @@ export function computeRtcTopologyWorkWrite(
                 read: accepted.promotionRead,
                 serviceId: input.serviceId,
                 entry,
+                sourceWorkId: input.sourceWorkId,
                 target
             })),
             connectWrites: computePublicationConnectTriggerRequests({

--- a/packages/shared-server/rallar-system/topology/replay/work/topology-promotion-request.ts
+++ b/packages/shared-server/rallar-system/topology/replay/work/topology-promotion-request.ts
@@ -33,6 +33,7 @@ interface ComputeTopologyPromotionRequestInput {
     readonly read: TopologyPromotionRead | null;
     readonly serviceId: string | undefined;
     readonly entry: ResourceEntry;
+    readonly sourceWorkId: string;
     readonly target: RallarOverlayTopologySnapshot | null;
 }
 
@@ -94,6 +95,7 @@ export function computeTopologyPromotionRequest(
             formationEpoch: group.formationEpoch,
             expectedLayout: targetIdentity
         },
+        sourceWorkId: input.sourceWorkId,
         senderId: input.serviceId ?? 'topology-promotion',
         createdAtEpochMs: input.entry.audit.createdTs.toZonedDateTime('UTC').epochMilliseconds,
         expireAtEpochMs: GROUP_MUTATION_QUEUE_EXPIRE_AT_EPOCH_MS

--- a/packages/tests/shared-server/rallar-system/group-state/mutation/group-planned-layout-promotion.test.ts
+++ b/packages/tests/shared-server/rallar-system/group-state/mutation/group-planned-layout-promotion.test.ts
@@ -312,6 +312,7 @@ describe('topology promotion outbox entry', () => {
     it('round-trips the work through the durable entry', () => {
         const entry = computeTopologyPromotionEntry({
             work: { groupRef: GROUP_REF, formationEpoch: 2, expectedLayout: IDENTITY },
+            sourceWorkId: 'rtc-topology:promotion-group:work-1',
             senderId: 'promotion-service',
             createdAtEpochMs: 1_000,
             expireAtEpochMs: 100_000

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/compute-rtc-topology-work-write.test.ts
@@ -91,6 +91,32 @@ describe('RTC topology complete write computation', () => {
         );
     });
 
+    it('gives each coalesced source generation a distinct promotion request identity', () => {
+        const firstInput = {
+            ...createWriteInput(),
+            sourceWorkId: 'rtc-topology:group-1:coalesced-work:1'
+        };
+        const secondInput = {
+            ...firstInput,
+            sourceWorkId: 'rtc-topology:group-1:coalesced-work:2'
+        };
+
+        const first = computeRtcTopologyWorkWrite(firstInput);
+        const second = computeRtcTopologyWorkWrite(secondInput);
+        if (
+            first.kind !== 'transaction' ||
+            second.kind !== 'transaction' ||
+            first.transaction.promotionWrite === null ||
+            second.transaction.promotionWrite === null
+        ) {
+            throw new Error('Expected topology promotion transaction fixtures');
+        }
+
+        expect(first.transaction.promotionWrite.entry.key.resourceId).not.toBe(
+            second.transaction.promotionWrite.entry.key.resourceId
+        );
+    });
+
     it('leaves durable replay checks to validation', () => {
         const snapshot = createTopologySnapshot(createGroupRef(), 1);
         const publication = createPublication(snapshot, 'work-1');

--- a/packages/tests/shared-server/rallar-system/topology/replay/work/topology-promotion-request.test.ts
+++ b/packages/tests/shared-server/rallar-system/topology/replay/work/topology-promotion-request.test.ts
@@ -41,6 +41,7 @@ describe('topology promotion request write', () => {
             read,
             serviceId: 'topology-service',
             entry: promotionEntry(),
+            sourceWorkId: 'rtc-topology:group-1:work-1',
             target: null
         })).toBeNull();
         expect(calls).toEqual(['group', 'policy']);


### PR DESCRIPTION
## Summary

- key topology-promotion outbox events by the canonical source topology execution ID plus the layout fence
- keep the decoded applyPlannedLayout command unchanged so distinct events still converge
- record RTC-B06 run 33997173287 / PR #522 and the next moving-main capture step in the active plan

## Validation

- focused topology tests: 22 passed
- shared-server suite: 2,187 passed, 12 skipped
- group-topology suite: 555 passed, 5 skipped
- PGlite topology/transaction tests: 21 passed
- three-browser memory RTC default scenario: 1 passed, 2 opt-in tests skipped
- shared-server and test typechecks passed
- repo governance, changed style, structure, retained legacy, structure coupling, formatting, and diff checks passed
- independent review: no actionable findings