### PR TITLE
Collect the retained-peer grace so a reset drops its lanes

### DIFF
--- a/packages/shared/services/web-rtc-group-manager.ts
+++ b/packages/shared/services/web-rtc-group-manager.ts
@@ -78,6 +78,8 @@ export class WebRtcGroupManager {
     private reconcileRequested = false;
     private reconcilePassRunning = false;
     private scheduledWake: Promise<void> | undefined;
+    private reconcileWakesRunning = false;
+    private retainedExpiryWake: ReturnType<typeof setTimeout> | undefined;
     private waitingDialCount = 0;
     private retainedOrder = 0;
     private readonly diagnostics = emptyGroupManagerDiagnostics();
@@ -104,20 +106,28 @@ export class WebRtcGroupManager {
 
     /**
      * Every setup ending frees a slot under the in-flight bound (product
-     * decision 18), so an ending re-plans the dials that wait for one. The
-     * composition root starts this once the service and manager exist; shutdown
-     * stops it before tearing peers down, because shutdown removes peers their
-     * groups still want and every removal would otherwise dial them back.
+     * decision 18), so an ending re-plans the dials that wait for one, and a
+     * retention's grace expires on a clock no event is bound to. The
+     * composition root starts these once the service and manager exist;
+     * shutdown stops them before tearing peers down, because shutdown removes
+     * peers their groups still want and every removal would otherwise dial
+     * them back.
      */
     startReconcileWakes(): void {
+        this.reconcileWakesRunning = true;
         this.rtcQBox.onRtcPeerLifecycleDo(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID, {
             onCreated: () => {},
             onDeleted: () => this.wakeAfterSetupEnded(),
             onEstablished: () => this.wakeAfterSetupEnded()
         });
+        // Retentions outlive a stop, so a restart adopts the ones already waiting rather than
+        // leaving them for whatever event happens to run the next pass.
+        this.startRetainedExpiryWake();
     }
 
     stopReconcileWakes(): void {
+        this.reconcileWakesRunning = false;
+        this.stopRetainedExpiryWake();
         this.rtcQBox.removeRtcPeerLifecycleById(WebRtcGroupManager.SETUP_COMPLETION_CALLBACK_ID);
         // A wake already on the microtask queue finds nothing waiting and stands down.
         this.waitingDialCount = 0;
@@ -423,6 +433,7 @@ export class WebRtcGroupManager {
         this.retainUndesiredKnownPeers(desiredPeerIds, reconciledKnownPeerIds);
         this.disconnectExpiredRetainedPeers(reconciledKnownPeerIds);
         this.evictRetainedPeers(desiredPeerIds, reconciledKnownPeerIds);
+        this.startRetainedExpiryWake();
 
         this.options.onDesiredPeerIdsChanged?.({
             desiredPeerIds: [...desiredPeerIds],
@@ -479,6 +490,44 @@ export class WebRtcGroupManager {
             });
             this.diagnostics.retainedCreatedCount += 1;
         }
+    }
+
+    /**
+     * A pass runs on an event, but a retention ends on a clock, and the
+     * transition that created one is usually the last event a group produces:
+     * a `reset` lands every member in `dormant`, where nothing is desired and
+     * nothing further arrives. Without this wake the grace would never be
+     * collected and the retired lanes would stay open for the session.
+     */
+    private startRetainedExpiryWake(): void {
+        this.stopRetainedExpiryWake();
+        if (!this.reconcileWakesRunning) {
+            return;
+        }
+
+        const expiresAtEpochMs = this.resolveEarliestRetainedExpiryAtEpochMs();
+        if (expiresAtEpochMs === undefined) {
+            return;
+        }
+
+        this.retainedExpiryWake = setTimeout(() => {
+            this.retainedExpiryWake = undefined;
+            void this.reconcileAllGroups().catch((caught) => {
+                console.error('Failed to reconcile groups after a retention expired', toError(caught));
+            });
+        }, Math.max(0, expiresAtEpochMs - this.now()));
+    }
+
+    private stopRetainedExpiryWake(): void {
+        clearTimeout(this.retainedExpiryWake);
+        this.retainedExpiryWake = undefined;
+    }
+
+    private resolveEarliestRetainedExpiryAtEpochMs(): number | undefined {
+        const expiries = Array.from(this.retainedPeerConnections.values())
+            .map((retained) => retained.expiresAtEpochMs)
+            .filter((expiresAtEpochMs): expiresAtEpochMs is number => expiresAtEpochMs !== null);
+        return expiries.length === 0 ? undefined : Math.min(...expiries);
     }
 
     private disconnectExpiredRetainedPeers(knownPeerIds: Set<PeerId>): void {

--- a/packages/tests/shared/webrtc-group-manager.test.ts
+++ b/packages/tests/shared/webrtc-group-manager.test.ts
@@ -1,8 +1,11 @@
 // dprint-ignore
 import {
+    afterEach,
+    beforeEach,
     describe,
     expect,
-    it
+    it,
+    vi
 } from 'vitest';
 
 import type { ClientInfo, OverlayInfo } from '@shared/api/api-config.ts';
@@ -19,7 +22,10 @@ import type {
 } from '@shared/api/group-types.ts';
 import { LatestRepository } from '@shared/cache/LatestRepository.ts';
 import type { WebRtcConnectionService } from '@shared/services/web-rtc-connection-service.ts';
-import { WebRtcGroupManager } from '@shared/services/web-rtc-group-manager.ts';
+import {
+    DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS,
+    WebRtcGroupManager
+} from '@shared/services/web-rtc-group-manager.ts';
 import type { WebRtcGroupPeerSelection } from '@shared/services/webrtc-group-manager-contracts.ts';
 import { createTestGroup } from '../create-test-group.ts';
 import type { SimulatedNativeRtcPeerConnection } from './native-rtc-connection-fixture.ts';
@@ -1331,7 +1337,202 @@ describe('WebRtcGroupManager', () => {
         expect(diagnostics.retainedEvictionCount).toBe(2);
         expect(rtcQBox.knownPeerIds()).toHaveLength(5);
     });
+
+    /**
+     * A reset is the case these pin: it lands the group in `dormant`, where the dial matrix wants
+     * nobody, and then the group is quiet. The transition's own pass is the last event there is, so
+     * whether the grace is ever collected is decided entirely by what that pass schedules.
+     */
+    describe('retained expiry wake', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('disconnects a retention whose grace expires with no further event', async () => {
+            const retirement = await retireLayoutOverPeers();
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+            expect(retirement.manager.readDiagnostics()).toMatchObject({
+                retainedCreatedCount: 2,
+                retainedExpiredCount: 0
+            });
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS + 1);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual([]);
+            expect(retirement.manager.readDiagnostics()).toMatchObject({
+                retainedExpiredCount: 2,
+                disconnectCount: 2
+            });
+        });
+
+        it('holds the lanes for the whole grace window before collecting them', async () => {
+            const retirement = await retireLayoutOverPeers();
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS - 1);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+            expect(retirement.manager.readDiagnostics().retainedExpiredCount).toBe(0);
+        });
+
+        // Shutdown stops the wakes and only then tears peers down, so a wake surviving the stop would
+        // reconcile against a half-dismantled transport and dial back the peers it just removed.
+        // The run count is what separates a cancelled wake from one that fired and found nothing.
+        it('stops the wake when shutdown stops the reconcile wakes', async () => {
+            const retirement = await retireLayoutOverPeers();
+            retirement.manager.stopReconcileWakes();
+            const passesBefore = retirement.manager.readDiagnostics().reconcileRunCount;
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS * 4);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+            expect(retirement.manager.readDiagnostics()).toMatchObject({
+                reconcileRunCount: passesBefore,
+                retainedExpiredCount: 0
+            });
+        });
+
+        // A stop leaves the retentions in place, so the restart has to adopt them: without an arm of
+        // its own the pair is asymmetric and every retention created before the stop is stranded.
+        it('re-arms the wake for retentions that outlived a stop', async () => {
+            const retirement = await retireLayoutOverPeers();
+            retirement.manager.stopReconcileWakes();
+            retirement.manager.startReconcileWakes();
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS + 1);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual([]);
+            expect(retirement.manager.readDiagnostics().retainedExpiredCount).toBe(2);
+        });
+
+        // Benches and the churn simulations drive their own clock and never start the wakes; arming a
+        // real timer for them would outlive the run that created it.
+        it('arms nothing for a manager that never started its reconcile wakes', async () => {
+            const retirement = await retireLayoutOverPeers({ startReconcileWakes: false });
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS * 4);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+            expect(retirement.manager.readDiagnostics().retainedExpiredCount).toBe(0);
+        });
+
+        // A flapping overlay re-desires what it retained, which empties the retention map; the wake
+        // the previous pass armed must go with it rather than fire on an empty set.
+        it('disarms the wake when the next epoch re-desires the retained peers', async () => {
+            const retirement = await retireLayoutOverPeers();
+            await acceptActiveLayoutGroup(
+                retirement.manager,
+                retirement.acceptedOverlayCache,
+                createGroupSnapshot({
+                    groupId: 'group-1',
+                    membershipVersion: 3,
+                    memberSessionIds: ['self', 'peer-a', 'peer-b']
+                })
+            );
+
+            const passesBefore = retirement.manager.readDiagnostics().reconcileRunCount;
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS * 4);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-a', 'peer-b']);
+            expect(retirement.manager.readDiagnostics()).toMatchObject({
+                reconcileRunCount: passesBefore,
+                retainedExpiredCount: 0,
+                disconnectCount: 0
+            });
+        });
+
+        /**
+         * Retentions created at different moments expire at different moments, so the pass a wake
+         * runs is the only thing that can arm the wake after it. Arming anywhere but the pass tail —
+         * at the event entry points, say — collects the first retention and strands every later one,
+         * and every other test here still passes, because they all retire in a single pass.
+         */
+        it('re-arms itself for a retention created after the one it collects', async () => {
+            const retirement = await retireLayoutOverPeers();
+            await vi.advanceTimersByTimeAsync(5_000);
+            await retireSecondGroupOverPeer(retirement, 'peer-c');
+
+            await vi.advanceTimersByTimeAsync(DEFAULT_WEBRTC_OVERLAY_TRANSITION_GRACE_MS - 5_000 + 1);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual(['peer-c']);
+            expect(retirement.manager.readDiagnostics().retainedExpiredCount).toBe(2);
+
+            await vi.advanceTimersByTimeAsync(5_000 + 1);
+
+            expect(retirement.rtcQBox.knownPeerIds()).toEqual([]);
+            expect(retirement.manager.readDiagnostics().retainedExpiredCount).toBe(3);
+        });
+    });
 });
