### PR TITLE
ci(deploy): refuse stale deploys only for newer deployable commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -299,12 +299,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      - name: Verify checked out commit is current main
+      # Archive commits ("perf(rtc): archive ...") change only performance-observations/**, which the
+      # paths-ignore above excludes from this workflow, so they must not count as a newer deploy of
+      # main: comparing against the raw tip refused the deploy of the code commit underneath them.
+      - name: Verify no newer deployable commit exists on main
         run: |
           git fetch --no-tags origin main
-          remote_main_sha="$(git rev-parse origin/main)"
-          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
-            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+          superseding_commit="$(git log -1 --format=%H "$GITHUB_SHA..origin/main" -- . ':(exclude)performance-observations')"
+          if [ -n "$superseding_commit" ]; then
+            echo "::error::Refusing stale production deploy: main has a newer deployable commit $superseding_commit"
             exit 1
           fi
 
@@ -358,12 +361,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      - name: Verify checked out commit is current main
+      # Archive commits ("perf(rtc): archive ...") change only performance-observations/**, which the
+      # paths-ignore above excludes from this workflow, so they must not count as a newer deploy of
+      # main: comparing against the raw tip refused the deploy of the code commit underneath them.
+      - name: Verify no newer deployable commit exists on main
         run: |
           git fetch --no-tags origin main
-          remote_main_sha="$(git rev-parse origin/main)"
-          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
-            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+          superseding_commit="$(git log -1 --format=%H "$GITHUB_SHA..origin/main" -- . ':(exclude)performance-observations')"
+          if [ -n "$superseding_commit" ]; then
+            echo "::error::Refusing stale production deploy: main has a newer deployable commit $superseding_commit"
             exit 1
           fi
 
@@ -398,12 +404,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      - name: Verify checked out commit is current main
+      # Archive commits ("perf(rtc): archive ...") change only performance-observations/**, which the
+      # paths-ignore above excludes from this workflow, so they must not count as a newer deploy of
+      # main: comparing against the raw tip refused the deploy of the code commit underneath them.
+      - name: Verify no newer deployable commit exists on main
         run: |
           git fetch --no-tags origin main
-          remote_main_sha="$(git rev-parse origin/main)"
-          if [ "$GITHUB_SHA" != "$remote_main_sha" ]; then
-            echo "::error::Refusing stale production deploy: workflow commit is no longer main tip"
+          superseding_commit="$(git log -1 --format=%H "$GITHUB_SHA..origin/main" -- . ':(exclude)performance-observations')"
+          if [ -n "$superseding_commit" ]; then
+            echo "::error::Refusing stale production deploy: main has a newer deployable commit $superseding_commit"
             exit 1
           fi
 

