### PR TITLE
fix(rtc): await accepted three-agent readiness

### DIFF
--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -65,25 +65,34 @@ observation stream, and B06 E3-memory observation tooling are merged. Five
 distinct valid B05 observations through 2026-09-05 are archived on `main`: PR
 #402 landed directly, and the four observations formerly published by PRs
 #405, #463, #474, and #494 landed through batch PRs #507 and #504 before the
-superseded PRs and branches were closed. Seven B06 observations have failed with
+superseded PRs and branches were closed. Eight B06 observations have failed with
 `acceptedMetrics: false` and are archived on `main`. The first five, their
 focused corrections in PRs #499 and #510, and the Branch Release quiescence
 correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
 PR #519; its focused publication-wake identity correction merged in PR #520.
 Run 33997173287 then produced the seventh failed archive in PR #522. Its first
 default warmup exposed the same missing source-generation dimension in the
-separate topology-promotion outbox identity. PR #523 keys
-each promotion request by the existing canonical topology execution ID while
-leaving the fenced promotion command unchanged. There is not yet a valid B06 E3
-result. B07 remains held, and evidence ranking cannot start until a valid B06
-primary and any required repeat are archived.
+separate topology-promotion outbox identity. PR #523 merged the correction that
+keys each promotion request by the existing canonical topology execution ID
+while leaving the fenced promotion command unchanged. Run 34000825989 then
+passed the default warmup plus all five retained default attempts before its
+all-scenarios warmup failed during replacement-C reconnect; PR #524 archived
+that eighth failed primary. The original pre-activation readiness gap cleared,
+but the reconnect helper refreshed and waited only for survivor B while the
+replacement endpoint's refresh and two-survivor readiness check remained
+queued behind B. All three peer establishments later timed out. The current
+focused correction makes one reconnect owner concurrently prove both survivors
+observe replacement C's new session and replacement C observes both survivor
+sessions. There is not yet a valid B06 E3 result. B07 remains held, and evidence
+ranking cannot start until a valid B06 primary and any required repeat are
+archived.
 
 ### Current execution horizon
 
-| Order | Slice                                          | Completion evidence                                                                                                                                                                                                                              |
-| ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Correct topology-promotion request identity    | PR #523 keys each promotion outbox event by the existing canonical topology execution ID, including coalescing generation, without changing the convergent fenced command; focused and relevant full-stack gates pass and the PR merges.         |
-| 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived. |
+| Order | Slice                                          | Completion evidence                                                                                                                                                                                                                                                              |
+| ----- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Merge the full reconnect-readiness correction  | The reconnect helper has one explicit three-participant readiness owner, direct semantic coverage proves replacement-session identity plus concurrent A/B/C waits, and focused unit, exact E3 all-scenarios, type/build/style/structure gates pass before the correction merges. |
+| 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived.                                 |
 
 After these two slices, Task 12 will choose the B05 observation window,
 revisit whether the candidate call path requires E4-pg, and reconcile the
@@ -3873,7 +3882,7 @@ performance-observations/rtc-b06/YYYY/MM/DD/<observation-id>.zip
 performance-observations/rtc-b06/index.jsonl
 ```
 
-Current evidence contains seven failed B06 primaries and no accepted metrics.
+Current evidence contains eight failed B06 primaries and no accepted metrics.
 The fourth archive is PR #498. Its first retained default attempt timed out
 receiving `messages.rtc` multicast on agent C after the warmup passed. That run
 exposed a post-activation readiness gap: the lifecycle driver proved readiness
@@ -3919,6 +3928,20 @@ execution ID in the outbox event identity. It intentionally leaves the decoded
 `applyPlannedLayout` work unchanged so multiple source events converge on the
 same fenced command, and it retains no old identity overload or fallback.
 
+PR #523 merged, and run 34000825989 observed the resulting moving-`main`
+snapshot. The default warmup and all five retained default attempts passed; the
+all-scenarios warmup then failed during replacement-C reconnect, and PR #524
+archived that eighth failed primary. Repeated refresh/recheck cleared the
+original pre-activation readiness failure, but the reconnect helper still
+owned only survivor B's wait. Replacement C's refresh and readiness check for
+both survivor sessions ran later in the caller, behind B's blocked readiness
+poll, so signaling could not complete and all involved peer establishments
+timed out. The focused test-tooling correction gives the reconnect helper one
+explicit owner for concurrent A/B/C readiness: both survivors must observe
+replacement C's new session ID, and replacement C must observe both surviving
+session IDs. It returns the maximum receiver-observed survivor duration used by
+the existing evidence timing field and removes the callers' duplicate waits.
+
 - [x] Merge the B06 E3-memory producer, recovery, verifier, and observation-PR
       publication path; configure `RTC_OBSERVATION_PR_TOKEN`.
 - [x] Preserve the first four unsuccessful primaries as failed evidence rather than
@@ -3940,10 +3963,18 @@ same fenced command, and it retains no old identity overload or fallback.
       merges.
 - [x] Verify and archive run 33997173287's failed primary through observation
       PR #522; do not accept its metrics or run a repeat.
-- [ ] Merge the focused topology-promotion request identity correction in PR
+- [x] Merge the focused topology-promotion request identity correction in PR
       #523 after relevant unit, type, full-stack, and branch validation.
+- [x] Manually dispatch run 34000825989 from the then-current `main` after that
+      correction merged.
+- [x] Verify and archive run 34000825989's failed primary through observation
+      PR #524; preserve its passed default warmup and five retained attempts,
+      and do not accept metrics or run a repeat.
+- [ ] Merge the focused full reconnect-readiness correction after direct
+      semantic, focused unit, exact E3 all-scenarios, type/build/style/structure,
+      and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
-      `main` after that correction merges.
+      moving `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
       integrity and merge the ZIP/index row. A valid primary must report
       `acceptedMetrics: true`; complete any controller-required repeat.
@@ -4408,19 +4439,25 @@ incomplete evidence milestone and do not mark this written plan complete.
 **2026-09-06 reconciliation:** Task 4B, B04, B05, both observation producers,
 and B06 E3-memory tooling are merged. Five valid B05 observations are archived
 on `main`; the overlapping source PRs and branches were consolidated and
-closed. Seven B06 primaries are archived as failed evidence with no accepted
+closed. Eight B06 primaries are archived as failed evidence with no accepted
 metrics. PRs #499 and #510 corrected the fourth and fifth failures, while PR
 #517 corrected their Branch Release regression recipe's quiescence race. Run
 33991439486 and archive PR #519 exposed the sixth failure: publication-wake
 identity omitted the generation of its mutable coalesced topology source. The
 focused correction merged in PR #520. Run 33997173287 and archive PR #522 then
 exposed the same omitted generation in the separate topology-promotion outbox