+
+interface RetiredLayoutFixture {
+    readonly manager: WebRtcGroupManager;
+    readonly rtcQBox: RtcConnectionHarness;
+    readonly acceptedOverlayCache: LatestRepository<string, OverlayInfo>;
+}
+
+/**
+ * An established two-peer mesh whose accepted layout is then retired into `dormant` — the state a
+ * manager `reset` leaves every member in, with both edges known, undesired and retained.
+ */
+async function retireLayoutOverPeers(
+    options: { readonly startReconcileWakes?: boolean; } = {}
+): Promise<RetiredLayoutFixture> {
+    const rtcQBox = createRtcConnectionHarness('self');
+    const acceptedOverlayCache = new LatestRepository<string, OverlayInfo>();
+    const manager = new WebRtcGroupManager(rtcQBox.service, {
+        groupCache: new LatestRepository<string, GroupSnapshot>(),
+        clientCache: new LatestRepository<string, ClientInfo>(),
+        acceptedOverlayCache
+    });
+    if (options.startReconcileWakes !== false) {
+        manager.startReconcileWakes();
+    }
+
+    const active = createGroupSnapshot({
+        groupId: 'group-1',
+        membershipVersion: 1,
+        memberSessionIds: ['self', 'peer-a', 'peer-b']
+    });
+    await acceptActiveLayoutGroup(manager, acceptedOverlayCache, active);
+    for (const peerId of ['peer-a', 'peer-b']) {
+        rtcQBox.nativePeer(peerId).setConnected();
+    }
+
+    acceptedOverlayCache.take(toScopedOverlayId(active.group));
+    await manager.acceptGroupUpdate({
+        ...active,
+        causalRevision: { groupRevision: 2, presenceRevision: 2 },
+        group: { ...active.group, lifecycleState: 'dormant', snapshotVersion: 2, presenceVersion: 2 }
+    });
+
+    return { manager, rtcQBox, acceptedOverlayCache };
+}
+
+/** A second group retired later than the first, so its edge carries its own, later expiry. */
+async function retireSecondGroupOverPeer(
+    fixture: RetiredLayoutFixture,
+    peerId: string
+): Promise<void> {
+    const active = createGroupSnapshot({
+        groupId: 'group-2',
+        membershipVersion: 1,
+        memberSessionIds: ['self', peerId]
+    });
+    await acceptActiveLayoutGroup(fixture.manager, fixture.acceptedOverlayCache, active);
+    fixture.rtcQBox.nativePeer(peerId).setConnected();
+
+    fixture.acceptedOverlayCache.take(toScopedOverlayId(active.group));
+    await fixture.manager.acceptGroupUpdate({
+        ...active,
+        causalRevision: { groupRevision: 2, presenceRevision: 2 },
+        group: { ...active.group, lifecycleState: 'dormant', snapshotVersion: 2, presenceVersion: 2 }
+    });
+}
 
 interface ReconciledPeerSelectionObservation extends WebRtcGroupPeerSelection {
     readonly knownPeerIds: readonly string[];


### PR DESCRIPTION
## The defect

A manager `reset` drives every browser to `dormant`, but it never drops the RTC lanes it retired.
Verified live on the three-browser lane, 43 s after the reset, on every agent:

| surface | reads |
| --- | --- |
| `formation` | `stage: dormant`, `dialing: none`, `transportState: halted`, no `accepted`, no `planned` |
| `formation.room` | `state: halted`, `desiredPeerIds: []`, `readyPeerIds: []`, `activePeerIds: []` |
| `rtcStatus` (facade) | `knownPeerIds` / `activePeerIds` / `readyPeerIds` **all still name both peers** |
| the peers themselves | `connectionState: connected`, `iceConnectionState: connected`, `readyLaneIds: ["reliable", "realtime"]` |

The room-scoped block is empty **by construction** — `selectRtcRoomPeers` filters by the accepted
layout's desired set, which a reset empties — so it reads the same whether or not a lane was actually
dropped. The facade-level lists are the honest witness, and they said the lanes were still open. So did
the event stream: no `peer-deleted` and no `lane-close` on `rallar.browser.rtc.lifecycle` after the
reset, until the pages themselves were closed a minute later.

This is exactly what the `reset-tears-down` acceptance scenario claims, and it is why
`tests/playwright/rallar-black-box/full-stack-live-rtc-lifecycle-acceptance.spec.ts` (landed in #542)
carries that scenario as `test.fixme`. The scenario reads the facade-level lists deliberately, and
that choice was right: the surface was honest, the behaviour was not.

## Root cause

`runReconcilePass` marks every known-but-undesired peer retained with
`expiresAtEpochMs = now + overlayTransitionGraceMs()` (default 15 s — the anti-flap grace, so a
flapping overlay converges to zero churn). `disconnectExpiredRetainedPeers` collects expired
retentions, but only ever **inside a reconcile pass**, and passes run purely on events: an overlay
message, a presence change, a topology hydration, or a setup ending while dials wait.

Nothing scheduled a pass at the expiry. The transition that creates the retentions is normally the
last event a group produces — a `reset` lands it in `dormant`, where nothing is desired and nothing
further arrives — so the grace was never collected and the retired lanes stayed open for the session.
`evictRetainedPeers` does not save it: that is a `maxPeerConnections` capacity valve, and two retained
peers never trip a budget of ten.

Not specific to reset: any replan that drops an edge and is followed by quiescence leaks the same way.

## The fix

The grace now arms a wake at the earliest finite retained expiry, re-armed by each pass and disarmed
when no finite retention is left. It joins the existing wake pair rather than becoming a third
mechanism:

- `startReconcileWakes()` arms it, so a restart adopts retentions that outlived a stop.
- `stopReconcileWakes()` cancels it — shutdown stops the wakes and only then tears peers down, so a
  surviving wake would reconcile against a half-dismantled transport and dial back what shutdown just
  removed.
- A manager that never started its wakes arms nothing, which keeps the bench workloads and the churn
  simulations — the only places that drive `options.now` as a virtual clock — timer-free.

The arm stays at the pass tail rather than in the drain's `finally`: the throw sites above it are
programmer-invariant asserts, and arming in `finally` would turn a repeatedly-throwing pass into an
unbounded 0 ms reconcile loop.

## Verification

- `packages/tests/shared/webrtc-group-manager.test.ts` gains seven cases. `disconnects a retention whose
  grace expires with no further event` fails on `main` (`expected [ 'peer-a', 'peer-b' ] to deeply
  equal []`) and passes here; `re-arms the wake for retentions that outlived a stop` fails without the
  `startReconcileWakes` arm; `re-arms itself for a retention created after the one it collects` fails
  if the arm is moved off the pass tail. That last one came out of review: a reviewer showed that
  relocating the arm to the event entry points — which reads tidier — leaves every other test in the
  file green while stranding every retention created after the first, so the self-chaining half of the
  design needed its own pin. The remaining three pin the boundaries: the grace is held for its full
  window, a stop cancels the wake, and an unstarted manager arms nothing; the disarm and shutdown
  cases pin `reconcileRunCount` so a wake that fired and found nothing cannot pass as a disarm.
- Focused suites — `webrtc-group-manager`, `webrtc-group-overlay-roles`, and both group-formation
  simulations — 51 tests, green.
- `npm run test:unit` — 9539 passing, with 3 failures in two repo-tooling files
  (`repo-style-changed-check`, `repo-style-structural-lineage`). They are not from this change: they
  pass 2/2 in isolation, the failing set differs run to run, and pristine `main` on the same machine
  fails 4 tests from a completely disjoint set (headless bundle boundary, presence-summary storage
  revision, stats runtime, IndexedDB AL stores). The local full-suite run is simply noisy under
  parallel load; CI is the arbiter.
- `npm run typecheck` — clean, including the `packages/tests` debt ratchet (1072 files, 0 debt).
- `npm run check:repo-style:changed -- origin/main HEAD` — `PASS: no new repository style findings`.
- `check-test-structure-coupling.mjs --changed` — pass.
- Bundle and surface gates: `headless-bundle-boundary`, `shared-web-browser-bundle-boundaries`,
  `shared-web-public-api-snapshots` — all pass, budgets unchanged.
- **Live browser, with the fix**: instrumented run reading `rtcDiagnostics.groupManager` around a
  reset. Before the grace expires every agent shows `retainedCreatedCount: 2`,
  `retainedExpiredCount: 0`; past it, agents A and B show `retainedExpiredCount: 1`,
  `disconnectCount: 1` and a `reconcileRunCount` that advanced (17 -> 21, 10 -> 13) **with no
  external event**, and all three agents read `knownPeerIds`/`activePeerIds`/`readyPeerIds` empty by
  reset + 25 s. That is the wake firing and collecting, and it is the state `reset-tears-down`
  asserts.

### What is not established

The `reset-tears-down` Playwright scenario itself has **not** been observed green end to end. Four
attempts with the fix failed at four different points: the peer-list poll once, the `dormant` stage
wait once, and `ECONNREFUSED` against the control server and the SPA once each — this machine's
live-RTC lane is unstable (agents routinely never establish a lane at all, and peer-establishment
timeouts fire throughout, on `main` as much as here). The scenario therefore stays `test.fixme`; it
should be un-fixmed by someone who can run it green on a stable lane, not on this evidence.

## Touched-file standards closure

`web-rtc-group-manager.ts` was already in the cohesion-warning tier and stays there: cognitive load
91 → 94 (warn 50, review 110), same tier, growth 3 against a `max(10%, 25)` allowance. Disposition:
no split. The file owns one responsibility — the reconcile lifecycle over group presence, overlays and
peer retention — and the wake is that lifecycle's clock, not a separate concern. `runReconcilePass`
stays at exactly 40 physical lines because the arm is one delegating statement.

## Known adjacent gap, deliberately not in this diff

`retainKnownPeersForGroup` (reason `left-group`, reached when a snapshot shows the local session is no
longer in an active group) stamps `expiresAtEpochMs: null` — "retains until budget eviction". Those
retentions have the same symptom and no clock at all, and this change does not touch them. It looks
deliberate (the lane is kept so a re-join reuses it), but the two retention reasons now have visibly
different lifetimes and that is worth deciding explicitly rather than inheriting.

## Follow-up

`reset-tears-down` in `tests/playwright/rallar-black-box/full-stack-live-rtc-lifecycle-acceptance.spec.ts`
(landed on main in #542) still carries `test.fixme` and the L8 note describing this defect as open.
Both want updating once the scenario is seen green on a stable lane. L8 is recorded in
`playground/rtc-design/2026-09-06-browser-acceptance-pins-implementation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