--- a/packages/tests/hetzner/deploy-release-gate.test.ts
+++ b/packages/tests/hetzner/deploy-release-gate.test.ts
@@ -188,7 +188,7 @@ describe('Deploy workflow release gate', () => {
 
         for (const jobName of ['deploy-api', 'deploy-control-server', 'deploy-relic-api']) {
             const jobBlock = getJobBlock(workflow, jobName);
-            const staleGuardIndex = jobBlock.indexOf('Verify checked out commit is current main');
+            const staleGuardIndex = jobBlock.indexOf('Verify no newer deployable commit exists on main');
             const firstMutationIndex = Math.min(
                 ...['Prisma migrate deploy', 'run: deno deploy .']
                     .map((marker) => jobBlock.indexOf(marker))

--- a/packages/tests/hetzner/deploy-stale-main-guard.test.ts
+++ b/packages/tests/hetzner/deploy-stale-main-guard.test.ts
@@ -1,0 +1,181 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const denoDeployJobNames = ['deploy-api', 'deploy-control-server', 'deploy-relic-api'] as const;
+const staleDeployGuardStepName = 'Verify no newer deployable commit exists on main';
+const serverSource = { 'apps/api-v1/src/main.ts': 'export {};\n' };
+const firstArchive = { 'performance-observations/rtc-b06/index.jsonl': '{"archive":"first"}\n' };
+const secondArchive = { 'performance-observations/rtc-b05/index.jsonl': '{"archive":"second"}\n' };
+const fixtureRoots: string[] = [];
+
+interface DeployWorkflow {
+    readonly jobs: Readonly<
+        Record<string, {
+            readonly steps: readonly { readonly name?: string; readonly run?: string; }[];
+        }>
+    >;
+}
+
+interface MainRepositoryFixture {
+    readonly root: string;
+    readonly originUrl: string;
+    readonly authorPath: string;
+    readonly gitEnvironment: Readonly<Record<string, string>>;
+}
+
+interface RunnerCheckout {
+    readonly path: string;
+    readonly checkedOutSha: string;
+}
+
+interface GuardVerdict {
+    readonly deploys: boolean;
+    readonly output: string;
+}
+
+afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+describe('Deploy workflow stale main guard', () => {
+    it('runs one identical guard in every Deno Deploy job', () => {
+        const scripts = denoDeployJobNames.map(readStaleDeployGuardScript);
+
+        expect(new Set(scripts).size).toBe(1);
+    });
+
+    it('deploys a code commit when only archive commits landed on main after it was checked out', () => {
+        const fixture = createMainRepository();
+        pushCommit(fixture, 'feat: initial server', serverSource);
+        const runner = createRunnerCheckout(fixture);
+        pushCommit(fixture, 'perf(rtc): archive first', firstArchive);
+        pushCommit(fixture, 'perf(rtc): archive second', secondArchive);
+
+        expect(readGuardVerdict(fixture, runner).deploys).toBe(true);
+    });
+
+    it('refuses a code commit once a newer commit outside performance-observations lands on main', () => {
+        const fixture = createMainRepository();
+        pushCommit(fixture, 'feat: initial server', serverSource);
+        const runner = createRunnerCheckout(fixture);
+        pushCommit(fixture, 'perf(rtc): archive first', firstArchive);
+        const supersedingSha = pushCommit(fixture, 'fix: later server change', {
+            'apps/api-v1/src/main.ts': 'export const later = true;\n'
+        });
+        pushCommit(fixture, 'perf(rtc): archive second', secondArchive);
+
+        const verdict = readGuardVerdict(fixture, runner);
+
+        expect(verdict.deploys).toBe(false);
+        expect(verdict.output).toContain(
+            `Refusing stale production deploy: main has a newer deployable commit ${supersedingSha}`
+        );
+    });
+
+    it('deploys a manual run checked out at an archive commit that is still the tip of main', () => {
+        const fixture = createMainRepository();
+        pushCommit(fixture, 'feat: initial server', serverSource);
+        pushCommit(fixture, 'perf(rtc): archive first', firstArchive);
+        const runner = createRunnerCheckout(fixture);
+
+        expect(readGuardVerdict(fixture, runner).deploys).toBe(true);
+    });
+});
+
+function createMainRepository(): MainRepositoryFixture {
+    const root = mkdtempSync(path.join(tmpdir(), 'deploy-stale-main-guard-'));
+    fixtureRoots.push(root);
+    const originPath = path.join(root, 'origin.git');
+    const fixture = {
+        root,
+        originUrl: `file://${originPath}`,
+        authorPath: path.join(root, 'author'),
+        gitEnvironment: {
+            GIT_CONFIG_GLOBAL: '/dev/null',
+            GIT_CONFIG_NOSYSTEM: '1',
+            GIT_AUTHOR_NAME: 'Deploy guard test',
+            GIT_AUTHOR_EMAIL: 'deploy-guard@example.invalid',
+            GIT_COMMITTER_NAME: 'Deploy guard test',
+            GIT_COMMITTER_EMAIL: 'deploy-guard@example.invalid'
+        }
+    };
+    git(fixture, root, ['init', '--quiet', '--bare', '--initial-branch', 'main', originPath]);
+    git(fixture, root, ['init', '--quiet', '--initial-branch', 'main', fixture.authorPath]);
+    git(fixture, fixture.authorPath, ['remote', 'add', 'origin', fixture.originUrl]);
+    return fixture;
+}
+
+function pushCommit(
+    fixture: MainRepositoryFixture,
+    message: string,
+    files: Readonly<Record<string, string>>
+): string {
+    for (const [relativePath, content] of Object.entries(files)) {
+        const filePath = path.join(fixture.authorPath, relativePath);
+        mkdirSync(path.dirname(filePath), { recursive: true });
+        writeFileSync(filePath, content);
+    }
+    git(fixture, fixture.authorPath, ['add', '--all']);
+    git(fixture, fixture.authorPath, ['commit', '--quiet', '--message', message]);
+    git(fixture, fixture.authorPath, ['push', '--quiet', 'origin', 'main']);
+    return git(fixture, fixture.authorPath, ['rev-parse', 'HEAD']);
+}
+
+function createRunnerCheckout(fixture: MainRepositoryFixture): RunnerCheckout {
+    const runnerPath = mkdtempSync(path.join(fixture.root, 'runner-'));
+    git(fixture, fixture.root, [
+        'clone',
+        '--quiet',
+        '--depth',
+        '1',
+        '--branch',
+        'main',
+        fixture.originUrl,
+        runnerPath
+    ]);
+    return { path: runnerPath, checkedOutSha: git(fixture, runnerPath, ['rev-parse', 'HEAD']) };
+}
+
+function readGuardVerdict(fixture: MainRepositoryFixture, runner: RunnerCheckout): GuardVerdict {
+    const guard = spawnSync('bash', ['-e', '-c', readStaleDeployGuardScript('deploy-api')], {
+        cwd: runner.path,
+        env: { ...process.env, ...fixture.gitEnvironment, GITHUB_SHA: runner.checkedOutSha },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    return { deploys: guard.status === 0, output: `${guard.stdout}${guard.stderr}` };
+}
+
+function readStaleDeployGuardScript(jobName: string): string {
+    const workflow = load(
+        readFileSync(path.join(repoRoot, '.github/workflows/deploy.yml'), 'utf8')
+    ) as DeployWorkflow;
+    const run = workflow.jobs[jobName]?.steps.find((step) => step.name === staleDeployGuardStepName)?.run;
+    if (typeof run !== 'string') {
+        throw new Error(`${jobName} has no "${staleDeployGuardStepName}" step`);
+    }
+    return run;
+}
+
+function git(fixture: MainRepositoryFixture, cwd: string, args: readonly string[]): string {
+    return execFileSync('git', args, {
+        cwd,
+        env: { ...process.env, ...fixture.gitEnvironment },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    }).trim();
+}


### PR DESCRIPTION
## Problem

`Deploy Web + API` ignores `performance-observations/**` in `on.push.paths-ignore`, but the step "Verify checked out commit is current main" in its three Deno Deploy jobs refused to deploy whenever `GITHUB_SHA` differed from the raw tip of `origin/main`. The automated `perf(rtc): archive …` commits change only `performance-observations/**`, land minutes after code commits, and trigger no deploy of their own, so they moved the tip without ever producing a deployable run.

Observed on `main`:

| Run | Commit under deploy | Guard ran at | Tip of `origin/main` at that moment |
| --- | --- | --- | --- |
| [34519992735](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34519992735) | ce4ab6ae1 `fix(rtc): centralize event-driven room readiness (#557)` | 2026-09-10 20:42Z | aeb671039 (archive, #558) |
| [34563534882](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34563534882) | 48717845a `test(rtc): retain publish failure diagnostics (#561)`, re-run | 2026-09-11 07:20Z | bf67bacb9 (archive, #562), with code commit 1656e283d in between |
| [34573446542](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34573446542) | 1656e283d `test(rtc): retain sender failure context (#563)` | 2026-09-11 08:09Z | bf67bacb9 (archive, #562), landed three minutes after 1656e283d |

All nine Deno Deploy jobs in those runs ended with `Refusing stale production deploy: workflow commit is no longer main tip`. The archive commits that had become the tip triggered no deploy, so the code on `main` did not reach production until f8db93762 (#559) pushed at 10:13Z and [run 34588123581](https://github.com/intact-software-systems/ar-eye-hunter/actions/runs/34588123581) succeeded.

## Change

The guard now asks whether any commit in `$GITHUB_SHA..origin/main` changes a path outside `performance-observations/`:

```sh
git fetch --no-tags origin main
superseding_commit="$(git log -1 --format=%H "$GITHUB_SHA..origin/main" -- . ':(exclude)performance-observations')"
if [ -n "$superseding_commit" ]; then
  echo "::error::Refusing stale production deploy: main has a newer deployable commit $superseding_commit"
  exit 1
fi
```

- The exclusion mirrors `paths-ignore`, so a newer commit counts exactly when it would itself have triggered this workflow, and the error names that commit. The guard's purpose is unchanged: a commit superseded by a newer deployable commit is never deployed.
- The range form, rather than comparing `GITHUB_SHA` against the newest deployable commit on `main`, keeps a `workflow_dispatch` run deployable when the tip itself is an archive commit. That manual run is the recovery path after exactly this failure, and comparing against the newest deployable commit would have refused it too. The range walk also never descends below `$GITHUB_SHA`, so it works in the runner's depth-1 checkout.
- Applied to all three Deno Deploy jobs (`deploy-api`, `deploy-control-server`, `deploy-relic-api`) with a short comment naming the archive-commit case. The Cloudflare build jobs have no such step, so they are unchanged.
- With this guard, run 34573446542 (1656e283d) would have deployed. The 48717845a re-run would still be refused, correctly, because 1656e283d had superseded it.

## Validation

- New `packages/tests/hetzner/deploy-stale-main-guard.test.ts` executes the step's shell straight from `deploy.yml` in a depth-1 clone of a scratch origin: archive-only commits after checkout deploy; a later code commit is refused and named; a manual run at an archive tip deploys; the three jobs carry one identical script. Pointed at the previous guard, the archive-only scenario fails with a refusal, reproducing the production failure.
- `npx vitest run packages/tests/hetzner/deploy-stale-main-guard.test.ts packages/tests/hetzner/deploy-release-gate.test.ts`: 12 passed.
- `npm run test:repo-governance` (includes `github-actions-runtime-governance.test.ts`): 27 files, 428 tests passed.
- `npm run typecheck:tests`: PASS, 0 errors.
- `npx dprint check` on the three touched files: PASS. dprint (yaml plugin) plus the vitest workflow suites are the repo's workflow linting; there is no actionlint in the tooling.
- `node scripts/check-test-structure-coupling.mjs --files …`: 0 candidates. `npm run check:repo-style -- --root packages/tests/hetzner`: no findings for the new file.
- `npm run check:repo-style:changed -- origin/main HEAD`: PASS, no new findings. `node scripts/check-test-structure-coupling.mjs --changed origin/main HEAD`: PASS, complete classifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
