### PR TITLE
Mask comment text before the boundary.unknown quote walk

### DIFF
--- a/packages/tests/repo/repo-style-check.test.ts
+++ b/packages/tests/repo/repo-style-check.test.ts
@@ -190,6 +190,70 @@ describe('repo style checker', () => {
         expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
     });
 
+    it('reports unknown after an apostrophe inside a line comment', () => {
+        const fixtureRoot = createFixture({
+            'reject.ts': [
+                '// the engine\'s own isWork -> runnable path',
+                'export const onReject = (reason: unknown): void => {',
+                '  throw reason;',
+                '};'
+            ].join('\n')
+        });
+
+        expect(runChecker(fixtureRoot)).toContain('[boundary.unknown]');
+    });
+
+    it('reports unknown after an apostrophe inside a block comment', () => {
+        const fixtureRoot = createFixture({
+            'reject.ts': [
+                '/* the engine\'s own isWork -> runnable path */',
+                'export const onReject = (reason: unknown): void => {',
+                '  throw reason;',
+                '};'
+            ].join('\n')
+        });
+
+        expect(runChecker(fixtureRoot)).toContain('[boundary.unknown]');
+    });
+
+    it('does not report unknown when the word only appears in a comment', () => {
+        const fixtureRoot = createFixture({
+            'notes.ts': [
+                '// this boundary once accepted unknown',
+                '/* and this one returned unknown too */',
+                'export const total = 1;'
+            ].join('\n')
+        });
+
+        expect(runChecker(fixtureRoot)).toContain('PASS (no issues found in this run)');
+    });
+
+    it('does not read a URL inside a string as a line comment', () => {
+        const fixtureRoot = createFixture({
+            'reject.ts': [
+                'export const endpoint = \'http://example.com\';',
+                'export const onReject = (reason: unknown): void => {',
+                '  throw reason;',
+                '};'
+            ].join('\n')
+        });
+
+        expect(runChecker(fixtureRoot)).toContain('[boundary.unknown]');
+    });
+
+    it('recovers quote state at the end of a line holding an unpaired quote', () => {
+        const fixtureRoot = createFixture({
+            'reject.ts': [
+                'export const quotePattern = /[\'"]/u;',
+                'export const onReject = (reason: unknown): void => {',
+                '  throw reason;',
+                '};'
+            ].join('\n')
+        });
+
+        expect(runChecker(fixtureRoot)).toContain('[boundary.unknown]');
+    });
+
     it('does not report synthetic TypeScript inside a multiline template literal', () => {
         const fixtureRoot = createFixture({
             'message.ts': [

--- a/scripts/repo-style-check/contract-rules.mjs
+++ b/scripts/repo-style-check/contract-rules.mjs
@@ -164,7 +164,7 @@ export function findUnknownUsages(lines) {
     let lineStartOffset = 0;
 
     for (const [index, text] of lines.entries()) {
-        const code = codeLines[index].split('//')[0];
+        const code = codeLines[index];
         const pattern = /\bunknown\b/gu;
         let match;
 
@@ -227,12 +227,20 @@ function stripQuotedLine(line, state) {
         code += step.code;
         index += step.width;
     }
+    // A single- or double-quoted string never spans lines, so an unpaired quote came from a regex
+    // character class or similar. Carrying the mode onward would mask every remaining line.
+    if (state.mode === 'single' || state.mode === 'double') {
+        state.mode = 'code';
+    }
     return code;
 }
 
 function quotedTextStep(line, index, state) {
     if (state.mode === 'template') {
         return templateTextStep(line, index, state);
+    }
+    if (state.mode === 'blockComment') {
+        return blockCommentTextStep(line, index, state);
     }
     if (state.mode === 'single' || state.mode === 'double') {
         return stringTextStep(line, index, state);
@@ -269,8 +277,23 @@ function stringTextStep(line, index, state) {
     return maskedStep(1);
 }
 
+function blockCommentTextStep(line, index, state) {
+    if (line[index] === '*' && line[index + 1] === '/') {
+        state.mode = 'code';
+        return maskedStep(2);
+    }
+    return maskedStep(1);
+}
+
 function codeTextStep(line, index, state) {
     const character = line[index];
+    if (character === '/' && line[index + 1] === '/') {
+        return maskedStep(line.length - index);
+    }
+    if (character === '/' && line[index + 1] === '*') {
+        state.mode = 'blockComment';
+        return maskedStep(2);
+    }
     if (character === '\'' || character === '"') {
         state.mode = character === '\'' ? 'single' : 'double';
         return maskedStep(1);


### PR DESCRIPTION
## The defect

The `boundary.unknown` rule silently stopped scanning a file after any comment containing an
apostrophe.

`findUnknownUsages` masks strings and template literals by walking a file character by character,
carrying quote state across lines. That walk had no notion of comments. An apostrophe inside one
opened a single-quoted string that never closed, so every later line was treated as string text and
no `unknown` after it was ever reported.

The reported flavour was a `//` line comment. The dominant flavour in this repo turns out to be
JSDoc: one possessive such as `connection's` in a header comment blinds the rest of the file. That
accounts for the three largest files unblinded here.

Confirmed against the originally reported file at revision `d986dcb94` of
`packages/tests/shared/alm/work/al-work-handler.test.ts`: the old scanner returned zero findings,
the fixed scanner reports the hidden `unknown` at line 321, and the trigger is the comment at line
261. That file has since been edited and no longer contains `unknown`, so the check used the
historical revision.

## The fix

Comment text is masked inside the walk itself, where the existing string modes already guard a `//`
that lives in a literal. Masking preserves column and offset positions, which the normalized
boundary exemptions depend on.

- `codeTextStep` masks a line comment to end of line and enters a new `blockComment` mode on `/*`.
- `blockCommentTextStep` masks until `*/`.
- `stripQuotedLine` returns to code mode at each line end, because a single- or double-quoted string
  never spans lines. This also bounds the damage from an unpaired quote in a regex character class,
  which was a second way to blind a file.
- The trailing `.split('//')[0]` in `findUnknownUsages` is now unreachable and is removed, so
  comment masking has exactly one owner.

## Tests

Five regression tests in `packages/tests/repo/repo-style-check.test.ts`: an apostrophe in a line
comment and in a block comment, `unknown` named only in a comment, a URL inside a string that must
not read as a comment, and quote-state recovery after an unpaired quote. Four failed before the fix.
The URL guard passed throughout and exists to catch a naive split-before-walk implementation.

## Effect on reported findings

Repo-wide this reveals 157 previously hidden findings across 30 files and removes 17 false positives
across 7 files.

| | Count | Files |
| --- | --- | --- |
| Newly visible | 157 | 30 |
| False positives removed | 17 | 7 |

Heaviest newly visible: `browser-adapter.ts` (33), `group-state-delta.ts` (18),
`api-v1-three-server-recipe-semantics.test.ts` (11), `control-protocol.ts` (10).

The removals are genuine false positives: `unknown` inside JSDoc block comments in five
`scripts/perf` files, and inside string literals in two others.

None of the newly visible findings are fixed here. The checker is warning-only, and the
changed-range gate scans the merge base and the target with the same checker, so a file that gains
previously hidden findings gains them on both sides. No other branch reddens as a result.

## Validation

| Command | Result |
| --- | --- |
| `npx vitest run packages/tests/repo/` | 101 files, 1294 tests passed |
| `npm run check:repo-style` | exit 0, 3985 to 4136 findings |
| `npm run check:repo-style:changed -- origin/main HEAD` | PASS, no new findings |
| `npx dprint check` on both touched files | clean |

Not run: the full `test:unit`, `test:ci`, and `build` gates. The changed module is a build script
whose only importers are `scripts/repo-style-check/**` and `packages/tests/repo/**`, both covered
above.

## Follow-up, not in this PR

Three sibling scanners strip comments with a naive `line.split('//')[0]` on raw lines, with no
string awareness and no block-comment handling: `extractCommandTypesWithOptionalFields` in
`contract-rules.mjs`, `factory-route-rules.mjs`, and `type-organization-rules.mjs`. The first two
then count braces on the truncated text, so a `//` inside a string can end a type-body scan early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
