### PR TITLE
test(rtc): retain publish failure diagnostics

### DIFF
--- a/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
+++ b/docs/superpowers/plans/2026-08-06-rallar-rtc-performance-baseline-plan.md
@@ -64,16 +64,19 @@ GitHub Actions, and ignored JSON evidence under `tmp/perf/rtc-baseline/**`.
 
 **Updated:** 2026-09-10
 
-**Status:** Tasks 4A/4B, B04, native-browser B05 capture, the continuous B05
-observation stream, and B06 E3-memory observation tooling are merged. Five
-distinct valid B05 observations through 2026-09-05 are archived on `main`: PR
-#402 landed directly, and the four observations formerly published by PRs
-#405, #463, #474, and #494 landed through batch PRs #507 and #504 before the
-superseded PRs and branches were closed. Ten B06 observations have failed with
-`acceptedMetrics: false` and are archived on `main`; an eleventh verified failed
-observation is pending unchanged in PR #556. The first five, their
-focused corrections in PRs #499 and #510, and the Branch Release quiescence
-correction in PR #517 are merged. Run 33991439486 produced the sixth archive in
+**Status:** `origin/main` is
+`aeb671039ec8c3f9ee3862ce1413b603fb1fd93f`. PRs #556 and #557 are merged;
+PR #558 merged the 2026-09-10 B05 observation on that same main snapshot.
+The repository has 12 B05 rows, all `passed` with `acceptedMetrics: true`, and
+11 B06 rows, all `failed` with `acceptedMetrics: false`. Publish run
+34524003896 passed source, tooling, capture recovery, archive verification, and
+publication; its six default attempts passed, then its first all-scenarios
+warmup timed out waiting for agent B to receive sender A's `messages.rtc`
+broadcast. No repeat is required. PR #560 is mergeable with green checks and
+awaits human review to merge that verified failed ZIP/index row unchanged.
+
+**Historical reconciliation (superseded current status):** Earlier focused
+corrections include PRs #499, #510, and #517. Run 33991439486 produced the sixth archive in
 PR #519; its focused publication-wake identity correction merged in PR #520.
 Run 33997173287 then produced the seventh failed archive in PR #522. Its first
 default warmup exposed the same missing source-generation dimension in the
@@ -245,7 +248,8 @@ expected peers in `rtcStatus.readyPeerIds` while its current formation still
 lacked the accepted overlay used by multicast routing. PR #556 contains the
 verified failed ZIP/index row with `acceptedMetrics: false` and no repeat.
 
-PR #557 is the next single correction-and-proof PR. Run 34430533353 exposed an
+At that historical point, PR #557 was the next single correction-and-proof PR.
+Run 34430533353 exposed an
 ownership error, not a need for another benchmark-local readiness condition:
 `BrowserRtcWaitRuntime.waitForRoomLane()` resolved the room transport target
 once, so an invocation that began before accepted-layout arrival could return
@@ -553,23 +557,23 @@ also makes the shared recipe fixture return the canonical `ScenarioRecipe`,
 validates its JSON-object boundary, and replaces every ad-hoc `unknown` recipe
 cast in the touched semantics owner; all seven dependent recipe-test files pass
 67/67 tests and the full 1,172-file TypeScript test project has zero errors.
-Replacement exact-head CI remains mandatory before PR #557 is ready.
+**Historical note:** Replacement exact-head CI was mandatory before PR #557
+was ready.
 
 ### Current execution horizon
 
-| Order | Slice                                               | Completion evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ----- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1     | Archive run 34430533353                             | PR #556 merges the verified failed ZIP/index row unchanged; no failed metric is accepted and no repeat is inferred.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| 2     | Complete and merge canonical room-readiness PR #557 | Make shared-web the canonical event-driven room-readiness owner; make black-box transport policy delegate to it; keep accepted layouts for their connection lifecycle; keep exact B06 topology assertions and bounded failed-control-result evidence; isolate full-stack browser services through their existing configuration owners; complete deterministic regressions, a green fresh/pinned state-write comparison, repeated default/all-scenarios local proof, touched-file closure, branch review, and final CI in one PR. No lock, polling, retry, timeout increase, library, migration, compatibility layer, or legacy path. |
+| Order | Slice                                          | Completion evidence                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Merge PR #560 unchanged after human review     | Merge the verified failed run-34524003896 ZIP/index row unchanged. Its 55,063-byte archive has SHA-256 `4411b6cf05decab2e3ac6746487aaa9940fb855a60cf75d93f1113cec9af0bdb`; no failed metric is accepted and no repeat is inferred.                                                                                                                                                                                   |
+| 2     | Complete and merge failure-evidence tooling PR | Retain one bounded, payload-free message-failure diagnostic in normal attempt evidence even when publish mode has no diagnostics output directory; preserve the optional sidecar and generic failed-result facts. Complete focused, type/style/structure, independent-review, local/browser, and branch gates. No RTC product/routing/retry/timeout change, migration, compatibility implementation, or legacy path. |
 
 After this two-slice horizon is complete, manually dispatch
 `RTC-B06 Performance Observation` in `publish` mode from the then-current
-moving `main`. The workflow must archive one verified primary with
-`acceptedMetrics: true`; when the controller requires a repeat, that repeat
-must also be valid and archived. If it fails, its archive itself contains the
-bounded facts needed for diagnosis. Task 12 then chooses the B05 observation
-window, revisits whether the candidate call path requires E4-pg, and reconciles
-the unlike-environment evidence before ranking at most one candidate—or `none`.
+moving `main`. Preserve and diagnose a failed primary; a valid primary plus any
+controller-required repeat unlocks Task 12, which then chooses the B05
+observation window, revisits whether the candidate call path requires E4-pg,
+and reconciles unlike-environment evidence before ranking at most one
+candidate—or `none`.
 
 If a later published B06 run fails, retain it as failed evidence and diagnose
 the first failed attempt from that run. Fix only the evidenced tooling or
