### PR TITLE
fix(recipe): pin the activation envelope to the causality the contract promises

### DIFF
--- a/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-status-lifecycle.json
+++ b/packages/shared-test/black-box-runner/tests/api-v1/api-v1-group-status-lifecycle.json
@@ -682,8 +682,14 @@
           "groupId": "{statusGroupId}",
           "actorKind": "service",
           "eventRevision": "integer",
-          "resultingRevision": "{activationEvent.event.causalRevision.groupRevision}"
-        }
+          "resultingRevision": "integer"
+        },
+        "comparators": [
+          {
+            "path": "resultingRevision",
+            "gte": "{activationEvent.event.causalRevision.groupRevision}"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
## Why

`Run API v1 black-box recipes` [failed](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34095512138/job/101658483168) on `api-v1-group-status-lifecycle`:

```
FAILED api-v1-group-status-lifecycle: exit=1 expected=0 success=27 failure=1
firstFailure: theActivationEventIsServiceAuthoredAndCausallyChained (ASSERT)
  expected: { eventRevision: "integer", resultingRevision: 5 }
  actual:   { eventRevision: 5,         resultingRevision: 6 }
  message:  "!isValueEqual(5, 6)"
```

Step 28 asserted `activationEvent.resultingCausalRevision.groupRevision == activationEvent.event.causalRevision.groupRevision`. **The envelope never promised that.**

`computeGroupStateDeltaEnvelope` always stamps `resultingCausalRevision: snapshot.causalRevision` — the revision at *expansion* time, not the event's own — and `resolveGroupStateDeltaPredecessorCausalRevision` returns that same value when the summary outcome is `no-op`. `GroupStateDeltaEnvelope`'s own doc comment states it: *"A summary no-op expansion has no CAS predecessor and stamps `predecessorCausalRevision === resultingCausalRevision`."*

The captured envelope is exactly that shape — event at revision 5, envelope stamped 6/6, group snapshot at 6. A background write advanced the group between the activation write and the expansion, so the envelope legitimately carried a later revision than the event.

This is not a server defect and not a flake to be reran away: the recipe pins a value the contract does not fix, so it fails whenever anything advances the group in that window. #540's own gate passed on timing luck.

## What changed

The step's stated intent is that the activation event is *service-authored and causally chained*. Both halves are still asserted, but the causal half now says what is actually invariant — the resulting revision is never **behind** the event it carries:

```json
"body": {
  "eventType": "group-activation-status-changed",
  "groupId": "{statusGroupId}",
  "actorKind": "service",
  "eventRevision": "integer",
  "resultingRevision": "integer"
},
"comparators": [
  { "path": "resultingRevision", "gte": "{activationEvent.event.causalRevision.groupRevision}" }
]
```

`eventType`, `groupId` and `actorKind` keep exact equality. The assertion keeps teeth: an event *ahead* of the state delivering it — a real causality violation — still fails.

## Verification

Driving `resolveComparators` and `validateAssertValueComparators` directly with the CI-observed context proves the template resolves to a numeric bound and the comparator discriminates:

```
resolved bound = [{"path":"resultingRevision","gte":5}]
resulting=6 -> PASS      <- the CI failure case
resulting=5 -> PASS      <- the ordinary case
resulting=4 -> FAIL: Expected value gte 5.
```

Full `npm run test:api-v1:black-box:postgres` locally: `PASSED api-v1-group-status-lifecycle: exit=0 durationMs=14716 success=38 failure=0` — the whole recipe now runs to completion, where fail-fast previously stopped it at step 28 of 38.

`check:repo-style:changed` and `check-test-structure-coupling --changed` both PASS; `dprint check` clean.

Branch CI on a clean runner confirms all three, including the two I could not baseline locally (two local baseline attempts died with `fetch failed` when the local API server dropped mid-run, one caused by a stray server squatting on 18080):

```
PASSED api-v1-group-status-lifecycle:        exit=0 success=38 failure=0
PASSED api-v1-group-data-policy:             exit=0 success=48 failure=0
PASSED api-v1-group-admission-decision-race: exit=0 success=14 failure=0
```

Branch Release Gate, Formation Gate and Topology Replay Gate all green. The Medium-Scale Gate failed once at `verifyoneGroupAcrossCluster` (interaction 2717) and passed on rerun; that profile loads only `api-v1-state-medium-scale-churn`, so this file is never read by it.

## Related

Separate from #543, which fixes an unrelated port-collision flake in the black-box control-server test harness. Main needs both to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