-identity. PR #523 threads the existing canonical execution ID
-into that event identity while preserving the unchanged convergent command and
-strict collision handling. After it merges, the next performance action is
-another manual Task 10 dispatch from moving `main`, followed by
-integrity-gated archive publication or evidence-led diagnosis of its first
-failed attempt. B07 remains held; Task 12 remains blocked on valid B06 evidence.
+identity. PR #523 merged the correction that threads the existing canonical
+execution ID into that event identity while preserving the unchanged
+convergent command and strict collision handling. Run 34000825989 then passed
+the default warmup and five retained default attempts before its all-scenarios
+warmup failed at replacement-C reconnect; PR #524 archived the result. The
+original readiness failure cleared, but the reconnect helper waited only for
+survivor B while replacement C's refresh/readiness remained queued behind it,
+so the three peer establishments timed out. The current correction owns the
+full reconnect readiness concurrently and proves replacement-session identity.
+The next two slices are to merge that focused correction and then dispatch B06
+again from moving `main`. B07 remains held; Task 12 remains blocked on valid
+B06 evidence.
 
 | Date       | Plan revision                                                                                                    | State                       | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Next action                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -80,19 +80,21 @@ all-scenarios warmup failed during replacement-C reconnect; PR #524 archived
 that eighth failed primary. The original pre-activation readiness gap cleared,
 but the reconnect helper refreshed and waited only for survivor B while the
 replacement endpoint's refresh and two-survivor readiness check remained
-queued behind B. All three peer establishments later timed out. The current
-focused correction makes one reconnect owner concurrently prove both survivors
-observe replacement C's new session and replacement C observes both survivor
-sessions. There is not yet a valid B06 E3 result. B07 remains held, and evidence
+queued behind B. All three peer establishments later timed out. PR #526 makes
+one reconnect owner concurrently prove both survivors observe replacement C's
+new session and replacement C observes both survivor sessions. It also keeps
+initial-pair readiness before activation, then makes post-activation A/B/C
+hydration a correctness barrier even when owner scope retains only A's timing
+sample. There is not yet a valid B06 E3 result. B07 remains held, and evidence
 ranking cannot start until a valid B06 primary and any required repeat are
 archived.
 
 ### Current execution horizon
 
-| Order | Slice                                          | Completion evidence                                                                                                                                                                                                                                                              |
-| ----- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | Merge the full reconnect-readiness correction  | The reconnect helper has one explicit three-participant readiness owner, direct semantic coverage proves replacement-session identity plus concurrent A/B/C waits, and focused unit, exact E3 all-scenarios, type/build/style/structure gates pass before the correction merges. |
-| 2     | Capture B06 E3-memory again from moving `main` | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived.                                 |
+| Order | Slice                                                     | Completion evidence                                                                                                                                                                                                                                                                                                                   |
+| ----- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Merge the accepted-layout readiness correction in PR #526 | The formation owner hydrates all accepted A/B/C routes after activation while filtering only timing evidence by scope; reconnect has one explicit three-participant readiness owner; direct semantic, focused unit, exact default/all-scenarios E3, type/build/style/structure, full-unit, and branch review gates pass before merge. |
+| 2     | Capture B06 E3-memory again from moving `main`            | Manually dispatch `RTC-B06 Performance Observation` after the correction reaches `main`. The workflow archives one verified primary with `acceptedMetrics: true`; when the controller requires a repeat, that repeat is also valid and archived.                                                                                      |
 
 After these two slices, Task 12 will choose the B05 observation window,
 revisit whether the candidate call path requires E4-pg, and reconcile the
@@ -3936,11 +3938,15 @@ original pre-activation readiness failure, but the reconnect helper still
 owned only survivor B's wait. Replacement C's refresh and readiness check for
 both survivor sessions ran later in the caller, behind B's blocked readiness
 poll, so signaling could not complete and all involved peer establishments
-timed out. The focused test-tooling correction gives the reconnect helper one
-explicit owner for concurrent A/B/C readiness: both survivors must observe
-replacement C's new session ID, and replacement C must observe both surviving
-session IDs. It returns the maximum receiver-observed survivor duration used by
-the existing evidence timing field and removes the callers' duplicate waits.
+timed out. PR #526 gives the reconnect helper one explicit owner for concurrent
+A/B/C readiness: both survivors must observe replacement C's new session ID,
+and replacement C must observe both surviving session IDs. The same correction
+preserves initial-pair readiness, activates the staged three-participant layout,
+and then requires all three endpoints to hydrate the accepted routes. Owner
+scope filters only the returned timing evidence to A; it does not remove B/C
+from the correctness barrier. Reconnect returns the maximum receiver-observed
+survivor duration used by the existing evidence timing field, and duplicate
+caller waits plus obsolete fixture modes and readiness APIs are removed.
 
 - [x] Merge the B06 E3-memory producer, recovery, verifier, and observation-PR
       publication path; configure `RTC_OBSERVATION_PR_TOKEN`.
@@ -3970,9 +3976,9 @@ the existing evidence timing field and removes the callers' duplicate waits.
 - [x] Verify and archive run 34000825989's failed primary through observation
       PR #524; preserve its passed default warmup and five retained attempts,
       and do not accept metrics or run a repeat.
-- [ ] Merge the focused full reconnect-readiness correction after direct
-      semantic, focused unit, exact E3 all-scenarios, type/build/style/structure,
-      and branch validation.
+- [ ] Merge PR #526's focused accepted-layout readiness correction after direct
+      semantic, focused unit, exact default/all-scenarios E3,
+      type/build/style/structure, full-unit, and branch validation.
 - [ ] Manually dispatch `RTC-B06 Performance Observation` from the then-current
       moving `main` after that correction merges.
 - [ ] Verify that its observation-only pull request passes RTC observation
@@ -4453,11 +4459,12 @@ the default warmup and five retained default attempts before its all-scenarios
 warmup failed at replacement-C reconnect; PR #524 archived the result. The
 original readiness failure cleared, but the reconnect helper waited only for
 survivor B while replacement C's refresh/readiness remained queued behind it,
-so the three peer establishments timed out. The current correction owns the
-full reconnect readiness concurrently and proves replacement-session identity.
-The next two slices are to merge that focused correction and then dispatch B06
-again from moving `main`. B07 remains held; Task 12 remains blocked on valid
-B06 evidence.
+so the three peer establishments timed out. PR #526 owns full reconnect
+readiness concurrently, proves replacement-session identity, and makes every
+post-activation A/B/C route a correctness barrier without adding receiver
+timings to owner-scope evidence. The next two slices are to merge PR #526 and
+then dispatch B06 again from moving `main`. B07 remains held; Task 12 remains
+blocked on valid B06 evidence.
 
 | Date       | Plan revision                                                                                                    | State                       | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Next action                                                                                                                                                                                                                                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