@@ -4355,9 +4359,26 @@ performance-observations/rtc-b06/YYYY/MM/DD/<observation-id>.zip
 performance-observations/rtc-b06/index.jsonl
 ```
 
-Current evidence contains ten failed B06 primaries archived on `main`, one
-verified failed primary pending in PR #556, and no accepted metrics.
-The fourth archive is PR #498. Its first retained default attempt timed out
+Current evidence contains 11 failed B06 primaries archived on `main` and no
+accepted metrics. PRs #556 and #557 are merged. Publish run 34524003896
+observed `aeb671039ec8c3f9ee3862ce1413b603fb1fd93f`: source, tooling, capture
+recovery, archive verification, and publication passed; six default attempts
+passed; then the first all-scenarios warmup timed out waiting for agent B to
+receive sender A's `messages.rtc` broadcast. No repeat is required. PR #560 is
+mergeable with green checks and awaits human review to merge that failed ZIP and
+index row unchanged (55,063 bytes; SHA-256
+`4411b6cf05decab2e3ac6746487aaa9940fb855a60cf75d93f1113cec9af0bdb`).
+
+The failure-evidence tooling correction retains one bounded, payload-free
+diagnostic in the normal attempt archive even when publish mode deliberately
+has no diagnostics output directory. The same constructed object still feeds
+the optional sidecar, while generic failed-control-result facts remain present.
+It adds no product behavior, routing, retry, timeout, migration, compatibility
+implementation, or legacy path. An exact-source local default plus
+all-scenarios run passed without retry, so the failed observation does not
+authorize an RTC behavior change.
+
+**Historical provenance:** The fourth archive is PR #498. Its first retained default attempt timed out
 receiving `messages.rtc` multicast on agent C after the warmup passed. That run
 exposed a post-activation readiness gap: the lifecycle driver proved readiness
 before activation, refreshed the accepted room layout after activation, and
@@ -4518,12 +4539,19 @@ the next pushed head restarts the three-run diagnostic proof from zero.
 - [x] Dispatch run 34430533353 from the then-current moving `main`; verify its
       failed primary, preserve it unchanged in observation PR #556, and do not
       accept metrics or run a repeat.
-- [ ] Merge PR #556's verified failed ZIP/index row unchanged.
-- [ ] Merge the single canonical room-readiness/proof PR #557 after shared-web
-      owns event-driven room readiness, black-box transport policy delegates to
-      that owner, exact B06 topology assertions remain at the benchmark edge,
-      and deterministic regressions, repeated default/all-scenarios E3 proof,
-      touched-file closure, branch review, and final gates pass.
+- [x] Merge PR #556's verified failed ZIP/index row unchanged.
+- [x] Merge the single canonical room-readiness/proof PR #557 after its
+      event-driven room-readiness, black-box delegation, deterministic
+      regressions, local E3 proof, touched-file closure, branch review, and
+      final gates passed.
+- [x] Dispatch run 34524003896 from moving `main`; preserve its verified failed
+      primary with six passing default attempts and its first all-scenarios
+      warmup broadcast timeout. Do not accept metrics or run a repeat.
+- [ ] Merge PR #560's verified failed ZIP/index row unchanged after human review.
+- [ ] Complete and merge the bounded failure-evidence tooling correction after
+      focused, type/style/structure, independent-review, local/browser, and
+      branch gates. Preserve the sidecar and generic failed-result facts; add
+      no RTC product/routing/retry/timeout, migration, compatibility, or legacy path.
 - [ ] Dispatch `RTC-B06 Performance Observation` in `publish` mode from the
       then-current moving `main`; accept only a valid primary and any
       controller-required repeat.
@@ -4982,7 +5010,24 @@ incomplete evidence milestone and do not mark this written plan complete.
 
 ## 13. Progress Record
 
-**2026-09-06 reconciliation:** Task 4B, B04, B05, both observation producers,
+**2026-09-10 reconciliation:** `origin/main` is
+`aeb671039ec8c3f9ee3862ce1413b603fb1fd93f`; PRs #556 and #557 are merged, and
+PR #558 records the current-main B05 observation. The repository has 12 B05
+rows, all passed with accepted metrics, and 11 B06 rows, all failed without
+accepted metrics. Run 34524003896 completed source, tooling, capture recovery,
+archive verification, and publication on that moving-main snapshot. Its six
+default attempts passed; its first all-scenarios warmup timed out waiting for
+agent B to receive sender A's `messages.rtc` broadcast, so later attempts did
+not run and no repeat is required. PR #560 is mergeable with green checks but
+awaits human review to merge the unchanged 55,063-byte archive (SHA-256
+`4411b6cf05decab2e3ac6746487aaa9940fb855a60cf75d93f1113cec9af0bdb`). The
+next two slices are that unchanged merge and the bounded failure-evidence
+tooling correction; then dispatch a fresh manual B06 publish from then-current
+moving `main`. Preserve a failure for diagnosis; only a valid primary and any
+required repeat unlock Task 12. B07 remains held and E4-pg remains conditional
+for Task 12.
+
+**2026-09-06 reconciliation (historical):** Task 4B, B04, B05, both observation producers,
 and B06 E3-memory tooling are merged. Five valid B05 observations are archived
 on `main`; the overlapping source PRs and branches were consolidated and
 closed. Nine B06 primaries are archived as failed evidence with no accepted

--- a/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
@@ -179,6 +179,7 @@ describe('live RTC control client', () => {
         ).toEqual({
             kind: 'control-result-failures',
             runCaptureSucceeded: true,
+            messageFailures: [],
             failedResults: [
                 {
                     agentId: 'agent-a',
@@ -314,8 +315,8 @@ describe('live RTC control client', () => {
             receiverAgentId: 'agent-b',
             matrixId: 'direct-timeout',
             healthByAgentId: {
-                'agent-a': { ok: true },
-                'agent-b': { ok: true }
+                'agent-a': { captureSucceeded: true, commandSucceeded: true },
+                'agent-b': { captureSucceeded: true, commandSucceeded: true }
             }
         });
         expect(artifact.recentResults).toEqual(
@@ -328,13 +329,11 @@ describe('live RTC control client', () => {
             ])
         );
         expect(artifact.sendResult).toEqual({
-            agentId: 'agent-a',
-            commandId: 'send-direct-timeout',
             ok: true,
             runtimeStatus: 'sent',
             admissionStatus: 'pending-admission',
-            reason: 'awaiting a durable admission retry',
-            messageId: 'message-direct-timeout',
+            reason: 'other',
+            messageIdPresent: true,
             entryCount: 1,
             entryStatuses: ['NEW']
         });
@@ -348,6 +347,90 @@ describe('live RTC control client', () => {
                 deliveryMode: 'direct'
             }
         ]);
+    });
+
+    it('retains a sanitized message delivery failure without a diagnostics directory', async () => {
+        results.push({
+            agentId: 'agent-a',
+            commandId: 'send-direct-timeout',
+            ok: true,
+            result: {
+                value: {
+                    status: 'sent',
+                    message: {
+                        status: 'pending-admission',
+                        reason: 'awaiting a durable admission retry',
+                        message: {
+                            id: { msgId: 'message-direct-timeout' },
+                            payload: { resource: 'must-not-be-retained' }
+                        },
+                        entries: [{ status: 'NEW', resource: 'must-not-be-retained' }]
+                    },
+                    credential: 'must-not-be-retained'
+                }
+            }
+        });
+        const controlWithoutDiagnosticsDirectory = new LiveRtcControlClient({
+            request: api,
+            baseUrl: `http://127.0.0.1:${(server.address() as { port: number; }).port}`,
+            monotonicNow: () => nowMs,
+            epochNow: () => 0
+        });
+
+        await expect(
+            controlWithoutDiagnosticsDirectory.waitForMessage({
+                runId: 'run-message-timeout',
+                senderAgentId: 'agent-a',
+                agentId: 'agent-b',
+                transport: 'messages.rtc',
+                matrixId: 'direct-timeout',
+                deliveryMode: 'direct',
+                startedAtMs: 100,
+                timeoutMs: 10
+            })
+        ).rejects.toThrow('direct-timeout');
+        await expect(
+            controlWithoutDiagnosticsDirectory.waitForMessage({
+                runId: 'run-message-timeout',
+                senderAgentId: 'agent-b',
+                agentId: 'agent-c',
+                transport: 'messages.rtc',
+                matrixId: 'cleanup-timeout',
+                deliveryMode: 'direct',
+                startedAtMs: 100,
+                timeoutMs: 10
+            })
+        ).rejects.toThrow('cleanup-timeout');
+
+        const attemptFailure = await controlWithoutDiagnosticsDirectory
+            .captureAttemptFailure({ runId: 'run-message-timeout' });
+        expect(JSON.stringify(attemptFailure)).not.toContain('must-not-be-retained');
+        expect(attemptFailure).toMatchObject({
+            kind: 'control-result-failures',
+            runCaptureSucceeded: true,
+            messageFailures: [
+                {
+                    kind: 'message-delivery-failure',
+                    senderAgentId: 'agent-a',
+                    receiverAgentId: 'agent-b',
+                    transport: 'messages.rtc',
+                    matrixId: 'direct-timeout',
+                    deliveryMode: 'direct',
+                    healthByAgentId: {
+                        'agent-a': { captureSucceeded: true, commandSucceeded: true },
+                        'agent-b': { captureSucceeded: true, commandSucceeded: true }
+                    },
+                    sendResult: {
+                        runtimeStatus: 'sent',
+                        admissionStatus: 'pending-admission',
+                        reason: 'other',
+                        messageIdPresent: true,
+                        entryCount: 1,
+                        entryStatuses: ['NEW']
+                    }
+                }
+            ]
+        });
     });
 
     it('reads the sent message identity from the RTC send-result envelope, not the command ID', () => {

--- a/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-control-client.test.ts
@@ -17,6 +17,8 @@ describe('live RTC control client', () => {
     let diagnosticsRoot: string;
     let results: LiveRtcControlClient.Result[];
     let events: LiveRtcControlClient.Event[];
+    let healthCommandFailure: { agentId: string; body: string; } | undefined;
+    let holdHealthCommand: ((agentId: string) => Promise<void>) | undefined;
     const refreshRoom = vi.fn<LiveRtcControlClient.FormationAgent['refreshRoom']>();
     const agent = { agentId: 'agent-a', prefix: 'A' as const, refreshRoom };
 
@@ -28,6 +30,8 @@ describe('live RTC control client', () => {
         );
         results = [];
         events = [];
+        healthCommandFailure = undefined;
+        holdHealthCommand = undefined;
         server = createServer(async (incoming, response) => {
             if (incoming.method === 'POST') {
                 const chunks: Buffer[] = [];
@@ -46,7 +50,20 @@ describe('live RTC control client', () => {
                     response.writeHead(400).end();
                     return;
                 }
+                const agentId = incoming.url?.split('/')[4];
+                if (
+                    healthCommandFailure &&
+                    agentId === healthCommandFailure.agentId &&
+                    command.commandId.startsWith('health-message-failure-')
+                ) {
+                    response.writeHead(500).end(healthCommandFailure.body);
+                    return;
+                }
+                if (holdHealthCommand && command.commandId.startsWith('health-message-failure-')) {
+                    await holdHealthCommand(agentId ?? 'missing-agent');
+                }
                 results.push({
+                    agentId,
                     commandId: command.commandId,
                     ok: true,
                     result: {
@@ -431,6 +448,104 @@ describe('live RTC control client', () => {
                 }
             ]
         });
+    });
+
+    it('does not retain a failed health-command response body in message failure evidence', async () => {
+        healthCommandFailure = {
+            agentId: 'agent-b',
+            body: `credential=must-not-be-retained ${'x'.repeat(10_000)}`
+        };
+        const controlWithoutDiagnosticsDirectory = new LiveRtcControlClient({
+            request: api,
+            baseUrl: `http://127.0.0.1:${(server.address() as { port: number; }).port}`,
+            monotonicNow: () => nowMs,
+            epochNow: () => 0
+        });
+
+        await expect(
+            controlWithoutDiagnosticsDirectory.waitForMessage({
+                runId: 'run-health-failure',
+                senderAgentId: 'agent-a',
+                agentId: 'agent-b',
+                transport: 'messages.rtc',
+                matrixId: 'health-failure',
+                deliveryMode: 'direct',
+                startedAtMs: 100,
+                timeoutMs: 10
+            })
+        ).rejects.toThrow('health-failure');
+
+        const attemptFailure = await controlWithoutDiagnosticsDirectory
+            .captureAttemptFailure({ runId: 'run-health-failure' });
+        expect(JSON.stringify(attemptFailure)).not.toContain('must-not-be-retained');
+        expect(attemptFailure.messageFailures[0]).toMatchObject({
+            failure: {
+                name: 'message-delivery-failed',
+                message: 'RTC message delivery observation failed.'
+            },
+            healthByAgentId: {
+                'agent-b': {
+                    captureSucceeded: false,
+                    commandSucceeded: null,
+                    captureFailure: {
+                        name: 'health-capture-failed',
+                        message: 'RTC health diagnostic capture failed.'
+                    }
+                }
+            }
+        });
+    });
+
+    it('waits for both first-case receiver captures before returning attempt failure evidence', async () => {
+        const releaseDelayedHealth = Promise.withResolvers<void>();
+        const delayedHealthStarted = Promise.withResolvers<void>();
+        holdHealthCommand = async (agentId) => {
+            if (agentId === 'agent-c') {
+                delayedHealthStarted.resolve();
+                await releaseDelayedHealth.promise;
+            }
+        };
+        const controlWithoutDiagnosticsDirectory = new LiveRtcControlClient({
+            request: api,
+            baseUrl: `http://127.0.0.1:${(server.address() as { port: number; }).port}`,
+            monotonicNow: () => nowMs,
+            epochNow: () => 0
+        });
+        const waitForAgentB = controlWithoutDiagnosticsDirectory.waitForMessage({
+            runId: 'run-two-receiver-timeout',
+            senderAgentId: 'agent-a',
+            agentId: 'agent-b',
+            transport: 'messages.rtc',
+            matrixId: 'two-receiver-timeout',
+            deliveryMode: 'multicast',
+            possibleReceiverAgentIds: ['agent-b', 'agent-c'],
+            startedAtMs: 100,
+            timeoutMs: 10
+        }).catch(() => undefined);
+        const waitForAgentC = controlWithoutDiagnosticsDirectory.waitForMessage({
+            runId: 'run-two-receiver-timeout',
+            senderAgentId: 'agent-a',
+            agentId: 'agent-c',
+            transport: 'messages.rtc',
+            matrixId: 'two-receiver-timeout',
+            deliveryMode: 'multicast',
+            possibleReceiverAgentIds: ['agent-b', 'agent-c'],
+            startedAtMs: 100,
+            timeoutMs: 10
+        }).catch(() => undefined);
+
+        await delayedHealthStarted.promise;
+        const attemptFailure = controlWithoutDiagnosticsDirectory
+            .captureAttemptFailure({ runId: 'run-two-receiver-timeout' });
+        releaseDelayedHealth.resolve();
+
+        await expect(attemptFailure).resolves.toMatchObject({
+            messageFailures: [
+                { receiverAgentId: 'agent-b' },
+                { receiverAgentId: 'agent-c' }
+            ]
+        });
+        await Promise.all([waitForAgentB, waitForAgentC]);
     });
 
     it('reads the sent message identity from the RTC send-result envelope, not the command ID', () => {

--- a/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
+++ b/packages/tests/rallar-black-box/live-rtc-delivery-operations.test.ts
@@ -537,6 +537,35 @@ describe('live RTC delivery owner', () => {
         ]);
     });
 
+    it('preserves the first receiver rejection after every receiver settles', async () => {
+        const recording = new RecordingLiveRtcControl();
+        const firstReceiverFailure = new Error('Room relay did not reach C first');
+        const laterReceiverFailure = new Error('Room relay did not reach B later');
+        let laterReceiverSettled = false;
+        vi.spyOn(recording, 'waitForMessage').mockImplementation(
+            async ({ agentId }) => {
+                if (agentId === 'C') {
+                    throw firstReceiverFailure;
+                }
+                await new Promise<void>((resolve) => setTimeout(resolve, 0));
+                laterReceiverSettled = true;
+                throw laterReceiverFailure;
+            }
+        );
+
+        await expect(
+            createLiveRtcDeliveryOperations(config).runAllDeliveryPermutations({
+                control: recording,
+                runId: 'run',
+                agents: recording.agents,
+                transport: 'messages.rtc',
+                groupId: 'room',
+                suffix: 'first-rejection'
+            })
+        ).rejects.toBe(firstReceiverFailure);
+        expect(laterReceiverSettled).toBe(true);
+    });
+
     it('propagates captured NACK evidence when reading the browser wire fails', async () => {
         const recording = new RecordingLiveRtcControl();
         const operations = createLiveRtcDeliveryOperations(config);

--- a/tests/playwright/rallar-black-box/live-rtc-control-client.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-control-client.ts
@@ -485,46 +485,29 @@ export class LiveRtcControlClient {
         input: LiveRtcControlClient.WaitForRtcReadinessInput
     ): Promise<number> {
         const deadlineMs = this.#monotonicNow() + 60_000;
+        const readyAtMs = await this.#observeRtcReadiness(input, deadlineMs);
+        if (readyAtMs >= deadlineMs) {
+            throw new Error(
+                `RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`
+            );
+        }
+        return readyAtMs - input.startedAtMs;
+    }
+
+    async #observeRtcReadiness(
+        input: LiveRtcControlClient.WaitForRtcReadinessInput,
+        deadlineMs: number
+    ): Promise<number> {
         let attempt = 0;
         try {
             await expect
                 .poll(
-                    async () => {
-                        const refreshTimeoutMs = deadlineMs - this.#monotonicNow();
-                        if (refreshTimeoutMs <= 0) {
-                            throw new Error(
-                                `RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`
-                            );
-                        }
-                        await input.agent.refreshRoom({ timeoutMs: refreshTimeoutMs });
-                        const healthTimeoutMs = Math.min(
-                            15_000,
-                            deadlineMs - this.#monotonicNow()
-                        );
-                        if (healthTimeoutMs <= 0) {
-                            throw new Error(
-                                `RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`
-                            );
-                        }
-                        const result = await this.executeResult({
-                            runId: input.runId,
-                            agentId: input.agent.agentId,
-                            commandId: `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt++}`,
-                            command: { kind: 'health' },
-                            timeoutMs: healthTimeoutMs
-                        }).catch(() => undefined);
-                        if (!result?.ok) {
-                            return false;
-                        }
-                        const rallar = jsonRecord(this.resultValue(result).rallar);
-                        const readyPeerIds = stringArrayValue(
-                            jsonRecord(rallar?.rtcStatus)?.readyPeerIds
-                        );
-                        const expectedPeersReady = input.expectedPeerIds.every((peerId) =>
-                            readyPeerIds.includes(peerId)
-                        );
-                        return expectedPeersReady;
-                    },
+                    async () =>
+                        await this.#readRtcReadiness(
+                            input,
+                            deadlineMs,
+                            attempt++
+                        ),
                     {
                         message: `Expected ${input.agent.agentId} to see ready peers ${
                             input.expectedPeerIds.join(
@@ -548,13 +531,45 @@ export class LiveRtcControlClient {
             }
             throw cause;
         }
-        const readyAtMs = this.#monotonicNow();
-        if (readyAtMs >= deadlineMs) {
+        return this.#monotonicNow();
+    }
+
+    async #readRtcReadiness(
+        input: LiveRtcControlClient.WaitForRtcReadinessInput,
+        deadlineMs: number,
+        attempt: number
+    ): Promise<boolean> {
+        const refreshTimeoutMs = deadlineMs - this.#monotonicNow();
+        if (refreshTimeoutMs <= 0) {
             throw new Error(
                 `RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`
             );
         }
-        return readyAtMs - input.startedAtMs;
+        await input.agent.refreshRoom({ timeoutMs: refreshTimeoutMs });
+        const healthTimeoutMs = Math.min(
+            15_000,
+            deadlineMs - this.#monotonicNow()
+        );
+        if (healthTimeoutMs <= 0) {
+            throw new Error(
+                `RTC room refresh for ${input.agent.agentId} exceeded the readiness deadline.`
+            );
+        }
+        const result = await this.executeResult({
+            runId: input.runId,
+            agentId: input.agent.agentId,
+            commandId: `health-ready-${input.agent.prefix.toLowerCase()}-${input.suffix}-${attempt}`,
+            command: { kind: 'health' },
+            timeoutMs: healthTimeoutMs
+        }).catch(() => undefined);
+        if (!result?.ok) {
+            return false;
+        }
+        const rallar = jsonRecord(this.resultValue(result).rallar);
+        const readyPeerIds = stringArrayValue(
+            jsonRecord(rallar?.rtcStatus)?.readyPeerIds
+        );
+        return input.expectedPeerIds.every((peerId) => readyPeerIds.includes(peerId));
     }
 
     async #recordReadinessFailure(

--- a/tests/playwright/rallar-black-box/live-rtc-control-client.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-control-client.ts
@@ -34,12 +34,17 @@ import type {
     LiveRtcAttemptFailureDiagnostic,
     LiveRtcDiagnosticsCheckpoint,
     LiveRtcFailedControlResult,
-    LiveRtcNackAgentHealth,
+    LiveRtcFailureAgentHealth,
+    LiveRtcMessageFailureAgentHealth,
+    LiveRtcMessageFailureDiagnostic,
+    LiveRtcMessageFailureEventSummary,
+    LiveRtcMessageFailureResultSummary,
     LiveRtcNackEventClassification,
     LiveRtcNackFailureDiagnostic,
     LiveRtcNackProbeStage,
     LiveRtcNackResultClassification,
-    LiveRtcNackSendResultSummary
+    LiveRtcNackSendResultSummary,
+    LiveRtcSendResultSummary
 } from './live-rtc-performance-evidence.ts';
 import { summarizeLiveRtcNackWireObservation } from './live-rtc-wire-observation.ts';
 
@@ -89,7 +94,7 @@ export namespace LiveRtcControlClient {
         readonly frames: readonly string[];
     }
 
-    export interface NackRunCapture {
+    export interface RunCapture {
         readonly succeeded: boolean;
         readonly run: RunSnapshot | undefined;
     }
@@ -151,6 +156,7 @@ export namespace LiveRtcControlClient {
         transport: 'realtime' | 'messages.rtc';
         matrixId: string;
         deliveryMode: string;
+        possibleReceiverAgentIds?: readonly string[];
         startedAtMs: number;
         timeoutMs?: number;
     }
@@ -188,12 +194,23 @@ export namespace LiveRtcControlClient {
     }
 }
 
+interface FirstMessageFailureCase {
+    readonly senderAgentId: string;
+    readonly transport: 'realtime' | 'messages.rtc';
+    readonly matrixId: string;
+    readonly deliveryMode: string;
+    readonly possibleReceiverAgentIds: readonly string[];
+}
+
 export class LiveRtcControlClient {
     readonly #request: APIRequestContext;
     readonly #baseUrl: string;
     readonly #diagnosticsOutDir: string | undefined;
     readonly #monotonicNow: () => number;
     readonly #epochNow: () => number;
+    readonly #messageFailures: LiveRtcMessageFailureDiagnostic[] = [];
+    readonly #messageFailureReceiverAgentIds = new Set<string>();
+    #firstMessageFailureCase: FirstMessageFailureCase | undefined;
 
     constructor(input: LiveRtcControlClient.Dependencies) {
         this.#request = input.request;
@@ -341,9 +358,53 @@ export class LiveRtcControlClient {
         input: LiveRtcControlClient.WaitForMessageInput,
         failure: Error
     ): Promise<void> {
-        if (!this.#diagnosticsOutDir) {
+        if (!this.#acceptsMessageFailure(input)) {
             return;
         }
+        const diagnostic = await this.#captureMessageFailure(input, failure);
+        this.#messageFailures.push(diagnostic);
+        await this.#writeDiagnosticsArtifact(
+            `live-rtc-message-failure-${safeFileName(input.matrixId)}-${safeFileName(input.agentId)}.json`,
+            JSON.stringify(diagnostic, null, 2)
+        );
+    }
+
+    #acceptsMessageFailure(
+        input: LiveRtcControlClient.WaitForMessageInput
+    ): boolean {
+        const possibleReceiverAgentIds = [
+            ...new Set(input.possibleReceiverAgentIds ?? [input.agentId])
+        ].slice(0, MAX_RETAINED_MESSAGE_FAILURES);
+        const firstMessageFailureCase = this.#firstMessageFailureCase;
+        if (!firstMessageFailureCase) {
+            this.#firstMessageFailureCase = {
+                senderAgentId: input.senderAgentId,
+                transport: input.transport,
+                matrixId: input.matrixId,
+                deliveryMode: input.deliveryMode,
+                possibleReceiverAgentIds
+            };
+        }
+        const retainedMessageFailureCase = this.#firstMessageFailureCase;
+        if (
+            !retainedMessageFailureCase ||
+            retainedMessageFailureCase.senderAgentId !== input.senderAgentId ||
+            retainedMessageFailureCase.transport !== input.transport ||
+            retainedMessageFailureCase.matrixId !== input.matrixId ||
+            retainedMessageFailureCase.deliveryMode !== input.deliveryMode ||
+            !retainedMessageFailureCase.possibleReceiverAgentIds.includes(input.agentId) ||
+            this.#messageFailureReceiverAgentIds.has(input.agentId)
+        ) {
+            return false;
+        }
+        this.#messageFailureReceiverAgentIds.add(input.agentId);
+        return true;
+    }
+
+    async #captureMessageFailure(
+        input: LiveRtcControlClient.WaitForMessageInput,
+        failure: Error
+    ): Promise<LiveRtcMessageFailureDiagnostic> {
         const agentIds = [...new Set([input.senderAgentId, input.agentId])];
         const healthEntries = await Promise.all(
             agentIds.map(async (agentId) => {
@@ -361,61 +422,59 @@ export class LiveRtcControlClient {
                         command: { kind: 'health', includeRtcDiagnostics: true },
                         timeoutMs: 15_000
                     });
-                    return [agentId, health] as const;
-                }
-                catch (cause) {
-                    const error = toError(cause);
                     return [
                         agentId,
-                        {
-                            captureFailure: { name: error.name, message: error.message }
-                        }
+                        health.ok
+                            ? summarizeMessageFailureAgentHealth(
+                                buildLiveRtcAgentDiagnostics(agentId, this.resultValue(health))
+                            )
+                            : unavailableMessageFailureAgentHealth(true, false, null)
+                    ] as const;
+                }
+                catch (cause) {
+                    return [
+                        agentId,
+                        unavailableMessageFailureAgentHealth(
+                            false,
+                            null,
+                            toError(cause)
+                        )
                     ] as const;
                 }
             })
         );
-        let run: LiveRtcControlClient.RunSnapshot | undefined;
-        let runCaptureFailure: Readonly<{ name: string; message: string; }> | undefined;
-        try {
-            run = await this.fetchRun(input.runId);
-        }
-        catch (cause) {
-            const error = toError(cause);
-            runCaptureFailure = { name: error.name, message: error.message };
-        }
-        const sendResult = summarizeSendResult(
-            (run?.results ?? []).find(
-                (result) =>
-                    result.agentId === input.senderAgentId &&
-                    result.commandId === `send-${input.matrixId}`
-            )
-        );
-        await this.#writeDiagnosticsArtifact(
-            `live-rtc-message-failure-${safeFileName(input.matrixId)}-${safeFileName(input.agentId)}.json`,
-            JSON.stringify(
-                {
-                    runId: input.runId,
-                    senderAgentId: input.senderAgentId,
-                    receiverAgentId: input.agentId,
-                    transport: input.transport,
-                    matrixId: input.matrixId,
-                    deliveryMode: input.deliveryMode,
-                    capturedAtEpochMs: this.#epochNow(),
-                    failure: { name: failure.name, message: failure.message },
-                    healthByAgentId: Object.fromEntries(healthEntries),
-                    ...(runCaptureFailure ? { runCaptureFailure } : {}),
-                    ...(sendResult ? { sendResult } : {}),
-                    recentResults: (run?.results ?? []).slice(-100).map((result) => ({
-                        agentId: result.agentId,
-                        commandId: result.commandId,
-                        ok: result.ok
-                    })),
-                    recentEvents: (run?.events ?? []).slice(-100).map(summarizeEvent)
-                },
-                null,
-                2
-            )
-        );
+        const runCapture = await this.#captureRun(input.runId);
+        const run = runCapture.run;
+        return {
+            kind: 'message-delivery-failure',
+            runId: input.runId,
+            senderAgentId: input.senderAgentId,
+            receiverAgentId: input.agentId,
+            transport: input.transport,
+            matrixId: input.matrixId,
+            deliveryMode: input.deliveryMode,
+            capturedAtEpochMs: this.#epochNow(),
+            failure: { name: failure.name, message: failure.message },
+            healthByAgentId: Object.fromEntries(healthEntries),
+            runCaptureSucceeded: runCapture.succeeded,
+            sendResult: summarizeLiveRtcSendResult(
+                (run?.results ?? []).find(
+                    (result) =>
+                        result.agentId === input.senderAgentId &&
+                        result.commandId === `send-${input.matrixId}`
+                )
+            ) ?? null,
+            recentResults: (run?.results ?? [])
+                .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
+                .map((result): LiveRtcMessageFailureResultSummary => ({
+                    agentId: result.agentId ?? null,
+                    commandId: result.commandId,
+                    ok: result.ok
+                })),
+            recentEvents: (run?.events ?? [])
+                .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
+                .map(summarizeMessageFailureEvent)
+        };
     }
 
     waitForPeerReadiness(
@@ -545,14 +604,16 @@ export class LiveRtcControlClient {
                         (result): result is LiveRtcControlClient.Result & { ok: false; } => result.ok === false
                     )
                     .slice(-20)
-                    .map(toFailedControlResult)
+                    .map(toFailedControlResult),
+                messageFailures: this.#messageFailures
             };
         }
         catch {
             return {
                 kind: 'control-result-failures',
                 runCaptureSucceeded: false,
-                failedResults: []
+                failedResults: [],
+                messageFailures: this.#messageFailures
             };
         }
     }
@@ -717,7 +778,7 @@ export class LiveRtcControlClient {
         input: LiveRtcControlClient.CaptureNackFailureInput
     ): Promise<LiveRtcNackFailureDiagnostic> {
         const healthByAgentId = await this.#captureNackHealth(input);
-        const runCapture = await this.#captureNackRun(input.runId);
+        const runCapture = await this.#captureRun(input.runId);
         const run = runCapture.run;
         return {
             kind: 'nack-probe-failure',
@@ -758,7 +819,7 @@ export class LiveRtcControlClient {
 
     async #captureNackHealth(
         input: LiveRtcControlClient.CaptureNackFailureInput
-    ): Promise<Readonly<Record<string, LiveRtcNackAgentHealth>>> {
+    ): Promise<Readonly<Record<string, LiveRtcFailureAgentHealth>>> {
         const agentIds = [...new Set([input.senderAgentId, input.targetAgentId])];
         const entries = await Promise.all(
             agentIds.map((agentId) => this.#captureNackAgentHealth(input, agentId))
@@ -769,7 +830,7 @@ export class LiveRtcControlClient {
     async #captureNackAgentHealth(
         input: LiveRtcControlClient.CaptureNackFailureInput,
         agentId: string
-    ): Promise<readonly [string, LiveRtcNackAgentHealth]> {
+    ): Promise<readonly [string, LiveRtcFailureAgentHealth]> {
         try {
             const health = await this.executeResult({
                 runId: input.runId,
@@ -781,20 +842,20 @@ export class LiveRtcControlClient {
             return [
                 agentId,
                 health.ok
-                    ? summarizeNackAgentHealth(
+                    ? summarizeLiveRtcFailureAgentHealth(
                         buildLiveRtcAgentDiagnostics(agentId, this.resultValue(health))
                     )
-                    : unavailableNackAgentHealth(true, false)
+                    : unavailableLiveRtcFailureAgentHealth(true, false)
             ];
         }
         catch {
-            return [agentId, unavailableNackAgentHealth(false, null)];
+            return [agentId, unavailableLiveRtcFailureAgentHealth(false, null)];
         }
     }
 
-    async #captureNackRun(
+    async #captureRun(
         runId: string
-    ): Promise<LiveRtcControlClient.NackRunCapture> {
+    ): Promise<LiveRtcControlClient.RunCapture> {
         try {
             return { succeeded: true, run: await this.fetchRun(runId) };
         }
@@ -892,9 +953,9 @@ function messageData(event: LiveRtcControlClient.Event): LiveRtcJsonRecord {
     return jsonRecord(runtimePayload.data ?? runtimeEvent.data) ?? {};
 }
 
-function summarizeNackAgentHealth(
+function summarizeLiveRtcFailureAgentHealth(
     diagnostics: LiveRtcAgentDiagnostics
-): LiveRtcNackAgentHealth {
+): LiveRtcFailureAgentHealth {
     return {
         captureSucceeded: true,
         commandSucceeded: true,
@@ -912,10 +973,19 @@ function summarizeNackAgentHealth(
     };
 }
 
-function unavailableNackAgentHealth(
+function summarizeMessageFailureAgentHealth(
+    diagnostics: LiveRtcAgentDiagnostics
+): LiveRtcMessageFailureAgentHealth {
+    return {
+        ...summarizeLiveRtcFailureAgentHealth(diagnostics),
+        captureFailure: null
+    };
+}
+
+function unavailableLiveRtcFailureAgentHealth(
     captureSucceeded: boolean,
     commandSucceeded: boolean | null
-): LiveRtcNackAgentHealth {
+): LiveRtcFailureAgentHealth {
     return {
         captureSucceeded,
         commandSucceeded,
@@ -928,6 +998,19 @@ function unavailableNackAgentHealth(
         peerCount: null,
         connectedPeerCount: null,
         relayPeerCount: null
+    };
+}
+
+function unavailableMessageFailureAgentHealth(
+    captureSucceeded: boolean,
+    commandSucceeded: boolean | null,
+    captureFailure: Error | null
+): LiveRtcMessageFailureAgentHealth {
+    return {
+        ...unavailableLiveRtcFailureAgentHealth(captureSucceeded, commandSucceeded),
+        captureFailure: captureFailure
+            ? { name: captureFailure.name, message: captureFailure.message }
+            : null
     };
 }
 
@@ -1000,26 +1083,24 @@ function classifyNackDeliveryMode(
     return value === undefined ? 'missing' : value === 'nack' ? 'nack' : 'other';
 }
 
-function summarizeEvent(
+function summarizeMessageFailureEvent(
     event: LiveRtcControlClient.Event
-): Readonly<Record<string, string>> {
+): LiveRtcMessageFailureEventSummary {
     const runtimeEvent = runtimeEventPayload(event);
     const data = messageData(event);
-    return Object.fromEntries(
-        Object.entries({
-            agentId: event.agentId,
-            kind: stringValue(runtimeEvent.kind) ?? event.kind,
-            transport: stringValue(runtimeEvent.transport),
-            topic: stringValue(runtimeEvent.topic),
-            matrixId: stringValue(data.matrixId),
-            deliveryMode: stringValue(data.deliveryMode)
-        }).filter(
-            (entry): entry is [string, string] => typeof entry[1] === 'string'
-        )
-    );
+    return {
+        agentId: event.agentId ?? null,
+        kind: stringValue(runtimeEvent.kind) ?? event.kind ?? null,
+        transport: stringValue(runtimeEvent.transport) ?? null,
+        topic: stringValue(runtimeEvent.topic) ?? null,
+        matrixId: stringValue(data.matrixId) ?? null,
+        deliveryMode: stringValue(data.deliveryMode) ?? null
+    };
 }
 
 const MAX_RETAINED_SEND_ENTRY_STATUSES = 20;
+const MAX_RETAINED_MESSAGE_FAILURES = 2;
+const MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS = 100;
 
 function summarizeNackSendResult(
     result: LiveRtcControlClient.Result | undefined,
@@ -1028,23 +1109,15 @@ function summarizeNackSendResult(
     if (!result) {
         return undefined;
     }
-    const diagnostics = jsonRecord(result.result?.value) ?? {};
-    const admission = jsonRecord(diagnostics.message) ?? {};
-    const messageId = stringValue(
-        jsonRecord(jsonRecord(admission.message)?.id)?.msgId
-    );
-    const entries = Array.isArray(admission.entries) ? admission.entries : [];
+    const summary = summarizeLiveRtcSendResult(result);
+    if (!summary) {
+        return undefined;
+    }
     return {
-        ok: result.ok,
-        runtimeStatus: classifyNackRuntimeStatus(stringValue(diagnostics.status)),
-        admissionStatus: classifyNackAdmissionStatus(stringValue(admission.status)),
-        reason: classifyNackReason(stringValue(admission.reason)),
-        messageIdPresent: messageId !== undefined,
-        messageIdMatchesProbe: probeMessageId === null ? null : messageId === probeMessageId,
-        entryCount: entries.length,
-        entryStatuses: entries
-            .slice(0, MAX_RETAINED_SEND_ENTRY_STATUSES)
-            .map((entry) => classifyNackEntryStatus(stringValue(jsonRecord(entry)?.status)))
+        ...summary,
+        messageIdMatchesProbe: probeMessageId === null
+            ? null
+            : messageIdFromSendResult(result) === probeMessageId
     };
 }
 
@@ -1104,37 +1177,34 @@ function classifyNackEntryStatus(
     }
 }
 
-function summarizeSendResult(
+function summarizeLiveRtcSendResult(
     result: LiveRtcControlClient.Result | undefined
-):
-    | Readonly<Record<string, boolean | number | string | readonly string[]>>
-    | undefined {
+): LiveRtcSendResultSummary | undefined {
     if (!result) {
         return undefined;
     }
     const diagnostics = jsonRecord(result.result?.value) ?? {};
     const admission = jsonRecord(diagnostics.message) ?? {};
-    const message = jsonRecord(admission.message) ?? {};
     const entries = Array.isArray(admission.entries) ? admission.entries : [];
-    const entryStatuses = entries
-        .map((entry) => stringValue(jsonRecord(entry)?.status))
-        .filter((status): status is string => Boolean(status))
-        .slice(0, MAX_RETAINED_SEND_ENTRY_STATUSES);
-    const runtimeStatus = stringValue(diagnostics.status);
-    const admissionStatus = stringValue(admission.status);
-    const reason = stringValue(admission.reason);
-    const messageId = stringValue(jsonRecord(message.id)?.msgId);
     return {
-        ...(result.agentId ? { agentId: result.agentId } : {}),
-        commandId: result.commandId,
         ok: result.ok,
-        ...(runtimeStatus ? { runtimeStatus } : {}),
-        ...(admissionStatus ? { admissionStatus } : {}),
-        ...(reason ? { reason } : {}),
-        ...(messageId ? { messageId } : {}),
+        runtimeStatus: classifyNackRuntimeStatus(stringValue(diagnostics.status)),
+        admissionStatus: classifyNackAdmissionStatus(stringValue(admission.status)),
+        reason: classifyNackReason(stringValue(admission.reason)),
+        messageIdPresent: messageIdFromSendResult(result) !== undefined,
         entryCount: entries.length,
-        entryStatuses
+        entryStatuses: entries
+            .slice(0, MAX_RETAINED_SEND_ENTRY_STATUSES)
+            .map((entry) => classifyNackEntryStatus(stringValue(jsonRecord(entry)?.status)))
     };
+}
+
+function messageIdFromSendResult(
+    result: LiveRtcControlClient.Result
+): string | undefined {
+    const diagnostics = jsonRecord(result.result?.value) ?? {};
+    const admission = jsonRecord(diagnostics.message) ?? {};
+    return stringValue(jsonRecord(jsonRecord(admission.message)?.id)?.msgId);
 }
 
 function toFailedControlResult(

--- a/tests/playwright/rallar-black-box/live-rtc-control-client.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-control-client.ts
@@ -32,6 +32,7 @@ import {
 } from './live-rtc-evidence-json.ts';
 import type {
     LiveRtcAttemptFailureDiagnostic,
+    LiveRtcDiagnosticFailure,
     LiveRtcDiagnosticsCheckpoint,
     LiveRtcFailedControlResult,
     LiveRtcFailureAgentHealth,
@@ -202,6 +203,23 @@ interface FirstMessageFailureCase {
     readonly possibleReceiverAgentIds: readonly string[];
 }
 
+interface ToMessageFailureDiagnosticInput {
+    readonly waitForMessage: LiveRtcControlClient.WaitForMessageInput;
+    readonly healthByAgentId: Readonly<Record<string, LiveRtcMessageFailureAgentHealth>>;
+    readonly runCapture: LiveRtcControlClient.RunCapture;
+    readonly capturedAtEpochMs: number;
+}
+
+const MESSAGE_DELIVERY_FAILURE: LiveRtcDiagnosticFailure = {
+    name: 'message-delivery-failed',
+    message: 'RTC message delivery observation failed.'
+};
+
+const HEALTH_CAPTURE_FAILURE: LiveRtcDiagnosticFailure = {
+    name: 'health-capture-failed',
+    message: 'RTC health diagnostic capture failed.'
+};
+
 export class LiveRtcControlClient {
     readonly #request: APIRequestContext;
     readonly #baseUrl: string;
@@ -209,6 +227,7 @@ export class LiveRtcControlClient {
     readonly #monotonicNow: () => number;
     readonly #epochNow: () => number;
     readonly #messageFailures: LiveRtcMessageFailureDiagnostic[] = [];
+    readonly #messageFailureCaptures = new Set<Promise<void>>();
     readonly #messageFailureReceiverAgentIds = new Set<string>();
     #firstMessageFailureCase: FirstMessageFailureCase | undefined;
 
@@ -340,8 +359,10 @@ export class LiveRtcControlClient {
                 .toBe(true);
         }
         catch (cause) {
+            const capture = this.#recordMessageFailure(input);
+            this.#messageFailureCaptures.add(capture);
             try {
-                await this.#recordMessageFailure(input, toError(cause));
+                await capture;
             }
             catch (diagnosticCause) {
                 console.error(
@@ -349,19 +370,21 @@ export class LiveRtcControlClient {
                     toError(diagnosticCause)
                 );
             }
+            finally {
+                this.#messageFailureCaptures.delete(capture);
+            }
             throw cause;
         }
         return this.#monotonicNow() - input.startedAtMs;
     }
 
     async #recordMessageFailure(
-        input: LiveRtcControlClient.WaitForMessageInput,
-        failure: Error
+        input: LiveRtcControlClient.WaitForMessageInput
     ): Promise<void> {
         if (!this.#acceptsMessageFailure(input)) {
             return;
         }
-        const diagnostic = await this.#captureMessageFailure(input, failure);
+        const diagnostic = await this.#captureMessageFailure(input);
         this.#messageFailures.push(diagnostic);
         await this.#writeDiagnosticsArtifact(
             `live-rtc-message-failure-${safeFileName(input.matrixId)}-${safeFileName(input.agentId)}.json`,
@@ -402,79 +425,54 @@ export class LiveRtcControlClient {
     }
 
     async #captureMessageFailure(
-        input: LiveRtcControlClient.WaitForMessageInput,
-        failure: Error
+        input: LiveRtcControlClient.WaitForMessageInput
     ): Promise<LiveRtcMessageFailureDiagnostic> {
+        const healthByAgentId = await this.#captureMessageFailureHealth(input);
+        const runCapture = await this.#captureRun(input.runId);
+        return toMessageFailureDiagnostic({
+            waitForMessage: input,
+            healthByAgentId,
+            runCapture,
+            capturedAtEpochMs: this.#epochNow()
+        });
+    }
+
+    async #captureMessageFailureHealth(
+        input: LiveRtcControlClient.WaitForMessageInput
+    ): Promise<Readonly<Record<string, LiveRtcMessageFailureAgentHealth>>> {
         const agentIds = [...new Set([input.senderAgentId, input.agentId])];
         const healthEntries = await Promise.all(
-            agentIds.map(async (agentId) => {
-                try {
-                    const health = await this.executeResult({
-                        runId: input.runId,
-                        agentId,
-                        commandId: `health-message-failure-${safeFileName(input.matrixId)}-${
-                            safeFileName(input.agentId)
-                        }-${
-                            safeFileName(
-                                agentId
-                            )
-                        }`,
-                        command: { kind: 'health', includeRtcDiagnostics: true },
-                        timeoutMs: 15_000
-                    });
-                    return [
-                        agentId,
-                        health.ok
-                            ? summarizeMessageFailureAgentHealth(
-                                buildLiveRtcAgentDiagnostics(agentId, this.resultValue(health))
-                            )
-                            : unavailableMessageFailureAgentHealth(true, false, null)
-                    ] as const;
-                }
-                catch (cause) {
-                    return [
-                        agentId,
-                        unavailableMessageFailureAgentHealth(
-                            false,
-                            null,
-                            toError(cause)
-                        )
-                    ] as const;
-                }
-            })
+            agentIds.map((agentId) => this.#captureMessageFailureAgentHealth(input, agentId))
         );
-        const runCapture = await this.#captureRun(input.runId);
-        const run = runCapture.run;
-        return {
-            kind: 'message-delivery-failure',
-            runId: input.runId,
-            senderAgentId: input.senderAgentId,
-            receiverAgentId: input.agentId,
-            transport: input.transport,
-            matrixId: input.matrixId,
-            deliveryMode: input.deliveryMode,
-            capturedAtEpochMs: this.#epochNow(),
-            failure: { name: failure.name, message: failure.message },
-            healthByAgentId: Object.fromEntries(healthEntries),
-            runCaptureSucceeded: runCapture.succeeded,
-            sendResult: summarizeLiveRtcSendResult(
-                (run?.results ?? []).find(
-                    (result) =>
-                        result.agentId === input.senderAgentId &&
-                        result.commandId === `send-${input.matrixId}`
-                )
-            ) ?? null,
-            recentResults: (run?.results ?? [])
-                .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
-                .map((result): LiveRtcMessageFailureResultSummary => ({
-                    agentId: result.agentId ?? null,
-                    commandId: result.commandId,
-                    ok: result.ok
-                })),
-            recentEvents: (run?.events ?? [])
-                .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
-                .map(summarizeMessageFailureEvent)
-        };
+        return Object.fromEntries(healthEntries);
+    }
+
+    async #captureMessageFailureAgentHealth(
+        input: LiveRtcControlClient.WaitForMessageInput,
+        agentId: string
+    ): Promise<readonly [string, LiveRtcMessageFailureAgentHealth]> {
+        try {
+            const health = await this.executeResult({
+                runId: input.runId,
+                agentId,
+                commandId: `health-message-failure-${safeFileName(input.matrixId)}-${safeFileName(input.agentId)}-${
+                    safeFileName(agentId)
+                }`,
+                command: { kind: 'health', includeRtcDiagnostics: true },
+                timeoutMs: 15_000
+            });
+            return [
+                agentId,
+                health.ok
+                    ? summarizeMessageFailureAgentHealth(
+                        buildLiveRtcAgentDiagnostics(agentId, this.resultValue(health))
+                    )
+                    : unavailableMessageFailureAgentHealth(true, false)
+            ];
+        }
+        catch {
+            return [agentId, unavailableMessageFailureAgentHealth(false, null)];
+        }
     }
 
     waitForPeerReadiness(
@@ -594,6 +592,7 @@ export class LiveRtcControlClient {
     async captureAttemptFailure(
         input: LiveRtcControlClient.CaptureAttemptFailureInput
     ): Promise<LiveRtcAttemptFailureDiagnostic> {
+        await Promise.allSettled(this.#messageFailureCaptures);
         try {
             const run = await this.fetchRun(input.runId);
             return {
@@ -1003,14 +1002,47 @@ function unavailableLiveRtcFailureAgentHealth(
 
 function unavailableMessageFailureAgentHealth(
     captureSucceeded: boolean,
-    commandSucceeded: boolean | null,
-    captureFailure: Error | null
+    commandSucceeded: boolean | null
 ): LiveRtcMessageFailureAgentHealth {
     return {
         ...unavailableLiveRtcFailureAgentHealth(captureSucceeded, commandSucceeded),
-        captureFailure: captureFailure
-            ? { name: captureFailure.name, message: captureFailure.message }
-            : null
+        captureFailure: captureSucceeded ? null : HEALTH_CAPTURE_FAILURE
+    };
+}
+
+function toMessageFailureDiagnostic(
+    input: ToMessageFailureDiagnosticInput
+): LiveRtcMessageFailureDiagnostic {
+    const run = input.runCapture.run;
+    return {
+        kind: 'message-delivery-failure',
+        runId: input.waitForMessage.runId,
+        senderAgentId: input.waitForMessage.senderAgentId,
+        receiverAgentId: input.waitForMessage.agentId,
+        transport: input.waitForMessage.transport,
+        matrixId: input.waitForMessage.matrixId,
+        deliveryMode: input.waitForMessage.deliveryMode,
+        capturedAtEpochMs: input.capturedAtEpochMs,
+        failure: MESSAGE_DELIVERY_FAILURE,
+        healthByAgentId: input.healthByAgentId,
+        runCaptureSucceeded: input.runCapture.succeeded,
+        sendResult: summarizeLiveRtcSendResult(
+            (run?.results ?? []).find(
+                (result) =>
+                    result.agentId === input.waitForMessage.senderAgentId &&
+                    result.commandId === `send-${input.waitForMessage.matrixId}`
+            )
+        ) ?? null,
+        recentResults: (run?.results ?? [])
+            .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
+            .map((result): LiveRtcMessageFailureResultSummary => ({
+                agentId: result.agentId ?? null,
+                commandId: result.commandId,
+                ok: result.ok
+            })),
+        recentEvents: (run?.events ?? [])
+            .slice(-MAX_RETAINED_MESSAGE_FAILURE_OBSERVATIONS)
+            .map(summarizeMessageFailureEvent)
     };
 }
 

--- a/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
@@ -809,6 +809,7 @@ async function runDeliveryCase(
                 transport: input.run.transport,
                 matrixId,
                 deliveryMode,
+                possibleReceiverAgentIds: receivers.map((possibleReceiver) => possibleReceiver.agentId),
                 startedAtMs
             })
         )

--- a/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
@@ -75,6 +75,12 @@ interface RunDeliveryMatrixResult {
     readonly timings: readonly LiveRtcPerformanceTiming[];
 }
 
+interface CompleteDeliveryCasesInput {
+    readonly run: RunDeliveryMatrixInput;
+    readonly sessions: Readonly<Record<AgentPrefix, string>>;
+    readonly deliveryCases: readonly DeliveryCase[];
+}
+
 interface RtcFailureProbeInput {
     readonly control: LiveRtcControlPort;
     readonly runId: string;
@@ -397,66 +403,16 @@ async function runDeliveryMatrix(
         ...input,
         readinessScope: 'owner'
     });
-    const [sender, agentB, agentC] = input.agents;
-    const cases: DeliveryCase[] = [
-        {
-            sender,
-            firstHopReceivers: [agentB],
-            deliveryMode: 'direct',
-            matrixId: `direct-${input.transport}-${input.suffix}`
-        },
-        {
-            sender,
-            firstHopReceivers: [agentB, agentC],
-            deliveryMode: 'multicast',
-            matrixId: `multicast-${input.transport}-${input.suffix}`
-        },
-        {
-            sender,
-            firstHopReceivers: [agentB, agentC],
-            deliveryMode: 'broadcast',
-            matrixId: `broadcast-${input.transport}-${input.suffix}`
-        }
-    ];
-    const completed: CompletedDeliveryCase[] = [];
-    for (const deliveryCase of cases) {
-        completed.push(
-            await runDeliveryCase(runtime, {
-                run: input,
-                sessions: formation.sessions,
-                deliveryCase
-            })
-        );
-        if (deliveryCase.deliveryMode === 'direct') {
-            await observeVisibleInbox(agentB, deliveryCase.matrixId);
-        }
-        if (deliveryCase.deliveryMode === 'broadcast') {
-            await observeVisibleInbox(agentC, deliveryCase.matrixId);
-        }
-    }
-    if (input.transport === 'realtime') {
-        const health = await input.control.executeOk({
-            runId: input.runId,
-            agentId: sender.agentId,
-            commandId: `health-a-${input.suffix}`,
-            command: { kind: 'health' }
-        });
-        expect(input.control.readyPeerIds(health)).toEqual(
-            expect.arrayContaining([formation.sessions.B, formation.sessions.C])
-        );
-    }
-    return {
-        commandIds: [
-            ...formation.commandIds,
-            ...completed.map((entry) => entry.commandId)
-        ],
+    const deliveryCases = createDeliveryCases(input);
+    const completed = await completeDeliveryCases(runtime, {
+        run: input,
         sessions: formation.sessions,
-        scenarios: completed.map((entry) => entry.scenario),
-        timings: [
-            ...toReadinessTimings(input, formation, 'owner'),
-            ...completed.map((entry) => entry.timing)
-        ]
-    };
+        deliveryCases
+    });
+    if (input.transport === 'realtime') {
+        await assertRealtimeSenderReadiness(input, formation.sessions);
+    }
+    return toDeliveryMatrixResult(input, formation, completed);
 }
 
 async function runAllDeliveryPermutations(
@@ -780,6 +736,104 @@ interface CompletedDeliveryCase {
     readonly scenario: LiveRtcControlClient.DeliveryScenario;
     readonly timing: LiveRtcPerformanceTiming;
 }
+
+interface WaitForDeliveryReceiptsInput {
+    readonly run: RunAllDeliveryPermutationsInput;
+    readonly deliveryCase: DeliveryCase;
+    readonly receivers: readonly LiveRtcControlClient.FormationAgent[];
+    readonly startedAtMs: number;
+}
+
+function createDeliveryCases(
+    input: RunDeliveryMatrixInput
+): readonly DeliveryCase[] {
+    const [sender, agentB, agentC] = input.agents;
+    return [
+        {
+            sender,
+            firstHopReceivers: [agentB],
+            deliveryMode: 'direct',
+            matrixId: `direct-${input.transport}-${input.suffix}`
+        },
+        {
+            sender,
+            firstHopReceivers: [agentB, agentC],
+            deliveryMode: 'multicast',
+            matrixId: `multicast-${input.transport}-${input.suffix}`
+        },
+        {
+            sender,
+            firstHopReceivers: [agentB, agentC],
+            deliveryMode: 'broadcast',
+            matrixId: `broadcast-${input.transport}-${input.suffix}`
+        }
+    ];
+}
+
+async function completeDeliveryCases(
+    runtime: LiveRtcDeliveryRuntime,
+    input: CompleteDeliveryCasesInput
+): Promise<readonly CompletedDeliveryCase[]> {
+    const completed: CompletedDeliveryCase[] = [];
+    for (const deliveryCase of input.deliveryCases) {
+        completed.push(
+            await runDeliveryCase(runtime, {
+                run: input.run,
+                sessions: input.sessions,
+                deliveryCase
+            })
+        );
+        await observeDeliveryCaseInbox(deliveryCase, input.run.agents);
+    }
+    return completed;
+}
+
+async function observeDeliveryCaseInbox(
+    deliveryCase: DeliveryCase,
+    agents: RunDeliveryMatrixInput['agents']
+): Promise<void> {
+    if (deliveryCase.deliveryMode === 'direct') {
+        await observeVisibleInbox(agents[1], deliveryCase.matrixId);
+    }
+    if (deliveryCase.deliveryMode === 'broadcast') {
+        await observeVisibleInbox(agents[2], deliveryCase.matrixId);
+    }
+}
+
+async function assertRealtimeSenderReadiness(
+    input: RunDeliveryMatrixInput,
+    sessions: Readonly<Record<AgentPrefix, string>>
+): Promise<void> {
+    const health = await input.control.executeOk({
+        runId: input.runId,
+        agentId: input.agents[0].agentId,
+        commandId: `health-a-${input.suffix}`,
+        command: { kind: 'health' }
+    });
+    expect(input.control.readyPeerIds(health)).toEqual(
+        expect.arrayContaining([sessions.B, sessions.C])
+    );
+}
+
+function toDeliveryMatrixResult(
+    input: RunDeliveryMatrixInput,
+    formation: Awaited<ReturnType<GroupFormationLifecycleDriver['run']>>,
+    completed: readonly CompletedDeliveryCase[]
+): RunDeliveryMatrixResult {
+    return {
+        commandIds: [
+            ...formation.commandIds,
+            ...completed.map((entry) => entry.commandId)
+        ],
+        sessions: formation.sessions,
+        scenarios: completed.map((entry) => entry.scenario),
+        timings: [
+            ...toReadinessTimings(input, formation, 'owner'),
+            ...completed.map((entry) => entry.timing)
+        ]
+    };
+}
+
 async function runDeliveryCase(
     runtime: LiveRtcDeliveryRuntime,
     input: RunDeliveryCaseInput
@@ -800,56 +854,76 @@ async function runDeliveryCase(
             ? undefined
             : firstHopReceivers.map((receiver) => input.sessions[receiver.prefix])
     });
-    const deliveryResults = await Promise.allSettled(
-        receivers.map((receiver) =>
-            input.run.control.waitForMessage({
-                runId: input.run.runId,
-                senderAgentId: sender.agentId,
-                agentId: receiver.agentId,
-                transport: input.run.transport,
-                matrixId,
-                deliveryMode,
-                possibleReceiverAgentIds: receivers.map((possibleReceiver) => possibleReceiver.agentId),
-                startedAtMs
-            })
-        )
-    );
-    const failedDelivery = deliveryResults.find(
-        (result): result is PromiseRejectedResult => result.status === 'rejected'
-    );
-    if (failedDelivery) {
-        throw failedDelivery.reason;
-    }
-    const durations = deliveryResults.map((result) => {
-        if (result.status === 'rejected') {
-            throw result.reason;
-        }
-        return result.value;
+    const durations = await waitForDeliveryReceipts({
+        run: input.run,
+        deliveryCase: input.deliveryCase,
+        receivers,
+        startedAtMs
     });
     const receiverAgentIds = receivers.map((receiver) => receiver.agentId);
     return {
         commandId,
-        scenario: {
-            matrixId,
+        scenario: toDeliveryScenario(input, receiverAgentIds, roomAudience),
+        timing: toDeliveryTiming(input, receiverAgentIds, durations)
+    };
+}
+
+async function waitForDeliveryReceipts(
+    input: WaitForDeliveryReceiptsInput
+): Promise<readonly number[]> {
+    const receiverWaits = input.receivers.map((receiver) =>
+        input.run.control.waitForMessage({
+            runId: input.run.runId,
+            senderAgentId: input.deliveryCase.sender.agentId,
+            agentId: receiver.agentId,
             transport: input.run.transport,
-            deliveryMode,
-            senderAgentId: sender.agentId,
-            expectedAgentIds: receiverAgentIds,
-            allowedAgentIds: roomAudience || deliveryMode === 'broadcast'
-                ? input.run.agents.map((agent) => agent.agentId)
-                : receiverAgentIds
-        },
-        timing: {
-            kind: deliveryMode === 'direct'
-                ? 'direct-delivery'
-                : deliveryMode === 'multicast'
-                ? 'multicast-delivery'
-                : 'broadcast-delivery',
-            transport: input.run.transport,
-            senderAgentId: sender.agentId,
-            receiverAgentIds,
-            durationMs: Math.max(...durations)
-        }
+            matrixId: input.deliveryCase.matrixId,
+            deliveryMode: input.deliveryCase.deliveryMode,
+            possibleReceiverAgentIds: input.receivers.map((agent) => agent.agentId),
+            startedAtMs: input.startedAtMs
+        })
+    );
+    try {
+        return await Promise.all(receiverWaits);
+    }
+    catch (cause) {
+        await Promise.allSettled(receiverWaits);
+        throw cause;
+    }
+}
+
+function toDeliveryScenario(
+    input: RunDeliveryCaseInput,
+    receiverAgentIds: readonly string[],
+    roomAudience: boolean
+): LiveRtcControlClient.DeliveryScenario {
+    return {
+        matrixId: input.deliveryCase.matrixId,
+        transport: input.run.transport,
+        deliveryMode: input.deliveryCase.deliveryMode,
+        senderAgentId: input.deliveryCase.sender.agentId,
+        expectedAgentIds: receiverAgentIds,
+        allowedAgentIds: roomAudience || input.deliveryCase.deliveryMode === 'broadcast'
+            ? input.run.agents.map((agent) => agent.agentId)
+            : receiverAgentIds
+    };
+}
+
+function toDeliveryTiming(
+    input: RunDeliveryCaseInput,
+    receiverAgentIds: readonly string[],
+    durations: readonly number[]
+): LiveRtcPerformanceTiming {
+    return {
+        kind: input.deliveryCase.deliveryMode === 'direct'
+            ? 'direct-delivery'
+            : input.deliveryCase.deliveryMode === 'multicast'
+            ? 'multicast-delivery'
+            : 'broadcast-delivery',
+        transport: input.run.transport,
+        senderAgentId: input.deliveryCase.sender.agentId,
+        receiverAgentIds,
+        durationMs: Math.max(...durations)
     };
 }
 async function observeVisibleInbox(

--- a/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-delivery-operations.ts
@@ -800,7 +800,7 @@ async function runDeliveryCase(
             ? undefined
             : firstHopReceivers.map((receiver) => input.sessions[receiver.prefix])
     });
-    const durations = await Promise.all(
+    const deliveryResults = await Promise.allSettled(
         receivers.map((receiver) =>
             input.run.control.waitForMessage({
                 runId: input.run.runId,
@@ -814,6 +814,18 @@ async function runDeliveryCase(
             })
         )
     );
+    const failedDelivery = deliveryResults.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+    if (failedDelivery) {
+        throw failedDelivery.reason;
+    }
+    const durations = deliveryResults.map((result) => {
+        if (result.status === 'rejected') {
+            throw result.reason;
+        }
+        return result.value;
+    });
     const receiverAgentIds = receivers.map((receiver) => receiver.agentId);
     return {
         commandId,

--- a/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
@@ -247,7 +247,7 @@ export interface LiveRtcMessageFailureDiagnostic {
     readonly matrixId: string;
     readonly deliveryMode: string;
     readonly capturedAtEpochMs: number;
-    readonly failure: Readonly<{ name: string; message: string; }>;
+    readonly failure: LiveRtcDiagnosticFailure;
     readonly healthByAgentId: Readonly<Record<string, LiveRtcMessageFailureAgentHealth>>;
     readonly runCaptureSucceeded: boolean;
     readonly sendResult: LiveRtcSendResultSummary | null;
@@ -255,8 +255,13 @@ export interface LiveRtcMessageFailureDiagnostic {
     readonly recentEvents: readonly LiveRtcMessageFailureEventSummary[];
 }
 
+export interface LiveRtcDiagnosticFailure {
+    readonly name: string;
+    readonly message: string;
+}
+
 export interface LiveRtcMessageFailureAgentHealth extends LiveRtcFailureAgentHealth {
-    readonly captureFailure: Readonly<{ name: string; message: string; }> | null;
+    readonly captureFailure: LiveRtcDiagnosticFailure | null;
 }
 
 export interface LiveRtcMessageFailureResultSummary {

--- a/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
+++ b/tests/playwright/rallar-black-box/live-rtc-performance-evidence.ts
@@ -132,7 +132,7 @@ export type LiveRtcNackProbeStage =
     | 'receive'
     | 'record-receipt';
 
-export interface LiveRtcNackAgentHealth {
+export interface LiveRtcFailureAgentHealth {
     readonly captureSucceeded: boolean;
     readonly commandSucceeded: boolean | null;
     readonly settledPeerCount: number | null;
@@ -146,7 +146,7 @@ export interface LiveRtcNackAgentHealth {
     readonly relayPeerCount: number | null;
 }
 
-export interface LiveRtcNackSendResultSummary {
+export interface LiveRtcSendResultSummary {
     readonly ok: boolean;
     readonly runtimeStatus: 'sent' | 'other' | 'missing';
     readonly admissionStatus:
@@ -165,7 +165,6 @@ export interface LiveRtcNackSendResultSummary {
         | 'missing';
     readonly reason: 'not-yet-in-sync' | 'other' | 'missing';
     readonly messageIdPresent: boolean;
-    readonly messageIdMatchesProbe: boolean | null;
     readonly entryCount: number;
     readonly entryStatuses: readonly (
         | 'NEW'
@@ -179,6 +178,10 @@ export interface LiveRtcNackSendResultSummary {
         | 'MERGED'
         | 'other'
     )[];
+}
+
+export interface LiveRtcNackSendResultSummary extends LiveRtcSendResultSummary {
+    readonly messageIdMatchesProbe: boolean | null;
 }
 
 export interface LiveRtcNackEventClassification {
@@ -208,7 +211,7 @@ export interface LiveRtcNackFailureDiagnostic {
     readonly targetSessionId: string;
     readonly capturedAtEpochMs: number;
     readonly failureMessage: string;
-    readonly healthByAgentId: Readonly<Record<string, LiveRtcNackAgentHealth>>;
+    readonly healthByAgentId: Readonly<Record<string, LiveRtcFailureAgentHealth>>;
     readonly runCaptureSucceeded: boolean;
     readonly sendResult: LiveRtcNackSendResultSummary | null;
     readonly wireObservation: LiveRtcNackWireObservationSummary;
@@ -232,6 +235,43 @@ export interface LiveRtcAttemptFailureDiagnostic {
     readonly kind: 'control-result-failures';
     readonly runCaptureSucceeded: boolean;
     readonly failedResults: readonly LiveRtcFailedControlResult[];
+    readonly messageFailures: readonly LiveRtcMessageFailureDiagnostic[];
+}
+
+export interface LiveRtcMessageFailureDiagnostic {
+    readonly kind: 'message-delivery-failure';
+    readonly runId: string;
+    readonly senderAgentId: string;
+    readonly receiverAgentId: string;
+    readonly transport: 'realtime' | 'messages.rtc';
+    readonly matrixId: string;
+    readonly deliveryMode: string;
+    readonly capturedAtEpochMs: number;
+    readonly failure: Readonly<{ name: string; message: string; }>;
+    readonly healthByAgentId: Readonly<Record<string, LiveRtcMessageFailureAgentHealth>>;
+    readonly runCaptureSucceeded: boolean;
+    readonly sendResult: LiveRtcSendResultSummary | null;
+    readonly recentResults: readonly LiveRtcMessageFailureResultSummary[];
+    readonly recentEvents: readonly LiveRtcMessageFailureEventSummary[];
+}
+
+export interface LiveRtcMessageFailureAgentHealth extends LiveRtcFailureAgentHealth {
+    readonly captureFailure: Readonly<{ name: string; message: string; }> | null;
+}
+
+export interface LiveRtcMessageFailureResultSummary {
+    readonly agentId: string | null;
+    readonly commandId: string;
+    readonly ok: boolean;
+}
+
+export interface LiveRtcMessageFailureEventSummary {
+    readonly agentId: string | null;
+    readonly kind: string | null;
+    readonly transport: string | null;
+    readonly topic: string | null;
+    readonly matrixId: string | null;
+    readonly deliveryMode: string | null;
 }
 
 export interface LiveRtcFailedControlResult {


### PR DESCRIPTION
## Goal

Make failed RTC-B06 publish archives self-diagnosing when a browser message
delivery times out. Publish mode intentionally has no diagnostics output
directory; previously that made the control client skip capture entirely.

## Changes

- Construct one bounded, payload-free message-delivery failure diagnostic and
  retain it in normal attempt evidence regardless of sidecar configuration.
- Send the same immutable object to the existing optional diagnostic sidecar.
- Preserve generic failed-control-result facts and limit message diagnostics to
  the first failing case's at-most-two possible receivers.
- Settle all started receiver capture work before finalization while preserving
  the temporally first receiver rejection.
- Use allowlisted failure descriptions; never archive caught response bodies,
  payloads, credentials, authorization data, raw frames, or unbounded history.
- Complete touched-file ownership/function-size closure without an exception or
  legacy/compatibility path.
- Refresh the active RTC performance plan for PRs #556/#557, failed run
  34524003896, pending archive PR #560, and the moving-main next slices.

No RTC product routing, QueueBox behavior, retry count, polling interval,
timeout, workload/sample rule, observation identity, workflow publication
behavior, migration, or compatibility implementation changes.

## Validation

- TDD RED/GREEN for no-output-directory retention, sensitive/oversized health
  errors, concurrent two-receiver capture, later-failure suppression, and
  temporal first-rejection propagation.
- Focused suites: 62/62 RTC tests and 47/47 evidence/finalization tests passed;
  final control/delivery run passed 24/24.
- Canonical test typecheck: 1,172 enforced files, zero debt/errors.
- Exact final-head unit suite: 1,182 files passed, 4 skipped; 10,686 tests
  passed, 12 skipped.
- Local browser proof on isolated ports: default passed in 1.2 minutes and the
  complete all-scenarios matrix passed in 2.2 minutes without retry; retention
  was intentionally skipped.
- Non-publishing exact-head diagnostic workflow
  [34535132797](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34535132797)
  passed in 5m4s; capture/publication remained skipped and its temporary
  diagnostic artifact was retained.
- shared-rtc-bench TypeScript, formatting, changed style/structure, legacy, and
  `git diff --check` gates passed.
- Independent task, fix-round, plan, whole-branch, and final scoped reviews have
  no remaining Critical or Important finding.

One earlier full-unit run under concurrent review load had three unrelated
timing/drain failures. Each passed unchanged in isolation, and the clean-load
full suite then passed. No unrelated test or timeout was changed.

## Follow-up

1. Human-review and merge PR #560 unchanged so run 34524003896 remains
   append-only failed evidence with `acceptedMetrics: false`.
2. Merge this tooling correction after its exact-head gates.
3. Dispatch a fresh RTC-B06 publish observation from then-current moving
   `main`. A valid primary plus any required repeat unlocks Task 12; B07 remains
   held and E4-pg remains conditional there.