@@ -17,11 +17,13 @@ describe('live RTC control client', () => {
     let api: APIRequestContext;
     let control: LiveRtcControlClient;
     let nowMs: number;
+    let readyPeerIds: string[];
     const refreshRoom = vi.fn<LiveRtcControlClient.FormationAgent['refreshRoom']>();
     const agent = { agentId: 'agent-a', prefix: 'A' as const, refreshRoom };
 
     beforeEach(async () => {
         nowMs = 100;
+        readyPeerIds = ['session-b', 'session-c'];
         const results: LiveRtcControlClient.Result[] = [];
         server = createServer(async (incoming, response) => {
             if (incoming.method === 'POST') {
@@ -37,7 +39,7 @@ describe('live RTC control client', () => {
                 results.push({
                     commandId: command.commandId,
                     ok: true,
-                    result: { value: { rallar: { rtcStatus: { readyPeerIds: ['session-b', 'session-c'] } } } }
+                    result: { value: { rallar: { rtcStatus: { readyPeerIds } } } }
                 });
                 response.writeHead(202).end('{}');
                 return;
@@ -99,6 +101,26 @@ describe('live RTC control client', () => {
         }
         expect(await readiness).toBe(250);
         expect(roomMembers).toEqual(['session-a', 'session-b', 'session-c']);
+    });
+
+    it('rechecks readiness after every room refresh while expected peers are missing', async () => {
+        let refreshCount = 0;
+        refreshRoom.mockImplementation(async () => {
+            refreshCount += 1;
+            nowMs += 100;
+            readyPeerIds = refreshCount === 1
+                ? ['session-b']
+                : ['session-b', 'session-c'];
+        });
+
+        await expect(control.waitForPeerReadiness({
+            runId: 'run-refresh-retry',
+            agent,
+            expectedPeerIds: ['session-b', 'session-c'],
+            suffix: 'delayed-topology',
+            startedAtMs: 100
+        })).resolves.toBe(200);
+        expect(refreshRoom).toHaveBeenCalledTimes(2);
     });
 
     it('rejects readiness when authoritative room refresh fails', async () => {

--- a/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
@@ -120,7 +120,6 @@ describe('live RTC control client', () => {
             suffix: 'delayed-topology',
             startedAtMs: 100
         })).resolves.toBe(200);
-        expect(refreshRoom).toHaveBeenCalledTimes(2);
     });
 
     it('rejects readiness when authoritative room refresh fails', async () => {

--- a/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
@@ -94,8 +94,8 @@ describe('live RTC delivery owner', () => {
             groupId: 'room/c',
             suffix: 'again'
         });
-        expect(formation.sessions).toEqual({ A: 'session-A', B: 'session-B', C: 'session-C' });
-        expect(reconnect.sessionId).toBe('session-C');
+        expect(formation.sessions).toEqual({ A: 'session-A-1', B: 'session-B-1', C: 'session-C-1' });
+        expect(reconnect.sessionId).toBe('session-C-2');
         await operations.sendMatrixPayload({
             control: recording,
             runId: 'run',
@@ -110,7 +110,7 @@ describe('live RTC delivery owner', () => {
         expect(recording.commands.at(-1)?.command).toMatchObject({
             kind: 'rtc.send',
             roomRef: { applicationId: 'app/a', workspaceId: 'work b', groupId: 'room/c' },
-            send: { nextHopPeerIds: ['session-C'], payload: { matrixId: 'reconnect-result' } }
+            send: { nextHopPeerIds: ['session-C-2'], payload: { matrixId: 'reconnect-result' } }
         });
         const beforeC = recording.milestones.slice(0, recording.milestones.indexOf('connect:C'));
         expect(beforeC).toEqual(expect.arrayContaining(['connect-layout:2', 'ready:A', 'ready:B', 'activate:2']));
@@ -144,7 +144,7 @@ describe('live RTC delivery owner', () => {
     });
 
     it('waits concurrently for both survivors and the replacement session before returning reconnect readiness', async () => {
-        const recording = RecordingLiveRtcControl.withReplacementSessions();
+        const recording = new RecordingLiveRtcControl();
         const operations = createLiveRtcDeliveryOperations(config);
         const formation = await operations.runGroupFormation({
             control: recording,
@@ -182,6 +182,12 @@ describe('live RTC delivery owner', () => {
         ]);
         recording.completeNextReadiness('A', 30);
         recording.completeNextReadiness('B', 40);
+        let reconnectResolved = false;
+        void reconnectPromise.then(() => {
+            reconnectResolved = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(reconnectResolved).toBe(false);
         recording.completeNextReadiness('C', 50);
 
         await expect(reconnectPromise).resolves.toEqual({
@@ -205,7 +211,7 @@ describe('live RTC delivery owner', () => {
             suffix: 'second-transport',
             readinessScope: 'all'
         });
-        expect(formation.sessions).toEqual({ A: 'session-A', B: 'session-B', C: 'session-C' });
+        expect(formation.sessions).toEqual({ A: 'session-A-1', B: 'session-B-1', C: 'session-C-1' });
         const pair = recording.milestones.slice(0, recording.milestones.indexOf('connect:C'));
         expect(pair.indexOf('reconfigure')).toBeGreaterThan(pair.indexOf('presence:2'));
         expect(pair.indexOf('planned')).toBeGreaterThan(pair.indexOf('reconfigure'));
@@ -284,7 +290,7 @@ describe('live RTC delivery owner', () => {
             groupId: 'room',
             suffix: 'post-activation',
             deliveryMode: 'multicast',
-            targetSessionIds: ['session-B', 'session-C'],
+            targetSessionIds: ['session-B-1', 'session-C-1'],
             matrixId: 'post-activation-delivery'
         });
         expect(recording.milestones.indexOf('send')).toBeGreaterThan(
@@ -376,7 +382,6 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
     private formationEpoch = 0;
     private groupRevision = 0;
     private deferReadiness: boolean;
-    private replacementSessions = false;
     private readonly connectionCountByAgentId = new Map<string, number>();
     private readonly sessionIdByAgentId = new Map<string, string>();
     private readonly pendingReadiness = new Map<LiveRtcControlClient.FormationAgent['prefix'], Array<(durationMs: number) => void>>();
@@ -403,12 +408,6 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
 
     static withDeferredReadiness(): RecordingLiveRtcControl {
         return new RecordingLiveRtcControl({ lifecycleState: 'forming', acceptedSessions: [] }, true);
-    }
-
-    static withReplacementSessions(): RecordingLiveRtcControl {
-        const recording = new RecordingLiveRtcControl();
-        recording.replacementSessions = true;
-        return recording;
     }
 
     deferReadinessObservations(): void {
@@ -445,6 +444,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
         this.commands.push(input);
         const command = input.command;
         const body = this.recordCommand(input, command);
+        const sessionId = this.sessionIdByAgentId.get(input.agentId);
         return {
             agentId: input.agentId,
             commandId: input.commandId,
@@ -452,8 +452,12 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
             result: {
                 value: {
                     body,
-                    sessionId: this.sessionIdByAgentId.get(input.agentId) ?? `session-${input.agentId}`,
-                    message: { message: { id: { msgId: 'attempted-message', senderId: `session-${input.agentId}` } } }
+                    ...(sessionId
+                        ? {
+                            sessionId,
+                            message: { message: { id: { msgId: 'attempted-message', senderId: sessionId } } }
+                        }
+                        : {})
                 }
             }
         };
@@ -464,22 +468,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
         command: LiveRtcControlClient.ExecuteInput['command']
     ): ReturnType<LiveRtcControlPort['resultValue']> {
         if (command.kind === 'rtc.connect') {
-            if (input.agentId === 'C' && this.lifecycleState !== 'active') {
-                throw new Error('Third agent connected before pair activation');
-            }
-            const connectionCount = (this.connectionCountByAgentId.get(input.agentId) ?? 0) + 1;
-            this.connectionCountByAgentId.set(input.agentId, connectionCount);
-            this.sessionIdByAgentId.set(
-                input.agentId,
-                this.replacementSessions
-                    ? `session-${input.agentId}-${connectionCount}`
-                    : `session-${input.agentId}`
-            );
-            this.connected.add(input.agentId);
-            if (this.lifecycleState === 'active' && connectionCount > 1) {
-                this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
-            }
-            this.milestones.push(`connect:${input.agentId}`);
+            this.recordConnection(input.agentId);
         }
         else if (command.kind === 'rtc.send') {
             this.milestones.push('send');
@@ -488,11 +477,36 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
             this.milestones.push(`${command.kind}:${input.agentId}`);
             this.connected.delete(input.agentId);
         }
-        else if (input.commandId.startsWith('group-presence')) {
+        else {
+            return this.recordHttpCommand(input, command);
+        }
+        return {};
+    }
+
+    private recordConnection(agentId: string): void {
+        if (agentId === 'C' && this.lifecycleState !== 'active') {
+            throw new Error('Third agent connected before pair activation');
+        }
+        const connectionCount = (this.connectionCountByAgentId.get(agentId) ?? 0) + 1;
+        this.connectionCountByAgentId.set(agentId, connectionCount);
+        this.sessionIdByAgentId.set(agentId, `session-${agentId}-${connectionCount}`);
+        this.connected.add(agentId);
+        if (this.lifecycleState === 'active' && connectionCount > 1) {
+            this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
+        }
+        this.milestones.push(`connect:${agentId}`);
+    }
+
+    private recordHttpCommand(
+        input: LiveRtcControlClient.ExecuteInput,
+        command: LiveRtcControlClient.ExecuteInput['command']
+    ): ReturnType<LiveRtcControlPort['resultValue']> {
+        const request = 'request' in command ? command.request : undefined;
+        if (input.commandId.startsWith('group-presence')) {
             this.milestones.push(`presence:${this.connected.size}`);
             return { causalRevision: { presenceRevision: this.connected.size } };
         }
-        else if (('request' in command ? command.request?.path : undefined)?.endsWith('/topology')) {
+        if (request?.path?.endsWith('/topology')) {
             this.milestones.push('planned');
             return {
                 snapshot: {
@@ -506,13 +520,19 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
                 }
             };
         }
-        else if (('request' in command ? command.request?.method : undefined) === 'GET') {
+        if (request?.method === 'GET') {
             return { group: { lifecycleState: this.lifecycleState } };
         }
-        else if (('request' in command ? command.request?.path : undefined)?.includes('/topology/config/')) {
+        return this.recordLifecycleRequest(request?.path);
+    }
+
+    private recordLifecycleRequest(
+        requestPath: string | undefined
+    ): ReturnType<LiveRtcControlPort['resultValue']> {
+        if (requestPath?.includes('/topology/config/')) {
             this.milestones.push('mesh');
         }
-        else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/plan/')) {
+        else if (requestPath?.includes('/lifecycle/plan/')) {
             this.formationEpoch++;
             this.groupRevision++;
             this.lifecycleState = 'connecting';
@@ -522,7 +542,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
                 causalRevision: { groupRevision: this.groupRevision }
             };
         }
-        else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/reconfigure/')) {
+        else if (requestPath?.includes('/lifecycle/reconfigure/')) {
             this.formationEpoch++;
             this.groupRevision++;
             this.lifecycleState = 'reconfiguring';
@@ -532,11 +552,11 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
                 causalRevision: { groupRevision: this.groupRevision }
             };
         }
-        else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/connect/')) {
+        else if (requestPath?.includes('/lifecycle/connect/')) {
             this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
             this.milestones.push(`connect-layout:${this.connected.size}`);
         }
-        else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/activate/')) {
+        else if (requestPath?.includes('/lifecycle/activate/')) {
             this.lifecycleState = 'active';
             this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
             this.milestones.push(`activate:${this.connected.size}`);
@@ -561,7 +581,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
         await input.agent.refreshRoom({ timeoutMs: 60_000 });
         const dialableSessions = this.acceptedSessions.length > 0
             ? this.acceptedSessions
-            : [...this.connected].map((id) => `session-${id}`);
+            : [...this.connected].map((id) => this.requireConnectedSessionId(id));
         if (input.expectedPeerIds.some((id) => !dialableSessions.includes(id))) {
             throw new Error('Readiness requested for a peer absent from the dialable layout');
         }

--- a/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
@@ -88,7 +88,8 @@ describe('live RTC delivery owner', () => {
             control: recording,
             runId: 'run',
             reconnectingAgent: recording.agents[2],
-            readinessAgent: recording.agents[1],
+            survivingAgents: [recording.agents[0], recording.agents[1]],
+            survivingSessionIds: [formation.sessions.A, formation.sessions.B],
             transport: 'messages.rtc',
             groupId: 'room/c',
             suffix: 'again'
@@ -140,6 +141,54 @@ describe('live RTC delivery owner', () => {
                     }
                 })
             ]));
+    });
+
+    it('waits concurrently for both survivors and the replacement session before returning reconnect readiness', async () => {
+        const recording = RecordingLiveRtcControl.withReplacementSessions();
+        const operations = createLiveRtcDeliveryOperations(config);
+        const formation = await operations.runGroupFormation({
+            control: recording,
+            runId: 'replacement-run',
+            agents: recording.agents,
+            transport: 'messages.rtc',
+            groupId: 'replacement-room',
+            suffix: 'initial',
+            readinessScope: 'all'
+        });
+        await recording.executeOk({
+            runId: 'replacement-run',
+            agentId: recording.agents[2].agentId,
+            commandId: 'close-original-c',
+            command: { kind: 'close' }
+        });
+        recording.deferReadinessObservations();
+
+        const reconnectPromise = operations.reconnectAndWaitForPeerReadiness({
+            control: recording,
+            runId: 'replacement-run',
+            reconnectingAgent: recording.agents[2],
+            survivingAgents: [recording.agents[0], recording.agents[1]],
+            survivingSessionIds: [formation.sessions.A, formation.sessions.B],
+            transport: 'messages.rtc',
+            groupId: 'replacement-room',
+            suffix: 'replacement'
+        });
+
+        await waitForPendingReadiness(recording, ['A', 'B', 'C']);
+        expect(recording.readinessObservations.slice(-3)).toEqual([
+            { agentPrefix: 'A', expectedPeerIds: ['session-C-2'] },
+            { agentPrefix: 'B', expectedPeerIds: ['session-C-2'] },
+            { agentPrefix: 'C', expectedPeerIds: [formation.sessions.A, formation.sessions.B] }
+        ]);
+        recording.completeNextReadiness('A', 30);
+        recording.completeNextReadiness('B', 40);
+        recording.completeNextReadiness('C', 50);
+
+        await expect(reconnectPromise).resolves.toEqual({
+            commandId: 'connect-c-messages-rtc-replacement',
+            sessionId: 'session-C-2',
+            receiverReadinessDurationMs: 40
+        });
     });
 
     it('promotes new pair sessions before readiness when an active group retains old accepted sessions', async () => {
@@ -326,9 +375,18 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
     private acceptedSessions: readonly string[];
     private formationEpoch = 0;
     private groupRevision = 0;
-    private readonly deferReadiness: boolean;
+    private deferReadiness: boolean;
+    private replacementSessions = false;
+    private readonly connectionCountByAgentId = new Map<string, number>();
+    private readonly sessionIdByAgentId = new Map<string, string>();
     private readonly pendingReadiness = new Map<LiveRtcControlClient.FormationAgent['prefix'], Array<(durationMs: number) => void>>();
     readonly messageObservations: LiveRtcControlClient.WaitForMessageInput[] = [];
+    readonly readinessObservations: Array<
+        Readonly<{
+            agentPrefix: LiveRtcControlClient.FormationAgent['prefix'];
+            expectedPeerIds: readonly string[];
+        }>
+    > = [];
     readonly agents: readonly [LiveRtcControlClient.FormationAgent, LiveRtcControlClient.FormationAgent, LiveRtcControlClient.FormationAgent] = [
         this.createAgent('A'),
         this.createAgent('B'),
@@ -345,6 +403,16 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
 
     static withDeferredReadiness(): RecordingLiveRtcControl {
         return new RecordingLiveRtcControl({ lifecycleState: 'forming', acceptedSessions: [] }, true);
+    }
+
+    static withReplacementSessions(): RecordingLiveRtcControl {
+        const recording = new RecordingLiveRtcControl();
+        recording.replacementSessions = true;
+        return recording;
+    }
+
+    deferReadinessObservations(): void {
+        this.deferReadiness = true;
     }
 
     pendingReadinessCount(prefix: LiveRtcControlClient.FormationAgent['prefix']): number {
@@ -384,7 +452,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
             result: {
                 value: {
                     body,
-                    sessionId: `session-${input.agentId}`,
+                    sessionId: this.sessionIdByAgentId.get(input.agentId) ?? `session-${input.agentId}`,
                     message: { message: { id: { msgId: 'attempted-message', senderId: `session-${input.agentId}` } } }
                 }
             }
@@ -399,7 +467,18 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
             if (input.agentId === 'C' && this.lifecycleState !== 'active') {
                 throw new Error('Third agent connected before pair activation');
             }
+            const connectionCount = (this.connectionCountByAgentId.get(input.agentId) ?? 0) + 1;
+            this.connectionCountByAgentId.set(input.agentId, connectionCount);
+            this.sessionIdByAgentId.set(
+                input.agentId,
+                this.replacementSessions
+                    ? `session-${input.agentId}-${connectionCount}`
+                    : `session-${input.agentId}`
+            );
             this.connected.add(input.agentId);
+            if (this.lifecycleState === 'active' && connectionCount > 1) {
+                this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
+            }
             this.milestones.push(`connect:${input.agentId}`);
         }
         else if (command.kind === 'rtc.send') {
@@ -423,7 +502,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
                     },
                     version: 1,
                     state: 'active',
-                    activeSessionIds: [...this.connected].map((id) => `session-${id}`)
+                    activeSessionIds: [...this.connected].map((id) => this.requireConnectedSessionId(id))
                 }
             };
         }
@@ -454,12 +533,12 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
             };
         }
         else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/connect/')) {
-            this.acceptedSessions = [...this.connected].map((id) => `session-${id}`);
+            this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
             this.milestones.push(`connect-layout:${this.connected.size}`);
         }
         else if (('request' in command ? command.request?.path : undefined)?.includes('/lifecycle/activate/')) {
             this.lifecycleState = 'active';
-            this.acceptedSessions = [...this.connected].map((id) => `session-${id}`);
+            this.acceptedSessions = [...this.connected].map((id) => this.requireConnectedSessionId(id));
             this.milestones.push(`activate:${this.connected.size}`);
         }
         return {};
@@ -472,15 +551,24 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
         return value;
     }
     requireSessionId(result: LiveRtcControlClient.Result): string {
-        return `session-${result.agentId}`;
+        const value = result.result?.value;
+        if (value && typeof value === 'object' && !Array.isArray(value) && typeof value.sessionId === 'string') {
+            return value.sessionId;
+        }
+        throw new Error('Recorded connect result must contain a session ID');
     }
     waitForPeerReadiness = async (input: LiveRtcControlClient.WaitForPeerReadinessInput): Promise<number> => {
+        await input.agent.refreshRoom({ timeoutMs: 60_000 });
         const dialableSessions = this.acceptedSessions.length > 0
             ? this.acceptedSessions
             : [...this.connected].map((id) => `session-${id}`);
         if (input.expectedPeerIds.some((id) => !dialableSessions.includes(id))) {
             throw new Error('Readiness requested for a peer absent from the dialable layout');
         }
+        this.readinessObservations.push({
+            agentPrefix: input.agent.prefix,
+            expectedPeerIds: input.expectedPeerIds
+        });
         this.milestones.push(`ready:${input.agent.prefix}`);
         this.milestones.push(`ready-start:${input.agent.prefix}`);
         if (!this.deferReadiness) {
@@ -505,5 +593,13 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
     };
     readyPeerIds(): string[] {
         return [];
+    }
+
+    private requireConnectedSessionId(agentId: string): string {
+        const sessionId = this.sessionIdByAgentId.get(agentId);
+        if (!sessionId) {
+            throw new Error(`Connected agent ${agentId} has no recorded session ID`);
+        }
+        return sessionId;
     }
 }

--- a/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
@@ -118,10 +118,10 @@ describe('live RTC delivery owner', () => {
         expect(afterC.indexOf('reconfigure')).toBeGreaterThan(afterC.indexOf('presence:3'));
         expect(afterC.indexOf('planned')).toBeGreaterThan(afterC.indexOf('reconfigure'));
         expect(afterC.indexOf('connect-layout:3')).toBeGreaterThan(afterC.indexOf('planned'));
+        expect(afterC.indexOf('activate:3')).toBeGreaterThan(afterC.indexOf('connect-layout:3'));
         for (const prefix of ['A', 'B', 'C']) {
-            expect(afterC.indexOf(`refresh:${prefix}`)).toBeGreaterThan(afterC.indexOf('connect-layout:3'));
+            expect(afterC.indexOf(`refresh:${prefix}`)).toBeGreaterThan(afterC.indexOf('activate:3'));
             expect(afterC.indexOf(`ready:${prefix}`)).toBeGreaterThan(afterC.indexOf(`refresh:${prefix}`));
-            expect(afterC.indexOf('activate:3')).toBeGreaterThan(afterC.indexOf(`ready:${prefix}`));
             expect(afterC.indexOf('send')).toBeGreaterThan(afterC.indexOf(`ready:${prefix}`));
         }
         expect(recording.commands.filter(({ command }) => 'request' in command).map(({ command }) => command))
@@ -222,8 +222,9 @@ describe('live RTC delivery owner', () => {
         }
     });
 
-    it('revalidates every RTC route after each activation refresh before delivery', async () => {
-        const recording = RecordingLiveRtcControl.withDeferredReadiness();
+    it('hydrates every accepted route after activation while owner scope emits only owner readiness', async () => {
+        const recording = new RecordingLiveRtcControl();
+        recording.deferReadinessObservations();
         const operations = createLiveRtcDeliveryOperations(config);
         const formationPromise = operations.runGroupFormation({
             control: recording,
@@ -232,7 +233,7 @@ describe('live RTC delivery owner', () => {
             transport: 'messages.rtc',
             groupId: 'room',
             suffix: 'post-activation',
-            readinessScope: 'all'
+            readinessScope: 'owner'
         });
 
         await waitForPendingReadiness(recording, ['A', 'B']);
@@ -254,14 +255,7 @@ describe('live RTC delivery owner', () => {
         expect(recording.milestones).not.toContain('connect:C');
         recording.completeNextReadiness('B', 22);
 
-        await waitForPendingReadiness(recording, ['A', 'B', 'C']);
-        expect(recording.milestones).not.toContain('activate:3');
-        recording.completeNextReadiness('A', 31);
-        recording.completeNextReadiness('B', 32);
-        await Promise.resolve();
-        expect(recording.milestones).not.toContain('activate:3');
-        recording.completeNextReadiness('C', 33);
-
+        await vi.waitFor(() => expect(recording.milestones).toContain('activate:3'));
         await waitForPendingReadiness(recording, ['A', 'B', 'C']);
         const activationIndex = recording.milestones.lastIndexOf('activate:3');
         for (const prefix of ['A', 'B', 'C'] as const) {
@@ -269,19 +263,20 @@ describe('live RTC delivery owner', () => {
             expect(refreshIndex).toBeGreaterThan(activationIndex);
             expect(recording.milestones.lastIndexOf(`ready-start:${prefix}`)).toBeGreaterThan(refreshIndex);
         }
-        recording.completeNextReadiness('A', 41);
-        recording.completeNextReadiness('B', 42);
-        await Promise.resolve();
         let formationResolved = false;
         void formationPromise.then(() => {
             formationResolved = true;
         });
+        recording.completeNextReadiness('A', 41);
+        await Promise.resolve();
+        expect(formationResolved).toBe(false);
+        recording.completeNextReadiness('B', 42);
         await Promise.resolve();
         expect(formationResolved).toBe(false);
         recording.completeNextReadiness('C', 43);
         const formation = await formationPromise;
 
-        expect(formation.readinessDurations).toEqual({ A: 41, B: 42, C: 43 });
+        expect(formation.readinessDurations).toEqual({ A: 41 });
         await operations.sendMatrixPayload({
             control: recording,
             runId: 'run',
@@ -381,7 +376,7 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
     private acceptedSessions: readonly string[];
     private formationEpoch = 0;
     private groupRevision = 0;
-    private deferReadiness: boolean;
+    private deferReadiness = false;
     private readonly connectionCountByAgentId = new Map<string, number>();
     private readonly sessionIdByAgentId = new Map<string, string>();
     private readonly pendingReadiness = new Map<LiveRtcControlClient.FormationAgent['prefix'], Array<(durationMs: number) => void>>();
@@ -397,17 +392,9 @@ class RecordingLiveRtcControl implements LiveRtcControlPort {
         this.createAgent('B'),
         this.createAgent('C')
     ];
-    constructor(
-        initial: RecordingLiveRtcControl.InitialState = { lifecycleState: 'forming', acceptedSessions: [] },
-        deferReadiness = false
-    ) {
+    constructor(initial: RecordingLiveRtcControl.InitialState = { lifecycleState: 'forming', acceptedSessions: [] }) {
         this.lifecycleState = initial.lifecycleState;
         this.acceptedSessions = initial.acceptedSessions;
-        this.deferReadiness = deferReadiness;
-    }
-
-    static withDeferredReadiness(): RecordingLiveRtcControl {
-        return new RecordingLiveRtcControl({ lifecycleState: 'forming', acceptedSessions: [] }, true);
     }
 
     deferReadinessObservations(): void {

--- a/tests/playwright/rallar-black-box/create-group-formation-lifecycle-driver.ts
+++ b/tests/playwright/rallar-black-box/create-group-formation-lifecycle-driver.ts
@@ -41,7 +41,11 @@ interface ReconnectFormationAgentInput {
     readonly control: LiveRtcControlPort;
     readonly runId: string;
     readonly reconnectingAgent: LiveRtcControlClient.FormationAgent;
-    readonly readinessAgent: LiveRtcControlClient.FormationAgent;
+    readonly survivingAgents: readonly [
+        LiveRtcControlClient.FormationAgent,
+        LiveRtcControlClient.FormationAgent
+    ];
+    readonly survivingSessionIds: readonly [string, string];
     readonly transport: TransportUnderTest;
     readonly groupId: string;
     readonly suffix: string;
@@ -54,7 +58,7 @@ export interface GroupFormationLifecycleDriver {
     ): Promise<GroupFormationLifecycleRun>;
     reconnectAndWaitForPeerReadiness(
         input: ReconnectFormationAgentInput
-    ): Promise<FormationAgentConnection>;
+    ): Promise<ReconnectedFormationAgent>;
 }
 
 export interface LiveRtcControlPort extends
@@ -91,6 +95,10 @@ interface ConnectFormationAgentInput {
 interface FormationAgentConnection {
     readonly commandId: string;
     readonly sessionId: string;
+}
+
+interface ReconnectedFormationAgent extends FormationAgentConnection {
+    readonly receiverReadinessDurationMs: number;
 }
 
 interface FormationConnections {
@@ -140,7 +148,6 @@ interface GroupLifecycleCommandInput {
 }
 
 interface ActivateGroupInput extends GroupLifecycleCommandInput {
-    readonly agents: readonly LiveRtcControlClient.FormationAgent[];
     readonly transport: TransportUnderTest;
 }
 
@@ -167,24 +174,49 @@ export function createGroupFormationLifecycleDriver(
     return {
         setupGroupMembership: (input) => setupGroupMembership(config, input),
         run: async (input) => await runGroupFormationLifecycle(config, input),
-        reconnectAndWaitForPeerReadiness: async (input) => {
-            const connection = await connectFormationAgent(config, {
-                control: input.control,
-                runId: input.runId,
-                agent: input.reconnectingAgent,
-                transport: input.transport,
-                groupId: input.groupId,
-                suffix: input.suffix
-            });
-            await input.control.waitForPeerReadiness({
-                runId: input.runId,
-                agent: input.readinessAgent,
-                expectedPeerIds: [connection.sessionId],
-                suffix: input.suffix,
-                startedAtMs: performance.now()
-            });
-            return connection;
-        }
+        reconnectAndWaitForPeerReadiness: async (input) => await reconnectFormationAgent(config, input)
+    };
+}
+
+async function reconnectFormationAgent(
+    config: CreateGroupFormationLifecycleDriverConfig,
+    input: ReconnectFormationAgentInput
+): Promise<ReconnectedFormationAgent> {
+    const startedAtMs = performance.now();
+    const connection = await connectFormationAgent(config, {
+        control: input.control,
+        runId: input.runId,
+        agent: input.reconnectingAgent,
+        transport: input.transport,
+        groupId: input.groupId,
+        suffix: input.suffix
+    });
+    const [firstReceiverDurationMs, secondReceiverDurationMs] = await Promise.all([
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.survivingAgents[0],
+            expectedPeerIds: [connection.sessionId],
+            suffix: input.suffix,
+            startedAtMs
+        }),
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.survivingAgents[1],
+            expectedPeerIds: [connection.sessionId],
+            suffix: input.suffix,
+            startedAtMs
+        }),
+        input.control.waitForPeerReadiness({
+            runId: input.runId,
+            agent: input.reconnectingAgent,
+            expectedPeerIds: input.survivingSessionIds,
+            suffix: `${input.suffix}-settled`,
+            startedAtMs
+        })
+    ]);
+    return {
+        ...connection,
+        receiverReadinessDurationMs: Math.max(firstReceiverDurationMs, secondReceiverDurationMs)
     };
 }
 
@@ -251,17 +283,15 @@ async function connectGroupLifecycle(
         expectedFormationEpoch: stageReceipt.formationEpoch,
         expectedLayout: plannedLayout.identity
     });
-    await refreshAgentRooms(input.run.agents);
     await waitForFormationReadiness({
         run: input.run,
         sessions: input.sessions,
         suffix: input.lifecycleSuffix,
         startedAtMs: input.readinessStartedAtMs
     });
-    const activateCommandId = await activateAndRefreshAcceptedLayout(config, {
+    const activateCommandId = await activateGroup(config, {
         ...input.run,
-        owner,
-        agents: input.run.agents
+        owner
     });
     const readinessDurations = await waitForFormationReadiness({
         run: input.run,
@@ -347,7 +377,6 @@ async function connectInitialPair(
         expectedFormationEpoch: stageReceipt.formationEpoch,
         expectedLayout: plannedLayout.identity
     });
-    await refreshAgentRooms(agents);
     const startedAtMs = performance.now();
     await Promise.all(agents.map(async (agent, index) =>
         await input.control.waitForPeerReadiness({
@@ -358,9 +387,8 @@ async function connectInitialPair(
             startedAtMs
         })
     ));
-    const activateCommandId = await activateAndRefreshAcceptedLayout(config, {
+    const activateCommandId = await activateGroup(config, {
         ...lifecycle,
-        agents,
         transport: input.transport
     });
     await Promise.all(agents.map(async (agent, index) =>
@@ -542,7 +570,7 @@ async function connectPublishedLayout(
     return commandId;
 }
 
-async function activateAndRefreshAcceptedLayout(
+async function activateGroup(
     config: CreateGroupFormationLifecycleDriverConfig,
     input: ActivateGroupInput
 ): Promise<string> {
@@ -569,14 +597,7 @@ async function activateAndRefreshAcceptedLayout(
             }
         }
     });
-    await refreshAgentRooms(input.agents);
     return commandId;
-}
-
-async function refreshAgentRooms(
-    agents: readonly LiveRtcControlClient.FormationAgent[]
-): Promise<void> {
-    await Promise.all(agents.map(async (agent) => await agent.refreshRoom({ timeoutMs: 15_000 })));
 }
 
 async function waitForPlannedLayout(
@@ -610,9 +631,10 @@ async function waitForPlannedLayout(
         plannedLayout = candidate.identity;
         return true;
     }, {
-        message: `Expected an epoch ${input.expectedFormationEpoch} planned topology at or after group revision ${
-            input.minimumGroupRevision
-        } with ${input.expectedSessionIds.join(', ')}`,
+        message:
+            `Expected an epoch ${input.expectedFormationEpoch} planned topology at or after group revision ${input.minimumGroupRevision} with ${
+                input.expectedSessionIds.join(', ')
+            }`,
         timeout: 30_000
     }).toBe(true);
     if (!plannedLayout) {

--- a/tests/playwright/rallar-black-box/create-group-formation-lifecycle-driver.ts
+++ b/tests/playwright/rallar-black-box/create-group-formation-lifecycle-driver.ts
@@ -283,12 +283,6 @@ async function connectGroupLifecycle(
         expectedFormationEpoch: stageReceipt.formationEpoch,
         expectedLayout: plannedLayout.identity
     });
-    await waitForFormationReadiness({
-        run: input.run,
-        sessions: input.sessions,
-        suffix: input.lifecycleSuffix,
-        startedAtMs: input.readinessStartedAtMs
-    });
     const activateCommandId = await activateGroup(config, {
         ...input.run,
         owner
@@ -673,10 +667,7 @@ async function waitForPresenceRevision(
 async function waitForFormationReadiness(
     input: WaitForFormationReadinessInput
 ): Promise<Readonly<Partial<Record<AgentPrefix, number>>>> {
-    const agents = input.run.readinessScope === 'owner'
-        ? [input.run.agents[0]]
-        : input.run.agents;
-    const durations = await Promise.all(agents.map(async (agent) => ({
+    const durations = await Promise.all(input.run.agents.map(async (agent) => ({
         prefix: agent.prefix,
         durationMs: await input.run.control.waitForPeerReadiness({
             runId: input.run.runId,
@@ -688,8 +679,11 @@ async function waitForFormationReadiness(
             startedAtMs: input.startedAtMs
         })
     })));
+    const measuredDurations = input.run.readinessScope === 'owner'
+        ? durations.slice(0, 1)
+        : durations;
     return Object.fromEntries(
-        durations.map(({ prefix, durationMs }) => [prefix, durationMs])
+        measuredDurations.map(({ prefix, durationMs }) => [prefix, durationMs])
     );
 }
 

--- a/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
+++ b/tests/playwright/rallar-black-box/full-stack-live-rtc-three-browser-matrix.spec.ts
@@ -809,35 +809,17 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     })
                 )
             );
-            const reconnectStartedAtMs = performance.now();
             const reconnectC = await liveRtcDeliveryOperations.reconnectAndWaitForPeerReadiness({
                 control,
                 runId,
                 reconnectingAgent: messageAgents[2],
-                readinessAgent: messageAgents[1],
+                survivingAgents: [messageAgents[0], messageAgents[1]],
+                survivingSessionIds: [messages.sessions.A, messages.sessions.B],
                 transport: 'messages.rtc',
                 groupId,
                 suffix: `${suffix}-reconnect-c`
             });
             commandIds.push(reconnectC.commandId);
-            const reconnectDurations = await Promise.all(
-                messageAgents.slice(0, 2).map((agent) =>
-                    control.waitForPeerReadiness({
-                        runId,
-                        agent,
-                        expectedPeerIds: [reconnectC.sessionId],
-                        suffix: `${suffix}-reconnect-c`,
-                        startedAtMs: reconnectStartedAtMs
-                    })
-                )
-            );
-            await control.waitForPeerReadiness({
-                runId,
-                agent: messageAgents[2],
-                expectedPeerIds: [messages.sessions.A, messages.sessions.B],
-                suffix: `${suffix}-reconnect-c-settled`,
-                startedAtMs: reconnectStartedAtMs
-            });
             timings.push({
                 kind: 'reconnect-ready',
                 transport: 'messages.rtc',
@@ -846,7 +828,7 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                     messageAgents[0].agentId,
                     messageAgents[1].agentId
                 ],
-                durationMs: Math.max(...reconnectDurations)
+                durationMs: reconnectC.receiverReadinessDurationMs
             });
             const reconnectMatrixId = `messages-rtc-reconnect-b-to-c-${suffix}`;
             const reconnectMessageStartedAtMs = performance.now();
@@ -1063,44 +1045,26 @@ test.describe('full-stack live three-browser RTC matrix', () => {
                         })
                     )
                 );
-                const reconnectStartedAtMs = performance.now();
                 const reconnected = await liveRtcDeliveryOperations.reconnectAndWaitForPeerReadiness({
                     control,
                     runId,
                     reconnectingAgent: agents[2],
-                    readinessAgent: agents[1],
+                    survivingAgents: [agents[0], agents[1]],
+                    survivingSessionIds: [
+                        initialFormation.sessions.A,
+                        initialFormation.sessions.B
+                    ],
                     transport: 'messages.rtc',
                     groupId,
                     suffix: `${suffix}-${cycle}`
                 });
                 commandIds.push(reconnected.commandId);
-                const reconnectDurations = await Promise.all(
-                    agents.slice(0, 2).map((agent) =>
-                        control.waitForPeerReadiness({
-                            runId,
-                            agent,
-                            expectedPeerIds: [reconnected.sessionId],
-                            suffix: `${suffix}-${cycle}`,
-                            startedAtMs: reconnectStartedAtMs
-                        })
-                    )
-                );
-                await control.waitForPeerReadiness({
-                    runId,
-                    agent: agents[2],
-                    expectedPeerIds: [
-                        initialFormation.sessions.A,
-                        initialFormation.sessions.B
-                    ],
-                    suffix: `${suffix}-${cycle}-settled`,
-                    startedAtMs: reconnectStartedAtMs
-                });
                 timings.push({
                     kind: 'reconnect-ready',
                     transport: 'messages.rtc',
                     senderAgentId: agents[2].agentId,
                     receiverAgentIds: [agents[0].agentId, agents[1].agentId],
-                    durationMs: Math.max(...reconnectDurations)
+                    durationMs: reconnected.receiverReadinessDurationMs
                 });
                 currentSessionId = reconnected.sessionId;
                 if (cycle % 10 === 0) {

--- a/tests/playwright/rallar-black-box/live-rtc-control-client.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-control-client.ts
@@ -281,12 +281,21 @@ export class LiveRtcControlClient {
         const deadlineMs = this.#monotonicNow() + 60_000;
         let attempt = 0;
         await expect.poll(async () => {
+            const refreshTimeoutMs = deadlineMs - this.#monotonicNow();
+            if (refreshTimeoutMs <= 0) {
+                throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);
+            }
+            await input.agent.refreshRoom({ timeoutMs: refreshTimeoutMs });
+            const healthTimeoutMs = Math.min(15_000, deadlineMs - this.#monotonicNow());
+            if (healthTimeoutMs <= 0) {
+                throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);
+            }
             const result = await this.executeResult({
                 runId: input.runId,
                 agentId: input.agent.agentId,
                 commandId: `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
                 command: { kind: 'health' },
-                timeoutMs: 15_000
+                timeoutMs: healthTimeoutMs
             }).catch(() => undefined);
             if (!result?.ok) {
                 return [];
@@ -302,11 +311,6 @@ export class LiveRtcControlClient {
             } for ${input.suffix}`,
             timeout: 60_000
         }).toEqual(expect.arrayContaining([...input.expectedPeerIds]));
-        const timeoutMs = deadlineMs - this.#monotonicNow();
-        if (timeoutMs <= 0) {
-            throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);
-        }
-        await input.agent.refreshRoom({ timeoutMs });
         const readyAtMs = this.#monotonicNow();
         if (readyAtMs >= deadlineMs) {
             throw new Error(`RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`);


### PR DESCRIPTION
## Goal

Make RTC-B06 browser evidence capture wait for the accepted three-agent topology instead of relying on one-shot refreshes or a single reconnect observer.

## Changes

- Refresh authoritative room state during every bounded peer-readiness poll.
- Keep the initial-pair barrier, then activate the staged three-agent layout before concurrently hydrating and awaiting A, B, and C.
- Treat `readinessScope` only as a measurement filter: owner scope still waits for every endpoint but emits only A's duration.
- Await both survivors and the replacement endpoint during reconnect, using canonical per-connection session identities.
- Remove obsolete readiness inputs, fixture modes, duplicate waits, fallbacks, and overloads.
- Update the RTC performance plan with the eighth failed B06 observation and the moving-main next slices.

## Acceptance

- Default and all-scenarios E3-memory browser paths complete the corrected formation and reconnect lifecycle.
- Owner-scope evidence contains only the owner duration while all three endpoints remain correctness barriers.
- No production RTC behavior, workload definition, artifact contract, or RTC-B07 authorization changes.

## Validation

- `npm test`: 1,076 files passed, 4 skipped; 9,337 tests passed, 12 skipped.
- Focused Vitest: 3 files, 15 tests passed.
- Default E3-memory browser scenario: 1/1 passed.
- All-scenarios E3-memory browser scenario: first attempt failed amid admission/signaling commit conflicts; one unchanged bounded rerun passed 1/1.
- `npm run typecheck:tests`, `npm run build:rallar`, formatting, changed-style, repository-structure, test-structure, and `git diff --check`: passed.
- Final scoped code review: prior owner-scope hydration finding addressed; no new Critical or Important findings.

## Risk and rollback

Risk is limited to browser test orchestration and its fakes. The correction may extend setup time while receivers hydrate, but recorded delivery timing and retained sample semantics are unchanged. Roll back the three commits in this PR if the corrected lifecycle proves incompatible with the live harness.

## Follow-up

After merge, manually dispatch a new RTC-B06 observation from then-current moving `main`, archive its append-only evidence, and continue evidence reconciliation only if the capture is valid. RTC-B07 remains held.
